### PR TITLE
fix(proprioception): run_wrap exit_code parser under-reports findings

### DIFF
--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -367,6 +367,40 @@ BUILTINS = {
 
 # ---------------------------------------------------------------- wraps
 
+_EXIT_CODE_EVIDENCE_CAP = 5
+
+
+def _parse_exit_code(rc: int, out: str, err: str) -> tuple[str, int, list[str]]:
+    """`parse: exit_code` verdict: RECONCILED/0-findings iff rc==0, otherwise DIVERGED
+    with a finding count that reflects the tool's own output — not a hardcoded 1.
+
+    §5-docsync-underreport (2026-08-07): the previous version took only the LAST line
+    of the wrapped tool's combined output and hardcoded n_findings=1 regardless of how
+    many things actually failed. Against docs_sync.py --check (2 stale files: README.md
+    + docs/AI_ONBOARDING.md, one line each under a "DOCSYNC STALE — run: ..." header)
+    this silently dropped README.md and reported "1 finding" when there were 2 — the
+    report SessionStart and the healers read under-counted by construction. A tool that
+    fails with MULTIPLE lines is assumed to emit one header/summary line (own name for
+    the problem, not itself a finding) followed by the real per-item detail lines; a
+    tool that fails with a SINGLE line, or with empty output, keeps the original shape
+    (that line — or "exit {rc}" — as the one finding) since there is no header to strip.
+    """
+    if rc == 0:
+        return RECONCILED, 0, []
+    combined = (out or err).strip()
+    if not combined:
+        return DIVERGED, 1, [f"exit {rc}"]
+    lines = [ln[:160] for ln in combined.splitlines() if ln.strip()]
+    if len(lines) <= 1:
+        return DIVERGED, 1, lines
+    detail = lines[1:]  # drop the tool's own header/summary line — never a finding itself
+    n = len(detail)
+    ev = detail[:_EXIT_CODE_EVIDENCE_CAP]
+    if n > _EXIT_CODE_EVIDENCE_CAP:
+        ev = ev + [f"... ({_EXIT_CODE_EVIDENCE_CAP} of {n} shown)"]
+    return DIVERGED, n, ev
+
+
 def run_wrap(root: Path, entry: dict, timeout: int) -> tuple[str, int, list[str]]:
     argv = [a.replace("{repo}", str(root)) for a in entry["target"]]
     if argv[0].startswith("python") and len(argv) > 1:
@@ -382,8 +416,7 @@ def run_wrap(root: Path, entry: dict, timeout: int) -> tuple[str, int, list[str]
         return UNPROBEABLE, 0, [f"wrapped reconciler missing: {e}"]
     parse = entry.get("parse", "exit_code")
     if parse == "exit_code":
-        return (RECONCILED if rc == 0 else DIVERGED), (0 if rc == 0 else 1), \
-            ([] if rc == 0 else [(out or err).strip().splitlines()[-1][:160] if (out or err).strip() else f"exit {rc}"])
+        return _parse_exit_code(rc, out, err)
     try:
         data = json.loads(out.strip() or "null")
     except json.JSONDecodeError:

--- a/scripts/tests/test_proprioception_run_wrap_exit_code.py
+++ b/scripts/tests/test_proprioception_run_wrap_exit_code.py
@@ -1,0 +1,153 @@
+"""Tests for proprioception.py's run_wrap() exit_code parser (§5-docsync-underreport).
+
+THE BUG (2026-08-07): a `parse: "exit_code"` registry entry (docs_sync is the only one
+in DEFAULT_REGISTRY) hardcoded n_findings=1 on any non-zero rc and took only the LAST
+line of the wrapped tool's combined output as evidence. docs_sync.py --check emits a
+"DOCSYNC STALE — run: ..." header line followed by ONE detail line per stale target
+file; with 2 stale files (README.md, docs/AI_ONBOARDING.md) this silently dropped the
+first (README.md) and reported "1 finding" where there were 2 — the proprioception
+report SessionStart and the healers read under-counted by construction.
+
+The fix treats a multi-line failure as header + detail lines (header dropped, detail
+lines counted and surfaced, capped at 5 with an explicit "N of M" note on truncation)
+while preserving the original single-line / empty-output shapes exactly, per the
+generator's own guilt/innocence spec.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "proprioception.py"
+_spec = importlib.util.spec_from_file_location("proprioception", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+prop = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(prop)  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------- guilt: under-report
+
+def test_multiline_failure_counts_detail_lines_not_hardcoded_one() -> None:
+    """The bug's exact shape: header + 2 detail lines must yield 2 findings, BOTH
+    detail lines present in evidence (not just the last one)."""
+    out = "DOCSYNC STALE — run: python scripts/docs_sync.py\n" \
+          "  README.md: aaaa -> bbbb\n" \
+          "  docs/AI_ONBOARDING.md: cccc -> dddd\n"
+    status, n, ev = prop._parse_exit_code(1, "", out)
+    assert status == prop.DIVERGED
+    assert n == 2
+    assert any("README.md" in e for e in ev)
+    assert any("AI_ONBOARDING.md" in e for e in ev)
+
+
+def test_real_docs_sync_two_file_shape_matches_the_reported_bug() -> None:
+    """Same case reproduced on stderr (docs_sync.py's real stream) — the wrapper reads
+    (out or err), and docs_sync writes everything to stderr under --check."""
+    err = "DOCSYNC STALE — run: python scripts/docs_sync.py\n" \
+          "  README.md: 85d7e38416c6 -> 994993795a72\n" \
+          "  docs/AI_ONBOARDING.md: 38e62b1fcd36 -> 24df2f705603\n"
+    status, n, ev = prop._parse_exit_code(1, "", err)
+    assert status == prop.DIVERGED
+    assert n == 2  # was 1 before the fix
+    assert len(ev) == 2
+    assert "README.md" in ev[0]
+    assert "AI_ONBOARDING.md" in ev[1]
+
+
+def test_header_line_is_never_counted_as_a_finding() -> None:
+    out = "SOME TOOL FAILED — run: fix-it\n  only-detail-line\n"
+    status, n, ev = prop._parse_exit_code(1, out, "")
+    assert n == 1
+    assert ev == ["  only-detail-line"]
+    assert not any("SOME TOOL FAILED" in e for e in ev)
+
+
+def test_six_detail_lines_reports_full_count_and_truncation_note() -> None:
+    header = "HEADER LINE\n"
+    details = "".join(f"  detail-{i}\n" for i in range(1, 7))
+    status, n, ev = prop._parse_exit_code(1, header + details, "")
+    assert status == prop.DIVERGED
+    assert n == 6
+    # capped display, but the truncation is stated explicitly (W97: never a bare slice)
+    assert len(ev) == prop._EXIT_CODE_EVIDENCE_CAP + 1
+    assert any("5 of 6" in e for e in ev)
+    for i in range(1, 6):
+        assert any(f"detail-{i}" in e for e in ev)
+    # the 6th detail line is the one that got truncated out of the capped display
+    assert not any("detail-6" in e for e in ev[:5])
+
+
+# ---------------------------------------------------------------- innocence
+
+def test_rc_zero_is_zero_findings_even_with_chatty_output() -> None:
+    """A successful tool that still prints something is not a finding."""
+    status, n, ev = prop._parse_exit_code(0, "all good, nothing to see\nreally\n", "")
+    assert status == prop.RECONCILED
+    assert n == 0
+    assert ev == []
+
+
+def test_single_line_failure_keeps_original_shape() -> None:
+    """No header to strip when there's only one line — today's exact behaviour."""
+    status, n, ev = prop._parse_exit_code(1, "the one and only failure line", "")
+    assert status == prop.DIVERGED
+    assert n == 1
+    assert ev == ["the one and only failure line"]
+
+
+def test_empty_output_falls_back_to_exit_code_marker() -> None:
+    status, n, ev = prop._parse_exit_code(1, "", "")
+    assert status == prop.DIVERGED
+    assert n == 1
+    assert ev == ["exit 1"]
+
+
+def test_empty_output_whitespace_only_also_falls_back() -> None:
+    status, n, ev = prop._parse_exit_code(3, "   \n  \n", "")
+    assert status == prop.DIVERGED
+    assert n == 1
+    assert ev == ["exit 3"]
+
+
+def test_run_wrap_end_to_end_with_real_multiline_python_tool(tmp_path: Path) -> None:
+    """Exercise the full run_wrap() path (not just the helper) against a real
+    subprocess, so the fix is proven wired in, not just unit-correct in isolation."""
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    tool = repo / "scripts" / "fake_exit_code_tool.py"
+    tool.write_text(
+        "import sys\n"
+        "print('TOOL STALE — run: fix-it', file=sys.stderr)\n"
+        "print('  itemA: x -> y', file=sys.stderr)\n"
+        "print('  itemB: x -> y', file=sys.stderr)\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+    entry = {"target": ["python3", "{repo}/scripts/fake_exit_code_tool.py"], "parse": "exit_code"}
+    status, n, ev = prop.run_wrap(repo, entry, 10)
+    assert status == prop.DIVERGED
+    assert n == 2
+    assert any("itemA" in e for e in ev)
+    assert any("itemB" in e for e in ev)
+
+
+# ---------------------------------------------------------------- mutation guard
+
+def test_mutation_guilt_fails_without_the_fix() -> None:
+    """Proves the guilt test actually distinguishes the fix from the pre-fix code:
+    re-implement the OLD (buggy) behaviour inline and confirm it does NOT satisfy the
+    guilt assertions — i.e. the guilt test goes red if the fix is reverted."""
+    def _old_buggy_exit_code(rc: int, out: str, err: str) -> tuple[str, int, list[str]]:
+        return (prop.RECONCILED if rc == 0 else prop.DIVERGED), (0 if rc == 0 else 1), \
+            ([] if rc == 0 else [(out or err).strip().splitlines()[-1][:160]
+                                  if (out or err).strip() else f"exit {rc}"])
+
+    out = "DOCSYNC STALE — run: python scripts/docs_sync.py\n" \
+          "  README.md: aaaa -> bbbb\n" \
+          "  docs/AI_ONBOARDING.md: cccc -> dddd\n"
+    status, n, ev = _old_buggy_exit_code(1, "", out)
+    # the old code hardcoded n=1 and kept only the LAST line — assert that shape to
+    # prove this is really the pre-fix behaviour, then assert it fails the new spec
+    assert n == 1
+    assert ev == ["  docs/AI_ONBOARDING.md: cccc -> dddd"]
+    assert not any("README.md" in e for e in ev)  # the dropped line — this is the bug


### PR DESCRIPTION
## What was measured today

Cure lane for `§5-docsync-underreport`. Worktree pinned fresh at `origin/main` (`269f9c8ee76f41b4718d9d276187ec4ad65a9304`, `git -C /Users/balizero/nuzantara fetch origin --quiet` then `agent_start.py`).

- `python3 scripts/docs_sync.py --check` on that fresh ref → `DOCSYNC OK (no changes)`, RC=0. Confirms PR #3674 landed the docs_sync regen in the same commit as its code change — the "2 stale, 1 named" symptom from the handoff is **gone on origin/main**.
- Same command against the (deliberately stale, ~120-behind) main checkout `/Users/balizero/nuzantara` still reproduces the exact bug, byte-identical hashes: `DOCSYNC STALE — run: python scripts/docs_sync.py` / `README.md: 85d7e38416c6 → 994993795a72` / `docs/AI_ONBOARDING.md: 38e62b1fcd36 → 24df2f705603`, RC=1. That checkout is a free positive control for real bug data.
- Feeding that real output through `run_wrap`'s exit_code branch (pre-fix): `n_findings` hardcoded to `1`, evidence = only the LAST line (`docs/AI_ONBOARDING.md: …`) — **README.md silently dropped**. Post-fix, same real data: `n_findings == 2`, evidence contains **both** files.

## What changed

`scripts/proprioception.py::run_wrap()`'s `parse == "exit_code"` branch (only registry entry using it today: `docs_sync`, line 539) is factored into a new `_parse_exit_code(rc, out, err)` helper:

- `rc == 0` → `RECONCILED`, 0 findings (unchanged).
- non-zero `rc`, **empty** output → `DIVERGED`, 1 finding, `["exit {rc}"]` (unchanged fallback).
- non-zero `rc`, **single-line** output → `DIVERGED`, 1 finding, that line (unchanged — no header to strip).
- non-zero `rc`, **multi-line** output → the first line is treated as the tool's own header/summary (never itself a finding); the rest are the real per-item findings, counted (`n_findings` = actual count, not hardcoded) and surfaced up to 5 with an explicit `"N of M"` note on truncation (W97 — never a bare slice read downstream as complete).

Nothing else touched: `fix_hint` strings at lines 428/590 (owned by a different sequence item), the `home_fork_scripts` args.pairs registry list, and `scripts/docs_sync.py` itself are all untouched (confirmed via `git diff --stat` = 1 file + 1 new test file).

## Guilt test

`scripts/tests/test_proprioception_run_wrap_exit_code.py`:
- `test_multiline_failure_counts_detail_lines_not_hardcoded_one` / `test_real_docs_sync_two_file_shape_matches_the_reported_bug`: header + 2 detail lines → `n==2`, **both** detail lines in evidence.
- `test_six_detail_lines_reports_full_count_and_truncation_note`: header + 6 detail lines → `n==6`, evidence capped at 5 plus a line containing `"5 of 6"`.
- `test_header_line_is_never_counted_as_a_finding`: the header string itself never appears in evidence.
- `test_run_wrap_end_to_end_with_real_multiline_python_tool`: exercises the full `run_wrap()` path (real subprocess, not just the helper in isolation).

Run: `python3 -m pytest scripts/tests/test_proprioception_run_wrap_exit_code.py -v` → 10 passed.

## Innocence test

- `test_rc_zero_is_zero_findings_even_with_chatty_output`: a successful tool that still prints something is not a finding.
- `test_single_line_failure_keeps_original_shape` / `test_empty_output_falls_back_to_exit_code_marker` / `test_empty_output_whitespace_only_also_falls_back`: today's exact behaviour preserved for the two shapes that have no header to strip.

## Mutation check

Restored the exact pre-fix inline body into `_parse_exit_code()` (same signature, so tests still resolve the call) and re-ran the corpus: **4 of the guilt tests went red** (`n==1` instead of `2`/`6`, README.md missing from evidence) while the 6 innocence/shape tests stayed green, confirming the corpus actually distinguishes the fix from the bug rather than testing a property of Python. Fix restored afterward and full corpus re-run green (10/10).

Also ran the full neighbouring/adjacent test surface for regressions: `test_proprioception_home_fork_merge.py`, `test_docs_sync_atlas.py`, `test_home_fork_stale_side_attribution.py`, `test_arsenal_probe.py`, `test_lint_worktree_husky_symlink.py`, `test_organism_stale_detector.py`, `test_launchagent_state_bridge_host_guard.py` → 199 passed. `python3 scripts/proprioception.py --selftest` → `SELFTEST OK — registry valid (11 probes), parser guards hold, redaction holds`, RC=0. `scripts/tests/test_proprioception_receptor_ranking.sh` → 7/7 passed. `ruff check` on both touched files → clean (the 3 pre-existing `E741` findings elsewhere in the file at lines 185/214/218 predate this diff, confirmed against `origin/main`).

## PROVE-LIVE

This is a signaler, never an actuator (W33/W81) — no cron currently runs it (v1 has no cron per the module's own docstring; the receptor is the consumption point). Once merged, the fix is live the next time anything invokes `run_wrap()` against an `exit_code`-parsed entry — currently only `docs_sync` — either via `python3 scripts/proprioception.py` (writes `~/.nuzantara-proprioception/last.json`/`last.md`, read by the SessionStart receptor) or an ad-hoc `--json --no-report` run. No separate deploy step; this is a repo-side Python script, not a service.

## Seen, not cured (out of scope per brief)

- `fix_hint` strings at lines 428/590 — belongs to a different sequence item.
- The dormant trigger note in the brief: today only `docs_sync` uses `parse: "exit_code"`, and its symptom is already fixed upstream on origin/main (PR #3674) — this PR fixes the shared parser so any *future* `exit_code`-parsed probe doesn't inherit the under-report.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>