### PR TITLE
fix(garuda): 40 nights down, two causes — a mute alarm and a scope the consent never granted

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -170,6 +170,8 @@ jobs:
               scripts/drive_token_watchdog.py|\
               scripts/tests/test_drive_watchdog_fly_path.py|\
               scripts/tests/test_drive_watchdog_tier_ratchet.py|\
+              apps/zantara-media/zantara_media/alerts.py|\
+              apps/zantara-media/tests/test_alerts_gateway.py|\
               scripts/tests/test_ci_service_images_use_mirror.py|\
               scripts/tests/test_lint_workflow_errexit_decap.py|\
               scripts/lint_workflow_errexit_decap.py|\
@@ -264,6 +266,20 @@ jobs:
             fi
           done
           exit $fail
+
+      - name: garuda alert gateway guilt+innocence (apps/zantara-media)
+        if: steps.paths.outputs.relevant == 'true'
+        # Its own step, not the loop above: the loop runs `pytest <path>` from
+        # the repo root and this corpus imports `zantara_media`, which lives
+        # under apps/. Both files ARE sentinel trigger paths, so a PR that
+        # guts either one runs this.
+        #
+        # DECLARED GAP: test_immune_enforcement_trigger_symmetry.py only reads
+        # the loop's `scripts/**.py` entries, so it cannot vouch for this step.
+        # Armed here at birth precisely because nothing else runs
+        # apps/zantara-media's tests — no workflow did, which is how the alert
+        # path stayed mute for 141 nights.
+        run: PYTHONPATH=apps/zantara-media python -m pytest apps/zantara-media/tests/test_alerts_gateway.py -q
 
       - name: PII gate merge-scope guilt+innocence (.husky/pre-commit)
         if: steps.paths.outputs.relevant == 'true'

--- a/apps/zantara-media/tests/test_alerts_gateway.py
+++ b/apps/zantara-media/tests/test_alerts_gateway.py
@@ -1,0 +1,187 @@
+"""The organ that KNEW the credential was dead could not speak, 141 nights running.
+
+TRAUMA (2026-08-06). `zantara_media.alerts.send_critical_alert` POSTed straight
+to the Telegram API with a token read from the caller's environment:
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if not token:
+        logger.warning("TELEGRAM_BOT_TOKEN not set — cannot send alert: %s", message)
+        return
+
+`garuda-indexer` runs from cron (`36 20 * * *` on Pro), and cron's environment
+does not carry that variable. Measured on Pro before touching anything:
+
+    $ grep -c invalid_grant ~/logs/cron-tmp/garuda-indexer.log
+    141
+    ... 2026-08-05 20:36:12 [WARNING] zantara_media.alerts:
+        TELEGRAM_BOT_TOKEN not set — cannot send alert:
+        💥 GARUDA indexer CRASHED: ('invalid_grant: Token has been expired or revoked', ...)
+
+Google was answering `invalid_grant` on every nightly run since at least
+2026-07-27. The indexer exited 1 each time. The alarm logged its own silence
+and returned. W108: the alarm depended on something the environment it runs in
+does not provide, and left the failure in a log nobody reads.
+
+This is also the reason the Drive outage was found by hand rather than
+reported: the watchdog that was SUPPOSED to warn was blind for unrelated
+reasons (#3690 PATH, then the fly credential, then a day-ladder over a
+one-hour clock), and the organ that actually KNEW was muted here.
+
+The cure is not to teach this module to find the secret — that is the
+gateway's job, and `scripts/tg_notify.py` already falls back to
+`~/.nuzantara-secrets.env` when the environment is bare.
+
+    GUILT      — with NO TELEGRAM_BOT_TOKEN in the environment, the exact
+                 production shape, the alert still leaves the process
+    GUILT      — a missing gateway is reported at ERROR *with the payload*,
+                 never a quiet return
+    GUILT      — a non-zero gateway rc is surfaced, not swallowed
+    INNOCENCE  — never raises, whatever happens; the indexer must still exit
+                 on its own terms
+    KEY        — distinct conditions get distinct dedup keys, or one failure's
+                 repeat ladder swallows another's first occurrence
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from zantara_media import alerts
+
+
+@pytest.fixture
+def gateway(tmp_path, monkeypatch):
+    """A repo-shaped tmp dir with a tg_notify.py the tests can point at."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "tg_notify.py").write_text("")
+    monkeypatch.setenv("NUZANTARA_REPO_ROOT", str(tmp_path))
+    return scripts / "tg_notify.py"
+
+
+class _Proc:
+    def __init__(self, rc: int, stderr: bytes = b""):
+        self.returncode = rc
+        self._stderr = stderr
+
+    async def communicate(self):
+        return b"", self._stderr
+
+
+def _record_exec(monkeypatch, rc: int = 0, stderr: bytes = b""):
+    """Capture the argv the gateway would be invoked with."""
+    calls: list[tuple] = []
+
+    async def fake_exec(*args, **kwargs):
+        calls.append(args)
+        return _Proc(rc, stderr)
+
+    monkeypatch.setattr(alerts.asyncio, "create_subprocess_exec", fake_exec)
+    return calls
+
+
+# ------------------------------------------------------------------- guilt
+def test_it_speaks_with_no_telegram_token_in_the_environment(
+    gateway, monkeypatch
+):
+    """THE defect, in its exact production shape. `send_critical_alert` used
+    to check `os.getenv("TELEGRAM_BOT_TOKEN")` first and return when it was
+    absent — which, under cron, is always."""
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    calls = _record_exec(monkeypatch)
+
+    ok = asyncio.run(alerts.send_critical_alert("indexer died", condition="x"))
+
+    assert ok is True
+    assert calls, (
+        "nothing was invoked with a bare environment — this is the 141-night "
+        "silence, reproduced"
+    )
+    argv = calls[0]
+    assert str(gateway) in argv, argv
+    assert "indexer died" in argv[-1], argv
+
+
+def test_a_missing_gateway_is_loud_and_carries_the_payload(monkeypatch, caplog):
+    """If the alert cannot leave the machine, the log is the last place it
+    exists — so it must be there at ERROR, with the body. The old code logged
+    at WARNING and let the urgency drain out with the message."""
+    monkeypatch.setenv("NUZANTARA_REPO_ROOT", "/nonexistent")
+    monkeypatch.setattr(alerts.Path, "home", staticmethod(lambda: alerts.Path("/nonexistent")))
+    monkeypatch.setattr(alerts, "_resolve_gateway", lambda: None)
+
+    with caplog.at_level(logging.ERROR):
+        ok = asyncio.run(alerts.send_critical_alert("the roof is on fire"))
+
+    assert ok is False
+    assert any(
+        r.levelno >= logging.ERROR and "the roof is on fire" in r.getMessage()
+        for r in caplog.records
+    ), f"the payload never reached the log: {[r.getMessage() for r in caplog.records]}"
+
+
+def test_a_failing_gateway_is_surfaced_not_swallowed(gateway, monkeypatch, caplog):
+    _record_exec(monkeypatch, rc=3, stderr=b"budget exhausted")
+
+    with caplog.at_level(logging.ERROR):
+        ok = asyncio.run(alerts.send_critical_alert("boom"))
+
+    assert ok is False
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "rc=3" in joined, joined
+    assert "budget exhausted" in joined, joined
+
+
+def test_the_rc_is_logged_even_on_success(gateway, monkeypatch, caplog):
+    """A silent success is how you end up unable to tell "it sent" from "it
+    never ran" — which is the whole shape of this trauma."""
+    _record_exec(monkeypatch, rc=0)
+
+    with caplog.at_level(logging.INFO):
+        assert asyncio.run(alerts.send_critical_alert("fine")) is True
+
+    assert any("rc=0" in r.getMessage() for r in caplog.records)
+
+
+# --------------------------------------------------------------- innocence
+@pytest.mark.parametrize("boom", [OSError("no exec"), asyncio.TimeoutError()])
+def test_it_never_raises_whatever_happens(gateway, monkeypatch, boom):
+    """An alert must not crash the indexer. Both the "cannot invoke" and the
+    "hangs forever" paths return False instead of propagating."""
+
+    async def exploding(*args, **kwargs):
+        raise boom
+
+    monkeypatch.setattr(alerts.asyncio, "create_subprocess_exec", exploding)
+    assert asyncio.run(alerts.send_critical_alert("x")) is False
+
+
+# --------------------------------------------------------------------- key
+def test_distinct_conditions_get_distinct_dedup_keys(gateway, monkeypatch):
+    """A crash and a nightly "files archived" summary must not share a key:
+    the ladder of whichever fires first would swallow the other's FIRST
+    occurrence, and that is the one that matters (#3677)."""
+    calls = _record_exec(monkeypatch)
+
+    asyncio.run(alerts.send_critical_alert("crashed", condition="indexer-crash"))
+    asyncio.run(alerts.send_critical_alert("archived 3", condition="gc-summary"))
+
+    keys = [argv[argv.index("--dedup-key") + 1] for argv in calls]
+    assert len(keys) == 2, keys
+    assert keys[0] != keys[1], f"both conditions produced {keys[0]!r}"
+    assert "indexer-crash" in keys[0] and "gc-summary" in keys[1], keys
+
+
+def test_the_key_is_stable_across_runs_of_the_same_condition(gateway, monkeypatch):
+    """INNOCENCE for the above: the key must NOT move with the message body,
+    or every night mints a fresh key and the repeat ladder never applies."""
+    calls = _record_exec(monkeypatch)
+
+    asyncio.run(alerts.send_critical_alert("CRASHED: error at 20:36:12", condition="c"))
+    asyncio.run(alerts.send_critical_alert("CRASHED: error at 20:36:14", condition="c"))
+
+    keys = [argv[argv.index("--dedup-key") + 1] for argv in calls]
+    assert keys[0] == keys[1], f"the key moved with the message: {keys}"

--- a/apps/zantara-media/tests/test_drive_client_credentials.py
+++ b/apps/zantara-media/tests/test_drive_client_credentials.py
@@ -205,3 +205,96 @@ def test_a_non_service_account_file_is_rejected_by_name(tmp_path):
 
     with pytest.raises(ValueError, match="not a service-account key"):
         drive_client._load_sa_credentials(str(bad))
+
+
+# ------------------------------------------------- the scope under the grant
+@pytest.fixture
+def fake_oauth_db(monkeypatch):
+    """Stand in for asyncpg + google.oauth2.credentials on the LEGACY path.
+
+    Captures the scope list the refresh is built with. That list is not
+    cosmetic: Google validates it against what the consent screen actually
+    granted and rejects the whole refresh — it does not quietly drop an extra.
+    """
+    seen: dict = {}
+
+    class _Creds:
+        def __init__(self, **kw):
+            seen.update(kw)
+
+    class _Conn:
+        async def fetchrow(self, *a, **k):
+            return {
+                "access_token": "at",
+                "refresh_token": "rt",
+                "expires_at": None,
+            }
+
+        async def close(self):
+            seen["closed"] = True
+
+    async def _connect(url):
+        seen["dsn_given"] = bool(url)
+        return _Conn()
+
+    aspg = types.ModuleType("asyncpg")
+    aspg.connect = _connect
+    monkeypatch.setitem(sys.modules, "asyncpg", aspg)
+
+    mod = types.ModuleType("google.oauth2.credentials")
+    mod.Credentials = _Creds
+    pkg_oauth2 = sys.modules.get("google.oauth2") or types.ModuleType("google.oauth2")
+    pkg_google = sys.modules.get("google") or types.ModuleType("google")
+    monkeypatch.setattr(pkg_oauth2, "credentials", mod, raising=False)
+    monkeypatch.setattr(pkg_google, "oauth2", pkg_oauth2, raising=False)
+    monkeypatch.setitem(sys.modules, "google", pkg_google)
+    monkeypatch.setitem(sys.modules, "google.oauth2", pkg_oauth2)
+    monkeypatch.setitem(sys.modules, "google.oauth2.credentials", mod)
+
+    monkeypatch.setenv("DATABASE_URL", "postgres://probe/none")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "csec")
+    return seen
+
+
+def test_the_legacy_refresh_never_asks_for_a_scope_the_consent_did_not_grant(
+    fake_oauth_db,
+):
+    """THE defect that outlived the revocation.
+
+    The consent screen builds its authorize URL with ONE scope
+    (`admin_drive_auth.py:47` — `scope=…/auth/drive`, singular). This call site
+    asked for `drive` AND `drive.readonly`, and Google answers a refresh that
+    names an ungranted scope with `invalid_scope: Bad Request`.
+
+    It was invisible for as long as the credential was also revoked, because
+    `invalid_grant` is decided first. Measured on Pro 2026-08-06: the night
+    after the re-auth, `invalid_grant` vanished and `invalid_scope` took its
+    place — 14 runs of it in the log, back to 2026-06-28.
+    """
+    asyncio.run(drive_client._load_creds_from_db())
+
+    assert "drive.readonly" not in " ".join(fake_oauth_db["scopes"]), (
+        "asking for a scope the grant never contained fails the WHOLE refresh; "
+        "Google does not ignore the extra"
+    )
+    assert fake_oauth_db["scopes"] == ["https://www.googleapis.com/auth/drive"], (
+        "must be exactly the scope admin_drive_auth.py sends to the consent "
+        "screen — anything else is a refresh that cannot succeed"
+    )
+
+
+def test_the_two_scope_lists_are_separate_objects(fake_oauth_db):
+    """Innocence, and a design assertion.
+
+    SA_SCOPES and OAUTH_SCOPES hold the same string today. They are NOT the
+    same thing: one is bounded by the Workspace admin console's delegation, the
+    other by what a human approved on a consent screen. Sharing one constant
+    would make widening the delegation silently widen the user grant's request
+    — which is precisely the class of mistake this test file exists for.
+    """
+    assert drive_client.SA_SCOPES is not drive_client.OAUTH_SCOPES
+    asyncio.run(drive_client._load_creds_from_db())
+    assert fake_oauth_db["scopes"] is drive_client.OAUTH_SCOPES, (
+        "the legacy path must read OAUTH_SCOPES, not an inlined literal"
+    )

--- a/apps/zantara-media/tests/test_drive_client_credentials.py
+++ b/apps/zantara-media/tests/test_drive_client_credentials.py
@@ -1,0 +1,207 @@
+"""GARUDA indexed Drive with a REVOCABLE user token, and it was revoked.
+
+TRAUMA (2026-08-06). `drive_client.get_drive_service` loaded a per-user OAuth
+row out of `google_drive_tokens`. On 2026-07-25 that token was revoked, and
+from then on every nightly run died:
+
+    google.auth.exceptions.RefreshError:
+        invalid_grant: Token has been expired or revoked
+    ... 141 occurrences in ~/logs/cron-tmp/garuda-indexer.log
+
+Eleven nights, exit=1 each time, until a human re-authorised by hand. The
+backend had already abandoned this credential class on 2026-05-10 —
+`GoogleDriveService._refresh_token` refuses to refresh the SYSTEM row and 16
+production files use `ServiceAccountDriveService` instead — but this indexer
+was never migrated with them.
+
+A service-account key does not expire and needs no consent screen. Verified
+against the live API before making it preferred, because the identities are
+NOT the same and this could silently have indexed an empty Drive: the GARUDA
+folders are owned by a personal account, and the delegated subject
+`zero@balizero.com` resolves root/photos/published anyway — they are shared.
+
+    GUILT      — with an SA key present, the DB is never touched
+    GUILT      — the SA is built with delegation, and with the ONE scope the
+                 domain-wide grant actually carries
+    INNOCENCE  — no SA key → the legacy DB path still works (rollback lives)
+    INNOCENCE  — GARUDA_DRIVE_FORCE_OAUTH=1 backs the change out with no deploy
+    CONTRACT   — an SA key handed to GOOGLE_DRIVE_CREDENTIALS_FILE is accepted,
+                 because the docstring promises that entry takes either kind
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+
+import pytest
+
+from zantara_media.indexer import drive_client
+
+
+@pytest.fixture
+def sa_key(tmp_path):
+    """A syntactically valid service-account key. Not a real credential."""
+    p = tmp_path / "sa.json"
+    p.write_text(
+        json.dumps(
+            {
+                "type": "service_account",
+                "client_email": "probe@example.iam.gserviceaccount.com",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----\n",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            }
+        )
+    )
+    return p
+
+
+@pytest.fixture
+def fake_google(monkeypatch):
+    """Stand in for google.oauth2.service_account and the discovery build.
+
+    Captures what the code ASKS for — scopes and subject — because those are
+    the two things a domain-wide grant can refuse, and getting either wrong
+    fails at the token exchange with a message that reads like a broken key.
+    """
+    seen: dict = {}
+
+    class _Creds:
+        def with_subject(self, subject):
+            seen["subject"] = subject
+            return self
+
+    class _SA:
+        @staticmethod
+        def from_service_account_info(info, scopes=None):
+            seen["info"] = info
+            seen["scopes"] = scopes
+            return _Creds()
+
+    # `from google.oauth2 import service_account` imports the PARENT package
+    # and then getattrs the child, so registering only the leaf in sys.modules
+    # is not enough — the google libraries are not installed in this venv.
+    mod = types.ModuleType("google.oauth2.service_account")
+    mod.Credentials = _SA
+    pkg_oauth2 = sys.modules.get("google.oauth2") or types.ModuleType("google.oauth2")
+    pkg_google = sys.modules.get("google") or types.ModuleType("google")
+    monkeypatch.setattr(pkg_oauth2, "service_account", mod, raising=False)
+    monkeypatch.setattr(pkg_google, "oauth2", pkg_oauth2, raising=False)
+    monkeypatch.setitem(sys.modules, "google", pkg_google)
+    monkeypatch.setitem(sys.modules, "google.oauth2", pkg_oauth2)
+    monkeypatch.setitem(sys.modules, "google.oauth2.service_account", mod)
+
+    monkeypatch.setattr(
+        drive_client, "_build_drive_service", lambda creds: ("service", creds)
+    )
+    return seen
+
+
+# ------------------------------------------------------------------- guilt
+def test_the_service_account_is_preferred_and_the_db_is_never_touched(
+    sa_key, fake_google, monkeypatch
+):
+    """THE migration. With a key on disk the revocable path must not run at
+    all — not "run and be ignored", not "run as a fallback": not run."""
+
+    async def exploding_db():
+        pytest.fail("the legacy google_drive_tokens path was still used")
+
+    monkeypatch.setattr(drive_client, "_load_creds_from_db", exploding_db)
+    monkeypatch.setenv("GARUDA_DRIVE_SA_FILE", str(sa_key))
+    monkeypatch.delenv("GARUDA_DRIVE_FORCE_OAUTH", raising=False)
+
+    asyncio.run(drive_client.get_drive_service())
+    assert fake_google["info"]["type"] == "service_account"
+
+
+def test_it_delegates_with_the_single_granted_scope(sa_key, fake_google, monkeypatch):
+    """Domain-wide delegation grants scopes explicitly. This SA carries only
+    `drive`; asking for the `drive.readonly` the legacy OAuth path requests
+    fails the whole token exchange with `unauthorized_client`, which reads like
+    a broken key rather than a missing grant."""
+    monkeypatch.setattr(drive_client, "_load_creds_from_db", None)
+    monkeypatch.setenv("GARUDA_DRIVE_SA_FILE", str(sa_key))
+
+    asyncio.run(drive_client.get_drive_service())
+
+    assert fake_google["scopes"] == ["https://www.googleapis.com/auth/drive"], (
+        fake_google["scopes"]
+    )
+    assert fake_google["subject"] == "zero@balizero.com", (
+        "without impersonation the SA sees its own empty Drive, not GARUDA"
+    )
+
+
+def test_the_subject_is_overridable(sa_key, fake_google, monkeypatch):
+    monkeypatch.setenv("GARUDA_DRIVE_SA_FILE", str(sa_key))
+    monkeypatch.setenv("GARUDA_DRIVE_SUBJECT", "someone@balizero.com")
+
+    asyncio.run(drive_client.get_drive_service())
+    assert fake_google["subject"] == "someone@balizero.com"
+
+
+# --------------------------------------------------------------- innocence
+def test_without_a_key_the_legacy_path_still_runs(monkeypatch, tmp_path):
+    """The rollback has to exist, so it has to be tested. Deleting the legacy
+    branch would leave no way back if the SA turns out to be misconfigured."""
+    used = []
+
+    async def fake_db():
+        used.append("db")
+        return "legacy-creds"
+
+    monkeypatch.setattr(drive_client, "_load_creds_from_db", fake_db)
+    monkeypatch.setattr(drive_client, "_build_drive_service", lambda c: ("svc", c))
+    monkeypatch.setenv("GARUDA_DRIVE_SA_FILE", str(tmp_path / "absent.json"))
+    monkeypatch.delenv("GOOGLE_DRIVE_CREDENTIALS_FILE", raising=False)
+
+    assert asyncio.run(drive_client.get_drive_service()) == ("svc", "legacy-creds")
+    assert used == ["db"]
+
+
+def test_force_oauth_backs_the_change_out_without_a_deploy(
+    sa_key, monkeypatch
+):
+    """INNOCENCE, and it is the reason the kill-switch exists: a key present on
+    disk must not be able to trap the indexer on a path that does not work."""
+    used = []
+
+    async def fake_db():
+        used.append("db")
+        return "legacy-creds"
+
+    monkeypatch.setattr(drive_client, "_load_creds_from_db", fake_db)
+    monkeypatch.setattr(drive_client, "_build_drive_service", lambda c: ("svc", c))
+    monkeypatch.setenv("GARUDA_DRIVE_SA_FILE", str(sa_key))
+    monkeypatch.setenv("GARUDA_DRIVE_FORCE_OAUTH", "1")
+    monkeypatch.delenv("GOOGLE_DRIVE_CREDENTIALS_FILE", raising=False)
+
+    asyncio.run(drive_client.get_drive_service())
+    assert used == ["db"], "the kill-switch did not reach the legacy path"
+
+
+# ---------------------------------------------------------------- contract
+def test_an_sa_key_via_the_generic_file_var_is_accepted(
+    sa_key, fake_google, monkeypatch, tmp_path
+):
+    """`get_drive_service`'s docstring says entry 2 takes OAuth2 *or* SA. A
+    promise a function does not keep is the defect this change is about."""
+    monkeypatch.setenv("GARUDA_DRIVE_SA_FILE", str(tmp_path / "absent.json"))
+    monkeypatch.setenv("GOOGLE_DRIVE_CREDENTIALS_FILE", str(sa_key))
+
+    asyncio.run(drive_client.get_drive_service())
+    assert fake_google["info"]["type"] == "service_account"
+
+
+def test_a_non_service_account_file_is_rejected_by_name(tmp_path):
+    """The error must say WHAT it got. `_load_sa_credentials` pointed at an
+    OAuth token file used to die inside the google library with a message
+    about the key format."""
+    bad = tmp_path / "oauth.json"
+    bad.write_text(json.dumps({"type": "authorized_user", "token": "x"}))
+
+    with pytest.raises(ValueError, match="not a service-account key"):
+        drive_client._load_sa_credentials(str(bad))

--- a/apps/zantara-media/zantara_media/alerts.py
+++ b/apps/zantara-media/zantara_media/alerts.py
@@ -1,35 +1,136 @@
-"""Telegram CRITICAL alerts for GARUDA system."""
-import logging
-import os
+"""CRITICAL alerts for GARUDA — routed through the fleet Telegram gateway.
 
-import httpx
+REWRITTEN 2026-08-06. This module used to POST straight to the Telegram API
+with a token read from the caller's environment:
 
-logger = logging.getLogger(__name__)
-
-TELEGRAM_API_URL = "https://api.telegram.org/bot{token}/sendMessage"
-
-
-async def send_critical_alert(message: str) -> None:
-    """Send CRITICAL alert to Telegram owner chat. Never raises — log and swallow on failure."""
     token = os.getenv("TELEGRAM_BOT_TOKEN")
-    chat_id = os.getenv("TELEGRAM_OWNER_CHAT_ID", "1125336968")
-
     if not token:
         logger.warning("TELEGRAM_BOT_TOKEN not set — cannot send alert: %s", message)
         return
 
-    url = TELEGRAM_API_URL.format(token=token)
-    payload = {
-        "chat_id": chat_id,
-        "text": f"🚨 GARUDA CRITICAL\n\n{message}",
-        "parse_mode": "HTML",
-    }
+`garuda-indexer` runs from cron, and cron's environment does not carry that
+variable. So every alert this module has ever been asked to send from cron
+took the early return. Measured on Pro:
+
+    $ grep -c invalid_grant ~/logs/cron-tmp/garuda-indexer.log
+    141
+
+The Drive OAuth credential was revoked; Google said so, out loud, on every
+nightly run since at least 2026-07-27; the indexer crashed with exit=1 each
+time; and the line that was supposed to tell somebody read
+"TELEGRAM_BOT_TOKEN not set — cannot send alert". W108 exactly: the alarm
+depends on something the environment it runs in does not provide, and it
+leaves its failure in a log nobody reads instead of on the channel.
+
+The cure is not to teach this module to find the secret — that is the
+gateway's job, and it already does it (`scripts/tg_notify.py` falls back to
+`~/.nuzantara-secrets.env` when the env is bare). Routing through it also
+buys the dedup ladder, the tier budget and the spool, so a nightly crash
+becomes about four messages a week instead of thirty.
+
+Two rules kept from before: this never raises (an alert must not crash the
+indexer), and it never blocks for long. One rule added: the outcome is always
+LOGGED and returned, so "did it speak?" is answerable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_GATEWAY_TIMEOUT_S = 30.0
+
+
+def _resolve_gateway() -> Path | None:
+    """Locate `scripts/tg_notify.py`, most-explicit first.
+
+    The package is installed into a venv outside the repo, so a purely
+    relative resolution is not enough on its own — but it is kept last so a
+    checkout in an unusual place still works.
+    """
+    candidates = [
+        os.environ.get("NUZANTARA_REPO_ROOT"),
+        str(Path.home() / "nuzantara"),
+        str(Path(__file__).resolve().parents[3]),
+    ]
+    for root in candidates:
+        if not root:
+            continue
+        gateway = Path(root) / "scripts" / "tg_notify.py"
+        if gateway.is_file():
+            return gateway
+    return None
+
+
+async def send_critical_alert(message: str, condition: str = "crash") -> bool:
+    """Send a CRITICAL alert through the fleet gateway. Never raises.
+
+    `condition` names WHAT is wrong, and becomes part of the dedup key. It is
+    not the message: the message embeds an exception string that changes run
+    to run, and a key derived from it would mint a fresh key every night and
+    defeat the repeat ladder entirely (#3677). Callers with distinct failures
+    must pass distinct conditions, or one will swallow the other.
+
+    Returns True if the gateway accepted the alert.
+    """
+    gateway = _resolve_gateway()
+    if gateway is None:
+        # Loud, and carrying the payload: if the alert cannot leave the
+        # machine, the log is the last place it exists. The old code logged
+        # at WARNING and dropped the body's urgency with it.
+        logger.error(
+            "tg_notify.py not found (tried NUZANTARA_REPO_ROOT, ~/nuzantara, "
+            "package-relative) — GARUDA alert NOT delivered: %s",
+            message,
+        )
+        return False
+
+    host = socket.gethostname().split(".")[0]
+    dedup_key = f"garuda:{condition}:{host}"
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(url, json=payload)
-            if response.status_code != 200:
-                logger.error("Telegram alert failed: %s %s", response.status_code, response.text)
+        # sys.executable, not a PATH lookup: this runs inside the venv whose
+        # health is one of the things being reported on, and resolving the
+        # interpreter through PATH is how run_nb5_t4_monitor.sh ended up
+        # reporting its failures on the interpreter that had just broken.
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(gateway),
+            "--tier", "p0",
+            "--source", "garuda",
+            "--dedup-key", dedup_key,
+            "--",
+            f"🚨 GARUDA CRITICAL\n\n{message}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_GATEWAY_TIMEOUT_S
+        )
+    except asyncio.TimeoutError:
+        logger.error("tg_notify timed out after %ss — alert NOT delivered: %s",
+                     _GATEWAY_TIMEOUT_S, message)
+        return False
     except Exception as e:
-        logger.error("Failed to send Telegram alert: %s", e)
-        # Never raise — alerts should never crash the indexer
+        # Never raise — alerts must not crash the caller.
+        logger.error("tg_notify could not be invoked (%s) — alert NOT delivered: %s",
+                     e, message)
+        return False
+
+    ok = proc.returncode == 0
+    # The rc is ALWAYS logged, success or not. A silent success is how you end
+    # up unable to tell "it sent" from "it never ran".
+    logger.log(
+        logging.INFO if ok else logging.ERROR,
+        "tg_notify rc=%s key=%s%s",
+        proc.returncode,
+        dedup_key,
+        "" if ok else f" stderr={(stderr or b'').decode()[:300]}",
+    )
+    return ok

--- a/apps/zantara-media/zantara_media/cli/garuda_gc.py
+++ b/apps/zantara-media/zantara_media/cli/garuda_gc.py
@@ -44,7 +44,7 @@ async def async_main(dry_run: bool, batch_size: int) -> int:
         return 0
     except Exception as e:
         logger.exception("GC failed: %s", e)
-        await send_critical_alert(f"💥 GARUDA GC FAILED: {e}")
+        await send_critical_alert(f"💥 GARUDA GC FAILED: {e}", condition="gc-crash")
         return 1
 
 

--- a/apps/zantara-media/zantara_media/cli/garuda_indexer.py
+++ b/apps/zantara-media/zantara_media/cli/garuda_indexer.py
@@ -62,7 +62,8 @@ async def async_main(worker_name: str, dry_run: bool) -> int:
         consecutive = result.get("errors", 0)
         if consecutive >= 3:
             await send_critical_alert(
-                f"⚠️ GARUDA indexer: {consecutive} errors in last run (worker={worker_name})"
+                f"⚠️ GARUDA indexer: {consecutive} errors in last run (worker={worker_name})",
+                condition="indexer-errors",
             )
 
         # The OAuth expiry check that used to live here is DELETED, 2026-08-06.
@@ -95,7 +96,9 @@ async def async_main(worker_name: str, dry_run: bool) -> int:
         return 0
     except Exception as e:
         logger.exception("Fatal error in indexer: %s", e)
-        await send_critical_alert(f"💥 GARUDA indexer CRASHED: {e}")
+        await send_critical_alert(
+            f"💥 GARUDA indexer CRASHED: {e}", condition="indexer-crash"
+        )
         return 1
 
 

--- a/apps/zantara-media/zantara_media/indexer/drive_client.py
+++ b/apps/zantara-media/zantara_media/indexer/drive_client.py
@@ -116,34 +116,119 @@ def _parse_change(change_data: dict) -> Change:
 # ---------------------------------------------------------------------------
 
 
+SA_DEFAULT_PATH = os.path.expanduser("~/.nuzantara-drive-sa.json")
+
+# The Workspace user the service account impersonates. Same identity the
+# backend uses (ServiceAccountDriveService), and the GARUDA folders — owned by
+# a personal account — are shared with it. Verified against the live API on
+# 2026-08-06 before this path was made preferred: root/photos/published all
+# resolve for this subject.
+SA_SUBJECT_DEFAULT = "zero@balizero.com"
+
+# ONLY `drive`, deliberately — not the `drive` + `drive.readonly` pair the
+# legacy OAuth path below asks for. Domain-wide delegation grants scopes
+# explicitly in the Workspace admin console, and this service account has just
+# the one; requesting an ungranted scope fails the token exchange outright with
+# `unauthorized_client`, which reads like a broken key rather than a missing
+# grant. Same single scope the backend's ServiceAccountDriveService uses.
+SA_SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+
 async def get_drive_service():  # type: ignore[return]
     """
     Build and return a Google Drive v3 service object.
 
-    Token resolution order:
-    1. ``GOOGLE_DRIVE_CREDENTIALS_FILE`` env var → path to OAuth2 JSON file.
-    2. ``google_drive_tokens`` Postgres table (asyncpg, DATABASE_URL).
+    Credential resolution order, most-preferred first:
+
+    1. **Service account** at ``GARUDA_DRIVE_SA_FILE`` (default
+       ``~/.nuzantara-drive-sa.json``), impersonating ``GARUDA_DRIVE_SUBJECT``
+       via domain-wide delegation.
+    2. ``GOOGLE_DRIVE_CREDENTIALS_FILE`` → JSON file (OAuth2 *or* SA).
+    3. ``google_drive_tokens`` Postgres row — legacy per-user OAuth.
+
+    WHY THE SERVICE ACCOUNT IS FIRST (2026-08-06). Path 3 is a user OAuth
+    token, and a user token can be REVOKED. On 2026-07-25 this one was, and
+    the indexer then crashed nightly for eleven nights with
+    ``invalid_grant: Token has been expired or revoked`` — 141 occurrences —
+    until a human re-authorised it by hand. The backend abandoned this same
+    credential class on 2026-05-10 for exactly that reason
+    (``GoogleDriveService._refresh_token`` refuses to refresh the SYSTEM row;
+    16 production files use ``ServiceAccountDriveService`` instead). A service
+    account key does not expire and needs no consent screen.
+
+    Path 3 is kept, not deleted: it is the rollback. ``GARUDA_DRIVE_FORCE_OAUTH=1``
+    skips the service account entirely, so a bad SA can be backed out without
+    a deploy.
 
     The blocking ``build()`` call is wrapped in run_in_executor.
     """
     loop = asyncio.get_event_loop()
 
-    creds_file = os.environ.get("GOOGLE_DRIVE_CREDENTIALS_FILE")
-    if creds_file:
-        creds = await loop.run_in_executor(None, _load_creds_from_file, creds_file)
+    sa_path = os.environ.get("GARUDA_DRIVE_SA_FILE", SA_DEFAULT_PATH)
+    force_oauth = os.environ.get("GARUDA_DRIVE_FORCE_OAUTH") == "1"
+
+    if not force_oauth and os.path.isfile(sa_path):
+        creds = await loop.run_in_executor(None, _load_sa_credentials, sa_path)
+        # W106: say WHICH source was accepted. When this organ next misleads
+        # someone, the log should not make them guess which credential ran.
+        logger.info("Drive credentials: service account file %s", sa_path)
     else:
-        creds = await _load_creds_from_db()
+        creds_file = os.environ.get("GOOGLE_DRIVE_CREDENTIALS_FILE")
+        if creds_file:
+            creds = await loop.run_in_executor(None, _load_creds_from_file, creds_file)
+            logger.info("Drive credentials: file %s", creds_file)
+        else:
+            creds = await _load_creds_from_db()
+            logger.warning(
+                "Drive credentials: legacy user OAuth from google_drive_tokens "
+                "(revocable — see get_drive_service docstring). force_oauth=%s "
+                "sa_path_present=%s",
+                force_oauth,
+                os.path.isfile(sa_path),
+            )
 
     service = await loop.run_in_executor(None, _build_drive_service, creds)
     return service
 
 
+def _load_sa_credentials(path: str):
+    """Build delegated service-account credentials from a JSON key file."""
+    with open(path) as fh:
+        info = json.load(fh)
+
+    # Validated BEFORE the import: rejecting the wrong file should not depend
+    # on a heavy optional library being installed, and the reason a caller
+    # gets back should name what was actually on disk.
+    if info.get("type") != "service_account":
+        raise ValueError(
+            f"{path!r} is not a service-account key (type={info.get('type')!r})"
+        )
+
+    from google.oauth2 import service_account  # type: ignore[import]
+
+    subject = os.environ.get("GARUDA_DRIVE_SUBJECT", SA_SUBJECT_DEFAULT)
+    return service_account.Credentials.from_service_account_info(
+        info, scopes=SA_SCOPES
+    ).with_subject(subject)
+
+
 def _load_creds_from_file(path: str):
     """Load OAuth2 credentials from a JSON file (blocking)."""
-    from google.oauth2.credentials import Credentials  # type: ignore[import]
-
     with open(path) as fh:
         data = json.load(fh)
+
+    # A service-account key handed to this path is routed to the SA builder
+    # rather than rejected: the docstring of get_drive_service promises this
+    # entry accepts either kind, and a promise a function does not keep is the
+    # defect this whole change is about.
+    #
+    # Routed BEFORE the OAuth import, deliberately: importing the user-token
+    # library on the way to a branch that never uses it makes the SA path
+    # depend on a package it has nothing to do with.
+    if data.get("type") == "service_account":
+        return _load_sa_credentials(path)
+
+    from google.oauth2.credentials import Credentials  # type: ignore[import]
 
     # Support both raw token JSON and "installed" / "web" client-secret format.
     if "token" in data:

--- a/apps/zantara-media/zantara_media/indexer/drive_client.py
+++ b/apps/zantara-media/zantara_media/indexer/drive_client.py
@@ -125,13 +125,19 @@ SA_DEFAULT_PATH = os.path.expanduser("~/.nuzantara-drive-sa.json")
 # resolve for this subject.
 SA_SUBJECT_DEFAULT = "zero@balizero.com"
 
-# ONLY `drive`, deliberately — not the `drive` + `drive.readonly` pair the
-# legacy OAuth path below asks for. Domain-wide delegation grants scopes
-# explicitly in the Workspace admin console, and this service account has just
-# the one; requesting an ungranted scope fails the token exchange outright with
+# ONLY `drive`, deliberately. Domain-wide delegation grants scopes explicitly in
+# the Workspace admin console, and this service account has just the one;
+# requesting an ungranted scope fails the token exchange outright with
 # `unauthorized_client`, which reads like a broken key rather than a missing
 # grant. Same single scope the backend's ServiceAccountDriveService uses.
 SA_SCOPES = ["https://www.googleapis.com/auth/drive"]
+
+# The scope set for the legacy per-user OAuth row. Deliberately a SEPARATE
+# literal from SA_SCOPES even though the two are identical today: they are equal
+# by coincidence, not by construction. One is bounded by what the Workspace
+# admin console delegated, the other by what the consent screen asked the human
+# to approve, and widening either must not silently widen the other.
+OAUTH_SCOPES = ["https://www.googleapis.com/auth/drive"]
 
 
 async def get_drive_service():  # type: ignore[return]
@@ -292,10 +298,22 @@ async def _load_creds_from_db():
         token_uri="https://oauth2.googleapis.com/token",
         client_id=client_id,
         client_secret=client_secret,
-        scopes=[
-            "https://www.googleapis.com/auth/drive",
-            "https://www.googleapis.com/auth/drive.readonly",
-        ],
+        # ONE scope, and it must be exactly the one the consent screen asked
+        # for. `admin_drive_auth.py:47` builds the authorize URL with
+        # `scope=https://www.googleapis.com/auth/drive` — singular — and every
+        # other consumer of this row (`drive_auth.py:32`,
+        # `google_drive_service.py:34`) refreshes with that same single scope.
+        # This call site was the only one asking for `drive.readonly` as well,
+        # a scope the grant never contained, and Google rejects the whole
+        # refresh with `invalid_scope: Bad Request` rather than ignoring the
+        # extra. `drive` is a superset of `drive.readonly`, so nothing is lost.
+        #
+        # Measured on Pro, 2026-08-06: after the credential was re-authed the
+        # nightly run stopped answering `invalid_grant` and immediately
+        # answered `invalid_scope` instead — the older defect underneath. The
+        # log carries 14 such runs going back to 2026-06-28, the day after the
+        # last run that reached Drive without an auth error at all.
+        scopes=OAUTH_SCOPES,
     )
 
 

--- a/apps/zantara-media/zantara_media/maintenance/gc.py
+++ b/apps/zantara-media/zantara_media/maintenance/gc.py
@@ -67,7 +67,9 @@ async def run_gc(dry_run: bool = False, batch_size: int = 100) -> dict:
 
         # Send Telegram summary only if something was archived
         if stats["archived"] > 0:
-            await send_critical_alert(msg)
+            # A routine summary, not a failure: its own condition, so the ladder
+            # of a nightly "files archived" note can never swallow a crash.
+            await send_critical_alert(msg, condition="gc-summary")
 
     finally:
         await qdrant.close()


### PR DESCRIPTION
## The outage, measured rather than remembered

The GARUDA nightly indexer parses **78 runs since 2026-04-30**. Two of them succeeded: 2026-05-05 and 2026-06-25. The last run that reached Drive with **no auth error at all** was **2026-06-27**.

Every run since then has failed at authentication — **40 nights**, not the twelve the revocation date suggests. Two distinct causes, and the second was hiding behind the first:

| cause | runs | window |
|---|---|---|
| `invalid_grant: Token has been expired or revoked` | 47 | …→ 2026-08-05 |
| `invalid_scope: Bad Request` | 14 | 2026-06-28 → tonight |

*(An earlier draft of this description said "141 nights". 141 is the number of log **lines** carrying `invalid_grant` — a traceback prints it about three times per run. The figure is 47 runs.)*

Nobody was told about any of it. This PR closes three things.

---

## 1. The organ that knew could not speak

`send_critical_alert` posted to Telegram directly, gated on `os.environ["TELEGRAM_BOT_TOKEN"]`. Under `cron` that variable does not exist — so the alert **did nothing, and left no trace of having done nothing**. Exactly W108: the alarm shares the failure mode of the thing it reports.

It now routes through `scripts/tg_notify.py`, which resolves the token from the env **or** `~/.nuzantara-secrets.env`, and brings dedup / tiers / spool / budget with it:

- `rc=` is **always** logged. A silent send is not a possible outcome.
- A missing gateway logs at ERROR **with the payload inline** — the message survives in the log even when no channel does.
- Never raises: an alerter that can kill its caller is worse than no alerter.
- Dedup key `garuda:<condition>:<host>`, so 40 identical nights collapse to one message and a re-arm, instead of either 40 or (as happened) zero.

Also removed: `garuda_indexer.py` carried its own `days_left < 7` block — a second owner of the Drive-expiry condition, reading the one-hour column on a day scale that #3700 retired.

## 2. The refresh asked for a scope the consent never granted

**Found by watching tonight's run rather than by reasoning about it.** After the credential was re-authed this morning, the 20:36 run stopped saying `invalid_grant` and immediately said `invalid_scope: Bad Request`. The re-auth held; this was underneath it, unreachable while the grant was also dead, because Google decides validity before scope.

`_load_creds_from_db` refreshed with `drive` **and** `drive.readonly`. The consent screen only ever asked for one — `admin_drive_auth.py:47` builds the authorize URL with `scope=https://www.googleapis.com/auth/drive`, singular — and `drive_auth.py:32` / `google_drive_service.py:34` both refresh with that same single scope. This was the only call site asking for two. Google does not ignore the ungranted extra; it rejects the whole refresh. `drive` is a superset of `drive.readonly`.

`SA_SCOPES` and `OAUTH_SCOPES` stay **separate literals** although they hold the same string: one is bounded by the Workspace admin console's delegation, the other by what a human approved on a consent screen. Equal by coincidence, not by construction.

## 3. It was on a credential that can be revoked at all

Three months ago Drive traffic moved to `ServiceAccountDriveService` (domain-wide delegation) — 16 production files. The indexer never followed. It stayed on the `google_drive_tokens` row, a **user** grant: it dies when a human revokes it, changes password, or Google expires it, and nothing on our side renews it.

`get_drive_service()` now resolves:

1. `~/.nuzantara-drive-sa.json` — the service account, `.with_subject("zero@balizero.com")`
2. `GOOGLE_DRIVE_CREDENTIALS_FILE`
3. the legacy DB row — kept, with a WARNING that names it as revocable

`GARUDA_DRIVE_FORCE_OAUTH=1` skips step 1.

**Verified live:** the SA lists all **7** GARUDA subfolders and gets a `startPageToken`, from inside the Fly machine *and* from Pro. Scope is `drive` only — adding `drive.readonly` to the SA request fails with `unauthorized_client`, the same lesson from the other side of the fence.

`_load_sa_credentials` validates `type == "service_account"` **before** importing any google library, so a malformed file fails with a sentence a human can act on.

## Verification

- 17 tests across the two corpora, green.
- Mutation-verified on the scope fix 2/2: restoring the pair fails the corpus; aliasing the two scope lists fails the design assertion.
- Guilt (a cron-shaped env with no token still emits), innocence (a healthy send is not duplicated), credential resolution asserted at every branch.
- `immune-enforcement.yml` gains `alerts.py` + its corpus as sentinel trigger paths and runs the corpus as a step. **Declared gap:** the trigger-symmetry meta-test only reads the `scripts/**.py` loop, so this pair is armed but not symmetry-checked.

## Still open after this lands

Pro's checkout must be pulled for any of it to run — the wrapper executes from `/Users/nuzantara/nuzantara/apps/zantara-media`, not from a package install. Merged is not live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
