### PR TITLE
fix(deps): nanoid high advisory fails npm audit on every PR — lock-only bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14633,9 +14633,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -24806,9 +24806,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
`Frontend Tests (Next.js)` went red repo-wide and **the failing step is not a test — it is `npm audit`.** GHSA-2v37-7h3g-55p8 / CVE-2026-67213 landed against `nanoid < 3.3.17` at **HIGH**, and `scripts/ci/npm_audit_gate.py` runs at `--audit-level=high --omit=dev`, so every PR opened after the advisory published fails on it.

**Attributed by measurement, not assumption:**

| PR | touches frontend? | Frontend Tests |
|---|---|---|
| #3794 (backend retention) | no | **FAILURE** |
| #3795 (one markdown file) | no | **FAILURE** |
| #3793 / #3792 / #3789 / #3787 / #3786 | — | SUCCESS |

The green ones branched before the advisory. Same shape as the pypdf CVE that blocked three PRs earlier today.

## Why lock-only

`nanoid` is transitive, pulled by two production dependencies that both already accept the patch range — `@vercel/microfrontends` (`^3.3.9`) and `postcss` (`^3.3.16`). So no manifest has to move: `npm audit fix --package-lock-only --omit=dev` resolves it inside the existing ranges. **The only file this PR touches is `package-lock.json`.**

## The dompurify hunk is deliberate

The same run also carried `dompurify` 3.4.12 → 3.4.13 (GHSA-55q2-fjhq-7xh7, **moderate** — below the gate's threshold, so never the blocker). Kept rather than hand-stripped: `npm audit fix` produced one coherent lock and surgically reverting half of it risks an inconsistent tree for no gain. This duplicates open PR **#3772**, a pure dompurify bump — if this lands first Dependabot closes it automatically, having found the dep already at 3.4.13; if #3772 lands first, this hunk is what rebases. Overlap is deliberate, not accidental.

## Proof, run locally exactly as CI does

```
npm audit --audit-level=high --omit=dev --json > /tmp/audit.json
python3 scripts/ci/npm_audit_gate.py /tmp/audit.json
→ npm audit: only waived advisories present — gate OK   (exit 0)
```

and `npm audit fix` reports `found 0 vulnerabilities` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)