### PR TITLE
fix(ops): cure 4 sensor_stale findings from ward-round 2026-08-07

### DIFF
--- a/scripts/launchagent_reconcile.py
+++ b/scripts/launchagent_reconcile.py
@@ -292,6 +292,71 @@ def canonical_for_compare(plist: dict) -> dict:
     return {k: v for k, v in plist.items() if k not in ENV_SPECIFIC_KEYS}
 
 
+# Install-time template placeholder, e.g. `__HOME__`, `__REPO_ROOT__/scripts/x.sh`.
+# A handful of repo canons (com.balizero.drive-intake-drain,
+# com.balizero.dropbox-intake, com.balizero.wr2.ig-metrics-scrape.daily) ship
+# with these tokens INSIDE ProgramArguments — not just EnvironmentVariables,
+# the only place ENV_SPECIFIC_KEYS already excludes — so a correctly-installed
+# live plist (tokens substituted with real paths) diffed byte-for-byte against
+# its own template canon reads as permanently "repo-divergent". Ward-round
+#2026-08-07, repo-divergent-placeholder-template-false-positive.
+_TEMPLATE_PLACEHOLDER_RE = re.compile(r"__[A-Z0-9_]+__")
+
+
+def _mask_templated(canon_value, live_value):
+    """Recursively mask fields whose CANON side is a template placeholder.
+
+    Only the CANON string decides whether a field is templated — if it
+    contains a `__TOKEN__` pattern, BOTH sides are replaced with the same
+    sentinel so the field can never register as a diff, regardless of what
+    the installer actually substituted (this function does not need to know
+    the correct value, only that canon says "this varies at install time").
+
+    Structural shape must still agree for the mask to apply: a placeholder
+    never hides a live value of the wrong type/length (e.g. live missing an
+    argv element, or an extra key live-only) — that stays a real diff, which
+    is exactly how genuine drift keeps getting caught.
+    """
+    if isinstance(canon_value, str):
+        if _TEMPLATE_PLACEHOLDER_RE.search(canon_value):
+            return "<template>", "<template>"
+        return canon_value, live_value
+    if (
+        isinstance(canon_value, list)
+        and isinstance(live_value, list)
+        and len(canon_value) == len(live_value)
+    ):
+        masked_canon, masked_live = [], []
+        for cv, lv in zip(canon_value, live_value):
+            mc, ml = _mask_templated(cv, lv)
+            masked_canon.append(mc)
+            masked_live.append(ml)
+        return masked_canon, masked_live
+    if isinstance(canon_value, dict) and isinstance(live_value, dict):
+        masked_canon, masked_live = {}, {}
+        for k, cv in canon_value.items():
+            if k in live_value:
+                mc, ml = _mask_templated(cv, live_value[k])
+                masked_canon[k] = mc
+                masked_live[k] = ml
+            else:
+                masked_canon[k] = cv  # live missing the key: real diff, preserved
+        for k, lv in live_value.items():
+            if k not in canon_value:
+                masked_live[k] = lv  # live-only key: real diff, preserved
+        return masked_canon, masked_live
+    return canon_value, live_value
+
+
+def plists_equivalent(live_plist: dict, repo_plist: dict) -> bool:
+    """True iff live and repo-canon agree once env-specific keys and
+    install-time template placeholders are both accounted for."""
+    lc = canonical_for_compare(live_plist)
+    cc = canonical_for_compare(repo_plist)
+    masked_canon, masked_live = _mask_templated(cc, lc)
+    return masked_canon == masked_live
+
+
 def name_stamp_age_days(name: str, now: datetime) -> Optional[float]:
     """Age from a YYYYMMDD embedded in the filename, if any."""
     m = _NAME_STAMP_RE.search(name)
@@ -474,7 +539,7 @@ def reconcile(
                 repo_symlinked.append(f.name)
             else:
                 repo_plist = parse_plist(twin)
-                if repo_plist is not None and canonical_for_compare(plist) != canonical_for_compare(repo_plist):
+                if repo_plist is not None and not plists_equivalent(plist, repo_plist):
                     repo_divergent.append({"label": label, "file": f.name})
 
     return {

--- a/scripts/launchd_liveness_detector.py
+++ b/scripts/launchd_liveness_detector.py
@@ -504,6 +504,48 @@ def _disabled_verdict(verdict: str, label: str, disabled_labels: set[str]) -> st
     return verdict
 
 
+# Labels whose non-zero LastExitStatus is an intentional REPORT, not a
+# crash — same convention organism_stale_detector.py's KNOWN_BENIGN_FAILED
+# already documents for pro.audit_launchd_daily ("exit 1 BY DESIGN = N
+# unhealthy jobs found"). Without this, each of these reads FAILING-HONESTLY
+# forever even on a run that behaved exactly as designed. Ward-round
+# 2026-08-07 (audit-launchd-daily-exit-by-design,
+# launchd-liveness-detector-self-flag) found 4:
+#   - com.balizero.audit-launchd.daily: exit reflects the unhealthy-job
+#     COUNT it just found — a true report, not a wrapper crash.
+#   - com.nuzantara.mcp-integrity: exit encodes RED/YELLOW/GREEN
+#     connectivity drift against a moving baseline, not a wrapper failure.
+#   - com.nuzantara.launchd-liveness-detector.daily: THIS detector's OWN
+#     cron. `main()` returns 1 whenever audit() finds an alarm-worthy job
+#     ELSEWHERE (`return 1 if alarms else 0`) — so a day with a real finding
+#     anywhere else makes the detector's own entry read FAILING-HONESTLY,
+#     self-flagging it for correctly reporting on something else.
+#   - com.balizero.zoho-mail-loop.daily: exit encodes a DEGRADED count for
+#     the day (draft failures), same convention as the W114/W115/W116 fixes.
+# Audit this list whenever a label is re-armed for a different purpose — a
+# genuinely broken job must NOT be added here to silence it.
+EXPECTED_NONZERO_LABELS: frozenset[str] = frozenset({
+    "com.balizero.audit-launchd.daily",
+    "com.nuzantara.mcp-integrity",
+    "com.nuzantara.launchd-liveness-detector.daily",
+    "com.balizero.zoho-mail-loop.daily",
+})
+
+
+def _expected_nonzero_verdict(verdict: str, label: str) -> str:
+    """Override FAILING-HONESTLY with EXPECTED-NONZERO for labels whose
+    non-zero exit is a documented reporting convention, not a crash.
+
+    Scoped STRICTLY to FAILING-HONESTLY, mirroring _disabled_verdict's own
+    scoping discipline: DEAD-GREEN / DEAD-NONZERO / ARMED-TO-NOTHING rest on
+    stronger evidence (a launch-failure marker, a missing program) that this
+    allowlist does not explain away — a listed label that starts showing one
+    of THOSE verdicts is still a real finding."""
+    if verdict == "FAILING-HONESTLY" and label in EXPECTED_NONZERO_LABELS:
+        return "EXPECTED-NONZERO"
+    return verdict
+
+
 def audit() -> list[dict]:
     findings: list[dict] = []
     if not LAUNCHAGENTS.exists():
@@ -542,6 +584,9 @@ def audit() -> list[dict]:
         # 2026-07-18 fix: a deliberate `launchctl disable` reads as DISABLED,
         # not NOT-LOADED — see _disabled_verdict.
         verdict = _disabled_verdict(verdict, label, disabled_labels)
+        # 2026-08-07 fix: a documented by-design non-zero exit reads as
+        # EXPECTED-NONZERO, not FAILING-HONESTLY — see _expected_nonzero_verdict.
+        verdict = _expected_nonzero_verdict(verdict, label)
 
         findings.append({
             "label": label,
@@ -604,6 +649,7 @@ def main() -> int:
                 flag = (
                     "🚨" if f["verdict"] in ALARM_VERDICTS
                     else "⛔" if f["verdict"] == "DISABLED"
+                    else "ℹ️ " if f["verdict"] == "EXPECTED-NONZERO"
                     else "⚠️ " if f["verdict"] == "FAILING-HONESTLY"
                     else "♻️ " if f["verdict"] == "RECOVERED"
                     else "✓ "
@@ -615,6 +661,8 @@ def main() -> int:
                     print(f"        ↳ program missing: {f['program']}")
                 if f["verdict"] == "DISABLED":
                     print("        ↳ deliberate disarm — launchctl disable (not an alarm)")
+                if f["verdict"] == "EXPECTED-NONZERO":
+                    print("        ↳ non-zero exit is a documented report, not a crash")
             print("\nDEAD-GREEN = launchd exit 0 but the log proves the worker never ran")
             print("(the W84 TCC vector). Cure is OPERATOR-ONLY: grant the launchd context")
             print("Full Disk Access in System Settings, OR relocate the wrapper outside ~/Desktop.")

--- a/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
+++ b/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Proof for the pg-proxy guard's success-path heartbeat in
+# scripts/wr2-cron-wrapper.sh.
+#
+# TRAUMA (ward-round 2026-08-07, id wr2_wrapper_guard_pg_proxy_stale, upheld
+# sensor_stale). GUARD_ORGAN_ID's sidecar was write-ONLY-on-failure: both
+# guard branches (DATABASE_URL_LOCAL absent, pg-proxy unreachable) called
+# `organism_heartbeat "$GUARD_ORGAN_ID" "error" ...`, but nothing ever wrote
+# "ok" when the guard passed. A heartbeat that can only ever say "error" can
+# never clear itself — one historical trip reads as N days of ongoing outage
+# even after the very next run passes clean (superscar #2, W110-adjacent: a
+# sidecar that never speaks on the happy path is a guardian aimed at silence).
+#
+# W107 family-check (done in the prose that shipped alongside this test, not
+# repeated here as code): every OTHER wrapper calling organism_heartbeat on
+# error (scripts/outbox-prune.sh, scripts/agent_worktree_cleanup_cron.sh)
+# already pairs it with an "ok" call on its success path. wr2-cron-wrapper.sh
+# was the only sibling missing it — this is a single-site fix, not a class fix.
+#
+# GUILT      — pg-proxy unreachable still writes "error" (regression guard on
+#              the branch the fix sits next to).
+# INNOCENCE  — DATABASE_URL_LOCAL absent (the OTHER guard, same organ id)
+#              still writes its own "error" and must NOT be clobbered by the
+#              new line, because that branch exits before reaching it.
+# THE FIX    — pg-proxy reachable writes "ok" with a note, before the module
+#              even runs.
+# SELF-HEAL  — a prior "error" trip is overwritten by "ok" on the next good
+#              run (heartbeat.sh's own contract: atomic overwrite, not append)
+#              — this is the actual behavior ward-round asked for: the sidecar
+#              must be able to clear itself.
+#
+# Run: bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER_SRC="$SCRIPT_DIR/wr2-cron-wrapper.sh"
+HEARTBEAT_SRC="$SCRIPT_DIR/lib/heartbeat.sh"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n     -> %s\n' "$1" "${2:-}"; }
+
+# ---------------------------------------------------------------- fake world
+# Real heartbeat.sh copied in (not stubbed) — the whole point of this test is
+# that the sidecar actually gets written, so a no-op stub would prove nothing.
+make_world() {  # make_world <nc_exit>
+    local nc_exit="$1"
+    W="$(mktemp -d)"
+    mkdir -p "$W/scripts/lib" "$W/repo/scripts/lib" \
+             "$W/repo/apps/backend-rag/.venv/bin" "$W/bin" "$W/logs" "$W/organism"
+    cp "$WRAPPER_SRC" "$W/scripts/wr2-cron-wrapper.sh"
+    cp "$HEARTBEAT_SRC" "$W/repo/scripts/lib/heartbeat.sh"
+
+    # Module interpreter: exits 0 (module "succeeds" — irrelevant to what
+    # this test checks, which all happens before the module ever runs).
+    printf '#!/bin/sh\nexit 0\n' > "$W/repo/apps/backend-rag/.venv/bin/python"
+    chmod +x "$W/repo/apps/backend-rag/.venv/bin/python"
+
+    printf '#!/bin/sh\nexit %s\n' "$nc_exit" > "$W/bin/nc"
+    chmod +x "$W/bin/nc"
+
+    printf 'DATABASE_URL_LOCAL=postgres://x@127.0.0.1:15432/y\n' > "$W/secrets.env"
+}
+
+run_wrapper() {
+    env NUZANTARA_REPO_ROOT="$W/repo" \
+        NUZANTARA_SECRETS="$W/secrets.env" \
+        ORGANISM_LAST_SEEN_DIR="$W/organism" \
+        WR2_LOG_DIR="$W/logs" \
+        WR2_CRON_ALERT=false \
+        PATH="$W/bin:$PATH" \
+        HOME="$W" \
+        bash "$W/scripts/wr2-cron-wrapper.sh" "$@" >"$W/stdout.txt" 2>"$W/stderr.txt"
+    echo $?
+}
+
+sidecar_status() {  # sidecar_status <organ_id>
+    python3 -c '
+import json, sys
+try:
+    print(json.load(open(sys.argv[1]))["status"])
+except Exception:
+    print("<missing>")
+' "$W/organism/$1.json" 2>/dev/null
+}
+
+ORGAN="pro.wr2_wrapper_guard.some.module"
+
+echo
+echo "wr2-cron-wrapper pg-proxy guard heartbeat"
+echo
+
+# ------------------------------------------------------------------- GUILT
+make_world 1   # nc fails: pg-proxy unreachable
+rc="$(run_wrapper some.module)"
+st="$(sidecar_status "$ORGAN")"
+if [[ "$rc" == "74" && "$st" == "error" ]]; then
+    ok "GUILT: pg-proxy unreachable still writes status=error"
+else
+    bad "GUILT: pg-proxy unreachable" "rc=$rc status=$st"
+fi
+
+# --------------------------------------------------------------- INNOCENCE
+# The OTHER guard on the same organ id (DATABASE_URL_LOCAL absent) exits
+# before ever reaching the new success-path line — must still read "error",
+# never silently upgraded to "ok" by a fix that sits three lines below it.
+make_world 0
+printf '' > "$W/secrets.env"   # DATABASE_URL_LOCAL absent
+rc="$(run_wrapper some.module)"
+st="$(sidecar_status "$ORGAN")"
+if [[ "$rc" == "74" && "$st" == "error" ]]; then
+    ok "INNOCENCE: DATABASE_URL_LOCAL guard (same organ id) still error, not ok"
+else
+    bad "INNOCENCE: DATABASE_URL_LOCAL guard" "rc=$rc status=$st"
+fi
+
+# ------------------------------------------------------------------ THE FIX
+make_world 0   # nc succeeds: pg-proxy reachable
+rc="$(run_wrapper some.module)"
+st="$(sidecar_status "$ORGAN")"
+if [[ "$rc" == "0" && "$st" == "ok" ]]; then
+    ok "FIX: pg-proxy reachable writes status=ok — the sidecar now has a voice"
+else
+    bad "FIX: pg-proxy reachable" "rc=$rc status=$st"
+fi
+
+# --------------------------------------------------------------- SELF-HEAL
+# The whole point: a prior error trip must clear on the next good run,
+# because heartbeat.sh overwrites atomically rather than appending.
+make_world 1
+run_wrapper some.module >/dev/null
+st1="$(sidecar_status "$ORGAN")"
+printf '#!/bin/sh\nexit 0\n' > "$W/bin/nc"; chmod +x "$W/bin/nc"
+rc="$(run_wrapper some.module)"
+st2="$(sidecar_status "$ORGAN")"
+if [[ "$st1" == "error" && "$rc" == "0" && "$st2" == "ok" ]]; then
+    ok "SELF-HEAL: an error sidecar clears to ok on the next good run"
+else
+    bad "SELF-HEAL: sidecar did not clear" "st1=$st1 rc=$rc st2=$st2"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/tests/test_launchagent_reconcile.py
+++ b/scripts/tests/test_launchagent_reconcile.py
@@ -490,6 +490,40 @@ def test_env_specific_keys_do_not_diverge(world):
     assert r["repo_divergent"] == []
 
 
+def test_template_placeholder_innocent_when_substituted_correctly(world):
+    """Ward-round 2026-08-07, repo-divergent-placeholder-template-false-positive:
+    canon ships install-time tokens (__HOME__, __REPO_ROOT__) INSIDE
+    ProgramArguments, not just EnvironmentVariables — a correctly-installed
+    live plist (tokens substituted) must not read as forever-divergent."""
+    name = "com.balizero.templated.plist"
+    write_plist(
+        world["agents"] / name, "com.balizero.templated",
+        program_args=["/bin/bash", "/Users/nuzantara/nuzantara/scripts/x.sh"],
+    )
+    write_plist(
+        world["repo"] / "infra" / "launchagents" / name, "com.balizero.templated",
+        program_args=["/bin/bash", "__REPO_ROOT__/scripts/x.sh"],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert r["repo_divergent"] == []
+
+
+def test_template_placeholder_does_not_mask_a_real_argv_change(world):
+    """Guilt twin: a placeholder element must not give the WHOLE argv list a
+    free pass — a genuinely different, non-template element must still flag."""
+    name = "com.balizero.templated2.plist"
+    write_plist(
+        world["agents"] / name, "com.balizero.templated2",
+        program_args=["/bin/bash", "/Users/nuzantara/nuzantara/scripts/x.sh", "--live-only-flag"],
+    )
+    write_plist(
+        world["repo"] / "infra" / "launchagents" / name, "com.balizero.templated2",
+        program_args=["/bin/bash", "__REPO_ROOT__/scripts/x.sh", "--repo-only-flag"],
+    )
+    r = run_reconcile(world, loaded=None)
+    assert [d["file"] for d in r["repo_divergent"]] == [name]
+
+
 def test_symlinked_repo_plist_never_divergent(world):
     name = "com.balizero.linked.plist"
     twin = world["repo"] / "infra" / "launchagents" / name

--- a/scripts/tests/test_launchd_liveness_expected_nonzero.py
+++ b/scripts/tests/test_launchd_liveness_expected_nonzero.py
@@ -1,0 +1,212 @@
+"""Ward-round 2026-08-07: `audit-launchd-daily-exit-by-design` +
+`launchd-liveness-detector-self-flag`, both upheld sensor_stale.
+
+`_classify()` correctly distinguishes DEAD-GREEN/DEAD-NONZERO (a launch
+failure marker in the log) from FAILING-HONESTLY (a non-zero exit with no
+such marker — "the job ran, and is telling the truth about failing"). But
+four labels have a non-zero exit that is not a failure at all: it is the
+job's own reporting convention.
+
+  - com.balizero.audit-launchd.daily: exit = the COUNT of unhealthy jobs it
+    found that run (organism_stale_detector.py's KNOWN_BENIGN_FAILED already
+    documents the identical convention for pro.audit_launchd_daily's sidecar).
+  - com.nuzantara.mcp-integrity: exit encodes RED/YELLOW/GREEN drift against
+    a moving connectivity baseline.
+  - com.nuzantara.launchd-liveness-detector.daily: THIS detector's own cron —
+    `main()` returns 1 whenever audit() finds an alarm-worthy job ELSEWHERE,
+    so a day with one real finding self-flags the detector's own entry too.
+  - com.balizero.zoho-mail-loop.daily: exit encodes a DEGRADED draft-failure
+    count for the day (W114/W115/W116 convention).
+
+Contract under test (EXPECTED_NONZERO_LABELS / _expected_nonzero_verdict):
+  - guilt: a FAILING-HONESTLY verdict for a listed label becomes
+    EXPECTED-NONZERO, and EXPECTED-NONZERO does not increment alarms
+  - innocence: a FAILING-HONESTLY verdict for an UNLISTED label stays
+    FAILING-HONESTLY — a bare-substring or wildcard match here would
+    silently swallow a real chronic failure
+  - innocence: any OTHER verdict (DEAD-GREEN, DEAD-NONZERO,
+    ARMED-TO-NOTHING, OK, RECOVERED, DISABLED) is left untouched even for a
+    listed label — those verdicts rest on independent evidence a reporting
+    convention does not explain away
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "launchd_liveness_detector.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("launchd_liveness_detector", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ------------------------------------------------------- _expected_nonzero_verdict
+
+
+def test_failing_honestly_becomes_expected_nonzero_for_listed_label():
+    """Guilt: FAILING-HONESTLY + label in EXPECTED_NONZERO_LABELS -> EXPECTED-NONZERO."""
+    mod = _load_module()
+    for label in mod.EXPECTED_NONZERO_LABELS:
+        assert mod._expected_nonzero_verdict("FAILING-HONESTLY", label) == "EXPECTED-NONZERO"
+
+
+def test_expected_nonzero_is_not_an_alarm_verdict():
+    """Guilt (structural): EXPECTED-NONZERO must never be added to
+    ALARM_VERDICTS — that's what makes the override actually silence the
+    noise instead of just relabeling it."""
+    mod = _load_module()
+    assert "EXPECTED-NONZERO" not in mod.ALARM_VERDICTS
+
+
+def test_all_four_ward_round_labels_are_covered():
+    """Guilt (regression pin): the exact 4 labels the 2026-08-07 ward-round
+    named must be on the allowlist — a future edit that drops one silently
+    reopens that finding."""
+    mod = _load_module()
+    assert mod.EXPECTED_NONZERO_LABELS == {
+        "com.balizero.audit-launchd.daily",
+        "com.nuzantara.mcp-integrity",
+        "com.nuzantara.launchd-liveness-detector.daily",
+        "com.balizero.zoho-mail-loop.daily",
+    }
+
+
+def test_failing_honestly_stays_failing_honestly_for_unlisted_label():
+    """Innocence: a genuinely chronic non-zero-exit job (not on the
+    allowlist) must keep reading FAILING-HONESTLY — the override must not
+    be a blanket 'any non-zero exit is fine' pass."""
+    mod = _load_module()
+    verdict = mod._expected_nonzero_verdict(
+        "FAILING-HONESTLY", "com.nuzantara.some-other-cron.daily"
+    )
+    assert verdict == "FAILING-HONESTLY"
+
+
+def test_other_verdicts_untouched_even_for_a_listed_label():
+    """Innocence: DEAD-GREEN / DEAD-NONZERO / ARMED-TO-NOTHING / OK /
+    RECOVERED / DISABLED are never rewritten to EXPECTED-NONZERO, even for a
+    label that IS on the allowlist — those verdicts carry independent
+    evidence a reporting convention doesn't explain away. A label re-armed
+    for a different, genuinely broken purpose must still alarm."""
+    mod = _load_module()
+    label = "com.balizero.audit-launchd.daily"
+    for other in ("DEAD-GREEN", "DEAD-NONZERO", "ARMED-TO-NOTHING",
+                  "OK", "RECOVERED", "DISABLED"):
+        assert mod._expected_nonzero_verdict(other, label) == other
+
+
+def test_empty_allowlist_membership_never_overrides():
+    """Innocence (2nd shape): an arbitrary label not on the allowlist at all
+    stays untouched regardless of verdict."""
+    mod = _load_module()
+    assert mod._expected_nonzero_verdict("FAILING-HONESTLY", "com.anything.here") == "FAILING-HONESTLY"
+
+
+# --------------------------------------------------------------- audit() wiring
+
+
+def _write_minimal_plist(path: Path, label: str) -> None:
+    import plistlib
+    path.write_bytes(plistlib.dumps({
+        "Label": label,
+        "ProgramArguments": ["/bin/echo"],
+        "RunAtLoad": True,
+    }))
+
+
+def test_audit_reports_expected_nonzero_and_does_not_alarm(tmp_path, monkeypatch):
+    """Guilt, end-to-end: a plist for a listed label, loaded, non-zero exit,
+    no log-failure marker, no missing program -> EXPECTED-NONZERO in
+    audit(), and that finding does not count toward alarms."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "LAUNCHAGENTS", tmp_path)
+    label = "com.nuzantara.mcp-integrity"
+    plist_path = tmp_path / f"{label}.plist"
+    _write_minimal_plist(plist_path, label)
+    # ProgramArguments[0] must resolve so `prog_exists` is True (otherwise
+    # _classify short-circuits to ARMED-TO-NOTHING before ever reaching the
+    # FAILING-HONESTLY branch this test targets).
+    monkeypatch.setattr(mod, "_program_path", lambda plist: "/bin/echo")
+
+    def _fake_run(cmd, **kwargs):
+        class _R:
+            returncode = 0
+            stdout = ""
+
+        if cmd[0] == "plutil":
+            r = _R()
+            r.stdout = label
+            return r
+        if cmd[0] == "launchctl" and cmd[1] == "print-disabled":
+            r = _R()
+            r.stdout = ""
+            return r
+        if cmd[0] == "launchctl" and cmd[1] == "list":
+            # `launchctl list <label>` — loaded, non-zero LastExitStatus, no PID.
+            r = _R()
+            r.stdout = (
+                '{\n\t"LastExitStatus" = 256;\n\t"Label" = "%s";\n}\n' % label
+            )
+            return r
+        r = _R()
+        r.returncode = 1
+        r.stdout = ""
+        return r
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(mod, "_log_has_failure_marker", lambda logs: None)
+    monkeypatch.setattr(mod, "_log_paths", lambda plist: [])
+    findings = mod.audit()
+    assert len(findings) == 1
+    assert findings[0]["verdict"] == "EXPECTED-NONZERO"
+    alarms = [f for f in findings if f["verdict"] in mod.ALARM_VERDICTS]
+    assert alarms == []
+
+
+def test_audit_reports_failing_honestly_for_unlisted_label_with_same_shape(tmp_path, monkeypatch):
+    """Innocence, end-to-end: the EXACT same loaded/non-zero/no-marker shape
+    for a label NOT on the allowlist still shows FAILING-HONESTLY, and does
+    not alarm (matching the pre-existing behavior this fix must not change
+    for anyone else) — proves the override is label-scoped, not shape-scoped."""
+    mod = _load_module()
+    monkeypatch.setattr(mod, "LAUNCHAGENTS", tmp_path)
+    label = "com.nuzantara.some-other-cron.daily"
+    plist_path = tmp_path / f"{label}.plist"
+    _write_minimal_plist(plist_path, label)
+    monkeypatch.setattr(mod, "_program_path", lambda plist: "/bin/echo")
+
+    def _fake_run(cmd, **kwargs):
+        class _R:
+            returncode = 0
+            stdout = ""
+
+        if cmd[0] == "plutil":
+            r = _R()
+            r.stdout = label
+            return r
+        if cmd[0] == "launchctl" and cmd[1] == "print-disabled":
+            r = _R()
+            r.stdout = ""
+            return r
+        if cmd[0] == "launchctl" and cmd[1] == "list":
+            r = _R()
+            r.stdout = (
+                '{\n\t"LastExitStatus" = 256;\n\t"Label" = "%s";\n}\n' % label
+            )
+            return r
+        r = _R()
+        r.returncode = 1
+        r.stdout = ""
+        return r
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    monkeypatch.setattr(mod, "_log_has_failure_marker", lambda logs: None)
+    monkeypatch.setattr(mod, "_log_paths", lambda plist: [])
+    findings = mod.audit()
+    assert len(findings) == 1
+    assert findings[0]["verdict"] == "FAILING-HONESTLY"

--- a/scripts/wr2-cron-wrapper.sh
+++ b/scripts/wr2-cron-wrapper.sh
@@ -226,6 +226,15 @@ if ! nc -z 127.0.0.1 15432 2>/dev/null; then
     organism_heartbeat "$GUARD_ORGAN_ID" "error" "pg-proxy 127.0.0.1:15432 unreachable"
     exit 74
 fi
+# Guard passed: clear the sidecar on the success path too. Until now this
+# organ only ever wrote "error" — a write-once-on-failure heartbeat that can
+# never self-heal, so a single historical trip reads as 17+ days of ongoing
+# outage even after the very next run passes clean (ward-round 2026-08-07,
+# wr2_wrapper_guard_pg_proxy_stale). Family-checked (W107): every OTHER
+# wrapper that calls organism_heartbeat on error (outbox-prune.sh,
+# agent_worktree_cleanup_cron.sh) already pairs it with an "ok" call on its
+# success path — this wrapper was the only sibling missing it.
+organism_heartbeat "$GUARD_ORGAN_ID" "ok" "pg-proxy reachable"
 
 # 3. Repo + venv + exec
 cd "$REPO_ROOT/apps/backend-rag"


### PR DESCRIPTION
## Summary
Cures 4 `sensor_stale` findings from the 2026-08-07 ward-round triage (worklist ids: `wr2_wrapper_guard_pg_proxy_stale`, `wr2_newsletter_heartbeat_unreachable_home`, `repo-divergent-placeholder-template-false-positive`, `audit-launchd-daily-exit-by-design` + `launchd-liveness-detector-self-flag`). Principle: the heartbeat CHANNEL was dead/miswired in each case, not the underlying organ — cure lives in the writer/reader of the signal, never a restart.

1. **scripts/wr2-cron-wrapper.sh**: the pg-proxy guard organ (`pro.wr2_wrapper_guard.*`) only ever wrote `organism_heartbeat(..., "error", ...)` on its two failure branches — there was no `"ok"` call on the success path, so a single historical trip could never self-clear and read as N days of fake ongoing outage. Added the missing `organism_heartbeat "$GUARD_ORGAN_ID" "ok" "pg-proxy reachable"` right after the `nc -z` check passes. New test `scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh` (guilt/innocence/fix/self-heal, run against the real `scripts/lib/heartbeat.sh`, not a stub).

2. **wr2.newsletter stale sidecar** (live-state fix, not in this diff): confirmed the `wr2.newsletter` organ is already `enabled: false` in `apps/organism/organism/organs_registry.yaml` (retired 2026-07-15) but Pro's local sidecar fossil `~/.organism/last_seen/wr2.newsletter.json` (last written 2026-07-14, before the architecture moved fully into the Fly container) kept getting flagged stale by `scripts/organism_stale_detector.py`, which scans the sidecar directory directly and has no concept of the registry's `enabled` flag. Renamed the fossil to `wr2.newsletter.json.retired-20260807`, mirroring the exact existing precedent for `mata_garuda.redis_split_brain_check.json.retired-20260717` — `organism_stale_detector.py --json` now reports zero newsletter findings. **Separately discovered and NOT fixed here** (flagged to the team via `mem save`): the OLD `com.balizero.wr2.newsletter` LaunchAgent is still loaded and has been successfully delivering the daily newsletter via `fly ssh console` since ~2026-07-26 (repaired incidentally by the W106 fly_credential.sh fix) — AT THE SAME TIME the 2026-07-15 in-process `daily_task.py` replacement is *also* confirmed alive (`system_settings.newsletter_daily_task_last`, ran 2026-08-06T18:29:59 UTC, ok=true). There is no idempotency guard between the two paths, so subscribers likely receive the daily digest twice per day. Recommend a follow-up: `launchctl bootout com.balizero.wr2.newsletter` + archive the plist.

3. **scripts/launchagent_reconcile.py**: `canonical_for_compare()` only excluded whole top-level keys (EnvironmentVariables, *Path, WorkingDirectory) from the repo-canon diff, with no concept of an inline `__TOKEN__` install-time placeholder inside a `ProgramArguments` string. Three canons (`com.balizero.drive-intake-drain`, `com.balizero.dropbox-intake`, `com.balizero.wr2.ig-metrics-scrape.daily`) ship `__HOME__`/`__REPO_ROOT__` tokens inside ProgramArguments, so their correctly-installed live plists read permanently `repo-divergent`. Added `_mask_templated()` (recursively masks any leaf whose CANON string contains a placeholder pattern, on both sides, before comparing — never needs to know the true substituted value, only that canon declares the field templated; structural shape still has to agree, so a real change next to a placeholder still flags) and `plists_equivalent()`. Verified live: the 3 false positives are gone; the 2 remaining repo-divergent entries are real drift already tracked separately. Two new tests (innocence + guilt).

4. **scripts/launchd_liveness_detector.py**: `_classify()` correctly separates a proven launch failure from a bare non-zero exit (`FAILING-HONESTLY`), but 4 labels have a non-zero exit that is a documented reporting convention, not a crash — including the detector's OWN cron (`com.nuzantara.launchd-liveness-detector.daily`), which self-flags every time `audit()` finds a real alarm anywhere else. Added `EXPECTED_NONZERO_LABELS` + `_expected_nonzero_verdict()`, mirroring the existing `_disabled_verdict()` override pattern (scoped strictly to `FAILING-HONESTLY`; `EXPECTED-NONZERO` is not in `ALARM_VERDICTS`). No wrapper touched — cure lives entirely in the reader, per the mandate. New test file mirrors `test_launchd_liveness_disabled_verdict.py`: unit guilt/innocence, a regression pin on the exact 4 labels, and 2 end-to-end `audit()` cases. Full `test_launchd_liveness*.py` suite: 62/62 green.

## Test plan
- [x] `bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh` — 4/4 passed (guilt/innocence/fix/self-heal)
- [x] `bash scripts/test_wr2_wrapper_alert.sh` — 10/10 passed, no regression
- [x] `pytest scripts/tests/test_launchagent_reconcile.py` — 37/37 passed
- [x] `pytest scripts/tests/test_launchd_liveness*.py` — 62/62 passed
- [x] Live-verified against real machine state: `organism_stale_detector.py`, `launchagent_reconcile.py`, `launchd_liveness_detector.py` all re-run post-fix and confirmed the targeted findings cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)