### PR TITLE
fix(organism): scan_sidecars judges by jurisdiction, not just staleness

### DIFF
--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -206,6 +206,74 @@ class StaleFinding:
         }
 
 
+def _machine_label(host: str | None = None) -> str:
+    """Return this machine's short label: m5 / mini / pro / <raw hostname>.
+
+    Self-contained port of proprioception.py::machine_label() (same file's
+    probe_guardian_freshness(), 2026-07-17 lesson: "a Pro-only guardian probed
+    on M5 is a false DIVERGED — jurisdiction, not divergence"). Duplicated
+    rather than imported: this detector is invoked as a standalone,
+    bootstrap-safe script (see module docstring: `cat ... | ssh pro python3 -`)
+    and must not gain an intra-repo import dependency.
+
+    host is injectable so tests can exercise jurisdiction scoping without
+    touching the real hostname (mirrors sync_cross_host_sidecars's own `host`
+    param below); defaults to socket.gethostname() in production.
+    """
+    h = (host or socket.gethostname()).split(".")[0].lower()
+    if "air-m5" in h:
+        return "m5"
+    if "mini" in h:
+        return "mini"
+    if h == "nuzantara":
+        return "pro"
+    return h
+
+
+# organ_id PREFIX -> the host whose jurisdiction the sidecar falls under.
+# Ported from proprioception.py::probe_guardian_freshness()'s per-item machine
+# scoping (same 2026-07-17 lesson as _machine_label() above). "cell" and
+# "infra" both resolve to "pro" because, as of today, EVERY cell.*/infra.*
+# sidecar in this organism is written exclusively by
+# launchagent-state-bridge.py, which is gated to run ONLY on Pro (see its
+# BRIDGED_TCP_PROBES + CORE_ORGANS_EXPECTED's comment above: "All five are
+# Pro-resident"). A prefix ABSENT from this map (wr2., codex., mata_garuda., a
+# bare "auth-sentinel", ...) is NOT jurisdiction-scoped — today's behaviour
+# (report it) is preserved, because an unrecognised prefix is evidence of
+# nothing: attribute-or-report, never attribute-or-drop. Audit this map if a
+# cell.*/infra.* organ is ever written from a host other than Pro.
+ORGAN_PREFIX_HOST: dict[str, str] = {
+    "pro": "pro",
+    "mini": "mini",
+    "m5": "m5",
+    "cell": "pro",
+    "infra": "pro",
+}
+
+
+def _is_foreign_jurisdiction(
+    organ_id: str,
+    here: str,
+    sources: dict[str, dict[str, str]] = CROSS_HOST_SIDECAR_SOURCES,
+) -> bool:
+    """True iff this sidecar belongs to another host's organ and is not an
+    explicit cross-host mirror (CROSS_HOST_SIDECAR_SOURCES).
+
+    Root cause this closes: a Pro-owned snapshot (e.g. pro.translate_hourly)
+    orphaned in a DIFFERENT machine's ~/.organism/last_seen/ — nothing on that
+    machine ever refreshes another host's organ, so the stray file freezes
+    forever and reads as a dead organ that is, in fact, alive on its own host
+    (2026-08-07). infra.eventbus_redis_mini is the deliberate exception: its
+    canonical writer also lives on Pro, but CROSS_HOST_SIDECAR_SOURCES exists
+    precisely so Mini (and, transitively, any other non-owning host) keeps
+    seeing it — silencing that mirror here would be the W94 under-match twin.
+    """
+    owner = ORGAN_PREFIX_HOST.get(organ_id.split(".", 1)[0])
+    if owner is None or owner == here:
+        return False
+    return organ_id not in sources
+
+
 def _parse_ts(raw: Any, fallback_mtime: float) -> float:
     """Parse both sidecar schemas (superscar #9 tolerance).
 
@@ -234,6 +302,7 @@ def scan_sidecars(
     stale_days: float = DEFAULT_STALE_DAYS,
     now: float | None = None,
     expect_core: tuple[str, ...] | None = None,
+    host: str | None = None,
 ) -> list[StaleFinding]:
     """Return findings for organs whose heartbeat is stale, missing, or corrupt.
 
@@ -244,6 +313,12 @@ def scan_sidecars(
     to the machine-resident core set (Pro only) when scanning the real organism
     dir; tests pass () so an isolated tmp dir does not spuriously flag the
     production core organs, and M5/Mini scans do not flag Pro-resident organs.
+
+    host is forwarded to _machine_label() for jurisdiction scoping (see
+    _is_foreign_jurisdiction): a sidecar owned by another host (by its
+    organ_id prefix) is skipped unless it is on the CROSS_HOST_SIDECAR_SOURCES
+    allow-list — a stray same-name snapshot orphaned on the wrong machine is
+    not evidence that organ is dead, it just isn't this machine's to judge.
     """
     if expect_core is None:
         expect_core = (
@@ -252,6 +327,7 @@ def scan_sidecars(
             else ()
         )
     now = time.time() if now is None else now
+    here = _machine_label(host)
     findings: list[StaleFinding] = []
 
     if not os.path.isdir(sidecar_dir):
@@ -263,6 +339,8 @@ def scan_sidecars(
             continue
         organ_id = fname[: -len(".json")]
         seen.add(organ_id)
+        if _is_foreign_jurisdiction(organ_id, here):
+            continue
         path = os.path.join(sidecar_dir, fname)
         try:
             with open(path, encoding="utf-8") as fh:
@@ -331,6 +409,7 @@ def scan_sidecars_status(
     now: float | None = None,
     benign: frozenset[str] = KNOWN_BENIGN_FAILED,
     expect_core: tuple[str, ...] | None = None,
+    host: str | None = None,
 ) -> list[StaleFinding]:
     """Full receptor scan: stale/dead/corrupt (via scan_sidecars) PLUS unhealthy.
 
@@ -341,10 +420,19 @@ def scan_sidecars_status(
 
     This is the status-aware extension (2026-06-28): the prior receptor saw the
     mute organs but ignored the ones crying for help.
+
+    host is forwarded to scan_sidecars() AND applied again in this function's
+    own unhealthy loop below — without the second application, a foreign-host
+    organ that scan_sidecars() correctly skips as out-of-jurisdiction would
+    fall through into `already` being empty for it and get reported here
+    instead as "unhealthy", turning a jurisdiction skip into a misclassified
+    finding rather than a clean skip (2026-08-07).
     """
     now = time.time() if now is None else now
+    here = _machine_label(host)
     findings = scan_sidecars(
-        sidecar_dir, stale_days=stale_days, now=now, expect_core=expect_core
+        sidecar_dir, stale_days=stale_days, now=now, expect_core=expect_core,
+        host=host,
     )
     already = {f.organ_id for f in findings}  # don't double-count stale/corrupt
 
@@ -356,6 +444,8 @@ def scan_sidecars_status(
             continue
         organ_id = fname[: -len(".json")]
         if organ_id in already or organ_id in benign:
+            continue
+        if _is_foreign_jurisdiction(organ_id, here):
             continue
         path = os.path.join(sidecar_dir, fname)
         try:

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -46,7 +46,7 @@ def test_stale_float_ts_flagged_guilt(tmp_path):
     d = str(tmp_path)
     old = time.time() - 28 * 86400
     _write(d, "pro.dlq_autopilot", {"ts": old, "status": "ok"})
-    findings = scan_sidecars(d, stale_days=7)
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
     assert len(findings) == 1
     f = findings[0]
     assert f.organ_id == "pro.dlq_autopilot"
@@ -61,7 +61,7 @@ def test_stale_iso_ts_flagged_schema_tolerant(tmp_path):
         "%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 20 * 86400)
     )
     _write(d, "pro.sentinel", {"ts": iso_old, "status": "degraded"})
-    findings = scan_sidecars(d, stale_days=7)
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
     assert len(findings) == 1
     assert findings[0].organ_id == "pro.sentinel"
     assert 19 <= findings[0].age_days <= 21
@@ -71,7 +71,7 @@ def test_corrupt_sidecar_flagged_not_skipped(tmp_path):
     """A guard that silently skips a broken sidecar is blind (#2)."""
     d = str(tmp_path)
     _write(d, "pro.broken", "{not valid json")
-    findings = scan_sidecars(d, stale_days=7)
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
     assert len(findings) == 1
     assert findings[0].kind == "corrupt"
 
@@ -83,7 +83,7 @@ def test_innocence_many_fresh_one_stale(tmp_path):
     for i in range(20):
         _write(d, f"pro.healthy_{i}", {"ts": now - 60, "status": "ok"})
     _write(d, "infra.pg_bridge_watchdog", {"ts": now - 22 * 86400, "status": "ok"})
-    findings = scan_sidecars(d, stale_days=7)
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
     assert len(findings) == 1
     assert findings[0].organ_id == "infra.pg_bridge_watchdog"
 
@@ -94,7 +94,7 @@ def test_threshold_boundary(tmp_path):
     now = time.time()
     _write(d, "pro.just_under", {"ts": now - 6 * 86400, "status": "ok"})
     _write(d, "pro.just_over", {"ts": now - 8 * 86400, "status": "ok"})
-    findings = scan_sidecars(d, stale_days=7)
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
     ids = {f.organ_id for f in findings}
     assert ids == {"pro.just_over"}
 
@@ -153,7 +153,7 @@ def test_guilt_canonical_checkout_stamp_still_flags_stale(tmp_path):
 def test_finding_is_serializable(tmp_path):
     d = str(tmp_path)
     _write(d, "pro.x", {"ts": time.time() - 30 * 86400, "status": "ok"})
-    findings = scan_sidecars(d, stale_days=7)
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
     blob = json.dumps([f.to_dict() for f in findings])
     assert "pro.x" in blob
 
@@ -208,7 +208,7 @@ def test_degraded_status_flagged(tmp_path):
     """degraded (not just failed) is also surfaced if not benign."""
     d = str(tmp_path)
     _write(d, "pro.real_degraded", {"ts": time.time(), "status": "degraded"})
-    findings = scan_sidecars_status(d, now=time.time())
+    findings = scan_sidecars_status(d, now=time.time(), host="nuzantara")
     assert any(f.organ_id == "pro.real_degraded" and f.kind == "unhealthy" for f in findings)
 
 
@@ -220,7 +220,7 @@ def test_stale_failed_not_double_counted(tmp_path):
     d = str(tmp_path)
     old = time.time() - 30 * 86400
     _write(d, "pro.old_and_failed", {"ts": old, "status": "failed"})
-    findings = scan_sidecars_status(d, now=time.time())
+    findings = scan_sidecars_status(d, now=time.time(), host="nuzantara")
     kinds = {f.kind for f in findings if f.organ_id == "pro.old_and_failed"}
     assert kinds == {"stale"}, f"expected only stale, got {kinds}"
 
@@ -419,3 +419,110 @@ def test_cross_host_sync_graceful_on_timeout(tmp_path, monkeypatch):
 
     with open(p, encoding="utf-8") as fh:
         assert json.load(fh)["ts"] == old_ts
+
+
+# ---------------------------------------------------------------------------
+# Jurisdiction scoping (2026-08-07): scan_sidecars() read every file in the
+# local ~/.organism/last_seen/ with no host/jurisdiction scoping, so a Pro
+# sidecar orphaned on M5 since 2026-07-21 (pro.translate_hourly, frozen wall-
+# clock, never refreshed by anything on M5) reported "heartbeat frozen 17.0d"
+# as a phantom P1 while the real Pro organ ran fine that same day. Straight
+# port of proprioception.py::probe_guardian_freshness()'s per-item machine
+# scoping (same 2026-07-17 "jurisdiction, not divergence" lesson).
+# ---------------------------------------------------------------------------
+
+from organism_stale_detector import _is_foreign_jurisdiction, _machine_label  # noqa: E402
+
+
+def test_guilt_pro_sidecar_orphaned_on_m5_not_flagged(tmp_path):
+    """GUILT (of the OLD code / innocence of the NEW code): a pro.* sidecar
+    frozen 17d, present in the local last_seen dir, must NOT be reported when
+    running on M5 — it is not M5's organ to judge (jurisdiction, not
+    divergence). This is the exact live shape of pro.translate_hourly.json."""
+    d = str(tmp_path)
+    old = time.time() - 17 * 86400
+    _write(d, "pro.translate_hourly", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7, host="air-m5")
+    assert findings == [], f"foreign-host sidecar wrongly flagged on M5: {findings}"
+
+
+def test_guilt_pro_sidecar_still_flags_on_pro(tmp_path):
+    """GUILT (of the finding surviving): the SAME frozen pro.* sidecar MUST
+    still be reported when scanned from Pro itself — jurisdiction skip must
+    not silently delete a real alarm on the machine that owns it."""
+    d = str(tmp_path)
+    old = time.time() - 17 * 86400
+    _write(d, "pro.translate_hourly", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
+    assert len(findings) == 1
+    assert findings[0].organ_id == "pro.translate_hourly"
+    assert findings[0].kind == "stale"
+
+
+def test_innocence_cross_host_allowlisted_organ_still_flags_on_m5(tmp_path):
+    """INNOCENCE (the W94 under-match twin): infra.eventbus_redis_mini is the
+    one legitimately cross-host-mirrored organ (CROSS_HOST_SIDECAR_SOURCES) —
+    silencing it via the new jurisdiction skip would be exactly the under-match
+    failure mode this repo has scarred on before. It must STILL be flagged
+    stale on M5 even though its organ_id prefix ("infra.") resolves to "pro"."""
+    d = str(tmp_path)
+    old = time.time() - 30 * 86400
+    _write(d, "infra.eventbus_redis_mini", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7, host="air-m5")
+    assert len(findings) == 1
+    assert findings[0].organ_id == "infra.eventbus_redis_mini"
+
+
+def test_innocence_m5_own_sidecar_still_flags_on_m5(tmp_path):
+    """INNOCENCE: an m5.* sidecar scanned on M5 is squarely in-jurisdiction —
+    the new skip must never suppress a machine's own organs."""
+    d = str(tmp_path)
+    old = time.time() - 30 * 86400
+    _write(d, "m5.arsenal_probe", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7, host="air-m5")
+    assert len(findings) == 1
+    assert findings[0].organ_id == "m5.arsenal_probe"
+
+
+def test_innocence_unrecognised_prefix_keeps_reporting(tmp_path):
+    """INNOCENCE: attribute-or-report, never attribute-or-drop. An organ_id
+    whose prefix isn't in ORGAN_PREFIX_HOST (or has no prefix at all) is not
+    evidence the sidecar is foreign — today's behaviour (report it) must be
+    unchanged regardless of which machine is scanning."""
+    d = str(tmp_path)
+    old = time.time() - 30 * 86400
+    _write(d, "auth-sentinel", {"ts": old, "status": "ok"})
+    _write(d, "wr2.html_apply.runtime", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7, host="air-m5")
+    ids = {f.organ_id for f in findings}
+    assert ids == {"auth-sentinel", "wr2.html_apply.runtime"}
+
+
+def test_scan_sidecars_status_does_not_reclassify_foreign_stale_as_unhealthy(tmp_path):
+    """GUILT of the two-loop consistency fix: scan_sidecars_status() must skip
+    a foreign-jurisdiction sidecar in ITS OWN unhealthy loop too — otherwise a
+    clean jurisdiction skip in scan_sidecars() turns into a misclassified
+    'unhealthy' finding one loop later (worse than the original bug: it fires
+    on the SAME data with a DIFFERENT, less legible verdict)."""
+    from organism_stale_detector import scan_sidecars_status
+
+    d = str(tmp_path)
+    _write(d, "pro.some_failed_organ", {"ts": time.time(), "status": "failed"})
+    findings = scan_sidecars_status(d, now=time.time(), host="air-m5")
+    assert findings == [], f"foreign sidecar reclassified as unhealthy: {findings}"
+
+
+def test_machine_label_recognises_all_three_hosts():
+    assert _machine_label("air-m5") == "m5"
+    assert _machine_label("Air-M5.local") == "m5"
+    assert _machine_label("mini-pro2") == "mini"
+    assert _machine_label("nuzantara") == "pro"
+    assert _machine_label("some-ci-runner") == "some-ci-runner"
+
+
+def test_is_foreign_jurisdiction_unit():
+    assert _is_foreign_jurisdiction("pro.translate_hourly", "m5") is True
+    assert _is_foreign_jurisdiction("pro.translate_hourly", "pro") is False
+    assert _is_foreign_jurisdiction("infra.eventbus_redis_mini", "m5") is False
+    assert _is_foreign_jurisdiction("m5.arsenal_probe", "m5") is False
+    assert _is_foreign_jurisdiction("auth-sentinel", "m5") is False


### PR DESCRIPTION
## What was measured today (2026-08-07)

- `python3 scripts/proprioception.py --json --no-report --no-fetch` on M5 (worktree, byte-identical
  to origin/main — `diff` rc=0): `organs_heartbeat` DIVERGED with **2** findings —
  `m5.arsenal_probe` (age 7.1d, in-jurisdiction, unrelated to this fix) and
  `pro.translate_hourly` (age 17.0d — the phantom).
- `date +%s` = `1786081244`; sidecar `ts` = `1784608561.718076` →
  `(1786081244 - 1784608561.718076) / 86400 = 17.045d` — matches the reported age exactly, confirming
  the file is frozen wall-clock and nothing on M5 ever refreshes it.
- `~/.organism/last_seen/` on M5 had 7 files, including the orphan `pro.translate_hourly.json`
  (mtime 21 lug) and a stray `pro.zsh_probe.json.tmp.523` (mtime 29 lug) — the latter does **not**
  end in `.json`, so `scan_sidecars()` already ignored it; not part of the class defect, pure cleanup.

## What changed

`scripts/organism_stale_detector.py`:
- `_machine_label(host=None)` — self-contained port of `proprioception.py::machine_label()`
  (duplicated, not imported: this detector is invoked as a standalone bootstrap-safe script per its
  own module docstring, `cat ... | ssh pro python3 -`).
- `ORGAN_PREFIX_HOST` — maps organ_id prefix → owning host (`pro`/`mini`/`m5`; `cell`/`infra` → `pro`,
  because every `cell.*`/`infra.*` sidecar today is written exclusively by
  `launchagent-state-bridge.py`, gated to run only on Pro).
- `_is_foreign_jurisdiction(organ_id, here)` — true iff the organ belongs to another host's
  jurisdiction AND is not on the `CROSS_HOST_SIDECAR_SOURCES` allow-list.
- `scan_sidecars()` now skips a foreign-jurisdiction sidecar before ever opening it (before the
  corrupt/staleness checks — jurisdiction is decided from the filename alone).
- `scan_sidecars_status()` also gained the same skip in its own second (unhealthy-status) loop —
  without it, a jurisdiction-skipped stale organ would fall through and get **misclassified** as
  "unhealthy" one loop later instead of cleanly skipped, which is worse than the original bug (same
  false positive, less legible verdict). Both functions accept an injectable `host` param for tests.

Deleted (after the scoping test went green, per the ordering constraint in the brief):
`~/.organism/last_seen/pro.translate_hourly.json` (the orphan) and
`~/.organism/last_seen/pro.zsh_probe.json.tmp.523` (stray, unrelated to the class defect).

## Guilt test

`test_guilt_pro_sidecar_orphaned_on_m5_not_flagged` — a `pro.*` sidecar frozen 17d, present in a tmp
`last_seen` dir, scanned with `host="air-m5"` → `findings == []` (was previously flagged).
Run: `apps/backend-rag/.venv/bin/python3 -m pytest scripts/tests/test_organism_stale_detector.py -q`
→ `32 passed`.

## Innocence tests

- `test_guilt_pro_sidecar_still_flags_on_pro` — same file, `host="nuzantara"` → still flagged stale
  (the finding survives on the owning host; the fix must not delete a real alarm).
- `test_innocence_cross_host_allowlisted_organ_still_flags_on_m5` — `infra.eventbus_redis_mini`
  (the one legitimately cross-host-mirrored organ) stale on M5 → still flagged (else this would be
  the W94 under-match twin — silencing the allow-listed mirror).
- `test_innocence_m5_own_sidecar_still_flags_on_m5` — `m5.*` sidecar on M5 → still flagged
  (in-jurisdiction).
- `test_innocence_unrecognised_prefix_keeps_reporting` — `auth-sentinel` / `wr2.html_apply.runtime`
  (no recognised prefix) → still flagged regardless of host (attribute-or-report, never
  attribute-or-drop).
- `test_scan_sidecars_status_does_not_reclassify_foreign_stale_as_unhealthy` — a foreign `pro.*`
  organ with `status=failed`, scanned via `scan_sidecars_status(host="air-m5")` → `[]`, not
  reclassified as "unhealthy".

## Mutation check

Replaced the `if _is_foreign_jurisdiction(organ_id, here): continue` guard with `if False: continue`
(jurisdiction check disabled), re-ran the suite: `test_guilt_pro_sidecar_orphaned_on_m5_not_flagged`
went **red** —
`AssertionError: foreign-host sidecar wrongly flagged on M5: [StaleFinding(organ_id='pro.translate_hourly', ...)]`
(1 failed, 31 passed). Restored the real fix, re-ran: `32 passed`.

## Live proof (real production directory, not synthetic)

```
$ hostname
Air-M5
$ python3 scripts/organism_stale_detector.py --json     # BEFORE (measured at session start via proprioception)
[{"organ_id": "m5.arsenal_probe", ...}, {"organ_id": "pro.translate_hourly", "kind": "stale", "age_days": 17.0, ...}]

$ python3 scripts/organism_stale_detector.py --json     # AFTER the fix, same real ~/.organism/last_seen/
[{"organ_id": "m5.arsenal_probe", "kind": "stale", "age_days": 7.1, ...}]
```

Also proved jurisdiction symmetry against the **same real directory** by calling `scan_sidecars_status`
with `host="nuzantara"` in-process: it flags `pro.translate_hourly` (17.1d) and *not*
`m5.arsenal_probe` — the exact mirror image of the M5 view. `proprioception.py`'s `organs_heartbeat`
probe went from `n_findings: 2` to `n_findings: 1` (only `m5.arsenal_probe`, an unrelated pre-existing
M5-jurisdiction finding — VCR pilot memory: M5 is not `arsenal_probe`'s primary, staleness there is
by-design, out of this cure's scope).

## Prove-live on consuming surfaces (post-merge)

- `proprioception.py`'s `organs_heartbeat` wrap probe (`{repo}/scripts/organism_stale_detector.py --json`) —
  will stop reporting `pro.translate_hourly` on M5 once main is pulled/worktree-refreshed there; command
  to verify: `python3 scripts/proprioception.py --json --no-report --no-fetch` on M5, and separately on
  Pro to confirm the finding still fires where it's owned.
- `~/.organism/alerts/open.jsonl` (SessionStart-hook-injected) — only populated by `--emit`, not armed
  by any cron on M5 per the module's own docstring ("v1 has NO cron: with no session there is no
  alarm"); nothing further to prove live beyond the two commands above.

## Seen, not cured (out of this finding's scope)

- `m5.arsenal_probe` staleness on M5 (7.1d) — pre-existing, separate, already-known finding (VCR pilot:
  M5 is not `arsenal_probe`'s primary; staleness there is by design). Left untouched.
- The general question of whether other `scan_sidecars_status()`-fed surfaces beyond the wrap probe
  exist was not re-audited beyond the grep in this PR's evidence trail.

## Scope discipline

Touched only the two files the brief named: `scripts/organism_stale_detector.py` and
`scripts/tests/test_organism_stale_detector.py`. Did not touch `organs_registry.yaml`,
`declared-pairs.json`, `PENDING-ARMS.md`, or `DOCS_INVENTORY.md`. Did not touch `proprioception.py`
(three other items own regions of that file, per the brief).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>