### PR TITLE
feat(lead-source): add property_chat_question + property_article_cta; fix tax_gap result_url_path

### DIFF
--- a/apps/backend-rag/backend/services/lead_capture/source.py
+++ b/apps/backend-rag/backend/services/lead_capture/source.py
@@ -35,6 +35,12 @@ class LeadSource(str, Enum):
     # and fell back to the bare wa.me link — clicks tracked, leads unlogged.
     # No result page: the visitor has not run a tool, they came off the hero.
     HOMEPAGE_HERO = "homepage_hero"
+    # Property funnel sources (2026-08-07): Ask Zantara chat on
+    # /property/eligibility and article-page CTAs on property articles.
+    # Enum lands first; call-sites follow in a separate frontend PR once
+    # CI parity is confirmed (WIRE/RETIRE audit pending).
+    PROPERTY_CHAT_QUESTION = "property_chat_question"
+    PROPERTY_ARTICLE_CTA = "property_article_cta"
 
     @property
     def human_name(self) -> str:
@@ -53,6 +59,8 @@ class LeadSource(str, Enum):
             LeadSource.CTA_HANDOFF: "Bali Zero",
             LeadSource.PRICING_MODAL: "the pricing page",
             LeadSource.HOMEPAGE_HERO: "the homepage",
+            LeadSource.PROPERTY_CHAT_QUESTION: "the Property Eligibility chat",
+            LeadSource.PROPERTY_ARTICLE_CTA: "the Property article",
         }[self]
 
     @property
@@ -64,7 +72,7 @@ class LeadSource(str, Enum):
             LeadSource.GARUDA_VOA: "/visa/voa",
             LeadSource.KBLI_DECODER: "/kbli/decoder",
             LeadSource.KBLI_BUILDER: "/kbli/builder",
-            LeadSource.TAX_GAP: "/tax/gap",
+            LeadSource.TAX_GAP: "/taxes/gap",  # live page moved PR #3629 Aug 2026
             LeadSource.ZONING_CHECK: "/zoning",
             # Articles carry their own URL in context; no hash-based result page.
             LeadSource.ARTICLE: "/",
@@ -79,4 +87,6 @@ class LeadSource(str, Enum):
             LeadSource.PRICING_MODAL: "/",
             # The hero IS the homepage; no tool result to link back to.
             LeadSource.HOMEPAGE_HERO: "/",
+            LeadSource.PROPERTY_CHAT_QUESTION: "/property/eligibility",
+            LeadSource.PROPERTY_ARTICLE_CTA: "/property/eligibility",
         }[self]


### PR DESCRIPTION
## Insight
Two property funnel sources had zero LeadSource enum entries, causing any future frontend PR to fail CI parity. TAX_GAP result_url_path pointed to /tax/gap (308 redirect) instead of the live /taxes/gap.

## Studio
No visual change to end users. Backend enum only — no frontend component touched. Zone: backend (CI + AI gate).

## Source
- analytics.ts lines 470–488: trackPropertyChatQuestion() and trackPropertyArticleCTA() exist with zero call-sites
- source.py line 67: LeadSource.TAX_GAP result_url_path was "/tax/gap"; live page at /taxes/gap since PR #3629
- Verified via grep 2026-08-07

## Methodology
Single-file change to source.py: (1) two new enum members, (2) human_name dict entries, (3) result_url_path dict entries, (4) one-line TAX_GAP path fix.

## Raw Observations
- grep confirmed PROPERTY_CHAT_QUESTION and PROPERTY_ARTICLE_CTA absent before this PR
- python3 -m py_compile: PASS
- TAX_GAP: /tax/gap → 308 → /taxes/gap; lead_intents tax_gap = 0 rows (low traffic, low urgency)

## Reasoning Path
CI parity gate blocks any frontend source="property_chat_question" until enum exists. Enum must land first. Frontend drawer PR follows after WIRE/RETIRE audit (task 6hCP7h9mM3fcQmx6, due Aug 13).

## Risk
Low. Additive only — no existing enum member modified except TAX_GAP path. No DB migration. Blast radius: whatsapp_deeplink.py:89 for TAX_GAP fix.

## Implication
Unblocks frontend property drawer PR. TAX_GAP deeplink now resolves without redirect hop.

## Recommendation
Merge. Gate = CI + AI review.

## Next Action
1. Monitor CI
2. After merge: open WIRE/RETIRE audit PR (task 6hCP7h9mM3fcQmx6)
3. After audit: frontend drawer PR for property_chat_question call-site