### PR TITLE
fix(cron): pin the single-voice contract against a payload that bypasses _alert.sh

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -154,7 +154,7 @@ jobs:
               scripts/cron-runner.sh|\
               scripts/test_cron_runner_alert.sh|\
               scripts/test_cron_single_voice.sh|\
-              apps/evaluator/nlm_deep_research/scripts/_alert.sh|\
+              apps/evaluator/nlm_deep_research/scripts/*|\
               infra/scripts/fly-backup.sh|\
               scripts/test_fly_backup_phases.sh|\
               scripts/ci/queue_rearm.sh|\

--- a/scripts/test_cron_single_voice.sh
+++ b/scripts/test_cron_single_voice.sh
@@ -171,6 +171,33 @@ JOB_EXIT=0 run_under_runner
 check "exit 0 preservato"                       "$(yes_if "$RC" 0)"
 check "nessun invio"                            "$(yes_if "$(sends)" 0)"
 
+echo "NESSUN BYPASS — i payload devono parlare SOLO tramite alert()"
+# Il rinvio vive dentro _alert.sh: un payload che invoca il gateway da se'
+# aggira la cura e la doppia voce ricresce, senza che niente diventi rosso
+# (W82 — la guardia sorveglia una superficie ed e' cieca all'altra).
+# "Invoca" != "nomina": run_nb5_t4_monitor.sh cita tg_notify in un COMMENTO ed e'
+# innocente, quindi i commenti si tolgono prima di guardare (over-match, #3).
+PAYLOADS="$REPO/apps/evaluator/nlm_deep_research/scripts"
+bypass=""
+for f in "$PAYLOADS"/run_*.sh; do
+    [ -f "$f" ] || continue
+    if sed 's/[[:space:]]*#.*$//' "$f" | grep -qE 'tg_notify|sendMessage'; then
+        bypass="$bypass $(basename "$f")"
+    fi
+done
+n_payloads=$(find "$PAYLOADS" -maxdepth 1 -name 'run_*.sh' | wc -l | tr -d ' ')
+check "i payload censiti sono >= 20 (non ho guardato una dir vuota)" \
+      "$([ "$n_payloads" -ge 20 ] && echo 0 || echo 1)"
+check "nessun payload invoca il gateway da se'" \
+      "$([ -z "$bypass" ] && echo 0 || { echo "     bypass:$bypass" >&2; echo 1; })"
+# innocenza del rilevatore: una menzione in commento NON e' un bypass
+probe_ok=$(printf '#!/bin/bash\n# see tg_notify for the dedup key\nalert p0 "x"\n' \
+    | sed 's/[[:space:]]*#.*$//' | grep -cE 'tg_notify|sendMessage')
+probe_guilt=$(printf '#!/bin/bash\npython3 scripts/tg_notify.py --tier p0 -- "x"\n' \
+    | sed 's/[[:space:]]*#.*$//' | grep -cE 'tg_notify|sendMessage')
+check "il rilevatore assolve una menzione in commento"   "$(yes_if "$probe_ok" 0)"
+check "…e condanna una invocazione vera"                 "$(yes_if "$probe_guilt" 1)"
+
 echo "ACCORDO — il marcatore duplicato nei tre file deve coincidere"
 mk () { grep -h '^CRON_ALERT_MARKER=' "$1" | head -1 | cut -d= -f2- | tr -d '"'; }
 M_RUN="$(mk "$RUNNER")"; M_WRAP="$(mk "$WRAPPER")"; M_LIB="$(mk "$ALERTLIB")"


### PR DESCRIPTION
Follow-up to #3726 (merged), closing the regrowth vector **its own probe exposed**.

## The hole

The deferral that makes one failure produce one message lives inside `_alert.sh`. A payload that invokes the gateway directly — `tg_notify.py`, or a raw curl to `sendMessage` — walks around it, and the double voice comes back **with nothing turning red**. The guard watched one surface and was blind to the other (W82, under-match).

Found by probing the sentinel `case` instead of trusting the green check: editing `_alert.sh` triggered the job, editing `run_nb2_pipeline.sh` **did not**.

## Two changes

**1. The corpus asserts no payload invokes the gateway itself.** "Invokes" is not "mentions" — `run_nb5_t4_monitor.sh` names `tg_notify` in a *comment* and is innocent, so comments are stripped before looking (superscar #3: an over-match here would block a legitimate edit). Both directions proven inline, plus a census guard that refuses to read an empty directory as clean (W84 blind-scan). Verified against a real injected bypass — caught and named:

```
     bypass: run_yt_monitor.sh
  FAIL  nessun payload invoca il gateway da se'
```

**2. The trigger widens** from the single `_alert.sh` entry to `apps/evaluator/nlm_deep_research/scripts/*`, so editing any of the 20 payloads wakes the job. Proved with the extracted `case` itself:

| path | verdict |
|---|---|
| `…/scripts/_alert.sh` | MATCH |
| `…/scripts/run_nb2_pipeline.sh` | MATCH |
| `scripts/test_cron_single_voice.sh` | MATCH |
| `…/nlm_deep_research/pipeline.py` | no match |
| `docs/innocente.md` | no match |

## Measured

**Zero payloads bypass today** — all 20 go through `alert()`, none references `sendMessage`. This is a fence around a currently empty field, which is the only time it is cheap to build one.

Corpus **34/34** under `/bin/bash` 3.2.57 (the interpreter cron actually uses, not CI's bash 5). `actionlint` clean, `shellcheck` clean, trigger-symmetry green.

## #3726 is live on the fleet

Pro and Mini pulled, `~/scripts/cron-runner.sh` re-copied on both (a real file, not a symlink — the merge alone does not reach it), `lint_home_fork.py --check` clean 110/110 on both, and both corpora re-run green **on Pro** in the real environment. Pro's 71 dirty files are cron output in flight and were left untouched — verified zero overlap with the incoming commits before fast-forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)