### PR TITLE
fix(cron-agent): equal time-slicing starved the only seat that could succeed

### DIFF
--- a/infra/launchagents/wrappers/cron-agent.sh
+++ b/infra/launchagents/wrappers/cron-agent.sh
@@ -63,6 +63,12 @@ case "$TIER" in
 esac
 TIMEOUT="${CRON_AGENT_TIMEOUT:-$DEFAULT_TIMEOUT}"
 
+# Floor for a single cascade attempt (see run_agent's allocation comment). The
+# slowest agent job measured succeeding on Pro takes 118s; 300s is ~2.5x that,
+# and the global TIMEOUT above still caps the whole cascade. Per-job override:
+# CRON_AGENT_MIN_ATTEMPT_SECONDS.
+MIN_ATTEMPT_SECONDS="${CRON_AGENT_MIN_ATTEMPT_SECONDS:-300}"
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] [$JOB_NAME] $*" >> "$LOG_FILE"; }
@@ -376,6 +382,26 @@ leaving no output (W89 class-audit, regulatory-watcher incident 2026-07-05)."
         fi
         local attempts_left=$(( ${#tokens[@]} - idx ))
         local attempt_timeout=$(( remaining / attempts_left ))
+        # Equal division assumes every attempt consumes its slice. A cascade is
+        # the opposite: a DEAD seat is refused in seconds and costs nothing,
+        # while the ONE seat that works needs real time. So an equal split
+        # starves the only attempt that was ever going to succeed — and it gets
+        # worse the healthier the fleet is. Measured on Pro 2026-08-07, right
+        # after all four seats were re-issued: 600s / 5 entries = 120s each,
+        # and `indexing-daily` (a job that takes 118s) passed with two seconds
+        # to spare while `weekly-dep-audit` was killed on all five in turn —
+        # five healthy seats, five timeouts, no work done. The wrapper already
+        # grants a legitimate long agent run 30 minutes of background ceiling
+        # (see CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS below); a 120s slice
+        # contradicts that by 15x.
+        #
+        # So: floor every attempt at a real working slice. Fast-failing seats
+        # never reach the floor (they are refused long before it), so rotation
+        # keeps its full depth; only a seat that is genuinely working gets the
+        # time. The global deadline is still the hard backstop — the cap on the
+        # next line means the floor can never overrun it.
+        [[ $attempt_timeout -lt $MIN_ATTEMPT_SECONDS ]] && attempt_timeout=$MIN_ATTEMPT_SECONDS
+        [[ $attempt_timeout -gt $remaining ]] && attempt_timeout=$remaining
         [[ $attempt_timeout -lt 1 ]] && attempt_timeout=1
 
         local env_args=()

--- a/scripts/tests/test_cron_agent_oauth_cascade.sh
+++ b/scripts/tests/test_cron_agent_oauth_cascade.sh
@@ -150,6 +150,113 @@ check "0|used: tier2-claude-token_3|3" "$(run_cascade dead-a dead-b live-c)" \
 check "0|used: tier2-claude-token_1|1" "$(run_cascade live-a live-b live-c)" \
     "innocence: a live first seat is used immediately, no needless rotation"
 
+# ── Part 3: the time budget — a WORKING seat must not be starved ─────────────
+# Equal division (remaining / attempts_left) starves the only attempt that was
+# ever going to succeed, because dead seats cost seconds and the live one costs
+# real time. Measured on Pro 2026-08-07 with all four seats re-issued: 120s per
+# entry, indexing-daily (118s) passed by two seconds, weekly-dep-audit was
+# killed on all five in turn.
+#
+# These two need a timeout that REALLY bounds its child — the fake above
+# ignores its duration on purpose, so it cannot judge an allocation. Neither
+# Mac in this fleet ships coreutils `timeout`, and a check that only ever runs
+# on CI is a check that hides defects (W108), so the stand-in below is built
+# here rather than depended upon. It honours the only two things the wrapper
+# reads: the child is really bounded, and a kill reports 124.
+
+cat > "$TMP/portable-timeout" <<'FAKE'
+#!/usr/bin/env bash
+dur="$1"; shift
+mark="$(mktemp "${TMPDIR:-/tmp}/pt-mark.XXXXXX")"
+"$@" &
+child=$!
+( sleep "$dur"; printf killed > "$mark"; kill -TERM "$child" 2>/dev/null ) &
+watcher=$!
+wait "$child" 2>/dev/null; rc=$?
+kill -TERM "$watcher" 2>/dev/null; wait "$watcher" 2>/dev/null
+# The mark is written BEFORE the kill, so this is a fact, not a race.
+[ -s "$mark" ] && rc=124
+rm -f "$mark"
+exit "$rc"
+FAKE
+chmod +x "$TMP/portable-timeout"
+REAL_TIMEOUT="$TMP/portable-timeout"
+
+run_slow() { # <budget> <floor> <sleep-seconds> -> "<rc>|<used>|<attempts>|<wall>"
+    local home="$TMP/home-slow-$RANDOM"
+    mkdir -p "$home"
+    : > "$TMP/attempts"
+    local t0 rc t1
+    t0=$(date +%s)
+    env -i \
+        HOME="$home" CRON_AGENT_HOME="$home" \
+        FAKE_CLAUDE_ATTEMPTS="$TMP/attempts" FAKE_TG_LOG="$TMP/tg" \
+        FAKE_CLAUDE_SLEEP="$3" \
+        CRON_AGENT_CLAUDE_BIN="$TMP/fake-slow-claude" \
+        CRON_AGENT_TIMEOUT_BIN="$REAL_TIMEOUT" \
+        CRON_AGENT_TIMEOUT="$1" \
+        CRON_AGENT_MIN_ATTEMPT_SECONDS="$2" \
+        CLAUDE_CODE_OAUTH_TOKEN_1=live-a \
+        CLAUDE_CODE_OAUTH_TOKEN_2=live-b \
+        /usr/bin/env bash "$TMP/bin/cron-agent.sh" agent slow-job "$TMP/prompt.txt" \
+        >/dev/null 2>&1
+    rc=$?
+    t1=$(date +%s)
+    local used
+    used="$(grep -o 'used: tier2-claude-[a-z0-9_]*' "$home/logs/cron-agent/slow-job.log" 2>/dev/null | tail -1)"
+    printf '%s|%s|%s|%s' "$rc" "${used:-none}" "$(wc -l < "$TMP/attempts" | tr -d ' ')" "$((t1-t0))"
+}
+
+echo "time budget:"
+
+if [[ -z "$REAL_TIMEOUT" ]]; then
+    echo "  SKIP no real timeout(1) on PATH — the allocation checks cannot run here"
+else
+    cat > "$TMP/fake-slow-claude" <<'FAKE'
+#!/usr/bin/env bash
+echo "$CLAUDE_CODE_OAUTH_TOKEN" >> "$FAKE_CLAUDE_ATTEMPTS"
+sleep "${FAKE_CLAUDE_SLEEP:-0}"
+echo 'PONG after honest work'
+FAKE
+    chmod +x "$TMP/fake-slow-claude"
+
+    # 3 entries (token_1, token_2, keychain), budget 21s.
+    #   equal division  -> 21/3 = 7s per attempt: an 8s job dies on all three
+    #   with the floor  -> max(10, 7) = 10s: the first seat finishes its work
+    # Asserted on the OUTCOME (succeeded, on the first seat, one attempt), not
+    # on a wall-clock value — pinning the exact second tests the test machine.
+    out="$(run_slow 21 10 8)"
+    check "0|used: tier2-claude-token_1|1" "${out%|*}" \
+        "guilt: a seat doing 8s of work is not killed by a 7s equal slice"
+
+    # The floor must never overrun the global deadline: a seat that never
+    # returns still has to be abandoned within the budget. Sized so the breach
+    # is VISIBLE — at 21s the last attempt never starts (the budget is already
+    # spent) and capped/uncapped measure 21s vs 22s, indistinguishable. At 25s
+    # the third attempt does start with 5s left, so dropping the cap hands it
+    # the full 10s floor: measured 26s capped vs 31s uncapped.
+    out="$(run_slow 25 10 999)"
+    rc="${out%%|*}"; wall="${out##*|}"
+    tries="$(printf '%s' "$out" | cut -d'|' -f3)"
+    if [[ "$rc" == "124" && "$wall" -le 28 ]]; then
+        ok "innocence: the floor never overruns the global deadline (rc=124, ${wall}s)"
+    else
+        bad "innocence: global deadline (want rc=124 and wall<=28, got rc=$rc wall=${wall}s)"
+    fi
+    # The other edge of the same knob, and the reason the floor is 300 and not
+    # the whole 600: a floor large enough to swallow the budget lets ONE hung
+    # seat consume everything, and the cascade never reaches a fallback — the
+    # cure would have re-created the disease it was written for, at the other
+    # sign. `attempt_timeout` is an upper bound, so a seat that FAILS fast still
+    # rotates freely; only a HUNG one exposes this, which is why it is asserted
+    # here rather than in the fast-failure checks above.
+    if [[ "$tries" -ge 2 ]]; then
+        ok "innocence: a hung seat does not eat the whole budget ($tries attempts, fallback still reached)"
+    else
+        bad "innocence: one hung seat consumed the entire cascade (only $tries attempt)"
+    fi
+fi
+
 echo
 if [[ $FAIL -eq 0 ]]; then
     echo "PASS ($PASS checks)"


### PR DESCRIPTION
Follow-on to #3747, and found by running the crons rather than reasoning about them.

#3747 made the cascade rotate past dead seats. Tonight's induced batch showed what that
unmasked: the budget is split `remaining / attempts_left`, which assumes every attempt
consumes its slice. **A cascade is the opposite** — a dead seat is refused in seconds and
costs nothing, while the ONE seat that works needs real time. The split starves the only
attempt that was ever going to succeed, and **it gets worse the healthier the fleet is**.

## Measured on Pro, right after all four seats were re-issued

`600s / 5 entries = 120s each`. Real durations of agent-tier jobs:

| job | duration | outcome |
|---|---|---|
| seo-guardian-observe | 40s | ok |
| learning-pipeline | 51s | ok |
| seo-guardian-weekly | 59s | ok |
| conversation-cleanup | 97s | ok |
| **indexing-daily** | **118s** | ok — **2 seconds** from the wall |
| **weekly-dep-audit** | >120s | **killed on all five seats in turn** |

```
Trying token_1... timed out, trying next
Trying token_2... timed out, trying next
Trying token_4... timed out, trying next
Trying token_5... timed out, trying next
Trying keychain... unavailable
```

Five healthy seats, five timeouts, no work done. And the wrapper already grants a
legitimate long agent run a **30-minute** background ceiling (`CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`)
— a 120s slice contradicts its own setting by 15×.

## The fix

Floor each attempt at a real working slice (**300s**, ~2.5× the slowest measured success,
`CRON_AGENT_MIN_ATTEMPT_SECONDS` to override), **capped by what is left of the global
deadline**. `attempt_timeout` is an upper bound, so fast failures never reach the floor and
rotation keeps its full depth — only a seat that is genuinely working gets the time.

## Three properties, three assertions, three mutations

| mutation | caught by |
|---|---|
| remove the floor | guilt check returns `124\|none\|3` — the live symptom exactly |
| remove the deadline cap | cascade overruns its stated budget (30s of 25s) |
| floor swallows the whole budget | one hung seat consumes everything, no fallback reached |

That third one is **the cure's own opposite sign**, and the reason the floor is 300 and not
the whole 600. It survived the first two versions of this corpus; the check that catches it
was added because it survived, not before.

## Two things about the test itself

- The timing checks need a timeout that really bounds its child, and **neither Mac in this
  fleet ships coreutils `timeout`**. A check that only runs on CI is a check that hides
  defects (W108), so the stand-in is built inside the corpus and it runs everywhere.
- The deadline check is **sized deliberately**: at a 21s budget the last attempt never starts
  (the budget is already spent) and capped/uncapped measure 21s vs 22s — indistinguishable.
  At 25s the third attempt starts with 5s left, so the breach becomes visible. It asserts
  outcomes, never an exact wall-clock second.

Armed in the same commit via `immune-enforcement.yml` (already covers this corpus from #3747).

🤖 Generated with [Claude Code](https://claude.com/claude-code)