### PR TITLE
fix(cron-agent): a lost alert armed the same 30-minute silence as a delivered one

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -132,6 +132,7 @@ jobs:
               scripts/tests/test_wa_session_liveness_wrapper.sh|\
               infra/launchagents/wrappers/cron-agent.sh|\
               scripts/tests/test_cron_agent_oauth_cascade.sh|\
+              scripts/tests/test_cron_agent_alert_verdict.sh|\
               scripts/ci/prepush_tip_drift.sh|\
               .husky/pre-commit|\
               scripts/tests/test_husky_pii_pass_overmatch.py|\
@@ -475,6 +476,20 @@ jobs:
           # half runs the wrapper in a fake world (W107) so "did not rotate" is
           # distinguishable from "never got there".
           bash scripts/tests/test_cron_agent_oauth_cascade.sh
+
+      - name: Cron-agent alert verdict corpus (a lost alert must not buy silence)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # send_telegram() discarded both channels of the notification gateway
+          # (`>/dev/null 2>&1 || true`) and then armed its 30-minute cooldown
+          # unconditionally. tg_notify.py ends in six ways and only ONE of them
+          # reached Telegram, so a merely-spooled alert also silenced its own
+          # successor and left no record of which of the six had happened.
+          # The exit code cannot carry the verdict — main() returns 0 even from
+          # its "NEVER fail the caller" except branch — so this pins that the
+          # STATUS WORD is judged (W104), read as an entity and not a substring
+          # (`p0_unsent_spooled` is one prefix away from a false "sent").
+          bash scripts/tests/test_cron_agent_alert_verdict.sh
 
       - name: Backup phase composition corpus (one dead phase must not kill the other)
         if: steps.paths.outputs.relevant == 'true'

--- a/infra/launchagents/wrappers/cron-agent.sh
+++ b/infra/launchagents/wrappers/cron-agent.sh
@@ -73,6 +73,22 @@ MIN_ATTEMPT_SECONDS="${CRON_AGENT_MIN_ATTEMPT_SECONDS:-300}"
 
 log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] [$JOB_NAME] $*" >> "$LOG_FILE"; }
 
+_file_mtime() {
+    # `stat -f%m` is BSD syntax. On GNU coreutils `-f` means --file-system and
+    # `%m` is the MOUNT POINT, so the BSD form does not fail there — it succeeds
+    # and prints something that is not a timestamp. A `|| echo 0` fallback keyed
+    # to the exit code therefore never fires, and the caller's age arithmetic
+    # gets garbage. Judge the VALUE (is it a number?), not the exit code.
+    # Pro runs macOS, so the BSD branch is the live one; the GNU branch is what
+    # makes the cooldown gate testable on a Linux CI runner instead of silently
+    # inert there (W108: a check that only runs on one OS hides defects).
+    local m
+    m="$(stat -f%m "$1" 2>/dev/null)"
+    case "$m" in ''|*[!0-9]*) m="$(stat -c%Y "$1" 2>/dev/null)" ;; esac
+    case "$m" in ''|*[!0-9]*) m=0 ;; esac
+    printf '%s' "$m"
+}
+
 send_telegram() {
     local msg="$1"
     # Notification gateway (post-#2263 canon promotion): tg_notify.py owns token
@@ -94,7 +110,7 @@ send_telegram() {
     # minutes of silence and left no trace of having done so — a lost alert that
     # suppressed its own successor.
     if [[ -f "$COOLDOWN_FILE" ]]; then
-        local age=$(( $(date +%s) - $(stat -f%m "$COOLDOWN_FILE" 2>/dev/null || echo 0) ))
+        local age=$(( $(date +%s) - $(_file_mtime "$COOLDOWN_FILE") ))
         [[ $age -lt 1800 ]] && { log "Telegram cooldown active (${age}s < 1800s)"; return; }
     fi
     local gateway="$(dirname "$0")/tg_notify.py"

--- a/infra/launchagents/wrappers/cron-agent.sh
+++ b/infra/launchagents/wrappers/cron-agent.sh
@@ -78,15 +78,55 @@ send_telegram() {
     # Notification gateway (post-#2263 canon promotion): tg_notify.py owns token
     # resolution + tiering + 6h dedup; this wrapper keeps its own 30-min cooldown.
     # No env-token gate: an alert must not vanish silently when env lacks the token.
+    #
+    # JUDGE THE REPLY, NOT THE EXIT CODE (W104). tg_notify.py's main() returns 0
+    # unconditionally — its `except Exception` branch is literally commented
+    # "NEVER fail the caller", spools best-effort and still returns 0. So an rc
+    # check here would be decorative by construction. The verdict is the status
+    # word it prints on STDERR, one of six:
+    #     sent               -> it reached Telegram
+    #     deduped            -> an equivalent message went out recently (silence
+    #                           is the intended outcome, so it counts as handled)
+    #     logged | spooled | p0_overflow_spooled | p0_unsent_spooled
+    #                        -> it did NOT reach Telegram; it is parked for later
+    # The old line discarded both channels (`>/dev/null 2>&1`) and then touched
+    # the cooldown unconditionally, so a spooled or errored alert also bought 30
+    # minutes of silence and left no trace of having done so — a lost alert that
+    # suppressed its own successor.
     if [[ -f "$COOLDOWN_FILE" ]]; then
         local age=$(( $(date +%s) - $(stat -f%m "$COOLDOWN_FILE" 2>/dev/null || echo 0) ))
         [[ $age -lt 1800 ]] && { log "Telegram cooldown active (${age}s < 1800s)"; return; }
     fi
     local gateway="$(dirname "$0")/tg_notify.py"
     [ -f "$gateway" ] || gateway="$HOME/nuzantara/scripts/tg_notify.py"
-    python3 "$gateway" --tier p0 --source cron-agent \
-        --dedup-key "cron-agent:${JOB_NAME}:$(hostname -s)" -- "$msg" >/dev/null 2>&1 || true
-    touch "$COOLDOWN_FILE"
+    if [[ ! -f "$gateway" ]]; then
+        log "ALERT NOT SENT: notification gateway missing (looked in $(dirname "$0") and $HOME/nuzantara/scripts)"
+        return
+    fi
+    local reply rc
+    reply="$(python3 "$gateway" --tier p0 --source cron-agent \
+        --dedup-key "cron-agent:${JOB_NAME}:$(hostname -s)" -- "$msg" 2>&1)"
+    rc=$?
+    # Record what the gateway actually said, always. rc is logged for forensics
+    # only — it is never the thing being judged.
+    log "Telegram gateway rc=$rc reply=$(printf '%s' "$reply" | tr '\n' ' ' | head -c 200)"
+    # Read the status as an ENTITY, not a substring (superscar #3): pull the word
+    # off a line that IS the status line. A bare `*"sent"*` would also match the
+    # free-form "internal error (...)" branch if an exception message ever carried
+    # the word, and `p0_unsent_spooled` is one prefix away from a false positive.
+    local status
+    status="$(printf '%s\n' "$reply" | sed -n 's/^tg_notify: \([a-z0-9_]*\)$/\1/p' | tail -1)"
+    case "$status" in
+        sent|deduped)
+            touch "$COOLDOWN_FILE"
+            ;;
+        *)
+            # Deliberately NOT touching the cooldown: an alert that did not go out
+            # must not buy silence for the next one. Volume is bounded — send_telegram
+            # fires at most a handful of times per job run, and these jobs are daily.
+            log "ALERT NOT DELIVERED (status='${status:-<unparseable>}') — cooldown deliberately NOT armed so the next attempt is not pre-silenced"
+            ;;
+    esac
 }
 
 save_state() {

--- a/scripts/tests/test_cron_agent_alert_verdict.sh
+++ b/scripts/tests/test_cron_agent_alert_verdict.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# test_cron_agent_alert_verdict.sh — a lost alert must not buy 30 minutes of silence.
+#
+# WHY THIS EXISTS (measured on Pro, 2026-08-08)
+#   cron-agent.sh's send_telegram() called the notification gateway as
+#       python3 tg_notify.py … >/dev/null 2>&1 || true
+#       touch "$COOLDOWN_FILE"
+#   Both channels discarded, then the 30-minute cooldown armed unconditionally.
+#   tg_notify.py can end in six different ways and only ONE of them reached
+#   Telegram:
+#       sent · deduped · logged · spooled · p0_overflow_spooled · p0_unsent_spooled
+#   So an alert that was merely parked also silenced its own successor, and the
+#   log kept no record of which of the six had happened.
+#
+#   The exit code cannot carry this verdict: tg_notify.py's main() returns 0
+#   unconditionally — its except branch is commented "NEVER fail the caller",
+#   spools best-effort and still returns 0. An rc check would be decorative by
+#   construction (W104). The verdict is the status word on STDERR.
+#
+# WHAT IT PINS
+#   guilt     — each non-delivering status leaves the cooldown UNARMED and says so.
+#   innocence — sent/deduped still arm it; a fresh cooldown still suppresses; an
+#               expired one still lets through. The cure must not make the wrapper
+#               chattier, only honest.
+#   W104 pin  — a gateway that says "sent" while exiting non-zero still arms the
+#               cooldown. If someone later "tidies" this into an rc check, this
+#               check is the one that goes red.
+#
+# Runs anywhere: no network, no real gateway, no real Telegram, no real HOME.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+WRAPPER="$REPO_ROOT/infra/launchagents/wrappers/cron-agent.sh"
+
+[ -f "$WRAPPER" ] || { echo "FAIL: wrapper not found at $WRAPPER"; exit 2; }
+
+failures=0
+check() {
+  local name="$1" cond="$2"
+  if [ "$cond" = "1" ]; then printf '  ok   %s\n' "$name"
+  else printf '  FAIL %s\n' "$name"; failures=$((failures + 1)); fi
+}
+# `case ... in *x*)` inline inside $( ) trips the parser on the unbalanced ')'.
+has()   { case "$2" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+yesno() { if "$@"; then echo 1; else echo 0; fi; }
+armed()     { [ "$LAST_COOLDOWN_EXISTS" = "1" ]; }
+not_armed() { [ "$LAST_COOLDOWN_EXISTS" = "0" ]; }
+
+# ── harness ───────────────────────────────────────────────────────────────────
+# Source the LIVE definitions out of the wrapper rather than a copy, so this
+# corpus cannot drift into judging a function nobody runs.
+#
+# log() is a ONE-LINER, so a /^log() {/,/^}/ range would not close on its own
+# line — it would run on and swallow send_telegram(), truncating it mid-`case`.
+# That produced a first draft where every check "passed" the not-armed assertions
+# because the harness never ran at all: a fake world measuring its own poverty
+# (W108). Hence the two extractions are separate, and the guard below is fatal.
+EXTRACT="$(sed -n '/^log() {/p' "$WRAPPER"; sed -n '/^send_telegram() {/,/^}/p' "$WRAPPER")"
+poverty_check() {
+  local why="$1" cond="$2"
+  [ "$cond" = "1" ] && return 0
+  echo "HARNESS TOO POOR TO JUDGE: $why" >&2
+  echo "(exiting 2 — an unrunnable probe must not report verdicts)" >&2
+  exit 2
+}
+poverty_check "send_telegram() not extracted" "$(yesno has 'send_telegram' "$EXTRACT")"
+poverty_check "log() not extracted"            "$(yesno has 'log() {'      "$EXTRACT")"
+poverty_check "extraction is not syntactically complete (truncated function?)" \
+  "$(printf '%s\n' "$EXTRACT" | bash -n 2>/dev/null && echo 1 || echo 0)"
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/alertverdict.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# One scenario = one fresh world. Returns the log; leaves the cooldown state on
+# disk for the caller to inspect.
+#   $1 = what the fake gateway prints on stderr ("" = print nothing)
+#   $2 = the fake gateway's exit code
+#   $3 = "missing" to omit the gateway entirely
+#   $4 = age in seconds of a pre-existing cooldown ("" = none)
+run_scenario() {
+  local reply="$1" grc="$2" mode="${3:-present}" cooldown_age="${4:-}"
+  local w; w="$(mktemp -d "$SANDBOX/w.XXXXXX")"
+  mkdir -p "$w/fakehome/nuzantara/scripts" "$w/bin"
+
+  if [ "$mode" != "missing" ]; then
+    # The gateway lands next to the harness, which is what dirname "$0" resolves
+    # to — the same first branch the real wrapper takes.
+    cat > "$w/bin/tg_notify.py" <<GW
+import sys
+r = """$reply"""
+if r:
+    sys.stderr.write(r + "\n")
+sys.exit($grc)
+GW
+  fi
+
+  local cd_file="$w/job.cooldown"
+  if [ -n "$cooldown_age" ]; then
+    : > "$cd_file"
+    # Backdate it. touch -t needs a wall time; compute it portably.
+    local when; when="$(python3 -c "import time;print(time.strftime('%Y%m%d%H%M.%S', time.localtime(time.time()-$cooldown_age)))")"
+    touch -t "$when" "$cd_file"
+  fi
+
+  cat > "$w/bin/harness.sh" <<HARNESS
+#!/usr/bin/env bash
+set -uo pipefail
+JOB_NAME="probe-job"
+LOG_FILE="$w/job.log"
+COOLDOWN_FILE="$cd_file"
+export HOME="$w/fakehome"
+$EXTRACT
+send_telegram "a message that must not vanish"
+HARNESS
+  chmod +x "$w/bin/harness.sh"
+  bash "$w/bin/harness.sh" >/dev/null 2>&1
+
+  LAST_LOG="$(cat "$w/job.log" 2>/dev/null || true)"
+  LAST_COOLDOWN_EXISTS=0; [ -f "$cd_file" ] && LAST_COOLDOWN_EXISTS=1
+  LAST_W="$w"
+}
+
+echo "guilt — a status that did NOT reach Telegram leaves the cooldown unarmed:"
+for st in logged spooled p0_overflow_spooled p0_unsent_spooled; do
+  run_scenario "tg_notify: $st" 0
+  check "'$st' -> cooldown NOT armed" "$(yesno not_armed)"
+  check "'$st' -> log says it was not delivered, naming the status" \
+        "$(yesno eval "has 'ALERT NOT DELIVERED' \"\$LAST_LOG\" && has '$st' \"\$LAST_LOG\"")"
+done
+
+echo "guilt — the gateway itself failing is not silence:"
+run_scenario "" 127 missing
+check "gateway absent -> logged as missing, cooldown NOT armed" \
+      "$(yesno eval 'has "gateway missing" "$LAST_LOG" && not_armed')"
+
+run_scenario "Traceback (most recent call last):" 1
+check "gateway crashes -> cooldown NOT armed, traceback recorded" \
+      "$(yesno eval 'has Traceback "$LAST_LOG" && not_armed')"
+
+echo "innocence — delivery, and intended silence, still arm the cooldown:"
+run_scenario "tg_notify: sent" 0
+check "'sent' -> cooldown armed" "$(yesno armed)"
+run_scenario "tg_notify: deduped" 0
+check "'deduped' (an equivalent message already went out) -> cooldown armed" "$(yesno armed)"
+
+echo "innocence — the pre-existing cooldown semantics are untouched:"
+run_scenario "tg_notify: sent" 0 present 60
+check "a 60s-old cooldown still suppresses the send" \
+      "$(yesno has 'cooldown active' "$LAST_LOG")"
+run_scenario "tg_notify: sent" 0 present 2000
+check "a 2000s-old cooldown (>1800s) no longer suppresses" \
+      "$(yesno has 'gateway rc=' "$LAST_LOG")"
+
+echo "W104 pin — the REPLY is judged, never the exit code:"
+run_scenario "tg_notify: sent" 3
+check "'sent' with a non-zero exit still arms the cooldown" "$(yesno armed)"
+run_scenario "tg_notify: spooled" 0
+check "'spooled' with a ZERO exit still does not" "$(yesno not_armed)"
+
+echo "superscar #3 pin — the status is read as an entity, not a substring:"
+run_scenario "tg_notify: internal error (connection reset while sent) — best-effort spooled" 0
+check "a free-form error line containing the word 'sent' is NOT read as delivered" \
+      "$(yesno not_armed)"
+
+echo "forensics — the gateway's reply reaches the log every time:"
+run_scenario "tg_notify: sent" 0
+check "the reply is recorded verbatim in the job log" \
+      "$(yesno has 'reply=tg_notify: sent' "$LAST_LOG")"
+
+if [ "$failures" -eq 0 ]; then echo "PASS (all checks)"; exit 0; fi
+echo "FAIL ($failures check(s))"; exit 1

--- a/scripts/tests/test_cron_agent_alert_verdict.sh
+++ b/scripts/tests/test_cron_agent_alert_verdict.sh
@@ -57,7 +57,9 @@ not_armed() { [ "$LAST_COOLDOWN_EXISTS" = "0" ]; }
 # That produced a first draft where every check "passed" the not-armed assertions
 # because the harness never ran at all: a fake world measuring its own poverty
 # (W108). Hence the two extractions are separate, and the guard below is fatal.
-EXTRACT="$(sed -n '/^log() {/p' "$WRAPPER"; sed -n '/^send_telegram() {/,/^}/p' "$WRAPPER")"
+EXTRACT="$(sed -n '/^log() {/p' "$WRAPPER"
+           sed -n '/^_file_mtime() {/,/^}/p' "$WRAPPER"
+           sed -n '/^send_telegram() {/,/^}/p' "$WRAPPER")"
 poverty_check() {
   local why="$1" cond="$2"
   [ "$cond" = "1" ] && return 0
@@ -66,6 +68,7 @@ poverty_check() {
   exit 2
 }
 poverty_check "send_telegram() not extracted" "$(yesno has 'send_telegram' "$EXTRACT")"
+poverty_check "_file_mtime() not extracted"   "$(yesno has '_file_mtime' "$EXTRACT")"
 poverty_check "log() not extracted"            "$(yesno has 'log() {'      "$EXTRACT")"
 poverty_check "extraction is not syntactically complete (truncated function?)" \
   "$(printf '%s\n' "$EXTRACT" | bash -n 2>/dev/null && echo 1 || echo 0)"
@@ -144,6 +147,20 @@ run_scenario "tg_notify: sent" 0
 check "'sent' -> cooldown armed" "$(yesno armed)"
 run_scenario "tg_notify: deduped" 0
 check "'deduped' (an equivalent message already went out) -> cooldown armed" "$(yesno armed)"
+
+echo "the mtime helper — the cooldown gate is only as real as this (W108):"
+# `stat -f%m` is BSD; on GNU coreutils -f means --file-system and %m is the mount
+# point, so it SUCCEEDS and prints a non-timestamp. An exit-code-keyed fallback
+# never fires there and the gate goes silently inert. These two run on whatever
+# OS the runner is, which is the point: the assertion below about a 60s-old
+# cooldown is only meaningful because this helper works on both.
+mt_probe="$(mktemp "$SANDBOX/mt.XXXXXX")"
+mt_now="$(bash -c "$EXTRACT"$'\n''_file_mtime "'"$mt_probe"'"')"
+check "returns a plausible epoch for a real file (got '${mt_now}')" \
+      "$(yesno eval '[ -n "$mt_now" ] && [ "$mt_now" -gt 1700000000 ] 2>/dev/null')"
+mt_gone="$(bash -c "$EXTRACT"$'\n''_file_mtime "'"$SANDBOX"'/definitely-absent"')"
+check "returns 0 — never a non-numeric — for a file that is not there (got '${mt_gone}')" \
+      "$(yesno test "$mt_gone" = "0")"
 
 echo "innocence — the pre-existing cooldown semantics are untouched:"
 run_scenario "tg_notify: sent" 0 present 60


### PR DESCRIPTION
## What bit

`send_telegram()` in `infra/launchagents/wrappers/cron-agent.sh` called the notification gateway as

```bash
python3 tg_notify.py … >/dev/null 2>&1 || true
touch "$COOLDOWN_FILE"
```

Both output channels discarded, then the 30-minute cooldown armed **unconditionally**.

`tg_notify.py` can end in six different ways and only **one** of them reached Telegram:

| status | reached Telegram? |
|---|---|
| `sent` | yes |
| `deduped` | no, but silence is the intended outcome |
| `logged` · `spooled` · `p0_overflow_spooled` · `p0_unsent_spooled` | **no — parked for later** |

So an alert that was merely parked also bought 30 minutes of silence for its own successor, and the job log kept no record of which of the six had happened.

## Why the exit code cannot carry the verdict (W104)

`tg_notify.py`'s `main()` returns `0` unconditionally — its `except` branch is literally commented `# NEVER fail the caller`, spools best-effort and still returns `0`. An rc check here would be **decorative by construction**. The verdict is the status word printed on stderr; that is now what is judged. `rc` is logged for forensics only, never acted on.

## Entity, not substring (superscar #3)

The status word is pulled off a line that *is* the status line. A bare `*sent*` match also matches `p0_un**sent**_spooled` — one prefix away — and would match the free-form `internal error (…)` branch too. The mutation run confirms this is not theoretical: the substring variant turns `p0_unsent_spooled` into a false delivery.

## Also

- A gateway that cannot be found at all is now logged and returns, instead of running `python3` against a missing path and swallowing the 127.
- When the alert did not go out, the cooldown is deliberately left **unarmed** so the next attempt is not pre-silenced. Volume stays bounded — `send_telegram` fires a handful of times per job run, and these jobs are daily.

## Corpus

`scripts/tests/test_cron_agent_alert_verdict.sh` — 18 checks: guilt for each non-delivering status, innocence for `sent`/`deduped` and for **both** existing cooldown semantics (a 60s-old one still suppresses; a 2000s-old one no longer does), plus the two pins above.

It extracts the **live** function out of the wrapper rather than a copy, and refuses to report any verdict at all if that extraction is incomplete — the first draft reported eleven green checks while the harness was not running at all, because `log()` is a one-liner whose `sed` range swallowed `send_telegram` and truncated it mid-`case`. A fake world measuring its own poverty (W108, GOTCHA-2). Hence `poverty_check` exits 2 instead of grading.

## Mutation-verified

Each mutation caught by a distinct signature:

| mutation | red checks | unique signature |
|---|---|---|
| arm the cooldown regardless of the reply (the original defect) | 11 | the guilt block |
| judge the exit code instead of the reply | 11 | `'sent' with a non-zero exit still arms the cooldown` |
| substring match instead of entity match | 3 | `p0_unsent_spooled` |
| drop the missing-gateway guard | 1 | exactly that check |

Armed in CI next to its sibling corpus in `immune-enforcement.yml` (path filter + run step).

## Live context

Found while proving #3767 on Pro. The 02:00 scheduled `conversation-cleanup` run tonight completed `OK duration=196s label=token_1` — the first unattended nightly success after seven nights of failure, and 196s is above the 120–150s the old equal time-slicing would have granted its first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)