### PR TITLE
fix(arsenal): probe could hang forever and report live seats dead — fail-visible contract

### DIFF
--- a/docs/DOCS_INVENTORY.md
+++ b/docs/DOCS_INVENTORY.md
@@ -553,7 +553,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/operations/cron-canonical-2026-05-20.md | LIVE | 2026-05-19 | 2026-08-17 | — | 0 | 0 | no | — | — |
 | docs/operations/docs-guardian-cron.md | LIVE | 2026-07-16 | 2026-10-14 | — | 1 | 0 | no | — | — |
 | docs/operations/docs-history-analyzer-cron.md | LIVE | 2026-07-16 | 2026-10-14 | — | 0 | 0 | no | — | — |
-| docs/operations/handoff-observability-block-2026-08-06.md | LIVE | 2026-08-06 | 2026-11-04 | — | 1 | 0 | no | — | — |
+| docs/operations/handoff-observability-block-2026-08-06.md | LIVE | 2026-08-07 | 2026-11-05 | — | 1 | 0 | no | — | — |
 | docs/operations/nb-mitochondrial-monitor.md | LIVE | 2026-07-16 | 2026-10-14 | — | 2 | 0 | no | — | — |
 | docs/operations/wa-mirror-email-manifest-runbook.md | LIVE | 2026-05-26 | 2026-08-24 | — | 0 | 0 | no | — | — |
 | docs/ops/2026-04-30-followup-cell-cron-sensor.md | ARCHIVED | 2026-04-29 | 2026-07-28 | 2026-07-29 | 0 | 0 | no | — | archive: orphan, last_touched=2026-04-29, refs=0 |
@@ -604,7 +604,7 @@ _`last_touched_date` / `orphan_eligible_on` / `orphan_flipped_on` are P3-prime d
 | docs/runbooks/2026-06-03-residual-ops-hub.md | LIVE | 2026-06-03 | 2026-09-01 | — | 1 | 0 | no | — | — |
 | docs/runbooks/README.md | LIVE | 2026-08-07 | 2026-11-05 | — | 11 | 0 | no | — | — |
 | docs/runbooks/agent-worktree-broker.md | LIVE | 2026-07-16 | 2026-10-14 | — | 4 | 0 | no | — | — |
-| docs/runbooks/arsenal-probe.md | LIVE | 2026-08-05 | 2026-11-03 | — | 2 | 0 | no | — | — |
+| docs/runbooks/arsenal-probe.md | LIVE | 2026-08-07 | 2026-11-05 | — | 2 | 0 | no | — | — |
 | docs/runbooks/auth-sentinel.md | LIVE | 2026-07-12 | 2026-10-10 | — | 1 | 0 | no | — | — |
 | docs/runbooks/autonomous-agents-decision-sheet.md | LIVE | 2026-07-05 | 2026-10-03 | — | 1 | 0 | no | — | — |
 | docs/runbooks/autonomous-lab-runtime-placement.md | LIVE | 2026-07-16 | 2026-10-14 | — | 2 | 0 | no | — | — |

--- a/docs/runbooks/arsenal-probe.md
+++ b/docs/runbooks/arsenal-probe.md
@@ -70,3 +70,63 @@ pair for each.
 `python3 scripts/arsenal_probe.py --selftest` — classifier table on canned provider outputs,
 scrub check, blind-scan guard (0 seats probed → exit 2). CI: `scripts/tests/test_arsenal_probe.py`
 in `immune-enforcement.yml` (offline, guilt+innocence per classifier).
+
+## 2026-08-07 incident: the probe could hang forever and print zero bytes
+
+`timeout 60 python3 scripts/arsenal_probe.py --table` produced **0 bytes on stdout+stderr** on
+Pro, while every seat answered fine in an interactive shell seconds later. Root cause, found by
+reproducing empirically (not guessed from the two leading hypotheses — codex-stdin and PATH
+poverty — which turned out to be adjacent, real, but not the dominant cause):
+
+- **agy's stdout pipe never closes.** agy's own process exits in ~1s, but a detached grandchild
+  (likely a background/telemetry helper) inherits the stdout/stderr file descriptors without
+  closing them. `subprocess.run()`'s `communicate()` waits for EOF on those pipes, which never
+  comes — the probe ate its FULL per-seat timeout (verified live at 12s/15s/45s cutoffs; `PONG`
+  was already sitting in the partial stdout every single time). Since all seats probe
+  concurrently in one `ThreadPoolExecutor` and nothing prints until every future resolves, agy's
+  old 120s timeout alone explained the reported hang under any outer wrapper shorter than that —
+  the process was not stuck, it was faithfully waiting out a 120s budget nobody could see.
+- Compounding: `claude`/`nlm`/`ollama`'s `resolve_bin()` fallback was wrong (claude) or absent
+  (nlm, ollama), so a PATH-poor calling context (the SessionStart hook receptor, which reported
+  `claude NOT_INSTALLED` the same day) reported false `NOT_INSTALLED` for genuinely-installed
+  seats. Real, but not the hang's cause — a separate manifestation of the same "sensor measures
+  its own environment, not the seat" disease (scar family #2, W108 lineage).
+
+Fix (PR that introduced this section):
+
+1. **Judge the reply, not the timeout** (scar W104) — every subprocess-backed probe now checks
+   the partial stdout for a live signal (`PONG`, valid JSON, etc.) BEFORE accepting `TIMEOUT`. A
+   seat whose process never cleanly exits but already answered is `LIVE`, full stop.
+2. **Per-seat timeouts collapsed from 30-180s to ~15s** — safe specifically because of (1): even
+   if a reply takes the full 15s to print, that's what gets judged, not whether the process later
+   tore itself down cleanly.
+3. **Fail-visible header**, printed and flushed to **stderr** before any probe fires
+   (`arsenal_probe <ts> — probing N seat(s) on <machine>: ...`) — stderr so `--json`'s stdout
+   stays machine-parseable. Zero bytes for 60s is now impossible by construction: something is on
+   the wire before the first probe even starts.
+4. **`stdin=subprocess.DEVNULL` is now the unconditional default** in `run_probe_cmd` (previously
+   opt-in per call — only kimi/codex had it). No seat probe may ever inherit an open stdin.
+5. **`resolve_bin()` gained `COMMON_BIN_DIRS` fallback** (`~/.local/bin`, `/opt/homebrew/bin`,
+   `/usr/local/bin`, `~/.kimi-code/bin`) and now returns `(path, found_via_path)` — a binary found
+   only through a fallback (not the process's own `$PATH`) gets a `[NOT_ON_PATH: ...]` evidence
+   note instead of silently reading as a normal `LIVE`/`NOT_INSTALLED`, or worse, being missed
+   entirely under a thin `$PATH`.
+6. Final line always states **`N of M seats OK`** (`render_table` and `summary_line`) — never let
+   a partial or all-dead run read as ambiguous about how many seats were actually probed.
+
+Known NOT fixed here (reported to the ledger, out of scope for this diff):
+
+- **glm can be genuinely LIVE but reported `UNKNOWN_ERR`.** `probe_glm`'s live-check is
+  `'"model"' in ev` where `ev` is `evidence_tail(raw, ...)` — the LAST 160 chars of the response.
+  A real glm PONG reply places the `"model"` field near the START of the JSON body (Anthropic
+  message-shape: `id, type, role, model, content, stop_reason, stop_sequence, usage`), so it is
+  routinely truncated away by the tail-slice before the live-check ever sees it. Observed live
+  2026-08-07: a genuine `HTTP 200` reply classified `UNKNOWN_ERR`. Fixing this correctly needs the
+  live-check to run against the untruncated (but still scrubbed) body, which means widening
+  `http_post_json`'s return contract — deliberately left out of this diff to keep it scoped to the
+  hang; tracked as a follow-up.
+- The SessionStart hook receptor's own environment (separate from this script) is a different
+  component — this diff does not touch anything under `~/.claude/hooks/` (control-plane,
+  operator-only per repo convention). If it still shows stale/wrong seat statuses after this
+  fix lands, that is a receptor-side issue (possibly reading a stale cached run, or a `--read-last`
+  call against an old `last.json`), not this tool.

--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -91,14 +91,28 @@ REQUIRED_SEATS = {
     "m5": ["claude", "glm", "agy", "codex", "kimi"],
 }
 
+# 2026-08-07 incident: these used to run 30-180s. agy in particular ALWAYS consumed its
+# FULL timeout regardless of value — its own process exits in ~1s but a detached
+# grandchild inherits the stdout pipe without closing it, so subprocess.run's
+# communicate() never sees EOF (empirically verified: PONG present in partial stdout
+# at every timeout tested, from 12s to 45s). Since all seats probe concurrently in a
+# ThreadPoolExecutor and the whole run blocks on the SLOWEST one before printing
+# anything, agy's old 120s timeout alone explained "0 bytes for 60s" under any outer
+# `timeout 60` wrapper — the process was still inside as_completed(), not hung, but
+# indistinguishable from hung to anything watching stdout. ~15s per seat (mandate) is
+# empirically safe for the fast path (claude/codex/kimi/glm/ollama/nlm all replied in
+# 0.03-15s live on Pro 2026-08-07) AND for the agy-style pipe-leak case, because every
+# probe now judges the REPLY in partial stdout before accepting TIMEOUT (see the
+# `live` computed before `res.timed_out` check in each probe_* function below) — a
+# seat that already said PONG is LIVE even if its process never cleanly exits.
 DEFAULT_TIMEOUTS = {
-    "claude": 120,
-    "glm": 45,
-    "kimi": 120,
-    "agy": 120,
-    "codex": 180,
-    "ollama": 30,
-    "nlm": 60,
+    "claude": 15,
+    "glm": 15,
+    "kimi": 15,
+    "agy": 15,
+    "codex": 15,
+    "ollama": 15,
+    "nlm": 15,
 }
 OLLAMA_LIVE_GEN_TIMEOUT = 120
 
@@ -273,8 +287,13 @@ class ProbeResult:
 
 
 def run_probe_cmd(
-    cmd: list[str], timeout: float, env: Optional[dict] = None, stdin_devnull: bool = False
+    cmd: list[str], timeout: float, env: Optional[dict] = None, stdin_devnull: bool = True
 ) -> ProbeResult:
+    """Run a probe subprocess. stdin_devnull defaults to True — NON-NEGOTIABLE (2026-08-07
+    incident): every seat probe must never inherit an open stdin, because a hook/launchd/
+    agent-harness caller can hand this process a pipe that is never explicitly closed. No
+    caller in this file opts out; the parameter survives only so a test can override it.
+    """
     try:
         kwargs: dict[str, Any] = dict(
             capture_output=True, text=True, timeout=timeout, env=env
@@ -291,15 +310,44 @@ def run_probe_cmd(
         return ProbeResult(-2, "", "not found")
 
 
-def resolve_bin(name: str, extra_paths: Optional[list[str]] = None) -> Optional[str]:
+# Common install roots for the seat CLIs on this organism's machines (Pro/Mini user
+# `nuzantara`, M5 user `balizero` — both covered since these are all `~`-relative).
+# 2026-08-07 root cause: probe_claude's ONLY fallback was the wrong absolute guess
+# (/opt/homebrew/bin/claude — claude has never lived there, it's a `~/.local/bin/claude`
+# symlink) and probe_ollama/probe_nlm had NO fallback at all — so a PATH-poor calling
+# context (a hook/launchd receptor whose $PATH lacks ~/.local/bin or /opt/homebrew/bin)
+# reported NOT_INSTALLED for seats that were genuinely installed and answering fine in
+# an interactive shell seconds earlier (scar family #2 Esiste!=Armato, W108 lineage: the
+# sensor was measuring its OWN environment's poverty, not the seat's absence).
+COMMON_BIN_DIRS = ["~/.local/bin", "/opt/homebrew/bin", "/usr/local/bin", "~/.kimi-code/bin"]
+
+
+def resolve_bin(name: str, extra_paths: Optional[list[str]] = None) -> tuple[Optional[str], bool]:
+    """Resolve a seat binary. Returns (path_or_None, found_via_path).
+
+    found_via_path=True means this process's own $PATH (shutil.which) resolved it — the
+    normal case. False means resolution only succeeded via an explicit fallback candidate
+    (extra_paths or COMMON_BIN_DIRS) — the binary IS installed, this process's $PATH was
+    just thin. A caller that reports NOT_INSTALLED only after trying $PATH AND every known
+    install root has earned the right to call it that; before this fix, NOT_INSTALLED
+    could mean either thing and a probe run under a poor-$PATH context (like a hook
+    receptor) could not tell them apart — distinguishing them is the point (docs/runbooks/
+    arsenal-probe.md), not adding a new status the taxonomy has to carry forever.
+    """
     found = shutil.which(name)
     if found:
-        return found
-    for p in extra_paths or []:
+        return found, True
+    candidates = list(extra_paths or [])
+    candidates += [f"{d}/{name}" for d in COMMON_BIN_DIRS]
+    for p in candidates:
         expanded = os.path.expanduser(p)
         if Path(expanded).exists():
-            return expanded
-    return None
+            return expanded, False
+    return None, False
+
+
+def _path_note(via_path: bool) -> str:
+    return "" if via_path else "[NOT_ON_PATH: resolved via fallback dir, binary present but $PATH was thin] "
 
 
 # ---------------------------------------------------------------- credential loaders
@@ -373,9 +421,16 @@ def http_post_json(
 
 def probe_claude(timeout: float, env_overrides: Optional[dict] = None) -> tuple[str, str, int]:
     t0 = time.monotonic()
-    binp = os.environ.get("ARSENAL_CLAUDE_BIN") or resolve_bin("claude", ["/opt/homebrew/bin/claude"])
+    env_bin = os.environ.get("ARSENAL_CLAUDE_BIN")
+    if env_bin:
+        binp, via_path = env_bin, True
+    else:
+        # claude has never lived at /opt/homebrew/bin — it's a ~/.local/bin/claude
+        # symlink (verified 2026-08-07); COMMON_BIN_DIRS now covers this generically,
+        # this stays as the accurate, seat-specific first guess.
+        binp, via_path = resolve_bin("claude", ["~/.local/bin/claude"])
     if not binp:
-        return NOT_INSTALLED, "claude binary not found", 0
+        return NOT_INSTALLED, "claude binary not found (checked $PATH + common install dirs)", 0
     env = dict(os.environ)
     env.pop("ANTHROPIC_API_KEY", None)  # scar-load-bearing: never let the paid key leak in
     # A stray GLM-session env (AUTH_TOKEN + base URL) would silently probe z.ai
@@ -397,10 +452,15 @@ def probe_claude(timeout: float, env_overrides: Optional[dict] = None) -> tuple[
         [binp, "-p", PONG_PROMPT, "--model", "claude-sonnet-5"], timeout=timeout, env=env
     )
     latency_ms = int((time.monotonic() - t0) * 1000)
-    ev = evidence_tail(res.stdout + " " + res.stderr)
-    if res.timed_out:
-        return TIMEOUT, ev or "probe timed out", latency_ms
+    ev = _path_note(via_path) + evidence_tail(res.stdout + " " + res.stderr)
     live = "PONG" in res.stdout
+    # scar W104: judge the REPLY, never the raw exit-code/timeout signal alone — a
+    # seat that already answered PONG in partial stdout is LIVE even if the probe's
+    # own timeout fired before the process cleanly exited (see run_probe_cmd/
+    # DEFAULT_TIMEOUTS comment — this is exactly the agy pipe-leak shape, kept generic
+    # here in case another CLI ever exhibits the same grandchild-holds-the-pipe defect).
+    if res.timed_out and not live:
+        return TIMEOUT, ev or "probe timed out", latency_ms
     combined = res.stdout + res.stderr
     # claude CLI's unauthenticated shape ("Not logged in · Please run
     # /login") carries no 401/oauth-token marker, only this short prose, and
@@ -437,34 +497,39 @@ def probe_glm(timeout: float) -> tuple[str, str, int]:
 
 def probe_agy(timeout: float) -> tuple[str, str, int]:
     t0 = time.monotonic()
-    binp = resolve_bin("agy", ["~/.local/bin/agy"])
+    binp, via_path = resolve_bin("agy", ["~/.local/bin/agy"])
     if not binp:
-        return NOT_INSTALLED, "agy binary not found", 0
+        return NOT_INSTALLED, "agy binary not found (checked $PATH + common install dirs)", 0
     res = run_probe_cmd([binp, "-p", PONG_PROMPT], timeout=timeout)
     latency_ms = int((time.monotonic() - t0) * 1000)
-    ev = evidence_tail(res.stdout + " " + res.stderr)
-    if res.timed_out:
-        return TIMEOUT, ev or "probe timed out", latency_ms
+    ev = _path_note(via_path) + evidence_tail(res.stdout + " " + res.stderr)
     live = "PONG" in res.stdout
+    # THE 2026-08-07 incident: agy's own process exits in ~1s but a detached
+    # grandchild keeps stdout's pipe fd open, so subprocess.run's communicate()
+    # never sees EOF — this probe ALWAYS hit its full timeout (verified live at
+    # 12s/15s/45s, PONG present in partial stdout every time) even though the
+    # seat is genuinely LIVE. Judge the reply, not the fact that the process
+    # never cleanly exited.
+    if res.timed_out and not live:
+        return TIMEOUT, ev or "probe timed out", latency_ms
     status = classify_generic(res.stdout + res.stderr, live, "agy", is_ssh_context())
     return status, ev, latency_ms
 
 
 def probe_kimi(timeout: float) -> tuple[str, str, int]:
     t0 = time.monotonic()
-    binp = resolve_bin("kimi", ["~/.kimi-code/bin/kimi"])
+    binp, via_path = resolve_bin("kimi", ["~/.kimi-code/bin/kimi"])
     if not binp:
-        return NOT_INSTALLED, "kimi binary not found", 0
+        return NOT_INSTALLED, "kimi binary not found (checked $PATH + common install dirs)", 0
     res = run_probe_cmd(
         [binp, "-p", PONG_PROMPT, "-m", "kimi-code/k3"],
         timeout=timeout,
-        stdin_devnull=True,
     )
     latency_ms = int((time.monotonic() - t0) * 1000)
-    ev = evidence_tail(res.stdout + " " + res.stderr)
-    if res.timed_out:
-        return TIMEOUT, ev or "probe timed out", latency_ms
+    ev = _path_note(via_path) + evidence_tail(res.stdout + " " + res.stderr)
     live = "PONG" in res.stdout
+    if res.timed_out and not live:
+        return TIMEOUT, ev or "probe timed out", latency_ms
     combined = res.stdout + res.stderr
     # kimi-code's unauthenticated state prints "No providers configured" /
     # "not logged in" with no 401 marker — that is a credential death (cure:
@@ -478,68 +543,77 @@ def probe_kimi(timeout: float) -> tuple[str, str, int]:
 
 def probe_codex(timeout: float) -> tuple[str, str, int]:
     t0 = time.monotonic()
-    binp = resolve_bin("codex", ["/opt/homebrew/bin/codex"])
+    binp, via_path = resolve_bin("codex", ["/opt/homebrew/bin/codex"])
     if not binp:
-        return NOT_INSTALLED, "codex binary not found", 0
+        return NOT_INSTALLED, "codex binary not found (checked $PATH + common install dirs)", 0
     res = run_probe_cmd(
         [binp, "exec", "--sandbox", "read-only", "--skip-git-repo-check", PONG_PROMPT],
         timeout=timeout,
-        stdin_devnull=True,  # codex blocks on an open stdin — must never inherit one
     )
     latency_ms = int((time.monotonic() - t0) * 1000)
-    ev = evidence_tail(res.stdout + " " + res.stderr)
-    if res.timed_out:
-        return TIMEOUT, ev or "probe timed out", latency_ms
+    ev = _path_note(via_path) + evidence_tail(res.stdout + " " + res.stderr)
     live = "PONG" in res.stdout
+    if res.timed_out and not live:
+        return TIMEOUT, ev or "probe timed out", latency_ms
     status = classify_generic(res.stdout + res.stderr, live, "codex", is_ssh_context())
     return status, ev, latency_ms
 
 
 def probe_ollama(timeout: float, live_gen: bool = False) -> tuple[str, str, int]:
     t0 = time.monotonic()
-    binp = resolve_bin("ollama")
+    # ollama ships via Homebrew (/opt/homebrew/bin/ollama on Apple Silicon) but had NO
+    # fallback path at all before 2026-08-07 — COMMON_BIN_DIRS now covers it generically.
+    binp, via_path = resolve_bin("ollama", ["/opt/homebrew/bin/ollama"])
     if not binp:
-        return NOT_INSTALLED, "ollama binary not found", 0
+        return NOT_INSTALLED, "ollama binary not found (checked $PATH + common install dirs)", 0
+    path_note = _path_note(via_path)
     res = run_probe_cmd([binp, "list"], timeout=timeout)
     latency_ms = int((time.monotonic() - t0) * 1000)
-    if res.timed_out:
-        return TIMEOUT, evidence_tail(res.stdout + res.stderr) or "probe timed out", latency_ms
     model_listed = "qwen3.5" in res.stdout
+    if res.timed_out and not model_listed:
+        return TIMEOUT, path_note + (evidence_tail(res.stdout + res.stderr) or "probe timed out"), latency_ms
     if not model_listed:
-        ev = evidence_tail(res.stdout + " " + res.stderr)
+        ev = path_note + evidence_tail(res.stdout + " " + res.stderr)
         status = classify_generic(res.stdout + res.stderr, False, "ollama", is_ssh_context())
         return status, ev or "qwen3.5 not listed", latency_ms
     if not live_gen:
-        return LIVE, "qwen3.5 listed", latency_ms
+        return LIVE, path_note + "qwen3.5 listed", latency_ms
+    # A bare `ollama run <model>` with no prompt argument drops into an interactive
+    # REPL that reads stdin — under the mandatory stdin=DEVNULL contract (every
+    # subprocess, no exceptions) that would read immediate EOF and exit having
+    # generated nothing, silently turning every --live-gen probe into a false-dead
+    # reading. Passing the prompt as an argv token makes it one-shot and non-interactive,
+    # so DEVNULL stdin (now unconditional in run_probe_cmd) is safe here too.
     gen_res = run_probe_cmd(
-        [binp, "run", "qwen3.5:9b"], timeout=OLLAMA_LIVE_GEN_TIMEOUT * timeout / DEFAULT_TIMEOUTS["ollama"],
-        stdin_devnull=False,
+        [binp, "run", "qwen3.5:9b", PONG_PROMPT],
+        timeout=OLLAMA_LIVE_GEN_TIMEOUT * timeout / DEFAULT_TIMEOUTS["ollama"],
     )
     latency_ms = int((time.monotonic() - t0) * 1000)
-    if gen_res.timed_out:
-        return TIMEOUT, "live-gen timed out", latency_ms
     live = bool(gen_res.stdout.strip())
-    ev = evidence_tail(gen_res.stdout + " " + gen_res.stderr)
+    if gen_res.timed_out and not live:
+        return TIMEOUT, path_note + "live-gen timed out", latency_ms
+    ev = path_note + evidence_tail(gen_res.stdout + " " + gen_res.stderr)
     status = classify_generic(gen_res.stdout + gen_res.stderr, live, "ollama", is_ssh_context())
     return status, ev or "live-gen produced no output", latency_ms
 
 
 def probe_nlm(timeout: float) -> tuple[str, str, int]:
     t0 = time.monotonic()
-    binp = resolve_bin("nlm")
+    # nlm lives at ~/.local/bin/nlm — had NO fallback path at all before 2026-08-07.
+    binp, via_path = resolve_bin("nlm", ["~/.local/bin/nlm"])
     if not binp:
-        return NOT_INSTALLED, "nlm binary not found", 0
+        return NOT_INSTALLED, "nlm binary not found (checked $PATH + common install dirs)", 0
     res = run_probe_cmd([binp, "list", "notebooks"], timeout=timeout)
     latency_ms = int((time.monotonic() - t0) * 1000)
-    ev = evidence_tail(res.stdout + " " + res.stderr)
-    if res.timed_out:
-        return TIMEOUT, ev or "probe timed out", latency_ms
+    ev = _path_note(via_path) + evidence_tail(res.stdout + " " + res.stderr)
     live = False
     try:
         parsed = json.loads(res.stdout)
         live = isinstance(parsed, (list, dict))
     except (json.JSONDecodeError, ValueError):
         live = False
+    if res.timed_out and not live:
+        return TIMEOUT, ev or "probe timed out", latency_ms
     combined = res.stdout + res.stderr
     # nlm's expired-credential shape ("Run nlm login to re-authenticate")
     # carries no 401/oauth-token marker, only this prose, and fell through
@@ -657,14 +731,20 @@ def render_table(report: dict) -> str:
         f"summary: live={summ['live']} dead_strict={summ['dead_strict']} "
         f"context_limited={summ['context_limited']} transient={summ['transient']}"
     )
+    # scar family #2/#97 (Esiste!=Armato / display-cap-reads-as-complete): always
+    # declare N of M explicitly — never let a reader infer "0 seats" reads as clean.
+    total = len(report["seats"])
+    lines.append(f"{summ['live']} of {total} seats OK")
     return "\n".join(lines)
 
 
 def summary_line(report: dict) -> str:
     summ = report["summary"]
+    total = len(report.get("seats", []))
     return (
-        f"arsenal_probe {report['machine']}: {summ['live']} live, {summ['dead_strict']} dead_strict, "
-        f"{summ['context_limited']} context_limited, {summ['transient']} transient"
+        f"arsenal_probe {report['machine']}: {summ['live']} of {total} seats OK "
+        f"({summ['dead_strict']} dead_strict, {summ['context_limited']} context_limited, "
+        f"{summ['transient']} transient)"
     )
 
 
@@ -907,6 +987,18 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 2
 
     machine = machine_label()
+    # Fail-visible contract (2026-08-07 incident): print something, flushed, to stderr
+    # BEFORE any probe fires — never stdout, so --json's stdout stays parseable. Before
+    # this, the whole run printed nothing at all until every seat's future resolved
+    # (agy alone could eat its full per-seat timeout — see DEFAULT_TIMEOUTS comment),
+    # so a `timeout 60 ...` wrapper killing a hung/slow run looked exactly like "0
+    # bytes, nothing happened" with zero way to tell a hang from a not-yet-started run.
+    ts_start = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    print(
+        f"arsenal_probe {ts_start} — probing {len(seats)} seat(s) on {machine}: {', '.join(seats)}",
+        file=sys.stderr,
+        flush=True,
+    )
     report = run(seats, timeout_mult=args.timeout, live_gen=args.live_gen, machine=machine)
 
     try:

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import textwrap
+import time
 from pathlib import Path
 from types import ModuleType
 from typing import Optional
@@ -461,7 +463,7 @@ class _FakeProc:
 
 
 def test_probe_claude_pong_is_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "PONG\n", ""))
     status, ev, latency = ap.probe_claude(timeout=5)
     assert status == ap.LIVE
@@ -476,7 +478,7 @@ def test_probe_claude_strips_anthropic_api_key_from_env(monkeypatch):
         return _FakeProc(0, "PONG\n", "")
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "should-never-be-passed-through")
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(ap.subprocess, "run", fake_run)
     ap.probe_claude(timeout=5)
     assert "ANTHROPIC_API_KEY" not in captured_env
@@ -494,7 +496,7 @@ def test_probe_claude_falls_back_to_oauth_token_slot_1(monkeypatch):
 
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "slot1-token-value")
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(ap.subprocess, "run", fake_run)
     ap.probe_claude(timeout=5)
     assert captured_env.get("CLAUDE_CODE_OAUTH_TOKEN") == "slot1-token-value"
@@ -512,14 +514,14 @@ def test_probe_claude_never_overrides_explicit_oauth_token(monkeypatch):
 
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "explicit-token-value")
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "slot1-token-value")
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(ap.subprocess, "run", fake_run)
     ap.probe_claude(timeout=5)
     assert captured_env.get("CLAUDE_CODE_OAUTH_TOKEN") == "explicit-token-value"
 
 
 def test_probe_claude_binary_absent_is_not_installed(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: None)
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: (None, False))
     monkeypatch.delenv("ARSENAL_CLAUDE_BIN", raising=False)
     status, ev, latency = ap.probe_claude(timeout=5)
     assert status == ap.NOT_INSTALLED
@@ -530,7 +532,7 @@ def test_probe_claude_timeout_classifies_timeout(monkeypatch):
     def fake_run(cmd, **kwargs):
         raise ap.subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 5))
 
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(ap.subprocess, "run", fake_run)
     status, ev, latency = ap.probe_claude(timeout=5)
     assert status == ap.TIMEOUT
@@ -543,7 +545,7 @@ def test_probe_claude_not_logged_in_classifies_auth_dead(monkeypatch):
     # through classify_generic() to a bare UNKNOWN_ERR. Same shape as kimi's
     # "No providers configured" (probe_kimi) — mirrored locally here so the
     # shared _AUTH_DEAD_PAT keeps its existing guilt+innocence corpus untouched.
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(
         ap.subprocess,
         "run",
@@ -557,7 +559,7 @@ def test_probe_claude_pong_mentioning_login_stays_live(monkeypatch):
     # innocence: a LIVE answer that happens to mention login in prose must
     # never be reclassified as a credential death (mirrors
     # test_probe_kimi_pong_with_provider_prose_stays_live).
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(
         ap.subprocess,
         "run",
@@ -604,34 +606,34 @@ def test_probe_glm_never_leaks_token_in_evidence(monkeypatch):
 
 
 def test_probe_agy_pong_is_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/agy")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/agy", True))
     monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "PONG\n", ""))
     status, ev, latency = ap.probe_agy(timeout=5)
     assert status == ap.LIVE
 
 
 def test_probe_agy_missing_binary_not_installed(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: None)
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: (None, False))
     status, ev, latency = ap.probe_agy(timeout=5)
     assert status == ap.NOT_INSTALLED
 
 
 def test_probe_kimi_pong_is_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/Users/x/.kimi-code/bin/kimi")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/Users/x/.kimi-code/bin/kimi", True))
     monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "• PONG\n", ""))
     status, ev, latency = ap.probe_kimi(timeout=5)
     assert status == ap.LIVE
 
 
 def test_probe_kimi_missing_binary_not_installed(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: None)
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: (None, False))
     status, ev, latency = ap.probe_kimi(timeout=5)
     assert status == ap.NOT_INSTALLED
 
 
 def test_probe_kimi_no_providers_is_auth_dead(monkeypatch):
     # guilt: the unauthenticated kimi-code shape has no 401 marker, only prose
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/Users/x/.kimi-code/bin/kimi")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/Users/x/.kimi-code/bin/kimi", True))
     monkeypatch.setattr(
         ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(1, "No providers configured.\n", "")
     )
@@ -642,7 +644,7 @@ def test_probe_kimi_no_providers_is_auth_dead(monkeypatch):
 def test_probe_kimi_pong_with_provider_prose_stays_live(monkeypatch):
     # innocence: a LIVE answer that happens to mention providers/login in prose
     # must never be reclassified as a credential death
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/Users/x/.kimi-code/bin/kimi")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/Users/x/.kimi-code/bin/kimi", True))
     monkeypatch.setattr(
         ap.subprocess,
         "run",
@@ -659,7 +661,7 @@ def test_probe_kimi_uses_devnull_stdin(monkeypatch):
         captured.update(kwargs)
         return _FakeProc(0, "PONG\n", "")
 
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/Users/x/.kimi-code/bin/kimi")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/Users/x/.kimi-code/bin/kimi", True))
     monkeypatch.setattr(ap.subprocess, "run", fake_run)
     ap.probe_kimi(timeout=5)
     assert captured.get("stdin") == ap.subprocess.DEVNULL
@@ -672,21 +674,21 @@ def test_probe_codex_uses_devnull_stdin(monkeypatch):
         captured.update(kwargs)
         return _FakeProc(0, "PONG\n", "")
 
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/codex")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/codex", True))
     monkeypatch.setattr(ap.subprocess, "run", fake_run)
     ap.probe_codex(timeout=5)
     assert captured.get("stdin") == ap.subprocess.DEVNULL
 
 
 def test_probe_codex_pong_is_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/codex")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/codex", True))
     monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "PONG\n", ""))
     status, ev, latency = ap.probe_codex(timeout=5)
     assert status == ap.LIVE
 
 
 def test_probe_codex_401_is_auth_dead(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/opt/homebrew/bin/codex")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/codex", True))
     monkeypatch.setattr(
         ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(1, "", "401 token_revoked")
     )
@@ -706,7 +708,7 @@ def test_deepseek_retired_not_in_all_seats_or_probe_funcs():
 
 
 def test_probe_ollama_qwen_listed_is_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/usr/local/bin/ollama")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/ollama", True))
     monkeypatch.setattr(
         ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "qwen3.5:9b\tabc\n", "")
     )
@@ -715,20 +717,70 @@ def test_probe_ollama_qwen_listed_is_live(monkeypatch):
 
 
 def test_probe_ollama_qwen_absent_is_not_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/usr/local/bin/ollama")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/ollama", True))
     monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "llama3:8b\n", ""))
     status, ev, latency = ap.probe_ollama(timeout=5, live_gen=False)
     assert status != ap.LIVE
 
 
 def test_probe_ollama_missing_binary_not_installed(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: None)
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: (None, False))
     status, ev, latency = ap.probe_ollama(timeout=5, live_gen=False)
     assert status == ap.NOT_INSTALLED
 
 
+def test_probe_ollama_live_gen_passes_prompt_as_argv_not_stdin(monkeypatch):
+    # 2026-08-07: a bare `ollama run <model>` with no prompt arg drops into an
+    # interactive REPL reading stdin — under the now-unconditional stdin=DEVNULL
+    # contract that would read immediate EOF and generate nothing, silently
+    # turning every --live-gen probe into a false-dead reading. The prompt must
+    # travel as an argv token, never depend on stdin.
+    calls = []
+
+    def fake_run_probe_cmd(cmd, timeout, **kwargs):
+        calls.append(cmd)
+        if "list" in cmd:
+            return ap.ProbeResult(0, "qwen3.5:9b\tabc\n", "")
+        return ap.ProbeResult(0, "PONG\n", "")
+
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/ollama", True))
+    monkeypatch.setattr(ap, "run_probe_cmd", fake_run_probe_cmd)
+    status, ev, latency = ap.probe_ollama(timeout=5, live_gen=True)
+    assert status == ap.LIVE
+    run_call = calls[1]
+    assert run_call[:3] == ["/usr/local/bin/ollama", "run", "qwen3.5:9b"]
+    assert ap.PONG_PROMPT in run_call
+
+
+def test_probe_ollama_live_gen_timeout_with_no_output_stays_timeout(monkeypatch):
+    # innocence: a live-gen call that times out with truly nothing produced must
+    # stay TIMEOUT, not be misread as live.
+    def fake_run_probe_cmd(cmd, timeout, **kwargs):
+        if "list" in cmd:
+            return ap.ProbeResult(0, "qwen3.5:9b\tabc\n", "")
+        return ap.ProbeResult(-1, "", "", timed_out=True)
+
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/ollama", True))
+    monkeypatch.setattr(ap, "run_probe_cmd", fake_run_probe_cmd)
+    status, ev, latency = ap.probe_ollama(timeout=5, live_gen=True)
+    assert status == ap.TIMEOUT
+
+
+def test_probe_ollama_live_gen_recovers_partial_output_on_timeout(monkeypatch):
+    # the same judge-the-reply-not-the-timeout fix applied to the live-gen path.
+    def fake_run_probe_cmd(cmd, timeout, **kwargs):
+        if "list" in cmd:
+            return ap.ProbeResult(0, "qwen3.5:9b\tabc\n", "")
+        return ap.ProbeResult(-1, "PONG partial\n", "", timed_out=True)
+
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/ollama", True))
+    monkeypatch.setattr(ap, "run_probe_cmd", fake_run_probe_cmd)
+    status, ev, latency = ap.probe_ollama(timeout=5, live_gen=True)
+    assert status == ap.LIVE
+
+
 def test_probe_nlm_valid_json_list_is_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/usr/local/bin/nlm")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/nlm", True))
     monkeypatch.setattr(
         ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, '[{"id": "nb1"}]', "")
     )
@@ -737,14 +789,14 @@ def test_probe_nlm_valid_json_list_is_live(monkeypatch):
 
 
 def test_probe_nlm_non_json_output_not_live(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/usr/local/bin/nlm")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/nlm", True))
     monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "not json at all", ""))
     status, ev, latency = ap.probe_nlm(timeout=5)
     assert status != ap.LIVE
 
 
 def test_probe_nlm_missing_binary_not_installed(monkeypatch):
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: None)
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: (None, False))
     status, ev, latency = ap.probe_nlm(timeout=5)
     assert status == ap.NOT_INSTALLED
 
@@ -758,7 +810,7 @@ def test_probe_nlm_login_to_reauthenticate_classifies_auth_dead(monkeypatch):
     # arsenal-probe.md documenting "nlm AUTH_DEAD -> `nlm login` on Pro" as
     # the expected cure. Mirrored locally (kimi/claude pattern) so the shared
     # _AUTH_DEAD_PAT keeps its existing guilt+innocence corpus untouched.
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/usr/local/bin/nlm")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/nlm", True))
     monkeypatch.setattr(
         ap.subprocess,
         "run",
@@ -778,7 +830,7 @@ def test_probe_nlm_valid_json_mentioning_login_stays_live(monkeypatch):
     # innocence: a LIVE answer (valid JSON notebook list) that happens to
     # mention "login" inside a notebook title must never be reclassified as a
     # credential death.
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/usr/local/bin/nlm")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/nlm", True))
     monkeypatch.setattr(
         ap.subprocess,
         "run",
@@ -1239,6 +1291,288 @@ def test_bracketed_numeric_codes_still_match():
     assert ap.classify_generic("HTTP 429 too many requests", False, "codex", False) == ap.QUOTA_DEAD
 
 
+
+# ---------------------------------------------------------------------------
+# 2026-08-07 incident: arsenal_probe could hang forever and print zero bytes.
+# `timeout 60 python3 scripts/arsenal_probe.py --table` produced 0 bytes on
+# stdout+stderr on Pro (live seats claude/agy/kimi/codex/ollama/nlm all answered
+# fine interactively). Root cause, found empirically (not guessed): agy's own
+# process exits in ~1s but a detached grandchild keeps stdout's pipe fd open,
+# so subprocess.run's communicate() never sees EOF — the probe ALWAYS ate its
+# FULL per-seat timeout (verified at 12s/15s/45s cutoffs, PONG present in
+# partial stdout every single time) even though the seat is genuinely LIVE.
+# Since all seats probe concurrently and nothing prints until every future
+# resolves, agy's old 120s timeout alone explained the reported hang under any
+# outer wrapper shorter than that. Fixed by: (1) judging partial stdout for a
+# live signal BEFORE accepting TIMEOUT, generically, in every subprocess-backed
+# probe; (2) collapsing all per-seat timeouts from 30-180s down to ~15s; (3) a
+# fail-visible header printed+flushed to stderr before any probe fires; (4)
+# stdin=DEVNULL unconditional on every subprocess; (5) resolve_bin() enriched
+# with common install-root fallbacks (claude/nlm/ollama had a wrong or absent
+# fallback, causing false NOT_INSTALLED under a PATH-poor hook/launchd context).
+# ---------------------------------------------------------------------------
+
+
+def test_run_probe_cmd_stdin_devnull_prevents_stdin_read_hang(tmp_path):
+    # innocence-of-the-fix, REAL subprocess (not mocked): a fake seat that reads
+    # stdin would block forever on an inherited open pipe — exactly the shape a
+    # hook/launchd/agent-harness caller can hand this process. With stdin=DEVNULL
+    # wired unconditionally, the read() gets immediate EOF and the process exits
+    # fast, well inside a generous timeout — it must never even approach TIMEOUT.
+    script = tmp_path / "fake_seat_reads_stdin.py"
+    script.write_text(textwrap.dedent("""
+        import sys
+        data = sys.stdin.read()  # hangs forever on an open, unclosed pipe
+        print("SEAT_OK")
+    """))
+    t0 = time.monotonic()
+    res = ap.run_probe_cmd([sys.executable, str(script)], timeout=10)
+    elapsed = time.monotonic() - t0
+    assert res.timed_out is False
+    assert "SEAT_OK" in res.stdout
+    assert elapsed < 5  # nowhere near the 10s timeout — proves no hang occurred
+
+
+def test_run_probe_cmd_stdin_devnull_is_the_default(monkeypatch):
+    # guilt-of-the-old-bug: stdin_devnull used to default to False, and only
+    # kimi/codex opted in explicitly — claude/agy/ollama/nlm inherited whatever
+    # stdin this process had. The contract is now unconditional (mandate:
+    # "stdin=subprocess.DEVNULL su OGNI subprocess").
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return _FakeProc(0, "ok", "")
+
+    monkeypatch.setattr(ap.subprocess, "run", fake_run)
+    ap.run_probe_cmd(["irrelevant"], timeout=5)  # no stdin_devnull kwarg passed
+    assert captured.get("stdin") == ap.subprocess.DEVNULL
+
+
+def test_run_probe_cmd_recovers_partial_output_when_process_hangs_after_replying(tmp_path):
+    # THE bug, reproduced with a REAL subprocess: prints PONG almost instantly,
+    # then never exits — the agy pipe-leak shape. run_probe_cmd must still return
+    # within its own timeout budget (never inherit the child's indefinite hang)
+    # and must hand back the partial stdout so a caller can judge the reply.
+    script = tmp_path / "fake_seat_hangs_after_reply.py"
+    script.write_text(textwrap.dedent("""
+        import time
+        print("PONG", flush=True)
+        time.sleep(30)
+    """))
+    t0 = time.monotonic()
+    res = ap.run_probe_cmd([sys.executable, str(script)], timeout=2)
+    elapsed = time.monotonic() - t0
+    assert res.timed_out is True
+    assert "PONG" in res.stdout  # the reply IS there — a caller must judge it
+    assert elapsed < 10  # bounded by the probe's own timeout, never the child's 30s sleep
+
+
+def test_probe_agy_classifies_live_when_pong_arrives_before_hard_timeout(monkeypatch):
+    # end-to-end regression for the 2026-08-07 incident: probe_agy must not
+    # report TIMEOUT for a seat that already answered PONG, even though
+    # run_probe_cmd itself hit its timeout (the live agy pipe-leak shape).
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/agy", True))
+    monkeypatch.setattr(
+        ap, "run_probe_cmd",
+        lambda cmd, timeout, **kw: ap.ProbeResult(-1, "PONG\n", "", timed_out=True),
+    )
+    status, ev, latency = ap.probe_agy(timeout=2)
+    assert status == ap.LIVE
+
+
+def test_probe_agy_genuine_hang_with_no_reply_still_classifies_timeout(monkeypatch):
+    # innocence: a seat that timed out AND never said anything must still be
+    # TIMEOUT, not silently promoted to LIVE — the recovery only applies when a
+    # real live signal is present in the partial output.
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/agy", True))
+    monkeypatch.setattr(
+        ap, "run_probe_cmd",
+        lambda cmd, timeout, **kw: ap.ProbeResult(-1, "", "", timed_out=True),
+    )
+    status, ev, latency = ap.probe_agy(timeout=2)
+    assert status == ap.TIMEOUT
+
+
+def test_probe_claude_classifies_live_when_pong_arrives_before_hard_timeout(monkeypatch):
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
+    monkeypatch.setattr(
+        ap, "run_probe_cmd",
+        lambda cmd, timeout, env=None: ap.ProbeResult(-1, "PONG\n", "", timed_out=True),
+    )
+    status, ev, latency = ap.probe_claude(timeout=2)
+    assert status == ap.LIVE
+
+
+def test_probe_codex_classifies_live_when_pong_arrives_before_hard_timeout(monkeypatch):
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/codex", True))
+    monkeypatch.setattr(
+        ap, "run_probe_cmd",
+        lambda cmd, timeout, **kw: ap.ProbeResult(-1, "PONG\n", "", timed_out=True),
+    )
+    status, ev, latency = ap.probe_codex(timeout=2)
+    assert status == ap.LIVE
+
+
+def test_probe_kimi_classifies_live_when_pong_arrives_before_hard_timeout(monkeypatch):
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/Users/x/.kimi-code/bin/kimi", True))
+    monkeypatch.setattr(
+        ap, "run_probe_cmd",
+        lambda cmd, timeout, **kw: ap.ProbeResult(-1, "PONG\n", "", timed_out=True),
+    )
+    status, ev, latency = ap.probe_kimi(timeout=2)
+    assert status == ap.LIVE
+
+
+def test_probe_nlm_genuine_timeout_with_truncated_json_stays_timeout(monkeypatch):
+    # innocence: truncated/incomplete JSON on timeout must not be misread as a
+    # live signal (json.loads legitimately fails) — TIMEOUT is still correct.
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/local/bin/nlm", True))
+    monkeypatch.setattr(
+        ap, "run_probe_cmd",
+        lambda cmd, timeout, **kw: ap.ProbeResult(-1, '[{"id": "nb1"', "", timed_out=True),
+    )
+    status, ev, latency = ap.probe_nlm(timeout=2)
+    assert status == ap.TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# resolve_bin() — enriched fallback + found_via_path signal (2026-08-07)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_bin_prefers_path_when_available(monkeypatch):
+    monkeypatch.setattr(ap.shutil, "which", lambda name: f"/usr/bin/{name}" if name == "foo" else None)
+    path, via_path = ap.resolve_bin("foo")
+    assert path == "/usr/bin/foo"
+    assert via_path is True
+
+
+def test_resolve_bin_falls_back_to_common_dirs_when_path_thin(monkeypatch, tmp_path):
+    # guilt: reproduces the real 2026-08-07 bug shape — a hook/launchd context's
+    # $PATH lacks ~/.local/bin even though the binary is genuinely installed
+    # there. found_via_path=False signals "PATH-poor context", not "absent".
+    monkeypatch.setattr(ap.shutil, "which", lambda name: None)
+    fake_bin_dir = tmp_path / ".local" / "bin"
+    fake_bin_dir.mkdir(parents=True)
+    fake_bin = fake_bin_dir / "claude"
+    fake_bin.write_text("#!/bin/sh\necho fake\n")
+    real_expanduser = ap.os.path.expanduser
+    monkeypatch.setattr(
+        ap.os.path, "expanduser",
+        lambda p: str(tmp_path) + p[1:] if p.startswith("~") else real_expanduser(p),
+    )
+    path, via_path = ap.resolve_bin("claude")
+    assert path == str(fake_bin)
+    assert via_path is False
+
+
+def test_resolve_bin_genuinely_absent_returns_none_and_false(monkeypatch, tmp_path):
+    # innocence: nothing anywhere (not $PATH, not extra_paths, not common dirs)
+    # must still cleanly report absent, never crash or false-positive.
+    monkeypatch.setattr(ap.shutil, "which", lambda name: None)
+    real_expanduser = ap.os.path.expanduser
+    monkeypatch.setattr(
+        ap.os.path, "expanduser",
+        lambda p: str(tmp_path) + p[1:] if p.startswith("~") else real_expanduser(p),
+    )
+    path, via_path = ap.resolve_bin("totally-not-a-real-binary-xyz")
+    assert path is None
+    assert via_path is False
+
+
+def test_probe_claude_notes_not_on_path_when_resolved_via_fallback(monkeypatch):
+    # the distinguishing signal the mandate asked for: NOT_ON_PATH (binary present,
+    # this process's $PATH was thin) must be visibly different from a plain LIVE
+    # resolved normally — surfaced in the evidence, not a new top-level status
+    # (avoids growing the taxonomy for what is fundamentally a context footnote).
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/some/fallback/claude", False))
+    monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "PONG\n", ""))
+    status, ev, latency = ap.probe_claude(timeout=5)
+    assert status == ap.LIVE
+    assert "NOT_ON_PATH" in ev
+
+
+def test_probe_claude_no_path_note_when_resolved_via_path(monkeypatch):
+    # innocence: the normal case (found via $PATH) must carry no such note.
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
+    monkeypatch.setattr(ap.subprocess, "run", lambda cmd, **kwargs: _FakeProc(0, "PONG\n", ""))
+    status, ev, latency = ap.probe_claude(timeout=5)
+    assert status == ap.LIVE
+    assert "NOT_ON_PATH" not in ev
+
+
+# ---------------------------------------------------------------------------
+# Fail-visible contract: header before probing, output never empty (2026-08-07)
+# ---------------------------------------------------------------------------
+
+
+def test_main_prints_header_to_stderr_before_any_probe_result(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(ap, "REPORT_DIR", tmp_path)
+    monkeypatch.setattr(ap, "HEARTBEAT_DIR", tmp_path)
+    monkeypatch.setitem(ap.PROBE_FUNCS, "claude", lambda timeout: (ap.LIVE, "PONG", 5))
+    code = ap.main(["--seats", "claude", "--table"])
+    assert code == 0
+    err = capsys.readouterr().err
+    assert "probing 1 seat(s)" in err
+    assert "claude" in err
+
+
+def test_main_output_never_empty_even_with_every_seat_dead(tmp_path, monkeypatch, capsys):
+    # (c) from the mandate: even with ALL seats dead, output must never be
+    # empty — the header alone (stderr, printed before any probe fires)
+    # guarantees this regardless of what every individual probe returns.
+    monkeypatch.setattr(ap, "REPORT_DIR", tmp_path)
+    monkeypatch.setattr(ap, "HEARTBEAT_DIR", tmp_path)
+    for seat in ap.ALL_SEATS:
+        monkeypatch.setitem(ap.PROBE_FUNCS, seat, lambda timeout: (ap.UNKNOWN_ERR, "dead", 1))
+    code = ap.main([])
+    out, err = capsys.readouterr()
+    assert (out + err).strip() != ""
+    assert "0 of 7 seats OK" in out
+
+
+def test_main_header_printed_even_if_every_probe_crashes(tmp_path, monkeypatch, capsys):
+    # the header is printed BEFORE run() is even called — it must survive a
+    # probe function that raises, not just one that returns a dead status.
+    monkeypatch.setattr(ap, "REPORT_DIR", tmp_path)
+    monkeypatch.setattr(ap, "HEARTBEAT_DIR", tmp_path)
+
+    def boom(timeout):
+        raise RuntimeError("simulated probe crash")
+
+    for seat in ap.ALL_SEATS:
+        monkeypatch.setitem(ap.PROBE_FUNCS, seat, boom)
+    code = ap.main([])
+    err = capsys.readouterr().err
+    assert "probing 7 seat(s)" in err
+
+
+def test_render_table_includes_n_of_m_seats_ok_line():
+    report = {
+        "machine": "pro",
+        "ts": "x",
+        "seats": [
+            {"seat": "claude", "status": ap.LIVE, "healthy": True, "latency_ms": 1, "evidence": "PONG", "required": True},
+            {"seat": "codex", "status": ap.AUTH_DEAD, "healthy": False, "latency_ms": 1, "evidence": "401", "required": True},
+        ],
+        "transitions": [],
+        "summary": {"live": 1, "dead_strict": 1, "context_limited": 0, "transient": 0},
+    }
+    table = ap.render_table(report)
+    assert "1 of 2 seats OK" in table
+
+
+def test_summary_line_includes_n_of_m_seats_ok():
+    report = {
+        "machine": "pro",
+        "seats": [{"seat": "claude"}, {"seat": "codex"}, {"seat": "glm"}],
+        "summary": {"live": 1, "dead_strict": 1, "context_limited": 1, "transient": 0},
+    }
+    line = ap.summary_line(report)
+    assert "1 of 3 seats OK" in line
+
+
 def test_probe_claude_strips_glm_session_env(monkeypatch):
     captured_env = {}
 
@@ -1247,7 +1581,7 @@ def test_probe_claude_strips_glm_session_env(monkeypatch):
         return ap.ProbeResult(0, "PONG", "")
 
     monkeypatch.setattr(ap, "run_probe_cmd", fake_run)
-    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: "/fake/claude")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/fake/claude", True))
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-paid-key-must-die")
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "glm-token-must-die")
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/api/anthropic")


### PR DESCRIPTION
## Summary

`timeout 60 python3 scripts/arsenal_probe.py --table` produced **0 bytes** on stdout+stderr on Pro today, while every seat (claude/codex/agy/kimi/ollama/nlm) answered fine in an interactive shell seconds later — the sensor was more broken than the arsenal it measures (scar family #2, Esiste≠Armato).

**Root cause (found by reproduction, not assumed):** agy's own process exits in ~1s, but a detached grandchild keeps the stdout pipe fd open, so `subprocess.run`'s `communicate()` never sees EOF. The probe therefore **always** ate its full per-seat timeout (verified live at 12s/15s/45s cutoffs — `PONG` was already sitting in the partial stdout every single time). Since all 7 seats probe concurrently in one `ThreadPoolExecutor` and nothing prints until every future resolves, agy's old 120s timeout alone explains "0 bytes for 60s" under any outer wrapper shorter than that.

The two hypotheses in the mandate were both **real but not the dominant cause**:
- codex already had `stdin_devnull=True` on `HEAD` — not the culprit, though the contract is now unconditional for every seat.
- PATH poverty is real and independently confirmed: `probe_claude`'s only fallback pointed at `/opt/homebrew/bin/claude`, a path claude has **never** lived at (it's a `~/.local/bin/claude` symlink); `ollama`/`nlm` had **no** fallback at all. Reproduced empirically: `PATH=/usr/bin:/bin python3 scripts/arsenal_probe.py --seats claude,ollama,nlm` reported `NOT_INSTALLED` for all three on `HEAD`, and correctly resolves + reports `LIVE` with the fix.

## Fixes

- **Judge the reply, not the timeout** (scar W104): every subprocess-backed probe now checks partial stdout for a live signal *before* accepting `TIMEOUT`.
- **Per-seat timeouts collapsed from 30–180s to ~15s** — safe specifically because of the above.
- **Fail-visible header**, printed+flushed to **stderr** before any probe fires (never stdout, so `--json` stays parseable). Zero bytes for 60s is now impossible by construction.
- **`stdin=subprocess.DEVNULL` is now the unconditional default** in `run_probe_cmd` (previously opt-in — only kimi/codex had it).
- **`resolve_bin()` gained a `COMMON_BIN_DIRS` fallback** and now returns `(path, found_via_path)` — a binary found only via fallback carries a `[NOT_ON_PATH: ...]` evidence note instead of silently reading as `NOT_INSTALLED` or a plain `LIVE`.
- **Final line always states `N of M seats OK`** (`render_table`, `summary_line`) — never let a partial/all-dead run read as ambiguous.
- `probe_ollama --live-gen`: a bare `ollama run <model>` with no prompt arg depends on interactive stdin, which the now-unconditional `DEVNULL` would starve into producing nothing — the prompt now travels as an argv token.

## Verified live on Pro

```
$ time timeout 60 python3 scripts/arsenal_probe.py --table
arsenal_probe 2026-08-07T13:14:32Z — probing 7 seat(s) on pro: claude, glm, kimi, agy, codex, ollama, nlm
  claude    LIVE              12961ms  PONG (required)
  glm       UNKNOWN_ERR        1404ms  ...
  kimi      UNKNOWN_ERR        2761ms  ...
  agy       LIVE              15016ms  PONG          <-- previously ALWAYS timed out at 120s
  codex     LIVE               7731ms  ...
  ollama    LIVE                 33ms  qwen3.5 listed
  nlm       LIVE               3812ms  ...
5 of 7 seats OK
... 15.1s total (was: 0 bytes / hang past 60s)
```

## Known NOT fixed here (reported for the ledger, out of scope for this diff)

- **glm can be genuinely LIVE but classified `UNKNOWN_ERR`.** `probe_glm`'s live-check (`'"model"' in ev`) runs against `evidence_tail`'s last-160-chars slice, which routinely truncates away the `"model"` field in a real Anthropic-shape JSON reply (`id, type, role, model, content, stop_reason, ...`). Observed live today. Fixing this needs `http_post_json`'s live-check to run against the untruncated (but still scrubbed) body — a signature change deliberately left out to keep this diff scoped to the hang.
- **kimi's current unauthenticated string** (`auth.login_required: OAuth provider "managed:kimi-code" requires login...`) isn't matched by the existing `AUTH_DEAD` regex (`no providers configured|not logged in`), so a real "please `kimi login`" reads as `UNKNOWN_ERR` instead of the documented `AUTH_DEAD`.
- The SessionStart hook receptor (`~/.claude/hooks/`, control-plane, not touched per mandate) reads `~/.organism/arsenal/last.json`/heartbeat sidecar — a separate component from this script.

Both documented in `docs/runbooks/arsenal-probe.md`.

## Test plan

- [x] `scripts/tests/test_arsenal_probe.py`: 122 pre-existing tests updated (`resolve_bin` mock signature: `Optional[str]` → `tuple[Optional[str], bool]`) + 22 new guilt/innocence tests — **144/144 passing** (throwaway venv, no repo pytest install found).
- [x] `python3 scripts/arsenal_probe.py --selftest` — 17 checks pass.
- [x] Reproduced the exact reported hang (`timeout 60 ... --table` → 0 bytes) and confirmed it now completes in ~15s with real output, exit 0.
- [x] Reproduced the PATH-poverty NOT_INSTALLED bug under `PATH=/usr/bin:/bin` and confirmed the fix resolves + probes correctly.
- [x] `--json` output confirmed to stay valid JSON (header goes to stderr only).
- [ ] CI (this PR did not arm auto-merge per mandate — orchestrator gates the merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
