### PR TITLE
chore(home-fork): declare auth_sentinel_cron, widen regulatory-watcher.md to mini, record wr2-cron-wrapper Mini ancestor

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -28,8 +28,8 @@
     {
       "live": "~/.claude/agents/regulatory-watcher.md",
       "repo": ".claude/agents/regulatory-watcher.md",
-      "_note": "Task #95 (2026-07-27, defects 3+4): the Tier-1 workflow spec PROMPT_CLAUDE (in the wrapper above) literally instructs 'Read ~/.claude/agents/regulatory-watcher.md for full spec' — this HOME file was never repo-tracked before, so the schema/URL fixes landing here had no way to reach the live cron without a manual sync. Promoted to repo canon alongside its wrapper pair; same machine scope for the same reason (Pro=active, M5=dormant aligned copy, no Mini).",
-      "machines": ["pro", "m5"]
+      "_note": "Task #95 (2026-07-27, defects 3+4): the Tier-1 workflow spec PROMPT_CLAUDE (in the wrapper above) literally instructs 'Read ~/.claude/agents/regulatory-watcher.md for full spec' — this HOME file was never repo-tracked before, so the schema/URL fixes landing here had no way to reach the live cron without a manual sync. Promoted to repo canon alongside its wrapper pair. Corrected 2026-08-07: this entry previously asserted 'same machine scope for the same reason (Pro=active, M5=dormant aligned copy, no Mini)' — that sentence, written while narrating the other two machines, was itself an unverified claim (W113: a replacement assertion written while correcting something else is unverified by default). Mini in fact HAS this file, sha256 4335975443… identical across repo canon, Pro, M5 AND Mini (re-verified 2026-08-07). Scope widened to include mini — no consumer-scope reasoning survives the correction, the file simply exists in the same place on all four copies.",
+      "machines": ["pro", "m5", "mini"]
     },
     {
       "live": "~/scripts/wr2-deploy-pull.sh",
@@ -350,7 +350,7 @@
     {
       "live": "~/.openclaw/bin/wr2/wr2-cron-wrapper.sh",
       "repo": "scripts/wr2-cron-wrapper.sh",
-      "_note": "WR2 deep audit 2026-07-14 (§4): the HOME copy (f17092b3) had DIVERGED from the repo copy (3cd52391) on the same machine — oracle/connector/newsletter were running the stale fork. Declared so --check catches this class of drift going forward. RESOLVED same day: the live copy self-realigned via a routine pull (mtime 14:05 WITA), re-verified read-only on Pro 2026-07-14 ~15:30 WITA — sha 3cd52391 both sides, byte-identical. No manual sync pending. Consumers verified via ProgramArguments grep: com.balizero.wr2.{oracle,connector,newsletter,dossier-compiler,learner-nightly,measurer,sla-worker,strategos,trend-hunter} + com.balizero.sota.m13-* all exec ~/.openclaw/bin/wr2/wr2-cron-wrapper.sh (NOT ~/scripts/, which does not exist on Pro).",
+      "_note": "WR2 deep audit 2026-07-14 (§4): the HOME copy (f17092b3) had DIVERGED from the repo copy (3cd52391) on the same machine — oracle/connector/newsletter were running the stale fork. Declared so --check catches this class of drift going forward. RESOLVED same day: the live copy self-realigned via a routine pull (mtime 14:05 WITA), re-verified read-only on Pro 2026-07-14 ~15:30 WITA — sha 3cd52391 both sides, byte-identical. No manual sync pending. Consumers verified via ProgramArguments grep: com.balizero.wr2.{oracle,connector,newsletter,dossier-compiler,learner-nightly,measurer,sla-worker,strategos,trend-hunter} + com.balizero.sota.m13-* all exec ~/.openclaw/bin/wr2/wr2-cron-wrapper.sh (NOT ~/scripts/, which does not exist on Pro). Mini fact (measured 2026-08-07, deliberately NOT added to machines): Mini also has a copy at this live path, sha256 3f07eed7d2… — DIFFERENT from both the repo canon and Pro's live copy (03486087a6…) — and it is an inert ancestor: 0 crontab entries and 0 LaunchAgent plist references to wr2-cron-wrapper on Mini (Pro has 36). Declaring 'mini' here would manufacture a permanent red on a fork nothing invokes; do not add it unless something on Mini starts executing this path.",
       "machines": ["pro"]
     },
     {
@@ -627,6 +627,12 @@
       "live": "~/Library/LaunchAgents/com.balizero.claude-settings-watcher.plist",
       "repo": "infra/launchagents/com.balizero.claude-settings-watcher.plist",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/.nuzantara-cron/auth_sentinel_cron.sh",
+      "repo": "scripts/auth_sentinel_cron.sh",
+      "machines": ["m5"],
+      "_note": "Found diverged on 2026-08-07 by a single line (the ~/Desktop path PR #2499 cured on 2026-07-16 had not reached this live copy) and realigned by the auth-sentinel item in the same pending-arms batch. Re-verified sha256-identical to the repo twin 2026-08-07 before this pair was declared (STRICT ORDERING: a pair is only declared after its live sync is proven, per family #1's own antidote — declaring an unsynced pair arms a permanent red on M5). Was UNDECLARED in both surfaces (0 hits in this file and in scripts/proprioception.py's home_fork_scripts args) — until today only scripts/launchagent_reconcile.py caught drift here, and only generically (plist->wrapper diff), not via a dedicated home-fork pair."
     }
   ],
   "allow": [


### PR DESCRIPTION
## Summary

Three edits to `infra/home-fork/declared-pairs.json` (superscar #1 SSOT — the shared
monotone registry assigned exclusively to this pending-arms item, to avoid the W109b
"two PRs shrink/grow the same monotone registry from different bases" collision).

## What was measured today (2026-08-07, this run, in a fresh worktree off origin/main)

- Registry before edit: `python3 -c "json.load(open('infra/home-fork/declared-pairs.json'))"` →
  **110 pairs**. Machine histogram: pro=78, mini=20, m5=5, all=4, (m5,pro)=2, (mini,pro)=1
  → pro-applicable **85**, m5-applicable **11**, mini-applicable **25**. Matches the brief
  exactly (re-derived independently, not copied).
- Positive control that the parse mechanism agrees with the tool: Pro's live
  `python3 scripts/lint_home_fork.py --check` (run read-only over ssh with the pre-edit
  registry) also reports **85** pro-applicable pairs, 0 breaches.
- `auth_sentinel_cron.sh`: `grep -n "auth_sentinel" infra/home-fork/declared-pairs.json
  scripts/proprioception.py` → **0 hits, rc=1** — undeclared in both surfaces, as the brief
  claimed. Repo file `scripts/auth_sentinel_cron.sh` exists (PR #2499, 2026-07-16, "repoint
  off ~/Desktop"). Live M5 copy `~/.nuzantara-cron/auth_sentinel_cron.sh`: sha256
  `fc7ed0b2b4...` — **already identical** to the repo twin at declare-time (re-verified this
  turn, satisfying the brief's STRICT ORDERING clause).
- `regulatory-watcher.md`: `shasum -a 256` on repo canon, and on the live copy on
  **all three machines** (`~/.claude/agents/regulatory-watcher.md` on M5 direct, on Pro and
  Mini via `ssh -n pro`/`ssh -n mini`) → all four **identical**:
  `4335975443625b1ebea644dd9a157b1b6398107ee438c9df8628eef3a092c752`. The existing entry's
  `machines: ["pro","m5"]` and its note ("no Mini") were wrong — re-measured, not trusted.
- `wr2-cron-wrapper.sh`: sha256 on repo (`03486087a6...`), Pro live (`03486087a6...`,
  matches), Mini live (`3f07eed7d2...`, **different**). Mini crontab: `grep -c
  "wr2-cron-wrapper"` → **0**. Mini `~/Library/LaunchAgents/*` grep → **0**. Positive
  control: the identical command against **Pro** returns **36** LaunchAgent hits — proves
  the grep mechanism isn't just failing to see anything (Rule 2, avoid measuring your own
  poverty).
- Six `wr2-*` agent specs under `.claude/agents/`: `grep -c <basename>` against
  `declared-pairs.json` for each → **0 hits, all six** — confirms "do not add" is a no-op
  today, not a removal (no W109b hazard).
- `~/.local/bin/nuzantara-repo-sync`: no repo twin file anywhere in the tree, 0 hits in the
  registry — impossible to declare by construction, unchanged.

## What changed

1. **ADD** `~/.nuzantara-cron/auth_sentinel_cron.sh` ↔ `scripts/auth_sentinel_cron.sh`,
   `machines: ["m5"]`, with a `_note` recording the 2026-07-16 PR #2499 divergence history
   and today's re-verified sync.
2. **WIDEN** the `regulatory-watcher.md` entry to `machines: ["pro","m5","mini"]` and
   rewrite its `_note` — the old note asserted "no Mini" while Mini has had the identical
   file the whole time (W113 pattern: a corrective sentence is itself an unverified claim
   until checked).
3. **EXTEND** (note only) the `wr2-cron-wrapper.sh` entry's `_note` with the measured Mini
   fact (sha-different, 0 crontab/LaunchAgent references) — **`machines` stays `["pro"]`**,
   per the brief's explicit instruction not to declare an inert divergent fork (would
   manufacture permanent red for nothing that runs).

Deliberately **not** touched, per the brief's §7 override: the six `wr2-*` agent specs
(intentional home/repo path-rewrite divergence — line 12 of the repo canon says "do not
edit the HOME copy") and `~/.local/bin/nuzantara-repo-sync` (no repo twin).

## Guilt test

Built a scratch `$HOME` (`/tmp/.../guilt_home/.nuzantara-cron/auth_sentinel_cron.sh`) —
copied the real live M5 file and reverted the one line PR #2499 fixed
(`REPO="$HOME/nuzantara"` → `REPO="$HOME/Desktop/nuzantara"`), then ran:

```
python3 scripts/lint_home_fork.py --check \
  --config <worktree>/infra/home-fork/declared-pairs.json \
  --repo-root <worktree> --home <scratch> --no-fetch
```

Result: **exit 1**, and it names the pair:
`DIVERGED: ~/.nuzantara-cron/auth_sentinel_cron.sh != scripts/auth_sentinel_cron.sh — a fix
is stranded on one side (the checkout matches origin/main, so the LIVE copy is the stale
side)`. Proves the new declaration actually arms rather than sitting decorative.

## Innocence test

- Same command against the **real** M5 `$HOME` (live copy already in sync): **exit 0**,
  `pairs_declared: 111`, `check_breaches: []`, `check_skipped_live_absent` does **not**
  contain the new pair (it's counted as checked-and-clean, not skipped-absent).
- Ran the same edited registry read-only on **Pro** (`ssh pro`, scp'd config to `/tmp`,
  cleaned up after): **exit 0**, 0 breaches. Pro-applicable count recomputed from the edited
  JSON: still exactly **85** (the mini addition to regulatory-watcher.md doesn't touch Pro's
  applicability — Pro was already in that entry's machines list).
- Ran the same edited registry read-only on **Mini**: **exit 0**, 0 breaches — confirms the
  newly mini-scoped `regulatory-watcher.md` pair is clean there too, and the
  `wr2-cron-wrapper.sh` pair (still `machines: ["pro"]`) is correctly never evaluated on
  Mini (no false report of Mini's inert ancestor).
- Registry math: **110 → 111** pairs, m5-applicable **11 → 12**, mini-applicable
  **25 → 26**, pro-applicable unchanged at **85** — matches the brief's predicted deltas
  exactly.

## Mutation / existing-suite check

Full existing test coverage for this tool still green post-edit (registry format unchanged,
only content):

```
python3 -m pytest scripts/tests/test_lint_home_fork.py \
  scripts/tests/test_home_fork_skipped_visibility.py \
  scripts/tests/test_home_fork_stale_side_attribution.py \
  scripts/tests/test_proprioception_home_fork_merge.py \
  scripts/tests/test_launchagent_reconcile.py -q
```
→ **90 passed** (23+9+23+35... exact: 23, then 32 for the middle three combined, then 35 —
all green, 0 failures).

`prettier --check <absolute-path>/infra/home-fork/declared-pairs.json` → clean (no CI
workflow enforces this on JSON, checked — but pre-commit's own prettier hook also passed).

## PROVE-LIVE on every consuming surface

- `scripts/lint_home_fork.py --check` on **M5** (this session, direct): exit 0, new pair
  counted, clean.
- `scripts/lint_home_fork.py --check` on **Pro** (via `ssh -n pro`, read-only, temp config,
  cleaned up): exit 0, clean, pro-applicable unaffected.
- `scripts/lint_home_fork.py --check` on **Mini** (via `ssh -n mini`, read-only, temp
  config, cleaned up): exit 0, clean, new mini-scoped pair verified in sync, inert
  `wr2-cron-wrapper.sh` ancestor correctly never flagged.
- `scripts/proprioception.py`'s `home_fork_scripts` probe merges this same registry at
  runtime (`load_declared_fork_pairs`) — no separate action needed, it picks up the new/
  edited pairs automatically on its next run.

## Seen, not cured (out of scope for this item)

- Whether `launchagent_reconcile.py`'s generic plist↔wrapper diff for auth-sentinel is
  itself armed anywhere (mentioned in the brief's rationale, not part of this registry).
- The §7(a) six `wr2-*` specs and the M5-Desktop-checkout doctrine-conflict note
  (`docs/operations/2026-08-07-nuzantara-repo-sync-doctrine-conflict.md`, already on main)
  are pre-existing/out of scope.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>