### PR TITLE
fix(nlm): the exit code reported the GATE, not the WORK — 8 pipelines lied green

### DIFF
--- a/apps/evaluator/nlm_deep_research/nb10_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb10_pipeline.py
@@ -25,6 +25,7 @@ from .claim_extractor import (
     load_claims_count,
 )
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_snapshot import take_snapshot
 from .source_management import (
     compute_nhs,
@@ -625,7 +626,13 @@ def main():
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/nb3_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb3_pipeline.py
@@ -25,6 +25,7 @@ from .claim_extractor import (
     load_claims_count,
 )
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_snapshot import take_snapshot
 from .source_management import (
     compute_nhs,
@@ -627,7 +628,13 @@ def main() -> None:
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/nb4_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb4_pipeline.py
@@ -24,6 +24,7 @@ from .claim_extractor import (
     load_claims_count,
 )
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_management import (
     NotebookHealthInput,
     classify_nhs,
@@ -631,7 +632,13 @@ def main():
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/nb5_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb5_pipeline.py
@@ -25,6 +25,7 @@ from .claim_extractor import (
     load_claims_count,
 )
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_snapshot import take_snapshot
 from .source_management import (
     compute_nhs,
@@ -607,7 +608,13 @@ def main() -> None:
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/nb6_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb6_pipeline.py
@@ -24,6 +24,7 @@ from .claim_extractor import (
     load_claims_count,
 )
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_management import (
     NotebookHealthInput,
     classify_nhs,
@@ -609,7 +610,13 @@ def main():
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/nb7_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb7_pipeline.py
@@ -25,6 +25,7 @@ from .claim_extractor import (
     load_claims_count,
 )
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_snapshot import take_snapshot
 from .source_management import (
     compute_nhs,
@@ -605,7 +606,13 @@ def main() -> None:
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/nb8_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb8_pipeline.py
@@ -25,6 +25,7 @@ from .claim_extractor import (
     load_claims_count,
 )
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_snapshot import take_snapshot
 from .source_management import (
     compute_nhs,
@@ -620,7 +621,13 @@ def main():
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/pipeline.py
+++ b/apps/evaluator/nlm_deep_research/pipeline.py
@@ -26,6 +26,7 @@ from .handoff import generate_handoff, save_handoff, validate_handoff_schema
 from .invariants import InvariantSeverity, check_all_invariants
 from .query_decomposer import QueryDecomposer
 from .registry import SourceRegistry
+from .run_verdict import verdict
 from .source_management import (
     LifecycleStage,
     NotebookHealthInput,
@@ -717,11 +718,13 @@ def main():
     result = pipeline.run()
 
     print(json.dumps(result, indent=2, ensure_ascii=False))
-    # An intentional calendar skip (weekend halt) is a healthy no-op, not a
-    # failure — exit 0 so set-euo cron wrappers don't record a fake death.
-    if result.get("halt_reason") == "weekend":
-        sys.exit(0)
-    sys.exit(0 if result.get("phases", {}).get("preflight", {}).get("passed") else 1)
+    # The exit code must report the WORK, not the gate. One rule for all
+    # eight pipelines lives in run_verdict.py — see its docstring for the
+    # night this was measured.
+    code, reason = verdict(result)
+    if code:
+        print(f"[verdict] FAILED: {reason}", file=sys.stderr)
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/apps/evaluator/nlm_deep_research/run_verdict.py
+++ b/apps/evaluator/nlm_deep_research/run_verdict.py
@@ -1,0 +1,104 @@
+"""One rule for "did this run actually do anything", read by all eight pipelines.
+
+WHY THIS EXISTS (2026-08-07). Every one of the eight NB pipeline modules ended
+main() with the same line:
+
+    sys.exit(0 if result["phases"]["preflight"]["passed"] else 1)
+
+**The exit code reported the GATE, not the WORK.** Everything after pre-flight —
+L1 dying, the circuit breaker tripping, `error_nlm_add`, zero sources ingested —
+was invisible to it. So a run that passed pre-flight and then achieved nothing
+exited 0, and its wrapper printed "completed successfully".
+
+Measured on Pro the day this was written, with the NotebookLM credential expired
+(`nlm`: "Authentication expired"):
+
+  - nb3's last TWELVE runs: `source_count: 0` every time, `status:
+    error_nlm_add`, `degradation: NOMINAL` — and twelve "[DONE] NB-3 pipeline
+    completed successfully".
+  - all seven sibling pipelines reported success the same night.
+
+The one job that told the truth did so **by accident**: nb2 is scheduled twice,
+an hour apart. Its 01:10 run trips the 4-hour breaker and exits 0 ("Completed
+Successfully", cron-agent `OK`); its 02:10 run then fails PRE-FLIGHT on that
+breaker and exits 1. The alarm Zero receives is the second run complaining about
+damage the first one did while declaring success. Remove the duplicate schedule
+— which is the obviously correct thing to do — and the whole family goes silent
+while the ground-truth layer sits frozen. That is why this had to be fixed
+first, and why it lives in ONE module that all eight read rather than eight
+copies of a corrected line.
+
+WHAT COUNTS AS FAILURE, and what deliberately does not:
+
+  - `halt_reason == "weekend"` → 0. An intentional calendar skip is a healthy
+    no-op, not a death; this rule already existed in pipeline.py and is kept.
+  - pre-flight failed → 1 (the only case the old line got right).
+  - `halted_at` set → 1. This is the case that was exiting 0.
+  - any `status` starting with "error" anywhere in the summary → 1. This is
+    nb3's `error_nlm_add`, nested inside a phase.
+  - **`success: False` is deliberately NOT a failure here.** A single L1 query
+    can fail below the breaker threshold and the run still does real work
+    downstream; failing on it would trade a false green for a false red, and a
+    guard that cries wolf gets disarmed (superscar #2 by another road). When it
+    matters, that failure reaches us anyway — it trips the breaker, and the
+    breaker sets `halted_at`.
+
+The verdict NAMES its reason, and the caller prints it: a run that exits 1
+without saying why is the `last_error: "exit 1"` that this repo already knows
+tells the reader nothing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["verdict", "error_markers"]
+
+
+def error_markers(node: Any, path: str = "") -> list[str]:
+    """Every `status: error*` anywhere in the summary, with its path.
+
+    Recursive rather than a fixed key path on purpose: the eight pipelines nest
+    their phase dicts differently (nb3's marker sits inside an integration
+    phase, pipeline.py's inside `phases.l1`), and a rule written against one
+    layout would silently pass the other — which is the whole failure mode this
+    file exists to end.
+    """
+    found: list[str] = []
+    if isinstance(node, dict):
+        status = node.get("status")
+        if isinstance(status, str) and status.lower().startswith("error"):
+            found.append(f"{path or 'run'}.status={status}")
+        for key, value in node.items():
+            found += error_markers(value, f"{path}.{key}" if path else str(key))
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            found += error_markers(value, f"{path}[{i}]")
+    return found
+
+
+def verdict(summary: Any) -> tuple[int, str]:
+    """(exit_code, human reason). See the module docstring for the rules."""
+    if not isinstance(summary, dict):
+        # A pipeline that returned nothing usable did not succeed. Fail loud
+        # rather than treating an unreadable summary as a clean run.
+        return 1, "pipeline returned no usable summary"
+
+    if summary.get("halt_reason") == "weekend":
+        return 0, "weekend skip (intentional no-op)"
+
+    phases = summary.get("phases")
+    preflight = phases.get("preflight") if isinstance(phases, dict) else None
+    if not (isinstance(preflight, dict) and preflight.get("passed")):
+        reason = summary.get("halt_reason") or "unnamed"
+        return 1, f"pre-flight failed ({reason})"
+
+    halted = summary.get("halted_at")
+    if halted:
+        return 1, f"halted at {halted}"
+
+    markers = error_markers(summary)
+    if markers:
+        return 1, "phase reported an error: " + ", ".join(sorted(markers)[:4])
+
+    return 0, "completed"

--- a/apps/evaluator/nlm_deep_research/tests/test_run_verdict.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_run_verdict.py
@@ -1,0 +1,164 @@
+"""Guilt + innocence for the shared run verdict, and a pin that all eight use it.
+
+The fixtures below are not invented: `_NB3_LAST_RUN` and `_NB2_0110_RUN` are the
+shapes measured on Pro on 2026-08-07, the night the NotebookLM credential was
+found expired — twelve consecutive nb3 runs with `source_count: 0` reported as
+"completed successfully", and nb2's 01:10 run halting on the breaker it had just
+tripped while exiting 0.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from apps.evaluator.nlm_deep_research.run_verdict import error_markers, verdict
+
+MODULES = [
+    "pipeline.py",
+    "nb3_pipeline.py",
+    "nb4_pipeline.py",
+    "nb5_pipeline.py",
+    "nb6_pipeline.py",
+    "nb7_pipeline.py",
+    "nb8_pipeline.py",
+    "nb10_pipeline.py",
+]
+PKG = Path(__file__).resolve().parents[1]
+
+# --- the two shapes that were exiting 0 (measured on Pro, 2026-08-07) --------
+
+_NB2_0110_RUN = {
+    "run_id": "836b4bc3",
+    "phases": {"preflight": {"passed": True}, "l1": {"success": False, "error": "nlm exited with code 1"}},
+    "halted_at": "l1_circuit_open",
+    "degradation": "DEGRADED_L1",
+    "claims_total": 4750,
+}
+
+_NB3_LAST_RUN = {
+    "phases": {
+        "preflight": {"passed": True},
+        "integration": {
+            "new_claims": 2,
+            "total_claims": 170,
+            "source_count": 0,
+            "notebook": "NB-3: Company Setup Indonesia",
+            "status": "error_nlm_add",
+        },
+    },
+    "degradation": "NOMINAL",
+    "claims_total": 170,
+}
+
+
+def test_a_run_halted_on_its_own_breaker_is_a_failure():
+    code, reason = verdict(_NB2_0110_RUN)
+    assert code == 1
+    assert "l1_circuit_open" in reason
+
+
+def test_a_run_that_ingested_nothing_and_said_NOMINAL_is_a_failure():
+    code, reason = verdict(_NB3_LAST_RUN)
+    assert code == 1
+    assert "error_nlm_add" in reason
+
+
+def test_the_error_marker_is_found_however_deeply_it_is_nested():
+    """A fixed key path would pass one pipeline's layout and miss the other's."""
+    deep = {"phases": {"a": {"b": [{"status": "error_nlm_add"}]}}}
+    assert error_markers(deep) == ["phases.a.b[0].status=error_nlm_add"]
+
+
+def test_preflight_failure_still_fails_and_now_names_its_cause():
+    code, reason = verdict(
+        {"phases": {"preflight": {"passed": False}}, "halted_at": "preflight", "halt_reason": "cb_nlm"}
+    )
+    assert code == 1
+    assert "cb_nlm" in reason
+
+
+def test_an_unusable_summary_fails_loud():
+    assert verdict(None)[0] == 1
+    assert verdict({})[0] == 1
+
+
+# --- innocence: the shapes that must stay green -----------------------------
+
+
+def test_a_clean_run_passes():
+    code, reason = verdict(
+        {"phases": {"preflight": {"passed": True}, "l1": {"success": True}}, "claims_total": 12}
+    )
+    assert (code, reason) == (0, "completed")
+
+
+def test_the_weekend_skip_is_a_healthy_no_op():
+    """It halts, but on purpose. Failing it would fabricate a death every Sunday."""
+    code, reason = verdict(
+        {"phases": {"preflight": {"passed": False}}, "halted_at": "preflight", "halt_reason": "weekend"}
+    )
+    assert code == 0
+    assert "weekend" in reason
+
+
+def test_a_single_tolerated_query_failure_does_NOT_fail_the_run():
+    """DECLARED LIMIT, not an oversight: an L1 miss below the breaker threshold
+    still lets real work happen downstream. Trading the false green for a false
+    red would get this guard disarmed. When it matters the breaker trips, and
+    that sets halted_at — which IS caught, above."""
+    code, _ = verdict(
+        {
+            "phases": {"preflight": {"passed": True}, "l1": {"success": False, "error": "one miss"}},
+            "claims_total": 12,
+        }
+    )
+    assert code == 0
+
+
+def test_a_status_that_merely_contains_error_elsewhere_is_not_a_marker():
+    """`status: no_errors` must not read as a failure (match the entity, #3)."""
+    assert error_markers({"phases": {"x": {"status": "no_errors"}}}) == []
+
+
+# --- the pin: all eight modules must actually USE it ------------------------
+
+
+@pytest.mark.parametrize("name", MODULES)
+def test_every_pipeline_module_uses_the_shared_verdict(name):
+    """Eight copies of a corrected line would drift; one rule cannot.
+
+    This is the check that would have caught the original defect: it was the
+    SAME wrong line in all eight files, so fixing seven of them would look
+    finished (W107 — the cure that goes to one member of a class).
+    """
+    src = (PKG / name).read_text()
+    assert "run_verdict" in src, f"{name} does not import the shared verdict"
+    assert re.search(r"\bverdict\s*\(", src), f"{name} imports it but never calls it"
+    assert not re.search(
+        r'sys\.exit\(\s*0 if result\.get\("phases"', src
+    ), f"{name} still decides its exit code from pre-flight alone"
+
+
+@pytest.mark.parametrize("name", MODULES)
+def test_every_pipeline_module_keeps_a_main_that_exits(name):
+    """Parses AND still has the entry point the wiring edited.
+
+    A bare `ast.parse()` here asserted nothing — the anti-reward-hacking linter
+    caught that on the way in, correctly: a rewrite that deleted main() would
+    have passed it.
+    """
+    tree = ast.parse((PKG / name).read_text())
+    mains = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "main"]
+    assert mains, f"{name} lost its main()"
+    exits = [
+        n
+        for n in ast.walk(mains[0])
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "exit"
+    ]
+    assert exits, f"{name}.main() no longer exits — nothing would set its exit code"


### PR DESCRIPTION
## The line, in all eight modules

```python
sys.exit(0 if result["phases"]["preflight"]["passed"] else 1)
```

**The exit code reported the gate, not the work.** Everything after pre-flight — L1 dying, the circuit breaker tripping, `error_nlm_add`, zero sources ingested — was invisible to it. A run that passed pre-flight and then achieved nothing exited 0, and its wrapper printed *"completed successfully"*.

## Measured on Pro, 2026-08-07

The NotebookLM credential is expired — `nlm`: *"Authentication expired. Run `nlm login`"*.

- **nb3's last TWELVE runs**: `source_count: 0` every time, `status: error_nlm_add`, `degradation: NOMINAL` → twelve `[DONE] NB-3 pipeline completed successfully`.
- All seven sibling pipelines reported success the same night.

**The only job that told the truth did so by accident.** nb2 is scheduled twice, an hour apart: the 01:10 run trips the 4h breaker and exits 0 (*"Completed Successfully"*, cron-agent `OK`); the 02:10 run then fails **pre-flight** on that breaker and exits 1. The nightly P0 is the second run complaining about damage the first did while declaring success.

That ordering is why this shipped first: removing the duplicate schedule — obviously the right thing — would have silenced the whole family while the ground-truth layer sat frozen.

## The cure

**One rule in one module** (`run_verdict.py`), read by all eight, because the defect *was* eight copies of one line — fixing seven would have looked finished (W107).

Failure = pre-flight failed · `halted_at` set · any `status: error*` anywhere in the summary. The marker scan is **recursive**: the eight nest their phases differently (nb3's sits in an integration phase, `pipeline.py`'s in `phases.l1`), and a fixed key path would pass one layout and silently miss the other — which is the exact failure mode this file exists to end. The weekend skip stays exit 0, and the verdict **names its reason**, because `last_error: "exit 1"` tells the reader nothing.

**Declared limit, deliberate:** `success: False` is *not* a failure. A single L1 miss below the breaker threshold still lets real work happen downstream; trading the false green for a false red is how a guard gets disarmed. When it matters it trips the breaker, and that sets `halted_at`, which **is** caught.

## Verification

25 tests, guilt + innocence, fixtures taken **verbatim from the two measured runs**. Mutation-verified **6/6**:

| mutation | |
|---|---|
| `halted_at` no longer fails | CAUGHT |
| error markers ignored | CAUGHT |
| weekend becomes a failure | CAUGHT |
| `success: False` fails (over-match) | CAUGHT |
| `error_markers` made non-recursive | CAUGHT |
| **ONE module of eight reverted** | CAUGHT |

The anti-reward-hacking linter rejected the first draft of the parse test for asserting nothing — correctly; it now asserts `main()` survives and still exits.

The 5 failures in `test_cross_notebook_correlator.py` reproduce identically on `origin/main`; untouched here.

## Next, and separate

The duplicate 01:10 schedule (live crontab on Pro) comes off after this merges. The root — `nlm login` — is Zero's: an interactive browser login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)