### PR TITLE
fix(visa-oracle): retention-binding triggers need SECURITY DEFINER under least-privilege (268) + preflight coverage + container-safe policy CLI

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/268_visa_retention_binding_security_definer.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/268_visa_retention_binding_security_definer.sql
@@ -1,0 +1,222 @@
+-- Migration 268: retention-binding triggers need SECURITY DEFINER under the
+-- least-privilege runtime model.
+--
+-- ============================================================================
+-- WHY THIS IS A NEW MIGRATION, NOT AN EDIT TO 264
+-- ============================================================================
+--   Migration 264 (`264_visa_decision_retention_policy.sql`) is
+--   already-applied history against production -- `migration_base.py` /
+--   `migration_manager.py` never re-run an applied migration's SQL body, so
+--   its on-disk text is an immutable record of what already executed (same
+--   convention 253's own header documents for 251). This migration is the
+--   roll-forward correction, targeting the LIVE post-264, post-D1-repair
+--   schema state -- 264's on-disk file stays SECURITY INVOKER; the
+--   prod-vs-repo drift this migration closes is deliberate and recorded
+--   here, not silently edited away.
+--
+-- ============================================================================
+-- THE DEFECT (2026-08-07 prod incident)
+-- ============================================================================
+--   The "D1" least-privilege repair moved ownership of the Visa Oracle
+--   ledger tables (and several already-`SECURITY DEFINER` functions) to
+--   `visa_ledger_owner`, leaving the runtime role (`backend_rag_v2`)
+--   SELECT-only on `visa_decision_retention_policies` / `visa_decisions` /
+--   `visa_decision_payloads`. Three migration-264 trigger functions were
+--   never converted to `SECURITY DEFINER` because, at the time they were
+--   written, the runtime role WAS the table owner and the gap was invisible:
+--
+--     * `bind_visa_evaluate_idempotency_retention_policy` (BEFORE INSERT on
+--       `visa_evaluate_idempotency`)
+--     * `bind_visa_decision_retention_policy` (BEFORE INSERT on
+--       `visa_decisions`)
+--     * `bind_visa_decision_payload_retention` (BEFORE INSERT on
+--       `visa_decision_payloads`)
+--
+--   Each runs a `SELECT ... FOR SHARE` against a `visa_ledger_owner`-owned
+--   table to resolve the active Zero-approved retention policy. Postgres'
+--   `FOR SHARE` row-lock requires the UPDATE privilege, not merely SELECT --
+--   a fact about row-locking, not about this schema. Once the runtime role
+--   was reduced to SELECT-only (correctly, per the least-privilege repair),
+--   every one of these three triggers -- running `SECURITY INVOKER`, i.e.
+--   with the CALLING role's privileges -- started failing every INSERT into
+--   the three tables it guards with `insufficient_privilege`, surfacing to
+--   callers as `TEMPORARILY_UNAVAILABLE` / `IDEMPOTENCY_UNAVAILABLE`. See
+--   `lesson_least_privilege_repair_breaks_invoker_triggers_that_lock_rows_
+--   2026_08_07.md` for the full incident writeup, including why no test
+--   caught it (CI/fullstack-smoke connect as a superuser, which is always
+--   both owner and invoker, so the INVOKER-vs-DEFINER distinction never
+--   mattered there) and why `operational_preflight.py`'s 622-check was also
+--   blind (these three functions were never added to `SENSITIVE_FUNCTIONS`
+--   -- fixed in this same PR, a separate commit).
+--
+--   The cure applied directly to production on 2026-08-07 (single manual
+--   transaction, superuser session, verified beforehand that every body
+--   already pins `SET search_path = pg_catalog, pg_temp` and references
+--   only schema-qualified `public.*` relations -- both prerequisites for a
+--   safe `SECURITY DEFINER` flip) was exactly the three `ALTER FUNCTION`
+--   pairs below: `SECURITY DEFINER` + `OWNER TO visa_ledger_owner`. This
+--   migration codifies that same cure so a fresh clone/CI/staging rebuild
+--   converges on the same state without a human re-typing it, and so
+--   `_schema_versions` eventually records that migration 268 is the
+--   intended, on-the-record state of production (it was not applied via the
+--   ordinary migration runner in prod on 2026-08-07 -- this migration's
+--   later, routine `apply-all` run against prod is expected to be a pure
+--   idempotent confirmation of already-live state, not a live behavior
+--   change).
+--
+-- ============================================================================
+-- WHY `OWNER TO` IS ROLE-GUARDED *AND* IDEMPOTENT *AND* BEST-EFFORT
+-- ============================================================================
+--   `ALTER FUNCTION ... OWNER TO <role>` requires the executing session to
+--   be either superuser or (the function's CURRENT owner AND a member of
+--   the TARGET role) -- see 253's own P0-2 note ("Function OWNERSHIP ... is
+--   a superuser-only operation this non-superuser migration role cannot
+--   perform -- it remains the operator provisioning script's job"). That
+--   constraint does not go away just because `visa_ledger_owner` now exists:
+--
+--     * On a superuser connection (CI's `test` role, or a local dev
+--       superuser) the ALTER always succeeds regardless of ordering --
+--       superuser bypasses every membership check. This is also why a test
+--       exercising the actual bug (see the accompanying test file) must
+--       explicitly restrict a SEPARATE low-privilege role rather than rely
+--       on the connecting role's own posture.
+--     * On the ordinary, non-superuser migration role (`backend_rag_v2`),
+--       once ownership has ALREADY moved to `visa_ledger_owner` (prod, after
+--       the 2026-08-07 manual cure), `backend_rag_v2` is no longer even the
+--       CURRENT owner of these three functions -- so re-running this
+--       migration's `OWNER TO` clause would unconditionally fail with
+--       `insufficient_privilege` if attempted, regardless of role-guard.
+--       The DO block below therefore checks the FUNCTION's actual current
+--       owner first and skips the `ALTER` entirely when it is already
+--       `visa_ledger_owner` (idempotent no-op, no privilege check ever
+--       attempted -- this is the prod re-run path).
+--     * When the current owner is NOT YET `visa_ledger_owner` (a fresh
+--       environment that has not had the D1-style repair's ownership
+--       transfer applied out-of-band), the block attempts the transfer and,
+--       if the executing role lacks the required membership, degrades to a
+--       `RAISE NOTICE` -- deliberately NOT a hard failure, because per the
+--       253 precedent this specific ALTER is expected to be beyond a
+--       non-superuser migration role's reach in that state; arming it is
+--       the operator provisioning script's job, same as always. This differs
+--       from this migration's own `REVOKE .. FROM PUBLIC` / `SECURITY
+--       DEFINER` statements below, which are unconditional and always
+--       within the current owner's own privilege regardless of
+--       `visa_ledger_owner`'s existence.
+--
+--   `SECURITY DEFINER` alone (independent of who ends up owning the
+--   function) is what fixes the runtime behavior: the function executes
+--   with ITS OWNER's privileges rather than the caller's. In every
+--   environment where the current owner already has (or, being a
+--   superuser, trivially has) UPDATE on the locked table -- which is true
+--   both in prod post-ownership-transfer AND in every existing test/CI
+--   superuser connection -- the `FOR SHARE` lock resolves regardless of
+--   whether the `OWNER TO` clause itself was able to fire. The three
+--   `ALTER ... SECURITY DEFINER` statements are therefore issued
+--   unconditionally, before the role-guarded ownership attempt, while the
+--   connecting role is still guaranteed to be the current owner.
+--
+-- ============================================================================
+-- EXECUTE FROM PUBLIC
+-- ============================================================================
+--   264 revoked `EXECUTE ... FROM PUBLIC` for every OTHER privileged
+--   function it introduced but never did so for these three trigger
+--   functions -- Postgres grants EXECUTE to PUBLIC by default at CREATE
+--   FUNCTION time, so today every role can directly `SELECT
+--   public.bind_visa_evaluate_idempotency_retention_policy()`. A bare
+--   direct call fails at runtime (`RETURNS trigger` functions may only be
+--   invoked as triggers), so this was never an information-disclosure
+--   defect on its own -- but making these three `SECURITY DEFINER` is
+--   exactly the moment an unconditional PUBLIC EXECUTE grant on a
+--   DEFINER-privileged function becomes worth closing as defense-in-depth,
+--   same rationale 267 gives for the analogous cleanup on
+--   `visa_replace_activation_set`. Costs nothing, deferred to no role guard.
+--
+-- NOTE: `-- === ROLLBACK ===` marker is mandatory (migration_base.py:29) for
+--   migrations > 111.
+
+-- ----------------------------------------------------------------------------
+-- Step 1: SECURITY DEFINER (unconditional -- the connecting role is still the
+-- current owner of all three at this point in every environment).
+-- ----------------------------------------------------------------------------
+
+ALTER FUNCTION public.bind_visa_evaluate_idempotency_retention_policy() SECURITY DEFINER;
+ALTER FUNCTION public.bind_visa_decision_retention_policy() SECURITY DEFINER;
+ALTER FUNCTION public.bind_visa_decision_payload_retention() SECURITY DEFINER;
+
+-- ----------------------------------------------------------------------------
+-- Step 2: close the unconditional default PUBLIC EXECUTE exposure (unconditional,
+-- same rationale as 267 -- costs nothing, no role dependency).
+-- ----------------------------------------------------------------------------
+
+REVOKE ALL ON FUNCTION public.bind_visa_evaluate_idempotency_retention_policy() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.bind_visa_decision_retention_policy() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.bind_visa_decision_payload_retention() FROM PUBLIC;
+
+-- ----------------------------------------------------------------------------
+-- Step 3: best-effort, idempotent ownership transfer to visa_ledger_owner.
+-- Role-guarded (251/253 convention: role absent -> RAISE NOTICE, no-op) AND
+-- current-owner-guarded (idempotent no-op if already transferred) AND
+-- privilege-guarded (insufficient_privilege degrades to RAISE NOTICE, not a
+-- hard failure -- see the header note on why this differs from 253's
+-- fail-loud GRANT precedent).
+-- ----------------------------------------------------------------------------
+
+DO $visa_268_owner_transfer$
+DECLARE
+    ledger_owner constant text := 'visa_ledger_owner';
+    target_function constant text[] := ARRAY[
+        'public.bind_visa_evaluate_idempotency_retention_policy()',
+        'public.bind_visa_decision_retention_policy()',
+        'public.bind_visa_decision_payload_retention()'
+    ];
+    signature text;
+    current_owner text;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = ledger_owner) THEN
+        RAISE NOTICE 'visa retention-binding SECURITY DEFINER (268): role % absent -- skipping ownership transfer, same convention as 251/253',
+            ledger_owner;
+        RETURN;
+    END IF;
+
+    FOREACH signature IN ARRAY target_function
+    LOOP
+        current_owner := (
+            SELECT pg_get_userbyid(proowner)
+              FROM pg_proc
+             WHERE oid = signature::regprocedure
+        );
+        IF current_owner IS DISTINCT FROM ledger_owner THEN
+            BEGIN
+                EXECUTE format('ALTER FUNCTION %s OWNER TO %I', signature, ledger_owner);
+            EXCEPTION
+                WHEN insufficient_privilege THEN
+                    RAISE NOTICE 'visa retention-binding SECURITY DEFINER (268): ownership transfer of % to % requires operator action (current owner %, insufficient privilege) -- deferring to operator provisioning, same as 251/253''s OWNER-TO note',
+                        signature, ledger_owner, current_owner;
+            END;
+        END IF;
+    END LOOP;
+END;
+$visa_268_owner_transfer$;
+
+-- === ROLLBACK ===
+
+-- Reverting SECURITY DEFINER -> SECURITY INVOKER restores 264's original
+-- functional behavior regardless of who ends up owning the function -- the
+-- caller's own privileges govern again, exactly as before this migration.
+-- This ALSO requires being the current owner (or superuser): if this
+-- migration's own forward ownership transfer succeeded against a
+-- non-superuser connection (never expected via the ordinary migration
+-- runner per the header above, but possible under a superuser test
+-- connection that also transferred ownership), a rollback run by a
+-- DIFFERENT, non-superuser role would hit the same one-way privilege wall
+-- 253 already documents for ownership-transferred objects -- reverting
+-- ownership itself back off visa_ledger_owner is intentionally left to
+-- operator action, same as the forward direction.
+
+ALTER FUNCTION public.bind_visa_evaluate_idempotency_retention_policy() SECURITY INVOKER;
+ALTER FUNCTION public.bind_visa_decision_retention_policy() SECURITY INVOKER;
+ALTER FUNCTION public.bind_visa_decision_payload_retention() SECURITY INVOKER;
+
+GRANT EXECUTE ON FUNCTION public.bind_visa_evaluate_idempotency_retention_policy() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bind_visa_decision_retention_policy() TO PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bind_visa_decision_payload_retention() TO PUBLIC;

--- a/apps/backend-rag/backend/scripts/visa_engine/fullstack_smoke.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fullstack_smoke.py
@@ -68,6 +68,7 @@ MIGRATION_NUMBERS = (
     265,
     266,
     267,
+    268,
 )
 TEST_RULE_PACK_ID = "8a57d996-c7f2-5abc-9c31-4128a29ed848"
 

--- a/apps/backend-rag/backend/scripts/visa_engine/operational_preflight.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/operational_preflight.py
@@ -32,12 +32,30 @@ PRIVACY_FUNCTIONS = (
     "public.set_visa_decision_legal_hold(uuid,boolean,text,text,text,text,"
     "timestamp with time zone)",
 )
+# Migration 264's three BEFORE INSERT trigger functions that resolve the
+# active Zero-approved retention policy via `SELECT ... FOR SHARE`. Migration
+# 268 made all three `SECURITY DEFINER` + owned by `visa_ledger_owner` (see
+# that migration's header for the 2026-08-07 incident this closes: `FOR
+# SHARE` requires UPDATE, which the least-privilege runtime role no longer
+# holds on the locked tables). Unlike every other entry in SENSITIVE_FUNCTIONS,
+# no role is expected to hold EXECUTE on these: they are pure trigger
+# functions Postgres invokes implicitly on INSERT, never called directly by
+# any caller, and migration 268 also REVOKEs the default PUBLIC EXECUTE grant
+# as defense-in-depth. Deliberately absent from every `_function_allowlist`
+# entry below so every `function:{role}:{signature}` check expects EXECUTE
+# False across the board -- only the `owner:{signature}` check applies.
+RETENTION_BINDING_TRIGGER_FUNCTIONS = (
+    "public.bind_visa_evaluate_idempotency_retention_policy()",
+    "public.bind_visa_decision_retention_policy()",
+    "public.bind_visa_decision_payload_retention()",
+)
 SENSITIVE_FUNCTIONS = (
     ACTIVATION_FUNCTION,
     ACTIVATION_SET_FUNCTION,
     PREPARE_IDEMPOTENCY_FUNCTION,
     *RETENTION_FUNCTIONS,
     *PRIVACY_FUNCTIONS,
+    *RETENTION_BINDING_TRIGGER_FUNCTIONS,
 )
 
 SENSITIVE_TABLES = (

--- a/apps/backend-rag/backend/scripts/visa_engine/register_privacy_policy.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/register_privacy_policy.py
@@ -193,16 +193,51 @@ async def run(args: argparse.Namespace) -> int:
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
+    # `--policy-file` used to default to `str(default_policy_path())` --
+    # an argparse `default=` expression that argparse evaluates EAGERLY,
+    # every time this function runs, before `parser.parse_args()` even
+    # looks at `argv`. `default_policy_path()` derives the checked-in
+    # policy path as `Path(__file__).resolve().parents[5]` (repo root),
+    # which raises `IndexError` in any container that only has a partial
+    # checkout (fewer than 6 ancestor directories above this file) -- so
+    # every invocation crashed before argument parsing, including a bare
+    # `--help`. The default is now `None` and resolved lazily, below, only
+    # when the caller did not pass `--policy-file` explicitly -- an
+    # explicit `--policy-file` never touches the filesystem in this
+    # function at all.
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--effective-from", required=True, type=_parse_aware_datetime)
-    parser.add_argument("--policy-file", default=str(default_policy_path()))
+    parser.add_argument(
+        "--policy-file",
+        default=None,
+        help=(
+            "defaults to the checked-in canonical policy JSON, resolved only "
+            "when this flag is omitted (never touches the filesystem otherwise)"
+        ),
+    )
     parser.add_argument("--database-url-env", default=POLICY_WRITER_DSN_ENV)
     parser.add_argument(
         "--apply",
         action="store_true",
         help="perform the idempotent insert; default only validates and reports",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.policy_file is None:
+        try:
+            canonical = default_policy_path()
+        except IndexError:
+            parser.error(
+                "--policy-file was not provided and the canonical checked-in "
+                "policy path could not be derived from this module's location "
+                "(no full repository checkout present); pass --policy-file explicitly"
+            )
+        if not canonical.is_file():
+            parser.error(
+                f"--policy-file was not provided and the canonical checked-in "
+                f"policy path does not exist: {canonical}; pass --policy-file explicitly"
+            )
+        args.policy_file = str(canonical)
+    return args
 
 
 def main(argv: list[str]) -> int:

--- a/apps/backend-rag/backend/scripts/visa_engine/register_privacy_policy.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/register_privacy_policy.py
@@ -231,12 +231,21 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
                 "policy path could not be derived from this module's location "
                 "(no full repository checkout present); pass --policy-file explicitly"
             )
-        if not canonical.is_file():
-            parser.error(
-                f"--policy-file was not provided and the canonical checked-in "
-                f"policy path does not exist: {canonical}; pass --policy-file explicitly"
-            )
-        args.policy_file = str(canonical)
+        else:
+            # `canonical` is only ever bound here -- this `else:` only runs
+            # when the `try` above did NOT raise, so the value is always
+            # initialized on every path that reaches it. `parser.error()` is
+            # typed `NoReturn` (it always raises `SystemExit`), but that
+            # contract isn't visible to every static analyzer -- moving the
+            # dependent read into `try/except/else` makes the initialization
+            # provably sound without relying on any NoReturn inference at
+            # all, rather than suppressing the finding.
+            if not canonical.is_file():
+                parser.error(
+                    f"--policy-file was not provided and the canonical checked-in "
+                    f"policy path does not exist: {canonical}; pass --policy-file explicitly"
+                )
+            args.policy_file = str(canonical)
     return args
 
 

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_fullstack_smoke.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_fullstack_smoke.py
@@ -63,6 +63,7 @@ def test_migration_set_is_exact_and_forward_only() -> None:
         265,
         266,
         267,
+        268,
     )
     for path in paths:
         text = Path(path).read_text(encoding="utf-8")

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_operational_preflight.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_operational_preflight.py
@@ -23,6 +23,9 @@ CANONICAL_SENSITIVE_FUNCTIONS = {
     "public.erase_visa_decision_for_dsr(uuid,text,text)",
     "public.set_visa_decision_legal_hold(uuid,boolean,text,text,text,text,"
     "timestamp with time zone)",
+    "public.bind_visa_evaluate_idempotency_retention_policy()",
+    "public.bind_visa_decision_retention_policy()",
+    "public.bind_visa_decision_payload_retention()",
 }
 CANONICAL_SENSITIVE_TABLES = {
     "visa_rule_packs",

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_retention_binding_security_definer.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_retention_binding_security_definer.py
@@ -1,0 +1,261 @@
+"""Integration test for migration 268 -- retention-binding trigger SECURITY
+DEFINER.
+
+Reproduces the 2026-08-07 production incident (see
+``lesson_least_privilege_repair_breaks_invoker_triggers_that_lock_rows_
+2026_08_07.md``) against a real, throwaway Postgres database: a
+low-privilege role holding only SELECT on
+``visa_decision_retention_policies`` -- the shape ``backend_rag_v2`` has
+after the "D1" least-privilege repair -- cannot complete the ``SELECT ...
+FOR SHARE`` inside migration 264's BEFORE INSERT trigger
+``bind_visa_evaluate_idempotency_retention_policy`` (``FOR SHARE`` requires
+the UPDATE privilege, not merely SELECT) until migration 268 makes that
+trigger, and its two siblings, ``SECURITY DEFINER``.
+
+Mirrors ``test_write_substrate.py``'s throwaway-database pattern (its own
+``CREATE DATABASE``/``DROP DATABASE`` against the ``postgres`` maintenance
+DB, migrations applied directly off disk) rather than the shared
+``nuzantara_test`` database conftest.py's ``visa_schema`` fixture targets --
+this test additionally creates a cluster-wide Postgres ROLE (a privilege
+boundary cannot be scoped to one database the way a table can), so
+isolation from a concurrent sibling test run matters even more here. The
+role name is uuid-suffixed per test invocation, so a cross-run collision is
+structurally impossible rather than merely unlikely, and the throwaway
+database is always dropped before the role is, so the role never has a
+dangling privilege blocking its own ``DROP ROLE``.
+
+Reuses ``fullstack_smoke``'s own ``MIGRATION_NUMBERS``/``_migration_paths``
+as the single source of truth for the full forward-migration chain (250
+through 268) rather than hand-picking a subset here and silently missing a
+dependency.
+
+Run manually (creates+drops its own throwaway database and role via an
+admin connection derived from ``TEST_DATABASE_URL``, swapped to the
+``postgres`` maintenance database; never touches ``nuzantara_dev``/
+``nuzantara_test`` themselves):
+
+    TEST_DATABASE_URL=postgresql://nuzantara@localhost:5432/nuzantara_dev \\
+    PYTHONPATH=. pytest \\
+      backend/tests/scripts/visa_engine/test_retention_binding_security_definer.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import uuid
+from collections.abc import AsyncIterator
+from typing import NamedTuple
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from backend.db.migration_base import split_migration_sql
+from backend.scripts.visa_engine import fullstack_smoke
+
+pytestmark = pytest.mark.asyncio
+
+# Same env-var convention as conftest.py / test_write_substrate.py: read
+# TEST_DATABASE_URL (the one env var CI actually exports), swap its database
+# name for the "postgres" maintenance database every Postgres install ships.
+_ADMIN_URL = (
+    os.environ.get(
+        "TEST_DATABASE_URL",
+        "postgresql://nuzantara@localhost:5432/nuzantara_test",
+    ).rsplit("/", 1)[0]
+    + "/postgres"
+)
+
+
+def _db_url_for(db_name: str) -> str:
+    return _ADMIN_URL.rsplit("/", 1)[0] + f"/{db_name}"
+
+
+async def _apply_migrations_through(database_dsn: str, *, through: int) -> None:
+    """Apply every Visa Engine migration up to and including ``through``, in
+    the exact order ``fullstack_smoke.MIGRATION_NUMBERS`` defines -- the
+    single source of truth for the full chain, so this never hand-picks a
+    subset and silently skips a dependency.
+    """
+
+    backend_root = fullstack_smoke._backend_root()
+    connection = await asyncpg.connect(database_dsn)
+    try:
+        for migration_path in fullstack_smoke._migration_paths(backend_root):
+            number = int(migration_path.name.split("_", 1)[0])
+            if number > through:
+                continue
+            forward_sql, _rollback_sql = split_migration_sql(
+                migration_path.read_text(encoding="utf-8")
+            )
+            async with connection.transaction():
+                await connection.execute(forward_sql)
+    finally:
+        await connection.close()
+
+
+async def _insert_test_retention_policy(database_dsn: str) -> None:
+    connection = await asyncpg.connect(database_dsn)
+    try:
+        await connection.execute(fullstack_smoke.POLICY_SQL)
+    finally:
+        await connection.close()
+
+
+async def _create_lowpriv_role(database_dsn: str, role: str) -> None:
+    """The shape ``backend_rag_v2`` has after the D1 least-privilege repair:
+    SELECT-only on the retention-policy table, SELECT+INSERT (never UPDATE)
+    on the idempotency table it writes to."""
+
+    connection = await asyncpg.connect(database_dsn)
+    try:
+        await connection.execute(f'CREATE ROLE "{role}" NOLOGIN')
+        await connection.execute(
+            f'GRANT SELECT ON TABLE public.visa_decision_retention_policies TO "{role}"'
+        )
+        await connection.execute(
+            f'GRANT SELECT, INSERT ON TABLE public.visa_evaluate_idempotency TO "{role}"'
+        )
+    finally:
+        await connection.close()
+
+
+def _idempotency_insert() -> tuple[str, bytes, bytes, str]:
+    sql = """
+        INSERT INTO public.visa_evaluate_idempotency
+            (key_sha256, request_hmac, request_hmac_key_id, environment,
+             reserved_at, created_at, expires_at)
+        VALUES
+            ($1, $2, $3, 'TEST',
+             statement_timestamp(), statement_timestamp(),
+             statement_timestamp() + INTERVAL '1 hour')
+    """
+    return sql, secrets.token_bytes(32), secrets.token_bytes(32), "test-key-1"
+
+
+class _Sandbox(NamedTuple):
+    database_dsn: str
+    lowpriv_role: str
+
+
+@pytest_asyncio.fixture
+async def m268_sandbox() -> AsyncIterator[_Sandbox]:
+    """A throwaway database plus a matching, uuid-suffixed low-privilege
+    role name. Neither the database nor the role is created empty-handed by
+    this fixture beyond the database itself -- each test decides how far to
+    apply migrations before creating the role, since the pre-268/post-268
+    comparison is the point. Teardown always drops the database FIRST (so
+    every ACL entry the role held vanishes with it) and only then the role
+    itself, so ``DROP ROLE`` never trips over a dangling privilege.
+    """
+
+    db_name = f"nuzantara_test_visa_m268_{uuid.uuid4().hex[:16]}"
+    role_name = f"visa268_lowpriv_{uuid.uuid4().hex[:12]}"
+    admin_conn = await asyncpg.connect(_ADMIN_URL)
+    try:
+        await admin_conn.execute(f'CREATE DATABASE "{db_name}"')
+    finally:
+        await admin_conn.close()
+
+    try:
+        yield _Sandbox(database_dsn=_db_url_for(db_name), lowpriv_role=role_name)
+    finally:
+        admin_conn = await asyncpg.connect(_ADMIN_URL)
+        try:
+            await admin_conn.execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = $1 AND pid <> pg_backend_pid()",
+                db_name,
+            )
+            await admin_conn.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+            await admin_conn.execute(f'DROP ROLE IF EXISTS "{role_name}"')
+        finally:
+            await admin_conn.close()
+
+
+async def test_pre_268_low_privilege_insert_fails_with_insufficient_privilege(
+    m268_sandbox: _Sandbox,
+) -> None:
+    """Reproduces the 2026-08-07 incident: migrations up to 267 only (264's
+    trigger is still SECURITY INVOKER), a role with SELECT-only on the
+    policy table cannot complete the trigger's ``FOR SHARE`` row lock."""
+
+    await _apply_migrations_through(m268_sandbox.database_dsn, through=267)
+    await _insert_test_retention_policy(m268_sandbox.database_dsn)
+    await _create_lowpriv_role(m268_sandbox.database_dsn, m268_sandbox.lowpriv_role)
+
+    sql, key_sha256, request_hmac, key_id = _idempotency_insert()
+    connection = await asyncpg.connect(m268_sandbox.database_dsn)
+    try:
+        async with connection.transaction():
+            await connection.execute(f'SET LOCAL ROLE "{m268_sandbox.lowpriv_role}"')
+            with pytest.raises(asyncpg.InsufficientPrivilegeError):
+                await connection.execute(sql, key_sha256, request_hmac, key_id)
+    finally:
+        await connection.close()
+
+
+async def test_post_268_low_privilege_insert_succeeds(m268_sandbox: _Sandbox) -> None:
+    """Migration 268 applied: the SAME low-privilege role, the SAME grants,
+    the SAME INSERT -- now succeeds because the trigger runs SECURITY
+    DEFINER, resolving the policy lookup with the function owner's
+    privileges instead of the caller's."""
+
+    await _apply_migrations_through(m268_sandbox.database_dsn, through=268)
+    await _insert_test_retention_policy(m268_sandbox.database_dsn)
+    await _create_lowpriv_role(m268_sandbox.database_dsn, m268_sandbox.lowpriv_role)
+
+    sql, key_sha256, request_hmac, key_id = _idempotency_insert()
+    connection = await asyncpg.connect(m268_sandbox.database_dsn)
+    try:
+        async with connection.transaction():
+            await connection.execute(f'SET LOCAL ROLE "{m268_sandbox.lowpriv_role}"')
+            await connection.execute(sql, key_sha256, request_hmac, key_id)
+
+        row = await connection.fetchrow(
+            "SELECT retention_policy_id, expires_at FROM public.visa_evaluate_idempotency "
+            "WHERE key_sha256 = $1",
+            key_sha256,
+        )
+    finally:
+        await connection.close()
+
+    assert row is not None
+    assert row["retention_policy_id"] is not None
+    assert row["expires_at"] is not None
+
+
+async def test_268_marks_all_three_retention_binding_triggers_security_definer(
+    m268_sandbox: _Sandbox,
+) -> None:
+    """Fallback structural proof, independent of the role-boundary
+    reproduction above: after 268, every one of the three "twin" trigger
+    functions (`lesson ... 2026_08_07.md`'s own phrase) is
+    ``prosecdef = true``, not only the one the other two tests exercise
+    end-to-end."""
+
+    await _apply_migrations_through(m268_sandbox.database_dsn, through=268)
+
+    connection = await asyncpg.connect(m268_sandbox.database_dsn)
+    try:
+        rows = await connection.fetch(
+            """
+            SELECT proname, prosecdef
+              FROM pg_proc
+             WHERE proname IN (
+                 'bind_visa_evaluate_idempotency_retention_policy',
+                 'bind_visa_decision_retention_policy',
+                 'bind_visa_decision_payload_retention'
+             )
+            """
+        )
+    finally:
+        await connection.close()
+
+    assert {row["proname"] for row in rows} == {
+        "bind_visa_evaluate_idempotency_retention_policy",
+        "bind_visa_decision_retention_policy",
+        "bind_visa_decision_payload_retention",
+    }
+    assert all(row["prosecdef"] for row in rows)

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_privacy_operations.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_privacy_operations.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -123,6 +123,63 @@ def test_new_policy_registration_rejects_backdating_but_allows_change_window() -
             effective_from=datetime(2026, 8, 5, 23, 59, tzinfo=timezone.utc),
             database_now=database_now,
         )
+
+
+def test_parse_args_with_explicit_policy_file_never_touches_the_filesystem() -> None:
+    """An explicit ``--policy-file`` must short-circuit before
+    ``default_policy_path()`` is ever called. The eager
+    ``default=str(default_policy_path())`` this replaces used to run on
+    every invocation -- including one that always passes ``--policy-file``
+    explicitly -- and crashed with ``IndexError`` in any container without
+    the full repository checkout."""
+
+    with patch.object(
+        register_privacy_policy,
+        "default_policy_path",
+        side_effect=AssertionError("default_policy_path() must not be called"),
+    ):
+        args = register_privacy_policy._parse_args(
+            [
+                "--effective-from",
+                "2026-08-10T02:00:00+00:00",
+                "--policy-file",
+                "/tmp/does-not-need-to-exist.json",
+            ]
+        )
+
+    assert args.policy_file == "/tmp/does-not-need-to-exist.json"
+
+
+def test_parse_args_defaults_to_the_checked_in_canonical_policy_path() -> None:
+    args = register_privacy_policy._parse_args(
+        ["--effective-from", "2026-08-10T02:00:00+00:00"]
+    )
+
+    assert args.policy_file == str(default_policy_path())
+    assert Path(args.policy_file).is_file()
+
+
+def test_parse_args_exits_cleanly_when_canonical_path_cannot_be_derived() -> None:
+    """The regression this closes: a container without the full repository
+    checkout used to crash with a bare, unhandled ``IndexError`` before
+    argument parsing even finished -- reproducing even for ``--help``. It
+    must now exit cleanly via argparse's own error path instead."""
+
+    with patch.object(
+        register_privacy_policy,
+        "default_policy_path",
+        side_effect=IndexError("tuple index out of range"),
+    ), pytest.raises(SystemExit):
+        register_privacy_policy._parse_args(["--effective-from", "2026-08-10T02:00:00+00:00"])
+
+
+def test_parse_args_exits_cleanly_when_canonical_path_is_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.json"
+
+    with patch.object(
+        register_privacy_policy, "default_policy_path", return_value=missing
+    ), pytest.raises(SystemExit):
+        register_privacy_policy._parse_args(["--effective-from", "2026-08-10T02:00:00+00:00"])
 
 
 @pytest.mark.asyncio

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 688 services · 1300 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 688 services · 1301 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Context

Prod was cured by hand on 2026-08-07 (manual superuser transaction, single
change window): three migration-264 BEFORE INSERT trigger functions
(`bind_visa_evaluate_idempotency_retention_policy`,
`bind_visa_decision_retention_policy`, `bind_visa_decision_payload_retention`)
started failing every INSERT into their guarded tables with
`insufficient_privilege` once the "D1" least-privilege repair moved
ownership of the retention tables to `visa_ledger_owner` and reduced the
runtime role to SELECT-only. Each trigger runs `SELECT ... FOR SHARE`
against a `visa_ledger_owner`-owned table, and Postgres' `FOR SHARE`
row-lock requires UPDATE, not merely SELECT — so once the runtime role lost
UPDATE, the invoker-privileged trigger broke. Manual fix: `ALTER FUNCTION
... SECURITY DEFINER` + `OWNER TO visa_ledger_owner` for all three.

No test caught it because CI/fullstack-smoke connect as a superuser
(always both owner and invoker, so the INVOKER-vs-DEFINER distinction never
mattered there), and the three functions were never added to
`operational_preflight.py::SENSITIVE_FUNCTIONS`, so the 622-check preflight
was also blind to them. See
`lesson_least_privilege_repair_breaks_invoker_triggers_that_lock_rows_2026_08_07.md`
for the full incident writeup.

This PR is the follow-up: migration 268 codifies the same cure the repo
into (idempotent — a no-op against prod, where it is already live), extends
the preflight, and separately fixes an unrelated container-crash bug found
while working the same script surface.

## Commits

1. **`c0140a30c` — `fix(db): migration 268 -- SECURITY DEFINER for retention-binding triggers`**
   `SECURITY DEFINER` (unconditional) + `REVOKE ALL ... FROM PUBLIC`
   (unconditional, defense-in-depth) + role-guarded/current-owner-guarded/
   privilege-guarded `OWNER TO visa_ledger_owner` (best-effort — degrades to
   `RAISE NOTICE`, never a hard failure, consistent with migration 253's own
   precedent that this specific `ALTER` is beyond a non-superuser migration
   role's reach until operator provisioning runs) for all three trigger
   functions. Idempotent forward SQL, `-- === ROLLBACK ===` section included.
   Migration 264's on-disk file is intentionally left untouched (already-
   applied history — the prod-vs-repo drift this closes is deliberate).
   Registers 268 in `fullstack_smoke.MIGRATION_NUMBERS` (+ updates that
   file's own frozen expected-tuple test) so the full forward-migration
   chain actually applies it. Also adds a real-Postgres reproduction test
   (`test_retention_binding_security_definer.py`): a throwaway database
   plus a uuid-scoped low-privilege role holding only SELECT on
   `visa_decision_retention_policies` proves the INSERT fails with
   `InsufficientPrivilegeError` against migrations 250-267, and succeeds
   once 268 is applied — plus a structural `pg_proc.prosecdef` check
   covering all three "twin" trigger functions.

2. **`9faabbbdc` — `feat(db): extend operational_preflight to the 3 retention-binding triggers`**
   Adds the three `bind_visa_*` functions to
   `operational_preflight.py::SENSITIVE_FUNCTIONS` (arms the existing
   `owner:{sig} == visa_ledger_owner` check for all three). They are pure
   trigger functions Postgres invokes implicitly, never called directly, so
   they're deliberately absent from every `_function_allowlist()` role
   entry — every `function:{role}:{signature}` check now expects
   `EXECUTE=False` across the board, matching migration 268's `REVOKE ALL
   ... FROM PUBLIC`. Mirrored into `test_operational_preflight.py`'s
   independently-frozen `CANONICAL_SENSITIVE_FUNCTIONS` set.

3. **`b410fa984` — `fix(scripts): register_privacy_policy CLI crashes before parsing any args`**
   Unrelated container-crash bug found while working this script surface:
   `--policy-file` defaulted to `str(default_policy_path())`, an argparse
   `default=` expression evaluated eagerly on every invocation — including
   `--help` — before any parsing happened. `default_policy_path()` derives
   the checked-in path as `Path(__file__).resolve().parents[5]`, which
   raises `IndexError` in any container lacking the full repo checkout.
   Default is now `None`, resolved lazily post-parse only when the caller
   omits `--policy-file`, with a clean `SystemExit` (not a raw traceback) on
   either failure mode. 4 new tests, including one proving an explicit
   `--policy-file` never touches the filesystem.

## Test numbers

- Targeted suite (`services/visa_engine` + `scripts/visa_engine` +
  compile/sign_pack): **1698 passed, 1 skipped (pre-existing, unrelated —
  `visa_activation_executor` role absent locally), 0 failed**.
- `squawk-cli` on migration 268 with the exact CI exclude list
  (`migration-lint.yml`): **0 issues**.
- Full backend pre-push suite (triggered by pushing to a non-`origin` HTTPS
  remote): **all green**, `PUSH_EXIT=0`.

No auto-merge armed — this PR contains a migration.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>