### PR TITLE
feat(cron): a plain script can now reach a live Claude seat — the bare call never could

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -132,6 +132,8 @@ jobs:
               scripts/tests/test_wa_session_liveness_wrapper.sh|\
               infra/launchagents/wrappers/cron-agent.sh|\
               scripts/tests/test_cron_agent_oauth_cascade.sh|\
+              scripts/lib/claude_seat.sh|\
+              scripts/tests/test_claude_seat_helper.sh|\
               scripts/tests/test_cron_agent_alert_verdict.sh|\
               scripts/ci/prepush_tip_drift.sh|\
               .husky/pre-commit|\
@@ -476,6 +478,24 @@ jobs:
           # half runs the wrapper in a fake world (W107) so "did not rotate" is
           # distinguishable from "never got there".
           bash scripts/tests/test_cron_agent_oauth_cascade.sh
+
+      - name: Claude seat helper corpus (a plain script must reach a live seat)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # Measured on Pro 2026-08-08 under `bash -lc` — the shell 27 of its 135
+          # crontab lines use: `claude` is not on PATH (the binary is in
+          # ~/.local/bin) and no OAuth seat is in the environment. The fallback
+          # everyone assumed covered this does not exist — the bare keychain
+          # identity was tried 905 times across ~/logs/cron-agent/ and succeeded
+          # 0 times, because reading the keychain secret needs `-g`, which
+          # returns rc=36 in any non-GUI session. An interactive login cannot
+          # fix that; cron is never a GUI session.
+          #
+          # The helper therefore has NO bare fallback and fails loudly instead.
+          # It also does not reimplement the refusal rule: it extracts the live
+          # classifier out of cron-agent.sh, so the two cannot drift into
+          # different answers to the same question. This corpus pins both.
+          bash scripts/tests/test_claude_seat_helper.sh
 
       - name: Cron-agent alert verdict corpus (a lost alert must not buy silence)
         if: steps.paths.outputs.relevant == 'true'

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -645,6 +645,18 @@
       "repo": "scripts/auth_sentinel_cron.sh",
       "machines": ["m5"],
       "_note": "Found diverged on 2026-08-07 by a single line (the ~/Desktop path PR #2499 cured on 2026-07-16 had not reached this live copy) and realigned by the auth-sentinel item in the same pending-arms batch. Re-verified sha256-identical to the repo twin 2026-08-07 before this pair was declared (STRICT ORDERING: a pair is only declared after its live sync is proven, per family #1's own antidote — declaring an unsynced pair arms a permanent red on M5). Was UNDECLARED in both surfaces (0 hits in this file and in scripts/proprioception.py's home_fork_scripts args) — until today only scripts/launchagent_reconcile.py caught drift here, and only generically (plist->wrapper diff), not via a dedicated home-fork pair."
+    },
+    {
+      "live": "~/scripts/nb-agents-daily-dr.sh",
+      "repo": "scripts/nb-agents-daily-dr.sh",
+      "_note": "PROMOTED 2026-08-08. Was HOME-only and undeclared while carrying three cures made live on 2026-08-07 (empty nlm alias -> hardcoded NB id; the flat-vs-{value:} JSON shape; a slug step whose error text became the FILENAME, `otloggedinleaserunlogin`). Promoted together with the fix that made its `claude` call reachable at all: under `bash -lc`, the shell its crontab line uses, `claude` is not on PATH and no OAuth seat is in the env, so the bare invocation degraded to the default slug every night. Now routes through scripts/lib/claude_seat.sh. Live consumer: crontab 07:30 daily via cron-state.sh.",
+      "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/lib/claude_seat.sh",
+      "repo": "scripts/lib/claude_seat.sh",
+      "_note": "NEW 2026-08-08, shipped with the promotion above. Sourceable OAuth-seat helper: resolves the claude binary absolutely (~/.local/bin is on neither the login-shell nor the cron PATH) and rotates the numbered seats, EXTRACTING the refusal classifier from cron-agent.sh rather than copying it — two tools that must agree on 'did this seat refuse' do not get two answers. Deliberately has no bare-keychain fallback: that rung answered 0 of 905 attempts and cannot work in a non-GUI session. Delivered next to ~/scripts/cron-agent.sh, which is the wrapper it extracts from in the delivered layout.",
+      "machines": ["pro"]
     }
   ],
   "allow": [

--- a/scripts/lib/claude_seat.sh
+++ b/scripts/lib/claude_seat.sh
@@ -1,0 +1,208 @@
+# shellcheck shell=bash
+# claude_seat.sh — reach a WORKING Claude seat from a plain script.
+#
+# WHY THIS EXISTS (measured on Pro, 2026-08-08)
+#   Scripts that just write `claude -p ...` get nothing under cron. Two separate
+#   reasons, both measured in the context the cron actually uses (`bash -lc`,
+#   which is what 27 of Pro's 135 crontab lines invoke):
+#
+#     * `claude: command not found` — the binary lives in ~/.local/bin, which is
+#       on neither the login-shell nor the default cron PATH.
+#     * no seat in the environment — the numbered OAuth tokens live in
+#       ~/.nuzantara-secrets.env, which a login shell does not read.
+#
+#   The fallback everyone assumed was there is not: the bare keychain identity
+#   answers `Not logged in - Please run /login`, because reading the keychain
+#   secret needs `-g`, which returns rc=36 (authorization denied, user
+#   interaction required) in any non-GUI session. Across every file in
+#   ~/logs/cron-agent/ that rung was tried 905 times and succeeded 0 times.
+#   An interactive login cannot fix it: cron is never a GUI session.
+#
+#   So a script needing Claude must bring its own seat. This is that.
+#
+# USAGE
+#   source "$(dirname "$0")/lib/claude_seat.sh"     # or an absolute path
+#   answer=$(claude_seat_run --model claude-sonnet-4-6 -p "...") || {
+#       # every seat refused; stderr already says which and why
+#   }
+#
+#   stdout is the model's answer and nothing else. Diagnostics go to stderr.
+#   No token value is ever printed, logged, or written to disk (superscar #4).
+#
+# THE REFUSAL RULE IS NOT REIMPLEMENTED HERE
+#   Deciding "this seat refused, try the next" is subtle: `claude` prints auth
+#   failures to STDOUT and exits 1, so an rc check misses them and a loose text
+#   match steals successful answers that merely discuss rate limits. That rule
+#   already exists, cured and pinned, in cron-agent.sh. Two tools that must
+#   agree on one question do not get to invent two answers, so this file
+#   EXTRACTS the live classifier rather than copying it. If the extraction
+#   fails, this file refuses to run instead of guessing.
+
+_claude_seat_wrapper_path() {
+    # Where is the cron-agent wrapper whose refusal classifier we reuse?
+    # This file is deployed in TWO shapes and both must work:
+    #   * in the repo, at <root>/scripts/lib/claude_seat.sh
+    #   * delivered live, at ~/scripts/lib/claude_seat.sh, next to ~/scripts/cron-agent.sh
+    # The first draft only handled the repo shape, and my probe did not catch it
+    # because the probe rebuilt the repo layout under /tmp — it measured the
+    # world I had staged, not the one the delivery creates.
+    #
+    # Resolve relative to THIS FILE before asking git: the classifier and this
+    # helper must be the same VERSION, and `git rev-parse --git-common-dir`
+    # answers with the MAIN checkout even from a worktree, which can sit
+    # hundreds of commits behind (W106b).
+    [ -n "${CLAUDE_SEAT_WRAPPER:-}" ] && { printf '%s' "$CLAUDE_SEAT_WRAPPER"; return 0; }
+    local here root cand
+    if [ -n "${CLAUDE_SEAT_REPO_ROOT:-}" ]; then
+        printf '%s' "$CLAUDE_SEAT_REPO_ROOT/infra/launchagents/wrappers/cron-agent.sh"; return 0
+    fi
+    here="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || here=""
+    if [ -n "$here" ]; then
+        # repo shape: scripts/lib -> <root>
+        cand="$(cd "$here/../.." 2>/dev/null && pwd)/infra/launchagents/wrappers/cron-agent.sh"
+        [ -f "$cand" ] && { printf '%s' "$cand"; return 0; }
+        # delivered shape: ~/scripts/lib -> ~/scripts/cron-agent.sh
+        cand="$(cd "$here/.." 2>/dev/null && pwd)/cron-agent.sh"
+        [ -f "$cand" ] && { printf '%s' "$cand"; return 0; }
+    fi
+    root="$(git rev-parse --git-common-dir 2>/dev/null)" || root=""
+    if [ -n "$root" ]; then
+        cand="$(cd "$(dirname "$root")" 2>/dev/null && pwd)/infra/launchagents/wrappers/cron-agent.sh"
+        [ -f "$cand" ] && { printf '%s' "$cand"; return 0; }
+    fi
+    return 1
+}
+
+_claude_seat_load_classifier() {
+    [ -n "${_CLAUDE_SEAT_CLASSIFIER_LOADED:-}" ] && return 0
+    local wrapper extracted
+    wrapper="$(_claude_seat_wrapper_path)" || {
+        echo "claude_seat: cannot locate cron-agent.sh (looked next to this file, in ~/scripts, and via git)" >&2
+        return 2
+    }
+    [ -f "$wrapper" ] || { echo "claude_seat: missing $wrapper" >&2; return 2; }
+    extracted="$(sed -n '/^claude_stderr_retryable()/,/^}/p;/^claude_stdout_retryable()/,/^}/p;/^claude_retryable_files()/,/^}/p;/^claude_oauth_env()/,/^}/p' "$wrapper")"
+    case "$extracted" in
+        *claude_retryable_files*) : ;;
+        *) echo "claude_seat: could not extract the refusal classifier from $wrapper — refusing to guess" >&2; return 2 ;;
+    esac
+    printf '%s\n' "$extracted" | bash -n 2>/dev/null || {
+        echo "claude_seat: extracted classifier does not parse — refusing to guess" >&2; return 2
+    }
+    eval "$extracted" || return 2
+    _CLAUDE_SEAT_CLASSIFIER_LOADED=1
+    return 0
+}
+
+_claude_seat_binary() {
+    if [ -n "${CLAUDE_SEAT_BIN:-}" ]; then
+        # An override that does not exist is a caller mistake, not a seat to try.
+        # Accepting it blindly turns "you pointed me at nothing" into whatever
+        # error the exec happens to produce three frames later.
+        [ -x "$CLAUDE_SEAT_BIN" ] || return 1
+        printf '%s' "$CLAUDE_SEAT_BIN"; return 0
+    fi
+    local c
+    c="$(command -v claude 2>/dev/null)" && [ -n "$c" ] && { printf '%s' "$c"; return 0; }
+    # ~/.local/bin is on neither the login-shell nor the cron PATH; this is the
+    # single most common reason a cron-side `claude` call does nothing at all.
+    [ -x "$HOME/.local/bin/claude" ] && { printf '%s' "$HOME/.local/bin/claude"; return 0; }
+    return 1
+}
+
+_claude_seat_load_secrets() {
+    # Only if the caller has not already supplied a seat — never clobber an
+    # environment that was set up deliberately.
+    local i var
+    for i in 1 2 3 4 5; do
+        var="CLAUDE_CODE_OAUTH_TOKEN_${i}"
+        [ -n "${!var:-}" ] && return 0
+    done
+    [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && return 0
+    local f="${CLAUDE_SEAT_SECRETS_FILE:-$HOME/.nuzantara-secrets.env}"
+    # `source <missing> || true` does NOT degrade under `set -e`: source is a
+    # special builtin and the shell exits before the `||` runs. Guard with -f.
+    if [ -f "$f" ]; then
+        set -a
+        # shellcheck disable=SC1090
+        . "$f" >/dev/null 2>&1 || true
+        set +a
+    fi
+    return 0
+}
+
+# claude_seat_run <claude args...>
+#   Tries each configured seat in order and returns the first answer that is not
+#   a refusal. Prints the answer on stdout; returns 1 if every seat refused.
+claude_seat_run() {
+    _claude_seat_load_classifier || return 2
+    _claude_seat_load_secrets
+
+    local bin
+    bin="$(_claude_seat_binary)" || {
+        echo "claude_seat: no claude binary (not on PATH, not at ~/.local/bin/claude)" >&2
+        return 2
+    }
+
+    local tokens=() labels=() i var tok existing is_dup
+    for i in 1 2 3 4 5; do
+        var="CLAUDE_CODE_OAUTH_TOKEN_${i}"
+        tok="${!var:-}"
+        [ -z "$tok" ] && continue
+        is_dup=0
+        for existing in ${tokens[@]+"${tokens[@]}"}; do
+            [ "$existing" = "$tok" ] && is_dup=1
+        done
+        [ "$is_dup" -eq 1 ] && continue
+        tokens+=("$tok"); labels+=("token_$i")
+    done
+    if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+        is_dup=0
+        for existing in ${tokens[@]+"${tokens[@]}"}; do
+            [ "$existing" = "$CLAUDE_CODE_OAUTH_TOKEN" ] && is_dup=1
+        done
+        [ "$is_dup" -eq 0 ] && { tokens+=("$CLAUDE_CODE_OAUTH_TOKEN"); labels+=("legacy"); }
+    fi
+
+    if [ "${#tokens[@]}" -eq 0 ]; then
+        # Deliberately NOT falling through to a bare invocation: that is the
+        # keychain identity, proven 0-for-905 under cron. Failing loudly beats
+        # a call that silently returns an auth error as if it were an answer.
+        echo "claude_seat: no OAuth seat configured (looked for CLAUDE_CODE_OAUTH_TOKEN_1..5 and the legacy var)" >&2
+        echo "claude_seat: the bare keychain identity is NOT used as a fallback — it cannot work in a non-GUI session" >&2
+        return 2
+    fi
+
+    local out err rc idx label env_args part
+    out="$(mktemp "${TMPDIR:-/tmp}/claude-seat-out.XXXXXX")"
+    err="$(mktemp "${TMPDIR:-/tmp}/claude-seat-err.XXXXXX")"
+    # shellcheck disable=SC2317
+    _claude_seat_cleanup() { rm -f "$out" "$err"; }
+
+    for idx in "${!tokens[@]}"; do
+        label="${labels[$idx]}"
+        env_args=()
+        while IFS= read -r -d '' part; do env_args+=("$part"); done \
+            < <(claude_oauth_env "${tokens[$idx]}")
+        : > "$out"; : > "$err"
+        "${env_args[@]}" "$bin" "$@" < /dev/null > "$out" 2> "$err"
+        rc=$?
+        if claude_retryable_files "$out" "$err" "$rc"; then
+            echo "claude_seat: $label refused (rc=$rc) — rotating" >&2
+            continue
+        fi
+        if [ "$rc" -ne 0 ]; then
+            echo "claude_seat: $label failed with a NON-auth error (rc=$rc) — not rotating, the next seat would fail the same way" >&2
+            cat "$err" >&2
+            _claude_seat_cleanup
+            return "$rc"
+        fi
+        cat "$out"
+        _claude_seat_cleanup
+        return 0
+    done
+
+    echo "claude_seat: every seat refused (${#tokens[@]} tried: ${labels[*]})" >&2
+    _claude_seat_cleanup
+    return 1
+}

--- a/scripts/nb-agents-daily-dr.sh
+++ b/scripts/nb-agents-daily-dr.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# NB-AGENTS daily adaptive Deep Research
+# Schedule: 07:30 WITA daily
+# Logic: read yesterday's DR, extract "open questions" section, query NB-AGENTS on the first one.
+# If no yesterday-file or no open questions: fall back to round-robin theme.
+#
+# Output: ~/nuzantara/research/agent-craft/YYYY-MM-DD-<slug>.md
+#
+# Hard rules (per CLAUDE.md):
+#   - No paid Anthropic API. Only nlm CLI + Sonnet 4.6 via the OAuth seat helper
+#     (scripts/lib/claude_seat.sh, free OAuth MAX) for slug derivation.
+#   - Adaptive: yesterday's "3 domande aperte" section drives today's taglio.
+#   - Idempotent same-day: if today's file exists, exit 0 (no duplicate DR).
+
+set -euo pipefail
+
+# The alias registry is HOME state and was found EMPTY on 2026-08-07 (`nlm alias list`
+# -> "No aliases defined"), so `nlm notebook query nb-agents` returned NOT_FOUND. The
+# dead NotebookLM credential had masked it since at least 2026-07-31 — curing the auth
+# only revealed this one. The notebook id is stable; an alias is a lookup that can vanish.
+NB_ALIAS="6d449787-04e3-430e-acbe-d6fc38d379a9"  # NB-AGENTS (was the alias "nb-agents")
+RESEARCH_DIR="$HOME/nuzantara/research/agent-craft"
+LOG_DIR="$HOME/.cron-agent/logs"
+mkdir -p "$LOG_DIR" "$RESEARCH_DIR/_assets"
+
+TODAY=$(date +%Y-%m-%d)
+YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d "yesterday" +%Y-%m-%d)
+TODAY_LOG="$LOG_DIR/nb-agents-daily-dr-$TODAY.log"
+
+exec >>"$TODAY_LOG" 2>&1
+echo "============================================================"
+echo "[$(date '+%Y-%m-%d %H:%M:%S %Z')] NB-AGENTS daily adaptive DR"
+echo "============================================================"
+
+# Round-robin fallback themes (Lun..Dom) — used only if no yesterday open-questions found.
+DOW=$(date +%u)  # 1=Mon..7=Sun
+declare -a FALLBACK_THEMES=(
+  ""  # index 0 unused
+  "anatomia di un agente Claude Code: struttura completa (frontmatter, body, tool gating, model, isolation, memory)"
+  "tassonomia funzionale degli agenti: orchestrator vs worker vs gate vs watcher vs synthesizer. Mappa i nostri 16 agenti su queste famiglie."
+  "principi ricorrenti: fan-out parallel, bipolar verifier, devils-advocate gate, multi-LLM cascade, ground-truth NB, no-silent-reuse. Quali sono load-bearing e quali decorativi?"
+  "anti-pattern visti live: capacity exhaustion, hallucinated tool output, brief stale premise, 17.2x error amplification, orchestrator race, hybrid quota trap. Quali sono ancora aperti?"
+  "evolution mechanics: Voyager skill library, Reflexion weekly synthesis, Kim et al. error amplification. Come applichiamo questi paper alla nostra stack?"
+  "case study: deconstruct WR2 pipeline a 5 agenti (architect → brief → storyboard → layout → critic). Cosa rende il pattern robusto? Cosa lo romperebbe?"
+  "weekly synthesis: cosa è cambiato in NB-AGENTS questa settimana? Quali pattern sono emersi dai DR di lun-sab? Quale dovrebbe diventare una skill atomica?"
+)
+
+# Look for yesterday's DR file
+YESTERDAY_FILE=$(ls -1 "$RESEARCH_DIR/${YESTERDAY}-"*.md 2>/dev/null | head -1 || true)
+
+# Try to extract "3 domande aperte" or "Open questions" section from yesterday
+ADAPTIVE_QUESTION=""
+if [ -n "$YESTERDAY_FILE" ]; then
+  echo "Yesterday file found: $YESTERDAY_FILE"
+  # Extract block after "Domande Aperte" or "Open questions" heading, grab first numbered item
+  ADAPTIVE_QUESTION=$(awk '
+    /[Dd]omande [Aa]perte|[Oo]pen [Qq]uestions|3 [Dd]omande [Aa]perte|[Tt]aglio.*[Dd]omani/ {found=1; next}
+    found && /^[0-9]+\.|^\*\*[0-9]+\./ {print; exit}
+  ' "$YESTERDAY_FILE" | sed 's/^[0-9]*\.\s*//; s/^\*\*[0-9]*\.\*\*\s*//' | head -1 || true)
+  echo "Extracted adaptive question: ${ADAPTIVE_QUESTION:0:200}..."
+fi
+
+# Decide question
+if [ -n "$ADAPTIVE_QUESTION" ]; then
+  MODE="adaptive"
+  QUESTION="In italiano. Approfondisci la domanda emersa dal Deep Research di ieri: $ADAPTIVE_QUESTION
+
+Per la risposta: (1) cita verbatim le fonti rilevanti tra i tuoi 86 sources, (2) confronta con come lo applichiamo già nei nostri agenti reali, (3) identifica almeno una linea di azione concreta che possiamo implementare nella libreria Bali Zero. Termina con altre 3 domande aperte che saranno il taglio del DR di domani."
+else
+  MODE="fallback"
+  THEME="${FALLBACK_THEMES[$DOW]}"
+  QUESTION="In italiano. Tema di oggi (round-robin giorno $DOW): $THEME
+
+Per la risposta: (1) cita verbatim le fonti rilevanti tra i tuoi 86 sources, (2) confronta con come lo applichiamo già nei nostri agenti reali, (3) identifica almeno una linea di azione concreta. Termina con 3 domande aperte per il DR di domani."
+fi
+
+echo "MODE: $MODE"
+echo "QUESTION: ${QUESTION:0:300}..."
+
+# Derive slug via claude CLI (Sonnet 4.6, free OAuth)
+# `claude` prints auth failures to STDOUT (the same property that kept the OAuth
+# seat cascade from ever rotating), and `sed` always exits 0 - so the `|| echo`
+# fallback below could never fire and the error text flowed straight into the
+# filename: on 2026-08-07 "Not logged in - Please run /login" became the slug
+# `otloggedinleaserunlogin`. Judge the EXIT CODE and the SHAPE, never the fact
+# that a pipeline survived.
+# The invocation goes through claude_seat.sh, not a bare `claude`. Measured on
+# Pro 2026-08-08 under `bash -lc` — the exact shell this script's crontab line
+# uses: `claude` is NOT on PATH there and no OAuth seat is in the environment,
+# so the bare call could never have produced a slug. It degraded to the default
+# one every night instead, silently, because the guard below is doing its job.
+# The helper resolves the binary absolutely and rotates through the numbered
+# seats; the keychain identity is deliberately not a fallback (0 successes in
+# 905 attempts — it cannot work in a non-GUI session).
+# shellcheck source=scripts/lib/claude_seat.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/claude_seat.sh"
+SLUG_RC=0
+SLUG_RAW=$(claude_seat_run --model claude-sonnet-4-6 -p "Genera uno slug kebab-case di max 6 parole in inglese che riassuma questo topic. Output: solo lo slug, niente altro. Topic: <<<$(echo "$QUESTION" | head -c 500)>>>" 2>/dev/null) || SLUG_RC=$?
+SLUG=$(printf '%s' "$SLUG_RAW" | tr -d '\n' | sed 's/[^a-z0-9-]//g; s/--*/-/g' | head -c 60)
+if [ "$SLUG_RC" -ne 0 ] \
+   || [ "${#SLUG}" -lt 3 ] \
+   || printf '%s' "$SLUG_RAW" | grep -qiE 'not logged in|please run|/login|authentication|unauthori|401|rate.?limit|quota'; then
+  echo "SLUG: claude unusable (rc=$SLUG_RC) - falling back to the default slug" >&2
+  SLUG="agent-craft-daily"
+fi
+[ -z "$SLUG" ] && SLUG="agent-craft-daily-$DOW"
+
+OUT_FILE="$RESEARCH_DIR/${TODAY}-${SLUG}.md"
+
+# Idempotent guard
+if [ -f "$OUT_FILE" ]; then
+  echo "OUT_FILE already exists: $OUT_FILE — skipping (idempotent)"
+  exit 0
+fi
+
+echo "OUT_FILE target: $OUT_FILE"
+
+# Run query
+RAW_JSON=$(nlm notebook query "$NB_ALIAS" --json --timeout 300 "$QUESTION" 2>&1 | tee "$LOG_DIR/dr-raw-$TODAY.json")
+
+# Parse and write markdown
+python3 - "$OUT_FILE" "$RAW_JSON" "$MODE" "$QUESTION" <<'PYEOF'
+import json, sys
+from pathlib import Path
+
+out_file = sys.argv[1]
+raw = sys.argv[2]
+mode = sys.argv[3]
+question = sys.argv[4]
+
+start = raw.find("{")
+data = json.loads(raw[start:])
+# The CLI returns the answer FLAT (answer/references/sources_used at the top
+# level); an older shape wrapped it in {"value": ...}. Measured 2026-08-07 on a
+# real 38KB response: no "value" key, so this raised KeyError AFTER a successful
+# query — the third of three stacked defects, each hidden by the one before it.
+# Accept both shapes, and if neither carries an answer say WHICH keys arrived.
+v = data["value"] if isinstance(data.get("value"), dict) else data
+if "answer" not in v:
+    raise SystemExit(
+        "unexpected nlm JSON shape - top-level keys: %s" % sorted(data)[:12]
+    )
+answer = v.get("answer", "")
+refs = v.get("references", [])
+conv_id = v.get("conversation_id", "")
+sources_used = v.get("sources_used", [])
+
+md = []
+md.append(f"# Agent-craft DR — {Path(out_file).stem}")
+md.append("")
+md.append(f"**Date**: {Path(out_file).stem.split('-')[0]}-{Path(out_file).stem.split('-')[1]}-{Path(out_file).stem.split('-')[2]}")
+md.append(f"**Mode**: {mode}")
+md.append(f"**NB**: NB-AGENTS (`6d449787-04e3-430e-acbe-d6fc38d379a9`)")
+md.append(f"**Conversation ID**: `{conv_id}`")
+md.append(f"**Sources used**: {len(sources_used)} / Citations: {len(refs)}")
+md.append("")
+md.append("## Question")
+md.append("")
+md.append(f"> {question}")
+md.append("")
+md.append("## Answer")
+md.append("")
+md.append(answer)
+md.append("")
+md.append(f"## Sources used ({len(sources_used)})")
+md.append("")
+for s in sources_used:
+    md.append(f"- `{s}`")
+md.append("")
+md.append(f"## Citations verbatim ({len(refs)})")
+md.append("")
+for c in refs:
+    n = c.get("citation_number", "?")
+    sid = c.get("source_id", "?")[:8]
+    txt = (c.get("cited_text") or "").strip()
+    md.append(f"### [{n}] source `{sid}…`")
+    md.append("")
+    md.append(f"> {txt}")
+    md.append("")
+
+Path(out_file).write_text("\n".join(md))
+print(f"WROTE: {out_file}  ({Path(out_file).stat().st_size} bytes)")
+PYEOF
+
+echo "[$(date '+%H:%M:%S')] DR completed successfully."

--- a/scripts/tests/test_claude_seat_helper.sh
+++ b/scripts/tests/test_claude_seat_helper.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# test_claude_seat_helper.sh — a plain script must be able to reach a live seat.
+#
+# WHY THIS EXISTS (measured on Pro, 2026-08-08)
+#   Under `bash -lc` — what 27 of Pro's 135 crontab lines use — `claude` is not
+#   on PATH and no OAuth seat is in the environment. The fallback everyone
+#   assumed covered this does not exist: the bare keychain identity answers
+#   `Not logged in`, because reading the keychain secret needs `-g`, which
+#   returns rc=36 in any non-GUI session. It was tried 905 times across
+#   ~/logs/cron-agent/ and succeeded 0 times.
+#
+# WHAT IT PINS
+#   guilt     — a refusing seat rotates; an unconfigured helper fails LOUDLY
+#               rather than falling through to the bare identity; a missing
+#               binary is named rather than silently doing nothing.
+#   innocence — a live first seat is used immediately; a SUCCESSFUL answer that
+#               merely discusses rate limits is not mistaken for a refusal; a
+#               genuine non-auth failure does not burn every remaining seat.
+#   shared rule — the refusal verdict comes from cron-agent.sh's live
+#               classifier, not a copy. If the extraction ever stops working
+#               the helper must refuse to run, not guess.
+#
+# Runs anywhere: no network, no real claude, no real seat, no real HOME.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+HELPER="$REPO_ROOT/scripts/lib/claude_seat.sh"
+
+[ -f "$HELPER" ] || { echo "FAIL: helper not found at $HELPER"; exit 2; }
+
+failures=0
+# `case ... in *x*)` inline inside $( ) trips the parser on the unbalanced ')'.
+has()   { case "$2" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+yesno() { if "$@"; then echo 1; else echo 0; fi; }
+check() {
+  if [ "$2" = "1" ]; then printf '  ok   %s\n' "$1"
+  else printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); fi
+}
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/claudeseat.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# A fake `claude` whose behaviour depends on the seat it is handed. It reads the
+# token from the environment exactly as the real binary would, and writes its
+# verdict to the channel the real CLI uses: auth refusals go to STDOUT with a
+# non-zero exit, which is the whole reason the classifier cannot judge rc.
+make_fake_claude() {  # $1 = script body deciding per-token behaviour
+  local d="$1/bin"; mkdir -p "$d"
+  cat > "$d/claude" <<FAKE
+#!/usr/bin/env bash
+echo "\$CLAUDE_CODE_OAUTH_TOKEN" >> "$1/seats-tried"
+$2
+FAKE
+  chmod +x "$d/claude"
+  printf '%s' "$d/claude"
+}
+
+run_helper() {  # $1 = fake binary, $2.. = env assignments; prints "rc|stdout|stderr-marker"
+  local bin="$1"; shift
+  local w; w="$(mktemp -d "$SANDBOX/w.XXXXXX")"
+  local out err; out="$w/out"; err="$w/err"
+  # Hermetic: strip any seat the RUNNER's shell happens to export, or this
+  # corpus tests the developer's environment instead of the helper (the first
+  # draft did exactly that — three checks passed on my own live token).
+  env -u CLAUDE_CODE_OAUTH_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN_1 -u CLAUDE_CODE_OAUTH_TOKEN_2 \
+      -u CLAUDE_CODE_OAUTH_TOKEN_3 -u CLAUDE_CODE_OAUTH_TOKEN_4 -u CLAUDE_CODE_OAUTH_TOKEN_5 \
+      "$@" \
+      CLAUDE_SEAT_BIN="$bin" \
+      CLAUDE_SEAT_SECRETS_FILE=/dev/null \
+      bash -c "source '$HELPER'; claude_seat_run --model m -p probe" > "$out" 2> "$err"
+  LAST_RC=$?
+  LAST_OUT="$(cat "$out")"
+  LAST_ERR="$(cat "$err")"
+}
+
+# ── the world where seat 1 and 2 are revoked and seat 4 answers ───────────────
+W1="$(mktemp -d "$SANDBOX/world.XXXXXX")"
+BIN1="$(make_fake_claude "$W1" '
+case "$CLAUDE_CODE_OAUTH_TOKEN" in
+  dead1|dead2) echo "Failed to authenticate. API Error: 401 OAuth access token has been revoked."; exit 1 ;;
+  live4)       echo "THE ANSWER"; exit 0 ;;
+  *)           echo "unexpected token"; exit 9 ;;
+esac')"
+
+echo "guilt — a refusing seat rotates to the next:"
+: > "$W1/seats-tried"
+run_helper "$BIN1" CLAUDE_CODE_OAUTH_TOKEN_1=dead1 CLAUDE_CODE_OAUTH_TOKEN_2=dead2 CLAUDE_CODE_OAUTH_TOKEN_4=live4
+check "the live seat's answer is returned on stdout" "$(yesno test "$LAST_OUT" = "THE ANSWER")"
+check "exit code is 0" "$(yesno test "$LAST_RC" -eq 0)"
+check "all three seats were actually tried, in order" \
+      "$(yesno test "$(tr '\n' ' ' < "$W1/seats-tried")" = "dead1 dead2 live4 ")"
+check "stderr names each rotation" \
+      "$(yesno eval 'has "token_1 refused" "$LAST_ERR" && has "token_2 refused" "$LAST_ERR"')"
+
+echo "innocence — a live first seat is used immediately, no needless rotation:"
+: > "$W1/seats-tried"
+run_helper "$BIN1" CLAUDE_CODE_OAUTH_TOKEN_1=live4
+check "only one seat tried" "$(yesno test "$(wc -l < "$W1/seats-tried" | tr -d ' ')" -eq 1)"
+check "no rotation message" "$(yesno eval '! has refused "$LAST_ERR"')"
+
+echo "innocence — a SUCCESSFUL answer discussing rate limits is not a refusal:"
+W2="$(mktemp -d "$SANDBOX/world.XXXXXX")"
+BIN2="$(make_fake_claude "$W2" '
+echo "Your quota and rate limit questions are answered in the docs: a 429 means slow down."
+exit 0')"
+: > "$W2/seats-tried"
+run_helper "$BIN2" CLAUDE_CODE_OAUTH_TOKEN_1=s1 CLAUDE_CODE_OAUTH_TOKEN_2=s2
+check "the answer is returned, not discarded" "$(yesno has "429 means slow down" "$LAST_OUT")"
+check "the second seat was never touched" "$(yesno test "$(wc -l < "$W2/seats-tried" | tr -d ' ')" -eq 1)"
+
+echo "innocence — a genuine NON-auth failure does not burn the remaining seats:"
+W3="$(mktemp -d "$SANDBOX/world.XXXXXX")"
+BIN3="$(make_fake_claude "$W3" 'echo "ENOENT: cannot read the prompt file" >&2; echo ""; exit 3')"
+: > "$W3/seats-tried"
+run_helper "$BIN3" CLAUDE_CODE_OAUTH_TOKEN_1=s1 CLAUDE_CODE_OAUTH_TOKEN_2=s2 CLAUDE_CODE_OAUTH_TOKEN_4=s4
+check "stopped after the first seat" "$(yesno test "$(wc -l < "$W3/seats-tried" | tr -d ' ')" -eq 1)"
+check "the underlying exit code is propagated" "$(yesno test "$LAST_RC" -eq 3)"
+
+echo "guilt — with no seat configured it fails LOUDLY, never bare:"
+W4="$(mktemp -d "$SANDBOX/world.XXXXXX")"
+BIN4="$(make_fake_claude "$W4" 'echo "BARE IDENTITY ANSWERED"; exit 0')"
+: > "$W4/seats-tried"
+run_helper "$BIN4"
+check "rc=2, not a silent success" "$(yesno test "$LAST_RC" -eq 2)"
+check "the binary was never invoked without a seat" \
+      "$(yesno test "$(wc -c < "$W4/seats-tried" | tr -d ' ')" -eq 0)"
+check "stderr says the keychain is not a fallback" \
+      "$(yesno has "NOT used as a fallback" "$LAST_ERR")"
+
+echo "guilt — a missing binary is named, not silently ignored:"
+run_helper "$SANDBOX/definitely-not-a-binary" CLAUDE_CODE_OAUTH_TOKEN_1=s1
+check "rc=2 and the reason mentions the binary" \
+      "$(yesno eval 'test "$LAST_RC" -eq 2 && has "no claude binary" "$LAST_ERR"')"
+
+echo "shared rule — the verdict comes from cron-agent.sh, not a copy:"
+copied=$(grep -c 'rate.?limit\|not logged in\|token_revoked' "$HELPER")
+check "the helper does NOT reimplement the refusal regex (found $copied occurrence(s))" \
+      "$(yesno test "$copied" -eq 0)"
+check "it extracts claude_retryable_files from the wrapper" \
+      "$(yesno grep -q 'claude_retryable_files' "$HELPER")"
+# And if the extraction breaks, it must refuse rather than guess.
+W5="$(mktemp -d "$SANDBOX/world.XXXXXX")"
+mkdir -p "$W5/infra/launchagents/wrappers"
+echo '# a wrapper with no classifier in it' > "$W5/infra/launchagents/wrappers/cron-agent.sh"
+BIN5="$(make_fake_claude "$W5" 'echo ANSWER; exit 0')"
+: > "$W5/seats-tried"
+env CLAUDE_SEAT_REPO_ROOT="$W5" CLAUDE_SEAT_BIN="$BIN5" CLAUDE_SEAT_SECRETS_FILE=/dev/null \
+    CLAUDE_CODE_OAUTH_TOKEN_1=s1 \
+    bash -c "source '$HELPER'; claude_seat_run -p probe" >/dev/null 2>"$SANDBOX/e5"
+rc5=$?
+check "an unextractable classifier => rc=2 and a refusal to guess" \
+      "$(yesno eval 'test "$rc5" -eq 2 && has "refusing to guess" "$(cat "$SANDBOX/e5")"')"
+
+if [ "$failures" -eq 0 ]; then echo "PASS (all checks)"; exit 0; fi
+echo "FAIL ($failures check(s))"; exit 1


### PR DESCRIPTION
> Zero: *"hai 4 token di 4 account claude, arrangiati."* So: the seats, not a login.

## Measured first

A census of every **real** `claude` invocation on Pro — comment lines and `--version` probes excluded, because a loose grep on that word lies — found **8 bare call sites**:

| call site | invocations |
|---|---|
| `scripts/r3/loop{1,2,2-v2,3,4,4-v2}.sh` (6 files) | **0** crontab, **0** plist, **0** callers — dead |
| `scripts/wr2-contract-test.sh` | **0** / **0** / **0** — dead |
| **`nb-agents-daily-dr.sh`** | **crontab 07:30 daily** — live |

And the live one **could never have worked**. Under `bash -lc` — the shell its crontab line uses, and **27 of Pro's 135 lines** do:

```
$ bash -lc 'command -v claude'      -> bash: claude: command not found
$ bash -lc 'echo ${CLAUDE_CODE_OAUTH_TOKEN_1:-unset}' -> unset
```

The binary lives in `~/.local/bin`; the seats live in `~/.nuzantara-secrets.env`, which a login shell does not read. The job stayed green only because last night's slug guard degrades to a default slug instead of dying — so it has silently produced the default every night.

## The fallback everyone assumed does not exist

The bare keychain identity answers `Not logged in`. The item **is** there (`acct=nuzantara`), but reading its secret needs `-g`, which returns **rc=36 — authorization denied, user interaction required** in any non-GUI session. Across every file in `~/logs/cron-agent/` that rung was tried **905 times and succeeded 0 times**.

An interactive login cannot fix it — cron is never a GUI session. That is why the operator ask I wrote yesterday was the wrong one.

## `scripts/lib/claude_seat.sh`

```bash
source "$(dirname "$0")/lib/claude_seat.sh"
answer=$(claude_seat_run --model claude-sonnet-4-6 -p "...") || { ... }
```

Resolves the binary absolutely and rotates the numbered seats. Two deliberate properties:

- **No bare-keychain fallback.** With no seat configured it returns 2 and says so, rather than making a call that returns an auth error shaped like an answer.
- **It does not reimplement the refusal rule.** Deciding *"this seat refused"* is the subtle part: `claude` prints auth failures to **stdout** and exits 1, so rc misses them, and a loose match steals successful answers that merely discuss rate limits. That rule is already cured and pinned in `cron-agent.sh`, so this **extracts the live classifier** instead of copying it — two tools that must agree on one question do not get two answers. If the extraction ever fails, the helper refuses to run rather than guess.

## Promotion

`nb-agents-daily-dr.sh` comes out of HOME in the same commit. It was undeclared while carrying three cures made live on 2026-08-07 (the empty `nlm` alias, the flat-vs-`{value:}` JSON shape, and a slug step whose error text became the **filename**). Both files declared in `declared-pairs.json`.

## Proven live on Pro, in both shapes

| shape | result |
|---|---|
| repo layout, `bash -lc` | `rc=0`, answer `PONG` |
| **delivered `~/scripts/lib` shape**, `bash -lc` | `rc=0`, answer `PONG` |

…where a bare call returns `command not found`.

The second shape is not decoration. The first draft only handled the repo layout, and **my own probe missed it** because the probe rebuilt the repo layout under `/tmp` — it measured the world I had staged, not the one the delivery creates.

## Corpus

`scripts/tests/test_claude_seat_helper.sh` — 17 checks, armed in `immune-enforcement.yml`.

- **guilt**: a refusing seat rotates (and all three are tried, in order); no seat ⇒ loud `rc=2` **and the binary is never invoked bare**; a missing binary is named.
- **innocence**: a live first seat is used immediately; an answer discussing 429s is not a refusal; a non-auth failure does not burn the remaining seats.
- **shared rule**: the helper contains zero refusal-regex of its own, and an unextractable classifier ⇒ `rc=2` + "refusing to guess".

Hermetic by `env -u`: the first draft passed three checks on my own exported token — testing my environment instead of the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)