### PR TITLE
fix(proprioception): stop prescribing a pull the m5 checkout forbids

### DIFF
--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -163,6 +163,74 @@ def verdict(pid: str, boundary: str, bclass: str, status: str, severity: str, n:
     }
 
 
+# ------------------------------------------------------- machine-aware remedy selection
+
+# A registry entry's fix_hint is a STATIC string chosen at authoring time — it cannot
+# know which machine or which finding-shape it will be printed for. Two entries in
+# DEFAULT_REGISTRY carry a standing decision that a generic remedy actively violates on
+# one machine, the same disease probe_guardian_freshness already cured for freshness
+# ITSELF (per-item `machines` scoping, W106b/#2): before printing a remedy, ask whether
+# a standing decision already forbids it. These two small pure functions are that ask —
+# called once per matching entry in main()'s probe loop, never touching the registry's
+# static fix_hint for anything else.
+
+_BEHIND_RE = re.compile(r"main checkout: (-?\d+) behind origin/main")
+_LEDGER_STALE_RE = re.compile(r"^LEDGER STALE: (\S+) differs from origin/main")
+
+
+def _git_alignment_remedy(entry: dict, machine: str, ev: list[str]) -> str:
+    """m5's main checkout is BY DESIGN left behind origin/main — Rule 0 of this
+    organ's own SessionStart contract (scripts/hooks/proprioception_sessionstart.sh)
+    and the probe_home_fork_scripts docstring above (W106b, 2026-07-27): pulling it
+    races live worktrees. The registry's static "interactive pull" fix_hint is correct
+    on pro/mini, where the checkout IS auto-pulled and 0-behind is the norm — return it
+    UNCHANGED there. On m5, override it only when the behind-count is actually part of
+    this finding (a fully RECONCILED probe, or one driven by ledger-drift alone at
+    behind=0, has nothing to caveat about pulling — the by-design text must not appear
+    spuriously): state the by-design truth instead of prescribing the destructive act,
+    and name the ledger as the one actionable half when it is stale too.
+    """
+    default = entry["fix_hint"]
+    if machine != "m5":
+        return default
+    behind = -1
+    for e in ev:
+        m = _BEHIND_RE.search(e)
+        if m:
+            behind = int(m.group(1))
+            break
+    if behind <= 0:
+        return default
+    by_design = ("m5's main checkout is deliberately left behind origin/main by design "
+                 "(pulling it races live worktrees — see probe_home_fork_scripts docstring, "
+                 "W106b): do NOT pull it, interactively or from an agent session.")
+    ledger = None
+    for e in ev:
+        m = _LEDGER_STALE_RE.search(e)
+        if m:
+            ledger = m.group(1)
+            break
+    if ledger:
+        return (f"{by_design} The actionable half is the ledger: refresh just that file from "
+                f"origin/main (e.g. `git checkout origin/main -- {ledger}` in the main "
+                f"checkout, not a full pull) so TRIAGE stops reading stale state.")
+    return f"{by_design} No other actionable half in this finding right now."
+
+
+def _arsenal_seats_vcr_m5_remedy(entry: dict) -> str:
+    """arsenal_seats_vcr_m5 is registered machines: ["m5"] only — every call to this
+    function IS on m5 by construction. docs/runbooks/arsenal-probe.md names Mini as
+    the primary for arsenal-seat freshness (the healer refreshes there every <=20h);
+    the sibling `arsenal_seats` entry (mini/pro) is what that cadence actually feeds.
+    FRESHNESS_EXPIRED here, between m5's own interactive runs, is the expected state of
+    a non-primary pilot subset — not a live-seat outage — so say that BEFORE the check
+    command, or the finding reads as arsenal trouble it usually isn't.
+    """
+    return ("Mini is the documented primary for arsenal-seat freshness "
+            '(docs/runbooks/arsenal-probe.md "Mini (primary)"); FRESHNESS_EXPIRED on m5 '
+            "between interactive runs is expected, not a seat outage. " + entry["fix_hint"])
+
+
 # ---------------------------------------------------------------- builtins
 
 def probe_git_alignment(root: Path, args: dict, timeout: int) -> tuple[str, int, list[str]]:
@@ -801,8 +869,13 @@ def main() -> int:
             status, n, ev = UNPROBEABLE, 0, [f"probe timed out after {timeout}s"]
         except Exception as e:  # a probe must never kill the organ
             status, n, ev = UNPROBEABLE, 0, [f"{type(e).__name__}: {str(e)[:140]}"]
+        fix_hint = entry["fix_hint"]
+        if entry["id"] == "git_alignment":
+            fix_hint = _git_alignment_remedy(entry, me, ev)
+        elif entry["id"] == "arsenal_seats_vcr_m5":
+            fix_hint = _arsenal_seats_vcr_m5_remedy(entry)
         results.append(verdict(entry["id"], entry["boundary"], entry["class"], status,
-                               entry["severity"], n, ev, entry["fix_hint"], t0))
+                               entry["severity"], n, ev, fix_hint, t0))
 
     if args.fleet:
         self_path = Path(__file__) if "__file__" in globals() and Path(__file__).exists() else None

--- a/scripts/tests/test_proprioception_remedy_selection.py
+++ b/scripts/tests/test_proprioception_remedy_selection.py
@@ -1,0 +1,216 @@
+"""Tests for proprioception.py's machine-aware remedy selection.
+
+TRAUMA (measured 2026-08-07, handoff §6): two DEFAULT_REGISTRY entries carry a
+STATIC fix_hint chosen at authoring time, printed unconditionally regardless of
+which machine or which finding-shape triggered the DIVERGED verdict.
+
+- `git_alignment`'s fix_hint reads "interactive pull on this machine's main
+  (never from an agent session)" — correct on pro/mini, where the checkout is
+  auto-pulled and 0-behind is the norm, but on m5 it directly contradicts the
+  standing decision (probe_home_fork_scripts docstring, W106b, 2026-07-27) that
+  the m5 checkout is deliberately left behind origin/main because pulling it
+  races live worktrees. That wrong prescription was already quoted verbatim in
+  PENDING-ARMS as justification for deferring action — the doctrine had trained
+  a prior session before this fix.
+- `arsenal_seats_vcr_m5` (machines: ["m5"] only) inherited a fix_hint written
+  for the sibling `arsenal_seats` (mini/pro) entry with no mention that Mini,
+  not m5, is the documented primary (docs/runbooks/arsenal-probe.md "Mini
+  (primary)") — so a routine FRESHNESS_EXPIRED between m5's own interactive
+  runs reads as a live-seat problem it usually isn't.
+
+Guilt + innocence per superscar #3 discipline (guard-over-match: a fix that
+fires on the wrong machine/shape is exactly that failure mode with a text
+payload instead of a block): every remedy-selection branch gets a case that
+IS overridden and one that correctly stays byte-identical to the registry's
+static fix_hint. Adopts the same per-item "ask whether a standing decision
+already forbids this" pattern probe_guardian_freshness proved for machine
+scoping (W106b family, `.claude/rules/cicatrix-superscar.md` #2).
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "proprioception.py"
+_spec = importlib.util.spec_from_file_location("proprioception", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+prop = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prop)  # type: ignore[union-attr]
+
+GIT_ALIGNMENT_ENTRY = next(e for e in prop.DEFAULT_REGISTRY if e["id"] == "git_alignment")
+ARSENAL_VCR_M5_ENTRY = next(e for e in prop.DEFAULT_REGISTRY if e["id"] == "arsenal_seats_vcr_m5")
+STATIC_GIT_FIX_HINT = GIT_ALIGNMENT_ENTRY["fix_hint"]
+STATIC_ARSENAL_FIX_HINT = ARSENAL_VCR_M5_ENTRY["fix_hint"]
+
+BEHIND_120_DIRTY_20_LEDGER_STALE = [
+    "main checkout: 120 behind origin/main, 20 dirty entries",
+    "LEDGER STALE: .claude/skills/modus/PENDING-ARMS.md differs from origin/main "
+    "— TRIAGE would read old state",
+]
+BEHIND_0_CLEAN = ["main checkout: 0 behind origin/main, 0 dirty entries"]
+
+
+# ---------------------------------------------------------------- guilt: m5, behind, ledger stale
+
+
+def test_guilt_m5_behind_and_stale_ledger_never_prescribes_pull() -> None:
+    hint = prop._git_alignment_remedy(
+        GIT_ALIGNMENT_ENTRY, "m5", BEHIND_120_DIRTY_20_LEDGER_STALE
+    )
+    # the exact static phrase this cure exists to stop m5 from ever printing
+    assert STATIC_GIT_FIX_HINT not in hint
+    assert "do NOT pull it" in hint
+
+
+def test_guilt_m5_behind_and_stale_ledger_names_the_ledger_half() -> None:
+    hint = prop._git_alignment_remedy(
+        GIT_ALIGNMENT_ENTRY, "m5", BEHIND_120_DIRTY_20_LEDGER_STALE
+    )
+    assert ".claude/skills/modus/PENDING-ARMS.md" in hint
+    assert "actionable half" in hint
+
+
+def test_guilt_m5_behind_and_stale_ledger_states_by_design_truth() -> None:
+    hint = prop._git_alignment_remedy(
+        GIT_ALIGNMENT_ENTRY, "m5", BEHIND_120_DIRTY_20_LEDGER_STALE
+    )
+    assert "deliberately left behind" in hint
+    assert "W106b" in hint
+
+
+def test_guilt_m5_seats_freshness_expired_names_mini() -> None:
+    hint = prop._arsenal_seats_vcr_m5_remedy(ARSENAL_VCR_M5_ENTRY)
+    assert "Mini" in hint
+    assert "primary" in hint
+    assert "expected" in hint
+    # the original check command must still be reachable, not replaced
+    assert "infra/vcr/cli.py check" in hint
+
+
+# ---------------------------------------------------------------- innocence: pro/mini, and m5 at behind=0
+
+
+@pytest.mark.parametrize("machine", ["pro", "mini"])
+def test_innocence_non_m5_pull_remedy_survives_byte_identical(machine: str) -> None:
+    """A machine where pulling IS correct must still be told to pull —
+    unconditionally, regardless of finding shape."""
+    for ev in (BEHIND_120_DIRTY_20_LEDGER_STALE, BEHIND_0_CLEAN, []):
+        hint = prop._git_alignment_remedy(GIT_ALIGNMENT_ENTRY, machine, ev)
+        assert hint == STATIC_GIT_FIX_HINT
+
+
+def test_innocence_m5_at_behind_zero_by_design_text_does_not_appear() -> None:
+    hint = prop._git_alignment_remedy(GIT_ALIGNMENT_ENTRY, "m5", BEHIND_0_CLEAN)
+    assert hint == STATIC_GIT_FIX_HINT
+    assert "deliberately left behind" not in hint
+
+
+def test_innocence_m5_no_behind_evidence_at_all_degrades_to_static() -> None:
+    """Evidence-format drift (regex miss) must fail SAFE — never assert the
+    by-design text without solid evidence backing it."""
+    hint = prop._git_alignment_remedy(GIT_ALIGNMENT_ENTRY, "m5", ["something unrelated"])
+    assert hint == STATIC_GIT_FIX_HINT
+
+
+def test_innocence_m5_behind_but_ledger_fresh_still_forbids_pull_without_naming_ledger() -> None:
+    """behind>0 with a fresh ledger: still m5's by-design truth (pulling is still
+    forbidden), but nothing false is claimed about a ledger that isn't stale."""
+    hint = prop._git_alignment_remedy(
+        GIT_ALIGNMENT_ENTRY, "m5", ["main checkout: 45 behind origin/main, 3 dirty entries"]
+    )
+    assert "deliberately left behind" in hint
+    assert "PENDING-ARMS" not in hint
+    assert "No other actionable half" in hint
+
+
+# ---------------------------------------------------------------- the verdict itself must be untouched
+
+
+def test_verdict_severity_and_status_never_downgraded_by_remedy_selection() -> None:
+    """The cure changes the PRESCRIPTION, never the VERDICT — the LEDGER STALE
+    sub-finding is real and must keep firing."""
+    status, findings, ev = prop.DIVERGED, 2, BEHIND_120_DIRTY_20_LEDGER_STALE
+    hint = prop._git_alignment_remedy(GIT_ALIGNMENT_ENTRY, "m5", ev)
+    assert status == prop.DIVERGED  # unrelated to the remedy call — sanity anchor
+    assert findings == 2
+    assert hint != STATIC_GIT_FIX_HINT  # the prescription changed
+    assert GIT_ALIGNMENT_ENTRY["severity"] == "P1"  # the registry's severity is untouched
+
+
+# ---------------------------------------------------------------- end-to-end wiring (real probe + real repo)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, timeout=30)
+
+
+@pytest.fixture()
+def diverged_m5_repo(tmp_path: Path):
+    """A real git repo shaped like m5's main checkout today: behind origin/main
+    AND carrying a locally-stale PENDING-ARMS.md, built the same way
+    test_home_fork_stale_side_attribution.py's `world` fixture builds its repo
+    (upstream commit -> published as origin/main -> working tree left behind)."""
+    repo = tmp_path / "repo"
+    ledger_rel = ".claude/skills/modus/PENDING-ARMS.md"
+    (repo / ".claude" / "skills" / "modus").mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+    (repo / ledger_rel).write_text("old ledger\n")
+    _git(repo, "add", ledger_rel)
+    _git(repo, "commit", "-qm", "c1")
+    (repo / "other.txt").write_text("x\n")
+    _git(repo, "add", "other.txt")
+    _git(repo, "commit", "-qm", "c2 (advances origin/main, not the ledger)")
+    (repo / ledger_rel).write_text("new ledger\n")
+    _git(repo, "add", ledger_rel)
+    _git(repo, "commit", "-qm", "c3 bumps the ledger on origin/main")
+    head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True, timeout=30,
+    ).stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", head)
+    # Roll the local checkout back to c1: behind=2, AND the ledger blob differs
+    # from origin/main's (superscar #9 content-comparison, never a proxy).
+    _git(repo, "reset", "-q", "--hard", "HEAD~2")
+    return repo, ledger_rel
+
+
+def test_end_to_end_probe_plus_remedy_matches_the_real_m5_shape(diverged_m5_repo) -> None:
+    repo, ledger_rel = diverged_m5_repo
+    status, findings, ev = prop.probe_git_alignment(repo, {"no_fetch": True}, 15)
+    assert status == prop.DIVERGED
+    assert findings == 1  # ledger-only: 2 behind is under the default behind_warn=10
+    hint = prop._git_alignment_remedy(GIT_ALIGNMENT_ENTRY, "m5", ev)
+    assert "do NOT pull it" in hint
+    assert ledger_rel in hint
+    assert GIT_ALIGNMENT_ENTRY["severity"] == "P1"  # verdict class untouched by the cure
+
+
+# ---------------------------------------------------------------- mutation proof (guilt test can go red)
+
+
+def test_mutation_proof_removing_the_machine_check_makes_pro_wrongly_overridden() -> None:
+    """Simulates disabling the fix (machine check removed): pro would then get
+    the by-design m5 text too. Proves the guilt tests actually distinguish the
+    cured code from the uncured code, not a tautology."""
+
+    def uncured_remedy(entry: dict, machine: str, ev: list[str]) -> str:
+        # the bug this test file exists to prevent: no `if machine != "m5": return default`
+        behind = -1
+        for e in ev:
+            m = prop._BEHIND_RE.search(e)
+            if m:
+                behind = int(m.group(1))
+                break
+        if behind <= 0:
+            return entry["fix_hint"]
+        return "m5's main checkout is deliberately left behind origin/main by design..."
+
+    mutated_hint = uncured_remedy(GIT_ALIGNMENT_ENTRY, "pro", BEHIND_120_DIRTY_20_LEDGER_STALE)
+    assert mutated_hint != STATIC_GIT_FIX_HINT  # the mutant IS wrong on pro
+    cured_hint = prop._git_alignment_remedy(GIT_ALIGNMENT_ENTRY, "pro", BEHIND_120_DIRTY_20_LEDGER_STALE)
+    assert cured_hint == STATIC_GIT_FIX_HINT  # the real code stays correct


### PR DESCRIPTION
## What was measured today (2026-08-07)

- `git -C /Users/balizero/nuzantara rev-list --count HEAD..origin/main` → **121** behind (handoff said 120, +1 commit landed between measurements — expected drift, not a discrepancy).
- `git -C /Users/balizero/nuzantara status --porcelain | wc -l` → **20** dirty (matches handoff).
- `NUZ_REPO_ROOT=/Users/balizero/nuzantara PYTHONPATH=. python3 scripts/proprioception.py --json --no-fetch --probes git_alignment` against the real M5 main checkout → `DIVERGED`, `n_findings: 2`, evidence `["main checkout: 121 behind origin/main, 20 dirty entries", "LEDGER STALE: .claude/skills/modus/PENDING-ARMS.md differs from origin/main — TRIAGE would read old state"]`.
- `python3 infra/vcr/cli.py findings --json` on m5 today → all three seats (claude/codex/kimi) `VERIFIER_DRIFTED_COVERAGE_MISSING_FRESHNESS_EXPIRED_TRUTH_UNVERIFIED` — a **disagreement with the brief's exact status strings** ("claude/codex FRESHNESS_EXPIRED, kimi FRESHNESS_EXPIRED_TRUTH_FALSE"): the underlying axis names have drifted since the handoff was written (state is time-varying, VCR verifier-hash included). Doesn't change the fix — the remedy text is derived generically from "this entry is `arsenal_seats_vcr_m5`, running on m5", not from parsing the specific status string.

## What changed

`scripts/proprioception.py`:
- Added `_git_alignment_remedy(entry, machine, ev)` and `_arsenal_seats_vcr_m5_remedy(entry)` — two pure functions that compute a machine/evidence-aware `fix_hint` at print time, called from `main()`'s per-entry loop only for these two ids. Every other entry's `fix_hint` is untouched (falls through the `if/elif`).
- `git_alignment` on m5: when the behind-count is part of the DIVERGED finding, the remedy now states the by-design truth (checkout deliberately left behind — cites `probe_home_fork_scripts`' docstring, W106b) instead of prescribing a pull, and names the ledger (`.claude/skills/modus/PENDING-ARMS.md`) as the one actionable half when it's stale. On pro/mini, and on m5 when behind=0, the original static "interactive pull..." fix_hint is returned unchanged.
- `arsenal_seats_vcr_m5` (m5-only entry): the remedy now leads with "Mini is the documented primary for arsenal-seat freshness (docs/runbooks/arsenal-probe.md 'Mini (primary)'); FRESHNESS_EXPIRED on m5 between interactive runs is expected, not a seat outage" before the original check command.
- `DEFAULT_REGISTRY`'s `home_fork_scripts` pairs list, `run_wrap`'s exit_code branch, and the other 9 fix_hints are **untouched** (out of scope, per brief).

No wiring changes, no VCR scope growth, text/selection logic only.

## Guilt test

`scripts/tests/test_proprioception_remedy_selection.py::test_guilt_m5_behind_and_stale_ledger_never_prescribes_pull` (+ 3 sibling guilt tests): with `machine="m5"`, `behind=120`, `dirty=20`, ledger stale — asserts the static `"interactive pull on this machine's main..."` string is absent, `"do NOT pull it"` is present, `".claude/skills/modus/PENDING-ARMS.md"` is named, and `"W106b"`/`"deliberately left behind"` appear. `test_guilt_m5_seats_freshness_expired_names_mini` asserts "Mini"/"primary"/"expected" appear and the original check command is preserved.

```
python3 -m pytest scripts/tests/test_proprioception_remedy_selection.py -v
```

## Innocence test

`test_innocence_non_m5_pull_remedy_survives_byte_identical[pro/mini]` — for both machines, across three evidence shapes (behind+stale-ledger, clean, empty), the remedy is byte-identical to the registry's static `fix_hint`. `test_innocence_m5_at_behind_zero_by_design_text_does_not_appear` — m5 at behind=0 also returns the static text unchanged. `test_innocence_m5_no_behind_evidence_at_all_degrades_to_static` — regex-miss on evidence format fails SAFE (no spurious by-design claim). `test_innocence_m5_behind_but_ledger_fresh_still_forbids_pull_without_naming_ledger` — behind>0 with a fresh ledger still states by-design truth but doesn't falsely name a ledger issue. `test_verdict_severity_and_status_never_downgraded_by_remedy_selection` — the registry's P1 severity is untouched; the cure changes only the prescription. `test_end_to_end_probe_plus_remedy_matches_the_real_m5_shape` runs the real `probe_git_alignment` against a synthetic git repo shaped like m5 today (behind + stale ledger blob) and confirms the wired-together output.

## Mutation result

Applied a mutation removing the `if machine != "m5": return default` gate in `_git_alignment_remedy` (verified via `diff` against a backup before restoring):

```
python3 -m pytest scripts/tests/test_proprioception_remedy_selection.py -v
# RC=1 — 3 failed, 9 passed:
#   test_innocence_non_m5_pull_remedy_survives_byte_identical[pro]  FAILED
#   test_innocence_non_m5_pull_remedy_survives_byte_identical[mini] FAILED
#   test_mutation_proof_removing_the_machine_check_makes_pro_wrongly_overridden FAILED
```

Restored the real fix; all 12 tests pass again (`RC=0`).

## PROVE-LIVE

`scripts/proprioception.py` has exactly one consuming surface: `scripts/hooks/proprioception_sessionstart.sh` (SessionStart hook, injects `~/.nuzantara-proprioception/last.md` into every session's context on this machine) plus any operator running the script by hand. This PR does not touch the hook or the report-writing path — verified end-to-end against the real M5 checkout in this worktree (not merely unit-tested):

```
NUZ_REPO_ROOT=/Users/balizero/nuzantara PYTHONPATH=. python3 scripts/proprioception.py --json --no-fetch --probes git_alignment
# fix_hint: "m5's main checkout is deliberately left behind origin/main by design
#  (pulling it races live worktrees — see probe_home_fork_scripts docstring, W106b):
#  do NOT pull it, interactively or from an agent session. The actionable half is
#  the ledger: refresh just that file from origin/main (e.g. `git checkout
#  origin/main -- .claude/skills/modus/PENDING-ARMS.md` in the main checkout,
#  not a full pull) so TRIAGE stops reading stale state."
# status: DIVERGED, severity: P1, n_findings: 2  (verdict unchanged)

PYTHONPATH=. python3 scripts/proprioception.py --json --no-fetch --probes arsenal_seats_vcr_m5
# fix_hint: "Mini is the documented primary for arsenal-seat freshness
#  (docs/runbooks/arsenal-probe.md \"Mini (primary)\"); FRESHNESS_EXPIRED on m5
#  between interactive runs is expected, not a seat outage. python3 infra/vcr/cli.py
#  check --seat <s> --host m5 --auth-context interactive (...)"
```

`python3 scripts/proprioception.py --selftest` → `SELFTEST OK — registry valid (11 probes), parser guards hold, redaction holds`.

The actual `~/.nuzantara-proprioception/last.md` file (read by the SessionStart hook) will carry this new remedy text the next time proprioception runs on m5 outside this worktree — that is the one surface this PR could not itself execute against without writing into the operator's live session state, which is out of scope for an agent lane per CLAUDE.md worktree discipline.

## Out of scope (seen, not cured)

- `python3 infra/vcr/cli.py findings --json` returning `VERIFIER_DRIFTED` (not just `FRESHNESS_EXPIRED`) for all three seats today — a state drift from the handoff's exact strings, noted above, not touched (VCR internals are out of this pilot's scope per the brief and per Zero's 2026-08-04 "no, basta così").
- The other 9 registry `fix_hint`s were spot-checked against today's material only, not against every standing decision in the repo — not re-audited here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>