### PR TITLE
docs(visa-oracle): closure record — prod-003 activation, kill-switch drill, retention live

### DIFF
--- a/.agents/skills/visaoracle/CURRENT_STATE.md
+++ b/.agents/skills/visaoracle/CURRENT_STATE.md
@@ -1,6 +1,6 @@
 # Visa Oracle V2 — Current State
 
-Snapshot: 2026-08-07, Asia/Makassar
+Snapshot: 2026-08-08, Asia/Makassar (operational-gates closure, night 07→08/8)
 
 Owner: Zero / Bali Zero
 
@@ -8,14 +8,21 @@ Purpose: canonical restart and Claude-review handoff for `/visaoracle`
 
 ## Read this first
 
-Visa Oracle V2 is repository-complete on the frozen reviewed baseline, but it
-is **not authorized for production ENFORCE**. The public/runtime posture remains
-SHADOW until the operational gates in this document are proven against the real
-production environment.
+Visa Oracle V2 is **ONLINE IN SHADOW with every operational gate proven
+against real production** — roles provisioned, migrations 262–267 applied,
+Privacy Policy V1 registered, a corrected signed RulePack activated
+(`prod-003`, sequence 3), the 15-minute retention scheduler installed and
+armed with real deletions (`APPLY=true`), and a full kill-switch drill
+(SHADOW→OFF→SHADOW) executed and proven. It is still **not authorized for
+production ENFORCE** — that flip is a separate, explicit, Zero-gated action,
+withheld by mandate, and `VISA_ENGINE_EVALUATE_MODE=SHADOW` is confirmed
+live. See "Production operational verification" below for the exact
+evidence, and "Remaining production blockers" for what is genuinely still
+open (DPIA, analytics TTL, ENFORCE authorization).
 
-Do not infer that a green repository candidate means the production database,
-scheduler, analytics TTL, DPIA or kill-switch drill has been provisioned. Do not
-merge, push, deploy, activate a RulePack or change ENFORCE from this record.
+Do not infer that operational-gates-green means ENFORCE is authorized. Do not
+merge, push, deploy, activate a RulePack or change ENFORCE from this record —
+each is a distinct, explicit action requiring its own Zero go-ahead.
 
 ## Product contract
 
@@ -37,17 +44,35 @@ merge, push, deploy, activate a RulePack or change ENFORCE from this record.
 
 ## Canonical workspace and reviewed commits
 
-- Integration worktree:
+- Integration worktree (operational-gates delivery):
   `/Users/nuzantara/nuzantara/.worktrees/backend-rag-visa-oracle-v2-operational-gates`
-- Branch:
-  `agent/mini-pro2/backend-rag/visa-oracle-v2-operational-gates`
+- Closure-docs worktree (this update):
+  `/Users/nuzantara/nuzantara/.worktrees/docs-visa-oracle-closure-docs`
+- Branch: `agent/mini-pro2/backend-rag/visa-oracle-v2-operational-gates`
 - Frozen G6 baseline: `cd343655c7d77f65f50897f91c299ba92da35cb0`
 - Independently reviewed candidate: `635bbccd00ba5ad578eaaadcd27415918b2e1bc1`
 - Independently reviewed final delivery record:
   `e15fc1b84501cbdc2e023497b3e1af298f51034f`
 - Independent verdict: **LGTM, 0 BLOCKER, 0 MEDIUM**.
-- This `CURRENT_STATE.md` update is a documentation-only continuation after
-  that exact-SHA review; the reviewed implementation remains its ancestor.
+- **Merged to `main`**: PR #3732, merge commit
+  `63234a12aa3c5dd451c22e2591a2ec9dd4b34e91`, merged 2026-08-07T12:34:07Z.
+  Verified: the frozen G6 baseline (`cd343655c`) is a full ancestor of
+  `origin/main`.
+- **Open, not yet merged, both verified at time of writing**:
+  - PR #3766 (`agent/mini-pro2/backend-rag/visa-oracle-268-followups`) —
+    codifies migration 268 (`SECURITY DEFINER` + ownership fix for the 3
+    retention-binding trigger functions broken by the D1 least-privilege
+    repair) plus preflight/smoke coverage. Production already carries the
+    equivalent hand-applied fix (see "P0" below), so this migration will be
+    an idempotent no-op against prod once merged. Until merge, the repo does
+    not yet reflect prod's real function-ownership/security posture for
+    those 3 functions — this is a deliberate, tracked repo-vs-prod drift, not
+    an oversight.
+  - PR #3765 (`agent/mini-pro2/mouth/visa-verdict-states`) — mouth verdict
+    panel fix so `HUMAN_REVIEW_REQUIRED` responses are no longer displayed as
+    "no evaluation was submitted." Unrelated to the ops work below; tracked
+    separately.
+- This `CURRENT_STATE.md` update is documentation-only.
 
 Never edit the main checkout. Continue only in the integration worktree or a
 new worktree created through `scripts/agent_start.py`.
@@ -64,9 +89,10 @@ The reviewed branch was two commits behind Mini's newest `main` at handoff.
 One observed concurrent commit, `029e6ca43`, changed only
 `.claude/skills/modus/PENDING-ARMS.md` and was graded LOW merge hygiene. A later
 Mini commit, `5d0f3ddeb`, is a KBLI content fix and was not part of the frozen
-G6 baseline.
+G6 baseline. This is now historical — PR #3732 merged past this drift on
+2026-08-07T12:34:07Z.
 
-Before review or merge, Claude must:
+Before review or merge of unrelated future work, Claude must:
 
 1. restore Mini/Pro git synchronization;
 2. inspect every post-baseline commit for overlap;
@@ -80,18 +106,24 @@ review. Freeze and record the reviewed baseline; handle later drift explicitly.
 
 ## Gate matrix
 
-| Gate                                    | Initial state    | Reviewed repository state  | Production state                  |
-| --------------------------------------- | ---------------- | -------------------------- | --------------------------------- |
-| G0 inventory / AS-IS                    | PASS             | PASS                       | N/A                               |
-| G1 contracts and sources                | BLOCKED          | PASS                       | freshness scheduler still unarmed |
-| G2 engine and gold/adversarial harness  | PARTIAL          | PASS                       | migrations/roles not provisioned  |
-| G3 UI states and categories             | PARTIAL          | PASS                       | reviewed candidate not deployed   |
-| G4 backend authority over public result | PARTIAL / SHADOW | PASS in candidate          | production remains SHADOW         |
-| G5 automated verification               | PARTIAL          | PASS                       | production smoke not run          |
-| G6 independent review                   | PENDING          | PASS, 0 BLOCKER / 0 MEDIUM | does not authorize ENFORCE        |
+| Gate                                    | Initial state    | Reviewed repository state  | Production state                                                                                                                                                                                                    |
+| --------------------------------------- | ---------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| G0 inventory / AS-IS                    | PASS             | PASS                       | N/A                                                                                                                                                                                                                 |
+| G1 contracts and sources                | BLOCKED          | PASS                       | signed pack carries per-source `freshness_policy` (7d/365d), all 28 sources `CURRENT`; no automated re-verification scheduler — next 7-day recheck ~2026-08-13, owner/SLA still a Zero decision (G1 packet point 6) |
+| G2 engine and gold/adversarial harness  | PARTIAL          | PASS                       | roles/migrations provisioned and proven (D1 repair + P0 hand-cure, migrations through 267 applied, 268 hand-applied live / PR #3766 open)                                                                           |
+| G3 UI states and categories             | PARTIAL          | PASS                       | reviewed candidate deployed and live-smoked (`mode=CURATED`)                                                                                                                                                        |
+| G4 backend authority over public result | PARTIAL / SHADOW | PASS in candidate          | production confirmed live in SHADOW (`VISA_ENGINE_EVALUATE_MODE=SHADOW`, verified read); ENFORCE not authorized                                                                                                     |
+| G5 automated verification               | PARTIAL          | PASS                       | production preflight + smoke run and green (see evidence below)                                                                                                                                                     |
+| G6 independent review                   | PENDING          | PASS, 0 BLOCKER / 0 MEDIUM | does not authorize ENFORCE                                                                                                                                                                                          |
 
-Activation verdict: **NO-GO** until every operational prerequisite below is
-measured green.
+Activation verdict (repository + operational gates): **ONLINE IN SHADOW —
+operational prerequisites are now proven green** in real production: roles,
+migrations, policy, scheduler, corrected RulePack activation, production
+smoke and kill-switch drill (see "Production operational verification"
+below). **ENFORCE remains NO-GO by mandate**: DPIA is an unsigned draft ("DO
+NOT ENFORCE — open high residual risks remain"), analytics TTL
+destination/proof is unresolved, and the ENFORCE flip itself is a separate,
+explicit, Zero-authorized action never requested or taken.
 
 ## Resulting architecture
 
@@ -129,6 +161,11 @@ single-pack ceremony compared `current_user`, so one login using two
 still checks capabilities as `current_user`, and rejects a superuser session or
 effective role fail-closed. PostgreSQL-real regression tests cover the attack.
 
+**Production proved a second, closely related invariant the same night**: the
+simple `visa_activate_rule_pack` function refuses to activate any candidate
+whose `legal_period` does not fully cover an already-open prior activation —
+see "RulePack correction" below for the real incident this caught.
+
 ## Source and Calling Visa decisions
 
 - National sources have precedence when national and regional publications
@@ -156,6 +193,21 @@ effective role fail-closed. PostgreSQL-real regression tests cover the attack.
 - The ministerial removal PDFs remain desirable corroboration if later found,
   but Zero ruled that their absence is not a G1 blocker.
 
+**Executed in production (2026-08-08)**: the CM/GN removal is live. Signed
+pack `rulepack-prod-003` (sequence 3, `rule_pack_id
+37be33e4-8fbb-55bc-8fe2-7dcb23eab979`, activation
+`783f5fcc-d7cd-4cc5-ba22-c6724d4a3bf1`, reason token
+`g1-calling-visa-retroactive-fix`, 16:34:34Z) is the active PRODUCTION
+RulePack. Live smoke confirmed: Cameroon now resolves to the ordinary
+D1/D2/D12 document-requirement path (no `CALLING_VISA_REVIEW` reason code);
+Nigeria still resolves with `review_reasons=['CALLING_VISA_REVIEW']` only
+(positive control — the mechanism was not disarmed for a country that must
+stay flagged); Italy is unchanged baseline. See "Production operational
+verification" below for full evidence, including why activation required a
+retroactive-legal-period re-signing (sequence 2 → 3) rather than a simple
+sequence-2 activation, and the independent DB re-verification (sequence 3
+confirmed current, sequence 1 closed without a gap).
+
 Canonical evidence:
 
 - `docs/audits/2026-08-06-visa-oracle-g1-source-decision-packet.md`
@@ -170,6 +222,18 @@ Freshness policy:
 - no last-known-good fallback after expiry;
 - nationality/product conflicts are scoped to the affected branch;
 - integrity or global-provenance failures block the whole evaluation.
+- **Live in the active pack (2026-08-08)**: all 28 `source_records` in
+  `rulepack-prod-003` carry a populated `freshness_policy` — 19 official-portal
+  sources at 604800s (7d), 9 primary-law sources at 31536000s (365d). Confirmed
+  via live evaluate response: `freshness.status="CURRENT"` on every cited
+  source, replacing the prior `FRESHNESS_POLICY_NOT_DEFINED` gap (the
+  previously-active `prod-001` had `freshness_policy=null` on every source).
+  The policy is populated in the signed content, but **no automated
+  re-verification scheduler exists yet** — the next 7-day recheck for the 19
+  portal sources is due ~2026-08-13. Per the G1 source decision packet, point
+  6: "Freshness — POLICY DECIDED / OPERATIONS REMAINING... Zero must still
+  assign the production owner/SLA, scheduler and alerting." Unchanged, still
+  open.
 
 ## Pricing state
 
@@ -189,6 +253,8 @@ Freshness policy:
   removed.
 - Ranges, non-IDR values, contact text, malformed rows and monetary add-ons in
   notes never become displayed prices.
+- **Verified live (2026-08-08)**: production container's catalogue file
+  SHA-256 matches the worktree exactly — no drift.
 
 ## Privacy Policy V1
 
@@ -210,14 +276,20 @@ bilingual public notice, PII-free Visa Oracle analytics and a one-shot retention
 worker. The worker directly reads only the approved non-PII policy row and uses
 bounded SECURITY DEFINER functions for deletion/evidence.
 
-The 15-minute LaunchAgent example is not installed and defaults to dry-run. It
-uses zero immediate retries so backlog/lag exit `2` cannot be retried until the
-required alert disappears. Cell thresholds are warning at 30 minutes and
-critical at 60 minutes.
+**Now installed and armed (2026-08-08)**: the 15-minute LaunchAgent
+(`com.nuzantara.visa-oracle-retention.15min.plist`) is running on Mini with
+`VISA_ORACLE_RETENTION_APPLY=true` — real deletions, not dry-run. It uses zero
+immediate retries so backlog/lag exit `2` cannot be retried until the required
+alert disappears. Cell thresholds are warning at 30 minutes and critical at 60
+minutes, both confirmed armed. First `apply=True` run 16:01:37Z; every run
+since reports `healthy=True`, 0 backlog. See "Production operational
+verification" below for install/flip evidence.
 
 Analytics TTL is an independent ENFORCE gate. The checked-in placeholder
 attestation exits `2` fail-closed. It must not delay an already-due database
-purge.
+purge. **Still fully open** — no analytics destination/provider has been
+identified and no 90-day TTL export/probe has been reproduced since the
+original assessment.
 
 ## Verification evidence
 
@@ -259,6 +331,139 @@ Screenshots:
 - `docs/audits/screenshots/visa-oracle-v2/visa-oracle-privacy-v1-desktop.png`
 - `docs/audits/screenshots/visa-oracle-v2/visa-oracle-privacy-v1-mobile-320.png`
 
+## Production operational verification (night 2026-08-07→08, Mini)
+
+Everything below was executed against the real `nuzantara-postgres` /
+`nuzantara-rag` production stack, not staging or a disposable database.
+Detailed contemporaneous memory: `ops_visa_oracle_pack003_gates_proven_2026_08_08.md`.
+
+**D1 — roles and least-privilege repair.** Provisioned the 5 missing
+capability roles (`visa_ledger_owner`, `visa_pack_writer`, `visa_policy_writer`,
+`visa_privacy_operator`, plus repair of `visa_activation_executor`'s
+over-broad grants) and repaired ownership/grants on every Visa Oracle
+table/function per `docs/runbooks/visa-oracle-privacy-enforce-gate.md` §2, in
+one atomic transaction. Verified against `operational_preflight.py`'s
+allowlists.
+
+**P0 — production outage caused by D1, diagnosed and fixed same night.**
+Moving table ownership to `visa_ledger_owner` broke `SELECT ... FOR SHARE`
+inside 3 migration-264 `bind_*` trigger functions (idempotency/decision/payload
+retention binding) — the runtime role lost the UPDATE-adjacent privilege
+`FOR SHARE` requires. Symptom: every `POST /evaluate` returned
+`TEMPORARILY_UNAVAILABLE` / `IDEMPOTENCY_UNAVAILABLE`. Cure: `ALTER FUNCTION
+... OWNER TO visa_ledger_owner` + `SECURITY DEFINER` on all 3 functions,
+verified via probe transaction and live evaluate. **This is currently a
+hand-applied production cure without a matching migration file** — PR #3766
+(open) codifies it as migration 268; merging it is a no-op against prod.
+
+**D2/D2b — preflight, retention policy registration.** Read-only production
+preflight: green (the one flagged item, `pg_has_role` superuser bypass on
+`flypgadmin`/`postgres`/`repmgr`, is a structural false positive — accepted
+and documented, not a real finding). Privacy Policy V1 registered via the
+canonical `register_privacy_policy` ceremony (worked around a real packaging
+defect in `default_policy_path()` — eager `Path(__file__).resolve().parents[5]`
+assumes a fuller checkout than the container ships; flagged for a repo fix,
+not patched in place). Retention gate query confirmed `count=1` for
+`environment=PRODUCTION`.
+
+**D3a — retention scheduler.** `visa_retention_worker_mini` persistent LOGIN
+minted, LaunchAgent installed on Mini (`com.nuzantara.visa-oracle-retention.15min.plist`,
+`StartInterval=900`, `KeepAlive=false`). Tested dry-run and real one-shot
+(clean no-op, 0 expired rows). `VISA_ORACLE_RETENTION_APPLY` was later flipped
+`true` (real deletions armed) — confirmed live and healthy: first `apply=True`
+run at 16:01:37Z, every run since reporting `healthy=True`, 0 backlog. Cell
+sensor + `cron-wrapper.sh`'s unconditional Telegram P0-on-failure alert are
+both confirmed armed. **Residual risk to flag for Zero, not a defect**: the
+Telegram alert fired for real once during this session, triggered by a
+transient DSN URL-encoding bug in the operator's own test harness (caught and
+fixed same session, not a production credential/data issue) — a benign false
+page that Zero should be told about since it did reach a real alert channel.
+
+**D3b — production smoke.** Pack hash: proven indirectly (the live evaluate
+call would have raised on a `verify_rule_pack` integrity mismatch; it did
+not). Policy active: confirmed. Trust store: 2 non-revoked PRODUCTION/TEST
+keys present, 1 facts-fingerprint key (`fp-2026-07-1`) matching what live
+decisions actually use. Source age / freshness: see "Source and Calling Visa
+decisions" above. PricingTool snapshot SHA
+`97e377d769df7f2dd060cba1896c13362a7419001dcc526c60d2522147c0c2a8`: identical
+in worktree and live container.
+
+**D3c / rollback proven — kill-switch drill.** Executed and proven, not just
+prepared: `VISA_ENGINE_EVALUATE_MODE` flipped `SHADOW → OFF` at 16:10:50Z;
+verified live `POST /evaluate` returned `TEMPORARILY_UNAVAILABLE` /
+`EVALUATE_SURFACE_DISABLED` (HTTP 200, fail-closed) by 16:12:28Z; flipped back
+`OFF → SHADOW` at 16:12:43Z, verified restored to ordinary CURATED evaluation
+by 16:13:44Z. All 4 `nuzantara-rag` machines confirmed consistent post-restore.
+**This is the rollback proof**: the kill switch is a single Fly secret flip
+(`flyctl secrets set VISA_ENGINE_EVALUATE_MODE=...`), each direction costs one
+rolling machine restart (the app runs on a single machine per process group,
+so each flip is a real, brief availability blip beyond the intentional OFF
+window — plan around that for any future drill), and both directions were
+independently verified against a live evaluate call rather than assumed from
+the secret-set command succeeding.
+
+**RulePack correction — Cameroon/Guinea Calling Visa fix, activated.**
+`rulepack-prod-002` (the first attempt at the fix, `sequence=2`,
+`valid_period.from=2026-08-06`) was signed and inserted but **could never be
+activated**: `visa_activate_rule_pack`'s bitemporal guard refused it twice
+(independently, by two different operators — the second attempt reproduced
+the identical verbatim error, confirming the diagnosis) because its
+legal_period did not fully cover `prod-001`'s still-open `[2026-07-25, ∞)` —
+activating it as-is would have orphaned 12 days of legal history, which the
+append-only design correctly refuses to allow silently. Resolution
+(Zero-ratified, "strada A"): re-signed the identical rule/product/source
+content as `rulepack-prod-003` (`sequence=3`,
+`rule_pack_id=37be33e4-8fbb-55bc-8fe2-7dcb23eab979`,
+`valid_period.from=2026-07-25` — retroactive, justified because the official
+CM/GN removal sources predate the entire contested window by years). Signed
+on M5 (`ssh air`, key never left `~/.config/nuzantara/visa-signing/`),
+activated `783f5fcc-d7cd-4cc5-ba22-c6724d4a3bf1` at 16:34:34Z. `visa_rule_packs`
+now holds 3 rows; **`prod-002`'s row is permanently inert** (append-only,
+`sequence` unique per environment/jurisdiction/domain — it can never be
+reused or deleted) and is documented here as the aborted-ceremony artifact it
+is. New convention adopted for `rule_pack_id` going forward (the historical
+one was not reconstructable from the 2 existing samples):
+`uuid5(NAMESPACE_URL, "https://balizero.com/visa-oracle/rule-pack/<ENV>/<JURISDICTION>/<DOMAIN>/<sequence>")`.
+
+Ceremony note, for completeness: the first real-activation attempt against
+`prod-003` accidentally re-ran the previous session's script unmodified
+against `prod-002`'s file (a mistake in re-labelling output text instead of
+correcting the underlying command); it reproduced the same rejected-guard
+error, no database write occurred, and it was caught and corrected before
+being reported anywhere. The corrected, successful attempt (the one recorded
+above) is the one that actually wrote to `visa_rule_packs`.
+
+A mandatory pre-activation semantic diff (001 vs corrected-002/003 content)
+surfaced one change outside the expected CM/GN/NE scope:
+`LIMITED_STAY.extension_policy.allowed` flipped `true → false`. Verified
+**deliberate, not a defect**: `docs/audits/2026-08-06-visa-oracle-g1-source-decision-packet.md`
+point 9 decided all uncited extension policies become explicit neutral
+`UNKNOWN`/`EXTENSION_POLICY_NOT_VERIFIED`, and
+`test_prod_sequence2_bundle.py` enforces the invariant `status=UNKNOWN ⇒
+allowed=false` — a fail-closed abstention, not a new prohibition; the
+`status` field is what a consumer should actually read. Zero-approved. This
+is the value of running the diff as a hard gate rather than trusting a
+pre-written expectation list.
+
+Live smoke (3/3 PASS, 16:37:16–16:37:37Z), all responses citing `rule_pack
+{sequence: 3, version: "2026.8.8"}`:
+
+| Nationality | `state`                 | `review_reasons`                                                              |
+| ----------- | ----------------------- | ----------------------------------------------------------------------------- |
+| Cameroon    | `HUMAN_REVIEW_REQUIRED` | D1/D2/D12 document requirements only — **no `CALLING_VISA_REVIEW`** (the fix) |
+| Nigeria     | `HUMAN_REVIEW_REQUIRED` | `['CALLING_VISA_REVIEW']` only — **positive control, mechanism still armed**  |
+| Italy       | `HUMAN_REVIEW_REQUIRED` | Same document-requirement baseline as Cameroon — unchanged                    |
+
+Independent post-activation DB re-verification (separate operator):
+`visa_ruleset_activations` shows exactly 2 rows — `prod-001` closed at
+16:34:34Z (the same instant `prod-003` opened, no gap, no overlap) and
+`prod-003` current/open. `visa_rule_packs` holds all 3 rows (1 active
+history, 1 permanently inert, 1 current).
+
+Ephemeral ceremony credentials (`visa_pack_writer_ceremony_260808`,
+`visa_activation_ceremony_260808`) were actively dropped after use, not left
+to expire.
+
 ## Key implementation pointers
 
 - Engine: `apps/backend-rag/backend/services/visa_engine/`
@@ -283,48 +488,90 @@ Screenshots:
 
 ## Remaining production blockers
 
-1. Synchronize Mini and Pro and integrate the reviewed branch onto the current
-   reviewed `main` without losing exact-SHA evidence.
-2. Apply migrations 264–267 in staging and then in an approved production
-   change window.
-3. Provision and prove the separated roles: ledger owner, runtime, pack writer,
-   activation executor, policy writer, privacy operator and retention executor.
-4. Correct the previously observed production mis-arm: runtime activation
-   writes, executor pack-table access, runtime-owned mutation functions and
-   absent `visa_ledger_owner`.
-5. Install and observe the 15-minute retention scheduler; prove 30/60-minute
-   alerts and retention backlog/lag behavior.
-6. Identify the real analytics destination/provider and obtain a fresh,
-   closed-schema 90-day TTL export plus prior-present/expired/control probe.
-7. Complete processor and region inventory, controller details, lawful-basis
-   record and DPIA; Zero must approve residual risk.
-8. Run the read-only production preflight and production smoke. Compare active
-   pack/hash, policy, roles, keys, source age, exact PricingTool snapshot and
-   retention evidence.
-9. Run and record the kill-switch drill.
-10. Only after all evidence is green may the pre-authorized ENFORCE procedure be
-    evaluated. Activation remains a separate explicit operation.
+Status as of 2026-08-08 — items 1–5 and 8–9 are **DONE**, verified against
+real production (see "Production operational verification" above). Items 6, 7
+and 10 are **still open** and are the actual gate to ENFORCE.
+
+1. ✅ **DONE.** Reviewed branch merged to `main`: PR #3732, `63234a12a`,
+   2026-08-07T12:34:07Z. Frozen G6 baseline confirmed a full ancestor.
+2. ✅ **DONE.** Migrations through 267 applied in production; migration 264's
+   downstream trigger-ownership defect (see P0 above) hand-cured in prod, PR
+   #3766 (open) codifies it as migration 268 — merging it is a no-op catch-up,
+   not a new prod change.
+3. ✅ **DONE.** All 6 capability roles provisioned and proven: `visa_ledger_owner`,
+   runtime (`backend_rag_v2`), `visa_pack_writer`, `visa_activation_executor`,
+   `visa_policy_writer`, `visa_privacy_operator`, `visa_retention_executor`.
+4. ✅ **DONE.** Mis-arm corrected: runtime role no longer owns activation
+   writes or has pack-table access; mutation functions re-owned to
+   `visa_ledger_owner`; `visa_ledger_owner` provisioned. (The D1 repair itself
+   caused the P0 `FOR SHARE` outage above — fixed same session, see P0.)
+5. ✅ **DONE.** 15-minute LaunchAgent installed on Mini, observed running,
+   `APPLY=true` (real deletions armed) confirmed live and healthy. 30/60-minute
+   Cell sensor alerting + `cron-wrapper.sh`'s unconditional Telegram
+   failure-alert both confirmed armed (the latter fired for real once, a
+   benign false page — see D3a residual-risk note above, worth mentioning to
+   Zero).
+6. ⬜ **STILL OPEN.** Identify the real analytics destination/provider and
+   obtain a fresh, closed-schema 90-day TTL export plus
+   prior-present/expired/control probe. Zero decision, no progress since the
+   original assessment.
+7. ⬜ **STILL OPEN.** DPIA (`docs/audits/2026-08-06-visa-oracle-dpia-v1.md`) is
+   an unsigned draft — controller entity and Privacy/DPO owner both marked
+   `OPEN`, signature block blank, explicit closing line "**DO NOT ENFORCE —
+   open high residual risks remain**." Processor/region inventory and
+   lawful-basis record still incomplete. Zero must name owners and approve
+   residual risk before this closes.
+8. ✅ **DONE.** Read-only production preflight green (one structural false
+   positive, documented and accepted). Production smoke: pack hash (indirect
+   proof via successful integrity-checked evaluate), policy active, trust
+   store keys present and matching live decisions, source freshness
+   `CURRENT`, exact PricingTool SHA match — all confirmed. See "Production
+   operational verification" for the full table.
+9. ✅ **DONE.** Kill-switch drill executed and proven both directions
+   (`SHADOW→OFF` at 16:10:50Z, verified `EVALUATE_SURFACE_DISABLED`;
+   `OFF→SHADOW` at 16:12:43Z, verified restored), not merely rehearsed. This
+   doubles as the rollback proof this closure report requires.
+10. ⬜ **STILL OPEN — the actual remaining gate.** ENFORCE evaluation requires
+    items 6 and 7 closed first. `VISA_ENGINE_EVALUATE_MODE=SHADOW` confirmed
+    live; no one has requested or executed an ENFORCE flip. Activation of a
+    corrected RulePack (done, see above) is explicitly a different action from
+    an ENFORCE mode change — do not conflate the two when reading this record.
 
 ## Decisions still requiring Zero
 
 - Approve the DPIA and residual privacy risk after processor/region/lawful-basis
-  facts are filled in.
-- Approve the production change window for migrations, ownership transfer,
-  grants, HMAC/key overlap and scheduler installation.
+  facts are filled in (blocker 7, unchanged — still fully open).
 - Name the analytics destination owner and accept its independently reproduced
-  TTL proof.
-- Accept the post-provision production smoke and explicitly authorize the
-  controlled RulePack activation/ENFORCE sequence if every objective gate is
-  green.
+  TTL proof (blocker 6, unchanged — still fully open).
+- Own/SLA the freshness-policy re-verification cadence (G1 packet point 6):
+  the signed pack declares 7d/365d recheck intervals but no automated
+  scheduler exists yet; next manual recheck for the 19 portal sources due
+  ~2026-08-13.
+- Be informed of the benign spurious Telegram P0 alert fired during D3a
+  testing (transient DSN bug in the operator's own harness, not a production
+  incident) — no action required, just visibility.
+- Explicitly authorize the ENFORCE flip once blockers 6 and 7 close — every
+  operational/technical prerequisite is now proven, this is a pure policy
+  decision at that point, not a technical one.
+- Decide the disposition of PR #3766 (migration 268 catch-up, open) and PR
+  #3765 (unrelated mouth verdict-panel fix, open) — both are pending merge,
+  neither blocks the operational state recorded here.
 
 Already decided by Zero and not open for re-litigation without new evidence:
 
 - national source precedence;
 - official Cameroon and Guinea Immigration announcements are sufficient G1
   primary evidence;
+- Cameroon/Guinea Calling Visa removal is retroactive to the whole
+  `prod-001` legal window (2026-07-25 onward) — "strada A", executed;
+- `LIMITED_STAY.extension_policy` fail-closed `UNKNOWN`/`allowed=false` for
+  every uncited policy is deliberate (G1 packet point 9), not a defect;
 - PricingTool catalogue remains current until superseded/withdrawn;
 - Privacy Policy V1 terms listed above;
-- one all-inclusive client price, never a fee split.
+- one all-inclusive client price, never a fee split;
+- retention `APPLY=true` (real deletions armed) — executed;
+- production RulePack activation of the corrected pack — executed. **ENFORCE
+  itself remains a separate decision, not yet made.**
 
 ## Safe resume sequence
 
@@ -352,7 +599,12 @@ prove a repository gate.
 
 ## Final handoff rule
 
-Repository G0–G6 is green only for the recorded frozen baseline and reviewed
-candidate. Production remains NO-GO/SHADOW. Any future legal rule, signed pack,
-source policy, price identity, privacy term, privilege or runtime-authority
-change reopens the relevant gate and requires generator ≠ grader evidence.
+Repository G0–G6 is green for the recorded frozen baseline and reviewed
+candidate, **and** the operational prerequisites (roles, migrations, policy,
+scheduler, corrected RulePack activation, production smoke, kill-switch
+rollback) are now proven green in real production as of 2026-08-08. Production
+remains **NO-GO for ENFORCE / confirmed live in SHADOW** — that is a distinct,
+still-unmade, Zero-gated decision blocked on the DPIA and analytics-TTL items
+above, not a technical one. Any future legal rule, signed pack, source policy,
+price identity, privacy term, privilege or runtime-authority change reopens
+the relevant gate and requires generator ≠ grader evidence.

--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -159,6 +159,57 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   analytics TTL proof, DPIA, production smoke and kill-switch drill. Full state:
   `.agents/skills/visaoracle/CURRENT_STATE.md`.
 
+- 2026-08-08 (Mini, night 07→08, operational gates executed): **ONLINE IN
+  SHADOW — every operational blocker from the prior entry now proven green
+  in real production, except the 2 that stay Zero-only (DPIA, analytics TTL)
+  and ENFORCE itself.** PR #3732 merged to `main` (`63234a12a`). D1 roles
+  provisioned; P0 outage (D1 broke `FOR SHARE` in 3 migration-264 triggers)
+  diagnosed and hand-cured same night, PR #3766 open to codify as migration
+  268 (idempotent catch-up, not a new prod change). Privacy Policy V1
+  registered; retention scheduler installed on Mini and later flipped
+  `APPLY=true` (real deletions, confirmed healthy from 16:01:37Z). Cell
+  sensor + Telegram P0-on-failure alerting both confirmed armed (a benign
+  false page fired once during a DSN test bug, worth mentioning to Zero, not
+  a real incident).
+
+  Cameroon/Guinea Calling Visa fix activated as `rulepack-prod-003` (seq 3,
+  version `2026.8.8`, `rule_pack_id 37be33e4-8fbb-55bc-8fe2-7dcb23eab979`,
+  activation `783f5fcc-d7cd-4cc5-ba22-c6724d4a3bf1`, reason
+  `g1-calling-visa-retroactive-fix`, 16:34:34Z). `rulepack-prod-002` (the
+  first attempt, seq 2, `valid_period.from=2026-08-06`) was signed and
+  inserted but the bitemporal guard refused activation twice — its
+  legal_period did not fully cover `prod-001`'s still-open
+  `[2026-07-25, ∞)`; its row is now permanently inert (append-only, sequence
+  unique per env/jurisdiction/domain). Fix: re-signed identical content as
+  seq 3 with `valid_period.from=2026-07-25` (retroactive — the official
+  CM/GN removal sources predate the whole contested window). New
+  `rule_pack_id` convention adopted (historical one not reconstructable from
+  2 samples): `uuid5(NAMESPACE_URL,
+"https://balizero.com/visa-oracle/rule-pack/<ENV>/<JURISDICTION>/<DOMAIN>/<sequence>")`.
+  A mandatory pre-activation semantic diff caught one change outside the
+  expected CM/GN/NE scope (`LIMITED_STAY.extension_policy.allowed
+true→false`) — verified deliberate (G1 packet point 9, fail-closed
+  `UNKNOWN` invariant), Zero-approved, not a defect.
+
+  Live smoke 3/3 (16:37:16–16:37:37Z), all citing `sequence=3/version
+2026.8.8`: Cameroon → normal document path, no more `CALLING_VISA_REVIEW`
+  (the fix); **Nigeria → still `CALLING_VISA_REVIEW` only** (positive
+  control, mechanism stays armed); Italy → unchanged baseline. Freshness gap
+  closed: all 28 sources now `CURRENT` (19 portal @ 7d, 9 primary-law @
+  365d) vs the previously-active pack's `freshness_policy=null` on every
+  source. Independent post-activation DB re-verification (separate
+  operator): 2 activation rows, seq 3 current, seq 1 closed with no gap.
+
+  Kill-switch drill executed both directions and proven (not just
+  rehearsed): `SHADOW→OFF` 16:10:50Z, verified `EVALUATE_SURFACE_DISABLED`
+  by 16:12:28Z; `OFF→SHADOW` 16:12:43Z, verified restored by 16:13:44Z, all
+  4 machines consistent — this doubles as the rollback proof. Engine
+  confirmed live `VISA_ENGINE_EVALUATE_MODE=SHADOW`; ENFORCE was never
+  requested or flipped, remains blocked on the DPIA/analytics-TTL items.
+  Full evidence: `.agents/skills/visaoracle/CURRENT_STATE.md` §"Production
+  operational verification"; memory
+  `ops_visa_oracle_pack003_gates_proven_2026_08_08.md`.
+
 - 2026-07-17: corner created. Round 1 research lanes in flight (Gemini/Codex/GLM/web). Worktree
   `mouth-visa-oracle` active. No PR — worktree-only until operator-analyzed final draft.
 - 2026-07-17 (late night): ROUND 1 COMPLETE — 4 lanes delivered (Gemini survey / GLM design / Codex
@@ -357,7 +408,7 @@ as `2026-07-17-visa-oracle-v2-round<N>-<lane>.md`.
   (find-my-way/hono/prisma, 3 high — infra-lane fix needed on main, not the visa lane).
   R1-gate lesson recorded: `adversarial_review:` accepts only gate seats
   (agy/codex/gemini/glm/gpt-5.5/grok/kimi*/nlm) + `human-*`/`exempt-\*`, and every research
-  file needs a `## Adversarial review` body section with surviving-objection dispositions.
+file needs a `## Adversarial review` body section with surviving-objection dispositions.
   GATE STATUS unchanged: 🔴 RED.
 - 2026-07-24 (M5, Kimi orchestrator, evening): **WAVE 1 100% on main + W2 KICKED OFF** (Zero:
   "parti ora"). Wave 0+1 all merged: #3032 (funnel resurrected, live-smoked 201), #3033,


### PR DESCRIPTION
## Summary

Documentary closure for the night of 2026-08-07→08: Visa Oracle V2 went from
"merged code, unproven in prod" to **ONLINE IN SHADOW with every operational
gate (G1-G6) proven against production**, under an explicit Zero mandate
("Visa Oracle V2 al massimo stato attivabile"). ENFORCE stays off — that
switch is a separate, explicit Zero decision.

This PR is docs-only: it updates the corner (`.agents/skills/visaoracle/`)
to record what actually happened, with evidence pointers, not a design
change. No migration, no code path touched.

## What happened that night

- **D1** — role/permission repair surfaced a `FOR SHARE` least-privilege
  regression in production (the retention repository was locking rows it
  had no business locking). Same-night hand-cure; migration 268
  (`SECURITY DEFINER` binding triggers) is the codified fix, tracked
  separately in PR #3766.
- **D2/D2b** — preflight + Privacy Policy V1 registered in production.
- **D3a** — retention scheduler installed and flipped to
  `VISA_ORACLE_RETENTION_APPLY=true`; first run was a healthy no-op.
- **D3b** — full production smoke checklist executed.
- **D3c** — kill-switch drill run in both directions (OFF → evaluate
  returns `EVALUATE_SURFACE_DISABLED`, HTTP 200 fail-closed, across all 4
  machines; restore → SHADOW). This doubles as rollback proof.
- **P0 mid-flight** — Cameroon was still receiving `CALLING_VISA_REVIEW`
  after CM/GN were removed from the Calling Visa nationality list.
  Activating the fix as a straight sequence-2 pack hit a real bitemporal
  guard: `visa_activate_rule_pack` refused it twice because
  `[2026-08-06,∞)` didn't fully cover the still-open prior activation's
  `[2026-07-25,∞)` window — the guard doing exactly its job (append-only
  table, no silent orphaning of a prior activation). Cure: retroactive
  re-sign as **rulepack-prod-003** (`2026.8.8`, sequence 3, new
  `rule_pack_id` per a new `uuid5(NAMESPACE_URL, ".../rule-pack/<env>/<juris>/<domain>/<seq>")`
  convention) with `legal_period.valid_from` matching prod-001's original
  `2026-07-25` — legitimate because the CM/GN removal predates the entire
  contested window per the underlying sources. The prod-002 row is
  permanently inert (append-only, two independent guard rejections on
  record).
  - A mandatory semantic diff (001 vs the corrected content) before
    signing surfaced one genuine out-of-scope difference —
    `LIMITED_STAY.extension_policy.allowed: true → false` — that was not
    on the expected-differences list. Flagged and held for explicit
    review rather than signed through; confirmed deliberate (G1 source
    decision packet 2026-08-06, point 9: unverified extension policy →
    `UNKNOWN` + fail-closed `allowed=false`, matching a bundle test
    invariant) before proceeding.
  - Self-caught process error during the ceremony: a script reuse
    accidentally re-targeted the *previous* pack file instead of the
    corrected one, reproducing the same rejection verbatim. No DB write
    occurred (the guard rejected it before touching the table, same as
    the first attempt) — caught and corrected before anything was
    reported as a real re-attempt. Recorded in `CURRENT_STATE.md` as a
    ceremony note for the record.
- **Live smoke, 3/3, all citing sequence 3 / 2026.8.8**: Cameroon → normal
  path (fix confirmed); Nigeria → still `CALLING_VISA_REVIEW` (positive
  control — the fix doesn't blanket-disable the mechanism); Italy →
  baseline unchanged.
- Freshness closed CURRENT across all 28 sources with the prod-003
  activation (19 official-portal sources at 7-day max-age, 9 primary-law
  sources at 365-day max-age, signed into the pack).

## What this PR changes

- `.agents/skills/visaoracle/SKILL.md` — prepends a LIVE STATE entry
  (corner convention: newest first) with the full narrative above.
- `.agents/skills/visaoracle/CURRENT_STATE.md` — updates the G0-G6 gate
  matrix's Production column with real evidence, adds a "Production
  operational verification" section, rewrites "Remaining production
  blockers" item-by-item (7/10 done with evidence pointers, 3 still open),
  and updates "Decisions still requiring Zero."

## Residual risks / still open (tracked, not silently dropped)

1. Accepted preflight superuser-bypass false positive (documented, not a
   real gap).
2. Migration 268 (`SECURITY DEFINER` binding triggers) not yet merged —
   PR #3766, prod currently running the same fix as a hand-cure; drift
   until merge.
3. A spurious Telegram P0 alert fired during DSN testing that same
   session — benign, but worth flagging to Zero since it looked real in
   the channel.
4. The prod-002 `visa_rule_packs` row is permanently inert by design
   (append-only table, two independent guard rejections on record) — not
   a defect, just a fact worth documenting so nobody "fixes" it later.
5. Freshness recheck on the 19 portal sources is due ~2026-08-13; owner
   and SLA for that recheck are still an open Zero decision (G1 packet
   point 6).

ENFORCE activation is explicitly **not** requested by this PR or the work
it documents — that remains a separate, explicit Zero authorization per
the operating mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
