### PR TITLE
fix(kbli): fourteen transport pages offered 100% foreign ownership on activities capped at 49%

### DIFF
--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
   "lastModified": "2026-08-06",
-  "datasetSha256": "sha256:8cc40250273a512bcdb5e3bd2868de32f0ee1417093b89424636cd4818d67698",
+  "datasetSha256": "sha256:383a469d3df1146ef8b75bc716b500d30fca5411b1ef739795586f99809e7e54",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/apps/mouth/data/kbli-dataset-version.json
+++ b/apps/mouth/data/kbli-dataset-version.json
@@ -1,5 +1,5 @@
 {
   "lastModified": "2026-08-06",
-  "datasetSha256": "sha256:68f6eddff3aebac140845c6928583fe9f17afd5426eb6c05450fe31d363194d4",
+  "datasetSha256": "sha256:8cc40250273a512bcdb5e3bd2868de32f0ee1417093b89424636cd4818d67698",
   "note": "Last real content change of KBLI_2025_FINAL_CLEAN.json (git commit date). File mtime is NOT usable as SEO lastmod: git/Vercel checkouts stamp clone time, so every deploy would claim all 1,559 /kbli pages 'modified today' (red-team finding 2026-07-05). A vitest guard fails when the dataset hash changes without bumping this file. The hash carries a 'sha256:' prefix so secret scanners do not flag it as a bare high-entropy hex string."
 }

--- a/apps/mouth/src/lib/kbli-internal-leak.test.ts
+++ b/apps/mouth/src/lib/kbli-internal-leak.test.ts
@@ -242,7 +242,11 @@ describe("internal-leak gate (real canonical)", () => {
     // baseline would have recorded that a client may read a field name as the
     // price of a cure — so the names came out of all six replacements instead,
     // which took four codes off this list that were already on it.
-    const BASELINE = 388;
+    // 388 -> 386 with the final prose lot (7 codes, 25 fields). Re-derived from
+    // the canonical with this file's own regex rather than subtracted from the
+    // previous number: two branches lowering the same monotone ratchet conflict
+    // even when both are right, and the resolution is to re-measure (W109b).
+    const BASELINE = 386;
     const leaking = records.filter((r) =>
       readerFacingStrings(r.intel_2026).some((s) => FIELD_RE.test(s)),
     );

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "ebfdadcfd0390e1b4c7fc6e6e13768d84b6dc6a3",
-  "canonical_sha256": "8cc40250273a512bcdb5e3bd2868de32f0ee1417093b89424636cd4818d67698",
+  "canonical_revision": "ea760058ae604cec07847c00ba230cbcbdc495fd",
+  "canonical_sha256": "383a469d3df1146ef8b75bc716b500d30fca5411b1ef739795586f99809e7e54",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/data/kbli-filiera/membership/batch-a-members.json
+++ b/data/kbli-filiera/membership/batch-a-members.json
@@ -1,8 +1,8 @@
 {
   "batch": "A",
   "plan": "research/operations/2026-07-18-kbli-batch-a-plan.md",
-  "canonical_revision": "7a81f1264d69f6fa53036b74b24dde0de1341210",
-  "canonical_sha256": "68f6eddff3aebac140845c6928583fe9f17afd5426eb6c05450fe31d363194d4",
+  "canonical_revision": "ebfdadcfd0390e1b4c7fc6e6e13768d84b6dc6a3",
+  "canonical_sha256": "8cc40250273a512bcdb5e3bd2868de32f0ee1417093b89424636cd4818d67698",
   "canonical_path": "data/source_documents/KBLI_2025_FINAL_CLEAN.json",
   "predicate_doc": {
     "A-serving/pp28": "per_skala non-empty AND pp28_sources non-empty AND no _l2_source",

--- a/scripts/kbli_dataset_lint.py
+++ b/scripts/kbli_dataset_lint.py
@@ -141,7 +141,18 @@ L10_PCT = re.compile(r"\b(\d{1,3})\s?%")
 L10_FOREIGN_CTX = re.compile(
     r"foreign\s+(?:ownership|owner|equity|shareholding|capital|investors?|stake|life\s+insurers?)"
     r"|own(?:ed|s)?\s+up\s+to|can\s+own|max\w*\s+foreign|capped\s+at|\basing\b"
-    r"|pma\s+cap|%\s*pma\b|pma\s+\d{1,3}\s?%",
+    r"|pma\s+cap|%\s*pma\b|pma\s+\d{1,3}\s?%"
+    # "ceiling" carries the ownership claim on its own in this corpus, and a
+    # sentence can state a ceiling without ever using the word "foreign": the
+    # pull quote "The national 100% ceiling does not automatically produce a Bali
+    # registration route" sat on a code whose ceiling is 0 and no probe could see
+    # it. Anchored — a bare "ceiling" is not enough; it must be an ownership/equity
+    # ceiling, or sit within 25 chars of ownership/foreign/PMA, or be the
+    # "national N% ceiling" idiom. Measured: 4 real contradictions unmasked
+    # (50125, 50221, 55105, 86201), 0 previously-reported findings lost.
+    r"|\b(?:ownership|equity)\s+ceiling"
+    r"|ceiling\b[^.]{0,25}\b(?:ownership|foreign|pma)\b"
+    r"|\bnational\s+\d{1,3}\s?%\s+ceiling",
     re.IGNORECASE,
 )
 # innocence: "100% closed" idiom (the % modifies closed-ness, consistent with TERTUTUP)
@@ -276,8 +287,32 @@ def l10_ownership_contradiction(text, code, maxa, maxa_by_code):
         win = text[max(0, m.start() - 80) : m.end() + 80]
         if L10_WORK_SHARE.search(win):
             continue
-        # BALI / regional cap: the figure is the l4_bali restriction, not national max
-        if L10_REGIONAL_CAP.search(win):
+        # BALI / regional cap: the figure is the l4_bali restriction, not national max.
+        #
+        # This used to search the whole ±80 window, so the mere PRESENCE of the word
+        # "Bali" anywhere near the number exonerated it — on a catalogue where every
+        # page is about Bali. "Nationally, this activity is 100% open to foreign
+        # ownership. However, in Bali, …" was read as a regional figure and waved
+        # through on a code whose ceiling is 0. Superscar #3 in its under-match form:
+        # the class judged a TOKEN's presence, not whether the region scopes the
+        # figure.
+        #
+        # A regional word exonerates only when it comes BEFORE the figure, which is
+        # the shape of a regional cap actually being stated — "in Bali the cap is
+        # 30%", "Bali's regime … caps foreign ownership at 67%". A region named
+        # AFTER the number is commentary on a national figure already asserted:
+        # "…100% open to foreign ownership. However, in Bali, the OSS system blocks…"
+        #
+        # A first draft also required no clause break between the region and the
+        # figure, and that was wrong: an introductory adverbial carries a comma by
+        # grammar ("On the ground in Bali, the record caps it at 49%") and the
+        # region still governs. Two innocence cases in the existing corpus said so
+        # immediately. Precedence alone is enough, because every case this unmasks
+        # names the region downstream.
+        #
+        # Measured over the whole catalogue: 8 real contradictions unmasked, 0
+        # previously-reported findings lost.
+        if L10_REGIONAL_CAP.search(text[max(0, m.start() - 80) : m.start()]):
             continue
         # "in practice" / no-Besar-tier operational figure — documented divergence
         # from the national OSS ceiling, not a contradiction of it

--- a/scripts/kbli_filiera/cure_prose_national_openness.py
+++ b/scripts/kbli_filiera/cure_prose_national_openness.py
@@ -88,6 +88,8 @@ if _FILIERA not in sys.path:
 
 import editorial_record_conformance as E  # noqa: E402
 
+import scripts.kbli_dataset_lint as _lint  # noqa: E402
+
 from scripts.kbli_filiera.cure_l4_withdrawn_umkm_prose import (  # noqa: E402
     reconcile_sidecar,
     run_sync_script,
@@ -102,6 +104,12 @@ SPEC = (
 
 logger = logging.getLogger("cure_prose_national_openness")
 
+# The lane marker every spec must carry. A literal, NOT `__name__`: run as a
+# script this module is called `__main__`, so a marker derived from it would
+# demand a different value from the CLI than from a test import — and the guard
+# proved that on its first invocation.
+LANE = "cure_prose_national_openness"
+
 _PERCENT = re.compile(r"(\d+)\s*%")
 
 
@@ -109,12 +117,33 @@ class CureError(RuntimeError):
     """Raised when a premise the spec rests on is no longer true."""
 
 
+_INDEXED = re.compile(r"^(?P<name>[^\[\]]+)\[(?P<idx>\d+)\]$")
+
+
+def _step(node: Any, key: str) -> Any:
+    """One segment of a dotted path, which may address a list element.
+
+    `editorial.byTheNumbers[0].value` is not decoration: two of the fourteen
+    transport codes state their (wrong) ceiling in a "By the numbers" CELL and
+    nowhere else in that field, so a path language that only walks dicts is blind
+    to the one place a reader sees the number first.
+    """
+    m = _INDEXED.match(key)
+    if m:
+        seq = node.get(m.group("name")) if isinstance(node, dict) else None
+        if not isinstance(seq, list):
+            return None
+        idx = int(m.group("idx"))
+        return seq[idx] if idx < len(seq) else None
+    return node.get(key) if isinstance(node, dict) else None
+
+
 def read_field(record: dict[str, Any], path: str) -> Any:
     cur: Any = record.get("intel_2026") or {}
     for key in path.split("."):
-        if not isinstance(cur, dict):
+        cur = _step(cur, key)
+        if cur is None:
             return None
-        cur = cur.get(key)
     return cur
 
 
@@ -122,8 +151,13 @@ def write_field(record: dict[str, Any], path: str, value: str) -> None:
     cur = record["intel_2026"]
     keys = path.split(".")
     for key in keys[:-1]:
-        cur = cur[key]
-    cur[keys[-1]] = value
+        cur = _step(cur, key)
+    last = keys[-1]
+    m = _INDEXED.match(last)
+    if m:
+        cur[m.group("name")][int(m.group("idx"))] = value
+    else:
+        cur[last] = value
 
 
 def check_premise(record: dict[str, Any], code: str, expect: dict[str, Any]) -> None:
@@ -136,13 +170,20 @@ def check_premise(record: dict[str, Any], code: str, expect: dict[str, Any]) -> 
                 f"holds {got!r}. Re-read and re-grade rather than writing prose onto a "
                 "record it no longer describes."
             )
-    needle = expect.get("pma_kondisi_contains")
-    if needle and needle not in (record.get("pma_kondisi") or ""):
-        raise CureError(
-            f"{code}: `pma_kondisi` no longer contains {needle!r}. Every replacement in "
-            "this spec names the Koperasi/UMKM allocation as the REASON the ceiling is "
-            "zero; without it on the record the sentences would assert their own basis."
-        )
+    # A `<field>_contains` key for every field a replacement CITES. The first
+    # spec only needed `pma_kondisi`, because the Koperasi/UMKM allocation lives
+    # there. The transport batch cites `pma_official_basis` instead — "Perpres
+    # 49/2021 Lampiran III … entry #22", a different number on every code — and
+    # a premise check that cannot see the field a sentence quotes is decoration.
+    for key in sorted(k for k in expect if k.endswith("_contains")):
+        field = key[: -len("_contains")]
+        needle = expect[key]
+        if needle and needle not in (record.get(field) or ""):
+            raise CureError(
+                f"{code}: `{field}` no longer contains {needle!r}. A replacement in this "
+                f"spec quotes that field as its BASIS; without it on the record the "
+                "sentence would be asserting its own authority."
+            )
 
 
 def plan_for(record: dict[str, Any], code: str, entry: dict[str, Any]) -> list[dict[str, Any]]:
@@ -179,6 +220,18 @@ def plan_for(record: dict[str, Any], code: str, entry: dict[str, Any]) -> list[d
 
 def run(spec_path: Path, canonical_path: Path, only: list[str] | None, apply: bool) -> int:
     spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    # Which specs belong to THIS lane is not answerable from a filename. The class
+    # checks over "everything this cure has shipped" used to glob a name prefix,
+    # so the transport batch — named after its instrument rather than its
+    # population — dropped out of every one of them and still read clean. The
+    # marker is required HERE, at the only door a spec can come through, so the
+    # marked set on disk is provably the set that has ever been applied.
+    if spec.get("compiler") != LANE:
+        raise CureError(
+            f"{spec_path.name}: missing `\"compiler\": \"{LANE}\"`. Without it this "
+            "spec is invisible to every check that enumerates this lane's shipped "
+            "cures, and a cure nobody enumerates is a cure nobody can re-verify."
+        )
     wanted: dict[str, Any] = spec["codes"]
     if only:
         unknown = sorted(set(only) - set(wanted))
@@ -189,6 +242,7 @@ def run(spec_path: Path, canonical_path: Path, only: list[str] | None, apply: bo
     doc = json.loads(canonical_path.read_text(encoding="utf-8"))
     records = doc["data"]
     by_code = {r.get("kode_kbli_2025"): r for r in records}
+    caps_by_code = {r.get("kode_kbli_2025"): r.get("pma_max_asing") for r in records}
 
     missing = sorted(set(wanted) - set(by_code))
     if missing:
@@ -231,6 +285,32 @@ def run(spec_path: Path, canonical_path: Path, only: list[str] | None, apply: bo
             "A half-cure leaves a page consistent enough to be believed and wrong where "
             "it counts.",
             still_lying,
+        )
+        return 1
+
+    # The SECOND opinion, and it is not this module's own. `editorial_record_
+    # conformance` reads for an ASSERTION and needs a national-scope word in the
+    # same sentence; the lint's L10 reads for a NUMBER against `pma_max_asing` and
+    # needs neither. Curing a page that satisfies one and not the other is how
+    # `55105` shipped saying 0% in one field and 100% in another. Living in the
+    # test file was not enough — a class check catches it after it has landed, and
+    # the point of a refusal is that it never lands.
+    numeric_survivors = []
+    for code in wanted:
+        record = patched_by_code[code]
+        cap = record.get("pma_max_asing")
+        for field, text in _lint.iter_prose(record):
+            hit = _lint.l10_ownership_contradiction(text, code, cap, caps_by_code)
+            if hit:
+                numeric_survivors.append(f"{code}.{field} says {hit[0]}% (record: {cap})")
+                break
+    if numeric_survivors:
+        logger.error(
+            "refusing to write: %d cured page(s) still state a foreign-ownership "
+            "percentage the record denies — %s. The assertion was removed and the "
+            "number left behind, which is the shape a reader trusts most.",
+            len(numeric_survivors),
+            numeric_survivors[:8],
         )
         return 1
 

--- a/scripts/kbli_filiera/cure_specs/prose_dejargonise_bali_paragraph_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/prose_dejargonise_bali_paragraph_2026_08_06.json
@@ -1,4 +1,5 @@
 {
+  "compiler": "cure_prose_national_openness",
   "_meta": {
     "spec": "prose_dejargonise_bali_paragraph_2026_08_06",
     "why": "A ratchet in apps/mouth/src/lib/kbli-internal-leak.test.ts counts codes whose reader-facing prose narrates a RAW FIELD NAME — `l4_bali_blocked`, `pma_max_asing` and friends. It may fall, never rise. My batch-2 Bali paragraphs pushed it from 392 to 394: `41016` and `41018` did not narrate a field name before and do now, because I wrote one into the replacement.",

--- a/scripts/kbli_filiera/cure_specs/prose_final_seven_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/prose_final_seven_2026_08_06.json
@@ -1,0 +1,199 @@
+{
+  "compiler": "cure_prose_national_openness",
+  "_why": "The last seven codes on the detector's backlog. Each carries a DIFFERENT recorded condition — a domestic-capital reservation, a defence-ministry route above 49%, a single-majority requirement, an Islamic-faith requirement, and one activity recorded closed with no condition under which it opens — so there is no shared paragraph here on purpose. Graded by a cross-family seat instructed to hunt the sentences WRITTEN rather than the ones removed; seven of its nine findings changed this text (the 'only route' exclusivity claim, the single-majority gloss, 'religious' for Islamic, an invented industrial-zone restriction, an absolute 'Bali adds no second obstacle', a false 'neither obstacle is removed by moving off the island', and four assertions on 84231 the record never made). Two were refuted on disk and are recorded so they are not re-litigated: the untouched byTheNumbers cells already carry the correct ceiling on all seven, and 51101's record does cite Perpres 10/2021 in pma_source.",
+  "codes": {
+    "16221": {
+      "expect": {
+        "pma_max_asing": 0,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "entry #3",
+        "pma_kondisi_contains": "Modal dalam negeri 100% — op"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "6a15331d36d144de2d4b895a5acb09cf214206ef376c1268bcaa50228ad378c1",
+          "old_excerpt": "This is a manufacturing activity built around wood as a construction material. The scope covers wooden building materials used mainly for construction",
+          "new": "This is a manufacturing activity built around wood as a construction material. The scope covers wooden building materials used mainly for construction: beams, rafters, roof frames finished on all four sides, and supporting posts made from finger-jointed wood with adhesive or connected with metal. It also reaches the more visible architectural elements of a building: doors, windows, shutters, frames, stairs, stair rails, wooden mouldings, wooden shingles, parquet blocks and strips assembled into panels from solid wood or engineering wood, decorative wall boards, and name boards.\n\nThe registration picture is broad at the national level. The record opens the activity to Mikro, Kecil, Menengah, and Besar scale businesses, so the code is not confined to one enterprise size. For foreign investment the position is the opposite of broad: Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — lists this activity at entry #3 as open to domestic capital only. Foreign shareholding is 0%, so a PT PMA cannot hold this code anywhere in Indonesia.\n\nBali changes the practical answer. The record marks the Bali status as Blocked (risk class) and sets l4_bali_blocked to true. The stated reason is that OSS risk at scale Besar is Rendah/Menengah-Rendah on every scope, placing it inside the Bali moratorium. The moratorium rule in the record says Bali province blocks all Low and Medium-Low risk activities for PMA, island-wide and permanently. The immediate planning consequence is simple: a foreign investor cannot register this activity as a PMA in Bali under the record as written.\n\nTwo separate obstacles sit on this activity, and they do not have the same reach. The national one is the reservation to domestic capital, and it applies wherever the company is registered. The Bali one is the moratorium, which stops PMA registration for activities assessed at low or medium-low risk — this one is, at every scope at the large scale. Registering somewhere other than Bali removes the second obstacle and leaves the first standing, which is the opposite of what a reader of the Bali half alone would conclude."
+        },
+        "editorial.headline": {
+          "old_sha256": "93bd8799be7f248e7c30e9ff26acfc802221334578bdf0217dedf314564ab074",
+          "old_excerpt": "Wood Building Components: Nationally Open, Bali Blocked",
+          "new": "Wood Building Components: Reserved to Domestic Capital, and Blocked in Bali"
+        },
+        "editorial.standfirst": {
+          "old_sha256": "c3d4e723d68b47454491f4b20e711263e9d4a78841aa0f745e446ca2b274e8f6",
+          "old_excerpt": "This code covers wooden construction components, open nationally to 100% foreign ownership across all scales, but blocked for PMA registration in Bali",
+          "new": "This code covers wooden construction components across all business scales — foreign shareholding is 0%, and Bali's risk-class moratorium blocks PMA registration on top of that."
+        },
+        "whoThisIsFor": {
+          "old_sha256": "a0181efb9ee48108ecd50044052836cd26eec329dcc21437aced2212dfae6af1",
+          "old_excerpt": "A foreign wood-product manufacturer or construction-supply exporter looking to produce high-quality, export-oriented timber building materials from In",
+          "new": "Indonesian-owned manufacturers of timber building components. Foreign shareholding in this activity is 0%, so it is not a code a PT PMA can be built around; a foreign manufacturer's route here is as a customer or an offtake partner of a domestic producer, not as its owner."
+        },
+        "whatYouNeed": {
+          "old_sha256": "830f240ead6e9bb32f26977eb64f8146f2f20b0dc4f67cf6a9037ae0b95d108d",
+          "old_excerpt": "Nationally, this activity is 100% open to foreign ownership. However, in Bali, the OSS system blocks PMA registration because even a 'large' scale pro",
+          "new": "This activity is reserved to domestic capital: foreign shareholding is 0%, so a PT PMA cannot register it anywhere in Indonesia. The reservation is set by Perpres 49/2021, Lampiran III, entry #3. Bali adds a second, independent obstacle — the island-wide moratorium blocks PMA registration for activities assessed at low or medium-low risk, and this one is assessed there at every scope. Moving the registration off the island clears the Bali obstacle and leaves the national one exactly where it was."
+        }
+      }
+    },
+    "25200": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "entry #7",
+        "pma_kondisi_contains": "may exceed 49% with Menteri "
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "199e56d70bb0a8b73bca21009ffce1f5f64ac2c003cd78ec68292270fe2bf0e3",
+          "old_excerpt": "KBLI 25200 is the manufacturing category for weapons and ammunition. Its centre of gravity is not retail, training, security services, or equipment br",
+          "new": "KBLI 25200 is the manufacturing category for weapons and ammunition. Its centre of gravity is not retail, training, security services, or equipment brokerage, but production: military artillery, cannons, rocket launchers, flamethrowers, grenade launchers, torpedo tubes, machine guns, heavy projectile weapons, light firearms such as pistols, revolvers, rifles, and shotguns, and the ammunition that serves them. The record also includes gas rifles, spring rifles, air rifles, war ammunition, shotgun, revolver, and pistol bullets, and military explosive devices such as bombs, grenades, torpedoes, mines, rockets, and missiles.\n\nThe scope is broader than a narrow defence-factory label. It also covers the manufacture of firearms and ammunition for hunting, sport, or protection, and it expressly reaches intercontinental ballistic missiles. That makes the code industrially precise but commercially wide: the activity is defined by making the weapon, ammunition, explosive, or missile system, not by the eventual user alone. A founder reading this should see a production classification for arms and munitions, spanning military-grade systems through certain civilian-use firearms and ammunition, all inside one activity record.\n\nOn business scale, the record is unusually broad: Mikro, Kecil, Menengah, and Besar are all listed as open. Foreign shareholding in this activity is capped at 49%. Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — lists it at entry #7, and the record notes a route above that ceiling: the approval of the Minister of Defence. Without that approval the 49% ceiling is the national position, and the remaining shares cannot be in foreign hands.\n\nBali's moratorium does not block it. That moratorium suspends new PMA registration for activities assessed at low or medium-low risk, and this one is recorded above that band. What the record does limit is the foreign side of the shareholding — 49%, in Bali exactly as anywhere else in Indonesia — with the defence-ministry approval as the recorded route above it."
+        },
+        "editorial.headline": {
+          "old_sha256": "9fba0b42d8d5a0fd67b290b47422c0c300cb13ce883d5be0d5a16000ba4d1d9a",
+          "old_excerpt": "Weapons and Ammunition Manufacturing, Open Nationally and Usable in Bali",
+          "new": "Weapons and Ammunition Manufacturing: Foreign Ownership Capped at 49%"
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "74e8a627bd7efa90a49b10055b733b561d057e7425aa68d3bcd6c05acf78bdf7",
+          "old_excerpt": "The honest reading is not a hidden Bali prohibition: nationally it is open, and the Bali moratorium field does not block PMA registration for this cod",
+          "new": "The reading is not a hidden Bali prohibition and not a national opening either: foreign shareholding stops at 49%, and Bali's moratorium is not what stops it."
+        },
+        "whatYouNeed": {
+          "old_sha256": "b1128f0828999cc3ed95fdc2296f5702c40458af7aa24a99bbd5d2d7beb273fe",
+          "old_excerpt": "Nationally, this sector is fully open to 100% foreign ownership. In Bali, it is not blocked but is flagged as higher-risk: a foreign-owned company can",
+          "new": "Foreign shareholding in this sector is capped at 49%: a PT PMA can hold up to 49% of the company and the rest cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #7, and the record notes a route above it — the approval of the Minister of Defence. Bali's moratorium does not block the activity: it reaches only low and medium-low risk lines, and this one sits above that band."
+        }
+      }
+    },
+    "30400": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "entry #7",
+        "pma_kondisi_contains": "may exceed 49% with Menteri "
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "68efbfab2a4a565b8de551ee9d96cbb24792df3cccb409f1a693568172f3eb8a",
+          "old_excerpt": "KBLI 30400 is a defence-manufacturing activity, not a general automotive line. The record defines it around the making of military war vehicles, wheth",
+          "new": "KBLI 30400 is a defence-manufacturing activity, not a general automotive line. The record defines it around the making of military war vehicles, whether already fitted with weapons or not, and around the parts that make those vehicles what they are: armoured bodies, turrets, doors, protective structures, armour plate identified as part of a military combat vehicle, and other military war vehicles. Its centre of gravity is the combat platform itself: tanks, armoured combat carriers for transporting people, armoured supply or recovery vehicles with cranes, armoured amphibious military vehicles, and remotely operated tanks.\n\nThe scope also reaches factory inspection and rebuilding of military war vehicles. That matters because this code is not limited to first manufacture from a blank production line; it includes industrial rebuilding activity at the factory level. At the same time, the record keeps the boundary tight. It is not the making of weapons and ammunition, not ordinary passenger cars or trucks with light or detachable armour, not military ships, not repair and maintenance of military combat vehicles, and not military drones. The editorial reading is therefore precise: this is the industrial manufacture and factory rebuilding of military combat vehicles and their identified vehicle parts.\n\nOn registration scale, the record is unusually broad. It is open to Mikro, Kecil, Menengah, and Besar scales. That does not make the business ordinary; it simply means the scale field does not reserve the activity for one size of enterprise. A founder reading this record should separate two ideas that are often blurred: the activity’s industrial seriousness comes from the scope, while the scale availability comes from the registration data. The code can be registered across all listed business scales, but the substance remains defence-vehicle manufacturing.\n\nForeign shareholding in this activity is capped at 49%. Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — lists it at entry #7, and the record notes a route above that ceiling: the approval of the Minister of Defence. Without that approval the 49% ceiling is the national position, and the remaining shares cannot be in foreign hands. Bali's moratorium does not block it. That moratorium suspends new PMA registration for activities assessed at low or medium-low risk, and this one is recorded above that band. What the record does limit is the foreign side of the shareholding — 49%, in Bali exactly as anywhere else in Indonesia — with the defence-ministry approval as the recorded route above it."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "de83009acef98e17272ec4f20db2e0328b10a788820459429c1943fbbbc49ccd",
+          "old_excerpt": "The honest conclusion is straightforward: KBLI 30400 is nationally foreign-open up to 100% and is not marked as blocked by Bali’s moratorium in this r",
+          "new": "The constraint on this activity is not Bali's moratorium: it is a 49% ceiling on foreign shareholding, with the Minister of Defence's approval recorded as the route above it."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "f832a0ab78d72bac633262978f788918cd424844a655acf2f1602824898a0fbe",
+          "old_excerpt": "KBLI 30400 covers the manufacture and rebuilding of military combat vehicles, nationally open to PMA and not blocked by Bali’s moratorium record.",
+          "new": "KBLI 30400 covers the manufacture and rebuilding of military combat vehicles — foreign shareholding is capped at 49%, and Bali's moratorium does not block registration."
+        },
+        "whatYouNeed": {
+          "old_sha256": "933d60a9a949b3be4f461da5164c1a8fe9c99485729f8876e0fe95da617d8af5",
+          "old_excerpt": "Nationally, this activity is 100% open to foreign ownership (PMA). In Bali, it is not blocked by the moratorium but carries a medium-high/high risk cl",
+          "new": "Foreign shareholding in this activity is capped at 49%: a PT PMA can hold up to 49% of the company and the rest cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #7, and the record notes a route above it — the approval of the Minister of Defence. Bali's moratorium does not block the activity: it reaches only low and medium-low risk lines, and this one sits above that band."
+        }
+      }
+    },
+    "51101": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "entry #31",
+        "pma_kondisi_contains": "national capital owner must "
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "fc46bd6590604c76025ded98a0aab07cd9fd96f8cc60d15d034d1aa99d09773c",
+          "old_excerpt": "KBLI 51101 is the operating category for commercial air transport provided on fixed routes and regular flight schedules, for a published fare. Its cen",
+          "new": "KBLI 51101 is the operating category for commercial air transport provided on fixed routes and regular flight schedules, for a published fare. Its centre of gravity is the scheduled service itself: carrying passengers, or passengers and cargo, by aircraft as part of a repeatable public timetable rather than a one-off flying arrangement. It accommodates both domestic scheduled services and international scheduled services. The code therefore describes an airline-style activity in the plain operational sense—an air service sold against established routes, established schedules and published charges.\n\nRegistration is not framed as a preserve of one business size. The record opens the activity to Mikro, Kecil, Menengah and Besar enterprises, recognising that the registered scale can sit anywhere from micro through large. That breadth does not change the activity’s defining character. A business registered here is putting forward a scheduled commercial passenger service, with cargo permitted alongside passengers; the fixed-route, regular-schedule and published-fare elements are the boundaries that give the category its shape.\n\nForeign shareholding in this activity is capped at 49%, and the record carries a second condition the ceiling alone does not express: a national capital owner must retain a single majority. That wording matters when the Indonesian side is split between several holders — whether such a structure satisfies it is a question to settle before incorporation, not after. Both conditions come from Perpres 49/2021, Lampiran III, entry #31.\n\nFor a founder, the useful distinction is simple but important. This is a code for a scheduled commercial air service, open across the listed enterprise scales, with the foreign side of the shareholding stopping at 49% and a single-majority condition on the national side. In Bali the relevant fact is equally plain: the provincial moratorium does not bar registration, because it reaches only low and medium-low risk lines and this activity sits above that band. The record cites Perpres 10/2021 and 49/2021 as the source for the national position, and Lampiran III entry #31 as the specific basis."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "3baec00d8dd38e3d27186778780650fab9404398cd169ed036c77ca8e93ad62f",
+          "old_excerpt": "A fixed-route, regular-schedule passenger air service can be fully foreign-owned nationally and is not blocked by Bali’s PMA moratorium.",
+          "new": "A fixed-route, regular-schedule passenger air service — foreign shareholding is capped at 49% with a single-majority condition on the national side, and Bali's moratorium does not block registration."
+        },
+        "whatYouNeed": {
+          "old_sha256": "453e2ff88a557fa011bb335ded7a04cc51b64794d674eed08a9136acba2232e7",
+          "old_excerpt": "Nationally, this KBLI is 100% open to foreign ownership. In Bali, it is not blocked by any local moratorium, but it's flagged as medium-high risk. Tha",
+          "new": "Foreign shareholding in this activity is capped at 49%, and the record adds a condition the ceiling alone does not express: a national capital owner must retain a single majority. Both come from Perpres 49/2021, Lampiran III, entry #31. If the Indonesian side would be split between several holders, settle whether that satisfies the single-majority condition before incorporating. In Bali the activity is not blocked: the island's moratorium reaches only low and medium-low risk lines, and this one sits above that band."
+        }
+      }
+    },
+    "51102": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "entry #30",
+        "pma_kondisi_contains": "national capital owner must "
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "8f84e55a6eab0f9e88a929e6959a9b3fec159fcdbf90edb0fee8c40a52fc845a",
+          "old_excerpt": "KBLI 51102 is the place for commercial, non-scheduled carriage of passengers—or passengers and cargo—by aircraft when neither route nor flight schedul",
+          "new": "KBLI 51102 is the place for commercial, non-scheduled carriage of passengers—or passengers and cargo—by aircraft when neither route nor flight schedule is fixed or regular. The fare is not a public rate: it is agreed between the air-transport provider and user. That definition gives the activity a particular commercial texture. It embraces charter passenger flights, sightseeing flights, and the hiring of an aircraft with its operator for passenger transport. The stated scope also reaches domestic and international non-scheduled commercial transport, whether the load is passengers alone or passengers and cargo.\n\nThis is therefore an activity for operators whose service is formed around an agreed journey rather than a published itinerary. The relevant question is not merely whether the aircraft carries people; it is whether the journey is offered on the non-fixed, non-regular basis described in the record, with a privately agreed tariff. In practice, the code’s own wording keeps the focus on the operating service: the aircraft comes with its operator, and the commercial task is passenger carriage. The entry is open to Mikro, Kecil, Menengah, and Besar businesses, giving the same defined activity a place across each listed business scale.\n\nForeign shareholding in this activity is capped at 49%, and the record carries a second condition the ceiling alone does not express: a national capital owner must retain a single majority. That wording matters when the Indonesian side is split between several holders — whether such a structure satisfies it is a question to settle before incorporation, not after. Both conditions come from Perpres 49/2021, Lampiran III, entry #30.\n\nBali requires its own reading rather than an automatic extension of the national result. The provincial moratorium permanently blocks PMA registration for Low and Medium-Low risk KBLI island-wide. This record, however, is marked OK_or_HIGHER_RISK and expressly says it is not blocked by that moratorium; at the Besar scale, its OSS risk is Menengah-Tinggi/Tinggi. A foreign investor can therefore register this activity in Bali today on the record presented here. The decisive point is not a special Bali ownership cap, but the recorded absence of a moratorium block."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "da56c9b50ab857b5454cb3c7c5c586bda00262a28d995bbacbf56c3bb74370c8",
+          "old_excerpt": "KBLI 51102 covers commercial passenger flights built around agreed journeys, with full foreign ownership nationally and no recorded Bali moratorium bl",
+          "new": "KBLI 51102 covers commercial passenger flights built around agreed journeys — foreign shareholding is capped at 49% with a single-majority condition on the national side, and Bali records no moratorium block."
+        }
+      }
+    },
+    "79122": {
+      "expect": {
+        "pma_max_asing": 0,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "entry #36",
+        "pma_kondisi_contains": "domestic capital and Islamic"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "45090a3c9b5a57289ac97b959a8bedb39fcb07f09ca49c3de0a3bfae2537f671",
+          "old_excerpt": "An Umrah and special-Hajj pilgrimage travel bureau plans and assembles travel packages for these forms of worship. Those packages may be channelled th",
+          "new": "An Umrah and special-Hajj pilgrimage travel bureau plans and assembles travel packages for these forms of worship. Those packages may be channelled through travel agents or sold directly to consumers, online or in person. The activity reaches beyond the itinerary itself: it includes services connected to the package sold, including transport, accommodation and meals, as well as handling travel documents such as passports, visas and equivalent documents. In practical terms, this is the organising business behind a pilgrimage journey, from the package design through the travel services and documentation that support it.\n\nThe activity is open at every stated business scale: Mikro, Kecil, Menengah and Besar. That breadth matters because the record does not confine the activity to a single size of operator. A bureau may operate around the planning and sale of pilgrimage packages while using either agent distribution or direct consumer sales, and may do so through digital or offline channels. Its defined scope keeps the focus on Umrah and special-Hajj travel packages and the services attached to those packages.\n\nThis activity is closed to foreign shareholding. Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — lists it at entry #36, reserved to domestic capital, with an Islamic-faith requirement recorded alongside it. Foreign shareholding is 0%, so a PT PMA cannot register an Umrah or special-Hajj travel bureau anywhere in Indonesia.\n\nThat is the distinction worth holding, because the Bali line points the other way and it is the weaker of the two. Bali's moratorium does not catch this activity — it is recorded above the low and medium-low risk band the moratorium blocks. But a provincial door standing open is of no use when the national one is shut: the reservation applies wherever the company would be registered."
+        },
+        "editorial.headline": {
+          "old_sha256": "b33ab66b0b3b357939dc83461e860c88d466ef24d64b027fdf8c0e4392a7bcf7",
+          "old_excerpt": "Umrah and Special-Hajj Travel: Open Nationally, Available in Bali",
+          "new": "Umrah and Special-Hajj Travel: Reserved to Domestic Capital"
+        },
+        "editorial.standfirst": {
+          "old_sha256": "c4a47f279bc0977bea2d92b05c0562186a2d704fc3d21b1d930087f41e8d3439",
+          "old_excerpt": "This activity covers the assembly and sale of Umrah and special-Hajj travel packages, with a fully open national foreign-ownership position and no Bal",
+          "new": "This activity covers the assembly and sale of Umrah and special-Hajj travel packages — foreign shareholding is 0%, and Bali's open moratorium position does not change that."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "41eadafdee3d4a48fbf1f3e029c7b10556583cf5a3b2b76da8ed4eae21aef9f9",
+          "old_excerpt": "This is a pilgrimage-travel bureau activity with an open PMA path that remains available in Bali.",
+          "new": "Bali's moratorium leaves this one alone, and it makes no difference: the reservation to domestic capital is national, so there is no PMA path to keep open."
+        },
+        "whoThisIsFor": {
+          "old_sha256": "e20bcedceccb84c3dbf4fe6cc427344aeeef927d3c9b3c532bd136f22c5f23e3",
+          "old_excerpt": "Foreign Muslim entrepreneurs or international travel operators looking to build a dedicated pilgrimage travel bureau in Indonesia.",
+          "new": "Indonesian-owned travel businesses. Foreign shareholding in this activity is 0%, so a foreign operator cannot build a PT PMA around it — an international travel company's route here runs through a domestic bureau as its partner or supplier, not through owning one."
+        },
+        "whatYouNeed": {
+          "old_sha256": "e70af35e958e74539b8aeaaf8d224ddcfa8b5c96557738339f77859b76ba4151",
+          "old_excerpt": "Nationally, a foreign-owned (PMA) company can hold up to 100% of this business. In Bali, it is not blocked by the local moratorium, but it is classifi",
+          "new": "This activity is reserved to domestic capital: foreign shareholding is 0%, so a PT PMA cannot register it anywhere in Indonesia. The reservation is set by Perpres 49/2021, Lampiran III, entry #36, and the record notes an Islamic-faith requirement alongside it. Bali's moratorium does not block the activity, but that is beside the point — the national reservation applies wherever the company is registered."
+        }
+      }
+    },
+    "84231": {
+      "expect": {
+        "pma_max_asing": 0,
+        "pma_status": "TERTUTUP"
+      },
+      "fields": {
+        "whoThisIsFor": {
+          "old_sha256": "db5cc5901381e096056024d80537d011459fc6fdade4eb603734973f39fa2b16",
+          "old_excerpt": "Foreign security consultants or firms providing specialized training or equipment to government agencies, though full foreign ownership is nationally ",
+          "new": "No foreign investor: this code is recorded TERTUTUP — closed — with foreign shareholding at 0%, and the record carries no condition under which it opens. The line it replaces suggested foreign security consultants could serve government agencies here \"with strong local partnerships\", which reads as a route where the record describes none."
+        }
+      }
+    }
+  }
+}

--- a/scripts/kbli_filiera/cure_specs/prose_numeric_openness_no_national_word_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/prose_numeric_openness_no_national_word_2026_08_06.json
@@ -1,4 +1,5 @@
 {
+  "compiler": "cure_prose_national_openness",
   "_meta": {
     "spec": "prose_numeric_openness_no_national_word_2026_08_06",
     "population": "One field, found by a pin rather than by the detector that owns this class.",

--- a/scripts/kbli_filiera/cure_specs/prose_perpres_cap49_transport_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/prose_perpres_cap49_transport_2026_08_06.json
@@ -1,0 +1,387 @@
+{
+  "compiler": "cure_prose_national_openness",
+  "_why": "The 14 transport codes whose recorded ceiling is 49% (Perpres 49/2021 Lampiran III) while their prose told a client the activity was nationally open to full foreign ownership. Each replacement names the annex entry the record itself carries.",
+  "codes": {
+    "50124": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #15"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "62d6cce998993c521d151ba18f10da3c587b045beb6a2d85be375d623f48fcc3",
+          "old_excerpt": "**A defined domestic transport operation.** KBLI 50124 covers domestic maritime transport intended to carry goods and/or animals. It names a particula",
+          "new": "**A defined domestic transport operation.** KBLI 50124 covers domestic maritime transport intended to carry goods and/or animals. It names a particular fleet: sailing vessels, traditional motor vessels, and motor-sailing vessels of specified sizes. The scope also includes hiring out that maritime transport with its operator. Read together, those elements identify a live transport activity whose substance is the carriage of goods or animals; the operator-inclusive hire is also expressly within its perimeter. The wording is operational: it tells the reader what is moved, the vessel forms used, and that the transport may be rented with the person operating it.\n\n**Scale is not a narrowing device here.** Registration is open to Mikro, Kecil, Menengah, and Besar enterprises. That is the full scale range presented in the record, so the activity is not confined to a single business size. The scope stays the same across that range: domestic sea transport for goods and/or animals using the named traditional and sailing vessel forms, alongside operator-inclusive rental. Scale is relevant to how the record frames the Bali risk position, but it does not replace the core activity definition. The essential question is whether the actual operation fits that stated transport-and-hire scope, then the scale at which it will be registered.\n\n**Foreign ownership here is capped at 49%.** Domestic sea carriage of goods and animals by traditional and sailing vessels is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #15, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\n**Bali does not add a second obstacle.** The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.headline": {
+          "old_sha256": "a41919db4cd29f6675deafef6ac1ebac7a135147c5261fc961015a70077df5e9",
+          "old_excerpt": "Domestic Sea Freight, Open Nationally and Not Blocked in Bali",
+          "new": "Domestic Sea Freight: Foreign Ownership Capped at 49%, Not Blocked in Bali"
+        },
+        "editorial.standfirst": {
+          "old_sha256": "aafcb495311232403c440006cc4b81a08dd01d30d2fe9389a31f18ce1873ee7b",
+          "old_excerpt": "A domestic sea-freight activity for goods and animals using specified traditional vessel types, including operator-inclusive hire, with full national ",
+          "new": "A domestic sea-freight activity for goods and animals using specified traditional vessel types, including operator-inclusive hire — foreign ownership is capped at 49%."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "3a40b0d40abe7ba80cbbf4f6088ecfb50d8fc75be502a034709f4729c2ad0929",
+          "old_excerpt": "The honest Bali conclusion is therefore clean: it is open to PMA nationally, and it is not blocked for PMA registration in Bali.",
+          "new": "The foreign side of the shareholding stops at 49%; what Bali does not do is add a registration block on top of that ceiling."
+        },
+        "whatYouNeed": {
+          "old_sha256": "ebaeb700dfc46994a49fc47fde6be8c8b655ef87b01eef1a000cb9fc68c7eec2",
+          "old_excerpt": "Nationally, this activity is open to 100% foreign ownership, but in Bali it is classified as medium-high risk, meaning while not blocked by the genera",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #15, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50125": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #16"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "cae52169613942f8a613c1c4a9c3dfb4e95a3e550e3fc496c04c5ec9e454b751",
+          "old_excerpt": "General cargo moving between Indonesian ports and ports abroad has its own clear operational frame here: sea transport carried by vessel across intern",
+          "new": "General cargo moving between Indonesian ports and ports abroad has its own clear operational frame here: sea transport carried by vessel across international port routes. It includes both the regularity of liner services, operating on fixed and scheduled routes, and the flexibility of tramper services, whose routes and schedules are not fixed. The scope also includes chartered sea transport provided together with its operator. In practical terms, this is an activity for businesses whose work is the organised maritime carriage of goods beyond Indonesia’s borders—not merely the ownership or hire of a vessel in isolation.\n\nRegistration is open at **Menengah** and **Besar** scales. That matters because the record positions the activity within operating businesses capable of undertaking international freight movements, whether through predictable scheduled services or less regular charter-based deployment. The distinction between liner and tramper activity is not decorative: it captures two legitimate ways a general-cargo operator may organise its service, while keeping the underlying activity focused on transport by sea between domestic and foreign ports.\n\nForeign ownership here is capped at 49%. International general-cargo shipping between Indonesian and overseas ports is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #16, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali does not add a second obstacle. The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "97e90d31973e195131f0de1669b3cdd291bf0acbb188688d84a5f9d480ab1a27",
+          "old_excerpt": "International general-cargo shipping is open to PMA nationally, and Bali does not impose a moratorium block on that basis.",
+          "new": "The foreign side of an international general-cargo operator stops at 49%; Bali's moratorium does not block the registration."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "8c1e5597a96d3a4d6f8195a049450b4ef866615f4843a9c0e723cfffed227a55",
+          "old_excerpt": "This activity covers scheduled and chartered general-cargo shipping between Indonesian and overseas ports, open nationally to foreign investment and n",
+          "new": "This activity covers scheduled and chartered general-cargo shipping between Indonesian and overseas ports — foreign ownership is capped at 49% nationwide, and Bali's moratorium does not bar registration."
+        },
+        "whatYouNeed": {
+          "old_sha256": "7e7377be8730be9f979ac5819985f96c56def661cf367048c788f6370317b5d9",
+          "old_excerpt": "In Bali, this activity is open to 100% foreign ownership but is classified as higher risk (medium-high/high). It is not blocked by the moratorium, but",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #16, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50131": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #18"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "f861a1aa5e09d351c725d79791d467ef3938d5f38b8716aa66a11f27edd64092",
+          "old_excerpt": "Interprovincial public ferry passenger transport is the business of carrying passengers from one province to another on ferries operating on establish",
+          "new": "Interprovincial public ferry passenger transport is the business of carrying passengers from one province to another on ferries operating on established routes. The route-bound character matters: this is public passenger movement organised through a ferry service, rather than an incidental voyage or a loosely defined maritime activity. Its commercial identity is shaped by regular interprovincial connection and the practical work of moving people across provincial boundaries by ferry.\n\nThe record opens this activity at the **Besar** scale. That places the code in a large-business setting: an operator registering under it is entering the public ferry transport field at that stated scale, with the focus on passenger carriage across provinces and on services tied to designated routes. The classification does not broaden into a general account of every kind of water transport; its centre of gravity is specific, public, scheduled ferry travel between provinces.\n\nForeign ownership here is capped at 49%. Interprovincial public passenger ferry transport is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #18, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali does not add a second obstacle. The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "0f10b9ee88d873418b212c672c88f76aef7610dbb33d1c7417dff8a8fb4e8462",
+          "old_excerpt": "For large-scale interprovincial public ferry passenger transport, Bali’s moratorium does not displace the national 100% foreign-ownership position.",
+          "new": "For large-scale interprovincial ferry transport, Bali's moratorium is not the constraint — the 49% ceiling on foreign shareholding is."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "e80657ec38feb96c7d0ffd0a1b2e95953d44c7822a1ae706f9e13c1f5aa4120f",
+          "old_excerpt": "This is the large-scale, route-bound public ferry business moving passengers between Indonesian provinces—and it remains open to full foreign ownershi",
+          "new": "This is the large-scale, route-bound public ferry business moving passengers between Indonesian provinces — foreign ownership in it is capped at 49%."
+        },
+        "whatYouNeed": {
+          "old_sha256": "b7c4b4e593a55156e49604c05a7a123bb133a534278a2ad57245c33a94db4429",
+          "old_excerpt": "Nationally, this KBLI is fully open (100% PMA), but in Bali it falls under a higher-risk category due to the nature of sea transportation. While not b",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #18, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50132": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #20"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "5084e3181a22b03a70a8cd2c7f0fd78b702e0e07d56a673cf15e8be2d71d0ade",
+          "old_excerpt": "Passenger ferry transport is sometimes described as a route across water. This activity is more specific: it covers passenger crossings between design",
+          "new": "Passenger ferry transport is sometimes described as a route across water. This activity is more specific: it covers passenger crossings between designated ferry ports in different regencies or cities, whether across seas, straits or bays. The ferry is understood here as a moving bridge between two particular places, extending a road and/or rail network rather than sitting apart from it. The scope also includes hiring out ferry transport together with its operator.\n\nThat definition gives the activity a clear operational centre of gravity. It is for businesses conducting the crossing itself, as well as businesses making ferry transport available with the operator who runs it. The eligible business scale in the record is **Besar**. The focus is therefore not simply on being near a port or serving passengers generally, but on the organised provision of passenger ferry crossings between the specified places and ports.\n\nForeign ownership here is capped at 49%. Public passenger ferry crossings between regencies or cities is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #20, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nFor a founder, the distinction is worth holding precisely. The ceiling is the national position and Bali does not soften it; equally, Bali does not stack a registration block on top of it. The practical reading is straightforward: a Besar-scale passenger ferry crossing business, including ferry hire with its operator, can be registered in Bali, with the foreign side of the shareholding stopping at 49% and the rest outside foreign hands."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "40717969ea6d5bf7593bb65ec4a60d87797b83f7a97da8fe93def2b373a0ae14",
+          "old_excerpt": "A Besar-scale passenger ferry crossing business may be structured with up to full foreign ownership and is not prevented from PMA registration in Bali",
+          "new": "A Besar-scale ferry crossing business can be registered in Bali; the foreign side of its shareholding stops at 49%."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "4d5dcdd513530cbf645b565f0c6fe7320686e5501ed527b7669a3ade8d957279",
+          "old_excerpt": "This activity covers intercity and inter-regency passenger ferry transport—and remains open to full foreign ownership, including for PMA registration ",
+          "new": "This activity covers intercity and inter-regency passenger ferry transport — foreign ownership is capped at 49%, and Bali's moratorium does not block registration."
+        },
+        "whatYouNeed": {
+          "old_sha256": "07803b2f60d12534fb0b5a75e617dbaf01fe2159141f0c44f0db8fa59f747a24",
+          "old_excerpt": "Nationally, this business line is 100% open to foreign ownership. In Bali, it’s not blocked by the general moratorium, but it’s flagged as medium-high",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #20, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50133": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #22"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "8c3e035b82661e372fdadab7ac1f8a13c4cf5b74956d936161bab54ded286d91",
+          "old_excerpt": "KBLI 50133 covers public passenger ferry transport between ferry ports within the same regency or city. Its arena is the sea, straits and bays; its ro",
+          "new": "KBLI 50133 covers public passenger ferry transport between ferry ports within the same regency or city. Its arena is the sea, straits and bays; its role is unusually terrestrial. The ferry is conceived as a moving bridge between two specified places, carrying forward a road and/or rail network rather than operating as a detached maritime service. The scope also includes the rental of ferry transport when supplied together with its operator. Put simply, the activity is defined by a local crossing and by the connection it completes within that local network.\n\nThat definition gives the code a clear operational shape. The journey is not merely waterborne movement from one port to another: it is a crossing structured around a particular link in the local transport network. Passenger transport is central to the designation, and the geography is bounded inside a regency or city. The record makes the scale equally clear: it is open to businesses classified as Besar. It also encompasses ferry rental when an operator is part of the provision. The commercial identity comes from that combination—public passenger crossings, a defined local corridor, and a large-scale operating frame.\n\nForeign ownership here is capped at 49%. Public passenger ferry crossings within one regency or city is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #22, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali does not add a second obstacle. The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "c8124f010b8057eff18cfbe2c2d1a86c6d5cbfd2688340269657d99406b622fc",
+          "old_excerpt": "This is nationally open to 100% foreign ownership, and its large-scale Bali case is not blocked by the stated moratorium.",
+          "new": "Registration in Bali is available for this ferry activity; what limits the foreign side is the 49% ceiling on shareholding."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "c5484473618edb1f6bd89c88e7d789e57226a00d625c4f5f4d7371a7cf31f90f",
+          "old_excerpt": "A large-scale passenger-ferry activity linking ports within one regency or city, open to full foreign ownership nationally and not blocked for PMA in ",
+          "new": "A large-scale passenger-ferry activity linking ports within one regency or city — foreign ownership is capped at 49%, and Bali's moratorium does not block it."
+        },
+        "whatYouNeed": {
+          "old_sha256": "acefc9e8a9e2a14c81c18a907456979222cfe3ee1cb32e32815f1c2bc5b1b11c",
+          "old_excerpt": "**Large scale**: Medium-High risk. NIB + Business License (Izin) — full review required.\n\n**PMA:** Fully open to PMA — 100% foreign ownership allowed.",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #22, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk. At the large-business scale, that is the risk class the record carries for this activity."
+        }
+      }
+    },
+    "50134": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #19"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "16f8c9dc14e3620b911f6594ac825e9da9918b7193a11f874d3a01f57f8554e2",
+          "old_excerpt": "KBLI 50134 covers passenger ferry transport between provinces across seas, straits and bays. Its stated purpose gives the activity a particular connec",
+          "new": "KBLI 50134 covers passenger ferry transport between provinces across seas, straits and bays. Its stated purpose gives the activity a particular connection role: it links remote areas, and areas that have potential but remain undeveloped and commercially unprofitable to serve, with developed areas. The scope also reaches the chartering of ferry transport when the operator is provided. It combines the transport service and a charter arrangement only where the operator accompanies the ferry. This is passenger crossing transport shaped around connecting the places specified in its scope to more developed destinations. The wording matters because the service is defined by both its inter-provincial route and the places it is meant to connect.\n\nThe definition should be read as a whole. It names passenger transport by ferry, the inter-provincial passage across the stated waters, and the connection of remote or not-yet-commercially-profitable areas to developed areas. It does not detach the charter element from the transport service: that element is included when the ferry is chartered with its operator. In a code meant to define an activity, those elements give the operation its precise perimeter.\n\nThe registration picture is deliberately narrow on scale. The record lists Besar as the scale open to this activity. For a founder assessing whether the code fits, that is part of the core boundary: the activity is presented here at the large-business scale, alongside ferry crossings, passenger transport, and operator-inclusive chartering. Foreign ownership here is capped at 49%. Pioneer interprovincial passenger ferry transport is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #19, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali does not add a second obstacle. The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.headline": {
+          "old_sha256": "278d0fafa4e98083a94d4981bf6ab9c3e6158dd0ce30dbf4b9a2229bd7244a30",
+          "old_excerpt": "Pioneer Passenger Ferries Across Provinces: Open Nationally, Clear in Bali",
+          "new": "Pioneer Passenger Ferries Across Provinces: Foreign Ownership Capped at 49%"
+        },
+        "editorial.standfirst": {
+          "old_sha256": "7d372807a27890404c9f0a98d187124bf31add7065df9d01e35ed0f70f1010e9",
+          "old_excerpt": "A large-scale passenger-ferry activity linking remote and not-yet-profitable areas between provinces to developed areas, nationally open to 100% forei",
+          "new": "A large-scale passenger-ferry activity linking remote and not-yet-profitable areas between provinces to developed areas — foreign ownership is capped at 49%, and Bali's moratorium does not block registration."
+        }
+      }
+    },
+    "50135": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #21"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "b35931d2d81107748efec321c8f41192d78a2c790cc0b148acccbe3424d81bd3",
+          "old_excerpt": "KBLI 50135 covers pioneer passenger-crossing transport over seas, straits and bays between regencies or cities. Its purpose is expressly connective: i",
+          "new": "KBLI 50135 covers pioneer passenger-crossing transport over seas, straits and bays between regencies or cities. Its purpose is expressly connective: it brings remote areas, and areas with potential that are still undeveloped or not yet commercially worthwhile to serve, into contact with developed areas. The scope also includes renting this crossing transport with its operator. The wording matters because the service is tied not merely to remote endpoints, but to their link with areas already developed.\n\nThe record opens this activity at **Besar** scale. That is therefore the scale at which an enterprise registers this line of business—whether it operates the passenger crossing itself or rents the relevant crossing transport together with an operator. The scale designation is not incidental; it is the record’s stated operating frame for the activity. Its centre of gravity remains passenger-crossing transport on the routes described: a service connecting areas whose commercial and developmental conditions are not the same.\n\n**Foreign ownership here is capped at 49%.** Pioneer passenger-crossing transport between regencies or cities is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #21, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\n**Bali does not add a second obstacle.** The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.byTheNumbers[0].value": {
+          "old_sha256": "32e48995f98ce3b76f2d3f5e2d2acddfeff6650b7b18628cfa739bfef4a03312",
+          "old_excerpt": "100%",
+          "new": "49%"
+        },
+        "whatYouNeed": {
+          "old_sha256": "ce5ee874885c8c241efb5cce9142c0ed0b4507aed7b711d3df8ce6dd03f59015",
+          "old_excerpt": "Nationally, this KBLI is 100% open to foreign ownership. In Bali, it is not blocked by the usual moratorium on certain maritime activities, but it is ",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #21, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50211": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #23"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "411833d92c6582756890a6cfb9e31b3ccf29cc0f0ee475556814c6b69edf4fb8",
+          "old_excerpt": "This activity is for passenger transport on rivers, canals, lakes, swamps and other inland waters when it operates through a fixed and regular route n",
+          "new": "This activity is for passenger transport on rivers, canals, lakes, swamps and other inland waters when it operates through a fixed and regular route network with a set timetable. The defining character is scheduled service: passengers are carried on established routes rather than through an ad hoc arrangement. Its scope reaches local services within a regency or city, services between regencies or cities within a province, interprovincial services, and cross-border international inland-water routes.\n\nThe registration is open across the full business-scale range recorded here: Micro, Small, Medium and Large. That matters because the activity is not framed as the preserve of only one type of operator. A business can be registered for this scheduled inland passenger-transport activity at any of those scales, provided its actual operation remains within the scope of fixed, regular routes and scheduled passenger services on inland waters.\n\nForeign ownership here is capped at 49%. Scheduled passenger transport on inland waters is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #23, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali does not add a second obstacle. The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.headline": {
+          "old_sha256": "6a45225aee0d8dc35da58bfebdc28b3ac18f9271709ef8ce627e03bbca29cee7",
+          "old_excerpt": "Scheduled Inland Passenger Routes: Open Nationally and in Bali",
+          "new": "Scheduled Inland Passenger Routes: Foreign Ownership Capped at 49%"
+        },
+        "whatYouNeed": {
+          "old_sha256": "c3f6c63ed69a442fc4d4b91edb50c41849671b1025d23640eaa47c4ab35c7f6a",
+          "old_excerpt": "Nationally, this activity is fully open (100% foreign ownership). In Bali, it's not blocked by any regional moratorium, but it's flagged as a higher-r",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #23, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50212": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #24"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "9433c36b1eed79821e019df8b8a8df0ba579fb1bacc2327dfce75c6b67531cda",
+          "old_excerpt": "This activity is for carrying passengers across rivers, canals, lakes, swamps and other inland waters where the route is neither fixed nor scheduled. ",
+          "new": "This activity is for carrying passengers across rivers, canals, lakes, swamps and other inland waters where the route is neither fixed nor scheduled. Its defining character is flexibility: the service does not operate on a permanent route or a regular timetable. Just as importantly, the scope expressly excludes tourism. The code therefore describes passenger transport on inland waterways as a transport activity in its own right, rather than a tourism offering.\n\nRegistration is open at every stated business scale: Micro, Small, Medium and Large. That breadth matters because the activity is not framed as the preserve of one particular size of operator. A founder considering this code should begin with the real operating model—passenger carriage on inland waters, without fixed or regular routes—and then identify the scale at which the business will be registered. The activity’s scope is precise about the mode of transport and the irregular nature of its service, which is where the classification’s practical centre of gravity lies.\n\nForeign ownership here is capped at 49%. Unscheduled passenger transport on inland waters is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #24, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nThe distinction is worth keeping clean. Bali's position here is not a second ownership cap and not an invented local condition: it is a risk-based reading, and at the large scale the risk assessment places the activity outside the moratorium. For an investor the honest conclusion is straightforward — the activity can be registered in Bali across the listed scales, and the foreign stake in the company that holds it stops at 49%."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "adcf1053637da699415c57a3475732e74622952536eb630929a122c7948a51bc",
+          "old_excerpt": "Nationally, the activity is open to PMA up to 100%, and Bali does not block it under the stated risk-based moratorium reading.",
+          "new": "The activity can be registered in Bali; the foreign stake in the company that holds it stops at 49%."
+        },
+        "whatYouNeed": {
+          "old_sha256": "253a0d9223f6873ce27ad4777e9e148fb6e1746b4bc1dec0882e65778c6291d9",
+          "old_excerpt": "Nationally, this activity is 100% open to foreign ownership (PMA). In Bali, it falls under a higher-risk category that is not blocked by the moratoriu",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #24, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50213": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #25"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "1700c5630506e63f4f97520731ae25fa6b0bb54e8e8f3ef5a179a5ac706722f9",
+          "old_excerpt": "This activity is about carrying passengers for tourism across Indonesia’s inland waters: rivers, canals, lakes, swamps and other inland waterways. Its",
+          "new": "This activity is about carrying passengers for tourism across Indonesia’s inland waters: rivers, canals, lakes, swamps and other inland waterways. Its scope is deliberately broader than a single type of excursion or customer. It can serve an individual traveller, an organised group, a family, or a social purpose, provided the journey is tourist passenger transport on those waters. The organising idea is not the destination alone, but the movement of visitors by inland water.\n\nA business registering this activity is therefore placing tourist passenger transport at the centre of its operation. The record opens it to Menengah and Besar scales, making scale an explicit part of the registration picture rather than an afterthought. That matters because the activity is defined by both its tourism purpose and its setting: inland waterways, not a generic transport category. The wording also accommodates the different ways tourism is experienced—privately, collectively, with family, or through social activity—without narrowing the activity to only one kind of passenger.\n\nForeign ownership here is capped at 49%. Tourist passenger transport on inland waters is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #25, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali does not add a second obstacle. The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "fda757c5017500477d90b0da4432a68524c8ea4deafb25a97a137459ed61b469",
+          "old_excerpt": "This activity covers tourist passenger journeys on inland waterways, open to PMA nationally and not blocked by Bali’s PMA moratorium.",
+          "new": "This activity covers tourist passenger journeys on inland waterways — foreign ownership is capped at 49%, and Bali's moratorium does not block registration."
+        },
+        "whatYouNeed": {
+          "old_sha256": "450b6c21bcd5c4466e0463c67015952573fddf19bb7d44dc53aa6c061b939947",
+          "old_excerpt": "Nationally it is fully open to 100% foreign ownership, but in Bali it is classified as medium‑high risk. It is not blocked by the current moratorium, ",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #25, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50221": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #26"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "501ac717866c10971bfa1be455caa8dcbaf42580ac0600d028e7c6e6728017f5",
+          "old_excerpt": "KBLI 50221 covers the carriage of general goods across Indonesia’s inland waters: rivers, canals, lakes, swamps and other internal waterways. Its focu",
+          "new": "KBLI 50221 covers the carriage of general goods across Indonesia’s inland waters: rivers, canals, lakes, swamps and other internal waterways. Its focus is freight transport, not a single specialised cargo stream; the goods carried may comprise more than one type. The boundary is equally clear. Hazardous goods, special goods and heavy equipment sit outside the activity described here. The result is a classification for general inland-water freight, defined by both its route and the ordinary character of the cargo.\n\nThe activity is open at every listed business scale: Micro, Small, Medium and Large. That breadth matters because the record does not confine this form of freight transport to a single size of enterprise. A business using this activity is situated in the practical movement of general goods on inland waters, whether the operation is registered at the smallest listed scale or at the largest. The classification’s scope remains consistent across those scales: transporting general freight by river, canal, lake, swamp or another inland waterway, while excluding the specified categories of cargo.\n\nForeign ownership here is capped at 49%. General freight transport on inland waters is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #26, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali does not add a second obstacle. The island-wide moratorium suspends new PMA registration only for activities assessed at low or medium-low risk. This one is recorded at medium-high risk, so the moratorium does not reach it and the company can be registered here. Bali states no percentage of its own and no local partnership requirement; what limits the foreign side is the 49% ceiling, in Bali exactly as anywhere else in Indonesia."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "9c6e68d1494407ca76ca2673486469eba73d0dd277f1f0906319dfc57001dee9",
+          "old_excerpt": "A clear route for general freight by river, canal, lake, swamp and other inland waters—with a nationally open PMA position and no Bali moratorium bloc",
+          "new": "A clear route for general freight by river, canal, lake, swamp and other inland waters — foreign ownership is capped at 49%, with no Bali moratorium block in this record."
+        },
+        "whatYouNeed": {
+          "old_sha256": "9026fc17e04cf762d3fdabab41b32ccbb219bc48340d459ba6cb529c44d3a377",
+          "old_excerpt": "Nationally, a PMA can be 100% foreign-owned. In Bali, this activity is not blocked by local moratoriums but is classified as higher risk, so you must ",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #26, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50222": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #27"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "bc03de9ca81271c6db3b9ad8ebbc40f9008e72f0832c1bb163195dbdfb2f383f",
+          "old_excerpt": "**KBLI 50222** covers the movement of specialised cargo on rivers, canals, lakes, swamps and other inland waters. It is not a general-cargo descriptio",
+          "new": "**KBLI 50222** covers the movement of specialised cargo on rivers, canals, lakes, swamps and other inland waters. It is not a general-cargo description: the vessel or cargo boat is specially modified and carries only one type of goods. The recorded scope includes logs; pipes, steel bars or rails; bulk cargo; liquids; goods requiring refrigeration; plants and live animals; containers; heavy equipment; and other specialised goods. The vessel must meet the technical and seaworthiness requirements appropriate to the particular cargo it carries.\n\nThe activity is open across the stated business spectrum: Mikro, Kecil, Menengah and Besar. That breadth does not dilute the defining feature of the code. What matters is the dedicated nature of the transport operation—the craft is adapted to its cargo and operates on inland waters, rather than being described as a vessel for mixed or general freight. For a business selecting this activity, the fit lies in that close relationship between vessel design, cargo type and inland-waterway transport.\n\nForeign ownership here is capped at 49%. Specialised cargo transport on inland waters is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #27, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nThe practical reading is deliberately narrow. A company undertaking this specialised inland cargo activity can be registered in Bali, and the foreign shareholding in it stops at 49% — there, and everywhere else in Indonesia. The activity itself remains defined by specialised vessels, a single cargo category and transport across inland waters."
+        },
+        "editorial.byTheNumbers[0].value": {
+          "old_sha256": "32e48995f98ce3b76f2d3f5e2d2acddfeff6650b7b18628cfa739bfef4a03312",
+          "old_excerpt": "100%",
+          "new": "49%"
+        },
+        "editorial.headline": {
+          "old_sha256": "d66e5303cce9a9b6de4147fd921d00f92b546cbce6a5caf3bd17fd133056d88c",
+          "old_excerpt": "Specialised Inland Cargo Transport: Open Nationally, Clear in Bali",
+          "new": "Specialised Inland Cargo Transport: Foreign Ownership Capped at 49%"
+        },
+        "editorial.standfirst": {
+          "old_sha256": "cc899b8036237efe677d4a1eb4252c1aa24260b3733c0cc947bfebfb6dfed64a",
+          "old_excerpt": "This activity is for purpose-modified vessels carrying one specialised cargo type on Indonesia’s inland waterways, with full foreign ownership open na",
+          "new": "This activity is for purpose-modified vessels carrying one specialised cargo type on Indonesia's inland waterways — foreign ownership is capped at 49%, with no Bali moratorium block."
+        },
+        "whatYouNeed": {
+          "old_sha256": "c90e7a5891468f625bcd1a43736f63fd3d9153a027025fecaa5dd6e9701cd68e",
+          "old_excerpt": "Nationally, 100% foreign ownership is open. In Bali, this KBLI is not caught by the general moratorium that blocks many businesses, but it's classifie",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #27, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "50223": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #28"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "e7e182b67d72280399737142a3044721bc255ad78b641c22b11c0b8725301ce7",
+          "old_excerpt": "This activity is a specialist inland-water freight operation: carrying dangerous goods on rivers, canals, lakes, swamps and other inland waters, from ",
+          "new": "This activity is a specialist inland-water freight operation: carrying dangerous goods on rivers, canals, lakes, swamps and other inland waters, from the loading point through to final unloading. Its stated cargo scope is substantial and specific. It includes hazardous and toxic waste, fuel oil, petroleum, processed petroleum products, and liquefied or compressed gas categories including LPG, LNG and CNG. The work described here is the movement itself across inland waters, with the transport chain running from loading to final discharge.\n\nIt is available to businesses registered at micro, small, medium and large scale. That breadth matters because the activity is not framed as a large-operator category alone; the record expressly lists every scale. Foreign ownership here is capped at 49%. Dangerous-goods transport on inland waters is listed in Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #28, and that entry limits foreign shareholding to 49%. A PT PMA can hold up to that 49% and no more; the rest of the shares cannot be in foreign hands. The record carries the ceiling and nothing beyond it: no named partner, no minimum stake for any single shareholder, and no recorded route for exceeding the cap. The ceiling is national — registering the company somewhere other than Bali does not change it.\n\nBali requires an equally direct reading. The island-wide moratorium suspends new PMA registration for activities assessed at low or medium-low risk, and at the large scale this one is recorded at medium-high risk. It therefore sits outside that restriction: a foreign investor seeking to register this inland-water transport activity in Bali does not face a moratorium block.\n\nThe two readings answer different questions. The ceiling answers how much of the company foreign shareholders may hold — 49%, with the rest outside foreign hands. Bali answers whether the company can be registered on the island at all, and here it can. No separate Bali percentage or local-partnership condition is recorded. Taken together: this is a registrable activity for a foreign-invested company, in Bali as elsewhere, provided the foreign side of the shareholding respects the 49% ceiling."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "c709cd169d3e0076ba6118479f460aa1b24dbc7384b074d464a9cb21aca43241",
+          "old_excerpt": "This activity covers hazardous cargo carried by inland waterway, open to foreign investment nationally and not blocked for PMA registration in Bali.",
+          "new": "This activity covers hazardous cargo carried by inland waterway — foreign ownership is capped at 49%, and registration in Bali is not blocked by the moratorium."
+        },
+        "whatYouNeed": {
+          "old_sha256": "65a6049e08c44b78bee80752762bfc675ab2ce7d7d408580e275910f105a94ef",
+          "old_excerpt": "Nationally, this activity is 100% open to foreign ownership. In Bali, it is not blocked by the foreign investment moratorium, but it is classified as ",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #28, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at medium-high risk."
+        }
+      }
+    },
+    "53200": {
+      "expect": {
+        "pma_max_asing": 49,
+        "pma_status": "TERBATAS",
+        "pma_official_basis_contains": "Lampiran III (Daftar Bidang Usaha dengan Persyaratan Tertentu) entry #32"
+      },
+      "fields": {
+        "editorial.body": {
+          "old_sha256": "8ffa384005165aa738fad5afb2fa2cb9557b4461d711b94ec6730e15cb1d51d0",
+          "old_excerpt": "Courier activity concerns the organised journey of a consignment, from collection or pickup through sorting or processing, transport and final deliver",
+          "new": "Courier activity concerns the organised journey of a consignment, from collection or pickup through sorting or processing, transport and final delivery. The materials expressly within scope are letters, documents, parcels, goods and packages. The service can operate domestically or internationally, with one or more transport modes, using either transport owned by the operator or public transport. Its line of definition is equally important: this is activity outside the universal-service obligation, with the operator’s work framed as collection, processing, carriage and delivery.\n\nThe food element is carefully limited but real. Door-to-door delivery is included, as is food delivery. The record also brings in non-prepared meals only when they are preserved or packed so they can undergo further processing and are not easily perishable during collection, processing, transport and distribution within a package service. Read plainly, this is a scope that follows the delivery chain rather than stopping at a single leg: pickup and preparation for dispatch are part of the picture alongside transport and the doorstep handover.\n\nRegistration is not reserved for one end of the enterprise spectrum. The activity is open to Mikro, Kecil, Menengah and Besar scale businesses—the complete range supplied in the record. Each scale belongs in the same listed range. That breadth gives the operational description room to serve a business from its smallest listed category through its largest, while remaining the same courier activity in the record.\n\nForeign ownership in courier activity is capped at 49%. The cap comes from Perpres 49/2021, Lampiran III — the annex of business fields carrying specific requirements — at entry #32, so a PT PMA can hold up to 49% of a courier company and the rest cannot be in foreign hands. Bali does not add a second obstacle to that. The island-wide moratorium suspends new PMA registration only for low and medium-low risk lines, and the record puts courier work at high risk at every scale, so it is not caught. The essential distinction is straightforward: registration in Bali is available, and what limits the foreign side is the 49% ceiling, nationally."
+        },
+        "editorial.pullQuote": {
+          "old_sha256": "5437bd0995baa7f83e85c0c6c12a4ca47d0733602f6973be551818f9d3e6bede",
+          "old_excerpt": "Full foreign ownership is open nationally, and this activity is not moratorium-blocked for PMA registration in Bali.",
+          "new": "Registration in Bali is available for courier work; the foreign side of the shareholding stops at 49%."
+        },
+        "editorial.standfirst": {
+          "old_sha256": "0fc12a2c31b7f7c1028e45cf2253cbd98359b46115bfe4974c8c708a81fb82cc",
+          "old_excerpt": "From parcel pickup to doorstep delivery, this activity spans domestic and international courier work across every listed scale, with full foreign owne",
+          "new": "From parcel pickup to doorstep delivery, this activity spans domestic and international courier work across every listed scale — foreign ownership is capped at 49%, with no Bali moratorium block."
+        },
+        "whatYouNeed": {
+          "old_sha256": "362c467f381ef9dab77ee0cb993e52548e2ee031561006c57bf27d80aa07469c",
+          "old_excerpt": "Nationally, this KBLI is fully open (100% PMA). In Bali, the island-wide moratorium (in force since 13 May 2026) only halts PMA registrations for Low ",
+          "new": "Foreign ownership in this activity is capped at 49%: a PT PMA can hold up to 49% of the company, and the rest of the shares cannot be in foreign hands. The cap is set by Perpres 49/2021, Lampiran III, entry #32, and applies throughout Indonesia. Bali does not add a block on top of it — the island's moratorium suspends PMA registration only for low and medium-low risk lines, and this activity is recorded at high risk. The moratorium has been in force since 13 May 2026."
+        }
+      }
+    }
+  }
+}

--- a/scripts/kbli_filiera/cure_specs/prose_residual_pullquotes_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/prose_residual_pullquotes_2026_08_06.json
@@ -1,0 +1,34 @@
+{
+  "compiler": "cure_prose_national_openness",
+  "_why": "Two pull quotes that survived the first two prose batches because every probe this lane had was blind to them: the detector acquits a sentence whose negation precedes the claim ('is NOT a hidden restriction: ... open to 100%'), and the token scan missed 'foreign ownership up to 100'. Both codes now carry a cured whatYouNeed saying 0% and a pull quote on the same page saying 100%.",
+  "codes": {
+    "41018": {
+      "expect": {
+        "pma_max_asing": 0,
+        "pma_status": "TERBATAS",
+        "pma_kondisi_contains": "dialokasikan untuk Koperasi dan UMKM"
+      },
+      "fields": {
+        "editorial.pullQuote": {
+          "old_sha256": "b3204562be00886cb3485b512fc6a217c842bad76d3c90fe0a0a5c88b746ade0",
+          "old_excerpt": "For this slim record, the conclusion is not a hidden restriction: KBLI 41018 is nationally open to foreign ownership up to 100%, and the Bali field do",
+          "new": "The obstacle here is not Bali. The bidang usaha is allocated to Koperasi and UMKM, which sets foreign ownership at 0%, so a PT PMA cannot register KBLI 41018 anywhere in Indonesia."
+        }
+      }
+    },
+    "55105": {
+      "expect": {
+        "pma_max_asing": 0,
+        "pma_status": "TERBATAS",
+        "pma_kondisi_contains": "dialokasikan untuk Koperasi dan UMKM"
+      },
+      "fields": {
+        "editorial.pullQuote": {
+          "old_sha256": "b02bf99da72ebd16f14408f7edd4c87800c4fe5df62975045b7c4a2489dc84b2",
+          "old_excerpt": "The national 100% ceiling does not automatically produce a Bali registration route.",
+          "new": "There is no national ceiling to fall back on: the allocation to Koperasi and UMKM sets foreign ownership at 0%, so the Bali scope test no longer decides whether a PT PMA can register."
+        }
+      }
+    }
+  }
+}

--- a/scripts/kbli_filiera/cure_specs/prose_umkm_reserved_openness_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/prose_umkm_reserved_openness_2026_08_06.json
@@ -1,4 +1,5 @@
 {
+  "compiler": "cure_prose_national_openness",
   "_meta": {
     "spec": "prose_umkm_reserved_openness_2026_08_06",
     "population": "6 of the 34 codes whose prose asserts national foreign-ownership openness the record denies. These six share one record fact: the bidang usaha is allocated to Koperasi and UMKM by Perpres 49/2021 Lampiran II, so pma_max_asing is 0 — a PT PMA cannot hold it ANYWHERE in Indonesia.",

--- a/scripts/kbli_filiera/cure_specs/prose_umkm_reserved_openness_batch2_2026_08_06.json
+++ b/scripts/kbli_filiera/cure_specs/prose_umkm_reserved_openness_batch2_2026_08_06.json
@@ -1,4 +1,5 @@
 {
+  "compiler": "cure_prose_national_openness",
   "_meta": {
     "spec": "prose_umkm_reserved_openness_batch2_2026_08_06",
     "population": "The 7 remaining codes with pma_max_asing = 0 whose bidang usaha is allocated to Koperasi and UMKM by Perpres 49/2021 Lampiran II, and whose prose still asserts national foreign-ownership openness.",

--- a/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
+++ b/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
@@ -257,9 +257,9 @@ def test_the_live_run_writes_the_real_catalogue_into_a_copy_and_changes_only_cel
     p.write_text(json.dumps(original, ensure_ascii=False), encoding="utf-8")
 
     authored_before = E.report(original["data"])["needs_an_author"]["codes"]
-    assert len(authored_before) == 7, (
-        "the prose backlog on this module's predicate, after the UMKM-reserved and "
-        "49%-transport batches were replaced"
+    assert len(authored_before) == 0, (
+        "the prose backlog on this module's predicate is closed — all four lots "
+        "of cure_prose_national_openness.py have landed"
     )
 
     # The catalogue is already cured, so this run is the IDEMPOTENCE check: a

--- a/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
+++ b/scripts/kbli_filiera/tests/test_cure_editorial_cells_from_record.py
@@ -257,7 +257,10 @@ def test_the_live_run_writes_the_real_catalogue_into_a_copy_and_changes_only_cel
     p.write_text(json.dumps(original, ensure_ascii=False), encoding="utf-8")
 
     authored_before = E.report(original["data"])["needs_an_author"]["codes"]
-    assert len(authored_before) == 21, "the prose backlog, after the first six were replaced"
+    assert len(authored_before) == 7, (
+        "the prose backlog on this module's predicate, after the UMKM-reserved and "
+        "49%-transport batches were replaced"
+    )
 
     # The catalogue is already cured, so this run is the IDEMPOTENCE check: a
     # second pass must find nothing, write nothing, and leave the document

--- a/scripts/kbli_filiera/tests/test_cure_prose_national_openness.py
+++ b/scripts/kbli_filiera/tests/test_cure_prose_national_openness.py
@@ -404,17 +404,22 @@ def test_the_six_are_gone_from_the_live_backlog_and_the_rest_are_untouched():
     run's own report — counting edits proves what a pass intended, not what it
     wrote.
 
-    The backlog went 34 -> 28 -> 21 across the two specs, and the difference is
-    exactly the codes they name. The
-    28 that remain are named in the detector's own pin, so a code leaving this
-    list without a cure would show up there.
+    The backlog went 34 -> 28 -> 21 -> 7 -> 0 across the four lots, and the
+    difference at each step is exactly the codes they name.
+
+    With the backlog at zero the intersection below is empty for a trivial
+    reason, so the assertion that carries the weight is the other one: every
+    code this lane CLAIMS to have cured must be absent from the live backlog.
+    That still fails if a spec names a code it did not actually fix, which is
+    the failure this test was written for.
     """
     cured = set()
     for sp in _lane_specs():
         cured |= set(json.loads(sp.read_text(encoding="utf-8"))["codes"])
+    assert cured, "the lane marker matched no spec — this test would pass on nothing"
     rep = E.report(E.load_records())
     remaining = set(rep["needs_an_author"]["codes"])
-    assert len(remaining) == 7
+    assert len(remaining) == 0
     assert cured & remaining == set(), f"a cured code still lies: {sorted(cured & remaining)}"
 
 

--- a/scripts/kbli_filiera/tests/test_cure_prose_national_openness.py
+++ b/scripts/kbli_filiera/tests/test_cure_prose_national_openness.py
@@ -64,9 +64,12 @@ def entry(old=OLD, new=NEW, cap=0, status="TERBATAS"):
     }
 
 
-def spec_file(tmp_path: Path, codes: dict) -> Path:
+def spec_file(tmp_path: Path, codes: dict, compiler: str | None = C.LANE) -> Path:
     p = tmp_path / "spec.json"
-    p.write_text(json.dumps({"_meta": {}, "codes": codes}, ensure_ascii=False), encoding="utf-8")
+    body: dict = {"_meta": {}, "codes": codes}
+    if compiler is not None:
+        body = {"compiler": compiler, **body}
+    p.write_text(json.dumps(body, ensure_ascii=False), encoding="utf-8")
     return p
 
 
@@ -93,6 +96,72 @@ def test_guilt_the_graded_replacement_is_written(tmp_path: Path, monkeypatch):
     after = json.loads(p.read_text(encoding="utf-8"))["data"][0]
     assert after["intel_2026"]["editorial"]["body"] == NEW
     assert E.classify(after)["body_asserts_national_openness"] is False
+
+
+def test_guilt_a_by_the_numbers_CELL_is_reachable_and_replaced(tmp_path: Path, monkeypatch):
+    """The number a reader meets first is not always in a paragraph.
+
+    Two of the fourteen transport codes state their (wrong) ceiling ONLY in an
+    `editorial.byTheNumbers` cell — a list element, invisible to a path language
+    that walks dicts. A cure that cannot address it leaves "Maximum foreign
+    ownership: 100%" sitting above prose that now says 49%, which is worse than
+    either alone: the page argues with itself and the reader picks.
+    """
+    monkeypatch.setattr(C, "run_sync_script", lambda: None)
+    monkeypatch.setattr(C, "reconcile_sidecar", lambda path: False)
+    record = rec()
+    record["intel_2026"]["editorial"]["byTheNumbers"] = [
+        {"label": "Maximum foreign ownership", "value": "100%"},
+        {"label": "Risk class", "value": "Low"},
+    ]
+    p = canonical_file(tmp_path, [record])
+    e = entry()
+    e["fields"]["editorial.byTheNumbers[0].value"] = {"old_sha256": sha("100%"), "new": "0%"}
+    s = spec_file(tmp_path, {"96210": e})
+
+    assert C.run(s, p, None, apply=True) == 0
+    cells = json.loads(p.read_text(encoding="utf-8"))["data"][0]["intel_2026"]["editorial"][
+        "byTheNumbers"
+    ]
+    assert cells[0]["value"] == "0%"
+    assert cells[1] == {"label": "Risk class", "value": "Low"}, "a sibling cell was disturbed"
+
+
+def test_refusal_when_a_spec_carries_no_compiler_marker(tmp_path: Path):
+    """The marker is what makes "everything this lane shipped" enumerable.
+
+    Guilt: an unmarked spec is refused (exit 2) and writes nothing. Innocence:
+    the same spec, marked, lands. Without the run-time refusal the marker is a
+    convention, and a convention is exactly what the filename prefix was.
+    """
+    p = canonical_file(tmp_path, [rec()])
+    before = p.read_bytes()
+    unmarked = spec_file(tmp_path, {"96210": entry()}, compiler=None)
+    assert C.main(["--spec", str(unmarked), "--canonical", str(p), "--apply"]) == 2
+    assert p.read_bytes() == before
+
+    other = tmp_path / "other"
+    other.mkdir()
+    wrong = spec_file(other, {"96210": entry()}, compiler="some_other_cure")
+    assert C.main(["--spec", str(wrong), "--canonical", str(p), "--apply"]) == 2
+    assert p.read_bytes() == before
+
+
+def test_an_indexed_path_that_does_not_resolve_is_a_REFUSAL_not_a_silent_skip(tmp_path: Path):
+    """An out-of-range cell must stop the run, not read as "nothing to do".
+
+    `read_field` returning None for a missing index would otherwise reach the
+    "field is NoneType, not prose" refusal — which is the correct outcome, and is
+    what this pins. The failure mode being excluded is a cure that writes the
+    prose half of a page and silently drops the number half.
+    """
+    p = canonical_file(tmp_path, [rec()])  # byTheNumbers is []
+    e = entry()
+    e["fields"]["editorial.byTheNumbers[0].value"] = {"old_sha256": sha("100%"), "new": "0%"}
+    s = spec_file(tmp_path, {"96210": e})
+    before = p.read_bytes()
+    assert C.main(["--spec", str(s), "--canonical", str(p), "--apply"]) == 2
+    assert p.read_bytes() == before
 
 
 def test_dry_run_writes_nothing(tmp_path: Path):
@@ -145,6 +214,31 @@ def test_refusal_when_the_reason_left_the_record(tmp_path: Path):
     p = canonical_file(tmp_path, [rec(kondisi="Reserved by a different instrument entirely")])
     s = spec_file(tmp_path, {"96210": entry()})
     assert C.main(["--spec", str(s), "--canonical", str(p), "--apply"]) == 2
+
+
+def test_refusal_when_any_cited_field_no_longer_carries_its_basis(tmp_path: Path):
+    """`<field>_contains` is generic, and it had to become generic.
+
+    The first spec only checked `pma_kondisi`, because the Koperasi/UMKM
+    allocation lives there. The transport batch cites `pma_official_basis`
+    instead — "Perpres 49/2021 Lampiran III … entry #22", a different number on
+    every code — and a premise check that cannot see the field a sentence quotes
+    is decoration.
+    """
+    r = rec()
+    r["pma_official_basis"] = "Perpres 49/2021 Lampiran III entry #22"
+    p = canonical_file(tmp_path, [r])
+    e = entry()
+    e["expect"]["pma_official_basis_contains"] = "Lampiran III entry #22"
+    assert C.main(["--spec", str(spec_file(tmp_path, {"96210": e})),
+                   "--canonical", str(p), "--apply"]) != 2, "premise holds, so it must not refuse"
+
+    r["pma_official_basis"] = "Perpres 49/2021 Lampiran III entry #99"
+    p2 = canonical_file(tmp_path, [r])
+    before = p2.read_bytes()
+    assert C.main(["--spec", str(spec_file(tmp_path, {"96210": e})),
+                   "--canonical", str(p2), "--apply"]) == 2
+    assert p2.read_bytes() == before
 
 
 def test_refusal_when_a_replacement_states_a_percentage_the_record_denies(tmp_path: Path):
@@ -220,6 +314,33 @@ def test_refusal_when_only_names_a_code_the_spec_does_not_carry(tmp_path: Path):
 # --------------------------------------------------------------------------
 
 
+def _lane_specs() -> list[Path]:
+    """Every spec THIS compiler has shipped, selected by a marker in the file.
+
+    It used to be `glob("prose_umkm_reserved_openness*.json")` — a filename
+    prefix, which is a proxy for authorship and lies the moment a batch is named
+    after something else. The transport batch is called
+    `prose_perpres_cap49_transport_*`, so the class guard below would have skipped
+    all fourteen codes and still passed, reporting a clean sweep of a population
+    it never looked at.
+
+    The first repair swapped the prefix for `prose_*` and demanded the marker on
+    every match — and it failed immediately on `prose_unverifiable_tier.json`,
+    which belongs to a different compiler entirely. The filename was still doing
+    the work. So the marker is enforced by `C.run` at apply time instead
+    (`test_refusal_when_a_spec_carries_no_compiler_marker`): an unmarked spec
+    cannot land, which makes the marked set on disk the complete set of specs this
+    lane has ever applied. Here it is only read.
+    """
+    marked = [
+        path
+        for path in sorted(C.SPEC.parent.glob("*.json"))
+        if json.loads(path.read_text(encoding="utf-8")).get("compiler") == C.LANE
+    ]
+    assert C.SPEC in marked, "the module's own default spec is unmarked — selection is broken"
+    return marked
+
+
 def test_the_cure_has_landed_and_the_six_now_carry_exactly_the_graded_text():
     """The pin that replaced "the spec still matches the live records".
 
@@ -289,11 +410,11 @@ def test_the_six_are_gone_from_the_live_backlog_and_the_rest_are_untouched():
     list without a cure would show up there.
     """
     cured = set()
-    for sp in sorted(C.SPEC.parent.glob("prose_umkm_reserved_openness*.json")):
+    for sp in _lane_specs():
         cured |= set(json.loads(sp.read_text(encoding="utf-8"))["codes"])
     rep = E.report(E.load_records())
     remaining = set(rep["needs_an_author"]["codes"])
-    assert len(remaining) == 21
+    assert len(remaining) == 7
     assert cured & remaining == set(), f"a cured code still lies: {sorted(cured & remaining)}"
 
 
@@ -326,9 +447,8 @@ def test_no_cured_code_still_carries_a_numeric_openness_claim_the_other_lint_can
     maxa_by_code = {r["kode_kbli_2025"]: r.get("pma_max_asing") for r in records}
 
     cured: set[str] = set()
-    for spec_path in sorted(C.SPEC.parent.glob("prose_umkm_reserved_openness*.json")):
+    for spec_path in _lane_specs():
         cured |= set(json.loads(spec_path.read_text(encoding="utf-8"))["codes"])
-    assert cured, "no cure specs found — this test would pass vacuously"
 
     survivors = []
     for code in sorted(cured):

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -496,15 +496,17 @@ def test_the_two_buckets_are_reported_separately_and_are_not_the_same_set():
     `cure_editorial_cells_from_record.py` while the authored one still holds
     31 codes, untouched, because replacing a sentence means writing one.
 
-    `50135` remains the specimen: clean cells, wrong prose. It was in the
-    authored bucket before the cure and it is there now, which is the whole
-    point of not having merged the two counts."""
+    The specimen used to be `50135` — clean cells, wrong prose — and it has
+    since been cured (the 49% transport batch), so the pin moved to `84231`,
+    which holds the same shape: nothing mechanical to fix, a sentence that has
+    to be written. Naming a LIVE member is the point; a specimen that has been
+    cured turns this into an assertion about history."""
     rep = E.report(E.load_records())
     mech = set(rep["mechanically_correctable"]["codes"])
     auth = set(rep["needs_an_author"]["codes"])
     assert mech == set(), "the mechanical bucket is cured; a new member is a regression"
     assert auth, "the authored backlog is not empty and must not be quietly emptied"
-    assert "50135" in auth
+    assert "84231" in auth
 
 
 def test_the_bali_exclusion_is_large_enough_to_matter_and_is_declared():
@@ -539,7 +541,7 @@ def test_the_live_populations_are_pinned():
     # `_l3_regen.model = deepseek-v4-pro` at `confidence: LOW`. No human wrote
     # them. The deference that left them standing was protecting an authorship
     # that does not exist, and Zero withdrew it on 2026-08-06.
-    assert len(rep["needs_an_author"]["codes"]) == 21
+    assert len(rep["needs_an_author"]["codes"]) == 7
 
     # WHERE the prose lies, and this is the number that matters — not the code
     # count above. A cross-family refutation left that count UNMOVED at 34 while
@@ -557,17 +559,25 @@ def test_the_live_populations_are_pinned():
     # Pinned by field for that reason: the total alone hid the first defect too,
     # when three fields were read and reported as "the bodies".
     #
-    # 102 -> 81 -> 60 as `cure_prose_national_openness.py` replaced 21 fields on
-    # six codes, then 21 more on seven. The dict below is the CURRENT state, re-derived from the live
-    # catalogue when this pin and #3687's were merged — two branches moving the
+    # 102 -> 81 -> 60 -> 20 as `cure_prose_national_openness.py` replaced 21 fields
+    # on six codes, 21 more on seven, then 51 on the fourteen transport codes whose
+    # ceiling is 49%. The dict below is the CURRENT state, re-derived from the live
+    # catalogue rather than arithmetic on the previous one — two branches moving the
     # same monotone number conflict textually even when both are right, and the
     # resolution is to re-measure, never to pick a side (W109b).
+    #
+    # This histogram counts only what THIS module's predicate sees. The transport
+    # batch was cured against the UNION of this predicate and the lint's numeric
+    # one, because four of its fields — a "By the numbers" cell, a standfirst
+    # reading "full national foreign ownership", two pull quotes — carried the
+    # falsehood in a form no sentence-level openness predicate matches. A pin on
+    # one predicate is a pin on one predicate.
     assert rep["needs_an_author"]["by_field"] == {
-        "editorial.body": 18,
-        "whatYouNeed": 16,
-        "editorial.standfirst": 12,
-        "editorial.headline": 7,
-        "editorial.pullQuote": 6,
+        "editorial.body": 6,
+        "whatYouNeed": 5,
+        "editorial.standfirst": 4,
+        "editorial.headline": 3,
+        "editorial.pullQuote": 1,
         "whoThisIsFor": 1,
     }
 
@@ -662,7 +672,7 @@ def test_the_relationship_to_both_existing_lint_rules_is_pinned():
     # of the three states, and only the disagreement between two rules surfaced
     # it. Cured; the pin is back to the two codes that run the OPPOSITE direction
     # (prose more restrictive than the record), which is a different adjudication.
-    assert l10 - mine == {"41011", "52292"}, (
+    assert l10 - mine == {"41011", "52292", "86201"}, (
         "the DECLARED gap in this module — numeric claims L10 catches and a "
         f"sentence-level openness predicate does not: {sorted(l10 - mine)}"
     )

--- a/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
+++ b/scripts/kbli_filiera/tests/test_editorial_record_conformance.py
@@ -490,23 +490,61 @@ def test_a_bali_sentence_that_also_states_the_national_position_is_still_guilty(
 
 def test_the_two_buckets_are_reported_separately_and_are_not_the_same_set():
     """A single "N codes are wrong" would hide that one bucket is a
-    find-and-replace on a field we own and the other needs a human to write a
-    sentence — and the live data now proves the split was real rather than
-    tidy: the mechanical bucket has been CURED to empty by
-    `cure_editorial_cells_from_record.py` while the authored one still holds
-    31 codes, untouched, because replacing a sentence means writing one.
+    find-and-replace on a field we own and the other needs a sentence written.
 
-    The specimen used to be `50135` — clean cells, wrong prose — and it has
-    since been cured (the 49% transport batch), so the pin moved to `84231`,
-    which holds the same shape: nothing mechanical to fix, a sentence that has
-    to be written. Naming a LIVE member is the point; a specimen that has been
-    cured turns this into an assertion about history."""
+    BOTH buckets are now empty on the live catalogue — the mechanical one by
+    `cure_editorial_cells_from_record.py`, the authored one by the four prose
+    lots of `cure_prose_national_openness.py`. That is the good news and it is
+    also the danger this test now has to survive: two empty sets are equal, so
+    an assertion that they DIFFER would pass on a detector that had gone blind.
+    The separation is therefore proved on constructed records, where each
+    bucket can be entered on purpose, and the live catalogue is asserted as a
+    tripwire at zero rather than as a specimen.
+
+    The specimen this test used to name went `50135` -> `84231` as each was
+    cured; there is no third, because there is no live member left to name."""
     rep = E.report(E.load_records())
     mech = set(rep["mechanically_correctable"]["codes"])
     auth = set(rep["needs_an_author"]["codes"])
     assert mech == set(), "the mechanical bucket is cured; a new member is a regression"
-    assert auth, "the authored backlog is not empty and must not be quietly emptied"
-    assert "84231" in auth
+    assert auth == set(), "the authored backlog is cured; a new member is a regression"
+
+    # The split itself, on records built to enter one bucket and not the other.
+    # A wrong CELL with honest prose is mechanical; wrong PROSE with honest
+    # cells needs an author. If these ever collapse into one bucket the report
+    # above stops meaning anything, and two empty sets would not have said so.
+    mechanical_only = E.classify(
+        rec(cap=49, status="TERBATAS", cells=[{"label": "Foreign ceiling", "value": "100%"}])
+    )
+    assert mechanical_only["ceiling_cells"] != []
+    assert mechanical_only["body_asserts_national_openness"] is False
+
+    authored_only = E.classify(
+        rec(
+            cap=49,
+            status="TERBATAS",
+            cells=[{"label": "Foreign ceiling", "value": "49%"}],
+            body="The national reading is direct: a foreign-owned company may "
+            "hold the activity with full foreign ownership, rather than under a "
+            "lower foreign-equity ceiling.",
+        )
+    )
+    assert authored_only["ceiling_cells"] == []
+    assert authored_only["body_asserts_national_openness"] is True
+
+
+def _mine_and_l10(record, lint_mod):
+    """Both predicates' verdicts on ONE record, so their reach can be compared
+    without a live population to compare it on."""
+    caps = {record["kode_kbli_2025"]: record.get("pma_max_asing")}
+    mine = E.classify(record)["body_asserts_national_openness"]
+    l10 = any(
+        lint_mod.l10_ownership_contradiction(
+            text, record["kode_kbli_2025"], record.get("pma_max_asing"), caps
+        )
+        for _field, text in lint_mod.iter_prose(record)
+    )
+    return mine, l10
 
 
 def test_the_bali_exclusion_is_large_enough_to_matter_and_is_declared():
@@ -541,7 +579,12 @@ def test_the_live_populations_are_pinned():
     # `_l3_regen.model = deepseek-v4-pro` at `confidence: LOW`. No human wrote
     # them. The deference that left them standing was protecting an authorship
     # that does not exist, and Zero withdrew it on 2026-08-06.
-    assert len(rep["needs_an_author"]["codes"]) == 7
+    #
+    # 7 -> 0 with the fourth and last lot. This is now a TRIPWIRE, not a
+    # backlog: any number above zero is a contradiction authored after the
+    # lane closed. It is deliberately an equality — `<= 7` would have let the
+    # backlog refill halfway and still read green.
+    assert len(rep["needs_an_author"]["codes"]) == 0
 
     # WHERE the prose lies, and this is the number that matters — not the code
     # count above. A cross-family refutation left that count UNMOVED at 34 while
@@ -572,14 +615,11 @@ def test_the_live_populations_are_pinned():
     # reading "full national foreign ownership", two pull quotes — carried the
     # falsehood in a form no sentence-level openness predicate matches. A pin on
     # one predicate is a pin on one predicate.
-    assert rep["needs_an_author"]["by_field"] == {
-        "editorial.body": 6,
-        "whatYouNeed": 5,
-        "editorial.standfirst": 4,
-        "editorial.headline": 3,
-        "editorial.pullQuote": 1,
-        "whoThisIsFor": 1,
-    }
+    # 102 -> 81 -> 60 -> 20 -> 0. The histogram is empty because the population
+    # is, and it stays here rather than being deleted: an empty dict asserted
+    # by EQUALITY is the only form of this pin that still fails when a single
+    # field starts lying again. A deleted histogram would fail nothing.
+    assert rep["needs_an_author"]["by_field"] == {}
 
 
 def test_the_relationship_to_both_existing_lint_rules_is_pinned():
@@ -595,10 +635,17 @@ def test_the_relationship_to_both_existing_lint_rules_is_pinned():
     * **L9** is disjoint. Its reachable half of the dangerous direction needs
       `pma_status == "TERTUTUP"` AND the literal "100% foreign", which no live
       record satisfies; its two findings are the mirror case.
-    * **L10** is a partial twin: 31 here, 17 there, 14 shared, and each side
-      holds real findings the other misses. Asserted in BOTH directions, so
-      neither can be retired as redundant on the strength of the other, and the
-      three codes only L10 sees stay a declared gap rather than a silent one.
+    * **L10** is a partial twin: it was 31 here, 17 there, 14 shared, and each
+      side held real findings the other missed.
+
+    THE OVERLAP IS NO LONGER MEASURABLE ON LIVE DATA, and pretending otherwise
+    is how this test would rot. This module's live population is now zero, so
+    every `mine & l10` / `mine - l10` assertion that used to carry the claim is
+    vacuously true or trivially false — an empty set intersects nothing and
+    subtracts to nothing. The complementary blind spots are therefore asserted
+    on CONSTRUCTED records, where each predicate's reach is permanent, and the
+    live catalogue keeps only the assertions that still have something to say:
+    this module clean, L9's two findings, L10's three.
 
     A failure here means the tools have started answering one question two ways
     (W105); the response is to make the lint consume this report, not to delete
@@ -624,15 +671,26 @@ def test_the_relationship_to_both_existing_lint_rules_is_pinned():
         f"consumes the other rather than both judging: {sorted(mine & l9)}"
     )
     assert l9 == {"43110", "86201"}, f"L9's live findings moved: {sorted(l9)}"
-    statuses = {
-        r["pma_status"]
-        for r in records
-        if r["kode_kbli_2025"] in mine
-    }
-    assert "TERBATAS" in statuses, (
-        "premise: this module's population is mostly TERBATAS, the status L9's "
-        "dangerous-direction test cannot reach"
+    assert mine == set(), (
+        "this module's live population is zero and the assertions below are "
+        f"written for that: {sorted(mine)}"
     )
+
+    # The premise that used to be checked here — "this module's population is
+    # mostly TERBATAS, the status L9's dangerous-direction test cannot reach" —
+    # read the statuses of `mine`, so with `mine` empty it asserted membership
+    # in an empty set and could only fail. Kept as a property of L9's REACH
+    # instead, which is what it was always about: a TERBATAS record stating full
+    # foreign ownership in words is invisible to L9, whatever else is true.
+    l9_blind = rec(
+        cap=49,
+        status="TERBATAS",
+        body="The national reading is direct: a foreign-owned company may hold "
+        "the activity with full foreign ownership, rather than under a lower "
+        "foreign-equity ceiling.",
+    )
+    assert not validate_pma_consistency(l9_blind["intel_2026"], l9_blind)
+    assert E.classify(l9_blind)["body_asserts_national_openness"] is True
 
     # L10 is the rule that actually resembles this module, and the first version
     # of this test did not look at it — it checked the rule whose NAME matched
@@ -653,10 +711,35 @@ def test_the_relationship_to_both_existing_lint_rules_is_pinned():
         ):
             l10.add(code)
 
-    assert mine & l10, "L10 and this module used to agree on 14 codes; agreeing on none means one went blind"
-    assert mine - l10, (
-        "this module no longer finds anything L10 misses — if that is real, it is "
-        "redundant and should be retired rather than maintained"
+    # The two blind spots, on records built to sit in exactly one predicate.
+    # These used to be read off the live overlap (14 shared, 3 only-L10); with
+    # this module's population at zero that reading is gone, and asserting
+    # `mine & l10` on an empty set would fail for a reason that has nothing to
+    # do with either rule. Constructed, the property is permanent — and it is
+    # the property that justifies keeping both rules.
+    only_mine = rec(
+        cap=49,
+        status="TERBATAS",
+        body="The national reading is direct: a foreign-owned company may hold "
+        "the activity with full foreign ownership, rather than under a lower "
+        "foreign-equity ceiling.",
+    )
+    assert _mine_and_l10(only_mine, lint) == (True, False), (
+        "this module no longer finds what L10 misses — a claim carried in WORDS "
+        "with no percentage. If that is real it is redundant and should be "
+        "retired rather than maintained"
+    )
+
+    only_l10 = rec(
+        cap=49,
+        status="TERBATAS",
+        body="Foreign investors may hold up to 100% of the equity in this line "
+        "of business.",
+    )
+    assert _mine_and_l10(only_l10, lint) == (False, True), (
+        "L10 no longer finds what this module misses — a percentage stated with "
+        "no national-scope word beside it. Agreeing everywhere means one of the "
+        "two went blind"
     )
     # Was {41011, 52292, 53200}. Widening the claim vocabulary on 2026-08-06
     # closed `53200` — it stated a maximum as a bare number ("the maximum is
@@ -672,9 +755,15 @@ def test_the_relationship_to_both_existing_lint_rules_is_pinned():
     # of the three states, and only the disagreement between two rules surfaced
     # it. Cured; the pin is back to the two codes that run the OPPOSITE direction
     # (prose more restrictive than the record), which is a different adjudication.
-    assert l10 - mine == {"41011", "52292", "86201"}, (
-        "the DECLARED gap in this module — numeric claims L10 catches and a "
-        f"sentence-level openness predicate does not: {sorted(l10 - mine)}"
+    # With `mine` empty this is now just L10's live population, and it is
+    # asserted as such rather than dressed up as a difference. `86201` joined
+    # 41011 and 52292 when the transport lot landed: all three run the OPPOSITE
+    # direction — prose MORE restrictive than the record — which is a different
+    # adjudication and deliberately not cured by this lane. `86201` also steers
+    # a foreign doctor to "code 86103 (klinik) … 67%", and 86103's cap is 100.
+    assert l10 == {"41011", "52292", "86201"}, (
+        "L10's live findings moved — these are the mirror-direction cases this "
+        f"lane declared rather than cured: {sorted(l10)}"
     )
 
 
@@ -707,7 +796,13 @@ def test_the_worst_members_are_named_not_counted():
         )
     assert set(rep["mechanically_correctable"]["codes"]) == set()
 
-    # Umrah/Hajj travel: the CARD is cured, the PROSE still reads as an opening
-    # and needs an author. Both halves named, because "79122 is fixed" would be
-    # a comfortable half-truth.
-    assert "79122" in set(rep["needs_an_author"]["codes"])
+    # Umrah/Hajj travel: the card was cured first and the prose stood for
+    # weeks — "79122 is fixed" was the comfortable half-truth this line was
+    # written to refuse. Both halves are cured now, so the assertion inverts,
+    # and it is asserted by CONTENT on the page rather than by absence from a
+    # bucket, for the same reason as the cards above.
+    prose_79122 = json.dumps(by_code["79122"]["intel_2026"], ensure_ascii=False).lower()
+    assert "79122" not in set(rep["needs_an_author"]["codes"])
+    assert "0%" in prose_79122 or "no foreign" in prose_79122 or "closed" in prose_79122, (
+        "79122's prose no longer states the closure anywhere a client reads"
+    )

--- a/scripts/tests/test_kbli_dataset_lint_guards.py
+++ b/scripts/tests/test_kbli_dataset_lint_guards.py
@@ -47,6 +47,14 @@ L10_GUILT = [
     # cap ASSERTED (no negation) — must still flag despite the cap-denial innocence class
     ("real cap asserted with ceiling noun", "This activity is capped at 67%; the foreign stake hits that ceiling and no further.", "73100", 100),
     ("real cap limited-to with noun", "The record limits the foreign stake to a 49% ceiling for this code.", "73100", 100),
+    # region named AFTER the figure — commentary on a national claim, not a regional cap.
+    # The word "Bali" anywhere in the +-80 window used to exonerate these outright, on a
+    # catalogue where every page mentions Bali (superscar #3, under-match form).
+    ("region named after the figure", "Nationally, this activity is 100% open to foreign ownership. However, in Bali, the OSS system blocks it.", "16221", 0),
+    ("Bali trailing the claim", "KBLI 41018 is nationally open to foreign ownership up to 100%, and the Bali field does not block PMA registration.", "41018", 0),
+    # a ceiling stated without ever using the word "foreign"
+    ("bare national ceiling idiom", "The national 100% ceiling does not automatically produce a Bali registration route.", "55105", 0),
+    ("ownership ceiling noun", "Nationally, the PMA status is open, with a foreign-ownership ceiling of 100%.", "50221", 49),
 ]
 
 L10_INNOCENCE = [
@@ -63,6 +71,11 @@ L10_INNOCENCE = [
     # cap-denial enumeration (01622 class): the prose lists caps only to DENY them
     ("cap-denial enumeration", "There is no capped foreign stake to explain here: the record does not impose a 67%, 49%, or minority ceiling.", "01622", 100),
     ("no-cap-here", "For this activity there is no 67% cap and no minority-partner rule — the national ceiling is the only figure.", "01622", 100),
+    # the region PRECEDES the figure, so it genuinely scopes it — including when an
+    # introductory adverbial puts a comma in between. A first draft of the precedence
+    # rule also demanded no clause break and these two said no immediately.
+    ("Bali precedes with comma", "In Bali, the applicable ceiling on foreign ownership is 49%.", "52292", 100),
+    ("provincial regime precedes", "The provincial regime sets an ownership ceiling of 67% here.", "41011", 100),
 ]
 
 


### PR DESCRIPTION
## What a client was told, and what the law says

Perpres 49/2021 Lampiran III caps foreign shareholding at **49%** for fourteen sea-freight, ferry, inland-waterway and courier activities. Every one of those pages said the opposite — *"nationally open to full foreign ownership"*, *"the maximum is 100%"*. The cap has been on the record since the July lampiran read; the prose never heard about it.

**51 fields on 14 codes**, whole fields rather than sentences, each replacement quoting the annex **entry number the record itself carries** (#15, #16, #18–#28, #32).

## The cross-family review changed the text, twice

Two seats (GLM 5.2, Codex GPT-5.6) were pointed at the sentences **written**, not the ones removed. Both returned the same defect: every `whatYouNeed` closed by naming documents — port permits, waterway approvals, customs clearance, environmental clearance — **that no record carries**. `per_skala[].persyaratan` names vessel and crew documents; `perizinan` is empty on all fourteen at every scale. That clause is gone rather than rewritten.

They also caught the risk class: `per_skala` records `Menengah Tinggi` on thirteen and `Tinggi` on 53200, so the generic *"medium-high or high"* understated one and blurred thirteen.

## The lie lived in fields no probe enumerated — and two "cured" codes were still lying

`41018` and `55105` shipped in #3694 with a `whatYouNeed` saying 0% and a **pull quote on the same page saying 100%**. The lint's L10 rule exonerated both: its BALI innocence class fired on the mere **presence** of the word "Bali" within 80 characters of the figure — on a catalogue where every page is about Bali. Superscar #3 in its under-match form: the class judged a token, not whether the region scopes the number.

- a regional word now exonerates only when it **precedes** the figure. A first draft also demanded no clause break, and two existing innocence cases said no immediately: *"On the ground in Bali, the record caps it at 49%"* carries a comma by grammar and the region still governs.
- **"ceiling" now carries the ownership claim on its own**, anchored — a sentence can state a ceiling without ever using the word "foreign", which is exactly what hid `55105`.

Measured catalogue-wide: **12 real contradictions unmasked, 0 previously-reported findings lost**, mutation-verified both ways.

One unmasked finding is **not cured here** and is worth naming: `86201` steers a foreign doctor to *"code 86103 (klinik), which our records show open to PMA at a foreign-ownership ceiling of 67%"*. `86103` is `Aktivitas Rumah Sakit Swasta` — a private hospital — and its ceiling is 100. Two errors in one sentence that hands a client a concrete alternative to pursue.

## Hardening, so the class cannot hide again

- the **numeric predicate is now a refusal inside the cure**, not only a test. A class check catches a half-cure after it lands; a refusal means it never lands.
- `editorial.byTheNumbers[0].value` is addressable. Two codes stated their wrong ceiling **only** in a "By the numbers" cell — a list element, invisible to a path language that walks dicts, and the first number a reader meets.
- the premise check reads any `<field>_contains` key, not just `pma_kondisi`. This batch quotes `pma_official_basis`; a premise check that cannot see the field a sentence quotes is decoration.
- every spec must carry `"compiler": "cure_prose_national_openness"` or the run is refused. The class checks used to enumerate this lane **by filename prefix**, so a batch named after its instrument dropped out of all of them and still read clean. The marker bit its own author on first use: derived from `__name__` it demands a different value from the CLI than from a test.

## Numbers

| | before | after |
|---|---|---|
| backlog, this module's predicate | 21 | **7** |
| backlog, union with the lint's numeric one (the honest number) | 23 | **10** |
| field-hits | 60 | **20** |
| raw-field-name leakers (ratchet) | 388 | 388 |

Python suite: **999 passed**.

## Declared, not closed

The seven remaining on this predicate are the defence pair (`25200`, `30400`), the air pair (`51101`, `51102`) and three cap-0 singletons (`16221`, `79122`, `84231`) — each needs its own record fact read, not a template. The three union-only codes (`41011`, `52292`, `86201`) run the **opposite** direction: prose more restrictive than the record, which is a different adjudication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)