### PR TITLE
docs(deps): the pypdf floor was raised for one CVE and kept the other one's name

### DIFF
--- a/apps/backend-rag/requirements-prod.txt
+++ b/apps/backend-rag/requirements-prod.txt
@@ -48,7 +48,7 @@ presidio-anonymizer>=2.2.362
 # Document Processing (lightweight)
 openpyxl>=3.1.5  # CVE-2023-43515 fixed in 3.1.5
 email-validator>=2.3.0
-pypdf>=6.15.0  # Security fix: CVE-2026-31826 memory exhaustion
+pypdf>=6.15.0  # Security: CVE-2026-71852 (patched 6.15.0). Floor was 6.13.3 for CVE-2026-31826; the bump kept the old CVE's name on the new number
 reportlab>=5.0.0  # PDF generation for invoices (lightweight alternative to WeasyPrint)
 beautifulsoup4>=4.15.0  # Security and stability updates
 python-magic>=0.4.27  # MIME type detection from file content

--- a/apps/backend-rag/requirements.txt
+++ b/apps/backend-rag/requirements.txt
@@ -48,7 +48,7 @@ presidio-anonymizer>=2.2.355
 # Document Processing
 openpyxl>=3.1.5  # CVE-2023-43515 fixed in 3.1.5
 email-validator>=2.3.0
-pypdf>=6.15.0  # Security fix: CVE-2026-31826 memory exhaustion
+pypdf>=6.15.0  # Security: CVE-2026-71852 (patched 6.15.0). Floor was 6.13.3 for CVE-2026-31826; the bump kept the old CVE's name on the new number
 Pillow>=12.3.0  # Updated 2026-03-24: CVE fixes for image parsers (was 10.0.0)
 EbookLib>=0.20
 beautifulsoup4>=4.15.0  # Security and stability updates


### PR DESCRIPTION
#3780 raised the floor `>=6.13.3` → `>=6.15.0` and carried the old inline comment across unchanged. Both manifests now read:

```
pypdf>=6.15.0  # Security fix: CVE-2026-31826 memory exhaustion
```

which attributes the 6.15.0 floor to the wrong advisory.

**Verified at source in this turn**, not from the merge conversation:

| fact | source |
|---|---|
| `CVE-2026-71852` → `first_patched_version = 6.15.0`, `vulnerable_version_range = < 6.15.0` | GitHub Dependabot advisory, read live |
| the pin immediately before the bump was `>=6.13.3` | `git show origin/main~1:apps/backend-rag/requirements.txt` |

So `6.13.3` is the floor CVE-2026-31826 required, and `6.15.0` belongs to CVE-2026-71852.

Small, but it is the W106 shape: an inline comment is a statement about the world, read months later by whoever audits **why** a security floor exists. Reconstructing the history from the current text yields "6.13.3 was insufficient for CVE-2026-31826" — false. The new wording names the CVE that owns the current number, keeps the older one's provenance, and says plainly how the two came to be conflated.

**No behaviour change**: pin, lock and resolved version untouched. `test_lock_honors_requirements.py` — the W98 tripwire that every lock pin must satisfy its manifest — passes 5/5 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)