### PR TITLE
chore(deps): bump nanoid to 3.3.18 — GHSA-2v37-7h3g-55p8 blocks every new PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24806,9 +24806,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What broke

The npm-audit gate went red repo-wide:

```
('nanoid', 'high', ['GHSA-2v37-7h3g-55p8'], 'not waived')
```

**No diff caused this.** [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) ("custom generators can loop indefinitely when size is zero") was published **2026-07-29** and the gate reads a live feed. PRs whose checks ran before it landed are green; every PR opened after is red for a reason its author did not cause.

Found on **#3794** — a Python-only retention change whose *only* failing check was the frontend job. Same shape as `fd9e30c76f` (#3586, "apart, each fails on the other's advisory").

## The fix

A patched release exists for the 3.x line (**3.3.17**), so this is a bump, not a waiver. `nanoid` is transitive via `postcss` (`^3.3.16`) and `@vercel/microfrontends` (`^3.3.9`) — **both ranges already admit it**, so only the lock moves and `package.json` is untouched. npm resolved **3.3.18**.

Diff: 3 lines, one package.

## Verification — with a guilt control

Run against the **real gate**, not reasoned about, and with a control so that "clean" means something rather than "the probe saw nothing":

| lock | `scripts/ci/npm_audit_gate.py` |
|---|---|
| pre-bump (3.3.16) | **exit 1** — `('nanoid', 'high', ['GHSA-2v37-7h3g-55p8'], 'not waived')`, verbatim what CI reported |
| post-bump (3.3.18) | **exit 0** — `only waived advisories present — gate OK` |

The gate's own corpus also passes (`11/11`).

Remaining finding: `dompurify` at **moderate**, below the gate's `high` threshold and already covered by **#3772**.

## Scope

Deliberately narrow. The audit surface carries other advisories, each waived with a recorded reachability argument at the top of `scripts/ci/npm_audit_gate.py`. **This touches none of them** — no waiver added, removed, or widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)