### PR TITLE
fix(infra): promote nuzantara-drive-sync.filter into the repo

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -210,6 +210,12 @@
       "machines": ["pro"]
     },
     {
+      "live": "~/scripts/nuzantara-drive-sync.filter",
+      "repo": "scripts/nuzantara-drive-sync.filter",
+      "_note": "Promoted 2026-08-08 after a 16h+ Google Drive 'Queries per minute' quota storm (2026-08-07): nuzantara-drive-sync.sh syncs the wa-mirror Baileys session dir (36k+ high-churn pre-key files) to Drive on every run — fixed by excluding apps/wa-mirror/sessions/** in this filter. The filter was previously genuinely HOME-only (no repo twin existed to declare — an entry with no repo side would have been fiction, per superscar #1's own definition of a pair). This entry closes that gap for the filter; nuzantara-drive-sync.sh itself (the script that consumes it) is STILL HOME-only and undeclared — a separate promotion, out of scope here.",
+      "machines": ["pro"]
+    },
+    {
       "live": "~/scripts/fly-pg-proxy-wrapper.sh",
       "repo": "infra/launchagents/wrappers/fly-pg-proxy-wrapper.sh",
       "_note": "W3 launchagent-canon reconcile (2026-07-18): was UNDECLARED (com.balizero.wr2.pg-proxy home_fork_target finding). Wrapper fixes a fly CLI v0.4.49 token regression (extracts access_token from config.yml, injects via FLY_ACCESS_TOKEN, validates before binding). Promoted verbatim; canon plist updated to match (ThrottleInterval 10->30).",

--- a/scripts/nuzantara-drive-sync.filter
+++ b/scripts/nuzantara-drive-sync.filter
@@ -1,0 +1,119 @@
+# rclone filter for nuzantara codebase → Drive sync
+# Syntax: + include, - exclude (first match wins)
+# Reference: https://rclone.org/filtering/
+#
+# Source of truth: scripts/nuzantara-drive-sync.filter (repo). After edits,
+# copy to ~/scripts/nuzantara-drive-sync.filter on Pro (HOME-fork discipline,
+# scar family #1/W50-52 — the sync script itself, nuzantara-drive-sync.sh,
+# is still HOME-only; this filter is the first piece promoted out of that
+# state, 2026-08-08).
+
+# ── Hard secrets exclude (defense in depth)
+- .env
+- .env.*
+- *.env
+- *.env.bak
+- *.env.bak.*
+- .nuzantara-secrets.env*
+- .nuzantara-backend-secrets.env*
+- .ai_keys.env*
+- .langfuse-secrets.env*
+- .git-credentials
+- *.key
+- *.pem
+- *.p12
+- *.pfx
+- credentials.json
+- *credentials*.json
+- *credential*.json
+- service-account*.json
+- *service-account*.json
+- *service_account*.json
+- *-sa.json
+- .nuzantara-drive-sa.json
+- .canva_tokens.json
+- google-credentials*
+- google_credentials*
+- kbli-indexer*.json
+- .secrets/**
+- .secrets.baseline
+- secrets/**
+- .ssh/**
+- .gnupg/**
+- .aws/**
+- .gcloud/**
+- .config/gcloud/**
+- env.combined*
+- *.token
+- *.tokens
+- .auth/**
+- auth.json
+- reference_mini_credentials.md
+
+# ── Worktrees (deploy + codex sandboxes — redundant with main)
+- .worktrees/**
+- worktrees/**
+
+# ── WA-mirror session state (Baileys pre-keys/tokens — high-churn, 36k+ files,
+#    regenerated continuously; syncing them drove a 16h+ Google Drive
+#    "Queries per minute" quota storm on 2026-08-07, see
+#    ~/.cache/nuzantara-drive-sync/launchd.stdout.log. Not secrets in the .env
+#    sense, but volatile runtime state with no business reason to live on
+#    Drive — never re-add without a churn-rate check first.)
+- apps/wa-mirror/sessions/**
+
+# ── Local Claude Code state (contains real JWTs in permission allowlist)
+- .claude/settings.local.json
+- .claude/settings.local.sync-conflict-*.json
+- .claude/.session*
+
+# ── AI dispatch transcripts (contain raw secrets caught during reviews)
+- ai-dispatch-output/**
+
+# ── NotebookLM dumps (derived, regeneratable, contain bundled secrets)
+- tmp_notebooklm/**
+
+# ── Build artifacts / dependencies
+- node_modules/**
+- .venv/**
+- venv/**
+- env/**
+- __pycache__/**
+- *.pyc
+- *.pyo
+- .pytest_cache/**
+- .mypy_cache/**
+- .ruff_cache/**
+- .next/**
+- .nuxt/**
+- dist/**
+- build/**
+- out/**
+- target/**
+- .turbo/**
+- .cache/**
+- .parcel-cache/**
+
+# ── VCS internals
+- .git/**
+- .hg/**
+- .svn/**
+
+# ── OS / IDE noise
+- .DS_Store
+- Thumbs.db
+- .idea/**
+- .vscode/**
+- *.swp
+- *.swo
+
+# ── Heavy / non-source
+- *.log
+- *.sqlite
+- *.sqlite3
+- *.db-journal
+- coverage/**
+- .nyc_output/**
+
+# ── Default include everything else
++ **


### PR DESCRIPTION
## Summary
- Promotes the `nuzantara-drive-sync.sh` rclone filter out of pure HOME-only state into `scripts/nuzantara-drive-sync.filter`, following the `scripts/dropbox_intake_sync.sh` "source of truth" convention.
- Content is the already-fixed filter (2026-08-07 hotfix): excludes `apps/wa-mirror/sessions/**` (36k+ high-churn Baileys pre-key files) that drove a 16h+ Google Drive "Queries per minute" quota storm.
- Adds the pair to `infra/home-fork/declared-pairs.json` (superscar #1 HOME-fork discipline) so `lint_home_fork.py --check` covers it going forward.
- Live copy at `~/scripts/nuzantara-drive-sync.filter` on Pro already matches this commit byte-for-byte (sha256 verified) — no further sync step needed on merge.

## Out of scope
`nuzantara-drive-sync.sh` itself (the script that reads this filter) is still HOME-only and undeclared — a separate promotion.

## Test plan
- [x] `python3 scripts/lint_home_fork.py --check` → "no HOME-fork" for the new pair (111 declared pairs total)
- [x] `sha256sum` match between repo file and live `~/scripts/nuzantara-drive-sync.filter`
- [x] `rclone lsf` with the new filter → 0 files under `apps/wa-mirror/sessions/**`
- [x] Full pre-push backend test suite green (this branch)
- [ ] No merge action needed — filter is passive config, live copy already updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)