### PR TITLE
feat(watchdog): a frozen refresh IS the signal — the verdict that would have caught the revoked token

### DIFF
--- a/apps/backend-rag/backend/tests/unit/scripts/test_drive_watchdog_health.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_drive_watchdog_health.py
@@ -32,11 +32,19 @@ are anchored to those shapes, not to invented day counts.
 
     GUILT      — a row that cannot renew itself is a real, nameable failure
     GUILT      — no rows at all is a different failure with a different remedy
-    INNOCENCE  — both live shapes (just-refreshed, idle-for-weeks) are SILENT
-    INNOCENCE  — the SYSTEM row, unrefreshed on purpose since 2026-05-10, is
-                 not an alarm
-    LIMIT      — the declared blind spot is asserted, so nobody re-derives a
-                 countdown from `updated_at` and calls it an expiry
+    GUILT      — a row FROZEN for 3+ days is reported: refresh is lazy-on-use,
+                 so `updated_at` advancing is a consumer succeeding, and when
+                 7dfe56b2's refresh token was revoked the column simply stopped
+                 moving for twelve days while GARUDA logged `invalid_grant`
+                 nightly. A revoked token still has `refresh_token IS NOT
+                 NULL`, so the P0 cannot see it; the freeze can.
+    INNOCENCE  — a recently-refreshed row is SILENT, at every age inside the
+                 window — that is the false CRITICAL this file exists for
+    INNOCENCE  — the SYSTEM row, frozen on purpose since 2026-05-10, is never
+                 called stale
+    INNOCENCE  — an unreadable timestamp is not staleness
+    PRECEDENCE — a dead credential outranks a frozen one, or a real outage
+                 goes out at digest tier
 """
 
 from __future__ import annotations
@@ -48,6 +56,7 @@ from scripts.drive_token_watchdog import (
     HEALTH_NO_REFRESH,
     HEALTH_NO_ROWS,
     HEALTH_OK,
+    HEALTH_STALE_REFRESH,
     _age_text,
     classify_oauth_health,
     parse_expires_at,
@@ -110,42 +119,107 @@ def test_one_broken_row_among_healthy_ones_still_speaks():
     "label,ago",
     [
         ("just refreshed", timedelta(minutes=1)),
-        ("idle twelve days", timedelta(days=12)),
-        ("idle since June", timedelta(days=52)),
+        ("refreshed yesterday", timedelta(days=1)),
+        ("just inside the window", timedelta(days=2, hours=23)),
     ],
 )
-def test_every_live_shape_with_a_refresh_token_is_silent(label, ago):
+def test_a_recently_refreshed_row_is_silent(label, ago):
     """THE regression this file exists for.
 
-    Under the old ladder: `just refreshed` → days_left 0 → "🚨 scade DOMANI",
-    CRITICAL; both idle shapes → negative → "🔴 SCADUTO". Three false alarms,
-    covering literally every state the table can be in.
+    Under the old ladder every one of these is an alarm: `just refreshed` →
+    days_left 0 → "🚨 scade DOMANI" CRITICAL, and the other two → negative →
+    "🔴 SCADUTO". Three false alarms over a credential that is working.
     """
-    health = classify_oauth_health([_row("SYSTEM", refreshed_ago=ago)])
+    health = classify_oauth_health([_row("7dfe56b2", refreshed_ago=ago)], now_utc=NOW)
     assert health.verdict == HEALTH_OK, f"{label} raised {health.verdict}"
     assert health.message == "", f"{label} produced an alert body: {health.message}"
 
 
-def test_the_deliberately_unrefreshed_system_row_is_not_an_alarm():
+def test_the_deliberately_unrefreshed_system_row_is_not_stale():
     """`_refresh_token` early-returns for SYSTEM since 2026-05-10 — Drive runs
-    on ServiceAccountDriveService and that row is left stale ON PURPOSE. Any
-    staleness rule over `updated_at` would fire on it every six hours."""
-    health = classify_oauth_health([_row("SYSTEM", refreshed_ago=timedelta(days=52))])
+    on ServiceAccountDriveService and that row is left frozen ON PURPOSE
+    (2026-06-15 and counting). The staleness rule must exclude it by ENTITY,
+    or it fires every six hours forever about the intended state."""
+    health = classify_oauth_health(
+        [_row("SYSTEM", refreshed_ago=timedelta(days=52))], now_utc=NOW
+    )
     assert health.verdict == HEALTH_OK
 
 
-# ------------------------------------------------------------------- limit
-def test_the_age_is_context_and_never_a_verdict():
-    """The declared blind spot: `updated_at` age cannot separate "unused" from
-    "refresh is failing". It appears in the detail line so a human reading the
-    log has it, and nowhere else — a threshold on it would rebuild the same
-    false positive one field to the left."""
-    fresh = classify_oauth_health([_row("SYSTEM", refreshed_ago=timedelta(minutes=1))])
-    stale = classify_oauth_health([_row("SYSTEM", refreshed_ago=timedelta(days=52))])
+# --------------------------------------------------------------- staleness
+def test_a_frozen_row_is_reported():
+    """The signal that would have caught the real outage.
 
-    assert fresh.verdict == stale.verdict == HEALTH_OK
-    assert fresh.detail != stale.detail, "the age must still be VISIBLE in the log"
-    assert fresh.message == stale.message == ""
+    Refresh is lazy-on-use, so `updated_at` advancing is a consumer
+    succeeding. Row 7dfe56b2 froze at 2026-07-25 19:02 when its refresh token
+    was revoked and stayed frozen twelve days while GARUDA collected
+    `invalid_grant` nightly. A revoked token still has `refresh_token IS NOT
+    NULL`, so the P0 above is blind to it — the freeze is not.
+    """
+    health = classify_oauth_health(
+        [_row("7dfe56b2", refreshed_ago=timedelta(days=12))], now_utc=NOW
+    )
+    assert health.verdict == HEALTH_STALE_REFRESH
+    assert "7dfe56b2" in health.message
+    assert "invalid_grant" in health.message, (
+        "the note must point at where the PROOF is — this verdict alone cannot "
+        "tell a revoked credential from an unused one"
+    )
+
+
+def test_the_boundary_is_the_stated_threshold():
+    """Just inside is silent, just outside speaks. Pinned because the value is
+    derived from something real — three missed runs of a daily consumer — and
+    a future edit that drifts it should have to say so here."""
+    from scripts.drive_token_watchdog import STALE_REFRESH_DAYS
+
+    inside = timedelta(days=STALE_REFRESH_DAYS, hours=-1)
+    outside = timedelta(days=STALE_REFRESH_DAYS, hours=1)
+    assert (
+        classify_oauth_health([_row("u", refreshed_ago=inside)], now_utc=NOW).verdict
+        == HEALTH_OK
+    )
+    assert (
+        classify_oauth_health([_row("u", refreshed_ago=outside)], now_utc=NOW).verdict
+        == HEALTH_STALE_REFRESH
+    )
+
+
+def test_an_unreadable_timestamp_is_not_staleness():
+    """"I could not read it" is not "it is old". Treating an unparseable
+    `updated_at` as stale would put a recurring digest note on a healthy row,
+    which is the false-positive family this whole change exists to end."""
+    row = _row("u", refreshed_ago=timedelta(minutes=1))
+    row["updated_at"] = "not a timestamp"
+    health = classify_oauth_health([row], now_utc=NOW)
+    assert health.verdict == HEALTH_OK
+    assert "?" in health.detail, "the unreadable field must still be VISIBLE"
+
+
+def test_a_dead_credential_outranks_a_stale_one():
+    """Precedence: a row that can never renew is actionable now; a frozen one
+    is a hint. If both are true of the same table the message must be the P0,
+    or a real outage goes out at digest tier."""
+    health = classify_oauth_health(
+        [_row("u", has_refresh=False, refreshed_ago=timedelta(days=12))], now_utc=NOW
+    )
+    assert health.verdict == HEALTH_NO_REFRESH
+
+
+# ------------------------------------------------------------------- limit
+def test_the_age_is_always_visible_in_the_detail_line():
+    """Whatever the verdict, a human reading the log gets the ages — the
+    verdict is a summary, and this organ has already been wrong once about
+    what a column means."""
+    fresh = classify_oauth_health(
+        [_row("u", refreshed_ago=timedelta(minutes=1))], now_utc=NOW
+    )
+    stale = classify_oauth_health(
+        [_row("u", refreshed_ago=timedelta(days=12))], now_utc=NOW
+    )
+    assert fresh.detail != stale.detail
+    assert "12g" in stale.detail, stale.detail
+    assert fresh.message == ""
 
 
 def test_age_text_never_raises_on_junk():

--- a/apps/cell/cell/sensors/oauth_health_sensor.py
+++ b/apps/cell/cell/sensors/oauth_health_sensor.py
@@ -59,6 +59,11 @@ _HEALTH_TO_COLOR: dict[str, tuple[str, str]] = {
     "ok": ("green", "credential present and renewable"),
     "no-token": ("red", "no OAuth row in google_drive_tokens"),
     "no-refresh": ("red", "no refresh_token — cannot renew, re-auth required"),
+    # Yellow, not red: a frozen `updated_at` means either the credential was
+    # revoked or nobody used Drive, and this table cannot tell them apart. The
+    # organ that knows is the consumer's own failure. Yellow is "look", which
+    # is exactly what it is worth.
+    "stale-refresh": ("yellow", "no refresh in 3+ days — revoked, or unused"),
 }
 
 # Values the watchdog wrote before 2026-08-06, off the wrong scale. A state

--- a/apps/cell/tests/test_oauth_health_sensor.py
+++ b/apps/cell/tests/test_oauth_health_sensor.py
@@ -78,6 +78,21 @@ class TestOAuthHealthSensor:
         assert reading.status == "red"
         assert reading.health == "no-token"
 
+    def test_a_frozen_refresh_is_yellow_not_red(self, tmp_path: Path) -> None:
+        """The watchdog's third verdict. Yellow because the table cannot tell
+        a revoked credential from an unused one — red would claim more than is
+        known, and unknown (the default for an unmapped verdict) would throw
+        the signal away entirely. Added with the verdict, not after it: an
+        unmapped verdict here is a consumer the producer forgot."""
+        path = _write_state(
+            tmp_path,
+            last_oauth_health="stale-refresh",
+            last_oauth_check_iso=NOW.isoformat(),
+        )
+        reading = OAuthHealthSensor(state_path=path).read(now=NOW)
+        assert reading.status == "yellow"
+        assert reading.health == "stale-refresh"
+
     # ----------------------------------------------------------- innocence
     def test_healthy_verdict_is_green(self, tmp_path: Path) -> None:
         path = _write_state(

--- a/scripts/drive_token_watchdog.py
+++ b/scripts/drive_token_watchdog.py
@@ -50,6 +50,19 @@ STATE_FILE = STATE_DIR / "drive_oauth_watchdog.state.json"
 HEALTH_OK = "ok"
 HEALTH_NO_ROWS = "no-token"
 HEALTH_NO_REFRESH = "no-refresh"
+HEALTH_STALE_REFRESH = "stale-refresh"
+
+# A row whose consumer runs daily refreshes daily — refresh is lazy-on-use, so
+# `updated_at` advancing IS the consumer succeeding. Three days = three missed
+# runs, past any single-night flake.
+STALE_REFRESH_DAYS = 3
+
+# Excluded from the staleness check, by ENTITY and not by shape: this exact row
+# is left unrefreshed ON PURPOSE since 2026-05-10 —
+# `GoogleDriveService._refresh_token` early-returns for it because Drive moved
+# to ServiceAccountDriveService. Its `updated_at` has been frozen since
+# 2026-06-15 and that is the intended state, not a fault.
+UNREFRESHED_BY_DESIGN = frozenset({"SYSTEM"})
 
 # SA key threshold (separate from OAuth — SA keys never expire by default,
 # but rotation policy = 30 days)
@@ -74,7 +87,9 @@ class OAuthHealth:
     detail: str   # one line of context for the log, always populated
 
 
-def classify_oauth_health(rows: list[dict]) -> OAuthHealth:
+def classify_oauth_health(
+    rows: list[dict], now_utc: datetime | None = None
+) -> OAuthHealth:
     """
     Judge the OAuth credential from what `google_drive_tokens` can actually say.
 
@@ -104,15 +119,35 @@ def classify_oauth_health(rows: list[dict]) -> OAuthHealth:
       - no rows                → the credential does not exist. Real P0.
       - a row without a        → `get_valid_token` returns None forever; no
         refresh_token            re-auth can happen by itself. Real P0.
-      - otherwise              → healthy. Refresh is lazy-on-use, so nothing
-                                 here predicts a future failure.
+      - a refreshable row      → its consumer has not succeeded in that long.
+        frozen for 3+ days       Not a P0; a digest note. See below.
+      - otherwise              → healthy.
 
-    DECLARED LIMIT, deliberately not alarmed on: the age of `updated_at` does
-    NOT separate "unused" from "refresh is failing" — both look identical from
-    this table — and the SYSTEM row is left unrefreshed *on purpose* since
-    2026-05-10 (`_refresh_token` early-returns for it; Drive runs on
-    ServiceAccountDriveService). Alarming on that age would rebuild the same
-    false-positive one field to the left. It is reported as context only.
+    THE STALENESS RULE, and why it is here rather than in the "declared limit"
+    where an earlier draft of this function put it. Refresh is lazy-on-use, so
+    `updated_at` advancing IS a consumer succeeding — and when a refresh token
+    is REVOKED the column simply stops moving, because every attempt now fails.
+    That is exactly what happened, and it is the only trace the table kept:
+
+        row 7dfe56b2…  last successful refresh  2026-07-25 19:02
+        GARUDA indexer (daily 20:36, GARUDA_DRIVE_USER_ID = that row):
+            `invalid_grant: Token has been expired or revoked`, every night
+        re-authorised by hand                   2026-08-06 11:11
+
+    Twelve days frozen, twelve nights of a real outage, and nothing said so.
+    A revoked token still has `refresh_token IS NOT NULL`, so the P0 above
+    cannot see this; the freeze can.
+
+    DECLARED LIMITS on that rule, both deliberate:
+      - It cannot distinguish "the credential is dead" from "nobody used
+        Drive". That is why it is a DIGEST note, not a P0 — the ground truth
+        is a consumer's own failure (`zantara_media.alerts`), and this is the
+        cheap early hint, not a replacement for it.
+      - It assumes a consumer that runs at least every STALE_REFRESH_DAYS. One
+        that ran weekly would read stale while perfectly healthy. Today the one
+        non-SYSTEM row has a daily consumer; a weekly one would need its own
+        threshold rather than a blanket raise.
+      - `SYSTEM` is excluded: unrefreshed on purpose since 2026-05-10.
     """
     if not rows:
         return OAuthHealth(
@@ -140,9 +175,37 @@ def classify_oauth_health(rows: list[dict]) -> OAuthHealth:
         )
 
     ages = ", ".join(
-        f"{r.get('user_id', '?')} rinnovato {_age_text(r.get('updated_at'))}"
+        f"{r.get('user_id', '?')} rinnovato {_age_text(r.get('updated_at'), now_utc)}"
         for r in rows
     )
+
+    frozen = []
+    for r in rows:
+        if str(r.get("user_id")) in UNREFRESHED_BY_DESIGN:
+            continue
+        age = _age_days(r.get("updated_at"), now_utc)
+        # An unparseable timestamp is NOT staleness: it is a read we could not
+        # make, and calling it a fault would put a false digest note on a
+        # healthy row every six hours. The parse failure surfaces as "?" in
+        # `detail`, where a human sees it.
+        if age is not None and age >= STALE_REFRESH_DAYS:
+            frozen.append((str(r.get("user_id", "?")), age))
+
+    if frozen:
+        who = ", ".join(f"{u} ({a:.0f}g)" for u, a in frozen)
+        return OAuthHealth(
+            verdict=HEALTH_STALE_REFRESH,
+            message=(
+                f"🟡 <b>Drive OAuth</b>: nessun rinnovo da {STALE_REFRESH_DAYS}+ "
+                f"giorni ({who})\n"
+                "Il rinnovo avviene all'uso: o il consumatore è fermo, o il "
+                "refresh_token è stato REVOCATO (in DB sembra identico).\n"
+                "Conferma nel log del consumatore — un <code>invalid_grant</code> "
+                "lì è la prova."
+            ),
+            detail=f"stale: {who} — {len(rows)} righe, {ages}",
+        )
+
     return OAuthHealth(
         verdict=HEALTH_OK,
         message="",
@@ -177,9 +240,9 @@ def should_alert(current: str, last: Optional[str]) -> bool:
     """
     Return True iff the OAuth verdict is broken AND it is not a repeat.
 
-    The severity ladder this replaced existed to rank six tiers. With two
-    failure modes and no countdown there is nothing to rank: speak when the
-    verdict is bad and it is not the same bad verdict we already sent.
+    The severity ladder this replaced existed to rank six tiers. With three
+    verdicts and no countdown there is nothing to rank: speak when the verdict
+    is bad and it is not the same bad verdict we already sent.
 
     A CHANGED failure (no-token → no-refresh) speaks again: it is different
     news, and the remedy line differs. Recovery is silent, as before.
@@ -210,8 +273,14 @@ def _load_env() -> dict[str, str]:
     return env
 
 
-def _send_telegram(text: str, bot_token: str, condition: str = "alert") -> bool:
+def _send_telegram(
+    text: str, bot_token: str, condition: str = "alert", tier: str = "p0"
+) -> bool:
     """Route via the tg_notify gateway (2026-07-11 migration, cohort-5).
+
+    `tier` is a parameter and not a constant since 2026-08-06: the staleness
+    note is a "look at this", not a "act now", and sending it p0 would spend
+    the daily budget of the two verdicts that ARE actionable.
 
     p0 tier: alerts only fire on an escalating tier (URGENT/CRITICAL) or an
     expired SA key — actionable now, Drive polling either already broke or
@@ -252,7 +321,7 @@ def _send_telegram(text: str, bot_token: str, condition: str = "alert") -> bool:
     dedup_key = f"drive-token-watchdog:{condition}:{socket.gethostname().split('.')[0]}"
     try:
         proc = subprocess.run(
-            [sys.executable, str(gateway), "--tier", "p0",
+            [sys.executable, str(gateway), "--tier", tier,
              "--source", "drive-token-watchdog",
              "--dedup-key", dedup_key, "--", text],
             capture_output=True, text=True, timeout=30,
@@ -454,24 +523,34 @@ def parse_expires_at(expires_str: str) -> datetime:
     return datetime.fromisoformat(expires_str).replace(tzinfo=timezone.utc)
 
 
-def _age_text(ts: object, now_utc: datetime | None = None) -> str:
-    """Human age of a timestamp, for CONTEXT lines only — never a verdict.
+def _age_days(ts: object, now_utc: datetime | None = None) -> float | None:
+    """Age of a timestamp in days, or None if it cannot be read.
 
-    Returns "?" rather than raising: this feeds the log/detail string, and a
-    watchdog must not die describing itself. Deliberately not a number a
-    caller could threshold on — see `classify_oauth_health`'s declared limit.
+    None is not zero and not "fresh": callers must treat it as "unknown" and
+    never as a fault, or an unparseable row becomes a recurring false alarm.
     """
     if not isinstance(ts, str) or not ts:
-        return "?"
+        return None
     try:
         when = parse_expires_at(ts)
     except Exception:
+        return None
+    return ((now_utc or datetime.now(timezone.utc)) - when).total_seconds() / 86400
+
+
+def _age_text(ts: object, now_utc: datetime | None = None) -> str:
+    """Human age of a timestamp, for CONTEXT lines only.
+
+    Returns "?" rather than raising: this feeds the log/detail string, and a
+    watchdog must not die describing itself.
+    """
+    days = _age_days(ts, now_utc)
+    if days is None:
         return "?"
-    delta = (now_utc or datetime.now(timezone.utc)) - when
-    hours = delta.total_seconds() / 3600
+    hours = days * 24
     if hours < 48:
         return f"{hours:.0f}h fa"
-    return f"{hours / 24:.0f}g fa"
+    return f"{days:.0f}g fa"
 
 
 # ---------------------------------------------------------------------------
@@ -517,7 +596,7 @@ def main() -> int:
             if not isinstance(rows, list):
                 raise TypeError(f"'rows' non è una lista: {type(rows).__name__}")
 
-            health = classify_oauth_health(rows)
+            health = classify_oauth_health(rows, now_utc)
             new_oauth_health = health.verdict
             log(f"OAuth: {health.verdict} — {health.detail}")
 
@@ -586,7 +665,17 @@ def main() -> int:
         # same combination always yields the same key, and joined so a message
         # that carries two facts cannot be mistaken for either one alone.
         condition = "+".join(sorted(set(alert_kinds))) or "alert"
-        delivered = _send_telegram(message, bot_token, condition)
+        # One message carries every fact of this run, so the tier is decided by
+        # the LOUDEST of them: digest only when staleness is all there is.
+        # Anything actionable in the bundle pulls the whole thing to p0 —
+        # burying a "no refresh_token" inside a digest flush would be the same
+        # class of mistake as shouting the staleness note.
+        tier = (
+            "digest"
+            if set(alert_kinds) == {HEALTH_STALE_REFRESH}
+            else "p0"
+        )
+        delivered = _send_telegram(message, bot_token, condition, tier)
         print(f"[drive-watchdog] {len(alerts)} alert{'s' if len(alerts) > 1 else ''} inviato: {delivered}")
     else:
         print(f"[drive-watchdog] {timestamp} — tutto OK (token valido, SA key OK)")

--- a/scripts/tests/test_drive_watchdog_tier_ratchet.py
+++ b/scripts/tests/test_drive_watchdog_tier_ratchet.py
@@ -33,15 +33,34 @@ outcomes were "🚨 scade DOMANI" about a healthy credential and "🔴 SCADUTO"
 about one nobody had used today. It never showed only because the read always
 failed: curing the read is what would have armed the false alarm.
 
+What replaced it is NOT "no signal at all". Refresh is lazy-on-use, so
+`updated_at` advancing IS a consumer succeeding, and when the refresh token was
+revoked that column simply froze:
+
+    row 7dfe56b2…  last successful refresh  2026-07-25 19:02
+    GARUDA indexer (daily, GARUDA_DRIVE_USER_ID = that row):
+        `invalid_grant: Token has been expired or revoked`, every night
+    re-authorised by hand                    2026-08-06 11:11
+
+Twelve days frozen, twelve nights of a real outage. So a frozen row IS worth
+saying — as a DIGEST note, because it cannot tell "revoked" from "unused" and
+the ground truth is the consumer's own failure. The old ladder did shout at
+this row, but for a reason that was false, and shouted identically at healthy
+ones, which is why it could never be trusted.
+
     GUILT ×2     — a failed delivery must NOT advance the ratchet, and the very
                    next run must still speak.
-    GUILT (B)    — the REAL measured row shape must be SILENT. This is the case
-                   the old corpus could not have: it only ever fed invented
-                   day-scale numbers to a pure function, never a row.
+    GUILT (B)    — a freshly-refreshed row must be SILENT, and a frozen one must
+                   speak at DIGEST. These are the cases the old corpus could not
+                   have: it only ever fed invented day-scale numbers to a pure
+                   function, never a row.
     SYMMETRY     — the SA lane carries the same ratchet and the same cure.
-    INNOCENCE ×2 — a delivered alert DOES advance it (or this spams every 6h),
-                   and a healthy verdict is still recorded so a later failure
-                   reads as a change.
+    INNOCENCE ×3 — a delivered alert DOES advance it (or this spams every 6h);
+                   a healthy verdict is still recorded so a later failure reads
+                   as a change; and SYSTEM, frozen BY DESIGN since 2026-05-10,
+                   is never called stale.
+    TIER         — an actionable fact anywhere in the bundle pulls the whole
+                   message to p0; digest only when staleness is all there is.
     ORDER        — send before write, pinned directly: every value-level
                    assertion here passes on the happy path under the old
                    sequence, which only diverges when the send fails.
@@ -98,7 +117,7 @@ def _healthy_rows(mod):
         {
             "rows": [
                 {
-                    "user_id": "SYSTEM",
+                    "user_id": "7dfe56b2",
                     "has_refresh": True,
                     "updated_at": (now - mod.timedelta(minutes=1)).strftime(
                         "%Y-%m-%d %H:%M:%S+00"
@@ -122,7 +141,7 @@ def _idle_rows(mod):
         {
             "rows": [
                 {
-                    "user_id": "SYSTEM",
+                    "user_id": "7dfe56b2",
                     "has_refresh": True,
                     "updated_at": (now - mod.timedelta(days=12)).strftime(
                         "%Y-%m-%d %H:%M:%S+00"
@@ -162,7 +181,7 @@ def test_a_failed_send_does_not_burn_the_one_alert(wd, monkeypatch):
     monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: _no_refresh_rows(wd))
     sends: list[str] = []
 
-    def failing_send(text, bot_token, condition="alert"):
+    def failing_send(text, bot_token, condition="alert", tier="p0"):
         sends.append(text)
         return False
 
@@ -189,7 +208,7 @@ def test_a_failed_send_of_a_changed_failure_still_retries(wd, monkeypatch):
     wd.STATE_FILE.write_text(json.dumps({"last_oauth_health": wd.HEALTH_NO_ROWS}))
     monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: _no_refresh_rows(wd))
     monkeypatch.setattr(
-        wd, "_send_telegram", lambda text, bot_token, condition="alert": False
+        wd, "_send_telegram", lambda text, bot_token, condition="alert", tier="p0": False
     )
 
     assert wd.main() == 0
@@ -198,23 +217,99 @@ def test_a_failed_send_of_a_changed_failure_still_retries(wd, monkeypatch):
     )
 
 
-@pytest.mark.parametrize("shape", ["fresh", "idle"])
-def test_a_live_shaped_row_never_speaks(wd, monkeypatch, shape):
+def test_a_freshly_refreshed_row_never_speaks(wd, monkeypatch):
     """TRAUMA B, and the case the old corpus was structurally unable to have.
 
     It tested `classify_tier(30)`, `classify_tier(14)`, `classify_tier(-1)` —
-    a pure function fed numbers nobody had ever measured. Feed it instead the
-    two shapes this table actually produces, both of them healthy, and the old
-    ladder alerts on BOTH: "scade DOMANI" on the fresh one (days_left == 0),
-    "SCADUTO" on the idle one.
+    a pure function fed numbers nobody had ever measured. Feed it the shape
+    the table actually produces one minute after a refresh, and the old ladder
+    says "🚨 scade DOMANI": `days_left` is 0, because the window is an hour.
     """
-    rows = _healthy_rows(wd) if shape == "fresh" else _idle_rows(wd)
-    monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: rows)
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: _healthy_rows(wd))
     monkeypatch.setattr(
         wd,
         "_send_telegram",
-        lambda text, bot_token, condition="alert": pytest.fail(
-            f"a healthy {shape} row raised an alert: {text[:200]}"
+        lambda text, bot_token, condition="alert", tier="p0": pytest.fail(
+            f"a healthy row raised an alert: {text[:200]}"
+        ),
+    )
+
+    assert wd.main() == 0
+    assert _saved_health(wd) == wd.HEALTH_OK
+
+
+def test_a_frozen_row_is_a_digest_note_not_a_critical(wd, monkeypatch):
+    """The signal that WOULD have caught the real outage — at the volume it
+    deserves.
+
+    Refresh is lazy-on-use, so `updated_at` advancing is a consumer
+    succeeding. Row 7dfe56b2 froze at 2026-07-25 19:02 when its refresh token
+    was revoked and stayed frozen twelve days while GARUDA collected
+    `invalid_grant` nightly. The old ladder DID shout at this row — "🔴
+    SCADUTO" — but for the wrong reason (a one-hour window it read as days),
+    and it shouted identically at healthy idle rows, which is why it could
+    never have been trusted.
+
+    p0 would be wrong too: this cannot tell "revoked" from "unused", and the
+    ground truth is the consumer's own failure. Digest.
+    """
+    sent: list[tuple[str, str]] = []
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: _idle_rows(wd))
+    monkeypatch.setattr(
+        wd,
+        "_send_telegram",
+        lambda text, bot_token, condition="alert", tier="p0": (
+            sent.append((tier, text)),
+            True,
+        )[1],
+    )
+
+    assert wd.main() == 0
+    assert len(sent) == 1, sent
+    tier, text = sent[0]
+    assert tier == "digest", f"a staleness note went out at {tier}"
+    assert "invalid_grant" in text, (
+        "the note must tell the reader where the PROOF is — the consumer's "
+        "log — since this verdict alone cannot distinguish revoked from unused"
+    )
+    assert _saved_health(wd) == wd.HEALTH_STALE_REFRESH
+
+
+def test_an_actionable_fact_in_the_bundle_pulls_the_whole_message_to_p0(
+    wd, monkeypatch
+):
+    """INNOCENCE for the tier choice: one message carries every fact of the
+    run, so burying a real P0 inside a digest flush would be the same class of
+    mistake as shouting the staleness note."""
+    sent: list[str] = []
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: _idle_rows(wd))
+    monkeypatch.setattr(wd, "_check_sa_key_age", lambda: wd.SA_KEY_MAX_AGE_DAYS + 5)
+    monkeypatch.setattr(
+        wd,
+        "_send_telegram",
+        lambda text, bot_token, condition="alert", tier="p0": (
+            sent.append(tier),
+            True,
+        )[1],
+    )
+
+    assert wd.main() == 0
+    assert sent == ["p0"], sent
+
+
+def test_the_system_row_frozen_by_design_is_not_stale(wd, monkeypatch):
+    """`_refresh_token` early-returns for SYSTEM since 2026-05-10 — Drive runs
+    on ServiceAccountDriveService and that row is left unrefreshed on purpose.
+    Its `updated_at` has been frozen since 2026-06-15. Alarming on it would
+    fire every six hours, forever, about the intended state."""
+    rows, _ = _idle_rows(wd)
+    rows["rows"][0]["user_id"] = "SYSTEM"
+    monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: (rows, None))
+    monkeypatch.setattr(
+        wd,
+        "_send_telegram",
+        lambda text, bot_token, condition="alert", tier="p0": pytest.fail(
+            f"SYSTEM's by-design staleness raised an alert: {text[:200]}"
         ),
     )
 
@@ -236,7 +331,7 @@ def test_the_sa_key_lane_has_the_same_defect_and_the_same_cure(wd, monkeypatch):
     monkeypatch.setattr(wd, "_check_sa_key_age", lambda: wd.SA_KEY_MAX_AGE_DAYS + 5)
     sends: list[str] = []
 
-    def failing_send(text, bot_token, condition="alert"):
+    def failing_send(text, bot_token, condition="alert", tier="p0"):
         sends.append(text)
         return False
 
@@ -268,7 +363,7 @@ def test_an_undelivered_sa_alert_does_not_freeze_the_oauth_verdict(wd, monkeypat
     monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: _healthy_rows(wd))
     monkeypatch.setattr(wd, "_check_sa_key_age", lambda: wd.SA_KEY_MAX_AGE_DAYS + 5)
     monkeypatch.setattr(
-        wd, "_send_telegram", lambda text, bot_token, condition="alert": False
+        wd, "_send_telegram", lambda text, bot_token, condition="alert", tier="p0": False
     )
 
     assert wd.main() == 0
@@ -288,7 +383,7 @@ def test_a_successful_send_does_advance_the_ratchet(wd, monkeypatch):
     monkeypatch.setattr(
         wd,
         "_send_telegram",
-        lambda text, bot_token, condition="alert": (sends.append(text), True)[1],
+        lambda text, bot_token, condition="alert", tier="p0": (sends.append(text), True)[1],
     )
 
     assert wd.main() == 0
@@ -311,7 +406,7 @@ def test_the_old_day_ladder_keys_are_purged_from_the_state_file(wd, monkeypatch)
     monkeypatch.setattr(
         wd,
         "_send_telegram",
-        lambda text, bot_token, condition="alert": pytest.fail("nothing to send"),
+        lambda text, bot_token, condition="alert", tier="p0": pytest.fail("nothing to send"),
     )
 
     assert wd.main() == 0
@@ -335,7 +430,7 @@ def test_the_send_happens_before_the_state_write(wd, monkeypatch):
     monkeypatch.setattr(
         wd,
         "_send_telegram",
-        lambda text, bot_token, condition="alert": (seq.append("send"), True)[1],
+        lambda text, bot_token, condition="alert", tier="p0": (seq.append("send"), True)[1],
     )
     real_save = wd.save_state
     monkeypatch.setattr(
@@ -448,7 +543,7 @@ def test_a_read_failure_and_a_credential_failure_do_not_share_a_dedup_key(
     monkeypatch.setattr(
         wd,
         "_send_telegram",
-        lambda text, bot_token, condition="alert": (keys.append(condition), True)[1],
+        lambda text, bot_token, condition="alert", tier="p0": (keys.append(condition), True)[1],
     )
 
     monkeypatch.setattr(
@@ -476,7 +571,7 @@ def test_the_key_carries_the_verdict_but_never_a_measurement(wd, monkeypatch):
     monkeypatch.setattr(
         wd,
         "_send_telegram",
-        lambda text, bot_token, condition="alert": (keys.append(condition), True)[1],
+        lambda text, bot_token, condition="alert", tier="p0": (keys.append(condition), True)[1],
     )
     monkeypatch.setattr(wd, "_check_drive_token_via_fly", lambda: _no_refresh_rows(wd))
 


### PR DESCRIPTION
## What

`#3700` removed the day-ladder that could only ever produce false CRITICALs. It left the watchdog with **two** verdicts — `no-token` and `no-refresh` — and neither of them can see the failure that actually happened on 2026-07-25.

This adds the third: **a frozen `updated_at` IS the signal.**

## Why this one would have caught it

Refresh is lazy-on-use (`google_drive_service.py:230`, 5-minute buffer). So `updated_at` advancing is not bookkeeping — it is a **consumer succeeding**. When `7dfe56b2`'s refresh token was revoked, the column simply stopped moving, and stayed frozen for twelve days while the GARUDA indexer collected `invalid_grant` nightly.

A revoked refresh token still satisfies `refresh_token IS NOT NULL`, so the `no-refresh` P0 is structurally blind to it. The freeze is not.

## Verdict shape

| verdict | tier | meaning |
|---|---|---|
| `no-token` | p0 | no row at all |
| `no-refresh` | p0 | cannot renew — only a human at the consent screen fixes it |
| `stale-refresh` | **digest** | frozen 3+ days: revoked, **or** simply unused |
| `ok` | silent | — |

`stale-refresh` is deliberately **not** a P0 and the Cell paints it **yellow**, not red: this table cannot tell a revoked credential from an unused one. Yellow is "look", which is exactly what it is worth. The message names where the proof lives (`invalid_grant` in the consumer's log), because the verdict alone cannot close the question.

## Two things that had to change with it

- **The query read one row.** `ORDER BY created_at DESC LIMIT 1` — a dead `SYSTEM` row hid behind a healthy per-user row that happened to be newer. Now every row, every field the classifier uses. Pinned by a test that reads the SQL, because a mutation reverting it survived the whole corpus.
- **`SYSTEM` is excluded from staleness by ENTITY.** `_refresh_token` has refused to refresh that row since 2026-05-10 — Drive runs on `ServiceAccountDriveService`. Frozen on purpose since 2026-06-15; without the exclusion this fires every six hours forever about the intended state.

## Verification

- 25 scripts-side + 16 backend + 11 cell tests green.
- **Mutation 7/7** on the new staleness behaviour (threshold, SYSTEM exclusion, precedence, unreadable-timestamp, the SQL itself, the recovery gate, `_age_days` junk handling); the 10/10 from #3700 still killed.
- Innocence: a row refreshed one minute ago, one day ago, and at 2d23h are all silent. Those are the three cases the old ladder called `🚨 scade DOMANI` / `🔴 SCADUTO`.
- `_age_days` returns `None` on junk — **"unknown", never "old"**. An unreadable timestamp is not staleness, but the unreadable field still shows in the detail line.

## Recovery gating (my own bug, caught by mutation)

The healthy verdict is persisted **unconditionally**; only failures gate on `delivered`. Gating the healthy one too would let an undelivered alert freeze `last_oauth_health` at the old failure, so the *next* real failure reads as a repeat and is swallowed by the ratchet. Pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
