### PR TITLE
docs(operations): record nuzantara-repo-sync vs M5 worktree-discipline doctrine conflict

### DIFF
--- a/docs/operations/2026-08-07-nuzantara-repo-sync-doctrine-conflict.md
+++ b/docs/operations/2026-08-07-nuzantara-repo-sync-doctrine-conflict.md
@@ -1,0 +1,127 @@
+# DECISION RECORD — `com.balizero.nuzantara-repo-sync` writes the M5 main checkout the standing M5 doctrine calls read-only
+
+> **Status: OPEN. No option below has been executed by this record.** This document exists so
+> that a future session grepping `nuzantara-repo-sync` lands on the full picture — both positions,
+> the measurement, and who is positioned to close it — instead of re-discovering the conflict from
+> scratch. Owner of the open call: **Zero** (M5 is his interactive workstation; the daemon is a
+> personal `~/.local/bin/` script, not repo canon — see §No repo canon below).
+
+## The conflict, in one sentence
+
+Two standing rules cannot both hold at once: **(1)** `scripts/proprioception.py`'s
+`probe_home_fork_scripts` docstring and the CLAUDE.md "Agent Worktree Discipline" section both say
+M5's `~/nuzantara` main checkout is deliberately left behind origin/main and reserved for
+operator-interactive + hotfix use — **(2)** a `launchd` job on the same machine fast-forward-merges
+`origin/main` into that exact checkout every 5 minutes, and has completed that merge 334 times.
+
+Verbatim, both sides, read from `origin/main` in this worktree (never the stale main checkout —
+see Rule 0):
+
+```
+$ git -C /Users/balizero/nuzantara/.worktrees/ops-repo-sync-doctrine-conflict show origin/main:CLAUDE.md \
+    | grep -n -A2 'Agent Worktree Discipline'
+## Agent Worktree Discipline (2026-05-24)
+
+OGNI agent session (subagent dispatch / cron-spawned claude / parallel Claude Code window) DEVE
+girare sotto `.worktrees/<lane>-<task-id>/` creato via `scripts/agent_start.py`. Il main checkout
+`~/nuzantara` resta read-only per agent — riservato a operator interactive + cicatrix hotfix.
+```
+
+```
+$ git -C /Users/balizero/nuzantara/.worktrees/ops-repo-sync-doctrine-conflict show origin/main:scripts/proprioception.py \
+    | grep -n -B4 -A4 'deliberately left behind'
+    A bare live≠checkout comparison cannot say which side is stale, yet the
+    remedy it printed ("realign live from repo") only makes sense when the
+    checkout is the current one. On 2026-07-27 this probe reported P1 DIVERGED
+    on M5 for two files whose LIVE copies matched origin/main exactly — the M5
+    checkout was 144 commits behind, and it is deliberately left behind
+    (pulling it races ~45 live worktrees). Acting on that P1 would have
+    overwritten a current worktree-isolation hook with a two-day-old one.
+```
+
+Neither document has been amended by the other since. They are both live doctrine, and they
+contradict each other in the presence of this daemon.
+
+## What was measured TODAY (2026-08-07), against yesterday's handoff numbers
+
+Every number below was re-run in this worktree/session on 2026-08-07; the 2026-08-06 figure from
+the handoff (`docs/operations/handoff-observability-block-2026-08-06.md` §2) is given alongside it
+for comparison — none of today's numbers were carried over from memory.
+
+| Measurement                                                                                                                                                                                                                                              | Command                                                                                                   | 2026-08-06 (handoff)                                                            | 2026-08-07 (this record)                                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Script identity                                                                                                                                                                                                                                          | `readonly REPO="$HOME/Desktop/nuzantara"` in `/Users/balizero/.local/bin/nuzantara-repo-sync`, 42 lines   | 42 lines                                                                        | 42 lines (unchanged)                                                                                                                                                                                                             |
+| `Desktop/nuzantara` resolves to the main checkout                                                                                                                                                                                                        | `stat -L -f '%d %i %N' /Users/balizero/Desktop/nuzantara /Users/balizero/nuzantara`                       | same (dev,inode) claimed                                                        | **confirmed**: both `16777233 758478` — `Desktop/nuzantara` is a symlink to `~/nuzantara` (`readlink` confirms), so the daemon writes the main checkout directly, not a separate copy                                            |
+| `launchctl` runs                                                                                                                                                                                                                                         | `launchctl print gui/501/com.balizero.nuzantara-repo-sync \| grep -E 'runs\|last exit\|run interval'`     | runs=1128, last exit=0, interval=300s                                           | **runs=1133, last exit code=0, interval=300s** (+5 runs in the elapsed time — consistent with a 300s cadence)                                                                                                                    |
+| Script's own log (`~/Library/Logs/nuzantara-repo-sync.log` — distinct from the launchd stdout/stderr capture at `nuzantara-repo-sync-launchd.log`, which is 0 lines/unused because the script redirects all its own output into the log path it manages) | `wc -l`; `grep -c "OK pulled"`; `grep -c "OK pushed"`; `grep "OK pulled" \| tail -1`                      | 23209 lines, 334 "OK pulled", 0 "OK pushed" ever, last pull 2026-08-04 07:47:17 | **23221 lines** (+12), **334 "OK pulled"** (unchanged — no pull since 2026-08-04), **0 "OK pushed"** ever (unchanged), last successful pull still **2026-08-04 07:47:17**                                                        |
+| Current cycle outcome                                                                                                                                                                                                                                    | `tail -15` of the script log                                                                              | postponing at "120 commit(s) behind"                                            | postponing at **"121 commit(s) behind"** as of 13:41 — the gap is still growing, one cycle at a time, because the checkout has 20 dirty (untracked/modified) entries that block the daemon's own `git diff --quiet` safety check |
+| Presence on Pro / Mini                                                                                                                                                                                                                                   | `ssh -n pro 'ls -la ~/.local/bin/nuzantara-repo-sync'` / `ssh -n mini '…'`                                | absent, both                                                                    | **absent, both** (`ls: … No such file or directory`, RC=1 on both hosts)                                                                                                                                                         |
+| Repo canon                                                                                                                                                                                                                                               | `git ls-tree -r origin/main --name-only \| grep -i 'repo-sync'`                                           | 0 hits                                                                          | **0 hits** — the script and its plist exist nowhere under `scripts/`, `infra/`, or `apps/*/scripts/` on `origin/main`                                                                                                            |
+| `declared-pairs.json`                                                                                                                                                                                                                                    | `grep -c 'repo-sync' infra/home-fork/declared-pairs.json`; pair count                                     | 0 hits / 110 pairs                                                              | **0 hits / 110 pairs** — confirmed no twin exists to declare (a declared-pairs entry needs a repo-side canon to compare the live copy against; this daemon has none)                                                             |
+| Main checkout state (informational only — not touched by this record)                                                                                                                                                                                    | `git -C ~/nuzantara rev-list --count HEAD..origin/main`; `git -C ~/nuzantara status --porcelain \| wc -l` | ~120 behind, ~20 dirty                                                          | **121 behind, 20 dirty**                                                                                                                                                                                                         |
+
+**Reconciliation of the one number that moved**: "OK pulled" stayed at 334 both days because the
+daemon has not successfully pulled since 2026-08-04 — the growing "commit(s) behind" figure (120 → 121) and the static pull count agree with each other and with the daemon's own log line ("SAFE
+tracked edits present; pull postponed"). No discrepancy to reconcile here; the daemon is currently
+inert by accident of the dirty tree, not by design.
+
+## Two options, recorded without a preference exercised
+
+### Option A — RETIRE
+
+Unload or disable the `launchd` job (`launchctl kickstart -k`/disable per the fleet memo — never
+`bootout` on a job with detached children, per the M5 fleet runbook) and delete nothing else. No
+CLAUDE.md doctrine changes. The daemon has never pushed (0 "OK pushed" in its entire lifetime),
+exists on no other machine, has no repo canon, and its sole function — auto-pulling origin into the
+main checkout — is the exact act the standing M5 doctrine (proprioception.py + Agent Worktree
+Discipline) already prohibits. Retiring it removes the conflict by removing the daemon; the M5
+doctrine is left unamended and needs no new exception carved into it.
+
+### Option B — PROMOTE
+
+Move the script + plist into `scripts/` and `infra/launchagents/` (hot-zone: lease-check + PR +
+adversarial review per CLAUDE.md §7's guardrail set), repoint `REPO` from the `~/Desktop/nuzantara`
+symlink to the canonical `~/nuzantara` path directly, add the pair to
+`infra/home-fork/declared-pairs.json` (a separate ledger item, not this record — see Scope below),
+write a runbook, and — the part that makes this option coherent rather than a silent policy
+override — publish an **explicit, written exception** to the Agent Worktree Discipline invariant in
+CLAUDE.md, naming this daemon and stating why a background auto-sync is safe alongside ~45 live
+worktrees. Without that written exception, promoting the script would leave the repo documenting
+one rule while running another — the same shape of doctrine/reality gap this record exists to close,
+just relocated instead of resolved.
+
+### What is recorded here, not decided here
+
+Option A is the lower-blast-radius path on the evidence gathered: the daemon has never performed
+its "push" branch in 1133 runs, has no cross-machine presence, and has no repo artifact for a
+review to examine — Option B's first review, on the evidence of `api_server.py`'s 2026-08-06 first
+CodeQL pass (7 high alerts and a production password in cleartext on first look, per the handoff
+this record follows on from), is not free. That observation is offered as context for whoever
+closes this record, not as an executed choice — closing either branch is out of scope for this
+item (see Scope).
+
+## Scope — what this record does NOT do
+
+- Does **not** unload, disable, `kickstart -k`, or otherwise touch the `launchd` job or its plist.
+- Does **not** promote the script into `scripts/`/`infra/launchagents/`.
+- Does **not** add an entry to `infra/home-fork/declared-pairs.json` — impossible by construction:
+  a declared-pairs entry needs a repo-tracked twin to hash against, and this daemon has none (0
+  hits confirmed above). That fact is itself part of why Option A carries less residual risk than
+  Option B, which would first have to create the twin this record found missing.
+- Does **not** add alerting to a daemon whose disposition is still open — alerting a component that
+  may be retired next would itself need retiring.
+- Does **not** clean, pull, or otherwise mutate the M5 main checkout `~/nuzantara` to "unstick" the
+  daemon. The 20 dirty entries currently blocking it are live sibling work — untracked
+  `apps/backend-rag/backend/services/mail_loop/**` and `HANDOFF-zoho-mail-loop.md` — under the
+  leave-dirty discipline of cicatrix superscar #5 (sibling-race). Touching them to make this
+  daemon's postponement logic succeed would be curing a false problem by causing a real one.
+- Does **not** write a `PENDING-ARMS.md` pointer line — per this lane's brief, that line is written
+  by the ledger item that dispatched this record, not by this record itself.
+
+## For the next reader
+
+If you are here to close this: re-run every command in the measurement table above before acting —
+this record is itself subject to Rule 1 (every number here is a measurement of 2026-08-07 and
+expires). If the numbers still show 0 pushes and 0 repo canon, Option A remains the lower-risk
+close. If either has changed — a push has happened, or the script has since been promoted from
+somewhere else — that change is the new finding, not this one.


### PR DESCRIPTION
## What was measured today (2026-08-07)

Re-run in the ops worktree, none carried over from the brief (a 2026-08-06 handoff):

| Measurement | Command | 08-06 | 08-07 |
|---|---|---|---|
| `Desktop/nuzantara` == main checkout | `stat -L -f '%d %i %N' /Users/balizero/Desktop/nuzantara /Users/balizero/nuzantara` | claimed same | **confirmed**: both `16777233 758478` |
| launchctl runs / last exit | `launchctl print gui/501/com.balizero.nuzantara-repo-sync` | 1128 / 0 | **1133 / 0** |
| Script's own log lines | `wc -l ~/Library/Logs/nuzantara-repo-sync.log` | 23209 | **23221** |
| Lifetime "OK pulled" | `grep -c "OK pulled" <log>` | 334 | **334** (unchanged — nothing has pulled since 08-04) |
| Lifetime "OK pushed" | `grep -c "OK pushed" <log>` | 0 | **0** |
| Last successful pull | `grep "OK pulled" <log> \| tail -1` | 08-04 07:47:17 | **08-04 07:47:17** |
| Currently behind | tail of log | 120 | **121** (still growing, one cycle at a time) |
| Present on Pro/Mini | `ssh -n pro/mini 'ls ~/.local/bin/nuzantara-repo-sync'` | absent both | **absent both** |
| Repo canon | `git ls-tree -r origin/main --name-only \| grep -i repo-sync` | 0 hits | **0 hits** |
| `declared-pairs.json` | grep + pair count | 0 hits / 110 pairs | **0 hits / 110 pairs** |
| Main checkout drift/dirt | `git rev-list --count HEAD..origin/main`; `status --porcelain \| wc -l` | ~120 / ~20 | **121 / 20** |

No number moved outside noise; the "still 334 pulls, gap growing" pair is internally consistent
(daemon inert only because 20 dirty entries block its own `git diff --quiet` safety check).

## What changed

New file: `docs/operations/2026-08-07-nuzantara-repo-sync-doctrine-conflict.md`. It states, without
executing either:

- **The conflict** (verbatim quotes from `origin/main`): CLAUDE.md's Agent Worktree Discipline
  ("main checkout `~/nuzantara` resta read-only per agent") and `scripts/proprioception.py`'s
  docstring ("deliberately left behind... pulling it races ~45 live worktrees") both say the M5
  checkout is exempt from auto-pull — while this `launchd` job pulls it every 5 minutes and has
  done so 334 times.
- **Option A — RETIRE**: unload/disable the job, touch nothing else, doctrine unamended.
- **Option B — PROMOTE**: move script+plist into the repo (hot-zone review), repoint `REPO` off the
  `~/Desktop` symlink, declare the pair, and — the load-bearing part — publish an explicit written
  exception to Agent Worktree Discipline, because otherwise the repo would document one rule and run
  another.
- A named owner (Zero) and an explicit "not decided here" framing.

This item's scope, per its brief, is the record only — not retiring or promoting the daemon, not
touching `declared-pairs.json`/`PENDING-ARMS.md`/`DOCS_INVENTORY.md`, not cleaning the main
checkout's 20 dirty entries (live sibling work under superscar #5 leave-dirty discipline).

Also saved (outside git, not part of this diff): a standalone memory file
`discovery_repo_sync_daemon_writes_the_readonly_main_checkout_2026_08_07.md` + a `mem save`
DB entry (id 11704). **`MEMORY.md` was deliberately NOT edited**: measured at 24970/24985 bytes
(the documented hard cap) before this run — 15 bytes of headroom, not enough for even a minimal
one-line pointer without either breaking the cap or doing an out-of-scope prose-compaction pass on
unrelated entries. Flagging this disagreement with the brief's expectation rather than silently
forcing it or silently skipping it.

## Guilt / innocence / mutation

**Guilt test** (must find both options, the measured numbers, both doctrine quotes, and a named
owner):
```bash
grep -q "Option A" "$DOC" && grep -q "Option B" "$DOC" && grep -q "RETIRE" "$DOC" && \
grep -q "PROMOTE" "$DOC" && grep -q "1133" "$DOC" && grep -q "334" "$DOC" && \
grep -q "2026-08-04 07:47:17" "$DOC" && grep -q "deliberately left behind" "$DOC" && \
grep -q "read-only per agent" "$DOC" && grep -q "Owner.*Zero" "$DOC"
```
Result on the real file: **PASS** (all elements present).

**Innocence test** (must NOT read as an already-taken decision):
```bash
grep -iE 'we (will|have) (retired|promoted)|decided to' "$DOC"
```
Result on the real file: **PASS** (no match, rc=1).

**Mutation check** (both directions, run against throwaway copies — the tracked file was never
touched):
1. Stripped the `### Option B` section out of a copy → guilt check went **RED**
   (`MISSING: PROMOTE`), confirming the check can actually fail.
2. Appended `"We have retired the daemon and it is no longer running."` to a copy → innocence check
   went **RED** (matched, rc=0), confirming it can catch premature-decision language.
3. Re-ran both checks against the real, unmodified file afterward: both still **PASS** — no residue
   from the mutation copies.

## PROVE-LIVE

This is a documentation-only change (no code, no config, no daemon touched). The only "consuming
surface" is a future session grepping `nuzantara-repo-sync` or reading `docs/operations/`:

```
$ git -C <worktree> show origin/main:docs/operations/2026-08-07-nuzantara-repo-sync-doctrine-conflict.md \
    | head -1
```
will resolve once merged — not executed pre-merge since the file doesn't exist on `origin/main` yet.
Verified instead that the pushed branch content matches the local commit exactly (`git diff` between
branch tip and working tree = empty) and that CI will see the identical bytes.

## Seen, not cured (explicitly out of scope for this item)

- Whether to actually retire or promote the daemon — left to the next reader per the brief.
- `docs/operations/handoff-observability-block-2026-08-06.md` §1 (auth-sentinel.daily HOME-fork,
  a different item in the same handoff) — untouched.
- `MEMORY.md` byte-cap: at 24970/24985 before this run, effectively full. A dedicated compaction
  pass (per its own doctrine: "comprimi la PROSA", never truncate the last entries) is a separate,
  larger piece of work than this item's scope.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>