### PR TITLE
fix(newsletter): idempotency guard against same-day double-send

### DIFF
--- a/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
+++ b/apps/backend-rag/backend/services/newsletter/newsletter_cli.py
@@ -28,7 +28,26 @@ NEWSLETTER_SUBJECT_PREFIX  optional prefix prepended to the subject (e.g. "[TEST
 Exit codes:
     0  sent (even if 0 recipients — log-only)
     1  config / pool init error
-    2  empty roundup/digest → nothing sent
+    2  empty roundup/digest → nothing sent (includes "already sent today")
+
+Idempotency (daily digest only, added 2026-08-07)
+--------------------------------------------------
+Two independent schedulers can call ``_run_daily`` for the same UTC calendar
+day: the legacy Pro LaunchAgent (``com.balizero.wr2.newsletter``, disarmed
+2026-08-07 but this guard survives it deliberately — HOME-fork drift, scar
+family #1, can silently reload a plist) via this CLI's ``--daily`` path, and
+the in-process ``daily_task.py`` loop (``_run_once`` calls ``_run_daily``
+directly). Neither ``send_daily_digest`` nor ``build_daily`` de-duplicates —
+confirmed live 2026-08-07: the old cron fired 00:00 UTC and the in-process
+loop fired 18:30 UTC the same UTC day, ~5.5h apart, both against a 48h
+lookback window with no "already included" filter, so the two runs' item
+sets overlap almost entirely. ``_already_sent_today``/``_mark_sent_today``
+close that gap using the SAME state mechanism ``daily_task.py`` already uses
+for its own receipt (``system_settings``, key/value/updated_at) — no new
+lock/queue invented. The claim is written BEFORE the send attempt (not
+after) so a slow first sender still wins the race against a second
+invocation that starts moments later; a caller that finds the day already
+claimed skips without touching the network.
 """
 
 from __future__ import annotations
@@ -39,6 +58,7 @@ import json
 import logging
 import os
 import sys
+from datetime import date, datetime, timezone
 
 import asyncpg
 
@@ -50,6 +70,13 @@ from backend.services.newsletter.publisher import NewsletterPublisher
 logger = logging.getLogger("newsletter.cli")
 
 DEFAULT_RECIPIENT = "zero@balizero.com"
+
+# system_settings key recording the last UTC calendar day the daily digest
+# was actually claimed for sending. Distinct from daily_task.py's
+# "newsletter_daily_task_last" (that one records ITS OWN last cycle outcome,
+# written by only one caller); this key is the cross-caller dedup guard both
+# the CLI path and the in-process loop consult and update.
+_DAILY_SENT_KEY = "newsletter_daily_digest_last_sent_day"
 
 
 def _hb(status: str, note: str = "") -> None:
@@ -92,6 +119,58 @@ def _recipients_from_env() -> list[str]:
     return recipients
 
 
+async def _already_sent_today(pool: asyncpg.Pool, day: date) -> bool:
+    """True if the daily digest for ``day`` was already claimed by some caller.
+
+    Read-only probe — never raises past the caller. On any DB error, returns
+    False (fail-open to "not yet sent"): a transient read failure must not
+    silently swallow a legitimate send (scar family #8 — never crash/starve
+    a task over a flaky connection). The real backstop against a genuine
+    duplicate under a DB outage is that BOTH schedulers would need to be
+    invoked within the outage window, same as before this guard existed.
+    """
+    try:
+        row = await pool.fetchrow("SELECT value FROM system_settings WHERE key = $1", _DAILY_SENT_KEY)
+    except Exception as exc:
+        logger.warning("[newsletter] idempotency check failed (%s) — proceeding as not-sent", exc)
+        return False
+    if row is None or row["value"] is None:
+        return False
+    try:
+        return json.loads(row["value"]).get("day") == day.isoformat()
+    except (TypeError, ValueError, AttributeError):
+        return False
+
+
+async def _mark_sent_today(pool: asyncpg.Pool, day: date) -> bool:
+    """Atomically claim ``day`` for sending. Returns True iff THIS call won.
+
+    Uses the same INSERT ... ON CONFLICT DO UPDATE upsert shape as
+    ``daily_task._persist_state`` (system_settings key/value/updated_at) but
+    adds a WHERE guard so a second caller racing shortly after does not
+    silently re-claim (and thus re-permit) an already-claimed day: the
+    UPDATE only fires — and RETURNING only yields a row — when the stored
+    value actually differs from what we're about to write.
+    """
+    try:
+        row = await pool.fetchrow(
+            """
+            INSERT INTO system_settings (key, value, updated_at)
+            VALUES ($1, $2, now())
+            ON CONFLICT (key) DO UPDATE
+                SET value = EXCLUDED.value, updated_at = now()
+                WHERE system_settings.value IS DISTINCT FROM EXCLUDED.value
+            RETURNING value
+            """,
+            _DAILY_SENT_KEY,
+            json.dumps({"day": day.isoformat()}),
+        )
+    except Exception as exc:
+        logger.warning("[newsletter] idempotency claim failed (%s) — sending unguarded", exc)
+        return True  # never block a real send over a persistence hiccup
+    return row is not None
+
+
 async def _run_weekly(pool: asyncpg.Pool, recipients: list[str], subject_prefix: str) -> int:
     intel_repo = IntelRepository(db_pool=pool)
     cognitive_repo = CognitiveRepository(db_pool=pool)
@@ -130,7 +209,39 @@ async def _run_weekly(pool: asyncpg.Pool, recipients: list[str], subject_prefix:
     return 0
 
 
+def _write_daily_skip(day: date, *, items_in_digest: int, scarce: bool, skip_reason: str) -> None:
+    """Emit the same JSON line shape as a real send, for a pre-send skip."""
+    sys.stdout.write(
+        json.dumps(
+            {
+                "mode": "daily",
+                "day": day.isoformat(),
+                "recipients_attempted": 0,
+                "recipients_sent": 0,
+                "recipients_failed": 0,
+                "subject": "",
+                "skipped": True,
+                "skip_reason": skip_reason,
+                "items_in_digest": items_in_digest,
+                "scarce": scarce,
+            },
+            default=str,
+        )
+        + "\n"
+    )
+
+
 async def _run_daily(pool: asyncpg.Pool, recipients: list[str], subject_prefix: str) -> int:
+    today = datetime.now(timezone.utc).date()
+    if await _already_sent_today(pool, today):
+        logger.warning(
+            "[newsletter] daily digest for %s already sent by another invocation "
+            "— skipping (idempotency guard)",
+            today.isoformat(),
+        )
+        _write_daily_skip(today, items_in_digest=0, scarce=False, skip_reason="already_sent_today")
+        return 2
+
     intel_repo = IntelRepository(db_pool=pool)
     cognitive_repo = CognitiveRepository(db_pool=pool)
 
@@ -139,6 +250,27 @@ async def _run_daily(pool: asyncpg.Pool, recipients: list[str], subject_prefix: 
         cognitive_repo=cognitive_repo,
     )
     content = await builder.build_daily()
+
+    # Claim the day BEFORE sending, not after: a second invocation starting
+    # while the first is still mid-flight on its per-recipient HTTP loop
+    # must see the day already taken. Only claim when there is something to
+    # actually send — an empty-digest or no-recipients run must not burn
+    # the day for a later, real attempt (both are already no-ops for the
+    # recipient, so there's nothing to duplicate).
+    if not content.is_empty and recipients:
+        if not await _mark_sent_today(pool, content.day):
+            logger.warning(
+                "[newsletter] daily digest for %s claimed by a concurrent invocation "
+                "— skipping",
+                content.day.isoformat(),
+            )
+            _write_daily_skip(
+                content.day,
+                items_in_digest=len(content.items),
+                scarce=content.scarce,
+                skip_reason="already_sent_today",
+            )
+            return 2
 
     publisher = NewsletterPublisher()
     result = await publisher.send_daily_digest(content, recipients, subject_prefix=subject_prefix)

--- a/apps/backend-rag/backend/tests/services/newsletter/test_newsletter_cli.py
+++ b/apps/backend-rag/backend/tests/services/newsletter/test_newsletter_cli.py
@@ -3,19 +3,32 @@
 2026-07-14: NEWSLETTER_RECIPIENTS was never set in prod, so the cron always
 skipped with "no_recipients" (permanent no-op). These tests pin the fix:
 a default internal recipient, and the new --daily dispatch flag.
+
+2026-08-07: also covers the daily-digest idempotency guard. Confirmed live
+that day: the legacy Pro LaunchAgent (disarmed the same day, but HOME-fork
+drift — scar family #1 — can silently reload a plist) and the in-process
+``daily_task.py`` loop both call ``_run_daily`` for the same UTC calendar
+day, ~5.5h apart, with neither ``build_daily`` nor ``send_daily_digest``
+de-duplicating. These tests pin: a second same-day invocation skips
+(logged, exit 2, no send attempted); the first invocation of the day still
+sends normally.
 """
 
 from __future__ import annotations
 
 import os
-from unittest.mock import patch
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from backend.services.newsletter.newsletter_cli import (
     DEFAULT_RECIPIENT,
+    _already_sent_today,
+    _mark_sent_today,
     _parse_args,
     _recipients_from_env,
+    _run_daily,
 )
 
 
@@ -73,3 +86,197 @@ def test_parse_args_subject_prefix_from_env():
     os.environ["NEWSLETTER_SUBJECT_PREFIX"] = "[TEST] "
     args = _parse_args(["--daily"])
     assert args.subject_prefix == "[TEST] "
+
+
+# ── idempotency guard (2026-08-07) ──────────────────────────────────
+
+
+def _fetchrow_pool(row: dict | None) -> AsyncMock:
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(return_value=row)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_already_sent_today_true_when_stored_day_matches():
+    pool = _fetchrow_pool({"value": '{"day": "2026-08-07"}'})
+    assert await _already_sent_today(pool, date(2026, 8, 7)) is True
+
+
+@pytest.mark.asyncio
+async def test_already_sent_today_false_when_stored_day_differs():
+    # Innocence: yesterday's claim must not block today's send.
+    pool = _fetchrow_pool({"value": '{"day": "2026-08-06"}'})
+    assert await _already_sent_today(pool, date(2026, 8, 7)) is False
+
+
+@pytest.mark.asyncio
+async def test_already_sent_today_false_when_no_row():
+    pool = _fetchrow_pool(None)
+    assert await _already_sent_today(pool, date(2026, 8, 7)) is False
+
+
+@pytest.mark.asyncio
+async def test_already_sent_today_false_on_malformed_value():
+    pool = _fetchrow_pool({"value": "not-json"})
+    assert await _already_sent_today(pool, date(2026, 8, 7)) is False
+
+
+@pytest.mark.asyncio
+async def test_already_sent_today_fails_open_on_db_error():
+    # Scar family #8: a transient read failure must not starve a real send.
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(side_effect=RuntimeError("connection lost"))
+    assert await _already_sent_today(pool, date(2026, 8, 7)) is False
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_today_wins_claim_when_row_returned():
+    # First claim of the day: UPDATE/INSERT affects a row, RETURNING yields it.
+    pool = _fetchrow_pool({"value": '{"day": "2026-08-07"}'})
+    assert await _mark_sent_today(pool, date(2026, 8, 7)) is True
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_today_loses_claim_when_no_row_returned():
+    # Guilt: a second claim for the same already-stored day hits the WHERE
+    # guard (value IS DISTINCT FROM EXCLUDED.value is false) — no row back.
+    pool = _fetchrow_pool(None)
+    assert await _mark_sent_today(pool, date(2026, 8, 7)) is False
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_today_fails_open_on_db_error():
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(side_effect=RuntimeError("connection lost"))
+    assert await _mark_sent_today(pool, date(2026, 8, 7)) is True
+
+
+# ── _run_daily end-to-end: second-same-day skip vs first-of-day pass ──
+
+
+def _content(*, day: date, empty: bool = False):
+    content = MagicMock()
+    content.day = day
+    content.is_empty = empty
+    content.items = [] if empty else [MagicMock()]
+    content.scarce = False
+    return content
+
+
+def _send_result(*, day: date, sent: int = 1, skipped: bool = False, reason: str = ""):
+    result = MagicMock()
+    result.day = day
+    result.recipients_attempted = sent
+    result.recipients_sent = sent
+    result.recipients_failed = 0
+    result.subject = "Bali Zero Daily · test"
+    result.skipped = skipped
+    result.skip_reason = reason
+    return result
+
+
+@pytest.mark.asyncio
+async def test_run_daily_second_invocation_same_day_skips_without_sending():
+    """Guilt case: already_sent_today=True → _run_daily must not build/send."""
+    pool = AsyncMock()
+    with (
+        patch(
+            "backend.services.newsletter.newsletter_cli._already_sent_today",
+            AsyncMock(return_value=True),
+        ),
+        patch("backend.services.newsletter.newsletter_cli.DailyDigestBuilder") as MockBuilder,
+        patch("backend.services.newsletter.newsletter_cli.NewsletterPublisher") as MockPublisher,
+    ):
+        rc = await _run_daily(pool, ["zero@balizero.com"], "")
+
+    assert rc == 2
+    MockBuilder.return_value.build_daily.assert_not_called()
+    MockPublisher.return_value.send_daily_digest.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_daily_first_invocation_of_day_sends_normally():
+    """Innocence case: already_sent_today=False → _run_daily builds, claims, sends."""
+    today = date(2026, 8, 7)
+    pool = AsyncMock()
+    content = _content(day=today)
+    result = _send_result(day=today)
+
+    with (
+        patch(
+            "backend.services.newsletter.newsletter_cli._already_sent_today",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.services.newsletter.newsletter_cli._mark_sent_today",
+            AsyncMock(return_value=True),
+        ) as mock_claim,
+        patch("backend.services.newsletter.newsletter_cli.DailyDigestBuilder") as MockBuilder,
+        patch("backend.services.newsletter.newsletter_cli.NewsletterPublisher") as MockPublisher,
+    ):
+        MockBuilder.return_value.build_daily = AsyncMock(return_value=content)
+        MockPublisher.return_value.send_daily_digest = AsyncMock(return_value=result)
+
+        rc = await _run_daily(pool, ["zero@balizero.com"], "")
+
+    assert rc == 0
+    mock_claim.assert_awaited_once_with(pool, today)
+    MockPublisher.return_value.send_daily_digest.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_daily_loses_race_on_claim_skips_send():
+    """A concurrent invocation claims the day between the check and the
+    claim — _run_daily must still not send (closes the narrower race)."""
+    today = date(2026, 8, 7)
+    pool = AsyncMock()
+    content = _content(day=today)
+
+    with (
+        patch(
+            "backend.services.newsletter.newsletter_cli._already_sent_today",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.services.newsletter.newsletter_cli._mark_sent_today",
+            AsyncMock(return_value=False),
+        ),
+        patch("backend.services.newsletter.newsletter_cli.DailyDigestBuilder") as MockBuilder,
+        patch("backend.services.newsletter.newsletter_cli.NewsletterPublisher") as MockPublisher,
+    ):
+        MockBuilder.return_value.build_daily = AsyncMock(return_value=content)
+
+        rc = await _run_daily(pool, ["zero@balizero.com"], "")
+
+    assert rc == 2
+    MockPublisher.return_value.send_daily_digest.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_daily_empty_digest_does_not_claim_the_day():
+    """An empty-digest run must not burn the day for a later real attempt."""
+    today = date(2026, 8, 7)
+    pool = AsyncMock()
+    content = _content(day=today, empty=True)
+    result = _send_result(day=today, sent=0, skipped=True, reason="empty_digest")
+
+    with (
+        patch(
+            "backend.services.newsletter.newsletter_cli._already_sent_today",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "backend.services.newsletter.newsletter_cli._mark_sent_today",
+            AsyncMock(return_value=True),
+        ) as mock_claim,
+        patch("backend.services.newsletter.newsletter_cli.DailyDigestBuilder") as MockBuilder,
+        patch("backend.services.newsletter.newsletter_cli.NewsletterPublisher") as MockPublisher,
+    ):
+        MockBuilder.return_value.build_daily = AsyncMock(return_value=content)
+        MockPublisher.return_value.send_daily_digest = AsyncMock(return_value=result)
+
+        rc = await _run_daily(pool, ["zero@balizero.com"], "")
+
+    assert rc == 2
+    mock_claim.assert_not_called()


### PR DESCRIPTION
## Summary
- Confirmed live (2026-08-07): the legacy Pro LaunchAgent (`com.balizero.wr2.newsletter`) and the in-process `daily_task.py` loop both delivered the internal daily digest on the same UTC calendar day, ~5.5h apart — `launchctl print` showed the plist loaded/firing (runs=7, last exit 0), `newsletter.log` showed `recipients_sent:1` daily through 08-07, and `system_settings.newsletter_daily_task_last` showed the in-process loop also sent (`ran_at 2026-08-06T18:29:59Z, ok=true`). Neither `send_daily_digest` nor `build_daily` (48h lookback, no "already included" filter) de-duplicated, so the two runs' item sets overlapped almost entirely.
- The vestigial LaunchAgent has been disarmed separately (`launchctl bootout` + plist moved to `~/Library/LaunchAgents/.graveyard-2026-08-07/`, reversible via `mv`) — the designated successor per the 2026-07-15 decision is the in-process loop.
- This PR adds a structural idempotency guard in `_run_daily` (`newsletter_cli.py`) so a same-day double-send can't happen again even if a plist gets silently reloaded (HOME-fork drift, scar family #1) or another caller is added later: `_already_sent_today` / `_mark_sent_today` reuse the SAME state mechanism `daily_task.py` already uses for its own receipt (`system_settings` key/value/updated_at) — no new lock invented. The claim is written *before* the send attempt so a slow first sender still wins the race; an empty-digest/no-recipients run never burns the day for a later real attempt.

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/services/newsletter/ -q` → 100 passed (8 new tests: guilt — second same-day invocation skips without building/sending; innocence — first invocation of the day claims and sends normally; plus race-narrowing and empty-digest-doesn't-claim cases)
- [x] `ruff check` clean on both changed files
- [x] Import-chain smoke (`get_current_user`) OK
- [x] Full backend pre-push suite green (local test-DB `ck_alert_outcomes_outcome` constraint drift — unrelated pre-existing machine-local issue, documented in memory `discovery_the_migration_ledger_said_applied_while_the_constraint_said_otherwise_and_it_blocked_every_push_2026_07_31` — re-applied migration 258's forward block to `nuzantara_test` and verified by content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)