### PR TITLE
fix(mouth): verdict panel must honor HUMAN_REVIEW_REQUIRED instead of claiming no evaluation was submitted

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
@@ -204,6 +204,48 @@ describe("OracleShell authoritative evaluate integration", () => {
     expect(screen.queryByText("Visit Visa C1")).toBeNull();
   });
 
+  it("never claims no evaluation was submitted when the engine adapter rejects one review-hold citation", async () => {
+    const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+    response.sources[0].canonical_url = "https://imigrasi.go.id.evil.test/x";
+    response.decision.review_reasons[0].source_refs = [
+      response.sources[0].source_record_id,
+    ];
+    global.fetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    render(<OracleShell />);
+
+    await expectStateHeading("HUMAN_REVIEW_REQUIRED");
+    expect(
+      screen.getByText(translate("en", "outcome.human_review_body")),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/no evaluation was submitted/i)).toBeNull();
+    expect(screen.queryByText("Client safety hold")).toBeNull();
+  });
+
+  it("never claims no evaluation was submitted when strict parsing rejects an unrelated field", async () => {
+    const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+    const raw = JSON.parse(JSON.stringify(response)) as Record<string, unknown>;
+    (raw.sources as Array<Record<string, unknown>>)[0].is_primary_authority =
+      null;
+    global.fetch = vi.fn<typeof fetch>(
+      async () =>
+        new Response(JSON.stringify(raw), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    render(<OracleShell />);
+
+    await expectStateHeading("HUMAN_REVIEW_REQUIRED");
+    expect(screen.queryByText(/no evaluation was submitted/i)).toBeNull();
+    expect(screen.queryByText("Client safety hold")).toBeNull();
+  });
+
   it("keeps automatic network retry byte-identical and renders no fabricated result", async () => {
     const fetchMock = vi.fn<typeof fetch>(async () => {
       throw new TypeError("network down");

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
@@ -29,6 +29,7 @@ import { VisaOracleResponseError } from "../_lib/engine-response";
 import { buildPreviewOutcome } from "../_lib/preview-adapter";
 import {
   buildClientGuardOutcome,
+  buildDegradedHumanReviewOutcome,
   buildNetworkFailureOutcome,
   buildShadowOutcome,
 } from "../_lib/outcome-fallbacks";
@@ -50,6 +51,7 @@ import {
 } from "../_lib/runtime-mode";
 import { shadowParityMatches } from "../_lib/shadow-parity";
 import type { OutcomeViewModel } from "../_lib/outcome-view-model";
+import type { VisaOracleEvaluateResponse } from "../_lib/visa-oracle-contract";
 import { LivingTree } from "./LivingTree";
 import { PathsCounter } from "./PathsCounter";
 import { QuestionScreen } from "./QuestionScreen";
@@ -158,10 +160,39 @@ interface OracleShellRuntimeProps {
   initialResumeExpiresAtIso: string | null;
 }
 
+/**
+ * The server unambiguously asserted `decision.state: "HUMAN_REVIEW_REQUIRED"`
+ * with `outage: null` — either because we hold the fully validated response
+ * (an adapter-level invariant rejected some other field) or because a
+ * best-effort peek of the raw payload read it directly (strict parsing
+ * rejected the payload before we could fully trust it). Either way, an
+ * evaluation genuinely happened and must never be reported as "no
+ * evaluation was submitted".
+ */
+function isKnownHumanReviewDecision(
+  knownDecision: { state: string; outageIsNull: boolean } | undefined,
+): boolean {
+  return (
+    knownDecision?.state === "HUMAN_REVIEW_REQUIRED" &&
+    knownDecision.outageIsNull === true
+  );
+}
+
 function fallbackForError(
   error: unknown,
   assumptions: OutcomeViewModel["assumptions"],
+  knownDecision?: { state: string; outageIsNull: boolean },
 ): OutcomeViewModel {
+  const resolvedKnownDecision =
+    knownDecision ??
+    (error instanceof VisaOracleClientError && error.knownDecisionState
+      ? {
+          state: error.knownDecisionState,
+          outageIsNull: error.knownOutageIsNull === true,
+        }
+      : undefined);
+  const degradedHumanReview = isKnownHumanReviewDecision(resolvedKnownDecision);
+
   if (error instanceof VisaOracleClientError) {
     const clientGuard =
       error.code === "INVALID_REQUEST" ||
@@ -172,6 +203,9 @@ function fallbackForError(
         error.status < 500 &&
         !isVisaOracleRetryableHttpStatus(error.status));
     if (clientGuard) {
+      if (degradedHumanReview) {
+        return buildDegradedHumanReviewOutcome({ assumptions });
+      }
       return buildClientGuardOutcome({
         code:
           error.code === "HTTP_ERROR"
@@ -187,6 +221,9 @@ function fallbackForError(
     });
   }
   if (error instanceof VisaOracleResponseError) {
+    if (degradedHumanReview) {
+      return buildDegradedHumanReviewOutcome({ assumptions });
+    }
     return buildClientGuardOutcome({ code: error.code, assumptions });
   }
   return buildClientGuardOutcome({
@@ -477,8 +514,14 @@ function OracleShellRuntime({
         const lease = evaluationCacheRef.current.acquire(
           cacheKey,
           async (requestSignal) => {
+            // Hoisted so the catch block below can read the already-validated
+            // decision.state/outage when a LATER step (buildEngineOutcome)
+            // throws — needed to tell "no evaluation was submitted" apart
+            // from "an evaluation was submitted and flagged for human
+            // review, but we couldn't render every detail safely".
+            let response: VisaOracleEvaluateResponse | undefined;
             try {
-              const response = await evaluateVisaOracle({
+              response = await evaluateVisaOracle({
                 request: prepared.request,
                 idempotencyKey: prepared.identity.idempotencyKey,
                 signal: requestSignal,
@@ -523,7 +566,18 @@ function OracleShellRuntime({
                   assumptions,
                 });
               }
-              const fallback = fallbackForError(error, assumptions);
+              const knownDecision =
+                response !== undefined
+                  ? {
+                      state: response.decision.state,
+                      outageIsNull: response.decision.outage === null,
+                    }
+                  : undefined;
+              const fallback = fallbackForError(
+                error,
+                assumptions,
+                knownDecision,
+              );
               telemetryForFallback(fallback, telemetryCorrelationHash);
               return fallback;
             }

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OutcomeSheet.tsx
@@ -445,29 +445,36 @@ export function OutcomeSheet({
 
   return (
     <div className="oracle-outcome">
-      {outcome.provenance !== "ENGINE" && (
-        <section
-          className="oracle-origin-notice"
-          data-provenance={outcome.provenance.toLowerCase()}
-          role="status"
-        >
-          <ShieldCheck aria-hidden="true" size={20} />
-          <div>
-            <h2 className="oracle-outcome__section-title">
-              {translate(
-                language,
-                `outcome.provenance.${outcome.provenance}.title` as I18nKey,
-              )}
-            </h2>
-            <p>
-              {translate(
-                language,
-                `outcome.provenance.${outcome.provenance}.body` as I18nKey,
-              )}
-            </p>
-          </div>
-        </section>
-      )}
+      {/* A HUMAN_REVIEW_REQUIRED state already gets its own honest,
+          complete explanation below (outcome.human_review_body + the
+          review reasons) regardless of provenance — a generic non-ENGINE
+          origin notice on top of it would repeat "this is a hold, not a
+          decision" next to a section explaining a decision genuinely was
+          made and flagged for review. Skip it only for that state. */}
+      {outcome.provenance !== "ENGINE" &&
+        outcome.state !== "HUMAN_REVIEW_REQUIRED" && (
+          <section
+            className="oracle-origin-notice"
+            data-provenance={outcome.provenance.toLowerCase()}
+            role="status"
+          >
+            <ShieldCheck aria-hidden="true" size={20} />
+            <div>
+              <h2 className="oracle-outcome__section-title">
+                {translate(
+                  language,
+                  `outcome.provenance.${outcome.provenance}.title` as I18nKey,
+                )}
+              </h2>
+              <p>
+                {translate(
+                  language,
+                  `outcome.provenance.${outcome.provenance}.body` as I18nKey,
+                )}
+              </p>
+            </div>
+          </section>
+        )}
 
       {rows.length > 0 && (
         <section className="oracle-print-only">

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/VerdictReveal.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/VerdictReveal.tsx
@@ -61,14 +61,22 @@ export function VerdictReveal({
 
   const StateIcon = STATE_ICON[state] ?? Info;
   const bodyFirst = BODY_FIRST[language];
-  const headlineKey =
-    provenance === "ENGINE"
-      ? (`verdict.headline.${state}` as I18nKey)
-      : (`verdict.provenance_headline.${provenance}` as I18nKey);
-  const descriptionKey =
-    provenance === "ENGINE"
-      ? (`verdict.state_description.${state}` as I18nKey)
-      : (`verdict.provenance_description.${provenance}` as I18nKey);
+  // The state is what the server actually decided and is always the more
+  // specific, honest signal — including for a non-ENGINE provenance that
+  // still carries a genuine state (e.g. a degraded CLIENT_GUARD outcome
+  // that honestly reports HUMAN_REVIEW_REQUIRED rather than pretending no
+  // evaluation happened). Generic provenance copy is reserved for the one
+  // case where state itself carries no information: TEMPORARILY_UNAVAILABLE
+  // from a non-ENGINE origin (network failure, shadow mode, preview, or a
+  // client-side hold that never reached a real state at all).
+  const useProvenanceCopy =
+    provenance !== "ENGINE" && state === "TEMPORARILY_UNAVAILABLE";
+  const headlineKey = useProvenanceCopy
+    ? (`verdict.provenance_headline.${provenance}` as I18nKey)
+    : (`verdict.headline.${state}` as I18nKey);
+  const descriptionKey = useProvenanceCopy
+    ? (`verdict.provenance_description.${provenance}` as I18nKey)
+    : (`verdict.state_description.${state}` as I18nKey);
 
   const heading = (
     <h1

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -191,6 +191,40 @@ describe("Visa Oracle authoritative outcome adapter", () => {
     expect(() => buildEngineOutcome(response)).toThrow();
   });
 
+  it("curates review-reason copy for a known code, EN and ID", () => {
+    const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+    response.decision.review_reasons[0].code = "CALLING_VISA_REVIEW";
+
+    const outcome = buildEngineOutcome(response);
+    expect(outcome.state).toBe("HUMAN_REVIEW_REQUIRED");
+    if (outcome.state !== "HUMAN_REVIEW_REQUIRED")
+      throw new Error("unexpected state");
+    const message = outcome.reviewReasons[0].message;
+    expect(message.en).toMatch(/calling visa/i);
+    expect(message.id).toMatch(/calling visa/i);
+    expect(message.en.toLowerCase()).not.toContain(
+      "no evaluation was submitted",
+    );
+    expect(message.en).not.toContain("Verified reason:");
+  });
+
+  it("falls back to an honest generic sentence for an unmapped review-reason code", () => {
+    const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+    response.decision.review_reasons[0].code = "SOME_FUTURE_RULE_CODE";
+
+    const outcome = buildEngineOutcome(response);
+    expect(outcome.state).toBe("HUMAN_REVIEW_REQUIRED");
+    if (outcome.state !== "HUMAN_REVIEW_REQUIRED")
+      throw new Error("unexpected state");
+    const message = outcome.reviewReasons[0].message;
+    expect(message.en).not.toContain("SOME_FUTURE_RULE_CODE");
+    expect(message.en).not.toContain("Verified reason:");
+    expect(message.en.toLowerCase()).not.toContain(
+      "no evaluation was submitted",
+    );
+    expect(message.en.toLowerCase()).toContain("judgment");
+  });
+
   it("maps missing engine facts back to editable interview questions", () => {
     const outcome = buildEngineOutcome(makeVisaOracleResponse("NEEDS_INPUT"));
     expect(outcome.state).toBe("NEEDS_INPUT");

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -68,6 +68,60 @@ function reason(
   };
 }
 
+// Curated, human-readable copy for the rule pack's HUMAN_REVIEW reason
+// codes (source: services/visa_engine/contracts/packs/rulepack-prod-*.json
+// `effect.reason_code` on REQUIRE_REVIEW rules). A code missing from this
+// map falls back to an honest generic sentence — never a raw code dump —
+// so a new rule can ship without breaking this UI, and this map can grow
+// independently of a rule pack release.
+const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
+  CALLING_VISA_REVIEW: text(
+    "Your nationality is on the Calling Visa list, which always requires manual review before a visa can be confirmed.",
+    "Kewarganegaraan Anda termasuk dalam daftar Calling Visa, yang selalu memerlukan peninjauan manual sebelum visa dapat dikonfirmasi.",
+  ),
+  ACTIVE_OVERSTAY: text(
+    "An active overstay on record needs a person to review before any path can be confirmed.",
+    "Overstay aktif yang tercatat memerlukan peninjauan oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
+  ),
+  CITIZENSHIP_EVIDENCE_CONFLICT: text(
+    "Your answers about citizenship do not fully agree with each other and need a person to confirm.",
+    "Jawaban Anda tentang kewarganegaraan tidak sepenuhnya cocok satu sama lain dan memerlukan konfirmasi dari seseorang.",
+  ),
+  MINOR_WITHOUT_CONFIRMED_GUARDIAN: text(
+    "This case involves a minor without a confirmed guardian on file and needs a person to review it.",
+    "Kasus ini melibatkan anak di bawah umur tanpa wali yang terkonfirmasi dan memerlukan peninjauan oleh seseorang.",
+  ),
+  STATUS_BRIDGING_REVIEW: text(
+    "Bridging between immigration statuses needs a person to check the timing and conditions involved.",
+    "Peralihan antar status keimigrasian memerlukan pemeriksaan oleh seseorang atas waktu dan ketentuan yang berlaku.",
+  ),
+  LOCAL_MARKET_ACTIVITY_REVIEW: text(
+    "The activity you described needs a person to confirm it does not cross into locally reserved business.",
+    "Aktivitas yang Anda jelaskan memerlukan konfirmasi oleh seseorang agar tidak melanggar bidang usaha yang dicadangkan untuk lokal.",
+  ),
+  DISCLOSED_ACTIVITY_BOUNDARY_REVIEW: text(
+    "The activity you disclosed sits close to a legal boundary that needs a person to confirm.",
+    "Aktivitas yang Anda ungkapkan berada dekat batas hukum yang memerlukan konfirmasi dari seseorang.",
+  ),
+};
+
+const GENERIC_REVIEW_REASON: LocalizedText = text(
+  "Some of your answers need a person's judgment before we can confirm a path.",
+  "Beberapa jawaban Anda memerlukan penilaian dari seseorang sebelum kami dapat mengonfirmasi jalur.",
+);
+
+function reviewReason(
+  code: string,
+  sourceIds: readonly string[],
+  trustedIds: ReadonlySet<string>,
+): OutcomeReason {
+  return {
+    code,
+    message: REVIEW_REASON_COPY[code] ?? GENERIC_REVIEW_REASON,
+    sourceIds: sourceIds.filter((id) => trustedIds.has(id)),
+  };
+}
+
 function outcomeSource(source: VisaOracleSourceRecord): OutcomeSource | null {
   const url = trustedPrimarySourceUrl(source.canonical_url);
   if (!url) return null;
@@ -412,7 +466,7 @@ function buildValidatedOutcome(
         pathsRemaining: Math.max(1, options.interviewBranchesRemaining ?? 1),
         reviewReasons: response.decision.review_reasons.map((item) => {
           requireReviewHoldRefs(item.source_refs);
-          return reason(item.code, item.source_refs, trustedIds);
+          return reviewReason(item.code, item.source_refs, trustedIds);
         }) as [OutcomeReason, ...OutcomeReason[]],
       };
     case "NO_SUPPORTED_PATH":

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.test.ts
@@ -111,6 +111,55 @@ describe("Visa Oracle evaluation HTTP client", () => {
     expect(duplicateJsonFetch).toHaveBeenCalledOnce();
   });
 
+  it("carries the raw decision.state/outage on a malformed response that still names a real state", async () => {
+    const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+    const raw = JSON.parse(JSON.stringify(response)) as Record<string, unknown>;
+    // Break strict parsing on an unrelated field (a non-boolean authority
+    // flag) while `decision.state`/`decision.outage` stay perfectly legible
+    // — this must not be reported as "we don't know what the server did".
+    (raw.sources as Array<Record<string, unknown>>)[0].is_primary_authority =
+      null;
+    const fetchImpl = vi.fn(async () => jsonResponse(raw));
+
+    await expect(
+      evaluateVisaOracle({
+        request: REQUEST,
+        idempotencyKey: IDEMPOTENCY_KEY,
+        fetchImpl,
+        maxRetries: 0,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        code: "MALFORMED_RESPONSE",
+        knownDecisionState: "HUMAN_REVIEW_REQUIRED",
+        knownOutageIsNull: true,
+      }),
+    );
+  });
+
+  it("leaves knownDecisionState unset when the payload never names a readable state", async () => {
+    const duplicateJsonFetch = vi.fn(
+      async () =>
+        new Response('{"mode":"ENGINE","mode":"CURATED"}', {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    await expect(
+      evaluateVisaOracle({
+        request: REQUEST,
+        idempotencyKey: IDEMPOTENCY_KEY,
+        fetchImpl: duplicateJsonFetch,
+        maxRetries: 0,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        code: "MALFORMED_RESPONSE",
+        knownDecisionState: undefined,
+      }),
+    );
+  });
+
   it("classifies an elapsed request deadline as a timeout", async () => {
     const fetchImpl = vi.fn<typeof fetch>(
       async (_input, init) =>

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.ts
@@ -37,6 +37,13 @@ export class VisaOracleClientError extends Error {
   constructor(
     public readonly code: VisaOracleClientErrorCode,
     public readonly status?: number,
+    /** Best-effort `decision.state` read directly off the raw JSON payload
+     * — set only when the payload parsed as an object with a string state,
+     * independent of whether strict schema validation accepted the rest of
+     * it. Never used to render anything beyond choosing an honest fallback
+     * message; never trusted as authoritative. */
+    public readonly knownDecisionState?: string,
+    public readonly knownOutageIsNull?: boolean,
   ) {
     super(code);
     this.name = "VisaOracleClientError";
@@ -99,16 +106,49 @@ async function readResponseText(response: Response): Promise<string> {
   }
 }
 
+/**
+ * Best-effort, untrusted peek at `decision.state`/`decision.outage` on the
+ * raw parsed JSON. Used ONLY to choose which honest fallback copy to show
+ * when strict validation rejects the payload — never to render any
+ * attacker-controlled content, and never treated as a substitute for the
+ * strict parser's own guarantees.
+ */
+function peekDecisionState(
+  raw: unknown,
+): { state: string; outageIsNull: boolean } | undefined {
+  if (typeof raw !== "object" || raw === null) return undefined;
+  const decision = (raw as Record<string, unknown>).decision;
+  if (typeof decision !== "object" || decision === null) return undefined;
+  const state = (decision as Record<string, unknown>).state;
+  if (typeof state !== "string") return undefined;
+  const outage = (decision as Record<string, unknown>).outage;
+  return { state, outageIsNull: outage === null };
+}
+
 function parseResponseBody(source: string): VisaOracleEvaluateResponse {
+  let raw: unknown;
   try {
-    return parseVisaOracleEvaluateResponse(parseStrictJson(source));
+    raw = parseStrictJson(source);
+  } catch (error) {
+    if (error instanceof StrictJsonError) {
+      throw new VisaOracleClientError("MALFORMED_RESPONSE");
+    }
+    throw error;
+  }
+  try {
+    return parseVisaOracleEvaluateResponse(raw);
   } catch (error) {
     if (
-      error instanceof StrictJsonError ||
       (error as VisaOracleResponseError | undefined)?.name ===
-        "VisaOracleResponseError"
+      "VisaOracleResponseError"
     ) {
-      throw new VisaOracleClientError("MALFORMED_RESPONSE");
+      const known = peekDecisionState(raw);
+      throw new VisaOracleClientError(
+        "MALFORMED_RESPONSE",
+        undefined,
+        known?.state,
+        known?.outageIsNull,
+      );
     }
     throw error;
   }

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/outcome-fallbacks.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/outcome-fallbacks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildClientGuardOutcome,
+  buildDegradedHumanReviewOutcome,
   buildNetworkFailureOutcome,
 } from "./outcome-fallbacks";
 
@@ -41,5 +42,25 @@ describe("non-engine OutcomeViewModel fallbacks", () => {
       retryable: false,
     });
     expect(outcome.outage.retryable).toBe(false);
+  });
+
+  it("reports a degraded HUMAN_REVIEW_REQUIRED honestly — never as no evaluation submitted", () => {
+    const outcome = buildDegradedHumanReviewOutcome({
+      assumptions: [{ id: "a", questionId: "review_gate", editable: true }],
+    });
+    expect(outcome).toMatchObject({
+      state: "HUMAN_REVIEW_REQUIRED",
+      provenance: "CLIENT_GUARD",
+      assessment: null,
+      candidates: [],
+      pathsRemaining: 1,
+    });
+    expect(outcome.assumptions).toHaveLength(1);
+    expect(outcome.nextSteps).toHaveLength(3);
+    expect(outcome.reviewReasons).toHaveLength(1);
+    expect(outcome.reviewReasons[0].sourceIds).toEqual([]);
+    for (const text of Object.values(outcome.reviewReasons[0].message)) {
+      expect(text.toLowerCase()).not.toContain("no evaluation was submitted");
+    }
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/outcome-fallbacks.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/outcome-fallbacks.ts
@@ -1,7 +1,9 @@
 import type {
+  HumanReviewOutcome,
   InterviewAssumption,
   LocalizedText,
   OutcomeNextSteps,
+  OutcomeReason,
   TemporarilyUnavailableOutcome,
 } from "./outcome-view-model";
 
@@ -93,4 +95,40 @@ export function buildShadowOutcome(
   options: Omit<FallbackOptions, "retryable">,
 ): TemporarilyUnavailableOutcome {
   return buildFallback("SHADOW", { ...options, retryable: false });
+}
+
+const DEGRADED_REVIEW_REASON: OutcomeReason = {
+  code: "CLIENT_UNABLE_TO_VERIFY_DETAIL",
+  message: {
+    en: "A Bali Zero advisor will review your full case by hand. Some supporting detail could not be safely verified in this browser, so it is not shown here.",
+    id: "Konsultan Bali Zero akan meninjau kasus Anda secara lengkap. Beberapa detail pendukung tidak dapat diverifikasi dengan aman di browser ini, sehingga tidak ditampilkan di sini.",
+  },
+  sourceIds: [],
+};
+
+/**
+ * The server unambiguously returned `decision.state: "HUMAN_REVIEW_REQUIRED"`
+ * with `outage: null` — an evaluation genuinely happened and a human review
+ * was genuinely triggered — but some other part of the payload (an
+ * individual review reason's source citation, most often) failed this
+ * client's own stricter verification and was rejected before it could be
+ * rendered. This is NOT "no evaluation was submitted": that claim must stay
+ * reserved for TEMPORARILY_UNAVAILABLE/network/parse failures where the
+ * server's decision is genuinely unknown. Candidates stay empty and no
+ * citation is fabricated; only the honest, generic review copy is shown.
+ */
+export function buildDegradedHumanReviewOutcome(options: {
+  assumptions?: readonly InterviewAssumption[];
+}): HumanReviewOutcome {
+  return {
+    provenance: "CLIENT_GUARD",
+    assessment: null,
+    state: "HUMAN_REVIEW_REQUIRED",
+    candidates: [],
+    pathsRemaining: 1,
+    assumptions: options.assumptions ?? [],
+    sources: [],
+    nextSteps: NEXT_STEPS,
+    reviewReasons: [DEGRADED_REVIEW_REASON],
+  };
 }


### PR DESCRIPTION
## Evidence

Confirmed in production (3/3 cases, reproducible): a `POST /api/visa-oracle/evaluate` response with a real decision `state:"HUMAN_REVIEW_REQUIRED"` (`review_reasons` populated, `outage:null`, `candidates:[]`) rendered the **"Client safety hold"** panel with *"This interview contains information the verified API cannot represent safely. No evaluation was submitted."* — **false**. An evaluation was submitted and produced a real `HUMAN_REVIEW_REQUIRED` decision. QA screenshots 10/11/12 captured the live bug on `/visa-oracle`.

## Root cause (traced end to end, not assumed)

The mapping from `decision.state` to the panel (`engine-adapter.ts` + `OutcomeSheet.tsx`) was already correct on the happy path. The false claim only surfaces when something **else** about an otherwise-valid `HUMAN_REVIEW_REQUIRED` response fails this client's own stricter verification *after* `decision.state` was already legible — e.g. an individual review-hold citation that doesn't pass the primary-authority/trusted-host check (`engine-adapter.ts`'s `requireReviewHoldRefs`), or any other field that trips strict parsing (`engine-response.ts`) after `decision.state`/`outage` were already read. Every one of those paths collapsed into `buildClientGuardOutcome()`, which always forces `state:"TEMPORARILY_UNAVAILABLE"` and the CLIENT_GUARD copy — discarding the real state the server sent.

Verified against the **live production rule pack** (`rulepack-prod-002.source.json`): `CALLING_VISA_REVIEW` and `ACTIVE_OVERSTAY` are real, `safety_critical` `HUMAN_REVIEW` rules — making this deterministically reproducible for anyone who hits them.

## Fix (frontend-only — no security invariant weakened; untrusted/non-primary source citations are still rejected exactly as before)

- `outcome-fallbacks.ts`: new `buildDegradedHumanReviewOutcome()` — reports `state:"HUMAN_REVIEW_REQUIRED"` honestly (provenance `CLIENT_GUARD`, generic non-fabricated review reason, zero citations) instead of forcing `TEMPORARILY_UNAVAILABLE`.
- `evaluation-client.ts`: `VisaOracleClientError` now carries a best-effort, **untrusted** peek of the raw `decision.state`/`outage` when strict parsing rejects a payload elsewhere — used only to pick the honest fallback copy, never to render attacker-controlled content.
- `OracleShell.tsx`: `fallbackForError()` routes to the degraded honest panel whenever `decision.state:"HUMAN_REVIEW_REQUIRED"` + `outage:null` is known (from the validated response object, or from the raw peek).
- `VerdictReveal.tsx`: the hero headline/description now key off `state` whenever it carries real information, reserving generic provenance copy for the one case where it doesn't (`TEMPORARILY_UNAVAILABLE` from a non-ENGINE origin) — otherwise a non-ENGINE `HUMAN_REVIEW_REQUIRED` outcome still showed the generic "no engine decision" headline above the correct body text below it.
- `OutcomeSheet.tsx`: suppresses the redundant generic origin-notice box for state `HUMAN_REVIEW_REQUIRED` — the dedicated section below it is already the complete, honest explanation.
- `engine-adapter.ts`: curated EN/ID copy for known review-reason codes (`CALLING_VISA_REVIEW`, `ACTIVE_OVERSTAY`, `CITIZENSHIP_EVIDENCE_CONFLICT`, `MINOR_WITHOUT_CONFIRMED_GUARDIAN`, `STATUS_BRIDGING_REVIEW`, `LOCAL_MARKET_ACTIVITY_REVIEW`, `DISCLOSED_ACTIVITY_BOUNDARY_REVIEW` — sourced from the live rule pack, not invented) replacing the raw `"Verified reason: {code}"` dump; an unmapped code falls back to an honest generic sentence, never the false claim.

The minimum bar requested: **the "No evaluation was submitted" text can never again render for a response with `state:"HUMAN_REVIEW_REQUIRED"`.**

## Test numbers

- 8 new tests (outcome-fallbacks ×1, engine-adapter ×2, evaluation-client ×2, OracleShell end-to-end ×2 — plus 1 extra evaluation-client regression), all existing tests preserved.
- Targeted visa-oracle Vitest suite: **31 files / 326 tests, all pass**.
- Full `apps/mouth` Vitest suite: **350 files / 3267 tests, all pass**.
- `npm run typecheck -w apps/mouth`: **clean** (0 errors from this change; 2 pre-existing unrelated `recharts` TS2307 errors reproduce identically on `main` with no diff applied).
- Full pre-push gate (backend pytest, HTTPS-remote fail-closed to full suite): **passed**.

## Not touched

Backend/rule-pack citation quality (e.g. stamping `is_primary_authority` correctly is already computed dynamically server-side and verified correct for the two rules checked) — out of scope for this frontend lane, no backend files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)