### PR TITLE
fix(cron): one failure, one Telegram — carrying the job's own sentence

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -153,6 +153,8 @@ jobs:
               scripts/test_cron_state_alert.sh|\
               scripts/cron-runner.sh|\
               scripts/test_cron_runner_alert.sh|\
+              scripts/test_cron_single_voice.sh|\
+              apps/evaluator/nlm_deep_research/scripts/_alert.sh|\
               infra/scripts/fly-backup.sh|\
               scripts/test_fly_backup_phases.sh|\
               scripts/ci/queue_rearm.sh|\
@@ -386,6 +388,20 @@ jobs:
           # anywhere. All three exits are asserted — a fix that covers only the path
           # that bit you is half a fix.
           bash scripts/test_cron_runner_alert.sh
+
+      - name: One voice per cron failure (payload + wrapper must not both send)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # The far side of the two steps above. Giving the wrappers a voice closed a
+          # real silence and opened a smaller one: the 20 nlm_deep_research payloads
+          # already alarmed for themselves, and 19 run under a wrapper that alarms too
+          # — one failure, two P0s ~2s apart, measured on run_nb2_pipeline 2026-08-06.
+          # Neither message contained the other (the payload names the log path, the
+          # wrapper quotes 600 bytes of raw stdout), so the wrapper now carries the
+          # payload's sentence. Innocence matters as much as guilt here:
+          # run_peraturan_ingestion.sh runs from crontab with NO wrapper, so an
+          # unconditional deferral would have made it mute.
+          bash scripts/test_cron_single_voice.sh
 
       - name: Connectome alert honesty corpus (freshness + truncation + delivery)
         if: steps.paths.outputs.relevant == 'true'

--- a/apps/evaluator/nlm_deep_research/scripts/_alert.sh
+++ b/apps/evaluator/nlm_deep_research/scripts/_alert.sh
@@ -45,10 +45,44 @@
 _ALERT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 TG_NOTIFY="${TG_NOTIFY:-$(cd "$_ALERT_LIB_DIR/../../../.." && pwd)/scripts/tg_notify.py}"
 
+# ── One voice per failure (2026-08-07) ───────────────────────────────────────
+# Nineteen of the twenty wrappers in this directory run under a cron wrapper
+# that ALSO alarms on their non-zero exit, so one failure produced two P0s ~2s
+# apart. Measured on the archived pair for run_nb2_pipeline, they carry
+# DIFFERENT information and neither contains the other:
+#
+#   script:   "🚨 NB2 Immigration pipeline FAILED (exit 1) — check <log path>"
+#   wrapper:  "CRON FAIL <host> / Job: … / Exit: 1 / Duration: 3s" + 600 bytes
+#             of raw tail — registry counts, a JSON run blob, no log path.
+#
+# So silencing either one loses something real. Instead the wrapper hands the
+# job its own sentence: a wrapper that will alarm on our failure AND can
+# capture our output exports CRON_ALARM_OWNER, and we print the text for it to
+# carry instead of sending a second message.
+#
+# The default direction is the safe one — with the variable unset we send
+# exactly as before. run_peraturan_ingestion.sh runs from crontab with NO
+# wrapper at all, so an unconditional deferral would have made it mute; the
+# opt-in is what keeps it speaking. The wrapper only claims the voice when it
+# can actually carry the words (cron-runner exports this only once its capture
+# tmpfile exists), so "deferred" can never mean "dropped".
+#
+# Marker string duplicated rather than sourced: the alarm path must not gain a
+# dependency that can fail the way the thing it reports fails (W108). The three
+# copies are pinned in agreement by scripts/test_cron_single_voice.sh.
+CRON_ALERT_MARKER="CRON_ALERT_P0:"
+
 alert() {  # alert <tier> <text...>
     local tier="$1"
     shift
     local source_name="${ALERT_SOURCE:-$(basename "${0:-nlm-deep-research}" .sh)}"
+
+    if [ "$tier" = "p0" ] && [ -n "${CRON_ALARM_OWNER:-}" ]; then
+        # Newlines collapsed: the wrapper greps this back out line-anchored.
+        printf '%s %s\n' "$CRON_ALERT_MARKER" "$(printf '%s' "$*" | tr '\n' ' ')"
+        echo "tg[p0] deferred to wrapper ${CRON_ALARM_OWNER} (single voice)" >&2
+        return 0
+    fi
 
     if [ ! -f "$TG_NOTIFY" ]; then
         echo "ALERT NOT SENT — gateway missing at $TG_NOTIFY [$tier]: $*" >&2

--- a/scripts/cron-runner.sh
+++ b/scripts/cron-runner.sh
@@ -111,6 +111,24 @@ PY
 #
 # Deliberately fail-open: the job's exit code is the contract this wrapper
 # exists to preserve, and an alerting problem must never rewrite it.
+# ── One voice per failure (2026-08-07) ──────────────────────────────────────
+# 19 of the 20 nlm_deep_research wrappers alarm for themselves AND run under
+# this runner, so one failure sent two P0s ~2s apart. Rather than silence
+# either — measured, the job's sentence names the log path and this one's raw
+# tail does not — the payload hands us its sentence and we carry it. Contract
+# in apps/evaluator/nlm_deep_research/scripts/_alert.sh; the marker is
+# duplicated there and in cron-wrapper.sh, pinned by test_cron_single_voice.sh.
+CRON_ALERT_MARKER="CRON_ALERT_P0:"
+
+deferred_summary() {  # deferred_summary <captured-output-file> -> the job's own line
+    [ -n "${1:-}" ] && [ -f "$1" ] || return 1
+    local line
+    line="$(grep -a "^${CRON_ALERT_MARKER}" "$1" 2>/dev/null | tail -1)"
+    [ -n "$line" ] || return 1
+    line="${line#"$CRON_ALERT_MARKER"}"
+    printf '%s' "${line# }"
+}
+
 alert_failure() {  # alert_failure <job_key> <exit_code> <start_ts> <end_ts> <tail>
     local job_key="$1" exit_code="$2" start_ts="$3" end_ts="$4" tail_text="$5"
     local gateway
@@ -158,6 +176,9 @@ fi
 # true exit code despite the pipe.
 ERR_TMP="$(mktemp "${TMPDIR:-/tmp}/cron-runner.XXXXXX" 2>/dev/null || true)"
 if [ -n "$ERR_TMP" ]; then
+    # Claim the voice ONLY on the branch that can capture the payload's output:
+    # without the tmpfile a deferred alarm would be a dropped one.
+    export CRON_ALARM_OWNER="$JOB_KEY"
     /bin/bash "$SCRIPT" "$@" 2>&1 | tee "$ERR_TMP"
     EXIT_CODE="${PIPESTATUS[0]}"
 else
@@ -166,15 +187,25 @@ else
 fi
 END_TS="$(date +%s)"
 STATUS="ok"
+ALERT_BODY=""
 if [ "$EXIT_CODE" -ne 0 ]; then
     STATUS="failed"
     if [ -n "$ERR_TMP" ] && [ -s "$ERR_TMP" ]; then
         export CRON_RUNNER_LAST_ERROR="$(tail -n 40 "$ERR_TMP" 2>/dev/null | tail -c 2000)"
     fi
+    ALERT_BODY="${CRON_RUNNER_LAST_ERROR:-}"
+    # Only the human-facing alarm swaps in the job's own sentence. The RECEIPT
+    # deliberately keeps the raw tail: the DLQ autopilot classifies on
+    # last_error, and a 40-line tail carries more for it to classify than one
+    # curated line (superscar #9 — don't change a contract its readers didn't
+    # ask to change).
+    if _summary="$(deferred_summary "$ERR_TMP")" && [ -n "$_summary" ]; then
+        ALERT_BODY="$_summary"
+    fi
 fi
 [ -n "$ERR_TMP" ] && rm -f "$ERR_TMP"
 write_state "$JOB_KEY" "$STATUS" "$START_TS" "$END_TS" "$EXIT_CODE" "$SCRIPT" "$@"
 if [ "$EXIT_CODE" -ne 0 ]; then
-    alert_failure "$JOB_KEY" "$EXIT_CODE" "$START_TS" "$END_TS" "${CRON_RUNNER_LAST_ERROR:-}"
+    alert_failure "$JOB_KEY" "$EXIT_CODE" "$START_TS" "$END_TS" "$ALERT_BODY"
 fi
 exit "$EXIT_CODE"

--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -166,6 +166,17 @@ run_command_with_timeout() {
     return "$exit_code"
 }
 
+# ── One voice per failure (2026-08-07) ───────────────────────────────────────
+# Same cure as cron-runner.sh, applied here because this wrapper alarms too and
+# two of the nlm_deep_research jobs (t4-monitor, db-nlm-sync) run under it —
+# curing one wrapper of five is how W107 happened. Both paths of
+# run_command_with_timeout land the payload's output in $OUTPUT, so this
+# wrapper can always carry the words and claims the voice unconditionally.
+# Marker duplicated on purpose (see _alert.sh); agreement pinned by
+# scripts/test_cron_single_voice.sh.
+CRON_ALERT_MARKER="CRON_ALERT_P0:"
+export CRON_ALARM_OWNER="$JOB_NAME"
+
 # ── Execute with retry ───────────────────────────────────────────────────────
 ATTEMPT=0
 EXIT_CODE=1
@@ -267,7 +278,16 @@ printf '{"job":"%s","ts":%d,"status":"%s","host":"%s","source":"cron-wrapper","d
 
 # ── Alert on failure ─────────────────────────────────────────────────────────
 if [ $EXIT_CODE -ne 0 ]; then
-    LAST_LINES=$(echo "$OUTPUT" | tail -5)
+    # Prefer the sentence the job named for itself over five lines of raw tail;
+    # fall back to the tail when it did not name one. The receipt above keeps
+    # the raw tail either way — only this human-facing body changes.
+    LAST_LINES=$(printf '%s' "$OUTPUT" | grep -a "^${CRON_ALERT_MARKER}" | tail -1)
+    if [ -n "$LAST_LINES" ]; then
+        LAST_LINES="${LAST_LINES#"$CRON_ALERT_MARKER"}"
+        LAST_LINES="${LAST_LINES# }"
+    else
+        LAST_LINES=$(echo "$OUTPUT" | tail -5)
+    fi
     MSG="CRON FAIL $HOSTNAME_SHORT
 Job: $JOB_NAME
 Exit: $EXIT_CODE (after $ATTEMPT attempts)

--- a/scripts/test_cron_single_voice.sh
+++ b/scripts/test_cron_single_voice.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Proof that ONE cron failure produces ONE Telegram, carrying the job's own words.
+#
+# TRAUMA (2026-08-07). Giving the cron wrappers a voice (W107, 2026-07-28) closed a
+# real silence and opened a smaller one at the other end: the payloads in
+# apps/evaluator/nlm_deep_research/scripts already alarmed for themselves, and 19 of
+# the 20 run under a wrapper that alarms too. One failure, two P0s ~2s apart.
+# Measured on the archived pair for run_nb2_pipeline (2026-08-06 02:10), they carry
+# DIFFERENT information and neither contains the other:
+#
+#   script:  "🚨 NB2 Immigration pipeline FAILED (exit 1) — check <log path>"
+#   wrapper: "CRON FAIL … Job: … Exit: 1 Duration: 3s" + 600 bytes of raw stdout —
+#            registry counts, a HALTED state line, a JSON run blob. No log path.
+#
+# So "silence the script" loses the path and "silence the wrapper" reopens W107.
+# The wrapper carries the job's sentence instead: it exports CRON_ALARM_OWNER, the
+# payload prints CRON_ALERT_P0: <text> rather than sending, and the wrapper prefers
+# that line over its raw tail.
+#
+#   GUILT ×2      — under EACH alarming wrapper (cron-runner, cron-wrapper): exactly
+#                   ONE send, and it carries the job's sentence including the log path.
+#   INNOCENCE ×4  — a payload with no wrapper must still send (run_peraturan_ingestion.sh
+#                   is invoked from crontab bare; an unconditional deferral would have
+#                   made it mute); a non-p0 tier is never deferred; a payload that names
+#                   no sentence still gets the raw tail; success still says nothing.
+#   RETRIES       — cron-wrapper retries a failing job, and the payload's own alarm
+#                   carries NO dedup key, so before this the retries multiplied the
+#                   messages. One failure must stay one message.
+#   AGREEMENT     — the marker literal is duplicated in three files on purpose (the
+#                   alarm path must not gain a dependency that fails the way the thing
+#                   it reports fails, W108). Duplication is only safe if something
+#                   pins it: this does.
+#
+# No network. The wrappers run from a tmp tree shaped like the repo, with a fake
+# tg_notify.py where BOTH the wrapper and _alert.sh resolve it — so the count below is
+# every message that would have been sent, from either mouth.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+TMP="$(mktemp -d)"
+trap '/bin/rm -rf "${TMP:?}"' EXIT
+
+RUNNER="$HERE/cron-runner.sh"
+WRAPPER="$HERE/cron-wrapper.sh"
+ALERTLIB="$REPO/apps/evaluator/nlm_deep_research/scripts/_alert.sh"
+for f in "$RUNNER" "$WRAPPER" "$ALERTLIB"; do
+    [ -f "$f" ] || { echo "missing: $f"; exit 1; }
+done
+
+PASS=0; FAIL=0
+check () {  # check <name> <0|1>
+    if [ "$2" = "0" ]; then PASS=$((PASS+1)); printf '  ok    %s\n' "$1"
+    else FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; fi
+}
+yes_if () { [ "$1" = "$2" ] && echo 0 || echo 1; }
+sends () { grep -c '^=== SEND ===$' "$TMP/gateway.log" 2>/dev/null || echo 0; }
+body_has () { grep -q -- "$1" "$TMP/gateway.log" 2>/dev/null && echo 0 || echo 1; }
+
+SENTENCE='NB-X pipeline FAILED — check /tmp/nbx-run.log'
+NOISE='raw stdout noise the wrapper would otherwise quote'
+
+build_world () {  # build_world ; payload behaviour tuned by PAYLOAD_BODY
+    rm -rf "${TMP:?}/repo" "${TMP:?}/home" "${TMP:?}/gateway.log"
+    mkdir -p "$TMP/repo/scripts" "$TMP/repo/apps/evaluator/nlm_deep_research/scripts" \
+             "$TMP/home/.agent/decisions/state" "$TMP/home/logs/cron"
+    cp "$RUNNER"   "$TMP/repo/scripts/cron-runner.sh"
+    cp "$WRAPPER"  "$TMP/repo/scripts/cron-wrapper.sh"
+    cp "$ALERTLIB" "$TMP/repo/apps/evaluator/nlm_deep_research/scripts/_alert.sh"
+
+    # One fake gateway at the single path BOTH mouths resolve to:
+    #   cron-runner/cron-wrapper -> $(dirname $0)/tg_notify.py
+    #   _alert.sh                -> <four levels up>/scripts/tg_notify.py
+    cat > "$TMP/repo/scripts/tg_notify.py" <<STUB
+import sys
+with open("$TMP/gateway.log", "a") as fh:
+    fh.write("=== SEND ===\n" + "\n".join(sys.argv[1:]) + "\n")
+STUB
+
+    cat > "$TMP/repo/apps/evaluator/nlm_deep_research/scripts/job.sh" <<PAYLOAD
+#!/bin/bash
+set -uo pipefail
+. "\$(dirname "\$0")/_alert.sh"
+echo "$NOISE"
+${PAYLOAD_BODY:-alert p0 "🚨 $SENTENCE"}
+exit \${JOB_EXIT:-5}
+PAYLOAD
+    chmod +x "$TMP/repo/apps/evaluator/nlm_deep_research/scripts/job.sh"
+}
+
+run_under_runner () {
+    HOME="$TMP/home" CRON_RUNNER_STATE_DIR="$TMP/home/.agent/decisions/state" \
+        bash "$TMP/repo/scripts/cron-runner.sh" \
+        "$TMP/repo/apps/evaluator/nlm_deep_research/scripts/job.sh" >/dev/null 2>&1
+    RC=$?
+}
+
+run_under_wrapper () {  # run_under_wrapper [retries]
+    HOME="$TMP/home" CRON_MAX_RETRIES="${1:-0}" CRON_LOG_DIR="$TMP/home/logs/cron" \
+        bash "$TMP/repo/scripts/cron-wrapper.sh" "singlevoice-probe-$$" \
+        /bin/bash "$TMP/repo/apps/evaluator/nlm_deep_research/scripts/job.sh" >/dev/null 2>&1
+    RC=$?
+}
+
+echo "GUILT 1 — sotto cron-runner: UN messaggio, e porta la frase del job"
+PAYLOAD_BODY="" build_world
+run_under_runner
+check "l'exit del job e' preservato (5)"        "$(yes_if "$RC" 5)"
+check "esattamente UN invio (era 2)"            "$(yes_if "$(sends)" 1)"
+check "il messaggio porta la frase del job"     "$(body_has "$SENTENCE")"
+check "…quindi porta il path del log"           "$(body_has '/tmp/nbx-run.log')"
+check "l'intestazione strutturata resta"        "$(body_has 'Exit: 5')"
+check "la coda grezza non e' piu' il corpo"     "$([ "$(body_has "$NOISE")" = 1 ] && echo 0 || echo 1)"
+check "il marcatore e' stato spogliato"         "$([ "$(body_has 'CRON_ALERT_P0:')" = 1 ] && echo 0 || echo 1)"
+check "la ricevuta e' comunque scritta"         "$([ -f "$TMP/home/.agent/decisions/state/job.last.json" ] && echo 0 || echo 1)"
+check "la ricevuta conserva la causa grezza"    "$(grep -q "$NOISE" "$TMP/home/.agent/decisions/state/job.last.json" 2>/dev/null && echo 0 || echo 1)"
+
+echo "GUILT 2 — sotto cron-wrapper: stessa cura (curarne uno su cinque e' W107)"
+PAYLOAD_BODY="" build_world
+run_under_wrapper 0
+check "esattamente UN invio (era 2)"            "$(yes_if "$(sends)" 1)"
+check "il messaggio porta la frase del job"     "$(body_has "$SENTENCE")"
+check "l'intestazione strutturata resta"        "$(body_has 'Exit: 5')"
+# Senza queste due, "porta la frase" passa anche col fallback alla coda grezza:
+# la coda CONTIENE la riga-marcatore, quindi contiene la frase. Un mutante che
+# spegneva la preferenza qui e' sopravvissuto esattamente cosi'.
+check "la coda grezza non e' piu' il corpo"     "$([ "$(body_has "$NOISE")" = 1 ] && echo 0 || echo 1)"
+check "il marcatore e' stato spogliato"         "$([ "$(body_has 'CRON_ALERT_P0:')" = 1 ] && echo 0 || echo 1)"
+
+echo "RETRIES — il ritentativo non moltiplica i messaggi"
+PAYLOAD_BODY="" build_world
+run_under_wrapper 1
+check "2 tentativi falliti => 1 solo invio"     "$(yes_if "$(sends)" 1)"
+
+echo "MULTI-RIGA — una frase su piu' righe arriva INTERA"
+# Il marcatore si rilegge con un grep ancorato a riga: senza il collasso dei
+# newline la seconda meta' resterebbe fuori dal messaggio, in silenzio. Oggi
+# nessuno dei 20 payload manda multi-riga — il contratto deve reggerlo lo stesso.
+PAYLOAD_BODY='alert p0 "prima meta della frase
+seconda meta della frase"' build_world
+run_under_runner
+check "un invio"                                "$(yes_if "$(sends)" 1)"
+check "la prima meta' c'e'"                     "$(body_has 'prima meta della frase')"
+check "e la seconda anche"                      "$(body_has 'seconda meta della frase')"
+check "…sulla stessa riga (newline collassati)" "$(body_has 'prima meta della frase seconda meta della frase')"
+
+echo "INNOCENZA 1 — nessun wrapper: il payload DEVE parlare da se'"
+# run_peraturan_ingestion.sh gira da crontab senza wrapper: se il rinvio fosse
+# incondizionato, questo caso sarebbe muto.
+PAYLOAD_BODY="" build_world
+( cd "$TMP" && HOME="$TMP/home" \
+    bash "$TMP/repo/apps/evaluator/nlm_deep_research/scripts/job.sh" >/dev/null 2>&1 )
+check "un invio (il payload non e' ammutolito)" "$(yes_if "$(sends)" 1)"
+check "e porta la sua frase"                    "$(body_has "$SENTENCE")"
+
+echo "INNOCENZA 2 — un tier diverso da p0 non viene mai rinviato"
+PAYLOAD_BODY='alert digest "riepilogo che non e un allarme"' build_world
+JOB_EXIT=0 run_under_runner
+check "il digest e' partito subito"             "$(body_has 'riepilogo che non e un allarme')"
+check "…e il job riuscito non ha aggiunto P0"   "$(yes_if "$(sends)" 1)"
+
+echo "INNOCENZA 3 — un payload che non nomina nulla: resta la coda grezza"
+PAYLOAD_BODY=':' build_world
+run_under_runner
+check "un invio"                                "$(yes_if "$(sends)" 1)"
+check "il corpo e' la coda grezza (fallback)"   "$(body_has "$NOISE")"
+
+echo "INNOCENZA 4 — un job che riesce non dice niente"
+PAYLOAD_BODY=':' build_world
+JOB_EXIT=0 run_under_runner
+check "exit 0 preservato"                       "$(yes_if "$RC" 0)"
+check "nessun invio"                            "$(yes_if "$(sends)" 0)"
+
+echo "ACCORDO — il marcatore duplicato nei tre file deve coincidere"
+mk () { grep -h '^CRON_ALERT_MARKER=' "$1" | head -1 | cut -d= -f2- | tr -d '"'; }
+M_RUN="$(mk "$RUNNER")"; M_WRAP="$(mk "$WRAPPER")"; M_LIB="$(mk "$ALERTLIB")"
+check "cron-runner dichiara un marcatore"       "$([ -n "$M_RUN" ] && echo 0 || echo 1)"
+check "cron-wrapper concorda"                   "$(yes_if "$M_WRAP" "$M_RUN")"
+check "_alert.sh concorda"                      "$(yes_if "$M_LIB" "$M_RUN")"
+
+echo
+printf 'cron single-voice corpus: %d ok, %d FAIL\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What

Giving the cron wrappers a voice (W107) closed a real silence and opened a smaller one at the other end: the 20 payloads in `apps/evaluator/nlm_deep_research/scripts` already alarmed for themselves, and **19 run under a wrapper that alarms too** — one failure, two P0s ~2s apart.

## Why not just silence one of them

Measured on the archived pair for `run_nb2_pipeline` (2026-08-06 02:10) — they carry **different** information and neither contains the other:

| | body |
|---|---|
| script | `🚨 NB2 Immigration pipeline FAILED (exit 1) — check <log path>` |
| wrapper | `CRON FAIL … Job … Exit: 1 … Duration: 3s` + 600 bytes of raw stdout: registry counts, a `HALTED` state line, a JSON run blob. **No log path.** |

Silencing the script drops the only pointer to the evidence; silencing the wrapper reopens W107. So the wrapper **carries the job's sentence**: it exports `CRON_ALARM_OWNER`, the payload's `p0` prints `CRON_ALERT_P0: <text>` instead of sending, the wrapper prefers that line over its raw tail. One message, better content.

## Scope was set by a census, not by the job that bit us

The 20 payloads run under **four** launchers, not one:

| launcher | alarms? | effect here |
|---|---|---|
| `cron-runner.sh` | yes | cured |
| `cron-wrapper.sh` | yes | cured — curing one wrapper of five *is* W107 |
| `cron-agent.sh` (HOME-only) | yes | untouched; payload keeps its own voice |
| none — `run_peraturan_ingestion.sh` runs bare from crontab | — | **would have gone mute** under an unconditional deferral |

That last row is why the deferral is **opt-in by the wrapper** rather than a property of the payload. The wrapper also claims the voice only once it can actually carry the words (`cron-runner` exports only after its capture tmpfile exists), so *deferred* can never mean *dropped*.

## Deliberately unchanged

The **receipt** keeps the raw tail. The DLQ autopilot classifies on `last_error`, and 40 lines give it more to classify than one curated sentence — only the human-facing alarm body changes (superscar #9: don't change a contract its readers didn't ask to change).

The marker literal is **duplicated** in three files rather than sourced: the alarm path must not gain a dependency that fails the way the thing it reports fails (W108). Duplication is only safe if something pins it — the corpus asserts the three agree.

## Verification

`scripts/test_cron_single_voice.sh` — **30 checks, 30 green**, no network (both mouths resolve to one fake gateway, so the count is every message that would have been sent):

- **guilt ×2** — one send under each alarming wrapper, carrying the sentence *and* the log path
- **innocence ×4** — bare payload still speaks · non-`p0` never deferred · a payload that names nothing still gets the raw tail · success stays silent
- **retries** — `cron-wrapper` retries and the payload's alarm carries no dedup key; one failure must stay one message
- **multi-line** — a sentence with a newline arrives whole (the marker is re-read line-anchored)
- **agreement** — the three marker literals must match

**Mutation-verified: 10 load-bearing mutations, all caught.** One earlier mutation survived and the fix belonged in the *test*: "carries the job's sentence" passed under the raw-tail fallback too, because the raw tail **contains the marker line** — W107, the probe that measures a disease can have it. Two assertions added (raw noise absent, marker stripped) and it is caught.

Armed in `immune-enforcement.yml` on **both** sides of the trigger/step pair, so editing `_alert.sh` or the corpus alone still wakes the job.

## Post-merge (this session owns it)

`~/scripts/cron-runner.sh` on Pro is a real file, not a symlink (W107 gotcha) — the merge alone leaves it inert; it gets re-copied and the HOME-fork lint re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)