### PR TITLE
fix(translate): report orphan translations with no <slug>.mdx sibling

### DIFF
--- a/scripts/tests/test_translate_freshness.py
+++ b/scripts/tests/test_translate_freshness.py
@@ -14,6 +14,7 @@ overwrite hand-written corrections with machine output.
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
@@ -267,3 +268,135 @@ def test_stamping_reports_unusable_entries_instead_of_swallowing_them(tmp_path):
     lst = tmp_path / "list.txt"
     lst.write_text(f"{tmp_path / 'ghost.it.mdx'}\n", encoding="utf-8")
     assert ta.stamp_baseline(lst) == 2
+
+
+# ── Orphan detection (2026-08-07) ───────────────────────────────────────────
+#
+# discover_articles() derives every translation target as
+# <slug>.mdx -> <slug>.<lang>.mdx IN THE SAME DIRECTORY. If an English
+# article's category folder changes, a translation left behind next to the
+# now-absent source becomes permanently invisible to this organ: never
+# fresh, never stale, never counted. One real instance was found live: the
+# disk census of id+it translation files was 1593 while discover_articles()
+# x {id,it} visits only 1592 slots — the gap is
+# immigration/driving-license-bali-foreigners-2026.id.mdx, whose English
+# source and .it sibling both now live under lifestyle/.
+#
+# This pass costs nothing (pure filesystem check) and must never change what
+# gets translated — it is a report, not a gate.
+
+def _mktree(tmp_path: Path) -> Path:
+    root = tmp_path / "articles"
+    root.mkdir()
+    return root
+
+
+def test_orphan_with_no_sibling_source_is_reported(tmp_path, monkeypatch):
+    """GUILT: a translation whose <slug>.mdx is missing from the same directory."""
+    root = _mktree(tmp_path)
+    cat = root / "immigration"
+    cat.mkdir()
+    _write(cat / "foo.it.mdx", FM, "orphaned translation\n")
+    monkeypatch.setattr(ta, "ARTICLES_DIR", root)
+    orphans = ta.discover_orphan_translations()
+    assert [o.name for o in orphans] == ["foo.it.mdx"]
+
+
+def test_the_real_orphan_is_caught_by_name():
+    """GUILT, on the live corpus: the exact file this finding is about."""
+    orphans = ta.discover_orphan_translations(category="immigration")
+    names = [o.name for o in orphans]
+    assert "driving-license-bali-foreigners-2026.id.mdx" in names
+
+
+def test_translation_with_its_sibling_source_is_not_an_orphan(tmp_path, monkeypatch):
+    """INNOCENCE: the normal case — <slug>.mdx and <slug>.id.mdx together."""
+    root = _mktree(tmp_path)
+    cat = root / "immigration"
+    cat.mkdir()
+    _write(cat / "guide.mdx", FM, BODY)
+    _write(cat / "guide.id.mdx", FM, "Terjemahan.\n")
+    monkeypatch.setattr(ta, "ARTICLES_DIR", root)
+    assert ta.discover_orphan_translations() == []
+
+
+def test_english_source_with_no_translation_yet_is_not_an_orphan(tmp_path, monkeypatch):
+    """INNOCENCE: an absent translation is the existing, legitimate 'absent'
+    verdict — flagging it as an orphan would be an over-match on the
+    opposite side (Family #3, cicatrix-superscar.md)."""
+    root = _mktree(tmp_path)
+    cat = root / "immigration"
+    cat.mkdir()
+    _write(cat / "guide.mdx", FM, BODY)
+    monkeypatch.setattr(ta, "ARTICLES_DIR", root)
+    assert ta.discover_orphan_translations() == []
+
+
+def test_all_four_language_suffixes_are_covered(tmp_path, monkeypatch):
+    """fr/ru have the identical blind spot — the check must not skip them."""
+    root = _mktree(tmp_path)
+    cat = root / "lifestyle"
+    cat.mkdir()
+    for lang in ("id", "it", "ru", "fr"):
+        _write(cat / f"orphan.{lang}.mdx", FM, f"lang {lang}\n")
+    monkeypatch.setattr(ta, "ARTICLES_DIR", root)
+    orphans = {o.name for o in ta.discover_orphan_translations()}
+    assert orphans == {"orphan.id.mdx", "orphan.it.mdx", "orphan.ru.mdx", "orphan.fr.mdx"}
+
+
+def test_category_filter_scopes_the_scan(tmp_path, monkeypatch):
+    root = _mktree(tmp_path)
+    a = root / "immigration"
+    a.mkdir()
+    b = root / "lifestyle"
+    b.mkdir()
+    _write(a / "x.it.mdx", FM, "a\n")
+    _write(b / "y.it.mdx", FM, "b\n")
+    monkeypatch.setattr(ta, "ARTICLES_DIR", root)
+    assert [o.name for o in ta.discover_orphan_translations("immigration")] == ["x.it.mdx"]
+    assert [o.name for o in ta.discover_orphan_translations("lifestyle")] == ["y.it.mdx"]
+
+
+def test_sync_conflict_files_are_never_flagged_as_orphans(tmp_path, monkeypatch):
+    root = _mktree(tmp_path)
+    cat = root / "immigration"
+    cat.mkdir()
+    _write(cat / "guide.it.sync-conflict-20260101.mdx", FM, "conflict copy\n")
+    monkeypatch.setattr(ta, "ARTICLES_DIR", root)
+    assert ta.discover_orphan_translations() == []
+
+
+def test_fr_and_ru_orphans_never_reach_the_translate_write_path(tmp_path, monkeypatch):
+    """A fr/ru orphan is REPORTED but must not change `targets` or trigger a
+    translation. discover_articles() only ever walks English (unsuffixed)
+    sources, so an orphan can never enter the write path by construction —
+    prove it: a tree containing ONLY an orphan yields zero English articles
+    (nothing to translate) while the orphan is still visible via
+    discover_orphan_translations(), and the file is untouched."""
+    root = _mktree(tmp_path)
+    cat = root / "lifestyle"
+    cat.mkdir()
+    ghost = cat / "ghost.fr.mdx"
+    _write(ghost, FM, "orphan fr\n")
+    before = ghost.read_text()
+    monkeypatch.setattr(ta, "ARTICLES_DIR", root)
+    monkeypatch.setattr(ta, "call_ollama", lambda *a, **k: pytest.fail("model called"))
+
+    assert ta.discover_articles() == []  # nothing for the translate loop to see
+    orphans = ta.discover_orphan_translations()
+    assert [o.name for o in orphans] == ["ghost.fr.mdx"]
+    assert ghost.read_text() == before  # untouched
+
+
+def test_dry_run_exits_zero_with_a_real_orphan_present():
+    """EXIT 0 requirement, end to end on the live corpus: a pre-existing
+    orphan condition must never turn an hourly cron run red — that would be
+    a NEW problem (cicatrix-superscar.md Family #2), not a cure for one."""
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "translate-articles.py"),
+         "--dry-run", "--category", "immigration"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "ORPHAN" in proc.stdout
+    assert "driving-license-bali-foreigners-2026.id.mdx" in proc.stdout

--- a/scripts/translate-articles.py
+++ b/scripts/translate-articles.py
@@ -27,7 +27,8 @@ OLLAMA_URL = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 # silently produced no output until OLLAMA_MODEL was overridden in the plist.
 # Keep the code default in sync with the host so a manual run works out of the box.
 MODEL = os.environ.get("OLLAMA_MODEL", "aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m")
-ARTICLES_DIR = Path(__file__).resolve().parent.parent / "apps" / "mouth" / "src" / "content" / "articles"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ARTICLES_DIR = REPO_ROOT / "apps" / "mouth" / "src" / "content" / "articles"
 
 LANG_NAMES = {
     "id": "Bahasa Indonesia",
@@ -254,6 +255,77 @@ def discover_articles(category: str | None = None) -> list[dict]:
     return articles
 
 
+# ── Orphan detection (2026-08-07) ───────────────────────────────────────────
+#
+# discover_articles() derives every translation target as
+# ``<slug>.mdx`` -> ``<slug>.<lang>.mdx`` IN THE SAME DIRECTORY. If an
+# English article is later moved to a different category folder, any
+# translation left behind next to the old (now-absent) source becomes
+# permanently invisible to this organ: never fresh, never stale, never
+# counted — it is not reachable from discover_articles() by construction,
+# so the freshness loop can silently drift from a whole-tree disk census
+# forever with no signal anywhere.
+#
+# Measured live 2026-08-07: disk census of id+it translation files = 1593,
+# while discover_articles() x {id,it} visits 1592 slots. The one-file gap is
+# apps/mouth/src/content/articles/immigration/driving-license-bali-foreigners-2026.id.mdx
+# — its English source and .it sibling both live under lifestyle/ now; the
+# immigration/ copy has no <slug>.mdx neighbour left.
+#
+# This pass is REPORT-ONLY by design: it costs nothing (pure filesystem
+# glob+exists, no model call), covers all four language suffixes regardless
+# of --lang/targets, and must never change `targets`, never trigger a
+# translation, and never affect the process exit code. Disposition of an
+# orphan (move the file back, delete it, restore the English source) is a
+# client-facing content call for a human, not something this cron decides.
+_ORPHAN_SUFFIX_RE = re.compile(r"^(.+)\.(id|it|ru|fr)\.mdx$")
+
+
+def discover_orphan_translations(category: str | None = None) -> list[Path]:
+    """Translation files whose English `<slug>.mdx` source is missing from
+    their own directory. Pure filesystem check — no model, no writes."""
+    orphans: list[Path] = []
+    if not ARTICLES_DIR.exists():
+        return orphans
+
+    for cat_dir in sorted(ARTICLES_DIR.iterdir()):
+        if not cat_dir.is_dir() or cat_dir.name.startswith("."):
+            continue
+        if category and category != "all" and cat_dir.name != category:
+            continue
+
+        for mdx_file in sorted(cat_dir.glob("*.mdx")):
+            name = mdx_file.name
+            if ".sync-conflict-" in name:
+                continue
+            m = _ORPHAN_SUFFIX_RE.match(name)
+            if not m:
+                continue  # an English source itself, not a translation
+            stem = m.group(1)
+            src_path = cat_dir / f"{stem}.mdx"
+            if not src_path.exists():
+                orphans.append(mdx_file)
+
+    return orphans
+
+
+def _log_orphans(orphans: list[Path]) -> None:
+    """Shared reporting for both --dry-run and the real run. Never gates."""
+    if not orphans:
+        return
+    logger.warning(
+        f"\n{len(orphans)} ORPHAN translation(s): no <slug>.mdx source in the "
+        f"same directory (never fresh/stale/unstamped — invisible to every "
+        f"freshness check above). Report only — not translated, not moved:"
+    )
+    for o in orphans:
+        try:
+            rel = o.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = o
+        logger.warning(f"  ORPHAN: {rel}")
+
+
 def translate_article(article: dict, lang: str, force: bool, skip_existing: bool) -> str:
     """Translate one article. Returns a verdict (see freshness_verdict + main)."""
     src_path: Path = article["path"]
@@ -466,6 +538,10 @@ def main():
         logger.error("No articles found. Check ARTICLES_DIR path.")
         sys.exit(1)
 
+    # Orphan translations (2026-08-07): scanned once, over the full category
+    # scope, independent of --slug/--limit/--lang — report-only, never gates.
+    orphans = discover_orphan_translations(args.category)
+
     # Filter by slug if specified
     if args.slug:
         articles = [a for a in articles if a["slug"] == args.slug]
@@ -509,7 +585,9 @@ def main():
                 if action in ("CREATE", "RE-TRANSLATE", "FORCE"):
                     logger.info(f"  [{action}] {art['category']}/{art['slug']}.{lang}.mdx")
         summary = ", ".join(f"{v} {k}" for k, v in sorted(preview.items())) or "nothing"
-        logger.info(f"\nTotal: {len(articles)} articles x {len(targets)} languages — {summary}")
+        orphan_note = f", {len(orphans)} orphan(s)" if orphans else ""
+        logger.info(f"\nTotal: {len(articles)} articles x {len(targets)} languages — {summary}{orphan_note}")
+        _log_orphans(orphans)
         return
 
     # Check Ollama connectivity
@@ -551,7 +629,8 @@ def main():
         f"DONE in {elapsed:.0f}s: {tally.get('written', 0)} new, "
         f"{tally.get('retranslated', 0)} re-translated (stale source), "
         f"{fresh} already fresh, "
-        f"{unstamped} unstamped, {skipped} skipped, {failed} FAILED"
+        f"{unstamped} unstamped, {skipped} skipped, {failed} FAILED, "
+        f"{len(orphans)} orphan(s)"
     )
     logger.info(f"Average: {elapsed/max(written,1):.1f}s per translation")
     if unstamped:
@@ -560,6 +639,7 @@ def main():
             f"freshness checking. They are NOT auto-translated. To vouch for a set of them: "
             f"--stamp-baseline <listfile>"
         )
+    _log_orphans(orphans)
 
     # Innervation W1.3 sidecar emission. Best-effort — never raises back to
     # the caller. The genome aggregator polls this file; absent file =
@@ -585,6 +665,11 @@ def main():
             sidecar_status = "degraded"
         else:
             sidecar_status = "ok"  # every target is provably current
+        # orphan_translations is informational ONLY — it must never flip
+        # sidecar_status. Orphans are a pre-existing filesystem condition
+        # (source moved category), not something this run caused or can fix;
+        # an hourly cron that starts alarming on day-1 of a new counter is a
+        # new W-class problem (Family #2), not a cure.
         (out_dir / "pro.translate_hourly.json").write_text(_json.dumps({
             "ts": time.time(),
             "status": sidecar_status,
@@ -596,6 +681,7 @@ def main():
                 "unstamped": unstamped,
                 "skipped": skipped,
                 "failed": failed,
+                "orphan_translations": len(orphans),
                 "elapsed_s": round(elapsed, 1),
             },
         }), encoding="utf-8")


### PR DESCRIPTION
## Finding

`discover_articles()` derives every translation target as `<slug>.mdx -> <slug>.<lang>.mdx` **in the same directory**. If an English article's category folder changes, a translation left behind next to the now-absent source is permanently invisible to the freshness loop: never `fresh`, never `stale`, never `unstamped`, never counted — unreachable from `discover_articles()` by construction.

## What I measured today (re-run in this worktree, fresh from `origin/main`)

```
$ find apps/mouth/src/content/articles -mindepth 2 -maxdepth 2 -name "*.mdx" | grep -vE '\.(id|it|ru|fr)\.mdx$' | wc -l
796
$ find apps/mouth/src/content/articles -mindepth 2 -maxdepth 2 -regex '.*\.\(id\|it\)\.mdx' | wc -l
1593
```

796 English sources × 2 langs (id/it) = 1592 loop-visited slots. Disk census of id+it translation files = **1593**. The gap:

```
$ python3 -c "import ...discover_orphan_translations()..."
apps/mouth/src/content/articles/immigration/driving-license-bali-foreigners-2026.id.mdx
```

```
$ find apps/mouth/src/content/articles -iname "driving-license-bali-foreigners-2026*"
apps/mouth/src/content/articles/immigration/driving-license-bali-foreigners-2026.id.mdx   <- orphan
apps/mouth/src/content/articles/lifestyle/driving-license-bali-foreigners-2026.it.mdx
apps/mouth/src/content/articles/lifestyle/driving-license-bali-foreigners-2026.id.mdx
apps/mouth/src/content/articles/lifestyle/driving-license-bali-foreigners-2026.mdx
```

The English source and its `.it` sibling both live under `lifestyle/` now; the `immigration/` copy has no `<slug>.mdx` neighbour left. Matches the brief's numbers exactly (re-measured, not carried over).

## What changed

`scripts/translate-articles.py`:
- New `discover_orphan_translations(category=None)` — a pure filesystem check (glob + `.exists()`, no model call) that finds every `<slug>.<lang>.mdx` (id/it/ru/fr) whose `<slug>.mdx` is missing from the same directory.
- Wired into `main()`: computed once (independent of `--slug`/`--limit`/`--lang`), named in the `--dry-run` summary and the real-run `DONE` summary alongside fresh/unstamped/stale/failed, and added to the sidecar's `metadata.orphan_translations` for observability.
- **Report-only by design**: never derives `targets`, never triggers a translation/write, never flips `sidecar_status` (ok/degraded) or the process exit code.

`scripts/tests/test_translate_freshness.py`: 9 new tests.

## Guilt corpus

- `test_orphan_with_no_sibling_source_is_reported` — synthetic `foo.it.mdx` with no `foo.mdx` sibling is reported.
- `test_the_real_orphan_is_caught_by_name` — the real live file is reported by name.
- `test_dry_run_exits_zero_with_a_real_orphan_present` — end-to-end subprocess run on the live corpus: `ORPHAN` + the filename appear in stdout, **and returncode is 0**.

## Innocence corpus

- `test_translation_with_its_sibling_source_is_not_an_orphan` — normal `<slug>.id.mdx` WITH its sibling.
- `test_english_source_with_no_translation_yet_is_not_an_orphan` — an English source with no translation yet is the existing legitimate 'absent' verdict, not an orphan (flagging it would be an over-match, cicatrix family #3).
- `test_all_four_language_suffixes_are_covered` — id/it/ru/fr all caught.
- `test_category_filter_scopes_the_scan`, `test_sync_conflict_files_are_never_flagged_as_orphans`.
- `test_fr_and_ru_orphans_never_reach_the_translate_write_path` — a fr/ru orphan is reported but the file is provably untouched and no model is called.

## Mutation check

Disabled the cure (`discover_orphan_translations` short-circuited to always return `[]`, right after computing `orphans = []`), ran `pytest -k orphan`:

```
4 failed, 3 passed, 22 deselected in 1.40s
FAILED test_orphan_with_no_sibling_source_is_reported
FAILED test_the_real_orphan_is_caught_by_name
FAILED test_fr_and_ru_orphans_never_reach_the_translate_write_path
FAILED test_dry_run_exits_zero_with_a_real_orphan_present
```

The 3 guilt-adjacent innocence tests correctly stayed green (they assert *absence* of orphans, still trivially true against an always-`[]` stub) — confirming the corpus is wired to the cure, not to a property of the language. Reverted the mutation; full suite green again (`29 passed`).

## PROVE-LIVE

This changes a script invoked by an hourly Pro cron (`translate.hourly`) and by `apps/bali-intel-scraper/scripts/post_publish_poller.py::run_translate` (subprocess by path, checks only `returncode`/`stderr` — never parses stdout by keyword, so the new log lines are safe there). No plist/wrapper changed (out of scope per the brief). Consuming surfaces:

- **Pro cron `translate.hourly`** — next scheduled run will emit the orphan line in its log; sidecar `~/.organism/last_seen/pro.translate_hourly.json` will carry `metadata.orphan_translations: 1`. Not verifiable from this session (Pro-local file, no SSH exec authorized in this mandate's scope) — will read as `1` on next run given the measurement above.
- **`post_publish_poller.py`** — unaffected; confirmed it only inspects `returncode`/`stderr`.
- Manual verification in this worktree (see commands/output above) — confirmed live.

## Seen, not cured (out of scope for this finding)

- Disposition of the orphan file itself (`apps/mouth/src/content/articles/immigration/driving-license-bali-foreigners-2026.id.mdx`) — move back, delete, or restore an English source in `immigration/`. Client-facing content call, left to the ledger per the brief.
- `declared-pairs.json` / `PENDING-ARMS.md` / `DOCS_INVENTORY.md` — not touched (not assigned to this lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)