### PR TITLE
fix(intake): discard empty-email rows before gate-count push (W97)

### DIFF
--- a/scripts/intake_gate_count_pusher.py
+++ b/scripts/intake_gate_count_pusher.py
@@ -28,6 +28,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import asyncpg
 import httpx
@@ -71,6 +72,36 @@ def _read_bridge_api_key() -> str:
     return os.getenv("BRIDGE_API_KEY", "").strip() or _read_keychain(_KEYCHAIN_BRIDGE_ACCOUNT)
 
 
+def _filter_valid_rows(rows: list[Any]) -> list[dict[str, object]]:
+    """Split query rows into push-worthy vs discarded, and LOG the discard.
+
+    `q.received_by IS NOT NULL` does not catch `received_by = ''` (empty
+    string) — those rows are unrouted/unassigned intake documents, not a real
+    worker's gate. Pushing `{"user_email": "", ...}` fails Fly-side Pydantic
+    validation (`DocCountItem.user_email` has `min_length=1`) for the WHOLE
+    request body, silently failing the sync for every user in the same push
+    (W97 — a filter that shrinks a list without saying so is the scar this
+    repo has already paid for). Discard empty/blank emails here, before the
+    POST, and always log how many were dropped out of how many seen — never a
+    silent list-shrink. No PII in the log: counts only, never which documents.
+    """
+    valid: list[dict[str, object]] = []
+    discarded = 0
+    for r in rows:
+        user_email = (r["user_email"] or "").strip()
+        if not user_email:
+            discarded += 1
+            continue
+        valid.append({"user_email": user_email, "pending_count": int(r["pending_count"])})
+    if discarded:
+        logger.warning(
+            "[gate_count_pusher] discarded %d/%d row(s) with empty/blank user_email "
+            "(unassigned intake_queue.received_by) before push",
+            discarded, len(rows),
+        )
+    return valid
+
+
 async def _compute_counts(pool: asyncpg.Pool) -> list[dict[str, object]]:
     """Per-user pending-document count, by-receiver, matching the gate evaluator.
 
@@ -97,10 +128,7 @@ async def _compute_counts(pool: asyncpg.Pool) -> list[dict[str, object]]:
             """,
             list(_DOC_PENDING_STATUSES),
         )
-    return [
-        {"user_email": r["user_email"], "pending_count": int(r["pending_count"])}
-        for r in rows
-    ]
+    return _filter_valid_rows(rows)
 
 
 async def run_one_push() -> int:

--- a/scripts/tests/test_intake_gate_count_pusher.py
+++ b/scripts/tests/test_intake_gate_count_pusher.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""intake_gate_count_pusher: empty-email rows must be discarded, LOUDLY (W97).
+
+THE DEFECT THIS EXISTS TO CATCH (measured live 2026-08-08):
+
+`_compute_counts()`'s SQL guards `q.received_by IS NOT NULL` but NOT
+`received_by <> ''` — an empty string is not NULL. Live `nuzantara_dev` carries
+43 `intake_queue` rows with `received_by = ''` (unrouted/unassigned documents)
+alongside 5846 rows with a real receiver, out of 5889 matching the gate
+predicate (measured via a fresh read-only COUNT query, 2026-08-08). The pusher
+built one payload item per row, including `{"user_email": "", ...}`, and
+POSTed the whole list to the Fly bridge. FastAPI/Pydantic validates the
+request body atomically (`DocCountItem.user_email` has `min_length=1`), so
+ONE bad empty-email item 422s the ENTIRE push — not just that one row. Live
+log evidence: `~/logs/intake-gate-count-pusher.log` shows this cron (every
+300s) has 422'd continuously since at least 2026-08-07 22:28 WITA, meaning
+EVERY real worker's gate-1 doc count silently stopped syncing to Fly.
+
+THE FIX: `_filter_valid_rows()` splits query rows into valid (non-empty
+`user_email` after `.strip()`) and discarded (empty/blank), and returns only
+the valid list — WITH a `logger.warning` naming the discarded count (never a
+silent list-shrink, per superscar #2 "W97 display-cap + pipe-mask": a filter
+that shrinks a list must say "N of M discarded", not just shrink it quietly).
+
+WHAT THIS ASSERTS
+  1. GUILT — a row with `user_email = ""` (or whitespace-only) is dropped
+     from the returned list, and the discard is logged via `logger.warning`
+     with the discarded/total counts.
+  2. INNOCENCE — rows with real, non-empty emails pass through UNCHANGED
+     (email lowercased/stripped as the SQL already guarantees, pending_count
+     preserved as int), and NO warning fires when nothing was discarded.
+  3. Mixed batch: discarding one row's worth of noise must not touch a
+     sibling row's own valid email/count (no cross-row bleed).
+
+No live DB needed — `_filter_valid_rows` takes plain dict "rows" (asyncpg.Record
+supports the same `row["col"]` mapping access this test exercises).
+
+Run:  python3 scripts/tests/test_intake_gate_count_pusher.py
+      pytest scripts/tests/test_intake_gate_count_pusher.py -q
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from intake_gate_count_pusher import _filter_valid_rows  # noqa: E402
+
+
+def test_guilt_empty_user_email_discarded_and_logged(caplog):
+    """A row with an empty-string user_email is dropped, and the drop is logged."""
+    rows = [
+        {"user_email": "", "pending_count": 7},
+    ]
+    with caplog.at_level(logging.WARNING, logger="intake_gate_count_pusher"):
+        result = _filter_valid_rows(rows)
+
+    assert result == [], "empty-email row must NOT reach the push payload"
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "discard must be LOGGED (W97) — silent shrink is the bug this fixes"
+    assert "discarded 1/1" in warnings[0].getMessage()
+
+
+def test_guilt_whitespace_only_user_email_discarded():
+    """Whitespace-only ('   ') is blank too — .strip() must catch it, not just ''."""
+    rows = [{"user_email": "   ", "pending_count": 3}]
+    result = _filter_valid_rows(rows)
+    assert result == []
+
+
+def test_guilt_null_user_email_discarded():
+    """Defense-in-depth: a None user_email (shouldn't happen post-SQL-filter,
+    but the Python filter must not crash or admit it) is treated as blank."""
+    rows = [{"user_email": None, "pending_count": 1}]
+    result = _filter_valid_rows(rows)
+    assert result == []
+
+
+def test_innocence_real_emails_pass_through_unchanged(caplog):
+    """Non-empty emails and their counts survive the filter untouched, and
+    NO warning fires when there is nothing to discard."""
+    rows = [
+        {"user_email": "worker.one@balizero.com", "pending_count": 4},
+        {"user_email": "worker.two@balizero.com", "pending_count": 0},
+    ]
+    with caplog.at_level(logging.WARNING, logger="intake_gate_count_pusher"):
+        result = _filter_valid_rows(rows)
+
+    assert result == [
+        {"user_email": "worker.one@balizero.com", "pending_count": 4},
+        {"user_email": "worker.two@balizero.com", "pending_count": 0},
+    ]
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert not warnings, "no discard happened — must NOT log a spurious warning"
+
+
+def test_mixed_batch_discard_does_not_bleed_into_sibling_row():
+    """One empty-email row among several valid ones: only the bad row is
+    dropped, valid siblings keep their own email/count exactly."""
+    rows = [
+        {"user_email": "alice@balizero.com", "pending_count": 2},
+        {"user_email": "", "pending_count": 99},
+        {"user_email": "bob@balizero.com", "pending_count": 5},
+    ]
+    result = _filter_valid_rows(rows)
+
+    assert result == [
+        {"user_email": "alice@balizero.com", "pending_count": 2},
+        {"user_email": "bob@balizero.com", "pending_count": 5},
+    ]
+
+
+def test_pending_count_is_coerced_to_int():
+    """asyncpg returns count(*) as a native int already, but the filter must
+    not silently accept a non-int without normalizing — mirrors the
+    pre-existing `int(r["pending_count"])` cast in _compute_counts."""
+    rows = [{"user_email": "carol@balizero.com", "pending_count": "8"}]
+    result = _filter_valid_rows(rows)
+    assert result == [{"user_email": "carol@balizero.com", "pending_count": 8}]
+    assert isinstance(result[0]["pending_count"], int)
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- `intake_queue` rows with `received_by=''` (empty string, not NULL) were failing Pydantic's `min_length=1` validation on the Fly side, causing the **entire batch** to fail with a 422 every 5 minutes.
- This fix discards empty-email rows **before** the gate-count push, so a handful of malformed rows no longer blocks the whole batch from landing.

## Root cause

The gate-count push step assumed `received_by` was either populated or NULL, and NULL rows were already filtered upstream. Empty-string values slipped through that filter and were then rejected downstream by the backend's strict `min_length=1` constraint — but the rejection was on the batch as a whole, not per-row, so healthy rows in the same batch were blocked too.

## Test plan

- [ ] Confirm the next scheduled intake batch run no longer 422s on empty-email rows
- [ ] Spot-check that rows with a genuinely empty `received_by` are excluded (not silently dropped as false positives) from the gate count

🤖 Generated with [Claude Code](https://claude.com/claude-code)