### PR TITLE
fix(nlm): six nights of "source add failed:" with nothing after the colon

### DIFF
--- a/apps/evaluator/nlm_deep_research/synthesis_roller.py
+++ b/apps/evaluator/nlm_deep_research/synthesis_roller.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -258,12 +259,29 @@ def nlm_source_add(
             timeout=timeout + 30,
         )
         if result.returncode != 0:
-            logger.error("nlm source add failed: %s", result.stderr[:300])
+            # Report BOTH streams. This CLI writes its human-readable output to
+            # STDOUT, so a handler that logs only stderr produces
+            # "nlm source add failed: " with nothing after the colon — which is
+            # exactly what six consecutive nights of failures recorded on Pro
+            # (2026-08-01..08-07): the log says THAT it gave up, never WHY, and
+            # the reader at 07:30 has nothing to go on. Say so explicitly when
+            # both streams really are empty, so "no diagnosis" is a stated fact
+            # rather than an empty string that looks like a truncated message.
+            detail = " | ".join(
+                f"{name}: {stream.strip()[:300]}"
+                for name, stream in (("stderr", result.stderr or ""), ("stdout", result.stdout or ""))
+                if stream.strip()
+            ) or "both streams empty — the CLI exited non-zero and said nothing"
+            logger.error("nlm source add failed (rc=%d): %s", result.returncode, detail)
             return None
 
-        # Try to parse source_id from JSON output
         output = result.stdout.strip()
         if output:
+            # JSON first — kept because a future --json flag would arrive here,
+            # but note it has NEVER matched: `nlm source add` has no --json
+            # option and prints prose. Measured 2026-08-07 across the eight
+            # synthesis state files: 279 of 279 recorded source_ids were the
+            # "ok" sentinel below, not one real id, ever.
             try:
                 data = json.loads(output)
                 # Handle {"value": {"source_id": "..."}} or {"source_id": "..."}
@@ -279,7 +297,16 @@ def nlm_source_add(
                     return str(source_id)
             except json.JSONDecodeError:
                 pass
-        # No parseable source_id but command succeeded — return sentinel
+            # The id IS printed, just as prose: "Source ID: <uuid>".
+            m = re.search(r"Source ID:\s*([0-9a-fA-F-]{8,})", output)
+            if m:
+                logger.info("NLM source added: id=%s", m.group(1))
+                return m.group(1)
+        # Command succeeded but we could not name the source. Return a TRUTHY
+        # sentinel, deliberately: callers gate the weekly/monthly roll-up on
+        # `if sid:` and use the stored TEXT, never the id — so returning None
+        # here would trade a mislabelled map for a dead roll-up. Widening the
+        # parse is safe; tightening this branch is not.
         logger.info("NLM source add succeeded (no source_id in output)")
         return "ok"
 

--- a/apps/evaluator/nlm_deep_research/tests/test_nlm_source_add.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_nlm_source_add.py
@@ -1,0 +1,109 @@
+"""Guilt + innocence for `nlm_source_add`: the diagnosis, and the sentinel.
+
+The CLI output below is not invented. It is what `nlm source add … --wait`
+printed on Pro on 2026-08-07 when probed directly (a throwaway source, added
+and then deleted, residue verified at zero):
+
+    Adding text and waiting for processing...
+    ✓ Added source: ZZ-PROBE-2026-08-07-delete-me (ready)
+    Source ID: ae22e663-2199-41ca-9abd-29fc1c8f7552
+
+Prose, not JSON — `nlm source add` has no `--json` flag. That is why the JSON
+branch had never once matched, and why all 279 recorded source_ids across the
+eight synthesis state files were the literal string "ok".
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from apps.evaluator.nlm_deep_research import synthesis_roller as sr
+
+REAL_OUTPUT = (
+    "Adding text and waiting for processing...\n"
+    "✓ Added source: ZZ-PROBE-2026-08-07-delete-me (ready)\n"
+    "Source ID: ae22e663-2199-41ca-9abd-29fc1c8f7552\n"
+)
+
+
+def _run(monkeypatch, *, rc: int, stdout: str = "", stderr: str = ""):
+    monkeypatch.setattr(
+        sr.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=rc, stdout=stdout, stderr=stderr),
+    )
+    return sr.nlm_source_add("nb-id", title="t", text="body")
+
+
+# --- the diagnosis: a failure must never log a blank reason ----------------
+
+
+def test_a_failure_with_output_only_on_stdout_is_still_diagnosed(monkeypatch, caplog):
+    """The exact shape that produced six blank nights: rc!=0, stderr empty."""
+    caplog.set_level(logging.ERROR)
+    assert _run(monkeypatch, rc=1, stdout="Error: notebook not found", stderr="") is None
+    logged = caplog.text
+    assert "notebook not found" in logged, "the only diagnosis available was dropped"
+    assert "rc=1" in logged
+
+
+def test_a_failure_with_nothing_anywhere_SAYS_it_has_nothing(monkeypatch, caplog):
+    """Silence must be stated, not rendered as an empty string after a colon."""
+    caplog.set_level(logging.ERROR)
+    assert _run(monkeypatch, rc=2, stdout="", stderr="") is None
+    assert "both streams empty" in caplog.text
+    assert not caplog.text.rstrip().endswith(":"), "blank reason is the defect"
+
+
+def test_stderr_is_still_reported_when_it_does_carry_the_error(monkeypatch, caplog):
+    """Innocence for the original behaviour: stderr must not be lost."""
+    caplog.set_level(logging.ERROR)
+    assert _run(monkeypatch, rc=1, stderr="Authentication expired") is None
+    assert "Authentication expired" in caplog.text
+
+
+# --- the sentinel: widen the parse, never tighten the branch ---------------
+
+
+def test_the_real_cli_output_yields_the_real_source_id(monkeypatch):
+    """279/279 stored ids were "ok" because the id is printed as prose."""
+    assert _run(monkeypatch, rc=0, stdout=REAL_OUTPUT) == "ae22e663-2199-41ca-9abd-29fc1c8f7552"
+
+
+def test_json_output_still_wins_if_the_cli_ever_grows_json(monkeypatch):
+    assert _run(monkeypatch, rc=0, stdout='{"value": {"source_id": "abc-123"}}') == "abc-123"
+
+
+def test_unparseable_success_still_returns_the_TRUTHY_sentinel(monkeypatch):
+    """DECLARED, not an oversight. Callers gate the weekly/monthly roll-up on
+    `if sid:` and consume the stored TEXT, never the id — so returning None on
+    an output we cannot parse would trade a mislabelled map for a DEAD roll-up.
+    Widening the parse is safe; tightening this branch is a regression."""
+    out = _run(monkeypatch, rc=0, stdout="✓ Added source: something (ready)")
+    assert out == "ok"
+    assert bool(out) is True
+
+
+def test_an_empty_stdout_on_success_is_also_the_sentinel(monkeypatch):
+    assert _run(monkeypatch, rc=0, stdout="") == "ok"
+
+
+# --- the failure paths that bypass returncode entirely ---------------------
+
+
+@pytest.mark.parametrize(
+    "exc", [subprocess.TimeoutExpired(cmd="nlm", timeout=1), FileNotFoundError(), RuntimeError("boom")]
+)
+def test_every_exception_path_returns_None_and_names_itself(monkeypatch, caplog, exc):
+    caplog.set_level(logging.ERROR)
+
+    def _raise(*a, **k):
+        raise exc
+
+    monkeypatch.setattr(sr.subprocess, "run", _raise)
+    assert sr.nlm_source_add("nb", title="t", text="b") is None
+    assert caplog.text.strip(), "a swallowed exception is a blank night"


### PR DESCRIPTION
Found by asking what tonight will sound like now that #3742 makes these eight pipelines exit honestly — not by looking for it.

## 1. The blank diagnosis

The failure branch logged `result.stderr` only. This CLI writes its output to **stdout**. Measured on Pro, six consecutive nights (08-01 → 08-07) recorded literally:

```
nlm source add failed:
```

Nothing after the colon. The log records **that** it gave up, never **why** — and it is read by whoever is looking for the cause at 07:30.

Now both streams are reported with the return code, and when both really are empty that is **stated** — so "no diagnosis" is a fact, not a string that looks truncated.

## 2. The parse that never once matched

`nlm source add` has **no `--json` flag**; it prints prose. So `json.loads` always raised and the function always fell through to its `"ok"` sentinel.

Measured across the eight synthesis state files:

| | |
|---|---|
| recorded `source_id` values | **279** |
| that are the literal string `"ok"` | **279** |
| that are a real id | **0** |

The map the code documents as `"2026-03-31" → source_id` has never held one. The id **is** printed — `Source ID: <uuid>` — it just was not read. Now it is.

## What is deliberately NOT changed — the whole care of this diff

The `"ok"` sentinel stays **truthy** on unparseable success.

Callers gate the weekly and monthly roll-ups on `if sid:` and consume the stored **text**, never the id. So the obvious tightening — *return None when we cannot name the source* — would trade a mislabelled map for a **dead roll-up**. Widening the parse is safe; tightening that branch is a regression, and the corpus pins it as one (`MUT3` fails 2 tests).

## Corpus

The CLI output in the fixtures is not imagined. I probed the live command on Pro tonight — throwaway source added, then deleted, residue verified at zero:

```
Adding text and waiting for processing...
✓ Added source: ZZ-PROBE-2026-08-07-delete-me (ready)
Source ID: ae22e663-2199-41ca-9abd-29fc1c8f7552
```

That probe also settled something I had gotten wrong: I had declared the NotebookLM credential "proven live" on a `query`, but the operation that fails is `source add`. Neighbouring operation, different scope. It works — now measured, not assumed.

10 tests, **mutation-verified 3/3**. Reverting to the original stderr-only handler reproduces the blank line in the test output, which is the clearest statement of the defect available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)