### PR TITLE
fix(infra): ward-round #1 canon batch — HOME/repo reconciliation (B, C, E)

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -640,6 +640,9 @@
     "~/Library/Google/GoogleSoftwareUpdate/*",
     "~/scripts/mini-git-pull-bridge.sh",
     "~/Applications/WR2 Control.app/*",
-    "~/.local/bin/zero-design/*"
+    "~/.local/bin/zero-design/*",
+    "~/.openclaw-node-host/service-env/ai.openclaw.node-env-wrapper.sh",
+    "~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh",
+    "~/.claude/daemons/guardrails.py"
   ]
 }

--- a/infra/launchagents/com.nuzantara.verify-the-verifiers.plist
+++ b/infra/launchagents/com.nuzantara.verify-the-verifiers.plist
@@ -13,11 +13,13 @@
     </dict>
     <key>ProgramArguments</key>
     <array>
-        <string>/opt/homebrew/bin/python3</string>
+        <string>/Users/nuzantara/nuzantara-deploy/apps/backend-rag/.venv/bin/python</string>
         <string>/Users/nuzantara/nuzantara-deploy/scripts/verify_the_verifiers.py</string>
         <string>--scope</string>
         <string>all</string>
     </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/nuzantara/nuzantara-deploy</string>
     <key>StartInterval</key>
     <integer>600</integer>
     <key>RunAtLoad</key>

--- a/infra/launchagents/com.nuzantara.verify-the-verifiers.plist
+++ b/infra/launchagents/com.nuzantara.verify-the-verifiers.plist
@@ -13,10 +13,12 @@
     </dict>
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/nuzantara/nuzantara-deploy/apps/backend-rag/.venv/bin/python</string>
-        <string>/Users/nuzantara/nuzantara-deploy/scripts/verify_the_verifiers.py</string>
-        <string>--scope</string>
-        <string>all</string>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>
+set -euo pipefail
+exec "/Users/nuzantara/nuzantara-deploy/apps/backend-rag/.venv/bin/python" "/Users/nuzantara/nuzantara-deploy/scripts/verify_the_verifiers.py" --scope all
+</string>
     </array>
     <key>WorkingDirectory</key>
     <string>/Users/nuzantara/nuzantara-deploy</string>

--- a/infra/sync-daemons/memory-sync-bidirectional.sh
+++ b/infra/sync-daemons/memory-sync-bidirectional.sh
@@ -16,8 +16,8 @@ CONFLICT_DIR="$HOME/.claude/memory-conflicts"
 # --- Air-M5 spoke (added 2026-06-01) ---
 # M5 = user balizero, path memory diverso, SSH richiede IdentitiesOnly+IdentityAgent=none.
 M5_ENABLED="${M5_SYNC_ENABLED:-true}"   # kill switch: M5_SYNC_ENABLED=false
-M5_IP="192.168.0.20"
-M5_TS="100.87.146.107"                  # tailscale fallback
+M5_IP="Air-M5.local"   # mDNS primario (subnet-independent), 2026-06-13 fix subnet-split
+M5_TS="air-m5-2.tail461666.ts.net"   # MagicDNS stabile (no IP hardcoded) 2026-06-01
 M5_USER="balizero"
 MEM_M5_PATH="/Users/balizero/.claude/projects/-Users-balizero/memory"
 M5_SSH_OPTS="-o ConnectTimeout=5 -o IdentitiesOnly=yes -o IdentityAgent=none -o BatchMode=yes -i $HOME/.ssh/id_ed25519"

--- a/scripts/mata_garuda_invalidation_sweep_wrapper.sh
+++ b/scripts/mata_garuda_invalidation_sweep_wrapper.sh
@@ -50,9 +50,25 @@ if [[ -z "${DATABASE_URL:-}" ]]; then
     exit 3
 fi
 
+# Pro-only routing: prefer DATABASE_URL_LOCAL (127.0.0.1:15432 → fly proxy
+# to nuzantara-postgres.flycast). The flycast hostname only resolves
+# through wireguard, which we don't run as a daemon — instead we keep a
+# `fly proxy 15432:5432 -a nuzantara-postgres` process up on Pro. Hitting
+# the proxy port avoids the DNS dependency. Falls back to DATABASE_URL
+# (flycast direct) if DATABASE_URL_LOCAL is not exported, in which case
+# wireguard must be active.
+if [[ -n "${DATABASE_URL_LOCAL:-}" ]]; then
+    export DATABASE_URL="${DATABASE_URL_LOCAL}"
+fi
+
 # Find the venv python — sweep imports asyncpg lazily; fall back to
 # system python3 if venv is missing (asyncpg import will then fail
 # loud at runtime, captured in the launchd stderr log).
+#
+# Pro-local copy: resolve script directory via BASH_SOURCE so this works
+# regardless of which branch is checked out at ${HOME}/nuzantara.
+# REPO_ROOT used only for venv lookup + cwd.
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 REPO_ROOT="${HOME}/nuzantara"
 VENV_PY="${REPO_ROOT}/apps/backend-rag/.venv/bin/python3"
 if [[ -x "${VENV_PY}" ]]; then
@@ -62,4 +78,4 @@ else
 fi
 
 cd "${REPO_ROOT}"
-exec "${PYTHON}" "${REPO_ROOT}/scripts/mata_garuda_invalidation_sweep.py" "$@"
+exec "${PYTHON}" "${SCRIPT_DIR}/mata_garuda_invalidation_sweep.py" "$@"


### PR DESCRIPTION
## Summary

Executes the B/C/E groups of the lane-canon-batch mandate (ward-round #1, 2026-08-07 canon board — all upheld post-refute). A/D/F were machine-local arming actions, documented separately (not part of this PR).

- **B — promote HOME→repo** (HOME was ahead, not the usual story):
  - `scripts/mata_garuda_invalidation_sweep_wrapper.sh`: Pro-local `DATABASE_URL_LOCAL` fly-proxy routing + `BASH_SOURCE`-relative sibling-script resolution (was `${HOME}/nuzantara`-relative).
  - `infra/sync-daemons/memory-sync-bidirectional.sh`: mDNS/MagicDNS addressing for the M5 spoke (`Air-M5.local` / `air-m5-2.tail461666.ts.net`), the 2026-06-13 subnet-split fix that was applied directly to HOME and never committed.
  - Both verified byte-identical to the live HOME copy after the edit.

- **C — declared-pairs.json allow-list** (3 per-host control-plane payloads that were never meant to be repo payload):
  - `~/.openclaw-node-host/service-env/ai.openclaw.node-env-wrapper.sh`
  - `~/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh` (different HOME base dir from the node shim — verified against both live plists via `plutil`, not assumed)
  - `~/.claude/daemons/guardrails.py` (backs `com.balizero.guardrails-daemon.plist`, MCP-destructive-pattern guard)
  - Verified with `lint_home_fork.py --discover --config <this file>` that all three clear the undeclared-payload check.

- **E — verify-the-verifiers plist**: repo canon was the stale/wrong side (`/opt/homebrew/bin/python3` system Python, violates Golden Rule #1) — brought in line with the live, already-self-corrected venv interpreter + `WorkingDirectory`.

## Test plan
- [x] `lint_home_fork.py --discover` against the edited config: all 3 new allow entries clear
- [x] `plutil -lint` on the edited plist: OK
- [x] `bash -n` on both edited wrapper scripts: OK
- [x] Full backend suite via pre-push gate: green
- [ ] Fable final-gate review (per mandate: no automerge armed — merge is gated on review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>