### PR TITLE
fix(docs): say so when the inventory is regenerated inside an open merge

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -143,6 +143,8 @@ jobs:
               scripts/tests/test_docs_audit.py|\
               scripts/tests/test_docs_inventory_refresh_liveness.py|\
               scripts/tests/test_docs_inventory_regen.py|\
+              scripts/lib/git_merge_state.sh|\
+              scripts/tests/test_docs_inventory_regen_merge_warning.sh|\
               scripts/tests/test_docs_inventory_render_is_clock_free.py|\
               scripts/lib/fly_credential.sh|\
               scripts/test_fly_credential.sh|\
@@ -324,6 +326,16 @@ jobs:
           # be mutation-killed here, not on the BSD-xargs dev machines.
           python -m pip install --quiet ruff
           bash scripts/tests/test_precommit_print_gate.sh
+
+      - name: The regen warns when it runs mid-merge (advice, never a refusal)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # Named explicitly, NOT left to the `scripts/tests/` sweep — that sweep
+          # is continue-on-error, so a test parked there is green by construction
+          # (W108: the defect only surfaced once the test was ARMED on every PR).
+          # The corpus builds real git repos in a tmp dir; nothing touches this
+          # checkout.
+          bash scripts/tests/test_docs_inventory_regen_merge_warning.sh
 
       - name: No run-block decapitates its own failure branch (W101, 4th instance)
         if: steps.paths.outputs.relevant == 'true'

--- a/scripts/docs_inventory_regen.sh
+++ b/scripts/docs_inventory_regen.sh
@@ -120,6 +120,24 @@ case "$#" in
     ;;
 esac
 
+# Advisory only — never changes this script's exit code. See the helper's
+# header for the 2026-08-07 measurement (PR #3750) and for why this warns
+# instead of refusing: regenerating to resolve a DOCS_INVENTORY.md conflict is
+# the CORRECT use, it just has to be repeated once the merge commit exists.
+#
+# Absence is a HARD error, not a shrug: this script runs without `set -e`, so a
+# failed `.` would sail on and leave `warn_if_merge_in_progress` undefined —
+# the guard would be gone with nothing saying so (superscar #2, exists-but-not-
+# armed). Same posture as the strict arg parsing below: never a silent fallback.
+MERGE_STATE_LIB="$SCRIPT_DIR/lib/git_merge_state.sh"
+if [[ ! -f "$MERGE_STATE_LIB" ]]; then
+  echo "docs_inventory_regen: missing $MERGE_STATE_LIB — broken checkout, refusing to run half-armed" >&2
+  exit 2
+fi
+# shellcheck source=scripts/lib/git_merge_state.sh
+. "$MERGE_STATE_LIB"
+warn_if_merge_in_progress "$SCRIPT_DIR/.."
+
 if [[ "$ORGAN_MODE" == "true" ]]; then
   TIME_MODE_ARGS=(--as-of "$(date -u +%Y-%m-%d)")
 else

--- a/scripts/lib/git_merge_state.sh
+++ b/scripts/lib/git_merge_state.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# git_merge_state.sh — "is a merge still open in this working tree?"
+#
+# Sourced by scripts/docs_inventory_regen.sh. Lives here, not inlined, for one
+# reason: that script's first act is `cd "$SCRIPT_DIR/.."`, so it always
+# operates on the real repo and a test can never put it in front of a fake one.
+# A guard nobody can execute in a controlled world is a guard nobody has proven
+# (scar #3: no guard ships without guilt AND innocence).
+#
+# WHY IT EXISTS, measured 2026-08-07 on PR #3750: the inventory was regenerated
+# between `git merge` and `git commit`, while the merge was still conflicted.
+# At that moment HEAD is still the BRANCH's own tip — the merged commits exist
+# only in MERGE_HEAD, not in HEAD's history — so `git log -1 -- <path>`, which
+# is where docs_audit.py reads `last_touched_date`, walked a history that did
+# not contain what main had just landed and returned the older date. Two rows
+# (docs/AI_ONBOARDING.md, docs/runbooks/README.md) went out a day stale and the
+# `inventory-check` gate charged the PR for them. Nothing was broken: the
+# ORDERING was wrong, and nothing said so.
+#
+# WARNING, NOT REFUSAL — deliberate. Resolving a DOCS_INVENTORY.md merge
+# conflict by re-running the generator IS the correct workflow (a derived file
+# has one authority, and it is not a hand-merge). A guard that refused would
+# block the very path it is meant to support; it would also be the kind of
+# obstacle whose documented escape is "disable the guard", which turns a
+# usability complaint into a disarmed check (superscar #3 → #2). So it informs
+# and gets out of the way: run the generator now to resolve the conflict, then
+# run it AGAIN after the merge commit exists.
+
+# Print a warning to stderr iff `repo` has an unfinished merge.
+# ALWAYS returns 0: this is advice, never a verdict. A caller must not be able
+# to fail because of it, and a future `set -e` in a caller must not turn advice
+# into an abort.
+warn_if_merge_in_progress() {
+  local repo="${1:-.}"
+  if ! git -C "$repo" rev-parse --verify -q MERGE_HEAD >/dev/null 2>&1; then
+    return 0
+  fi
+  cat >&2 <<'EOF'
+docs_inventory_regen: WARNING — a merge is still open in this working tree.
+
+  Until you commit it, HEAD is your branch's own tip: the commits you are
+  merging live in MERGE_HEAD and are NOT yet in the history `git log` walks.
+  Commit dates computed now will therefore MISS whatever the other side just
+  landed, and the rows for files that side touched will be written stale.
+
+  Running the generator now to resolve a docs/DOCS_INVENTORY.md conflict is
+  correct — that is what it is for. Just run it ONCE MORE after `git commit`,
+  and commit that result too.
+EOF
+  return 0
+}
+
+# DECLARED LIMIT — what this deliberately does not look at:
+#   * A rebase in progress is NOT flagged, and that is a claim about the
+#     mechanism rather than an omission: while a rebase is stopped, the
+#     upstream commits are already IN HEAD's history (that is what rebase
+#     does), so the failure above cannot occur.
+#   * CHERRY_PICK_HEAD / REVERT_HEAD are not flagged. They share the "not yet
+#     in HEAD" property in principle, but neither has been measured biting this
+#     pipeline, and a guard that names a case it has never seen invites the
+#     reader to trust a coverage claim nobody checked. If one shows up, it gets
+#     its own corpus row here.

--- a/scripts/tests/test_docs_inventory_regen.py
+++ b/scripts/tests/test_docs_inventory_regen.py
@@ -18,6 +18,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REAL_REGEN_SH = REPO_ROOT / "scripts" / "docs_inventory_regen.sh"
+# The wrapper sources this and REFUSES to run without it (exit 2, rather than
+# sailing on with the guard undefined — it runs without `set -e`). The fake
+# repo must therefore carry it: a world missing a real dependency is an
+# incomplete world, not a minimal one, and every test here would otherwise
+# measure the refusal instead of the control flow it was written for.
+REAL_MERGE_STATE_LIB = REPO_ROOT / "scripts" / "lib" / "git_merge_state.sh"
 
 _STUB_SYNC_OK = "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n"
 _STUB_AUDIT_OK = "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n"
@@ -31,6 +37,8 @@ def _make_fake_repo(tmp_path: Path, *, sync_exit: str, audit_exit: str) -> Path:
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir(parents=True)
     shutil.copy(REAL_REGEN_SH, scripts_dir / "docs_inventory_regen.sh")
+    (scripts_dir / "lib").mkdir()
+    shutil.copy(REAL_MERGE_STATE_LIB, scripts_dir / "lib" / "git_merge_state.sh")
     (scripts_dir / "docs_sync.py").write_text(sync_exit, encoding="utf-8")
     (scripts_dir / "docs_audit.py").write_text(audit_exit, encoding="utf-8")
     return tmp_path
@@ -295,3 +303,55 @@ def test_organ_alone_still_works_after_strict_validation(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
     captured = (fake_repo / "scripts" / "captured_argv.txt").read_text()
     assert "--as-of" in captured.split("\n"), captured
+
+
+def test_missing_merge_state_helper_refuses_instead_of_running_half_armed(tmp_path):
+    """GUILT — a checkout missing scripts/lib/git_merge_state.sh must exit 2 and
+    say why, NOT run with the guard silently absent.
+
+    This wrapper deliberately runs without `set -e`, so a failed `.` would sail
+    straight on and leave `warn_if_merge_in_progress` undefined: the guard would
+    be gone with nothing saying so (superscar #2, exists-but-not-armed). That is
+    the one failure mode a guard must never have.
+
+    Written 2026-08-07 AFTER the refusal fired for real: the fake repo above did
+    not carry the helper, so every test in this file hit exit 2 and CI went red.
+    The harness was the thing that was wrong — but the refusal itself had no
+    test, and a behaviour discovered by breaking its neighbours is a behaviour
+    nobody pinned. It has one now.
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_OK
+    )
+    (fake_repo / "scripts" / "lib" / "git_merge_state.sh").unlink()
+
+    result = _run_regen(fake_repo)
+
+    assert result.returncode == 2, (
+        "a checkout missing the merge-state helper must REFUSE (exit 2), never "
+        f"run half-armed — got {result.returncode}: {result.stdout}{result.stderr}"
+    )
+    assert "refusing to run half-armed" in result.stderr, (
+        "the refusal must name its cause, or a reader has to go find it — "
+        f"stderr was: {result.stderr}"
+    )
+
+
+def test_helper_present_does_not_disturb_a_clean_run(tmp_path):
+    """INNOCENCE, sharing the mechanism above: same fake repo, helper in place.
+
+    The fake repo is not a git repo at all, so `git rev-parse MERGE_HEAD` cannot
+    succeed and the advice must stay silent — a guard that fired here would fire
+    on every CI checkout that is not mid-merge, i.e. all of them.
+    """
+    fake_repo = _make_fake_repo(
+        tmp_path, sync_exit=_STUB_SYNC_OK, audit_exit=_STUB_AUDIT_OK
+    )
+
+    result = _run_regen(fake_repo)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "a merge is still open" not in result.stderr, (
+        "the merge advice must not fire outside an open merge — "
+        f"stderr was: {result.stderr}"
+    )

--- a/scripts/tests/test_docs_inventory_regen_merge_warning.sh
+++ b/scripts/tests/test_docs_inventory_regen_merge_warning.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Proof that the "you are mid-merge" advice fires when it should, stays quiet
+# when it should, and can never fail its caller.
+#
+# Measured 2026-08-07 (PR #3750): the docs inventory was regenerated between
+# `git merge` and `git commit`, while the merge was still conflicted. HEAD was
+# still the branch's own tip, so `git log -1 -- <path>` — where docs_audit.py
+# reads `last_touched_date` — walked a history without the commits being merged
+# and wrote two rows a day stale. The `inventory-check` gate charged the PR.
+#
+#   GUILT     — a real conflicted merge is open: the advice must be printed, and
+#               it must name the FIX (run again after the commit), not just the
+#               symptom. An alarm that says "something is off" costs a reader
+#               the same investigation the alarm was supposed to save.
+#   INNOCENCE — a clean tree, and a tree with UNCOMMITTED CHANGES that are not a
+#               merge: silence. The second is the case that matters — the naive
+#               guard is "is the tree dirty?", which would fire on every ordinary
+#               edit and be muted within a week.
+#   SYMMETRY  — a merge that has been COMMITTED is silent again, because that is
+#               precisely the state in which regenerating is correct.
+#   CONTRACT  — the function returns 0 in every one of those states. It is
+#               advice; a caller must not be able to fail because of it, and a
+#               future `set -e` upstream must not turn advice into an abort.
+#
+# Everything runs in throwaway git repos under a tmp dir; the real repo is only
+# ever READ (to source the helper).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+LIB="$REPO_ROOT/lib/git_merge_state.sh"
+[ -f "$LIB" ] || { echo "helper not found at $LIB"; exit 1; }
+# shellcheck source=/dev/null
+. "$LIB"
+
+TMP="$(mktemp -d)"
+trap '/bin/rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+check() { # check <label> <expected: fires|silent> <repo>
+  local label="$1" expect="$2" repo="$3" out rc
+  out="$(warn_if_merge_in_progress "$repo" 2>&1 >/dev/null)"
+  rc=$?
+  local got="silent"
+  [ -n "$out" ] && got="fires"
+  if [ "$got" != "$expect" ]; then
+    echo "  FAIL $label: expected $expect, got $got"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [ "$rc" -ne 0 ]; then
+    echo "  FAIL $label: advice returned rc=$rc — it must always be 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  ok   $label ($got, rc=0)"
+  PASS=$((PASS + 1))
+}
+
+mkrepo() { # mkrepo <dir>  -> a repo with one commit on `main`
+  local d="$1"
+  mkdir -p "$d"
+  git -C "$d" init -q -b main
+  git -C "$d" config user.email t@example.com
+  git -C "$d" config user.name Test
+  printf 'base\n' > "$d/f.txt"
+  git -C "$d" add f.txt
+  git -C "$d" commit -qm base
+}
+
+# --- INNOCENCE 1: clean tree -------------------------------------------------
+mkrepo "$TMP/clean"
+check "clean tree" silent "$TMP/clean"
+
+# --- INNOCENCE 2: dirty, but NOT a merge ------------------------------------
+# The naive guard ("tree is dirty") would fire here on every ordinary edit.
+mkrepo "$TMP/dirty"
+printf 'edited\n' >> "$TMP/dirty/f.txt"
+check "uncommitted edits, no merge" silent "$TMP/dirty"
+
+# --- GUILT: a genuinely conflicted, uncommitted merge ------------------------
+mkrepo "$TMP/merging"
+git -C "$TMP/merging" checkout -q -b other
+printf 'theirs\n' > "$TMP/merging/f.txt"
+git -C "$TMP/merging" commit -qam theirs
+git -C "$TMP/merging" checkout -q main
+printf 'ours\n' > "$TMP/merging/f.txt"
+git -C "$TMP/merging" commit -qam ours
+git -C "$TMP/merging" merge other >/dev/null 2>&1  # expected to conflict
+if ! git -C "$TMP/merging" rev-parse --verify -q MERGE_HEAD >/dev/null 2>&1; then
+  echo "  FAIL setup: the fixture did not actually leave a merge open — the"
+  echo "             guilt case would have measured its own setup, not the guard"
+  FAIL=$((FAIL + 1))
+else
+  check "conflicted merge in progress" fires "$TMP/merging"
+  msg="$(warn_if_merge_in_progress "$TMP/merging" 2>&1 >/dev/null)"
+  # shellcheck disable=SC2016  # the literal is the point: this asserts the
+  # advice's own wording, so expansion would defeat the assertion.
+  if printf '%s' "$msg" | grep -q 'ONCE MORE after `git commit`'; then
+    echo "  ok   the advice names the fix, not just the symptom"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL the advice fires but never tells the reader what to do"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+# --- SYMMETRY: the same repo, once the merge is COMMITTED --------------------
+if git -C "$TMP/merging" rev-parse --verify -q MERGE_HEAD >/dev/null 2>&1; then
+  printf 'resolved\n' > "$TMP/merging/f.txt"
+  git -C "$TMP/merging" add f.txt
+  git -C "$TMP/merging" commit -qm merged
+  check "merge committed" silent "$TMP/merging"
+fi
+
+echo
+echo "merge-state advice: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Follow-up to #3750, from a defect that PR hit while landing.

## What happened, measured

The inventory was regenerated between `git merge` and `git commit`, while the merge was still conflicted. At that moment HEAD is still the **branch's own tip** — the merged commits live in `MERGE_HEAD`, not yet in the history `git log` walks. So `git log -1 -- <path>`, which is where `docs_audit.py` reads `last_touched_date`, returned dates from before the other side landed:

```
inventory rows this PR makes STALE: 2
    docs/AI_ONBOARDING.md
    docs/runbooks/README.md
```

Both were touched by #3732, which had just merged. Nothing was broken — the generator was right, the rows were right, the **ordering** was wrong, and nothing said so. Regenerating after the merge commit exists is idempotent; regenerating before it is not.

I also had to correct my own first diagnosis while writing it: "the merge commit re-dates the files" is wrong. The simplified log points at #3732 itself. The mechanism is the opposite — it is not the merge adding a date, it is the pre-merge state not seeing one yet.

## Warning, not refusal — deliberate

Resolving a `docs/DOCS_INVENTORY.md` conflict by re-running the generator **is** the correct workflow: a derived file has one authority, and it is not a hand-merge. A guard that refused would block the very path it exists to serve — and its documented escape would be "turn the guard off", promoting a usability complaint into a disarmed check (superscar #3 → #2).

So it informs and steps aside: regenerate now to resolve the conflict, then once more after `git commit`. The message names the fix, not just the symptom.

## Why a separate helper

`docs_inventory_regen.sh`'s first act is `cd "$SCRIPT_DIR/.."` — it always operates on the real repo, so an inlined check could never be executed in front of a controlled world. **A guard nobody can run against a fake repo is a guard nobody has proven.** In `scripts/lib/`, the corpus builds real throwaway git repos and drives it through every state.

Two details the scars made mandatory:

- **A missing helper is a hard error (exit 2).** This script runs without `set -e`, so a failed `.` would sail on leaving `warn_if_merge_in_progress` undefined — the guard gone with nothing saying so (superscar #2, exists-but-not-armed). Same posture as the strict arg parsing it sits next to.
- **The call sits after arg validation**, so a usage error does not print advice nobody asked for. Verified: `--bogus` still exits 2 with only its own message.

## Armed by name, not parked in the sweep

`scripts/tests/` is `continue-on-error` — a test left there is green by construction. This is the exact shape of W108, where the defect only surfaced once the test ran on every PR. So the test is invoked by name in `immune-enforcement.yml`, like its siblings (`test_precommit_print_gate.sh`, `test_cron_agent_oauth_cascade.sh`), and both files are added to the job's path filter. `actionlint`: clean.

## Corpus and mutations

Five assertions: fires on a real conflicted merge and names the fix; silent on a clean tree, on a **committed** merge, and — the one that matters — on a tree with uncommitted changes that are not a merge. Every state also asserts `rc == 0`: this is advice, and a caller must never be able to fail because of it.

| mutation | kills |
|---|---|
| never fires | only the 2 guilt assertions |
| always fires | only the 3 silence assertions |
| **the naive guard** (`is the tree dirty?`) | **only** "dirty tree, no merge" |

That third one is why the innocence case earns its place: the obvious "is the tree dirty?" implementation **passes the guilt test** and fails only there. Without it I could not distinguish this guard from one that would be muted within a week for firing on every ordinary edit.

## Declared limits, in the code

A stopped rebase is not flagged, and that is a claim about the mechanism rather than an omission: during a rebase the upstream commits are already in HEAD's history, so this failure cannot occur. `CHERRY_PICK_HEAD`/`REVERT_HEAD` share the property in principle but have never been measured biting this pipeline — a guard that names a case it has never seen invites trust in coverage nobody checked. If one shows up, it gets its own corpus row.

Not touched: `scripts/docs_inventory_regen.sh:93`'s pre-existing `cd` without `|| exit` (shellcheck SC2164) — real, but not this PR's subject. My own files are shellcheck-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)