### PR TITLE
docs(operations): retract the false 426/1167 translation-stamp count

### DIFF
--- a/docs/operations/handoff-observability-block-2026-08-06.md
+++ b/docs/operations/handoff-observability-block-2026-08-06.md
@@ -135,11 +135,38 @@ DONE in 1s: 0 new, 0 re-translated (stale source), 847 already fresh, 745 unstam
 ```
 
 `847 + 745 = 1592`, sulle 1593 di `id`+`it`: internamente coerente. Ma il mio conteggio
-indipendente di `source_sha256` sulle stesse due lingue dà **426 timbrate / 1167 no** — anche
-questo somma a 1593. **Due misure della stessa proprietà, tagli diversi.** Ipotesi non verificate:
-«already fresh» dell'organo non significa «timbrato»; oppure la mia sonda leggeva solo i primi
-2000 byte e alcune frontmatter sono più lunghe. **Riconciliare questo è il PRIMO lavoro** —
-partire dal numero sbagliato butta il lavoro E lo fa sopravvivere nel report finale.
+indipendente di `source_sha256` sulle stesse due lingue dava **426 timbrate / 1167 no** —
+**RETRACTED 2026-08-07** (sbagliato di quasi un fattore 2; non cancellato, resta annotato
+perché chi legge dopo lo trovi già smentito invece di ri-derivarlo da capo — W113).
+
+**Ri-misurato oggi, lettura FULL-FILE con le stesse `split_frontmatter`/`read_stamp` di
+`scripts/translate-articles.py` (non reinventate): 847 timbrate / 746 non-timbrate sui 1593
+file `id`+`it` su disco.** Coincide con l'847 «already fresh» del log dell'organo qui sopra —
+il log riporta 0 stale, quindi ogni file timbrato è ANCHE fresco, e le due misure indipendenti
+(mia, oggi; dell'organo, ieri 19:30) collimano esattamente. `746 = 745 + 1`: il file in più è
+un **orfano invisibile al loop** — `immigration/driving-license-bali-foreigners-2026.id.mdx`
+esiste sul disco ma la sua sorgente inglese (`driving-license-bali-foreigners-2026.mdx`) è
+sparita, quindi `discover_articles()` non lo scopre mai e non entra né negli 847 né nei 745
+(PR #3736, aperta in parallelo sullo stesso reperto, lo rende visibile a livello di codice).
+
+Le due ipotesi lasciate aperte:
+
+- **«already fresh ≠ timbrato» — REFUTATA dal codice.** `freshness_verdict()`
+  (`scripts/translate-articles.py:165-180`) ritorna `"fresh"` _solo_ quando `stamp == digest`,
+  e uno stamp esiste solo se il campo è già scritto: «already fresh» IMPLICA timbrato, il
+  contrario non regge.
+- **byte-cap sulla mia sonda — CONFERMATA, ed è la causa.** Leggevo solo i primi ~2000
+  caratteri di ogni file. `stamp_frontmatter()` (riga 146) aggiunge `source_sha256` **per
+  ultimo** nel blocco frontmatter, e la SEO frontmatter di questo corpus supera regolarmente i
+  2KB — la sonda mancava sistematicamente proprio i file con frontmatter lunga, non a caso.
+  Ri-eseguita oggi con lo STESSO taglio (`_STAMP_RE.search(text[:2000])`, la regex dell'organo,
+  non una reinventata): degli 847 file davvero timbrati, **425 hanno il timbro oltre il
+  carattere 2000** (persi dal taglio) e **422 sono catturati entro il taglio** —
+  `422 + 425 = 847`. Una ri-esecuzione byte-capped riproduce **422**, stesso ordine di
+  grandezza del vecchio 426 sbagliato: il meccanismo è dimostrato riproducibile, non solo
+  affermato.
+
+**Riconciliato: il lavoro parte da 847/746, non dal numero vecchio.**
 
 ### §4 — il battito di `pro.translate_hourly` mente, l'organo sta bene `[famiglia #2, rovesciata]`
 


### PR DESCRIPTION
## Finding

`docs/operations/handoff-observability-block-2026-08-06.md` §3 cited an independent
count of `source_sha256`-stamped translations (`id`+`it`) as **426 stamped / 1167
unstamped** — presented alongside the organ's own hourly log in the *same section*,
which says `847 already fresh, 745 unstamped`. Nearly a factor-of-2 disagreement
between two measurements of the same property, flagged in the handoff as unreconciled
("Riconciliare questo è il PRIMO lavoro").

## What I measured today (fresh worktree from `origin/main`)

Full-file read, using the organ's own `split_frontmatter`/`read_stamp`
(`scripts/translate-articles.py`), not reimplemented:

```
$ python3 -c "... walks apps/mouth/src/content/articles/**/*.{id,it}.mdx,
               calls ta.split_frontmatter + ta.read_stamp on the FULL file ..."
total id+it files: 1593
FULL-FILE stamped=847 unstamped=746
```

**847 reconciles exactly** with the organ's own `847 already fresh` (the log reports 0
stale in that run, so every stamped file is also fresh — two independent measurements,
one from today, one from the organ's own log, land on the same number).

`746 = 745 (loop-visible) + 1 (loop-invisible orphan)`:
`immigration/driving-license-bali-foreigners-2026.id.mdx` exists on disk but its English
source (`driving-license-bali-foreigners-2026.mdx`) is gone, so `discover_articles()`
never sees it — it's counted in neither the 847 nor the 745. (Same file independently
found by sibling PR #3736, which makes it visible at the code level; this PR only fixes
the doc.)

### Root cause, confirmed and reproduced (not just hypothesized)

`stamp_frontmatter()` (`scripts/translate-articles.py:146`) appends `source_sha256` as
the **last line** of the frontmatter block. This corpus's SEO frontmatter
(seoTitle/seoDescription/excerpt/faq/...) routinely exceeds 2000 characters, so a probe
that only reads the first ~2000 chars of each file systematically misses the stamp on
long-frontmatter files — not at random.

Reproduced today with the organ's own `_STAMP_RE` regex applied to the truncated
prefix:

```
of 847 truly-stamped: MISSED by the 2000-char cap = 425
of 847 truly-stamped: caught within 2000 chars    = 422
422 + 425 = 847
```

422 reproduces, in the same order of magnitude, the old wrong 426 — the failure mode is
demonstrated reproducible, not asserted.

### Refuted hypothesis

The doc's other open hypothesis — `"already fresh" ≠ "timbrato"` — is false by code:
`freshness_verdict()` (`scripts/translate-articles.py:165-180`) returns `"fresh"`
**only** when `stamp == digest`, and a stamp can only exist if the field is already
written. "already fresh" implies stamped, not the other way around.

## What changed

Only the false paragraph in §3 (lines 137-142 of the pre-edit doc). The line is
annotated `RETRACTED 2026-08-07` **in place**, not deleted (W113 discipline: a
retraction is corrected *alongside* the claim, so a future reader finds it already
refuted instead of re-deriving it from a dated record).

**Checked `infra/retracted-claims/registry.json` / `scripts/lint_retracted_claims.py`
before writing the annotation, per the brief's instruction not to assume**: this
specific claim is not a registered entry — the registry is purpose-built and scoped to
two unrelated claims (the Kim et al. 17.2x / "Centralized best" citations, retracted
2026-08-02). Adding a new unrelated claim family to that registry is out of the files
this cure was assigned to touch, so I used the same `RETRACTED` textual convention
without implying machine-gating that doesn't exist for this claim.
`python3 scripts/lint_retracted_claims.py --files docs/operations/handoff-observability-block-2026-08-06.md`
→ `OK — 1 file(s) scanned, no un-annotated retracted claim` (rc=0).

## Guilt / innocence / mutation

- **Guilt (false pair is not live)**: `grep -n '426' <doc>` returns 2 lines, both inside
  the retraction/mechanism-explanation block (the annotation line, and a sentence
  explicitly calling it "il vecchio 426 sbagliato"). No occurrence presents 426 as a
  correct measurement.
- **Innocence (neighbours untouched)**: `git diff --stat` shows exactly 1 file changed;
  the table above §3 (3356 total .mdx, 796 sources, 797/796/485/482 per-language) and
  the organ's own quoted log block (`847 already fresh, 745 unstamped, 0 skipped, 0
  FAILED`) are byte-identical before/after (diffed directly, confirmed no hunk touches
  them).
- **Mutation / reproducibility**: reverting the edit reproduces the original false
  claim (trivial, since this is a prose correction, not a guard). The actual
  "reproducibility" proof requested by the brief is the byte-capped re-run itself
  (422/425/847 above), run fresh in this worktree in this turn, with the organ's own
  regex — not copied from the brief's numbers.

## Seen, not cured (out of scope for this PR)

The table just above §3 (lines 118-119 of the doc, untouched by this PR) reads `con
source_sha256 (mia lettura): 573` / `senza: 2783`, covering all 4 languages
(id+it+fr+ru, N=2560). I measured this out of due diligence (not to fix): full-file
count across all 4 languages today is **1294 stamped / 1266 unstamped**, while the same
2000-char-capped method gives **569 stamped** — i.e. that table appears to carry the
**same byte-cap defect**, off by roughly the same magnitude. Not touched here: my brief
scoped this PR to the specific 426/1167 pair in the id+it discrepancy only ("Cure THIS
finding. Do not opportunistically fix neighbours").

## PROVE-LIVE

This is a documentation-only correction to an internal ops handoff file — there is no
runtime surface to prove live. The claim is verified structurally (grep-based guilt +
innocence above) and the corrected numbers are independently reproducible by re-running
the commands quoted in the doc/PR body against `scripts/translate-articles.py` on
`origin/main`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>