### PR TITLE
fix(docs): close the over-match and three under-matches #3737 left open

### DIFF
--- a/docs/DOCS_INVENTORY.md
+++ b/docs/DOCS_INVENTORY.md
@@ -19,14 +19,14 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | File | Status | last_touched_date | orphan_eligible_on | orphan_flipped_on | refs_in | broken | drift | cluster | action |
 |------|--------|--------------------|---------------------|--------------------|--------:|-------:|-------|---------|--------|
 | docs/AI_DISPATCH_REFERENCE.md | LIVE | 2026-05-22 | 2026-08-20 | — | 2 | 0 | no | — | — |
-| docs/AI_ONBOARDING.md | LIVE | 2026-08-06 | 2026-11-04 | — | 21 | 0 | no | — | — |
+| docs/AI_ONBOARDING.md | LIVE | 2026-08-06 | 2026-11-04 | — | 19 | 0 | no | — | — |
 | docs/ANTHROPIC_API_REFERENCE.md | LIVE | 2026-07-25 | 2026-10-23 | — | 1 | 0 | no | — | — |
 | docs/API_REFERENCE.md | LIVE | 2026-02-26 | 2026-05-27 | — | 3 | 0 | no | — | whitelist |
 | docs/APPLICAZIONE_COMPONENTI_UTILITY.md | ARCHIVED | 2026-04-24 | 2026-07-23 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-24, refs=0 |
 | docs/ARCHITECTURE_DECISION_RECORDS.md | LIVE | 2026-03-22 | 2026-06-20 | — | 5 | 0 | no | — | whitelist |
 | docs/AUTOMATIONS.md | STALE | 2026-04-24 | 2026-07-23 | — | 2 | 0 | no | automations-catalog | keep (canonical of automations-catalog) |
-| docs/AUTOMATIONS_REFERENCE.md | LIVE | 2026-07-26 | 2026-10-24 | — | 15 | 0 | no | — | — |
-| docs/AUTOMATION_AUTONOMY_SYSTEM_V3_3.md | STALE | 2026-03-31 | 2026-06-29 | — | 4 | 0 | no | automation-autonomy | keep (canonical of automation-autonomy) |
+| docs/AUTOMATIONS_REFERENCE.md | LIVE | 2026-07-26 | 2026-10-24 | — | 13 | 0 | no | — | — |
+| docs/AUTOMATION_AUTONOMY_SYSTEM_V3_3.md | STALE | 2026-03-31 | 2026-06-29 | — | 3 | 0 | no | automation-autonomy | keep (canonical of automation-autonomy) |
 | docs/BLOG_100_ARTICLES_PLAN.md | LIVE | 2026-03-22 | 2026-06-20 | — | 3 | 0 | no | — | — |
 | docs/BLOG_LAYOUT_GUIDE.md | LIVE | 2026-04-24 | 2026-07-23 | — | 2 | 0 | no | — | — |
 | docs/CHRONIC_PROBLEMS_AUTOMATION_PLAN.md | ARCHIVED | 2026-03-26 | 2026-06-24 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-03-26, refs=0 |
@@ -58,14 +58,14 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/KG_LANGGRAPH_TEST_REPORT.md | LIVE | 2026-03-22 | 2026-06-20 | — | 1 | 0 | no | — | — |
 | docs/KG_VALUE_ASSESSMENT_2026_01_18.md | LIVE | 2026-02-17 | 2026-05-18 | — | 1 | 0 | no | — | — |
 | docs/LEAD_ASSIGNMENT_AGENT.md | LIVE | 2026-04-24 | 2026-07-23 | — | 1 | 0 | no | — | — |
-| docs/LIVING_ARCHITECTURE.md | STALE | 2026-04-21 | 2026-07-20 | — | 9 | 0 | no | system-map | keep (canonical of system-map) |
+| docs/LIVING_ARCHITECTURE.md | STALE | 2026-04-21 | 2026-07-20 | — | 7 | 0 | no | system-map | keep (canonical of system-map) |
 | docs/MULTI_DOMAIN_FUSION_ARCHITECTURE.md | ARCHIVED | 2026-04-25 | 2026-07-24 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-25, refs=0 |
 | docs/NOTEBOOKLM_CAPABILITY_MATRIX.md | ARCHIVED | 2026-04-25 | 2026-07-24 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-25, refs=0 |
 | docs/NOTEBOOKLM_STRATEGY.md | ARCHIVED | 2026-04-25 | 2026-07-24 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-25, refs=0 |
-| docs/NOTEBOOKLM_STRATEGY_4LLM_BRAINSTORM.md | LIVE | 2026-03-24 | 2026-06-22 | — | 1 | 0 | no | — | — |
+| docs/NOTEBOOKLM_STRATEGY_4LLM_BRAINSTORM.md | LIVE | 2026-03-24 | 2026-06-22 | — | 0 | 0 | no | — | — |
 | docs/OMNICHANNEL_2_0_SPEC.md | LIVE | 2026-02-17 | 2026-05-18 | — | 1 | 0 | no | — | — |
 | docs/OPENCLAW_SYSTEM.md | LIVE | 2026-07-16 | 2026-10-14 | — | 1 | 0 | no | — | — |
-| docs/PDP_COMPLIANCE_PLAN.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
+| docs/PDP_COMPLIANCE_PLAN.md | LIVE | 2026-03-31 | 2026-06-29 | — | 0 | 0 | no | — | — |
 | docs/PHASE1_CLOSURE_NEXT_SESSION_PROMPT.md | LIVE | 2026-05-22 | 2026-08-20 | — | 0 | 0 | no | — | — |
 | docs/PHASE1_SINAPSI_STATUS_2026-04-16.md | LIVE | 2026-07-16 | 2026-10-14 | — | 1 | 0 | no | — | — |
 | docs/PROJECT_STRUCTURE.md | LIVE | 2026-01-21 | 2026-04-21 | — | 2 | 0 | no | — | — |
@@ -77,18 +77,18 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/SKILL_REGISTRY_OPS.md | LIVE | 2026-07-16 | 2026-10-14 | — | 0 | 0 | no | — | — |
 | docs/SLO.md | LIVE | 2026-04-06 | 2026-07-05 | — | 1 | 0 | no | — | — |
 | docs/SYMBIOSIS_TURNON_PLAN.md | LIVE | 2026-07-16 | 2026-10-14 | — | 2 | 0 | no | — | — |
-| docs/SYSTEM_AUDIT_FINAL_2026-04-03.md | STALE | 2026-04-05 | 2026-07-04 | — | 2 | 0 | no | system-audit | keep (canonical of system-audit) |
-| docs/SYSTEM_BRIEF_FOR_AGENTS.md | LIVE | 2026-04-06 | 2026-07-05 | — | 1 | 0 | no | — | — |
-| docs/TECHNOLOGY_ENHANCEMENT_PLAN.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
+| docs/SYSTEM_AUDIT_FINAL_2026-04-03.md | STALE | 2026-04-05 | 2026-07-04 | — | 1 | 0 | no | system-audit | keep (canonical of system-audit) |
+| docs/SYSTEM_BRIEF_FOR_AGENTS.md | LIVE | 2026-04-06 | 2026-07-05 | — | 0 | 0 | no | — | — |
+| docs/TECHNOLOGY_ENHANCEMENT_PLAN.md | LIVE | 2026-03-31 | 2026-06-29 | — | 0 | 0 | no | — | — |
 | docs/TYPE_SAFETY_GUIDE.md | LIVE | 2026-02-17 | 2026-05-18 | — | 1 | 0 | no | — | — |
-| docs/UU_PDP_COMPLIANCE_REPORT.md | LIVE | 2026-03-31 | 2026-06-29 | — | 2 | 0 | no | — | — |
+| docs/UU_PDP_COMPLIANCE_REPORT.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
 | docs/WHATSAPP_STRATEGY_2026.md | LIVE | 2026-08-05 | 2026-11-03 | — | 1 | 0 | no | — | — |
-| docs/XAI_FULL_CAPABILITIES_AND_OPTIMIZATION.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
+| docs/XAI_FULL_CAPABILITIES_AND_OPTIMIZATION.md | LIVE | 2026-03-31 | 2026-06-29 | — | 0 | 0 | no | — | — |
 | docs/X_BRAND_VOICE.md | LIVE | 2026-03-31 | 2026-06-29 | — | 3 | 0 | no | — | — |
-| docs/X_PREMIUM_BLITZ_BATTLE_PLAN.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
+| docs/X_PREMIUM_BLITZ_BATTLE_PLAN.md | LIVE | 2026-03-31 | 2026-06-29 | — | 0 | 0 | no | — | — |
 | docs/adr/ADR-006-nb-mitochondrial-monitor-bootstrap-json.md | LIVE | 2026-05-06 | 2026-08-04 | — | 1 | 0 | no | — | — |
 | docs/ai/AI_HANDOVER_PROTOCOL.md | LIVE | 2026-04-25 | 2026-07-24 | — | 2 | 0 | no | — | — |
-| docs/ai/GEMINI.md | LIVE | 2026-03-31 | 2026-06-29 | — | 4 | 0 | no | — | — |
+| docs/ai/GEMINI.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
 | docs/analysis/nlm-sacred-integration/SESSION_REPORT.md | LIVE | 2026-04-21 | 2026-07-20 | — | 0 | 0 | no | — | — |
 | docs/architecture/CHAIN_ONBOARDING_IMPROVEMENTS.md | LIVE | 2026-03-10 | 2026-06-08 | — | 1 | 0 | no | — | — |
 | docs/architecture/KG_LANGGRAPH_FIX_SUMMARY.md | LIVE | 2026-03-10 | 2026-06-08 | — | 2 | 0 | no | — | — |
@@ -342,16 +342,16 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/audits/2026-04-22-kg-gap-triage.md | ARCHIVED | 2026-04-24 | 2026-07-23 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-24, refs=0 |
 | docs/audits/2026-04-22-orchestrator-state-machine.md | LIVE | 2026-04-24 | 2026-07-23 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-22-orchestrator-test-gaps.md | ARCHIVED | 2026-04-24 | 2026-07-23 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-24, refs=0 |
-| docs/audits/2026-04-29-zero-crash-audit/00_executive_summary.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-04-29-zero-crash-audit/00_executive_summary.md | LIVE | 2026-04-29 | 2026-07-28 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/01_brief_dispatched.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/02_opus_analysis.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/03_codex_analysis.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/04_gemini_analysis.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/05_deepseek_analysis.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/06_notebooklm_analysis.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
-| docs/audits/2026-04-29-zero-crash-audit/07_dispatch_resilience_log.md | LIVE | 2026-04-29 | 2026-07-28 | — | 4 | 0 | no | — | — |
+| docs/audits/2026-04-29-zero-crash-audit/07_dispatch_resilience_log.md | LIVE | 2026-04-29 | 2026-07-28 | — | 3 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/08_convergent_findings.md | LIVE | 2026-04-29 | 2026-07-28 | — | 3 | 0 | no | — | — |
-| docs/audits/2026-04-29-zero-crash-audit/09_intervention_plan.md | LIVE | 2026-04-29 | 2026-07-28 | — | 8 | 0 | no | — | — |
+| docs/audits/2026-04-29-zero-crash-audit/09_intervention_plan.md | LIVE | 2026-04-29 | 2026-07-28 | — | 7 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/10_cell_genoma_alignment.md | LIVE | 2026-04-29 | 2026-07-28 | — | 3 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/11_brainstorms/00_INDEX.md | ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-29, refs=0 |
 | docs/audits/2026-04-29-zero-crash-audit/11_brainstorms/P0-0_health_endpoint_classify.md | LIVE | 2026-04-29 | 2026-07-28 | — | 2 | 0 | no | — | — |
@@ -366,54 +366,54 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/audits/2026-04-29-zero-crash-audit/_codex_iteration_2.md | ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-29, refs=0 |
 | docs/audits/2026-04-29-zero-crash-audit/_codex_iteration_3_final.md | ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-29, refs=0 |
 | docs/audits/2026-04-29-zero-crash-audit/p0-5-httpx-audit-report.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
-| docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/README.md | LIVE | 2026-04-29 | 2026-07-28 | — | 10 | 0 | no | — | — |
+| docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/README.md | LIVE | 2026-04-29 | 2026-07-28 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/kakuro-S1.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/kakuro-S2.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/kakuro-S3.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/kakuro-S4-final.md | ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-29, refs=0 |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave1/kakuro-S4.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
-| docs/audits/2026-04-29-zero-crash-audit/prompts/wave2/00_README.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-04-29-zero-crash-audit/prompts/wave2/00_README.md | LIVE | 2026-04-29 | 2026-07-28 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave2/wave2-team-air.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave2/wave2-team-pro.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
-| docs/audits/2026-04-29-zero-crash-audit/prompts/wave3/00_README.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-04-29-zero-crash-audit/prompts/wave3/00_README.md | LIVE | 2026-04-29 | 2026-07-28 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-04-29-zero-crash-audit/prompts/wave3/wave3-team-pro.md | LIVE | 2026-04-29 | 2026-07-28 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-05-02-cell-openclaw-brainstorm/00_briefing.md | LIVE | 2026-05-02 | 2026-07-31 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-05-02-cell-openclaw-brainstorm/00b_briefing_v2.md | ARCHIVED | 2026-05-02 | 2026-07-31 | 2026-08-01 | 0 | 0 | no | — | archive: orphan, last_touched=2026-05-02, refs=0 |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/01_codex_gpt55_response.md | LIVE | 2026-05-02 | 2026-07-31 | — | 0 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/01_codex_gpt55_response.md | LIVE | 2026-05-02 | 2026-07-31 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-05-02-cell-openclaw-brainstorm/01b_codex_round2.md | LIVE | 2026-05-02 | 2026-07-31 | — | 2 | 0 | no | — | — |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/02_gemini_response.md | LIVE | 2026-05-02 | 2026-07-31 | — | 0 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/02_gemini_response.md | LIVE | 2026-05-02 | 2026-07-31 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-05-02-cell-openclaw-brainstorm/02b_gemini_round2.md | ARCHIVED | 2026-05-02 | 2026-07-31 | 2026-08-01 | 0 | 0 | no | — | archive: orphan, last_touched=2026-05-02, refs=0 |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/03_deepseek_response.md | LIVE | 2026-05-02 | 2026-07-31 | — | 0 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/03_deepseek_response.md | LIVE | 2026-05-02 | 2026-07-31 | — | 1 | 0 | no | — | — |
 | docs/audits/2026-05-02-cell-openclaw-brainstorm/03b_deepseek_round2.md | LIVE | 2026-05-02 | 2026-07-31 | — | 1 | 0 | no | — | — |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/04_automation_inventory_complete.md | LIVE | 2026-05-02 | 2026-07-31 | — | 3 | 0 | no | — | — |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/05_cell_architecture_complete.md | LIVE | 2026-05-02 | 2026-07-31 | — | 2 | 0 | no | — | — |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/06_openclaw_ecosystem_audit.md | LIVE | 2026-05-02 | 2026-07-31 | — | 5 | 0 | no | — | — |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/07_openclaw_deep_research.md | LIVE | 2026-05-02 | 2026-07-31 | — | 2 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/04_automation_inventory_complete.md | LIVE | 2026-05-02 | 2026-07-31 | — | 4 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/05_cell_architecture_complete.md | LIVE | 2026-05-02 | 2026-07-31 | — | 3 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/06_openclaw_ecosystem_audit.md | LIVE | 2026-05-02 | 2026-07-31 | — | 6 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/07_openclaw_deep_research.md | LIVE | 2026-05-02 | 2026-07-31 | — | 3 | 0 | no | — | — |
 | docs/audits/2026-05-02-cell-openclaw-brainstorm/99_synthesis.md | LIVE | 2026-05-02 | 2026-07-31 | — | 1 | 0 | no | — | — |
-| docs/audits/2026-05-02-cell-openclaw-brainstorm/99b_synthesis_v2.md | LIVE | 2026-05-02 | 2026-07-31 | — | 14 | 0 | no | — | — |
+| docs/audits/2026-05-02-cell-openclaw-brainstorm/99b_synthesis_v2.md | LIVE | 2026-05-02 | 2026-07-31 | — | 13 | 0 | no | — | — |
 | docs/audits/2026-05-05-phase-1-5-spike/DECISION.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
-| docs/audits/2026-05-05-phase-1-5-spike/README.md | LIVE | 2026-05-07 | 2026-08-05 | — | 11 | 0 | no | — | — |
+| docs/audits/2026-05-05-phase-1-5-spike/README.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-05-phase-1-5-spike/nlm_callsite_map.md | LIVE | 2026-05-07 | 2026-08-05 | — | 2 | 0 | no | — | — |
-| docs/audits/2026-05-12-phase3-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-05-12-phase3-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-phase3-spec-brainstorm/01_claude_self_critique.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-phase3-spec-brainstorm/02_gemini_review.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-phase3-spec-brainstorm/03_deepseek_review.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-phase3-spec-brainstorm/04_nb1_review.md | LIVE | 2026-05-12 | 2026-08-10 | — | 1 | 0 | no | — | — |
-| docs/audits/2026-05-12-phase3-spec-brainstorm/04_nb1_review_meta.md | LIVE | 2026-05-12 | 2026-08-10 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-05-12-phase3-spec-brainstorm/04_nb1_review_meta.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-phase3-spec-brainstorm/05_synthesis.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
-| docs/audits/2026-05-12-ticket-a1-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-05-12-ticket-a1-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-ticket-a1-spec-brainstorm/01_claude_self_critique.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-ticket-a1-spec-brainstorm/02_gemini_review.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-ticket-a1-spec-brainstorm/03_deepseek_review.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
-| docs/audits/2026-05-12-ticket-a1-spec-brainstorm/04_nb1_review.md | LIVE | 2026-05-12 | 2026-08-10 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-05-12-ticket-a1-spec-brainstorm/04_nb1_review.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-12-ticket-a1-spec-brainstorm/05_synthesis.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
-| docs/audits/2026-05-13-ticket-a2-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-05-13-ticket-a2-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-a2-spec-brainstorm/01_claude.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-a2-spec-brainstorm/02_gemini.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-a2-spec-brainstorm/03_deepseek.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-a2-spec-brainstorm/04_nb1.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-a2-spec-brainstorm/05_synthesis.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
-| docs/audits/2026-05-13-ticket-b-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 1 | 0 | no | — | — |
+| docs/audits/2026-05-13-ticket-b-spec-brainstorm/00_briefing.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-b-spec-brainstorm/01_claude.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-b-spec-brainstorm/02_gemini.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
 | docs/audits/2026-05-13-ticket-b-spec-brainstorm/03_deepseek.md | LIVE | 2026-05-12 | 2026-08-10 | — | 0 | 0 | no | — | — |
@@ -441,17 +441,17 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/automations/runtime-ownership.md | LIVE | 2026-05-02 | 2026-07-31 | — | 1 | 0 | no | — | — |
 | docs/automations/runtime-register.md | LIVE | 2026-05-02 | 2026-07-31 | — | 2 | 0 | no | — | — |
 | docs/brainstorms/2026-04-26-oss-injections/00_SYNTHESIS.md | LIVE | 2026-04-26 | 2026-07-25 | — | 1 | 0 | no | — | — |
-| docs/brainstorms/2026-04-26-oss-injections/01_instructor_deepseek.md | LIVE | 2026-04-26 | 2026-07-25 | — | 1 | 0 | no | — | — |
-| docs/brainstorms/2026-04-26-oss-injections/01_instructor_gemini.md | LIVE | 2026-04-26 | 2026-07-25 | — | 1 | 0 | no | — | — |
-| docs/brainstorms/2026-04-26-oss-injections/02_openllmetry_deepseek.md | LIVE | 2026-04-26 | 2026-07-25 | — | 1 | 0 | no | — | — |
-| docs/brainstorms/2026-04-26-oss-injections/02_openllmetry_gemini.md | LIVE | 2026-04-26 | 2026-07-25 | — | 1 | 0 | no | — | — |
-| docs/brainstorms/2026-04-26-oss-injections/03_atlas_deepseek.md | LIVE | 2026-04-26 | 2026-07-25 | — | 1 | 0 | no | — | — |
-| docs/brainstorms/2026-04-26-oss-injections/03_atlas_gemini.md | LIVE | 2026-04-26 | 2026-07-25 | — | 1 | 0 | no | — | — |
-| docs/brainstorms/2026-04-26-oss-injections/README.md | LIVE | 2026-04-26 | 2026-07-25 | — | 11 | 0 | no | — | — |
+| docs/brainstorms/2026-04-26-oss-injections/01_instructor_deepseek.md | LIVE | 2026-04-26 | 2026-07-25 | — | 2 | 0 | no | — | — |
+| docs/brainstorms/2026-04-26-oss-injections/01_instructor_gemini.md | LIVE | 2026-04-26 | 2026-07-25 | — | 2 | 0 | no | — | — |
+| docs/brainstorms/2026-04-26-oss-injections/02_openllmetry_deepseek.md | LIVE | 2026-04-26 | 2026-07-25 | — | 2 | 0 | no | — | — |
+| docs/brainstorms/2026-04-26-oss-injections/02_openllmetry_gemini.md | LIVE | 2026-04-26 | 2026-07-25 | — | 2 | 0 | no | — | — |
+| docs/brainstorms/2026-04-26-oss-injections/03_atlas_deepseek.md | LIVE | 2026-04-26 | 2026-07-25 | — | 2 | 0 | no | — | — |
+| docs/brainstorms/2026-04-26-oss-injections/03_atlas_gemini.md | LIVE | 2026-04-26 | 2026-07-25 | — | 2 | 0 | no | — | — |
+| docs/brainstorms/2026-04-26-oss-injections/README.md | LIVE | 2026-04-26 | 2026-07-25 | — | 0 | 0 | no | — | — |
 | docs/brainstorms/2026-04-26-oss-injections/_initial_report.md | LIVE | 2026-04-26 | 2026-07-25 | — | 2 | 0 | no | — | — |
 | docs/briefs/2026-02-06-openapi-type-safety-brief.md | ARCHIVED | 2026-04-24 | 2026-07-23 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-24, refs=0 |
 | docs/caching/GEMINI_BATCH_GUIDE.md | LIVE | 2026-02-17 | 2026-05-18 | — | 1 | 0 | no | — | — |
-| docs/caching/README.md | LIVE | 2026-02-17 | 2026-05-18 | — | 11 | 0 | no | — | — |
+| docs/caching/README.md | LIVE | 2026-02-17 | 2026-05-18 | — | 0 | 0 | no | — | — |
 | docs/caching/WORKFLOW_GUIDE.md | LIVE | 2026-02-17 | 2026-05-18 | — | 2 | 0 | no | — | — |
 | docs/cell-core/admission-test-rubric.md | LIVE | 2026-05-02 | 2026-07-31 | — | 2 | 0 | no | — | — |
 | docs/cell-core/cognitive-levels-matrix.md | LIVE | 2026-05-08 | 2026-08-06 | — | 3 | 0 | no | — | — |
@@ -459,16 +459,16 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/cell-core/observed-shell-tier.md | LIVE | 2026-05-02 | 2026-07-31 | — | 2 | 0 | no | — | — |
 | docs/client_briefs/2026-01-27_fausti_bank_statement.md | LIVE | 2026-01-27 | 2026-04-27 | — | 1 | 0 | no | — | — |
 | docs/codex/CODEX_SPALLA.md | LIVE | 2026-05-03 | 2026-08-01 | — | 1 | 0 | no | — | — |
-| docs/connectome/README.md | LIVE | 2026-07-16 | 2026-10-14 | — | 11 | 0 | no | — | — |
+| docs/connectome/README.md | LIVE | 2026-07-16 | 2026-10-14 | — | 0 | 0 | no | — | — |
 | docs/cowork-integration.md | LIVE | 2026-07-16 | 2026-10-14 | — | 0 | 0 | no | — | — |
 | docs/crm/2026-05-10-bali-zero-drive-map.md | LIVE | 2026-05-10 | 2026-08-08 | — | 0 | 0 | no | — | — |
 | docs/crm/2026-05-10-tax-company-pilot-plan.md | LIVE | 2026-05-10 | 2026-08-08 | — | 0 | 0 | no | — | — |
 | docs/crm/action-items-2026-04-20-errors.md | ARCHIVED | 2026-04-20 | 2026-07-19 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-20, refs=0 |
 | docs/crm/assignment-mismatches-2026-04-20.md | LIVE | 2026-04-20 | 2026-07-19 | — | 1 | 0 | no | — | — |
-| docs/crm/reports-2026-04-20/README.md | LIVE | 2026-04-20 | 2026-07-19 | — | 11 | 0 | no | — | — |
+| docs/crm/reports-2026-04-20/README.md | LIVE | 2026-04-20 | 2026-07-19 | — | 0 | 0 | no | — | — |
 | docs/cro/2026-04-19-4-app-engagement-conversion.md | LIVE | 2026-04-19 | 2026-07-18 | — | 2 | 0 | no | — | — |
 | docs/cro/2026-04-19-funnel-audit.md | LIVE | 2026-04-19 | 2026-07-18 | — | 6 | 0 | no | — | — |
-| docs/database/postgresql/README.md | LIVE | 2026-03-10 | 2026-06-08 | — | 11 | 0 | no | — | — |
+| docs/database/postgresql/README.md | LIVE | 2026-03-10 | 2026-06-08 | — | 0 | 0 | no | — | — |
 | docs/decisions/2026-05-03-codex-spalla-architecture.md | LIVE | 2026-05-03 | 2026-08-01 | — | 2 | 0 | no | — | — |
 | docs/design/2026-07-19-garuda-os-unified-surfaces/EXECUTION-WORKFLOW.md | LIVE | 2026-07-20 | 2026-10-18 | — | 0 | 0 | no | — | — |
 | docs/design/2026-07-19-garuda-os-unified-surfaces/PLAN.md | LIVE | 2026-07-19 | 2026-10-17 | — | 1 | 0 | no | — | — |
@@ -479,8 +479,8 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/design-palettes/funnels/research/tax-deepseek-brainstorm.md | LIVE | 2026-04-12 | 2026-07-11 | — | 0 | 0 | no | — | — |
 | docs/design-palettes/funnels/research/tax-gemini-brainstorm.md | LIVE | 2026-04-12 | 2026-07-11 | — | 0 | 0 | no | — | — |
 | docs/design-palettes/funnels/research/tax-web-research.md | LIVE | 2026-04-12 | 2026-07-11 | — | 0 | 0 | no | — | — |
-| docs/design-palettes/research/MASTER-synthesis.md | LIVE | 2026-04-12 | 2026-07-11 | — | 2 | 0 | no | — | — |
-| docs/design-palettes/research/ORIGINAL-color-inventory.md | LIVE | 2026-04-12 | 2026-07-11 | — | 2 | 0 | no | — | — |
+| docs/design-palettes/research/MASTER-synthesis.md | LIVE | 2026-04-12 | 2026-07-11 | — | 1 | 0 | no | — | — |
+| docs/design-palettes/research/ORIGINAL-color-inventory.md | LIVE | 2026-04-12 | 2026-07-11 | — | 1 | 0 | no | — | — |
 | docs/design-palettes/research/claude-exa-futuristic-dark-ui.md | LIVE | 2026-04-13 | 2026-07-12 | — | 1 | 0 | no | — | — |
 | docs/design-palettes/research/codex-futuristic-dark-ui.md | LIVE | 2026-04-13 | 2026-07-12 | — | 1 | 0 | no | — | — |
 | docs/design-palettes/research/deepseek-futuristic-dark-ui.md | LIVE | 2026-04-13 | 2026-07-12 | — | 1 | 0 | no | — | — |
@@ -490,7 +490,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/graphrag-rrf-weight-decision.md | LIVE | 2026-04-17 | 2026-07-16 | — | 2 | 0 | no | — | — |
 | docs/graphrag-v2-completion-2026-04-17.md | LIVE | 2026-04-17 | 2026-07-16 | — | 1 | 0 | no | — | — |
 | docs/graphrag-v2-ctx-header-pass-2026-04-18.md | ARCHIVED | 2026-04-17 | 2026-07-16 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-17, refs=0 |
-| docs/infra/launchagents/nuz-sync/README.md | LIVE | 2026-07-16 | 2026-10-14 | — | 11 | 0 | no | — | — |
+| docs/infra/launchagents/nuz-sync/README.md | LIVE | 2026-07-16 | 2026-10-14 | — | 0 | 0 | no | — | — |
 | docs/innervation-2026-04-29/00_design_intent.md | LIVE | 2026-04-29 | 2026-07-28 | — | 2 | 0 | no | — | — |
 | docs/innervation-2026-04-29/01_innervation_matrix.md | LIVE | 2026-04-29 | 2026-07-28 | — | 3 | 0 | no | — | — |
 | docs/innervation-2026-04-29/02_dispatch_resilience_log.md | LIVE | 2026-04-29 | 2026-07-28 | — | 5 | 0 | no | — | — |
@@ -506,8 +506,8 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/innervation-2026-04-29/99c_w0a_bis_kickoff.md | ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-29, refs=0 |
 | docs/marketing/spec-tax.md | LIVE | 2026-05-11 | 2026-08-09 | — | 0 | 0 | no | — | — |
 | docs/mata-garuda/00-INDEX.md | ARCHIVED | 2026-04-24 | 2026-07-23 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-24, refs=0 |
-| docs/mata-garuda/01-VISION.md | LIVE | 2026-04-09 | 2026-07-08 | — | 2 | 0 | no | — | — |
-| docs/mata-garuda/02-ARCHITECTURE.md | LIVE | 2026-04-09 | 2026-07-08 | — | 4 | 0 | no | — | — |
+| docs/mata-garuda/01-VISION.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
+| docs/mata-garuda/02-ARCHITECTURE.md | LIVE | 2026-04-09 | 2026-07-08 | — | 3 | 0 | no | — | — |
 | docs/mata-garuda/03-LLM-POLICY.md | LIVE | 2026-04-09 | 2026-07-08 | — | 2 | 0 | no | — | — |
 | docs/mata-garuda/04-SECURITY-FIREWALL.md | LIVE | 2026-04-09 | 2026-07-08 | — | 2 | 0 | no | — | — |
 | docs/mata-garuda/11-NLM-BRAIN.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
@@ -517,20 +517,20 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/mata-garuda/40-EXTERNAL-TOOLS.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
 | docs/mata-garuda/40a-CIVIC-STACK-EVAL.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
 | docs/mata-garuda/40b-AGENT-TAXONOMY.md | LIVE | 2026-04-09 | 2026-07-08 | — | 4 | 0 | no | — | — |
-| docs/mata-garuda/40c-AUTOAGENT-EVAL.md | LIVE | 2026-04-09 | 2026-07-08 | — | 5 | 0 | no | — | — |
-| docs/mata-garuda/40d-AUTOAGENT-PATTERNS.md | LIVE | 2026-04-09 | 2026-07-08 | — | 4 | 0 | no | — | — |
+| docs/mata-garuda/40c-AUTOAGENT-EVAL.md | LIVE | 2026-04-09 | 2026-07-08 | — | 4 | 0 | no | — | — |
+| docs/mata-garuda/40d-AUTOAGENT-PATTERNS.md | LIVE | 2026-04-09 | 2026-07-08 | — | 3 | 0 | no | — | — |
 | docs/mata-garuda/41-RESEARCH-LOG.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
-| docs/mata-garuda/50-BUILD-ORDER.md | LIVE | 2026-04-09 | 2026-07-08 | — | 3 | 0 | no | — | — |
+| docs/mata-garuda/50-BUILD-ORDER.md | LIVE | 2026-04-09 | 2026-07-08 | — | 2 | 0 | no | — | — |
 | docs/mata-garuda/51-EXISTING-INVENTORY.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
 | docs/mata-garuda/90-SESSIONS.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
 | docs/mata-garuda/bridge-wr2-schema.md | ARCHIVED | 2026-04-19 | 2026-07-18 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-19, refs=0 |
-| docs/mata-garuda/poc/README.md | LIVE | 2026-04-09 | 2026-07-08 | — | 12 | 0 | no | — | — |
+| docs/mata-garuda/poc/README.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
 | docs/mata-garuda/poc/dummy_agent_GENOME.md | LIVE | 2026-04-09 | 2026-07-08 | — | 1 | 0 | no | — | — |
 | docs/nb-lifecycle/round1-19-ambiguous-decisions-2026-05-07.md | LIVE | 2026-05-07 | 2026-08-05 | — | 2 | 0 | no | — | — |
-| docs/nlm-sources/KBLI_2025_VIDEO_SOURCE.md | LIVE | 2026-03-31 | 2026-06-29 | — | 2 | 0 | no | — | — |
-| docs/nlm-sources/POST_PRODUCTION_CHECKLIST.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
+| docs/nlm-sources/KBLI_2025_VIDEO_SOURCE.md | LIVE | 2026-03-31 | 2026-06-29 | — | 0 | 0 | no | — | — |
+| docs/nlm-sources/POST_PRODUCTION_CHECKLIST.md | LIVE | 2026-03-31 | 2026-06-29 | — | 0 | 0 | no | — | — |
 | docs/nlm-sources/PRO_EXECUTION_INSTRUCTIONS.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
-| docs/observability/README.md | LIVE | 2026-04-17 | 2026-07-16 | — | 11 | 0 | no | — | — |
+| docs/observability/README.md | LIVE | 2026-04-17 | 2026-07-16 | — | 0 | 0 | no | — | — |
 | docs/operations/2026-08-07-fr-ru-translation-freshness-decision.md | LIVE | 2026-08-07 | 2026-11-05 | — | 0 | 0 | no | — | — |
 | docs/operations/2026-08-07-nuzantara-repo-sync-doctrine-conflict.md | LIVE | 2026-08-07 | 2026-11-05 | — | 0 | 0 | no | — | — |
 | docs/operations/AGENT_ARSENAL.md | LIVE | 2026-01-25 | 2026-04-25 | — | 1 | 0 | no | — | — |
@@ -571,7 +571,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/plans/2026-04-19-4apps/02-kbli-check.md | LIVE | 2026-04-19 | 2026-07-18 | — | 1 | 0 | no | — | — |
 | docs/plans/2026-04-19-4apps/03-tax-gap.md | LIVE | 2026-04-19 | 2026-07-18 | — | 1 | 0 | no | — | — |
 | docs/plans/2026-04-19-4apps/04-zoning-check.md | LIVE | 2026-04-19 | 2026-07-18 | — | 1 | 0 | no | — | — |
-| docs/plans/2026-04-19-4apps/README.md | LIVE | 2026-04-19 | 2026-07-18 | — | 11 | 0 | no | — | — |
+| docs/plans/2026-04-19-4apps/README.md | LIVE | 2026-04-19 | 2026-07-18 | — | 0 | 0 | no | — | — |
 | docs/plans/2026-06-15-team-photos-ssot.md | LIVE | 2026-06-15 | 2026-09-13 | — | 0 | 0 | no | — | — |
 | docs/plans/2026-07-17-visa-oracle-v2/00-product-design.md | LIVE | 2026-07-17 | 2026-10-15 | — | 1 | 0 | no | — | — |
 | docs/plans/2026-07-17-visa-oracle-v2/track-c-experience-spec.md | LIVE | 2026-07-17 | 2026-10-15 | — | 0 | 0 | no | — | — |
@@ -581,7 +581,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/plans/2026-07-27-crm-portal-live-reliability-design.md | LIVE | 2026-07-27 | 2026-10-25 | — | 0 | 0 | no | — | — |
 | docs/pricing/Bali_Zero_Price_List_2026.md | LIVE | 2026-08-04 | 2026-11-02 | — | 2 | 0 | no | — | — |
 | docs/prompts/codex-my-balizero-client-ready.md | LIVE | 2026-06-25 | 2026-09-23 | — | 0 | 0 | no | — | — |
-| docs/prompts/nuzantara-rebrand-brainstorm.md | LIVE | 2026-03-08 | 2026-06-06 | — | 1 | 0 | no | — | — |
+| docs/prompts/nuzantara-rebrand-brainstorm.md | LIVE | 2026-03-08 | 2026-06-06 | — | 0 | 0 | no | — | — |
 | docs/research/2026-03-27-nb9-results.md | LIVE | 2026-03-26 | 2026-06-24 | — | 1 | 0 | no | — | — |
 | docs/research/2026-04-14-agentic-rag-sota.md | ARCHIVED | 2026-04-14 | 2026-07-13 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-14, refs=0 |
 | docs/research/2026-04-14-chat-ui-sota.md | ARCHIVED | 2026-04-14 | 2026-07-13 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-14, refs=0 |
@@ -597,7 +597,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/research/voice-concierge-open-source-plan-2026-06-17.md | LIVE | 2026-06-17 | 2026-09-15 | — | 0 | 0 | no | — | — |
 | docs/runbooks/2026-05-20-wr2-zombie-fix.md | LIVE | 2026-05-28 | 2026-08-26 | — | 1 | 0 | no | — | — |
 | docs/runbooks/2026-06-03-residual-ops-hub.md | LIVE | 2026-06-03 | 2026-09-01 | — | 1 | 0 | no | — | — |
-| docs/runbooks/README.md | LIVE | 2026-08-04 | 2026-11-02 | — | 11 | 0 | no | — | — |
+| docs/runbooks/README.md | LIVE | 2026-08-04 | 2026-11-02 | — | 1 | 0 | no | — | — |
 | docs/runbooks/agent-worktree-broker.md | LIVE | 2026-07-16 | 2026-10-14 | — | 4 | 0 | no | — | — |
 | docs/runbooks/arsenal-probe.md | LIVE | 2026-08-05 | 2026-11-03 | — | 2 | 0 | no | — | — |
 | docs/runbooks/auth-sentinel.md | LIVE | 2026-07-12 | 2026-10-10 | — | 1 | 0 | no | — | — |
@@ -711,7 +711,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/plans/2026-05-07-symbiosis-w1.5-miss-critici.md | LIVE | 2026-05-06 | 2026-08-04 | — | 0 | 0 | no | — | — |
 | docs/superpowers/plans/2026-05-07-symbiosis-w2-kg-mcp-bridge.md | LIVE | 2026-05-06 | 2026-08-04 | — | 2 | 0 | no | — | — |
 | docs/superpowers/plans/2026-05-08-canva-apply-image-residue-cleanup.md | LIVE | 2026-05-08 | 2026-08-06 | — | 0 | 0 | no | — | — |
-| docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md | LIVE | 2026-05-07 | 2026-08-05 | — | 4 | 0 | no | — | — |
+| docs/superpowers/plans/2026-05-08-domain-mesh-phase0-foundations.md | LIVE | 2026-05-07 | 2026-08-05 | — | 3 | 0 | no | — | — |
 | docs/superpowers/plans/2026-05-08-domain-mesh-phase1-setup-team.md | LIVE | 2026-05-07 | 2026-08-05 | — | 4 | 0 | no | — | — |
 | docs/superpowers/plans/2026-05-10-crm-tax-company-pilot.md | LIVE | 2026-05-10 | 2026-08-08 | — | 0 | 0 | no | — | — |
 | docs/superpowers/plans/2026-05-12-crm-evidence-dossier.md | LIVE | 2026-05-11 | 2026-08-09 | — | 0 | 0 | no | — | — |
@@ -753,33 +753,33 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/prompts/domain-mesh/05-phase6-bali-macro.md | LIVE | 2026-05-08 | 2026-08-06 | — | 2 | 0 | no | — | — |
 | docs/superpowers/prompts/domain-mesh/06-phase7-nexus-osint.md | LIVE | 2026-05-08 | 2026-08-06 | — | 2 | 0 | no | — | — |
 | docs/superpowers/prompts/domain-mesh/07-phase8-cross-domain-federation.md | LIVE | 2026-05-08 | 2026-08-06 | — | 1 | 0 | no | — | — |
-| docs/superpowers/prompts/domain-mesh/README.md | LIVE | 2026-05-08 | 2026-08-06 | — | 11 | 0 | no | — | — |
+| docs/superpowers/prompts/domain-mesh/README.md | LIVE | 2026-05-08 | 2026-08-06 | — | 0 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-04-21-partners-v1/01-gemini.md | LIVE | 2026-04-21 | 2026-07-20 | — | 2 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-04-21-partners-v1/02-codex.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-04-21-partners-v1/03-deepseek.md | LIVE | 2026-04-21 | 2026-07-20 | — | 2 | 0 | no | — | — |
-| docs/superpowers/reviews/2026-04-21-partners-v1/04-nb2.md | LIVE | 2026-04-21 | 2026-07-20 | — | 3 | 0 | no | — | — |
+| docs/superpowers/reviews/2026-04-21-partners-v1/04-nb2.md | LIVE | 2026-04-21 | 2026-07-20 | — | 2 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-04-21-partners-v1/99-synthesis.md | LIVE | 2026-04-21 | 2026-07-20 | — | 3 | 0 | no | — | — |
-| docs/superpowers/reviews/2026-04-21-partners-v1/ASYA-withholding-rates-runbook.md | LIVE | 2026-04-21 | 2026-07-20 | — | 0 | 0 | no | — | — |
+| docs/superpowers/reviews/2026-04-21-partners-v1/ASYA-withholding-rates-runbook.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-04-21-partners-v1/POST-MERGE-deploy-runbook.md | ARCHIVED | 2026-04-21 | 2026-07-20 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-21, refs=0 |
 | docs/superpowers/reviews/2026-04-21-partners-v1/v1.1-backlog.md | ARCHIVED | 2026-04-21 | 2026-07-20 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-21, refs=0 |
-| docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/00-review-brief.md | LIVE | 2026-07-25 | 2026-10-23 | — | 6 | 0 | no | — | — |
+| docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/00-review-brief.md | LIVE | 2026-07-25 | 2026-10-23 | — | 0 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/01-fable-5-architecture-judge.md | LIVE | 2026-07-25 | 2026-10-23 | — | 2 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/02-gemini-3.1-pro-constructive.md | LIVE | 2026-07-25 | 2026-10-23 | — | 2 | 0 | no | — | — |
-| docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/03-glm-5.2-adversarial.md | LIVE | 2026-07-25 | 2026-10-23 | — | 4 | 0 | no | — | — |
+| docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/03-glm-5.2-adversarial.md | LIVE | 2026-07-25 | 2026-10-23 | — | 2 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/04-fable-5-revised-gate.md | LIVE | 2026-07-25 | 2026-10-23 | — | 1 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/05-fable-5-final-amendment-gate.md | LIVE | 2026-07-25 | 2026-10-23 | — | 1 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/06-fable-5-formatted-spec-integrity-gate.md | LIVE | 2026-07-25 | 2026-10-23 | — | 1 | 0 | no | — | — |
-| docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/99-synthesis.md | LIVE | 2026-07-25 | 2026-10-23 | — | 3 | 0 | no | — | — |
-| docs/superpowers/reviews/2026-07-17-modular-worker-plane-implementation-plan/00-review-brief.md | LIVE | 2026-07-25 | 2026-10-23 | — | 6 | 0 | no | — | — |
+| docs/superpowers/reviews/2026-07-17-backend-modular-kernel-worker-plane/99-synthesis.md | LIVE | 2026-07-25 | 2026-10-23 | — | 1 | 0 | no | — | — |
+| docs/superpowers/reviews/2026-07-17-modular-worker-plane-implementation-plan/00-review-brief.md | LIVE | 2026-07-25 | 2026-10-23 | — | 1 | 0 | no | — | — |
 | docs/superpowers/reviews/2026-07-17-modular-worker-plane-implementation-plan/2026-07-23-current-system-refresh.md | LIVE | 2026-07-26 | 2026-10-24 | — | 1 | 0 | no | — | — |
 | docs/superpowers/sessions/2026-04-12-symbiosis-genome-session.md | ARCHIVED | 2026-04-13 | 2026-07-12 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-13, refs=0 |
 | docs/superpowers/sessions/2026-04-17-strategic-8/2026-04-17-v2-team-ops-draft-pr.md | ARCHIVED | 2026-04-17 | 2026-07-16 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-17, refs=0 |
 | docs/superpowers/sessions/2026-04-17-strategic-8/2026-04-17-v2-team-ops-lighthouse-deferred.md | LIVE | 2026-04-17 | 2026-07-16 | — | 1 | 0 | no | — | — |
-| docs/superpowers/sessions/2026-04-17-strategic-8/DOCKER-CLAUDE-CLI.md | LIVE | 2026-04-17 | 2026-07-16 | — | 0 | 0 | no | — | — |
+| docs/superpowers/sessions/2026-04-17-strategic-8/DOCKER-CLAUDE-CLI.md | LIVE | 2026-04-17 | 2026-07-16 | — | 1 | 0 | no | — | — |
 | docs/superpowers/sessions/2026-04-17-strategic-8/MERGE-STRATEGY.md | ARCHIVED | 2026-04-17 | 2026-07-16 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-17, refs=0 |
 | docs/superpowers/sessions/2026-04-17-strategic-8/OAUTH-LIVE-VALIDATION.md | ARCHIVED | 2026-04-17 | 2026-07-16 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-17, refs=0 |
 | docs/superpowers/sessions/2026-04-17-strategic-8/P0-REVIEW.md | ARCHIVED | 2026-04-17 | 2026-07-16 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-17, refs=0 |
-| docs/superpowers/sessions/2026-04-17-strategic-8/README.md | LIVE | 2026-04-17 | 2026-07-16 | — | 11 | 0 | no | — | — |
+| docs/superpowers/sessions/2026-04-17-strategic-8/README.md | LIVE | 2026-04-17 | 2026-07-16 | — | 0 | 0 | no | — | — |
 | docs/superpowers/sessions/2026-04-17-strategic-8/air-1-pdp-coverage.md | LIVE | 2026-04-17 | 2026-07-16 | — | 1 | 0 | no | — | — |
 | docs/superpowers/sessions/2026-04-17-strategic-8/air-2-s09-services.md | LIVE | 2026-04-17 | 2026-07-16 | — | 1 | 0 | no | — | — |
 | docs/superpowers/sessions/2026-04-17-strategic-8/air-3-graphrag-completion.md | LIVE | 2026-04-17 | 2026-07-16 | — | 1 | 0 | no | — | — |
@@ -802,7 +802,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/solidification-prompts/11-air-mcp-server.md | LIVE | 2026-04-06 | 2026-07-05 | — | 1 | 0 | no | — | — |
 | docs/superpowers/solidification-prompts/12-cowork-vector-search.md | LIVE | 2026-04-06 | 2026-07-05 | — | 1 | 0 | no | — | — |
 | docs/superpowers/solidification-prompts/13-cowork-frontend.md | LIVE | 2026-07-25 | 2026-10-23 | — | 1 | 0 | no | — | — |
-| docs/superpowers/solidification-prompts/README.md | LIVE | 2026-04-06 | 2026-07-05 | — | 11 | 0 | no | — | — |
+| docs/superpowers/solidification-prompts/README.md | LIVE | 2026-04-06 | 2026-07-05 | — | 0 | 0 | no | — | — |
 | docs/superpowers/solidification-reports/PDP-pass-2.md | ARCHIVED | 2026-04-17 | 2026-07-16 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-17, refs=0 |
 | docs/superpowers/solidification-reports/S09-services-layer.md | LIVE | 2026-04-17 | 2026-07-16 | — | 1 | 0 | no | — | — |
 | docs/superpowers/solidification-reports/S11-agents-layer.md | ARCHIVED | 2026-04-17 | 2026-07-16 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-17, refs=0 |
@@ -812,7 +812,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/specs/2026-03-14-autonomous-agents-v2-enhanced-architecture.md | ARCHIVED | 2026-03-22 | 2026-06-20 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-03-22, refs=0 |
 | docs/superpowers/specs/2026-03-14-redis-full-operativity-design.md | LIVE | 2026-03-15 | 2026-06-13 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-03-20-process-kanban-redesign.md | LIVE | 2026-03-20 | 2026-06-18 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/2026-03-25-nlm-knowledge-fabric-integration-design.md | LIVE | 2026-03-25 | 2026-06-23 | — | 2 | 0 | no | — | — |
+| docs/superpowers/specs/2026-03-25-nlm-knowledge-fabric-integration-design.md | LIVE | 2026-03-25 | 2026-06-23 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-03-25-team-agent-assistants-brainstorm.md | LIVE | 2026-03-25 | 2026-06-23 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-03-26-cell-dashboard-design.md | LIVE | 2026-03-26 | 2026-06-24 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-03-26-cell-essere-perfetto-design.md | LIVE | 2026-03-26 | 2026-06-24 | — | 1 | 0 | no | — | — |
@@ -855,11 +855,11 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/specs/2026-04-19-llm-cost-tracking-v2-design.md | LIVE | 2026-04-19 | 2026-07-18 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-04-20-crm-partners-module.md | LIVE | 2026-04-21 | 2026-07-20 | — | 2 | 0 | no | — | — |
 | docs/superpowers/specs/2026-04-20-partners-brainstorm/00-brief.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/2026-04-20-partners-brainstorm/01-gemini.md | LIVE | 2026-04-21 | 2026-07-20 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/2026-04-20-partners-brainstorm/02-codex.md | LIVE | 2026-04-21 | 2026-07-20 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/2026-04-20-partners-brainstorm/03-deepseek.md | LIVE | 2026-04-21 | 2026-07-20 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/2026-04-20-partners-brainstorm/04-nb2.md | LIVE | 2026-04-21 | 2026-07-20 | — | 3 | 0 | no | — | — |
-| docs/superpowers/specs/2026-04-20-partners-brainstorm/99-synthesis.md | LIVE | 2026-04-21 | 2026-07-20 | — | 5 | 0 | no | — | — |
+| docs/superpowers/specs/2026-04-20-partners-brainstorm/01-gemini.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
+| docs/superpowers/specs/2026-04-20-partners-brainstorm/02-codex.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
+| docs/superpowers/specs/2026-04-20-partners-brainstorm/03-deepseek.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
+| docs/superpowers/specs/2026-04-20-partners-brainstorm/04-nb2.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
+| docs/superpowers/specs/2026-04-20-partners-brainstorm/99-synthesis.md | LIVE | 2026-04-21 | 2026-07-20 | — | 3 | 0 | no | — | — |
 | docs/superpowers/specs/2026-04-20-visa-check-ui-design.md | ARCHIVED | 2026-04-20 | 2026-07-19 | 2026-07-25 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-20, refs=0 |
 | docs/superpowers/specs/2026-04-21-visa-catalogue-rebuild.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-04-21-visa-funnel-fusion.md | LIVE | 2026-04-21 | 2026-07-20 | — | 1 | 0 | no | — | — |
@@ -875,7 +875,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/specs/2026-05-03-codex-spalla-design.md | LIVE | 2026-05-03 | 2026-08-01 | — | 2 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-04-subhi-tutor-design.md | LIVE | 2026-05-04 | 2026-08-02 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-06-bali-zero-pricelist-2026-design.md | LIVE | 2026-07-14 | 2026-10-12 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/2026-05-07-nb-mitochondrial-monitor-design.md | LIVE | 2026-05-06 | 2026-08-04 | — | 3 | 0 | no | — | — |
+| docs/superpowers/specs/2026-05-07-nb-mitochondrial-monitor-design.md | LIVE | 2026-05-06 | 2026-08-04 | — | 2 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-07-nb-senescent-decomm-design.md | LIVE | 2026-05-06 | 2026-08-04 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-07-symbiosis-w1-genome-enroll-design.md | LIVE | 2026-05-06 | 2026-08-04 | — | 2 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-07-symbiosis-w1.5-miss-critici-design.md | LIVE | 2026-05-06 | 2026-08-04 | — | 1 | 0 | no | — | — |
@@ -890,13 +890,13 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/deepseek-w2.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave2/sonnet-w2.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-08-domain-mesh-research/external-reviews-wave3/deepseek-w3.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
-| docs/superpowers/specs/2026-05-08-domain-mesh-research/r1-sota-agentic-ingestion-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/2026-05-08-domain-mesh-research/r2-regulatory-monitoring-id-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/2026-05-08-domain-mesh-research/r3-djp-coretax-tax-tech-2026-05-08.md | STALE | 2026-05-07 | 2026-08-05 | — | 2 | 3 | no | — | fix: 3 broken link(s) |
-| docs/superpowers/specs/2026-05-08-domain-mesh-research/r4-marketing-intelligence-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/2026-05-08-domain-mesh-research/r5-research-agents-2026-05-08.md | STALE | 2026-05-07 | 2026-08-05 | — | 2 | 1 | no | — | fix: 1 broken link(s) |
-| docs/superpowers/specs/2026-05-08-domain-mesh-research/r6-country-intelligence-id-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/2026-05-08-domain-mesh-research/r7-osint-entity-people-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 2 | 0 | no | — | — |
+| docs/superpowers/specs/2026-05-08-domain-mesh-research/r1-sota-agentic-ingestion-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
+| docs/superpowers/specs/2026-05-08-domain-mesh-research/r2-regulatory-monitoring-id-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
+| docs/superpowers/specs/2026-05-08-domain-mesh-research/r3-djp-coretax-tax-tech-2026-05-08.md | STALE | 2026-05-07 | 2026-08-05 | — | 1 | 3 | no | — | fix: 3 broken link(s) |
+| docs/superpowers/specs/2026-05-08-domain-mesh-research/r4-marketing-intelligence-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 1 | 0 | no | — | — |
+| docs/superpowers/specs/2026-05-08-domain-mesh-research/r5-research-agents-2026-05-08.md | STALE | 2026-05-07 | 2026-08-05 | — | 1 | 1 | no | — | fix: 1 broken link(s) |
+| docs/superpowers/specs/2026-05-08-domain-mesh-research/r6-country-intelligence-id-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 1 | 0 | no | — | — |
+| docs/superpowers/specs/2026-05-08-domain-mesh-research/r7-osint-entity-people-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-08-nb-source-freshness-alternative.md | LIVE | 2026-05-07 | 2026-08-05 | — | 0 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-10-mini-h24-server-migration-design.md | LIVE | 2026-05-10 | 2026-08-08 | — | 0 | 0 | no | — | — |
 | docs/superpowers/specs/2026-05-12-crm-evidence-dossier-design.md | LIVE | 2026-05-11 | 2026-08-09 | — | 0 | 0 | no | — | — |
@@ -924,34 +924,34 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/superpowers/specs/2026-07-18-bali-zero-magazine-sites-design.md | LIVE | 2026-07-21 | 2026-10-19 | — | 0 | 0 | no | — | — |
 | docs/superpowers/specs/2026-07-31-kita-dashboard-warm-refinement-design.md | LIVE | 2026-07-31 | 2026-10-29 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/brainstorm-crm-strategy.md | LIVE | 2026-03-29 | 2026-06-27 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/00_mega_synthesis.md | LIVE | 2026-03-28 | 2026-06-26 | — | 0 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/00_mega_synthesis.md | LIVE | 2026-03-28 | 2026-06-26 | — | 1 | 0 | no | — | — |
 | docs/superpowers/specs/nlm-deep-research/01_query_design.md | LIVE | 2026-03-28 | 2026-06-26 | — | 4 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/02_sequencing.md | LIVE | 2026-03-28 | 2026-06-26 | — | 4 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/03_quality_verification.md | LIVE | 2026-03-28 | 2026-06-26 | — | 4 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/04_source_management.md | LIVE | 2026-03-28 | 2026-06-26 | — | 6 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/02_sequencing.md | LIVE | 2026-03-28 | 2026-06-26 | — | 2 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/03_quality_verification.md | LIVE | 2026-03-28 | 2026-06-26 | — | 2 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/04_source_management.md | LIVE | 2026-03-28 | 2026-06-26 | — | 4 | 0 | no | — | — |
 | docs/superpowers/specs/nlm-deep-research/04b_source_management_codex.md | LIVE | 2026-03-28 | 2026-06-26 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/05_scraper_integration.md | LIVE | 2026-03-28 | 2026-06-26 | — | 7 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/05b_scraper_integration_codex.md | LIVE | 2026-03-28 | 2026-06-26 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/05b_scraper_integration_deepseek.md | LIVE | 2026-03-28 | 2026-06-26 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/06_failure_modes.md | LIVE | 2026-03-28 | 2026-06-26 | — | 6 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/05_scraper_integration.md | LIVE | 2026-03-28 | 2026-06-26 | — | 5 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/05b_scraper_integration_codex.md | LIVE | 2026-03-28 | 2026-06-26 | — | 3 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/05b_scraper_integration_deepseek.md | LIVE | 2026-03-28 | 2026-06-26 | — | 2 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/06_failure_modes.md | LIVE | 2026-03-28 | 2026-06-26 | — | 4 | 0 | no | — | — |
 | docs/superpowers/specs/nlm-deep-research/06b_failure_modes_gemini.md | LIVE | 2026-03-28 | 2026-06-26 | — | 2 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-deep-research/07_testing_protocol.md | LIVE | 2026-03-28 | 2026-06-26 | — | 5 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-deep-research/07_testing_protocol.md | LIVE | 2026-03-28 | 2026-06-26 | — | 3 | 0 | no | — | — |
 | docs/superpowers/specs/nlm-deep-research/07b_testing_protocol_deepseek.md | LIVE | 2026-03-28 | 2026-06-26 | — | 4 | 0 | no | — | — |
 | docs/superpowers/specs/nlm-deep-research/NB2_FULL_REPORT.md | LIVE | 2026-03-28 | 2026-06-26 | — | 0 | 0 | no | — | — |
 | docs/superpowers/specs/nlm-deep-research/PROGRESS.md | LIVE | 2026-03-28 | 2026-06-26 | — | 2 | 0 | no | — | — |
 | docs/superpowers/specs/nlm-deep-research/phase1_adversarial_reviews.md | LIVE | 2026-03-28 | 2026-06-26 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-nb5-brainstorm-gemini-search.md | LIVE | 2026-03-29 | 2026-06-27 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-nb5-brainstorm-ops.md | LIVE | 2026-03-29 | 2026-06-27 | — | 1 | 0 | no | — | — |
-| docs/superpowers/specs/nlm-nb5-brainstorm-reasoning.md | LIVE | 2026-03-29 | 2026-06-27 | — | 1 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-nb5-brainstorm-gemini-search.md | LIVE | 2026-03-29 | 2026-06-27 | — | 0 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-nb5-brainstorm-ops.md | LIVE | 2026-03-29 | 2026-06-27 | — | 0 | 0 | no | — | — |
+| docs/superpowers/specs/nlm-nb5-brainstorm-reasoning.md | LIVE | 2026-03-29 | 2026-06-27 | — | 0 | 0 | no | — | — |
 | docs/symbiosis/W2-kg-bridge-runbook.md | LIVE | 2026-07-16 | 2026-10-14 | — | 2 | 0 | no | — | — |
 | docs/war-room-2.0-design.md | LIVE | 2026-07-16 | 2026-10-14 | — | 3 | 0 | no | — | — |
 | docs/war-room-v2/ACTIVATION_PLAN.md | ARCHIVED | 2026-04-19 | 2026-07-18 | 2026-07-19 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-19, refs=0 |
 | docs/war-room-v2/DEPLOY_RUNBOOK.md | LIVE | 2026-07-16 | 2026-10-14 | — | 0 | 0 | no | — | — |
-| docs/war-room-v2/README.md | LIVE | 2026-07-16 | 2026-10-14 | — | 13 | 0 | no | — | — |
+| docs/war-room-v2/README.md | LIVE | 2026-07-16 | 2026-10-14 | — | 2 | 0 | no | — | — |
 | docs/wr2/2026-05-08-sprint-b-to-f-detailed-plan.md | LIVE | 2026-07-14 | 2026-10-12 | — | 0 | 0 | no | — | — |
 | docs/wr2/SUPERVISOR.md | LIVE | 2026-07-14 | 2026-10-12 | — | 6 | 0 | no | — | — |
 | docs/wr2/canonical-bypass-prevention-2026-05-15.md | LIVE | 2026-07-14 | 2026-10-12 | — | 1 | 0 | no | — | — |
-| docs/wr2/flowkit-integration.md | LIVE | 2026-07-16 | 2026-10-14 | — | 1 | 0 | no | — | — |
+| docs/wr2/flowkit-integration.md | LIVE | 2026-07-16 | 2026-10-14 | — | 2 | 0 | no | — | — |
 | docs/wr2/operator-driven-mode-spec-2026-05-26.md | LIVE | 2026-07-14 | 2026-10-12 | — | 0 | 0 | no | — | — |
 | docs/wr2/pipeline-architecture-2026-05-10.md | LIVE | 2026-07-14 | 2026-10-12 | — | 1 | 0 | no | — | — |
 | docs/wr2/skill-snapshots/canva-apply-2026-05-07-prewipe.md | LIVE | 2026-05-06 | 2026-08-04 | — | 0 | 0 | no | — | — |
@@ -960,9 +960,9 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/wr2/skill-snapshots/deploy-pull-2026-05-08.md | LIVE | 2026-05-07 | 2026-08-05 | — | 1 | 0 | no | — | — |
 | docs/wr2/sprint2-mapping.md | LIVE | 2026-07-14 | 2026-10-12 | — | 2 | 0 | no | — | — |
 | docs/wr3/2026-07-26-wr3-into-wr2-single-media-surface.md | LIVE | 2026-07-26 | 2026-10-24 | — | 0 | 0 | no | — | — |
-| docs/wr3/README.md | LIVE | 2026-05-18 | 2026-08-16 | — | 11 | 0 | no | — | — |
-| docs/wr3/runbook-supervisor.md | LIVE | 2026-07-26 | 2026-10-24 | — | 0 | 0 | no | — | — |
-| docs/wr3/symbiosis-precedence.md | LIVE | 2026-05-18 | 2026-08-16 | — | 1 | 0 | no | — | — |
+| docs/wr3/README.md | LIVE | 2026-05-18 | 2026-08-16 | — | 0 | 0 | no | — | — |
+| docs/wr3/runbook-supervisor.md | LIVE | 2026-07-26 | 2026-10-24 | — | 1 | 0 | no | — | — |
+| docs/wr3/symbiosis-precedence.md | LIVE | 2026-05-18 | 2026-08-16 | — | 2 | 0 | no | — | — |
 | docs/x-articles/001_KBLI_2025_DEADLINE.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |
 | docs/x-articles/001_PROMO_ASSETS.md | LIVE | 2026-03-31 | 2026-06-29 | — | 0 | 0 | no | — | — |
 | docs/x-articles/KBLI_DECODED_001_56101.md | LIVE | 2026-03-31 | 2026-06-29 | — | 1 | 0 | no | — | — |

--- a/infra/tcc-desktop-paths/allowlist.txt
+++ b/infra/tcc-desktop-paths/allowlist.txt
@@ -87,24 +87,43 @@
 #      .github/workflows/immune-enforcement.yml's step name/comments for the
 #      lint step this PR adds.
 #
-# SIZE NOTE (added 2026-07-16, final-gate review): this file has ~298 declared
-# entries, which reads as a large exception surface for a guard meant to be
-# strict. It is NOT — the standing lint's own extension filter
-# (LINT_EXTENSIONS = {.sh, .py, .plist}) discards a line before ever checking
-# whether it's allowlisted, so only entries with those THREE extensions are
-# load-bearing for scripts/lint_tcc_desktop_paths.py's ongoing CI gate. As of
-# this writing that's 10 lines: the 2 guard-test-corpus files (class 2), the
-# 1 historical audit script + 2 dated research renderers + 1 frozen research
-# note (class 1), and the 4 self-referential tool source/test files (class 3).
-# The remaining ~288 entries (.md/.json/.txt/.yml/.tsv) exist ONLY as
-# provenance for scripts/tcc_migrate_desktop_paths.py's one-time --git-scope
-# --extensions .md sweep (commit 2 of the migration PR) — they document why
-# each historical doc was deliberately left un-swept, but the standing lint
-# never reads them because it never reads .md files at all. Kept per-file
-# (not directory-glob'd to research/**, docs/audits/**, etc.) deliberately:
-# scar #3 discipline ("no guard ships without its exceptions being explicit")
+#   4. DOCS-AUDIT REGRESSION-PIN CORPUS (added 2026-08-07,
+#      scripts/docs_audit.py's compute_refs_in follow-up) —
+#      scripts/docs_audit.py and scripts/tests/test_docs_audit.py.
+#      docs/audits/2026-05-02-cell-openclaw-brainstorm/00b_briefing_v2.md
+#      (already class 1 above) cites its siblings with fully-qualified
+#      `` `~/Desktop/nuzantara/docs/audits/.../NN_x.md` `` paths —
+#      compute_refs_in() gained a resolver for that exact shape
+#      (`_strip_home_prefix`). scripts/docs_audit.py's docstrings/comments
+#      quote that REAL, LIVE citation text verbatim so the regression stays
+#      traceable to its source; scripts/tests/test_docs_audit.py's guilt/
+#      innocence corpus constructs the identical shape (both the
+#      `Desktop/`-prefixed and un-prefixed `~/nuzantara/...` forms this
+#      repo's own prose uses, depending on which machine wrote it — see
+#      CLAUDE.md's machine table) as fixture content to prove the resolver
+#      recognises it. Neither file executes or depends on the path — same
+#      reasoning as class 2/3, applied to a different guard.
+#
+# SIZE NOTE (added 2026-07-16, final-gate review; counts updated 2026-08-07
+# when class 4 landed): this file has ~300 declared entries, which reads as
+# a large exception surface for a guard meant to be strict. It is NOT — the
+# standing lint's own extension filter (LINT_EXTENSIONS = {.sh, .py,
+# .plist}) discards a line before ever checking whether it's allowlisted, so
+# only entries with those THREE extensions are load-bearing for
+# scripts/lint_tcc_desktop_paths.py's ongoing CI gate. As of this writing
+# that's 12 lines: the 2 guard-test-corpus files (class 2), the 1 historical
+# audit script + 2 dated research renderers + 1 frozen research note (class
+# 1), the 4 self-referential tool source/test files (class 3), and the 2
+# docs-audit regression-pin files (class 4). The remaining ~288 entries
+# (.md/.json/.txt/.yml/.tsv) exist ONLY as provenance for
+# scripts/tcc_migrate_desktop_paths.py's one-time --git-scope --extensions
+# .md sweep (commit 2 of the migration PR) — they document why each
+# historical doc was deliberately left un-swept, but the standing lint never
+# reads them because it never reads .md files at all. Kept per-file (not
+# directory-glob'd to research/**, docs/audits/**, etc.) deliberately: scar
+# #3 discipline ("no guard ships without its exceptions being explicit")
 # argues for explicit enumeration over implicit directory exemption, and the
-# guard's REAL exception surface is already narrow (10 lines) once you
+# guard's REAL exception surface is already narrow (12 lines) once you
 # account for the extension filter — collapsing 288 lines that don't affect
 # the guard's behavior into a directory glob would trade a currently-tiny,
 # fully-auditable surface for a coarser one, to solve a bloat problem that
@@ -405,8 +424,10 @@ research/wr3/06-architecture-skeleton.md
 research/wr3/07-genesis-execution-state.md
 research/wr3/08-s78-pilot-runbook.md
 scripts/mini-migration/preflight-results-2026-05-10.tsv
+scripts/docs_audit.py
 scripts/lint_tcc_desktop_paths.py
 scripts/tcc_migrate_desktop_paths.py
+scripts/tests/test_docs_audit.py
 scripts/tests/test_lint_tcc_desktop_paths.py
 scripts/tests/test_tcc_migrate_desktop_paths.py
 skills/bali-zero-brand/_external-bench-2026-05.md

--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -337,13 +337,48 @@ def walk_docs(repo: Path) -> List[Path]:
 
 
 REF_DELIM_CHARS = ("/", "`", "(")
+# ASCII-tree box-drawing characters (U+251C/2514/2502/2500 — distinct from the
+# ASCII pipe "|" used in Markdown tables, so a table cell never false-matches
+# this). Verified live 2026-08-07: docs/wr3/README.md and
+# docs/superpowers/specs/nlm-deep-research/PROGRESS.md both cite a sibling
+# file this way inside a fenced ``` listing, e.g. "├── runbook-supervisor.md".
+BOX_DRAWING_CHARS = "├└│─"
+# Marker used to recover a repo-relative path out of a home-relative one
+# (`~/Desktop/nuzantara/docs/x.md` or `~/nuzantara/docs/x.md` — both forms
+# occur in this repo's prose, depending on which machine's home layout the
+# writer had). Text-based, not filesystem-based — this repo's own directory
+# name, not the CWD at audit time.
+_HOME_REPO_MARKER = "nuzantara/"
 
 
 def _resolve_link_target(citing_file: Path, raw_target: str, repo: Path) -> str | None:
     """Resolve a markdown link's `(...)` target relative to the CITING file's
     own directory into a repo-relative POSIX path, or None for a URL/anchor-
-    only/outside-repo target. Mirrors compute_broken_links()'s resolution so
-    the two functions never disagree about what a link "points at".
+    only/outside-repo target.
+
+    Corrected 2026-08-07 (Defect D(iii), post-#3737 review): this function's
+    own path-resolution ALGORITHM is the same one `compute_broken_links()`
+    applies inline (join against `citing_file.parent`, `.resolve()`, then
+    require containment under `repo`) — the two never disagree about what a
+    GIVEN raw href string resolves to. But the two top-level CALLERS do not
+    scan the same candidate text: `compute_broken_links()` runs
+    `_strip_code_regions()` first, so a link written as a syntax EXAMPLE
+    inside a fenced block or inline-code span is never even considered a
+    real link there. `compute_refs_in()` deliberately does NOT strip code
+    regions before scanning (see its own docstring) — this repo's real
+    citations commonly live inside fenced ASCII-tree diagrams and backtick
+    spans, and stripping them would silently re-open the exact under-match
+    this file's `_has_bare_delimited_mention()` exists to close. So a link
+    inside a fenced example CAN be treated as a real citation by
+    `compute_refs_in()` while `compute_broken_links()` ignores the same text
+    entirely — a deliberate, asymmetric divergence between the two
+    functions' candidate sets, not a bug in this function's own resolution
+    logic. The previous docstring claimed the two "never disagree about
+    what a link points at" — true only for THIS function's own algorithm in
+    isolation, false as a description of the two callers' overall behavior.
+    Corrected outright rather than reworded into something vaguer: a
+    weakened claim is still a claim, and this one was checked against both
+    call sites, not just re-read for tone.
     """
     target = raw_target.strip()
     if not target or target.startswith(("http://", "https://", "mailto:", "#")):
@@ -357,6 +392,95 @@ def _resolve_link_target(citing_file: Path, raw_target: str, repo: Path) -> str 
     except ValueError:
         return None
     return rel.as_posix()
+
+
+def _strip_home_prefix(token: str) -> str | None:
+    """`~/Desktop/nuzantara/docs/x.md` / `~/nuzantara/docs/x.md` -> `docs/x.md`,
+    or None if `token` isn't home-relative or names no repo-root marker.
+
+    Live regression (2026-08-07): docs/audits/2026-05-02-cell-openclaw-
+    brainstorm/00b_briefing_v2.md cites its 3 sibling response files by a
+    fully-qualified `` `~/Desktop/nuzantara/docs/audits/.../NN_x_response.md` ``
+    path. Neither the repo-root-relative nor the citing-file-relative
+    resolution in `_has_bare_delimited_mention()` recognises a leading `~` —
+    pathlib's `/` operator treats a value starting with `/` as an ABSOLUTE
+    replacement of the left operand, not a join, so
+    `(citing_file.parent / "/Desktop/nuzantara/...")` silently discards
+    `citing_file.parent` entirely and resolves to a real filesystem path
+    outside `repo`, which `relative_to(repo)` then rejects — a citation lost
+    with no error. `rfind` (not `find`) picks the LAST `nuzantara/` segment,
+    so a path with an incidental earlier occurrence of that word still
+    resolves on the segment nearest the actual repo-relative suffix.
+    """
+    if not token.startswith("~/"):
+        return None
+    rest = token[2:]
+    idx = rest.rfind(_HOME_REPO_MARKER)
+    if idx == -1:
+        return None
+    return rest[idx + len(_HOME_REPO_MARKER) :]
+
+
+def _trailing_boundary_ok(content: str, end: int) -> bool:
+    """True if the text immediately after a basename match does not continue
+    what looks like a longer filename (`README.mdx`, `README.md.bak`).
+
+    A trailing "." is special-cased rather than rejected outright (Defect C
+    fix, post-#3737 review, 2026-08-07): `README.md.bak` (period followed by
+    more word characters — a real, different file) must still be rejected,
+    but `docs/a/TARGET.md.` at the end of a sentence (period followed by
+    whitespace/punctuation/end-of-string) must not — that period belongs to
+    the SENTENCE, not the filename. The pre-fix rule rejected any trailing
+    period unconditionally, so a bare (non-backticked) mention ending a
+    sentence silently lost its citation while the identical backticked form
+    (where a closing backtick, not a period, supplies the boundary) did not
+    — an asymmetry with no basis in what a real citation looks like, caught
+    by re-deriving this function's OWN guarantee against real prose rather
+    than trusting the prior implementation's inline comment.
+    """
+    n = len(content)
+    if end >= n:
+        return True
+    c = content[end]
+    if c.isalnum() or c in "_-":
+        return False
+    if c == ".":
+        nxt = content[end + 1] if end + 1 < n else ""
+        return not nxt.isalnum()
+    return True
+
+
+def _enclosed_in_open_paren_same_line(content: str, idx: int) -> bool:
+    """True if position `idx` sits inside an OPEN, unclosed "(" that starts
+    earlier on the SAME LINE — e.g. "(see X.md)" or "(vedi X.md)": the
+    basename is not immediately preceded by "(" (there is lead-in text like
+    "see "/"vedi " in between), but it is still structurally inside a
+    parenthetical — a real anchor, not accidental prose. Requires an actual
+    open paren, so the guilt case ("the file README.md is a common
+    convention", no parens anywhere on the line) still correctly returns
+    False. Bounded to the current line only — a paren opened on a prior
+    line is not "the same parenthetical" for this purpose.
+
+    Live regression (2026-08-07): docs/superpowers/reviews/2026-04-21-
+    partners-v1/POST-MERGE-deploy-runbook.md cites its sibling via
+    "(see ASYA-withholding-rates-runbook.md)" and docs/superpowers/sessions/
+    2026-04-17-strategic-8/MERGE-STRATEGY.md via "(vedi DOCKER-CLAUDE-
+    CLI.md)" — in both, the character immediately before the basename is a
+    plain space (from "see "/"vedi "), not "(" — the immediate-adjacency
+    check alone does not see them. A hardcoded phrase list ("see"/"vedi")
+    was deliberately rejected in favour of this structural check — this
+    repo's guard-over-match superscar (#3, cicatrix-superscar.md) calls out
+    exactly that shape ("escape-clause che tiene/scusa solo su UNA frase
+    esatta") as its own recurring disease.
+    """
+    line_start = content.rfind("\n", 0, idx) + 1
+    depth = 0
+    for c in content[line_start:idx]:
+        if c == "(":
+            depth += 1
+        elif c == ")" and depth > 0:
+            depth -= 1
+    return depth > 0
 
 
 def _has_bare_delimited_mention(
@@ -374,36 +498,69 @@ def _has_bare_delimited_mention(
     §3 — every substring guard eventually needs both a guilt AND an
     innocence corpus, pinned here in test_docs_audit.py):
       - the character immediately BEFORE the match must be a real delimiter
-        (`/`, a backtick, or `(`) — this alone rejects the basename-inside-
-        basename hole (ANTHROPIC_API_REFERENCE.md must never credit
-        API_REFERENCE.md: the char before "API_REFERENCE.md" there is "_",
-        not a delimiter).
+        (`/`, a backtick, `(`, a box-drawing character, or whitespace that
+        itself leads back to one of those — see below); this alone rejects
+        the basename-inside-basename hole (ANTHROPIC_API_REFERENCE.md must
+        never credit API_REFERENCE.md: the char before "API_REFERENCE.md"
+        there is "_", not a delimiter).
       - the character immediately AFTER the match must not be a word
-        character either — so "README.mdx" or "README.md.bak" can't credit
-        "README.md" by mere prefix.
+        character, and a trailing "." only survives if what follows it is
+        NOT a word character either (`_trailing_boundary_ok` — Defect C fix,
+        2026-08-07): "README.mdx" / "README.md.bak" still can't credit
+        "README.md" by mere prefix, but a bare, non-backticked citation that
+        happens to end a SENTENCE ("...docs/a/TARGET.md.") is no longer
+        punished for it just because the backticked form isn't.
       - when the leading delimiter is "/", the full contiguous path token
-        walked backward from the match (e.g. "docs/sub/README.md" or
-        "../sub/README.md") must resolve to `target_rel_posix` under EITHER
-        of two conventions actually observed in this repo's prose: (a)
-        repo-root-relative (writers paste the "docs/..." path they'd type
-        from the repo root, regardless of where the citing file lives), or
-        (b) citing-file-relative, exactly like a real markdown link (so a
-        backticked "../sibling.md" resolves against the CITING file's own
-        directory, not the repo root — this is what makes a genuine
-        sibling reference like `` `../assignment-mismatches-2026-04-20.md` ``
-        count; a naive trailing-segment string match does NOT handle ".."
-        and was measured to silently drop this exact real citation before
-        this fix). Two different docs/**/README.md files must still not
-        credit each other purely because both happen to end in
-        "README.md" preceded by a slash — neither resolution makes that
-        happen, since neither produces the OTHER file's actual path.
-      - a backtick or "(" immediately before a BARE basename (no path
-        prefix at all, e.g. `` `README.md` ``) is accepted with no further
-        check — a deliberate, documented BROADENING beyond bare-markdown-
-        link anchoring (see compute_refs_in docstring for the decision and
-        the measured impact of NOT making this choice).
+        walked backward from the match (e.g. "docs/sub/README.md",
+        "../sub/README.md", or "~/Desktop/nuzantara/docs/sub/README.md")
+        must resolve to `target_rel_posix` under ONE of three conventions
+        actually observed in this repo's prose: (a) repo-root-relative
+        (writers paste the "docs/..." path they'd type from the repo root,
+        regardless of where the citing file lives), (b) citing-file-
+        relative, exactly like a real markdown link (so a backticked
+        "../sibling.md" resolves against the CITING file's own directory,
+        not the repo root — this is what makes a genuine sibling reference
+        like `` `../assignment-mismatches-2026-04-20.md` `` count; a naive
+        trailing-segment string match does NOT handle ".." and was measured
+        to silently drop this exact real citation before the original
+        #3737 fix), or (c) home-relative (`_strip_home_prefix` — a fully-
+        qualified `~/Desktop/nuzantara/...` or `~/nuzantara/...` path, the
+        form this repo's own audit-brainstorm docs use to cross-reference
+        their siblings). Two different docs/**/README.md files must still
+        not credit each other purely because both happen to end in
+        "README.md" preceded by a slash — none of the three resolutions
+        makes that happen, since none produces the OTHER file's actual
+        path.
+      - a BARE basename (no path prefix at all) is credited only if it
+        resolves, SIBLING-style, against the CITING file's own directory
+        (`_resolve_link_target(citing_file, basename, repo)` — i.e.
+        `citing_file.parent / basename` must literally BE `target`). This
+        replaces the #3737 original's "accept with no further check" for a
+        backtick/`(`-preceded bare basename, which was an over-match found
+        live 2026-08-07: a `` `README.md` `` mention anywhere in the repo,
+        about ANY README, credited EVERY docs/**/README.md target
+        regardless of directory (measured: all 14 docs/**/README.md rows
+        sitting at near-identical refs_in, entirely from this hole — see
+        compute_refs_in's docstring). The sibling requirement is what a
+        bare mention actually means in this repo's prose: a doc names its
+        OWN neighbour without spelling out the shared directory. Reached
+        from four surface shapes, all sibling-anchored the same way:
+          * immediately after a backtick or "(" (the original two, now
+            resolved instead of blindly accepted);
+          * immediately after (or, skipping whitespace, preceded by) a box-
+            drawing character (`BOX_DRAWING_CHARS`) — an ASCII-tree child
+            listing, e.g. "├── runbook-supervisor.md";
+          * inside an unclosed "(" earlier on the same line
+            (`_enclosed_in_open_paren_same_line` — "(see X.md)", "(vedi
+            X.md)"), gated to when the immediately-preceding character is
+            whitespace, so it only ever widens the two directly-adjacent
+            cases to tolerate a short lead-in word, never bare undelimited
+            prose (the guilt case has no enclosing paren at all).
+        A bare, wholly UNDELIMITED prose mention ("the file README.md is a
+        common convention") still matches none of these and is rejected —
+        the one shape this fix exists to kill (see compute_refs_in's
+        docstring for the measured impact of the broadening as a whole).
     """
-    n = len(content)
     blen = len(basename)
     idx = 0
     while True:
@@ -411,35 +568,56 @@ def _has_bare_delimited_mention(
         if idx == -1:
             return False
         end = idx + blen
-        # "." is excluded too, not just word chars: "README.md.bak" and
-        # "README.mdx" must not credit "README.md" by mere prefix — a "."
-        # right after the match means the real filename continues past it.
-        trailing_ok = end >= n or not (content[end].isalnum() or content[end] in "_-.")
-        if idx == 0 or not trailing_ok:
+        if idx == 0 or not _trailing_boundary_ok(content, end):
             idx = end
             continue
         prev = content[idx - 1]
-        if prev not in REF_DELIM_CHARS:
+
+        if prev == "/":
+            # Walk backward through path-token characters (incl. "." so a
+            # leading "../" or "./" is captured whole, and "~" so a home-
+            # relative prefix is captured whole too) to recover the full
+            # cited path, then try all three resolutions described above.
+            start = idx - 1
+            while start > 0 and (
+                content[start - 1].isalnum() or content[start - 1] in "_-./~"
+            ):
+                start -= 1
+            token = content[start:end]
+            # (a) repo-root-relative: the token IS the repo-relative path.
+            if token.lstrip("/") == target_rel_posix:
+                return True
+            # (b) citing-file-relative: resolve against the citing file's
+            # own directory, exactly like a real markdown link.
+            if _resolve_link_target(citing_file, token, repo) == target_rel_posix:
+                return True
+            # (c) home-relative: strip a leading "~/.../nuzantara/" prefix.
+            stripped = _strip_home_prefix(token)
+            if stripped is not None and stripped == target_rel_posix:
+                return True
             idx = end
             continue
-        if prev != "/":
-            # Bare basename preceded directly by a backtick or "(" — accept.
-            return True
-        # prev == "/": walk backward through path-token characters (incl.
-        # "." so a leading "../" or "./" is captured whole) to recover the
-        # full cited path, then try BOTH resolutions described above.
-        start = idx - 1
-        while start > 0 and (
-            content[start - 1].isalnum() or content[start - 1] in "_-./"
-        ):
-            start -= 1
-        token = content[start:end]
-        # (a) repo-root-relative: the token IS the repo-relative path.
-        if token.lstrip("/") == target_rel_posix:
-            return True
-        # (b) citing-file-relative: resolve against the citing file's own
-        # directory, exactly like a real markdown link (_resolve_link_target).
-        if _resolve_link_target(citing_file, token, repo) == target_rel_posix:
+
+        # Bare basename (no path prefix): find whether there is a real
+        # anchor immediately before it — backtick, "(", or a box-drawing
+        # character reached directly or by skipping back over whitespace
+        # (tree indentation), or (whitespace-gated) an unclosed "(" earlier
+        # on the line. Anything else (alnum, "_", punctuation with no
+        # enclosing paren) is not an anchor — rejected, matching the
+        # pre-#3737 guilt cases unchanged.
+        bare_anchor = False
+        if prev in ("`", "(") or prev in BOX_DRAWING_CHARS:
+            bare_anchor = True
+        elif prev in (" ", "\t"):
+            j = idx - 1
+            while j >= 0 and content[j] in " \t":
+                j -= 1
+            if j >= 0 and content[j] in BOX_DRAWING_CHARS:
+                bare_anchor = True
+            elif _enclosed_in_open_paren_same_line(content, idx):
+                bare_anchor = True
+
+        if bare_anchor and _resolve_link_target(citing_file, basename, repo) == target_rel_posix:
             return True
         idx = end
     return False
@@ -464,26 +642,40 @@ def compute_refs_in(repo: Path, target: Path) -> int:
     refs_in==0 overnight if done too strictly.
 
     DECISION, pinned by the guilt/innocence corpus in test_docs_audit.py:
-    an UNLINKED backticked/parenthesized bare filename (`` `README.md` ``,
-    no path, no `[text](...)` syntax) DOES count as a citation. This repo's
-    docs corpus commonly cites a doc that way (backtick-wrapped filename in
-    prose, no markdown link). Measured directly (2026-08-07, this exact
-    implementation, not a prior estimate) against the old substring scan
-    across every docs/** + reference-root candidate pair (979-file
-    universe): 561 files had refs_in>0 under the old scan, 533 under this
-    one — 28 lose their only (substring-inflated) inbound reference, ZERO
-    gain one. Of those 28, 16 are ALSO already past their own
-    orphan_eligible_on and not whitelisted — i.e. this counting fix alone
-    makes them newly eligible for the scheduled --organ refresh's NEXT run
-    to archive (this PR's own --gate-consistent regen does not itself flip
-    any of them — verified empirically, zero ARCHIVED-status rows changed
-    in this PR's diff — --gate-consistent only ever carries forward an
-    ALREADY-committed flip, never invents one). See the PR body for the
-    full 16-doc list: that archival is intentionally left as a separate,
-    later decision, not a side effect of this fix. A bare, UNDELIMITED
-    prose mention ("the file README.md is a common convention") does NOT
-    count — that is the
-    one shape this fix exists to kill.
+    an UNLINKED backticked/parenthesized/box-drawing/enclosed-paren bare
+    filename (`` `README.md` ``, "├── README.md", "(see README.md)" — no
+    path, no `[text](...)` syntax) DOES count as a citation, but ONLY when
+    it resolves SIBLING-style against the citing file's own directory (see
+    `_has_bare_delimited_mention`'s docstring for the exact rule and why —
+    corrected 2026-08-07, post-#3737 review: the original "accept with no
+    further check" for this shape was itself an over-match, measured live —
+    a `` `README.md` `` mention anywhere in the repo credited EVERY
+    docs/**/README.md target regardless of directory).
+
+    UNIVERSE, corrected 2026-08-07 (Defect D(i), post-#3737 review): the
+    prior text here said "979-file universe" for a refs_in>0/==0 count —
+    979 is the CANDIDATE set size (row targets + the extra root reference
+    files + apps/*/README.md, which are only ever CITERS, never targets
+    themselves). The count that actually matters — how many of the ROWS
+    `classify()` acts on sit at refs_in>0 — is over the ROW set, measured
+    at 948 (`len(walk_docs(repo))`) on the same day. Re-measured on THIS
+    exact implementation, same day, same row universe (948): the pre-#3737
+    substring scan (`basename in text`, no anchoring at all) gives 530 rows
+    at refs_in>0; this implementation gives 471. The fix, LIKE #3737's
+    original, is a pure NARROWING of the substring scan — every anchored
+    match (link-resolution, path-form, or sibling-resolved bare mention)
+    necessarily contains `basename` as a literal substring too, so refs_in
+    under this rule can never exceed the substring count for the same
+    target: 0 rows moved OFF refs_in==0 relative to the substring scan,
+    verified empirically on this exact 948-row run. See the PR body for the
+    corpus-level archival-impact list (which specific docs newly sit at
+    refs_in==0, and which of those are past their own orphan_eligible_on) —
+    a point-in-time report, deliberately not duplicated as a number in this
+    docstring, where it would go stale the next time the corpus changes
+    without anyone re-measuring it (the exact failure this correction
+    exists to fix). A bare, UNDELIMITED prose mention ("the file README.md
+    is a common convention") does NOT count — that is the one shape this
+    fix exists to kill.
     """
     basename = target.name
     target_rel_posix = target.relative_to(repo).as_posix()

--- a/scripts/tests/test_docs_audit.py
+++ b/scripts/tests/test_docs_audit.py
@@ -2400,9 +2400,20 @@ def test_refs_in_backticked_full_relative_path_counts(tmp_path):
 def test_refs_in_unlinked_backticked_bare_basename_counts(tmp_path):
     """INNOCENCE (documented broadening, decision pinned here): an unlinked
     backticked BARE filename (no path, no markdown-link syntax) still
-    counts — the deliberate broadening beyond strict link-only anchoring
-    (see compute_refs_in's docstring for the measured impact of NOT making
-    this choice: 28 real citations lost vs. 0 under this rule)."""
+    counts, when it resolves sibling-style against the citing file's own
+    directory — the deliberate broadening beyond strict link-only/path-only
+    anchoring. Measured impact of NOT making this choice (i.e. disabling
+    the whole bare-no-path branch — backtick, "(", box-drawing, and
+    enclosed-paren alike — keeping only markdown links and full-path
+    mentions): re-measured 2026-08-07 against THIS implementation, same
+    948-row universe as compute_refs_in's docstring — 69 rows currently at
+    refs_in>0 would drop to refs_in==0, ZERO would gain one. (The original
+    #3737 commit's docstring here claimed "28 real citations lost vs. 0
+    under this rule" for the narrower pre-review shape of this same
+    broadening — a number never re-measured after review found the
+    broadening itself was partly an over-match; corrected rather than
+    reused, per this repo's discipline of re-deriving a stale number
+    instead of copying it forward.)"""
     sys.path.insert(0, str(AUDIT_SCRIPT.parent))
     import docs_audit  # noqa: E402
 
@@ -2601,3 +2612,317 @@ def test_refs_in_real_inbound_link_keeps_doc_off_the_orphan_path(tmp_path):
         "a doc with a real inbound link must never be orphan-eligible — "
         f"cells: {cells}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Post-#3737 follow-up (2026-08-07): the bare-mention broadening in the
+# original fix accepted a backtick/"("-preceded BARE basename with NO
+# further check — an over-match found live: a `` `README.md` `` mention
+# anywhere in the repo, about ANY README, credited EVERY docs/**/README.md
+# target regardless of directory. It also missed three real citation shapes:
+# a fully-qualified `~/...` home path, a "(see X.md)"/"(vedi X.md)" sibling
+# mention, and a name inside a fenced ASCII-tree diagram. Both classes are
+# fixed by requiring a bare basename to resolve SIBLING-style (against the
+# CITING file's own directory) instead of being accepted blind — see
+# _has_bare_delimited_mention's docstring.
+# ---------------------------------------------------------------------------
+
+
+def test_refs_in_link_syntax_non_resolving_paren_does_not_leak_into_bare_fallback(
+    tmp_path,
+):
+    """GUILT — the exact Defect A repro: a real markdown link `[text](README.md)`
+    that resolves to docs/a/README.md must NOT ALSO be picked up by the bare-
+    mention fallback for an unrelated docs/b/README.md, just because the raw
+    link text "(README.md)" is a literal substring match for the fallback's
+    "(" delimiter. The original #3737 fallback blind-accepted ANY basename
+    preceded by "(" — including the "(" that opens a markdown link's OWN
+    target syntax, even after `_resolve_link_target` had already correctly
+    said that link does not point at this target."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "a").mkdir(parents=True)
+    (repo / "docs" / "b").mkdir(parents=True)
+    (repo / "docs" / "a" / "citer.md").write_text(
+        "[the a readme](README.md)\n", encoding="utf-8"
+    )
+    (repo / "docs" / "a" / "README.md").write_text("# A readme\n", encoding="utf-8")
+    target_b = repo / "docs" / "b" / "README.md"
+    target_b.write_text("# B readme\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target_b) == 0
+    # Innocence, same fixture: the link DOES still count for its real target.
+    assert docs_audit.compute_refs_in(repo, repo / "docs" / "a" / "README.md") == 1
+
+
+def test_refs_in_bare_backtick_mention_requires_sibling_directory(tmp_path):
+    """GUILT — live regression pin (2026-08-07): a `` `README.md` `` bare
+    mention in docs/x/citer.md, about the readme IN docs/x/, must not credit
+    an unrelated docs/y/README.md just because both basenames match. This is
+    the exact shape measured live: docs/DOCSYNC_SENTINEL.md mentions
+    `` `README.md` `` meaning the repo-root README, and under the #3737
+    original that blindly credited docs/wr3/README.md and 13 other unrelated
+    docs/**/README.md files."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "x").mkdir(parents=True)
+    (repo / "docs" / "y").mkdir(parents=True)
+    (repo / "docs" / "x" / "citer.md").write_text(
+        "`README.md` refers to the project readme.\n", encoding="utf-8"
+    )
+    target_y = repo / "docs" / "y" / "README.md"
+    target_y.write_text("# Y readme\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target_y) == 0
+
+
+def test_refs_in_bare_backtick_mention_same_directory_counts(tmp_path):
+    """INNOCENCE, twin of the above: the SAME bare mention, when the target
+    actually IS in the citing file's own directory, still counts — the
+    sibling-resolution fix narrows the over-match, it does not kill the
+    broadening itself."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "x").mkdir(parents=True)
+    (repo / "docs" / "x" / "citer.md").write_text(
+        "`README.md` refers to the project readme.\n", encoding="utf-8"
+    )
+    target_x = repo / "docs" / "x" / "README.md"
+    target_x.write_text("# X readme\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target_x) == 1
+
+
+def test_refs_in_ascii_tree_sibling_child_counts(tmp_path):
+    """INNOCENCE — live regression pin: docs/wr3/README.md lists its sibling
+    docs/wr3/runbook-supervisor.md inside a fenced ASCII-tree diagram
+    ("├── runbook-supervisor.md"). Box-drawing characters (├ └ │ ─) must be
+    recognised as a leading anchor for a bare, sibling-resolved mention."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "wr3").mkdir(parents=True)
+    (repo / "docs" / "wr3" / "README.md").write_text(
+        "# WR3\n\n```\ndocs/wr3/\n"
+        "├── README.md                # this file\n"
+        "└── runbook-supervisor.md    # supervisor procedures\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    target = repo / "docs" / "wr3" / "runbook-supervisor.md"
+    target.write_text("# Runbook\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 1
+
+
+def test_refs_in_ascii_tree_wrong_directory_rejected(tmp_path):
+    """GUILT, twin of the above: the identical tree LINE ("├── SIBLING.md")
+    living in a citing file whose own directory does NOT contain the real
+    target must not credit a same-basename file that lives elsewhere — the
+    ASCII-tree anchor is sibling-scoped like every other bare-mention shape,
+    not a blanket accept."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "other").mkdir(parents=True)
+    (repo / "docs" / "real").mkdir(parents=True)
+    (repo / "docs" / "other" / "README.md").write_text(
+        "```\n├── SIBLING.md    # some unrelated file\n```\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "real" / "SIBLING.md"
+    target.write_text("# Sibling\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 0
+
+
+def test_refs_in_see_paren_sibling_mention_counts(tmp_path):
+    """INNOCENCE — live regression pin: docs/superpowers/reviews/2026-04-21-
+    partners-v1/POST-MERGE-deploy-runbook.md cites its sibling via
+    "(see ASYA-withholding-rates-runbook.md)". The character immediately
+    before the basename is a plain space (from "see "), not "(" — this
+    requires the enclosed-open-paren check, not the immediate-adjacency one."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "p").mkdir(parents=True)
+    (repo / "docs" / "p" / "citer.md").write_text(
+        "Prerequisite confirmed (see SIBLING.md).\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "p" / "SIBLING.md"
+    target.write_text("# Sibling\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 1
+
+
+def test_refs_in_vedi_paren_sibling_mention_counts(tmp_path):
+    """INNOCENCE — live regression pin, different lead-in word: docs/
+    superpowers/sessions/2026-04-17-strategic-8/MERGE-STRATEGY.md cites its
+    sibling via "(vedi DOCKER-CLAUDE-CLI.md)". Proves the enclosed-paren
+    check is a STRUCTURAL anchor (an actual open "("), not a hardcoded
+    "see"/"vedi" phrase list — cicatrix-superscar.md family #3 calls out a
+    fragile phrase list as its own recurring disease."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "p").mkdir(parents=True)
+    (repo / "docs" / "p" / "citer.md").write_text(
+        "Bloccato da Dockerfile update (vedi OTHER.md).\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "p" / "OTHER.md"
+    target.write_text("# Other\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 1
+
+
+def test_refs_in_paren_mention_wrong_directory_rejected(tmp_path):
+    """GUILT, twin of the two above: "(see SIBLING.md)" must not credit a
+    same-basename file living OUTSIDE the citing file's own directory."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "p").mkdir(parents=True)
+    (repo / "docs" / "q").mkdir(parents=True)
+    (repo / "docs" / "p" / "citer.md").write_text(
+        "Prerequisite confirmed (see SIBLING.md).\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "q" / "SIBLING.md"
+    target.write_text("# Sibling\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 0
+
+
+def test_refs_in_closed_paren_before_bare_mention_rejected(tmp_path):
+    """GUILT: the enclosed-paren anchor requires the "(" to still be OPEN
+    (unclosed) at the point of the match. A paren that already closed
+    earlier on the same line is not an anchor for a later, unrelated bare
+    mention — otherwise ANY parenthetical anywhere on a line would license
+    crediting any basename appearing later on it."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "p").mkdir(parents=True)
+    (repo / "docs" / "p" / "citer.md").write_text(
+        "(unrelated aside) then casually mentions SIBLING.md later.\n",
+        encoding="utf-8",
+    )
+    target = repo / "docs" / "p" / "SIBLING.md"
+    target.write_text("# Sibling\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 0
+
+
+def test_refs_in_home_prefixed_desktop_path_counts(tmp_path):
+    """INNOCENCE — live regression pin: docs/audits/2026-05-02-cell-openclaw-
+    brainstorm/00b_briefing_v2.md cites its 3 sibling response files by a
+    fully-qualified `` `~/Desktop/nuzantara/docs/audits/.../NN_x.md` `` path.
+    Neither the repo-root-relative nor citing-file-relative resolution
+    recognised a leading "~" before this fix — pathlib's "/" operator
+    silently discards `citing_file.parent` for an absolute-looking RHS."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "h").mkdir(parents=True)
+    (repo / "docs" / "h" / "citer.md").write_text(
+        "- `~/Desktop/nuzantara/docs/h/TARGET.md` (round 1)\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "h" / "TARGET.md"
+    target.write_text("# Target\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 1
+
+
+def test_refs_in_home_prefixed_no_desktop_path_counts(tmp_path):
+    """INNOCENCE — a different machine's home layout (no "Desktop/" segment,
+    e.g. `~/nuzantara/...` on M5) must resolve the same way: the marker
+    search is for "nuzantara/" itself, not a fixed "Desktop/nuzantara/"
+    prefix."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "h").mkdir(parents=True)
+    (repo / "docs" / "h" / "citer.md").write_text(
+        "- `~/nuzantara/docs/h/TARGET2.md` (round 1)\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "h" / "TARGET2.md"
+    target.write_text("# Target 2\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 1
+
+
+def test_refs_in_home_prefixed_wrong_subpath_rejected(tmp_path):
+    """GUILT, twin of the two above: a home-prefixed path whose SUFFIX (the
+    part after the "nuzantara/" marker) does not match the target's actual
+    repo-relative path must not credit it — the marker recovers a real
+    repo-relative path, it does not blanket-accept any "~/...nuzantara/..."
+    mention."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "h").mkdir(parents=True)
+    (repo / "docs" / "other").mkdir(parents=True)
+    (repo / "docs" / "h" / "citer.md").write_text(
+        "- `~/Desktop/nuzantara/docs/other/TARGET.md` (round 1)\n",
+        encoding="utf-8",
+    )
+    target = repo / "docs" / "h" / "TARGET.md"
+    target.write_text("# Target\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 0
+
+
+def test_refs_in_sentence_final_period_after_bare_path_counts(tmp_path):
+    """INNOCENCE — Defect C fix: a bare (non-backticked) repo-relative-path
+    mention ending a sentence ("...docs/a/TARGET.md.") must count — the
+    period there ends the SENTENCE, not the filename. Before this fix, the
+    trailing-boundary check rejected ANY char-after-match "." unconditionally,
+    so this exact shape returned 0 while the backticked form
+    (`` `docs/a/TARGET.md` ``, where a backtick supplies the boundary instead
+    of a period) returned 1 — an asymmetry with no basis in the citation
+    itself."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "a").mkdir(parents=True)
+    (repo / "docs" / "a" / "citer.md").write_text(
+        "The plan lives at docs/a/TARGET.md.\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "a" / "TARGET.md"
+    target.write_text("# Target\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 1
+
+
+def test_refs_in_bare_path_dotbak_extension_still_rejected(tmp_path):
+    """GUILT, twin of the above: a bare (non-backticked) repo-relative-path
+    mention where the "." is followed by MORE word characters
+    ("docs/a/TARGET.md.bak" — a real, different file) must still be
+    rejected. Only a period that ends the match with nothing-alnum
+    following it is treated as a sentence-final period."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    repo = tmp_path / "repo"
+    (repo / "docs" / "a").mkdir(parents=True)
+    (repo / "docs" / "a" / "citer.md").write_text(
+        "The backup lives at docs/a/TARGET.md.bak now.\n", encoding="utf-8"
+    )
+    target = repo / "docs" / "a" / "TARGET.md"
+    target.write_text("# Target\n", encoding="utf-8")
+
+    assert docs_audit.compute_refs_in(repo, target) == 0


### PR DESCRIPTION
## Summary

Independent review of #3737 (`dcd930b4a2`) found the fix incomplete in
both directions, plus three false sentences landed in the commit itself
(the "sentence written while correcting something else" pattern —
cicatrix-superscar.md family #6, W113).

## Defects closed

**Defect A — over-match, still open.** `_has_bare_delimited_mention`'s
bare-basename branch (`` `README.md` `` / `(README.md)`) blind-accepted
with **zero resolution**. Measured live: a `` `README.md` `` mention
*anywhere in the repo*, about *any* README, credited **every**
`docs/**/README.md` target — 14 rows sat at near-identical `refs_in`,
entirely from this hole. It also let a real link's own `"("`
(`[text](README.md)`, correctly rejected by `_resolve_link_target`) leak
back in through the fallback's raw-text substring scan. **Fixed**: a bare
basename now counts only if it resolves **sibling-style** against the
citing file's own directory (`citing_file.parent / basename == target`).

**Defect B — under-match, 3 shapes restored** (same sibling anchor):
- fully-qualified `` `~/Desktop/nuzantara/...` `` / `` `~/nuzantara/...` ``
  home paths (`_strip_home_prefix`)
- ASCII-tree child listing, box-drawing chars `├ └ │ ─` (`BOX_DRAWING_CHARS`)
- `"(see X.md)"` / `"(vedi X.md)"` sibling mention, via a **structural**
  unclosed-open-paren scan (`_enclosed_in_open_paren_same_line`), not a
  hardcoded phrase list — cicatrix-superscar.md #3 calls out a fragile
  phrase list as its own recurring disease.

**Defect C — trailing-boundary twin.** Any char-after-match `"."` was
rejected unconditionally, so a bare (non-backticked) citation ending a
**sentence** (`"...docs/a/TARGET.md."`) silently lost its citation while
the identical backticked form did not. **Fixed** (`_trailing_boundary_ok`):
a `"."` only rejects if what follows it is itself a word character (a real
extension continuation, e.g. `.bak`).

**Defect D — 3 false sentences, corrected not softened:**
1. `compute_refs_in`'s docstring conflated the 979-file **candidate** set
   (rows + root files + `apps/*/README.md` — the latter two only ever
   citers) with the 948-row **row** set the archival decision acts on.
   Both universes now named explicitly.
2. `test_refs_in_unlinked_backticked_bare_basename_counts`'s "28 real
   citations lost vs. 0" counterfactual was never re-measured after this
   exact broadening turned out to be partly an over-match. Re-measured
   against the FINAL implementation, same 948-row universe: **69**, not 28.
3. `_resolve_link_target`'s docstring claimed it "mirrors
   `compute_broken_links()`'s resolution so the two functions never
   disagree" — true only for the shared resolution *algorithm*;
   `compute_broken_links()` strips code regions first and
   `compute_refs_in()` deliberately does not (real citations here commonly
   live inside fenced ASCII-tree diagrams), so the two **do** disagree on
   fenced/backticked links. Docstring corrected outright.

## Corpus, re-measured 2026-08-07 (row universe 948, `len(walk_docs(repo))`)

| Rule | rows at refs_in>0 |
|---|---|
| pre-#3737 substring scan | 530 |
| #3737 as shipped (`dcd930b4a2`) | 502 |
| **this fix** | **471** |

Shipped → this fix: **102** rows change `refs_in` (that column ONLY — 0
STATUS/action/`orphan_flipped_on` diffs, confirmed on the regenerated
`docs/DOCS_INVENTORY.md`, `--gate-consistent`):
- **38** move TO `refs_in==0` — of those, **28** are past their own
  `orphan_eligible_on` and not whitelisted (archival-eligible on the
  scheduled `--organ` refresh's **next** run, not this PR — `--gate-consistent`
  never invents a fresh flip, confirmed empirically: 0 status changes).
- **7** move OFF `refs_in==0` (the Defect B restorations: 3 home-prefixed
  audit-brainstorm siblings, `ASYA-withholding-rates-runbook.md` via
  "(see …)", `DOCKER-CLAUDE-CLI.md` via "(vedi …)",
  `nlm-deep-research/00_mega_synthesis.md` and `wr3/runbook-supervisor.md`
  via ASCII tree).

Counterfactual (bare-mention broadening fully disabled vs. this fix): 402
rows at refs_in>0 → **69** lose their only citation, 0 gain one.

## Guilt tests (14 new)

- `test_refs_in_link_syntax_non_resolving_paren_does_not_leak_into_bare_fallback` — the exact Defect A repro
- `test_refs_in_bare_backtick_mention_requires_sibling_directory`
- `test_refs_in_ascii_tree_wrong_directory_rejected`
- `test_refs_in_paren_mention_wrong_directory_rejected`
- `test_refs_in_closed_paren_before_bare_mention_rejected`
- `test_refs_in_home_prefixed_wrong_subpath_rejected`
- `test_refs_in_bare_path_dotbak_extension_still_rejected`

## Innocence tests (7 new)

- `test_refs_in_bare_backtick_mention_same_directory_counts`
- `test_refs_in_ascii_tree_sibling_child_counts`
- `test_refs_in_see_paren_sibling_mention_counts`
- `test_refs_in_vedi_paren_sibling_mention_counts`
- `test_refs_in_home_prefixed_desktop_path_counts`
- `test_refs_in_home_prefixed_no_desktop_path_counts`
- `test_refs_in_sentence_final_period_after_bare_path_counts`

Full suite: 80/80 passing (66 pre-existing + 14 new).

## Mutation testing (5 mutations, each reverted after)

| Mutation | Guilt tests that went red |
|---|---|
| bare-mention resolve → blind-accept | 4 (the exact 4 over-match guilt tests) |
| `BOX_DRAWING_CHARS = ""` | 1 (ASCII-tree innocence) |
| `_strip_home_prefix` → always `None` | 2 (both home-prefix innocence tests) |
| `_enclosed_in_open_paren_same_line` → always `False` | 2 (both see/vedi innocence tests) |
| Defect C fix reverted (any trailing `.` rejects) | 1 (sentence-final-period innocence) |

Each mutation flipped **exactly** its own tests and nothing else; full
suite green after each revert.

## What I did NOT close

- The two `docs/design-palettes/funnels/research/tax-*.md` (×5) and
  `NB2_FULL_REPORT.md` ASCII-tree citations from `docs/archive/**` files
  living in a **different** directory than their target are still at
  `refs_in==0` — the task's own instruction anchors ASCII-tree support "to
  the sibling rule", and those citer/target pairs are genuinely not
  siblings (the citing tree textually nests a `research/` subdirectory
  several lines below its own header, which would need a real indentation-
  aware tree parser, not just a box-drawing delimiter). Left open by design.
- `docs/superpowers/plans/2026-04-21-visa-{catalogue-rebuild,funnel-fusion}.md`
  are cited only by a *different* file at the *same basename* living in
  `docs/superpowers/specs/` (self-referential backtick paths, not actual
  citations of the `plans/` copy) — correctly still `refs_in==0`, not a gap.

## How I verified

- `python3 -m pytest scripts/tests/test_docs_audit.py -q` → 80 passed
- `ruff check scripts/docs_audit.py scripts/tests/test_docs_audit.py` → clean
- `bash scripts/docs_inventory_regen.sh` (regenerates `docs/DOCS_INVENTORY.md`
  in this same commit) → `python3 scripts/docs_audit.py --check` (same
  whitelist/cluster args as `docs-guardian.yml`) → exit 0, no drift

🤖 Generated with Claude Code

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>