### PR TITLE
fix(broker): symlink apps/mouth/node_modules, or every mouth lane fails to typecheck

### DIFF
--- a/scripts/agent_start.py
+++ b/scripts/agent_start.py
@@ -108,8 +108,24 @@ TASK_METADATA_FILENAME = ".agent-task.json"
 # SYMLINK_TARGETS entry, and .husky/.gitignore does not cover it, so without
 # this the broker's own shim symlink would read as `?? .husky/_` and re-create
 # the very never-cleanup-eligible bug the node_modules note describes.
+# `apps/mouth/node_modules` is listed for that same reason, and the reason is
+# NOT visible on every machine — which is exactly why it is listed rather than
+# left to the ignore rules. Measured 2026-08-07 across the fleet: the symlink
+# reads as ignored on M5 and Pro purely because a BARE `node_modules` line sits
+# in their `.git/info/exclude` — a local, untracked, per-machine file. Mini has
+# no such line (0 matches), and the repo's own .gitignore only carries the
+# directory-only `node_modules/`, which does not match a symlink-to-a-directory.
+# So on Mini this entry would read `?? apps/mouth/node_modules` and permanently
+# trip the WIP guard. Trusting one machine's clean `git status` here would have
+# been trusting a machine-local accident.
 BROKER_GENERATED_FILES = frozenset(
-    {".agent-task.json", ".env.worktree", "node_modules", ".husky/_"}
+    {
+        ".agent-task.json",
+        ".env.worktree",
+        "node_modules",
+        "apps/mouth/node_modules",
+        ".husky/_",
+    }
 )
 LSOF_FALLBACK_PATHS: tuple[Path, ...] = (Path("/usr/sbin/lsof"),)
 
@@ -152,10 +168,25 @@ ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9\-]{0,63}$")
 # lands exactly where CLAUDE.md mandates all agent work happen. Measured
 # 2026-07-16: three probe pushes from two worktrees, no gate; symlink the dir in
 # and the same push runs the full suite.
+# `apps/mouth/node_modules` is load-bearing for the same class of reason as
+# `.husky/_`, one layer down. This is an npm WORKSPACE monorepo, so a workspace
+# package's own deps are installed NESTED (`apps/mouth/node_modules/<pkg>`), not
+# hoisted to the root — `recharts` lives only there. Node resolves upward from
+# the importing file, so a worktree that symlinks only the ROOT node_modules
+# still finds nothing, and `npm run typecheck` dies with
+# `TS2307: Cannot find module 'recharts'` on two files. That is the command the
+# pre-commit hook runs whenever apps/mouth TS/TSX is staged, so without this
+# every mouth lane hits a hard failure whose cause names a package the lockfile
+# demonstrably resolves — and the obvious readings ("the lock is broken", "the
+# dep is missing") are both wrong. Measured 2026-08-07: only 5 of 37 live
+# worktrees had this directory, each because someone ran the install by hand.
+# Reproduced and proven in a fresh worktree before this change: typecheck exits
+# 2 without the symlink and 0 with it, nothing else altered.
 SYMLINK_TARGETS: tuple[tuple[str, str], ...] = (
     ("apps/backend-rag/.venv", "apps/backend-rag/.venv"),
     ("apps/backend-rag/.env", "apps/backend-rag/.env"),
     ("node_modules", "node_modules"),
+    ("apps/mouth/node_modules", "apps/mouth/node_modules"),
     (".husky/_", ".husky/_"),
 )
 

--- a/scripts/tests/test_agent_start.py
+++ b/scripts/tests/test_agent_start.py
@@ -188,6 +188,90 @@ def test_node_modules_symlink_does_not_mask_real_wip(fake_repo):
     assert mod._worktree_has_wip(wt) is True
 
 
+def _seed_mouth_workspace(repo, mod):
+    """Give the fake repo a TRACKED file under apps/mouth, then the nested
+    node_modules dir in main.
+
+    The tracked file is not decoration — it is what makes the fixture
+    representative, and leaving it out makes every assertion below vacuous.
+    `git status --porcelain` COLLAPSES untracked directories to their shallowest
+    untracked ancestor: with nothing tracked under apps/, git reports `?? apps/`
+    and never `?? apps/mouth/node_modules`, so the BROKER_GENERATED_FILES entry
+    can neither help (innocence fails) nor be needed (guilt passes for the wrong
+    reason — `?? apps/` trips WIP no matter what the exemption says). Measured
+    both worlds side by side on 2026-08-07 before writing this. The real repo
+    tracks apps/mouth/src/**, so it is always the rich world.
+    """
+    (repo / "apps" / "mouth" / "src").mkdir(parents=True, exist_ok=True)
+    (repo / "apps" / "mouth" / "src" / "page.tsx").write_text("export {}\n")
+    (repo / ".gitignore").write_text("node_modules/\n")
+    _commit_in_worktree(repo, mod, ".", "seed mouth workspace")
+    subprocess.run(
+        ["git", "push", "origin", "main"], cwd=repo, check=True, capture_output=True
+    )
+    nm = repo / "apps" / "mouth" / "node_modules"
+    nm.mkdir(parents=True, exist_ok=True)
+    (nm / "placeholder.txt").write_text("x\n")
+    return nm
+
+
+def test_mouth_node_modules_is_symlinked_into_worktree(fake_repo):
+    """This is an npm WORKSPACE monorepo: a workspace package's own deps are
+    installed NESTED (`apps/mouth/node_modules/<pkg>`), not hoisted to the root.
+    Node resolves upward from the importing file, so symlinking ONLY the root
+    node_modules leaves `recharts` unresolvable and `npm run typecheck` — the
+    command the pre-commit hook runs on any staged apps/mouth TS/TSX — dies with
+    TS2307. Measured 2026-08-07: 5 of 37 live worktrees had this directory, each
+    because someone ran the install by hand.
+    """
+    mod, repo = fake_repo
+    nm = _seed_mouth_workspace(repo, mod)
+
+    wt = mod.cmd_create("mouth", "mouth-nm-link", ttl_minutes=5)
+    link = wt / "apps" / "mouth" / "node_modules"
+    assert link.is_symlink()
+    assert link.resolve() == nm.resolve()
+
+
+def test_mouth_node_modules_symlink_not_counted_as_wip(fake_repo):
+    """Innocence, and it reproduces the MINI condition on purpose.
+
+    On M5 and Pro this symlink reads as ignored only because a BARE
+    `node_modules` line sits in their `.git/info/exclude` — a local, untracked,
+    per-machine file. Mini has no such line (measured 2026-08-07: 0 matches),
+    and the repo's own .gitignore carries only the directory-only
+    `node_modules/`, which does not match a symlink-to-a-directory. This fake
+    repo has no local exclude either, so it stands in for Mini: without the
+    BROKER_GENERATED_FILES entry the worktree would read `?? apps/mouth/
+    node_modules` forever and `--cleanup` would WARN-skip it on every run.
+    """
+    mod, repo = fake_repo
+    _seed_mouth_workspace(repo, mod)
+
+    wt = mod.cmd_create("mouth", "mouth-nm-innocent", ttl_minutes=5)
+    assert (wt / "apps" / "mouth" / "node_modules").is_symlink()
+    # Premise check: git must actually be reporting the FULL path here, not a
+    # collapsed `?? apps/`. Without this the assertion below could pass in a
+    # world where the exemption is never consulted.
+    porcelain = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=wt, capture_output=True, text=True
+    ).stdout
+    assert "apps/mouth/node_modules" in porcelain or porcelain.strip() == "", porcelain
+    assert mod._worktree_has_wip(wt) is False
+
+
+def test_mouth_node_modules_exemption_does_not_mask_real_wip(fake_repo):
+    """Guilt: the new exemption must not swallow genuine WIP — including WIP
+    that lives INSIDE apps/mouth, next to the exempted path rather than at the
+    repo root, which is where a too-broad prefix match would go wrong."""
+    mod, repo = fake_repo
+    _seed_mouth_workspace(repo, mod)
+
+    wt = mod.cmd_create("mouth", "mouth-nm-guilty", ttl_minutes=5)
+    (wt / "apps" / "mouth" / "src" / "real_work.tsx").write_text("// uncommitted\n")
+    assert mod._worktree_has_wip(wt) is True
+
+
 def test_husky_shim_dir_symlinked_into_worktree(fake_repo):
     """`.husky/_` must reach every worktree or the pre-push gate is OFF there.
 


### PR DESCRIPTION
This is an npm **workspace** monorepo, so a workspace package's own deps
install **nested** at `apps/mouth/node_modules/<pkg>`, not hoisted to the root.
`recharts` lives only there. Node resolves upward from the importing file, so a
worktree that symlinks only the **root** `node_modules` still finds nothing and
`npm run typecheck` dies:

```
apps/mouth/src/components/analytics/FunnelChart.tsx(12,8):
  error TS2307: Cannot find module 'recharts' or its corresponding type declarations.
apps/mouth/src/components/hr/OwnerCashoutCharts.tsx(14,8): ...same
```

That is the command the **pre-commit hook** runs whenever `apps/mouth` TS/TSX is
staged. So every mouth lane hit a hard failure naming a package the lockfile
demonstrably resolves — and both obvious readings ("the lock is broken", "the
dep is missing") are wrong. **I published one of them as a finding earlier
today** before measuring properly; this is the actual cause.

Measured 2026-08-07: only **5 of 37** live worktrees had the directory, each
because someone ran the install by hand. Proven in a fresh broker-made
worktree, before and after: typecheck exits **2** without the symlink, **0**
with it, nothing else changed.

## The second entry is the one a single machine would have hidden

`apps/mouth/node_modules` also goes into `BROKER_GENERATED_FILES`, because a
symlink-to-a-directory is **not** matched by the repo's directory-only
`node_modules/` rule — the same trap the existing root-`node_modules` comment
was written about.

On M5 and Pro the symlink nevertheless reads as ignored — but only because a
**bare** `node_modules` line sits in their `.git/info/exclude`, a **local,
untracked, per-machine** file. Measured over ssh:

| machine | bare `node_modules` in `.git/info/exclude` |
|---|---|
| M5 | present (line 9) |
| Pro | present |
| **Mini** | **absent (0 matches)** |

So on Mini the entry would read `?? apps/mouth/node_modules` forever,
permanently tripping the WIP guard and making `--cleanup` a silent no-op. One
machine's clean `git status` was a machine-local accident, not evidence.

## Tests — and the fixture is the load-bearing part

Three added: symlink created · innocence (not WIP) · guilt (real WIP still
caught, placed **inside** `apps/mouth` where a too-broad prefix match would go
wrong).

**My first fixture was too poor and measured its own poverty.**
`git status --porcelain` **collapses** untracked directories to their
shallowest untracked ancestor, so with nothing tracked under `apps/`, git
reports `?? apps/` and never the full path:

```
rich tree (tracked file under apps/mouth, like the real repo):  ?? apps/mouth/node_modules
poor tree (my first fixture):                                   ?? apps/
```

That made innocence fail for the wrong reason **and guilt pass for the wrong
reason** — `?? apps/` trips WIP regardless of what the exemption says, so the
assertion was vacuous. Both worlds reproduced side by side before fixing it.
The helper now seeds a tracked `apps/mouth/src` file, and the innocence test
**asserts its own premise** (git really is reporting the full path) before
asserting the verdict.

## Mutation-verified

| mutation | result |
|---|---|
| drop the `SYMLINK_TARGETS` entry | **2 tests red** |
| drop the `BROKER_GENERATED_FILES` entry | **1 test red** |
| restored | **54 passed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
