### PR TITLE
fix(garuda): log the reason in words, not an env-derived flag (clears the CodeQL high on #3704)

### DIFF
--- a/apps/zantara-media/zantara_media/indexer/drive_client.py
+++ b/apps/zantara-media/zantara_media/indexer/drive_client.py
@@ -185,12 +185,23 @@ async def get_drive_service():  # type: ignore[return]
             logger.info("Drive credentials: file %s", creds_file)
         else:
             creds = await _load_creds_from_db()
+            # Say WHY the preferred path was skipped, in words. Two booleans a
+            # reader has to recombine is worse, and echoing the env value back
+            # is worse still: `GARUDA_DRIVE_FORCE_OAUTH` matches CodeQL's
+            # sensitive-name heuristic (it contains "AUTH") and logging it
+            # raises py/clear-text-logging-sensitive-data — a false positive on
+            # the entity, since the flag is a bool, but the honest answer is
+            # that a reason belongs in the log, not a flag dump.
+            reason = (
+                "forced by GARUDA_DRIVE_FORCE_OAUTH"
+                if force_oauth
+                else "no service-account key on disk"
+            )
             logger.warning(
                 "Drive credentials: legacy user OAuth from google_drive_tokens "
-                "(revocable — see get_drive_service docstring). force_oauth=%s "
-                "sa_path_present=%s",
-                force_oauth,
-                os.path.isfile(sa_path),
+                "— REVOCABLE, dies when the grant is withdrawn and nothing here "
+                "can renew it (see get_drive_service docstring). Reason: %s.",
+                reason,
             )
 
     service = await loop.run_in_executor(None, _build_drive_service, creds)


### PR DESCRIPTION
Follow-up to #3704, which merged with one red non-required check.

## What CodeQL said

`py/clear-text-logging-sensitive-data` — 1 high — on the new warning that
names the legacy credential as revocable. The flagged expression is
`force_oauth`, which is **already a bool**:

```python
force_oauth = os.environ.get("GARUDA_DRIVE_FORCE_OAUTH") == "1"
```

The scanner classifies it from the NAME of the environment variable it
derives from, and `GARUDA_DRIVE_FORCE_OAUTH` contains **AUTH**. It is judging
by form, not by entity — the same shape as superscar #3, this time inside the
scanner.

It went in anyway because the two *required* contexts are `CodeQL Analysis
(python)` and `(javascript)`, both green; the aggregate `CodeQL` check that
reports new alerts is not required. That is worth saying out loud: **the
required contexts prove the scanner ran, not that it found nothing.**

## Why this is a fix and not a suppression

I did not add a `codeql[...]` suppression comment. A suppression is an
assertion about the code, and I would be asserting "reviewed, not sensitive"
to silence a line that was mediocre for an unrelated reason: it printed two
booleans and left the reader to recombine them into a cause.

The branch now selects a sentence:

```python
reason = ("forced by GARUDA_DRIVE_FORCE_OAUTH" if force_oauth
          else "no service-account key on disk")
```

Nothing derived from the environment reaches the log, so the finding is gone
by construction rather than by annotation, and the line says what happened.
The warning also now spells out what "revocable" costs, since preferring the
service account is the entire point of #3704.

## Verification

17 tests green (`test_drive_client_credentials.py` + `test_alerts_gateway.py`).
No behaviour change: the branch that selects the credential is untouched, only
what it writes to the log.

*(`tests/test_atomic.py`, `test_dedup.py`, `test_gc.py` fail to collect in this
venv on `No module named 'openai'` — pre-existing, unrelated, present on main.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
