### PR TITLE
feat(rag): add shadow finalization spine

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ nuzantara/
 ## Tech Stack
 
 <!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 330 routers · 689 services
+- Backend: FastAPI · 330 routers · 690 services
 - Vector DB: Qdrant · 12 collections · 104,154 documents
 - Knowledge Graph: 108,068 nodes · 242,827 edges
 - Apps: 32 · Packages: 6

--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -18,6 +18,7 @@ import logging
 import os
 import time
 import uuid
+from collections.abc import Callable
 from typing import Any
 
 from langsmith import traceable
@@ -32,6 +33,12 @@ from backend.services.rag.agentic.entity_extractor import EntityExtractionServic
 from backend.services.rag.agentic.llm_gateway import LLMGateway
 from backend.services.rag.agentic.memory_handler import MemoryHandler
 from backend.services.rag.agentic.orchestrator_context import OrchestratorContextManager
+from backend.services.rag.agentic.orchestrator_finalization import (
+    FinalizationContext,
+    classify_result_origin,
+    finalize_core_result,
+    is_canonically_finalized,
+)
 from backend.services.rag.agentic.orchestrator_metrics import OrchestratorMetricsManager
 from backend.services.rag.agentic.orchestrator_response import OrchestratorResponseBuilder
 from backend.services.rag.agentic.orchestrator_routing import OrchestratorRoutingManager
@@ -40,7 +47,12 @@ from backend.services.rag.agentic.query_gates import QueryGates
 from backend.services.rag.agentic.query_helpers import wrap_query_with_language_instruction
 from backend.services.rag.agentic.query_planner import QueryPlanner  # GraphRAG v6.0
 from backend.services.rag.agentic.reasoning import ReasoningEngine
-from backend.services.rag.agentic.schema import CoreResult
+from backend.services.rag.agentic.schema import (
+    AnalyticsReceiptStatus,
+    CoreResult,
+    ProducerOrigin,
+    TrustedBypassReason,
+)
 from backend.services.rag.agentic.team_crm_tools import is_team_or_creator_profile
 from backend.services.rag.crag_router import CRAGRouter
 from backend.services.rag.grading import (
@@ -135,6 +147,7 @@ def _apply_e33_claim_guard(result: CoreResult) -> None:
             [v.pattern_id for v in guard_outcome.violations],
         )
 
+
 # SPEC v2 D3-L2 (F1b, 2026-07-17): curated_qa grounding injection.
 # NOT verbatim serving — a hit is prepended to the ReAct system context as
 # high-priority evidence; the LLM still answers the real question and the
@@ -193,6 +206,9 @@ _MULTI_AGENT_COORDINATOR_ENABLED = os.getenv(
     "true",
     "yes",
 )
+
+
+_FinalizationAnalyticsClaim = Callable[[], bool]
 
 
 class OrchestratorCore:
@@ -1115,6 +1131,119 @@ class OrchestratorCore:
                 set_span_status("error", f"unexpected:{type(unexpected_error).__name__}")
                 raise RuntimeError(f"ReAct loop failed: {unexpected_error}") from unexpected_error
 
+    async def finalize_result(
+        self,
+        result: CoreResult,
+    ) -> CoreResult:
+        """Purely recompute shadow metadata; never perform or schedule I/O."""
+        if is_canonically_finalized(result):
+            return result
+        producer_origin, trusted_bypass_reason = classify_result_origin(result)
+
+        return finalize_core_result(
+            result,
+            producer_origin=producer_origin,
+            trusted_bypass_reason=trusted_bypass_reason,
+            analytics_receipt=AnalyticsReceiptStatus.SKIPPED,
+        )
+
+    def _claim_execution_analytics_receipt(
+        self,
+        context: FinalizationContext,
+        *,
+        query: str,
+        user_id: str | None,
+        session_id: str | None,
+        claim_analytics: _FinalizationAnalyticsClaim,
+    ) -> AnalyticsReceiptStatus:
+        """Consume one invocation-local capability and return its receipt."""
+        if not claim_analytics():
+            raise RuntimeError("finalization analytics capability already consumed or invalid")
+
+        # ReAct already awaited the canonical repository call. Its receipt is
+        # accepted only from the private ReAct producer context, never public
+        # model fields or another producer. A missing/impossible scheduled
+        # state is fail-visible and never triggers a second write.
+        if context.producer_origin is ProducerOrigin.REACT_PIPELINE:
+            if isinstance(
+                context.analytics_receipt, AnalyticsReceiptStatus
+            ) and context.analytics_receipt in {
+                AnalyticsReceiptStatus.WRITTEN,
+                AnalyticsReceiptStatus.SKIPPED,
+                AnalyticsReceiptStatus.FAILED,
+            }:
+                return context.analytics_receipt
+            return AnalyticsReceiptStatus.FAILED
+
+        if not self.db_pool:
+            return AnalyticsReceiptStatus.SKIPPED
+
+        result = context.result
+        try:
+            sources = list(result.sources)
+            timings = dict(result.timings)
+            collections_used = {
+                str(source.get("collection") or source.get("source"))
+                for source in sources
+                if isinstance(source, dict) and (source.get("collection") or source.get("source"))
+            }
+            token_usage = TokenUsage(
+                prompt_tokens=result.prompt_tokens,
+                completion_tokens=result.completion_tokens,
+                model=result.model_used or "unknown",
+                cost_usd=result.cost_usd,
+            )
+            analytics_work = self._log_query_analytics(
+                query=query,
+                user_id=user_id,
+                session_id=session_id,
+                collections_used=collections_used,
+                sources=sources,
+                model_used=result.model_used or "unknown",
+                token_usage=token_usage,
+                timings=timings,
+                response_generated=bool(result.answer) and not result.abstain,
+            )
+            try:
+                spawn(
+                    analytics_work,
+                    name="orchestrator_finalization_analytics",
+                )
+            except Exception:
+                analytics_work.close()
+                raise
+        except Exception:
+            logger.warning(
+                "Finalization analytics scheduling failed before background execution",
+                exc_info=True,
+            )
+            return AnalyticsReceiptStatus.FAILED
+        return AnalyticsReceiptStatus.SCHEDULED
+
+    def _finalize_process_context(
+        self,
+        context: FinalizationContext,
+        *,
+        query: str,
+        user_id: str | None,
+        session_id: str | None,
+        claim_analytics: _FinalizationAnalyticsClaim,
+    ) -> CoreResult:
+        """Finalize one canonical execution with its single-use authority."""
+        analytics_receipt = self._claim_execution_analytics_receipt(
+            context,
+            query=query,
+            user_id=user_id,
+            session_id=session_id,
+            claim_analytics=claim_analytics,
+        )
+        return finalize_core_result(
+            context.result,
+            producer_origin=context.producer_origin,
+            trusted_bypass_reason=context.trusted_bypass_reason,
+            analytics_receipt=analytics_receipt,
+        )
+
     @traceable(run_type="chain", name="Agentic RAG Query", tags=["nuzantara", "rag", "production"])
     async def process_query_core(
         self,
@@ -1129,8 +1258,54 @@ class OrchestratorCore:
         agent_role: Any | None = None,
         memory_subject: str | None = None,
     ) -> CoreResult:
+        """Run the core pipeline and cross the shared finalization boundary."""
+        analytics_claimed = False
+
+        def _claim_finalization_analytics_once() -> bool:
+            # This lexical capability cannot be reconstructed by copying or
+            # serialization: function copies share this invocation's cell and
+            # local closures are deliberately not pickleable.
+            nonlocal analytics_claimed
+            if analytics_claimed:
+                return False
+            analytics_claimed = True
+            return True
+
+        context = await self._process_query_core_unfinalized(
+            query=query,
+            user_id=user_id,
+            conversation_history=conversation_history,
+            start_time=start_time,
+            session_id=session_id,
+            tool_execution_counter=tool_execution_counter,
+            profile=profile,
+            max_steps=max_steps,
+            agent_role=agent_role,
+            memory_subject=memory_subject,
+        )
+        return self._finalize_process_context(
+            context,
+            query=query,
+            user_id=user_id,
+            session_id=session_id,
+            claim_analytics=_claim_finalization_analytics_once,
+        )
+
+    async def _process_query_core_unfinalized(
+        self,
+        query: str,
+        user_id: str | None,
+        conversation_history: list[dict] | None,
+        start_time: float,
+        session_id: str | None = None,
+        tool_execution_counter: dict[str, int] | None = None,
+        profile: dict[str, Any] | None = None,
+        max_steps: int | None = None,
+        agent_role: Any | None = None,
+        memory_subject: str | None = None,
+    ) -> FinalizationContext:
         """
-        Core query processing logic coordinando tutti i moduli.
+        Unfinalized implementation; only ``process_query_core`` may call it.
 
         Questo è il metodo principale che orchestra tutto il flusso:
         1. Load context + Extract Entities/KG (PARALLEL)
@@ -1231,10 +1406,14 @@ class OrchestratorCore:
             conversation_history=optimized_history,
         )
         if gate_result.triggered:
-            return self.query_gates.gate_result_to_core_result(
-                gate_result,
-                start_time,
-                extracted_entities=extracted_entities,
+            return FinalizationContext(
+                result=self.query_gates.gate_result_to_core_result(
+                    gate_result,
+                    start_time,
+                    extracted_entities=extracted_entities,
+                ),
+                producer_origin=ProducerOrigin.QUERY_GATE,
+                trusted_bypass_reason=TrustedBypassReason.DETERMINISTIC_QUERY_GATE,
             )
 
         # WA team-assistant Phase 2 (2026-07-20 ruling): team/creator
@@ -1259,7 +1438,10 @@ class OrchestratorCore:
             )
         )
         if faq_cached_result:
-            return faq_cached_result
+            return FinalizationContext(
+                result=faq_cached_result,
+                producer_origin=ProducerOrigin.FAQ_CACHE,
+            )
 
         # 3b. Check semantic cache (vector similarity, ~50ms)
         # (Already have entities from parallel step 1)
@@ -1273,7 +1455,10 @@ class OrchestratorCore:
             )
         )
         if cached_result:
-            return cached_result
+            return FinalizationContext(
+                result=cached_result,
+                producer_origin=ProducerOrigin.SEMANTIC_CACHE,
+            )
 
         # 3c. [SPEC v2 D3-L2] Curated QA grounding injection — NOT verbatim
         # serving: on a high-confidence curated_qa hit, prepend it as
@@ -1302,13 +1487,16 @@ class OrchestratorCore:
                     grounding_context=system_context_for_prompt,
                 )
                 if ma_result.get("final_answer"):
-                    return CoreResult(
-                        answer=ma_result["final_answer"],
-                        sources=[],
-                        model_used="multi-agent-coordinator",
-                        entities=extracted_entities,
-                        timings={"total": time.time() - start_time},
-                        tools_called=["legal_agent", "financial_agent", "timeline_agent"],
+                    return FinalizationContext(
+                        result=CoreResult(
+                            answer=ma_result["final_answer"],
+                            sources=[],
+                            model_used="multi-agent-coordinator",
+                            entities=extracted_entities,
+                            timings={"total": time.time() - start_time},
+                            tools_called=["legal_agent", "financial_agent", "timeline_agent"],
+                        ),
+                        producer_origin=ProducerOrigin.MULTI_AGENT_COORDINATOR,
                     )
             except Exception as e:
                 logger.warning("⚠️ [Phase 6] Multi-agent failed, falling back to ReAct: %s", e)
@@ -1329,13 +1517,16 @@ class OrchestratorCore:
                     user_id or "anonymous",
                 )
             if ssr_result and ssr_result.get("response"):
-                return CoreResult(
-                    answer=ssr_result["response"],
-                    sources=[],
-                    model_used=ssr_result.get("model", "specialized-router"),
-                    entities=extracted_entities,
-                    timings={"total": time.time() - start_time},
-                    tools_called=[ssr_result.get("category", "specialized_service")],
+                return FinalizationContext(
+                    result=CoreResult(
+                        answer=ssr_result["response"],
+                        sources=[],
+                        model_used=ssr_result.get("model", "specialized-router"),
+                        entities=extracted_entities,
+                        timings={"total": time.time() - start_time},
+                        tools_called=[ssr_result.get("category", "specialized_service")],
+                    ),
+                    producer_origin=ProducerOrigin.SPECIALIZED_SERVICE_ROUTER,
                 )
 
         # 3b.6. R5 Phase 5: KG fast-path — entity/relationship queries bypass Qdrant ReAct loop
@@ -1347,7 +1538,10 @@ class OrchestratorCore:
         )
         if kg_fast_result:
             logger.info("✅ [R5 KG] Fast-path returned answer (skipping ReAct loop)")
-            return kg_fast_result
+            return FinalizationContext(
+                result=kg_fast_result,
+                producer_origin=ProducerOrigin.KNOWLEDGE_GRAPH,
+            )
 
         # 4. Route query (intent classification + tier selection)
         model_tier, _deep_think_mode, state = await self.routing_manager.route_query(query)
@@ -1471,18 +1665,6 @@ class OrchestratorCore:
             token_usage=token_usage,
         )
 
-        # 10. Log to query_analytics (fire-and-forget, non-blocking)
-        await self._log_query_analytics(
-            query=query,
-            user_id=user_id,
-            session_id=session_id,
-            collections_used=collections_used,
-            sources=sources,
-            model_used=model_used_name,
-            token_usage=token_usage,
-            timings=timings,
-        )
-
         # 11. Build and return response (with KG LangGraph workflow if available)
         # Extract reasoning from langgraph_result if available
         langgraph_reasoning = None
@@ -1582,7 +1764,26 @@ class OrchestratorCore:
                 ),
             )
 
-        return result
+        # Canonical ReAct analytics write. This predates the finalization
+        # spine and remains awaited; recording it after the response policy
+        # makes ``response_generated`` reflect the actual abstain decision.
+        analytics_receipt = await self._log_query_analytics(
+            query=query,
+            user_id=user_id,
+            session_id=session_id,
+            collections_used=collections_used,
+            sources=sources,
+            model_used=model_used_name,
+            token_usage=token_usage,
+            timings=timings,
+            response_generated=bool(result.answer) and not result.abstain,
+        )
+
+        return FinalizationContext(
+            result=result,
+            producer_origin=ProducerOrigin.REACT_PIPELINE,
+            analytics_receipt=analytics_receipt,
+        )
 
     async def _run_query_planner_shadow(
         self,
@@ -1812,32 +2013,38 @@ class OrchestratorCore:
         model_used: str,
         token_usage: TokenUsage,
         timings: dict[str, float],
+        response_generated: bool,
         error_message: str | None = None,
-    ) -> None:
+    ) -> AnalyticsReceiptStatus:
         """
         Persist query execution data to query_analytics table.
-        Fails silently to never block the main query flow.
+        Return a closed, non-PII receipt; failures never block the response.
         """
         if not self.db_pool:
-            return
+            return AnalyticsReceiptStatus.SKIPPED
 
         try:
             repo = QueryAnalyticsRepository(self.db_pool)
-            await repo.log_query(
+            query_id = await repo.log_query(
                 query_text=query,
                 user_id=user_id,
                 session_id=session_id,
                 collections_queried=list(collections_used) if collections_used else [],
                 chunks_retrieved_count=len(sources),
-                response_generated=len(sources) > 0,
+                response_generated=response_generated,
                 model_used=model_used,
                 execution_time_ms=int(timings.get("total", 0) * 1000),
                 token_usage_total=token_usage.total_tokens,
                 cost_usd=token_usage.cost_usd,
                 error_message=error_message,
             )
+            if query_id is None:
+                logger.warning("Query analytics returned no receipt (non-critical)")
+                return AnalyticsReceiptStatus.FAILED
+            return AnalyticsReceiptStatus.WRITTEN
         except Exception as e:
             logger.warning("Failed to log query analytics (non-critical): %s", e)
+            return AnalyticsReceiptStatus.FAILED
 
     # ========== COMMON METHODS FOR STREAMING AND NON-STREAMING ==========
 

--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_finalization.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_finalization.py
@@ -1,0 +1,322 @@
+"""Deterministic, I/O-free finalization contract for user-visible RAG results.
+
+The orchestration layer owns transport and analytics scheduling. This module
+only classifies a result's producer and stamps additive metadata on the one
+public ``CoreResult`` schema. It deliberately does not grade, rewrite, or
+recompute answers, abstention decisions, confidence, or sources.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backend.services.rag.agentic.schema import (
+    AnalyticsReceiptStatus,
+    CoreResult,
+    EvidenceProvenance,
+    FinalizationStatus,
+    ProducerOrigin,
+    TrustedBypassReason,
+)
+
+_FINALIZATION_STAMP = object()
+
+_QUERY_GATE_MODELS = frozenset(
+    {
+        "security-gate",
+        "greeting-gate",
+        "casual-gate",
+        "identity-gate",
+        "clarification-gate",
+        "out_of_domain-gate",
+    }
+)
+_EVIDENCE_PROVENANCE_BY_ORIGIN = {
+    ProducerOrigin.FAQ_CACHE: EvidenceProvenance.FAQ_CACHE,
+    ProducerOrigin.SEMANTIC_CACHE: EvidenceProvenance.SEMANTIC_CACHE,
+    ProducerOrigin.MULTI_AGENT_COORDINATOR: EvidenceProvenance.MULTI_AGENT_COORDINATOR,
+    ProducerOrigin.SPECIALIZED_SERVICE_ROUTER: EvidenceProvenance.SPECIALIZED_SERVICE_ROUTER,
+    ProducerOrigin.KNOWLEDGE_GRAPH: EvidenceProvenance.KNOWLEDGE_GRAPH,
+    ProducerOrigin.REACT_PIPELINE: EvidenceProvenance.REACT_PIPELINE,
+}
+_EVIDENCE_IDENTITY_FIELDS = (
+    "source",
+    "title",
+    "collection",
+    "url",
+    "source_url",
+    "id",
+    "doc_id",
+    "document_id",
+    "chunk_id",
+)
+_PLACEHOLDER_VALUES = frozenset(
+    {"", "-", "n/a", "na", "none", "null", "placeholder", "unknown", "unspecified"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizationContext:
+    """Internal producer attribution carried across the shared wrapper."""
+
+    result: CoreResult
+    producer_origin: ProducerOrigin
+    trusted_bypass_reason: TrustedBypassReason | None = None
+    analytics_receipt: AnalyticsReceiptStatus | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _FinalizationMetadataSnapshot:
+    """Canonical public metadata protected by the private identity seal."""
+
+    finalization_status: FinalizationStatus | None
+    producer_origin: ProducerOrigin | None
+    evidence_provenance: EvidenceProvenance | None
+    trusted_bypass_reason: TrustedBypassReason | None
+    analytics_receipt: AnalyticsReceiptStatus | None
+
+
+@dataclass(frozen=True, slots=True)
+class _FinalizationDecisionSnapshot:
+    """Only result inputs that can change the deterministic classification."""
+
+    model_used: str
+    route_used: str
+    cache_hit: bool
+    tools_called: tuple[str, ...]
+    has_valid_evidence: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _FinalizationSeal:
+    """Identity-bound canonical snapshot; clones cannot inherit authority."""
+
+    token: object
+    owner_id: int
+    metadata: _FinalizationMetadataSnapshot
+    decisions: _FinalizationDecisionSnapshot
+
+
+def _normalized_text(value: object) -> str:
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
+def _normalized_tools(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(sorted({_normalized_text(tool) for tool in value if isinstance(tool, str)}))
+
+
+def _metadata_snapshot(result: CoreResult) -> _FinalizationMetadataSnapshot:
+    return _FinalizationMetadataSnapshot(
+        finalization_status=result.finalization_status,
+        producer_origin=result.producer_origin,
+        evidence_provenance=result.evidence_provenance,
+        trusted_bypass_reason=result.trusted_bypass_reason,
+        analytics_receipt=result.analytics_receipt,
+    )
+
+
+def _decision_snapshot(result: CoreResult) -> _FinalizationDecisionSnapshot:
+    return _FinalizationDecisionSnapshot(
+        model_used=_normalized_text(result.model_used),
+        route_used=_normalized_text(result.route_used),
+        cache_hit=result.cache_hit is True,
+        tools_called=_normalized_tools(result.tools_called),
+        has_valid_evidence=_has_valid_evidence(result.sources),
+    )
+
+
+def _attribution_inputs(
+    snapshot: _FinalizationDecisionSnapshot,
+) -> tuple[str, str, bool, tuple[str, ...]]:
+    return (
+        snapshot.model_used,
+        snapshot.route_used,
+        snapshot.cache_hit,
+        snapshot.tools_called,
+    )
+
+
+def _owned_seal(result: CoreResult) -> _FinalizationSeal | None:
+    seal = result._finalization_stamp
+    if (
+        isinstance(seal, _FinalizationSeal)
+        and seal.token is _FINALIZATION_STAMP
+        and seal.owner_id == id(result)
+    ):
+        return seal
+    return None
+
+
+def _restore_metadata(
+    result: CoreResult,
+    snapshot: _FinalizationMetadataSnapshot,
+) -> None:
+    result.finalization_status = snapshot.finalization_status
+    result.producer_origin = snapshot.producer_origin
+    result.evidence_provenance = snapshot.evidence_provenance
+    result.trusted_bypass_reason = snapshot.trusted_bypass_reason
+    result.analytics_receipt = snapshot.analytics_receipt
+
+
+def _metadata_matches_snapshot(
+    result: CoreResult,
+    snapshot: _FinalizationMetadataSnapshot,
+) -> bool:
+    """Require the exact canonical enum objects, not StrEnum-equal strings."""
+    return (
+        result.finalization_status is snapshot.finalization_status
+        and result.producer_origin is snapshot.producer_origin
+        and result.evidence_provenance is snapshot.evidence_provenance
+        and result.trusted_bypass_reason is snapshot.trusted_bypass_reason
+        and result.analytics_receipt is snapshot.analytics_receipt
+    )
+
+
+def is_canonically_finalized(result: CoreResult) -> bool:
+    """Return whether identity, decisions, and public metadata all match."""
+    seal = _owned_seal(result)
+    return (
+        seal is not None
+        and _metadata_matches_snapshot(result, seal.metadata)
+        and seal.decisions == _decision_snapshot(result)
+    )
+
+
+def _has_valid_evidence(sources: object) -> bool:
+    """Recognize existing source shapes without normalizing or rewriting them."""
+    if not isinstance(sources, list):
+        return False
+    for source in sources:
+        if not isinstance(source, dict) or not source:
+            continue
+        for field in _EVIDENCE_IDENTITY_FIELDS:
+            value = source.get(field)
+            if isinstance(value, str):
+                if value.strip().lower() not in _PLACEHOLDER_VALUES:
+                    return True
+            elif isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                return True
+    return False
+
+
+def classify_result_origin(
+    result: CoreResult,
+) -> tuple[ProducerOrigin, TrustedBypassReason | None]:
+    """Return the closed producer attribution for a ``CoreResult``."""
+    model_used = _normalized_text(result.model_used)
+    route_used = _normalized_text(result.route_used)
+    tools_called = set(_normalized_tools(result.tools_called))
+
+    if model_used in _QUERY_GATE_MODELS:
+        return ProducerOrigin.QUERY_GATE, TrustedBypassReason.DETERMINISTIC_QUERY_GATE
+    if model_used == "faq_cache":
+        return ProducerOrigin.FAQ_CACHE, None
+    if result.cache_hit is True or model_used == "cache":
+        return ProducerOrigin.SEMANTIC_CACHE, None
+    if model_used == "multi-agent-coordinator":
+        return ProducerOrigin.MULTI_AGENT_COORDINATOR, None
+    if model_used in {"kg_langgraph", "knowledge-graph"} or route_used == "kg_fast_path":
+        return ProducerOrigin.KNOWLEDGE_GRAPH, None
+    if tools_called.intersection(
+        {"autonomous_research", "cross_oracle_synthesis", "client_journey"}
+    ) or model_used in {
+        "specialized-router",
+        "autonomous-research",
+        "client-journey",
+    }:
+        return ProducerOrigin.SPECIALIZED_SERVICE_ROUTER, None
+    if route_used == "react":
+        return ProducerOrigin.REACT_PIPELINE, None
+    return ProducerOrigin.UNKNOWN, None
+
+
+def finalize_core_result(
+    result: CoreResult,
+    *,
+    producer_origin: ProducerOrigin,
+    trusted_bypass_reason: TrustedBypassReason | None,
+    analytics_receipt: AnalyticsReceiptStatus,
+) -> CoreResult:
+    """Stamp the shadow contract exactly once without changing response data.
+
+    The function is intentionally idempotent: a second invocation returns the
+    byte-equivalent model without reclassification or any I/O. Runtime enum
+    checks prevent producers from self-asserting arbitrary trust strings.
+    """
+    existing_seal = _owned_seal(result)
+    decision_snapshot = _decision_snapshot(result)
+    if existing_seal is not None and existing_seal.decisions == decision_snapshot:
+        # The exact object was finalized already. Public metadata may have been
+        # changed afterward, so restore the private canonical snapshot rather
+        # than trusting an identity-only early return.
+        _restore_metadata(result, existing_seal.metadata)
+        return result
+
+    if existing_seal is not None and _attribution_inputs(
+        existing_seal.decisions
+    ) == _attribution_inputs(decision_snapshot):
+        # Once an instance crosses the boundary, producer attribution is
+        # authority carried by the private seal. Later changes to routing
+        # hints cannot promote the result to a trusted producer or query-gate.
+        # Evidence-validity drift is recomputed under the sealed origin.
+        producer_origin = existing_seal.metadata.producer_origin
+        trusted_bypass_reason = existing_seal.metadata.trusted_bypass_reason
+    elif existing_seal is not None:
+        # Attribution-input drift after sealing is fail-closed. Public routing
+        # hints are not authority to reclassify a previously finalized result.
+        producer_origin = ProducerOrigin.UNKNOWN
+        trusted_bypass_reason = None
+
+    if not isinstance(producer_origin, ProducerOrigin):
+        raise TypeError("producer_origin must be a ProducerOrigin")
+    if trusted_bypass_reason is not None and not isinstance(
+        trusted_bypass_reason, TrustedBypassReason
+    ):
+        raise TypeError("trusted_bypass_reason must be a TrustedBypassReason")
+    if not isinstance(analytics_receipt, AnalyticsReceiptStatus):
+        raise TypeError("analytics_receipt must be an AnalyticsReceiptStatus")
+    if trusted_bypass_reason is not None and producer_origin is not ProducerOrigin.QUERY_GATE:
+        raise ValueError("trusted bypass is only valid for the allowlisted query-gate origin")
+
+    # Even the internal producer context cannot extend the trusted surface by
+    # inventing a new ``*-gate`` model. A new deterministic gate must be added
+    # deliberately to the finite allowlist above; until then it is fail-visible.
+    if (
+        producer_origin is ProducerOrigin.QUERY_GATE
+        and trusted_bypass_reason is TrustedBypassReason.DETERMINISTIC_QUERY_GATE
+        and (result.model_used or "").strip().lower() not in _QUERY_GATE_MODELS
+    ):
+        producer_origin = ProducerOrigin.UNKNOWN
+        trusted_bypass_reason = None
+
+    has_valid_evidence = decision_snapshot.has_valid_evidence
+
+    # A same-instance decision-input change requires metadata recomputation,
+    # but never means the analytics side effect should run again. Preserve the
+    # receipt protected by the prior private seal when one exists.
+    if existing_seal is not None and existing_seal.metadata.analytics_receipt is not None:
+        analytics_receipt = existing_seal.metadata.analytics_receipt
+
+    # Every public field is recomputed.  A producer/user payload can prefill
+    # these fields, but cannot create the private identity stamp above.
+    result.producer_origin = producer_origin
+    result.evidence_provenance = (
+        _EVIDENCE_PROVENANCE_BY_ORIGIN.get(producer_origin) if has_valid_evidence else None
+    )
+    result.trusted_bypass_reason = trusted_bypass_reason
+    result.analytics_receipt = analytics_receipt
+    result.finalization_status = (
+        FinalizationStatus.SHADOW_INCOMPLETE
+        if producer_origin is ProducerOrigin.UNKNOWN
+        or (not has_valid_evidence and trusted_bypass_reason is None)
+        else FinalizationStatus.SHADOW_RECORDED
+    )
+    result._finalization_stamp = _FinalizationSeal(
+        token=_FINALIZATION_STAMP,
+        owner_id=id(result),
+        metadata=_metadata_snapshot(result),
+        decisions=_decision_snapshot(result),
+    )
+    return result

--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_streaming_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_streaming_core.py
@@ -27,6 +27,10 @@ from backend.services.rag.agentic.thinking_indicators import ThinkingIndicatorSe
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+# Full ReAct streaming finalization requires a separate TTFT/abstain design:
+# raw tokens leave the process before confidence and analytics are available.
+REACT_STREAM_FINALIZATION_COMPLETE = False
+
 
 class OrchestratorStreamingCore:
     """
@@ -179,6 +183,9 @@ class OrchestratorStreamingCore:
         )
 
         if gate_or_cache_result:
+            gate_or_cache_result = await self.core.finalize_result(
+                gate_or_cache_result,
+            )
             # Stream gate/cache response
             async for event in self._stream_core_result(
                 result=gate_or_cache_result,
@@ -266,7 +273,12 @@ class OrchestratorStreamingCore:
         # This is applied AFTER prepare_react_execution via state mutation below.
         _crm_precall_has_data = len(crm_precall_context) > 0
 
-        model_tier, _deep_think_mode, state, system_prompt = await self.core.prepare_react_execution(
+        (
+            model_tier,
+            _deep_think_mode,
+            state,
+            system_prompt,
+        ) = await self.core.prepare_react_execution(
             query=query,
             user_context=user_context,
             history=optimized_history,
@@ -377,9 +389,7 @@ class OrchestratorStreamingCore:
                 )
 
                 policy = build_abstain_policy(getattr(state, "query", "") or "")
-                confidence_zone = policy.confidence_zone(
-                    evidence_score, trusted=trusted
-                )
+                confidence_zone = policy.confidence_zone(evidence_score, trusted=trusted)
 
             # 6. Yield done event with metrics
             execution_time = time.time() - start_time
@@ -426,7 +436,32 @@ class OrchestratorStreamingCore:
                 correlation_id=correlation_id,
             )
         finally:
-            pass  # R5 Phase 6: NLM task cleanup removed (no speculative NLM task)
+            # Exactly one fail-visible marker for every raw ReAct stream exit:
+            # normal exhaustion, handled exception, cancellation, or a caller
+            # closing the async generator. Marker failures must not mask the
+            # original exception/cancellation.
+            try:
+                self._mark_react_stream_unfinalized()
+            except Exception as marker_error:
+                logger.warning(
+                    "[FinalizationSpine] stream gap marker failed: %s",
+                    marker_error,
+                )
+
+    @staticmethod
+    def _mark_react_stream_unfinalized() -> None:
+        """Emit the fail-visible shadow marker for the raw ReAct stream gap."""
+        add_span_event(
+            "finalization.stream_react_unfinalized",
+            {
+                "coverage_complete": REACT_STREAM_FINALIZATION_COMPLETE,
+                "reason": "tokens_emitted_before_confidence_and_analytics",
+            },
+        )
+        logger.warning(
+            "[FinalizationSpine] stream_react_unfinalized: raw tokens precede "
+            "confidence and analytics; full parity is a separate TTFT design"
+        )
 
     async def _stream_core_result(
         self,
@@ -469,13 +504,25 @@ class OrchestratorStreamingCore:
                 if verification_status and verification_status != "passed"
                 else "success"
             )
+        metadata = {
+            "status": status,
+            "route": route_used,
+            "model_used": model_used,
+        }
+        finalization_status = getattr(result, "finalization_status", None)
+        if finalization_status is not None:
+            metadata.update(
+                {
+                    "finalization_status": finalization_status,
+                    "producer_origin": getattr(result, "producer_origin", None),
+                    "evidence_provenance": getattr(result, "evidence_provenance", None),
+                    "trusted_bypass_reason": getattr(result, "trusted_bypass_reason", None),
+                    "analytics_receipt": getattr(result, "analytics_receipt", None),
+                }
+            )
         yield {
             "type": "metadata",
-            "data": {
-                "status": status,
-                "route": route_used,
-                "model_used": model_used,
-            },
+            "data": metadata,
             "timestamp": time.time(),
         }
 

--- a/apps/backend-rag/backend/services/rag/agentic/schema.py
+++ b/apps/backend-rag/backend/services/rag/agentic/schema.py
@@ -7,15 +7,67 @@ result with attribute access (historically a Pydantic model).
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
+
+
+class EvidenceProvenance(StrEnum):
+    """Closed evidence paths stamped only when sources cross the boundary."""
+
+    FAQ_CACHE = "faq_cache"
+    SEMANTIC_CACHE = "semantic_cache"
+    MULTI_AGENT_COORDINATOR = "multi_agent_coordinator"
+    SPECIALIZED_SERVICE_ROUTER = "specialized_service_router"
+    KNOWLEDGE_GRAPH = "knowledge_graph"
+    REACT_PIPELINE = "react_pipeline"
+
+
+class ProducerOrigin(StrEnum):
+    """Closed origin set, separate from whether evidence was transferred."""
+
+    QUERY_GATE = "query_gate"
+    FAQ_CACHE = "faq_cache"
+    SEMANTIC_CACHE = "semantic_cache"
+    MULTI_AGENT_COORDINATOR = "multi_agent_coordinator"
+    SPECIALIZED_SERVICE_ROUTER = "specialized_service_router"
+    KNOWLEDGE_GRAPH = "knowledge_graph"
+    REACT_PIPELINE = "react_pipeline"
+    UNKNOWN = "unknown"
+
+
+class TrustedBypassReason(StrEnum):
+    """Closed reasons allowed to ship without evidence provenance."""
+
+    DETERMINISTIC_QUERY_GATE = "deterministic_query_gate"
+
+
+class AnalyticsReceiptStatus(StrEnum):
+    """Truthful state of the analytics side effect at response finalization."""
+
+    SCHEDULED = "scheduled"
+    WRITTEN = "written"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+class FinalizationStatus(StrEnum):
+    """Rollout state for the additive finalization contract."""
+
+    SHADOW_RECORDED = "shadow_recorded"
+    SHADOW_INCOMPLETE = "shadow_incomplete"
 
 
 class CoreResult(BaseModel):
     """Standard result object returned by AgenticRAGOrchestrator."""
 
     model_config = ConfigDict(protected_namespaces=())
+
+    # Internal identity stamp set only by the deterministic finalizer.  It is
+    # deliberately absent from model fields/serialization: public shadow
+    # metadata is observable output, not an authority for idempotence.
+    _finalization_stamp: object | None = PrivateAttr(default=None)
 
     answer: str
     sources: list[Any] = Field(default_factory=list)
@@ -25,6 +77,13 @@ class CoreResult(BaseModel):
     route_used: str | None = None
     collection_used: str | None = None
     cache_hit: bool | str = False
+
+    # Deterministic finalization spine (shadow-first, additive metadata only)
+    finalization_status: FinalizationStatus | None = None
+    producer_origin: ProducerOrigin | None = None
+    evidence_provenance: EvidenceProvenance | None = None
+    trusted_bypass_reason: TrustedBypassReason | None = None
+    analytics_receipt: AnalyticsReceiptStatus | None = None
 
     # Quality / verification
     verification_status: str | None = None

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_kg_fast_path.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_kg_fast_path.py
@@ -97,6 +97,10 @@ class TestKGFastPath:
         assert result is not None
         assert isinstance(result, CoreResult)
         assert result.model_used == "kg_langgraph"
+        # Parent contract: KG fast-path never populated the public route field.
+        assert result.route_used is None
+        # SurfaceRouter confidence chooses a route; it is not evidence quality.
+        assert result.evidence_score == 0.0
 
     @pytest.mark.asyncio
     async def test_kg_fast_path_returns_none_when_no_orchestrator(self):

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_orchestrator_streaming_core.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_orchestrator_streaming_core.py
@@ -1,10 +1,21 @@
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from backend.services.rag.agentic import orchestrator_streaming_core
+from backend.services.rag.agentic.orchestrator_core import OrchestratorCore
 from backend.services.rag.agentic.orchestrator_streaming_core import OrchestratorStreamingCore
+from backend.services.rag.agentic.schema import (
+    AnalyticsReceiptStatus,
+    CoreResult,
+    EvidenceProvenance,
+    FinalizationStatus,
+    ProducerOrigin,
+    TrustedBypassReason,
+)
+from backend.services.tools.definitions import AgentState
 
 
 class FakeStreamingManager:
@@ -16,6 +27,26 @@ class FakeStreamingManager:
 
     def create_initial_status_event(self, correlation_id: str) -> dict:
         return {"type": "status", "data": {"correlation_id": correlation_id}}
+
+    def create_error_event(
+        self,
+        *,
+        error_type: str,
+        message: str,
+        correlation_id: str,
+    ) -> dict:
+        return {
+            "type": "error",
+            "data": {
+                "error_type": error_type,
+                "message": message,
+                "correlation_id": correlation_id,
+            },
+        }
+
+    async def process_event_stream(self, *, event_generator, **_kwargs):
+        async for event in event_generator:
+            yield event
 
 
 @pytest.mark.asyncio
@@ -74,6 +105,193 @@ async def test_single_event_generator_yields_original_event() -> None:
     event = {"type": "token", "data": "hello"}
 
     assert [item async for item in core._single_event_generator(event)] == [event]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("result", "expected_origin", "expected_provenance", "expected_trust"),
+    [
+        (
+            CoreResult(answer="hello", model_used="greeting-gate"),
+            ProducerOrigin.QUERY_GATE,
+            None,
+            TrustedBypassReason.DETERMINISTIC_QUERY_GATE,
+        ),
+        (
+            CoreResult(
+                answer="cached",
+                sources=[{"source": "cache-source"}],
+                model_used="cache",
+                cache_hit=True,
+            ),
+            ProducerOrigin.SEMANTIC_CACHE,
+            EvidenceProvenance.SEMANTIC_CACHE,
+            None,
+        ),
+    ],
+)
+async def test_gate_and_cache_stream_cross_finalization_before_first_token(
+    monkeypatch,
+    result: CoreResult,
+    expected_origin: ProducerOrigin,
+    expected_provenance: EvidenceProvenance | None,
+    expected_trust: TrustedBypassReason | None,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(orchestrator_streaming_core.asyncio, "sleep", no_sleep)
+    real_core = OrchestratorCore.__new__(OrchestratorCore)
+    real_core.db_pool = None
+    real_core.prepare_query_context = AsyncMock(return_value=({}, [], {}, "", None))
+    real_core.check_gates_and_cache = AsyncMock(return_value=result)
+    streaming_core = OrchestratorStreamingCore(
+        core=real_core,
+        streaming_manager=FakeStreamingManager(),
+    )
+
+    with patch.object(streaming_core, "_mark_react_stream_unfinalized") as marker:
+        events = [
+            event
+            async for event in streaming_core.stream_query_core(
+                query="stream contract",
+                user_id="contract-user",
+                conversation_history=None,
+                session_id=None,
+                images=None,
+                tool_execution_counter={"count": 0},
+                correlation_id="contract-correlation",
+            )
+        ]
+
+    marker.assert_not_called()
+
+    first_token_index = next(
+        index for index, event in enumerate(events) if event["type"] == "token"
+    )
+    finalization_metadata = next(
+        event
+        for event in events[:first_token_index]
+        if event["type"] == "metadata" and "finalization_status" in event["data"]
+    )
+    assert (
+        finalization_metadata["data"]["finalization_status"] is FinalizationStatus.SHADOW_RECORDED
+    )
+    assert finalization_metadata["data"]["producer_origin"] is expected_origin
+    assert finalization_metadata["data"]["evidence_provenance"] is expected_provenance
+    assert finalization_metadata["data"]["trusted_bypass_reason"] is expected_trust
+    assert finalization_metadata["data"]["analytics_receipt"] is AnalyticsReceiptStatus.SKIPPED
+    assert result.answer in {"hello", "cached"}
+
+
+def test_react_stream_gap_is_fail_visible_and_cannot_claim_complete() -> None:
+    core = OrchestratorStreamingCore(core=object(), streaming_manager=FakeStreamingManager())
+
+    with (
+        patch.object(orchestrator_streaming_core, "add_span_event") as span_event,
+        patch.object(orchestrator_streaming_core.logger, "warning") as warning,
+    ):
+        core._mark_react_stream_unfinalized()
+
+    assert orchestrator_streaming_core.REACT_STREAM_FINALIZATION_COMPLETE is False
+    span_event.assert_called_once_with(
+        "finalization.stream_react_unfinalized",
+        {
+            "coverage_complete": False,
+            "reason": "tokens_emitted_before_confidence_and_analytics",
+        },
+    )
+    warning.assert_called_once()
+
+
+class _RawReactReasoningEngine:
+    def __init__(self, outcome: str) -> None:
+        self.outcome = outcome
+        self.tool_map: dict = {}
+
+    async def execute_react_loop_stream(self, **_kwargs):
+        yield {"type": "token", "data": "raw-token"}
+        if self.outcome == "error":
+            raise RuntimeError("raw stream failed")
+        if self.outcome == "cancel":
+            raise asyncio.CancelledError
+
+
+class _RawReactCore:
+    def __init__(self, outcome: str) -> None:
+        self.reasoning_engine = _RawReactReasoningEngine(outcome)
+        self.llm_gateway = SimpleNamespace(
+            create_chat_with_history=lambda **_kwargs: object(),
+        )
+        self.metrics_manager = SimpleNamespace(
+            extract_collections_from_state=lambda _state: set(),
+            extract_sources_from_state=lambda _state: [],
+        )
+        self.db_pool = None
+
+    async def prepare_query_context(self, **_kwargs):
+        return ({"profile": None}, [], {}, "", None)
+
+    async def check_gates_and_cache(self, **_kwargs):
+        return None
+
+    async def prepare_react_execution(self, **_kwargs):
+        state = AgentState(query="raw stream contract", intent_type="business_complex")
+        state.evidence_score = 0.8
+        state.trusted_tools_used = True
+        return ("gemini-parent", False, state, "system prompt")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("outcome", "expect_error_event", "expect_cancel"),
+    [
+        ("complete", False, False),
+        ("error", True, False),
+        ("cancel", False, True),
+    ],
+)
+async def test_real_raw_react_stream_marks_every_terminal_path_exactly_once(
+    outcome: str,
+    expect_error_event: bool,
+    expect_cancel: bool,
+) -> None:
+    streaming_core = OrchestratorStreamingCore(
+        core=_RawReactCore(outcome),
+        streaming_manager=FakeStreamingManager(),
+    )
+
+    with patch.object(streaming_core, "_mark_react_stream_unfinalized") as marker:
+        if expect_cancel:
+            with pytest.raises(asyncio.CancelledError):
+                async for _event in streaming_core.stream_query_core(
+                    query="raw stream contract",
+                    user_id="contract-user",
+                    conversation_history=None,
+                    session_id=None,
+                    images=None,
+                    tool_execution_counter={"count": 0},
+                    correlation_id="contract-correlation",
+                ):
+                    pass
+            events = []
+        else:
+            events = [
+                event
+                async for event in streaming_core.stream_query_core(
+                    query="raw stream contract",
+                    user_id="contract-user",
+                    conversation_history=None,
+                    session_id=None,
+                    images=None,
+                    tool_execution_counter={"count": 0},
+                    correlation_id="contract-correlation",
+                )
+            ]
+
+    marker.assert_called_once_with()
+    assert any(event.get("data") == "raw-token" for event in events) is not expect_cancel
+    assert any(event["type"] == "error" for event in events) is expect_error_event
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_finalization_spine.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_finalization_spine.py
@@ -1,0 +1,1061 @@
+"""Contract tests for the shadow deterministic finalization spine."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import pickle
+import time
+from copy import copy, deepcopy
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.rag.agentic import orchestrator_core as orchestrator_core_module
+from backend.services.rag.agentic.orchestrator_core import OrchestratorCore
+from backend.services.rag.agentic.orchestrator_finalization import (
+    FinalizationContext,
+    finalize_core_result,
+    is_canonically_finalized,
+)
+from backend.services.rag.agentic.schema import (
+    AnalyticsReceiptStatus,
+    CoreResult,
+    EvidenceProvenance,
+    FinalizationStatus,
+    ProducerOrigin,
+    TrustedBypassReason,
+)
+
+
+def _producer_result(producer: str) -> CoreResult:
+    source = {"type": "test", "source": "contract-source"}
+    common: dict[str, Any] = {
+        "answer": f"answer:{producer}",
+        "sources": [source],
+        "abstain": producer == "react",
+        "abstain_reason": "contract-abstain" if producer == "react" else None,
+    }
+    if producer == "gate":
+        return CoreResult(**(common | {"model_used": "greeting-gate", "sources": []}))
+    if producer == "faq":
+        return CoreResult(**common, model_used="faq_cache")
+    if producer == "semantic_cache":
+        return CoreResult(**common, model_used="cache", cache_hit=True)
+    if producer == "multi_agent":
+        return CoreResult(**(common | {"sources": []}), model_used="multi-agent-coordinator")
+    if producer == "specialized_router":
+        return CoreResult(
+            **(common | {"sources": []}),
+            model_used="specialized-router",
+            tools_called=["autonomous_research"],
+        )
+    if producer == "kg":
+        return CoreResult(**common, model_used="kg_langgraph")
+    return CoreResult(
+        **common,
+        model_used="gemini-3.5-flash",
+    )
+
+
+def _producer_context(producer: str) -> FinalizationContext:
+    origins = {
+        "gate": ProducerOrigin.QUERY_GATE,
+        "faq": ProducerOrigin.FAQ_CACHE,
+        "semantic_cache": ProducerOrigin.SEMANTIC_CACHE,
+        "multi_agent": ProducerOrigin.MULTI_AGENT_COORDINATOR,
+        "specialized_router": ProducerOrigin.SPECIALIZED_SERVICE_ROUTER,
+        "kg": ProducerOrigin.KNOWLEDGE_GRAPH,
+        "react": ProducerOrigin.REACT_PIPELINE,
+    }
+    return FinalizationContext(
+        result=_producer_result(producer),
+        producer_origin=origins[producer],
+        trusted_bypass_reason=(
+            TrustedBypassReason.DETERMINISTIC_QUERY_GATE if producer == "gate" else None
+        ),
+        analytics_receipt=(AnalyticsReceiptStatus.WRITTEN if producer == "react" else None),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "producer",
+        "expected_origin",
+        "expected_provenance",
+        "expected_trust",
+        "expected_status",
+    ),
+    [
+        (
+            "gate",
+            ProducerOrigin.QUERY_GATE,
+            None,
+            TrustedBypassReason.DETERMINISTIC_QUERY_GATE,
+            FinalizationStatus.SHADOW_RECORDED,
+        ),
+        (
+            "faq",
+            ProducerOrigin.FAQ_CACHE,
+            EvidenceProvenance.FAQ_CACHE,
+            None,
+            FinalizationStatus.SHADOW_RECORDED,
+        ),
+        (
+            "semantic_cache",
+            ProducerOrigin.SEMANTIC_CACHE,
+            EvidenceProvenance.SEMANTIC_CACHE,
+            None,
+            FinalizationStatus.SHADOW_RECORDED,
+        ),
+        (
+            "multi_agent",
+            ProducerOrigin.MULTI_AGENT_COORDINATOR,
+            None,
+            None,
+            FinalizationStatus.SHADOW_INCOMPLETE,
+        ),
+        (
+            "specialized_router",
+            ProducerOrigin.SPECIALIZED_SERVICE_ROUTER,
+            None,
+            None,
+            FinalizationStatus.SHADOW_INCOMPLETE,
+        ),
+        (
+            "kg",
+            ProducerOrigin.KNOWLEDGE_GRAPH,
+            EvidenceProvenance.KNOWLEDGE_GRAPH,
+            None,
+            FinalizationStatus.SHADOW_RECORDED,
+        ),
+        (
+            "react",
+            ProducerOrigin.REACT_PIPELINE,
+            EvidenceProvenance.REACT_PIPELINE,
+            None,
+            FinalizationStatus.SHADOW_RECORDED,
+        ),
+    ],
+)
+async def test_public_sync_boundary_finalizes_each_producer_once_and_is_byte_idempotent(
+    producer: str,
+    expected_origin: ProducerOrigin,
+    expected_provenance: EvidenceProvenance | None,
+    expected_trust: TrustedBypassReason | None,
+    expected_status: FinalizationStatus,
+) -> None:
+    context = _producer_context(producer)
+    raw_result = context.result
+    answer_before = raw_result.answer
+    abstain_before = raw_result.abstain
+    sources_before = deepcopy(raw_result.sources)
+
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+    core._process_query_core_unfinalized = AsyncMock(return_value=context)
+
+    with patch.object(
+        orchestrator_core_module,
+        "finalize_core_result",
+        wraps=finalize_core_result,
+    ) as finalizer:
+        result = await core.process_query_core(
+            query="contract query",
+            user_id="contract-user",
+            conversation_history=None,
+            start_time=0.0,
+        )
+        assert finalizer.call_count == 1
+        serialized_once = result.model_dump_json().encode()
+
+        finalized_again = await core.finalize_result(result)
+
+        assert finalizer.call_count == 1
+        assert finalized_again.model_dump_json().encode() == serialized_once
+
+    assert result.answer == answer_before
+    assert result.abstain is abstain_before
+    assert result.sources == sources_before
+    assert result.finalization_status is expected_status
+    assert result.producer_origin is expected_origin
+    assert result.evidence_provenance is expected_provenance
+    assert result.trusted_bypass_reason is expected_trust
+    expected_receipt = (
+        AnalyticsReceiptStatus.WRITTEN if producer == "react" else AnalyticsReceiptStatus.SKIPPED
+    )
+    assert result.analytics_receipt is expected_receipt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("receipt", "expected_receipt"),
+    [
+        (AnalyticsReceiptStatus.WRITTEN, AnalyticsReceiptStatus.WRITTEN),
+        (AnalyticsReceiptStatus.FAILED, AnalyticsReceiptStatus.FAILED),
+        (AnalyticsReceiptStatus.SKIPPED, AnalyticsReceiptStatus.SKIPPED),
+        (AnalyticsReceiptStatus.SCHEDULED, AnalyticsReceiptStatus.FAILED),
+        ("written", AnalyticsReceiptStatus.FAILED),
+        (None, AnalyticsReceiptStatus.FAILED),
+    ],
+)
+async def test_internal_react_analytics_receipt_prevents_second_write(
+    receipt: AnalyticsReceiptStatus | str | None,
+    expected_receipt: AnalyticsReceiptStatus,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    core._log_query_analytics = AsyncMock()
+    context = _producer_context("react")
+    core._process_query_core_unfinalized = AsyncMock(
+        return_value=FinalizationContext(
+            result=context.result,
+            producer_origin=context.producer_origin,
+            analytics_receipt=receipt,  # type: ignore[arg-type]
+        )
+    )
+
+    with patch.object(orchestrator_core_module, "spawn") as spawn_mock:
+        finalized = await core.process_query_core(
+            query="react query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+
+    spawn_mock.assert_not_called()
+    core._log_query_analytics.assert_not_called()
+    assert finalized.analytics_receipt is expected_receipt
+
+
+@pytest.mark.asyncio
+async def test_forged_public_status_and_receipt_cannot_suppress_one_canonical_write() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    core._log_query_analytics = AsyncMock(return_value=AnalyticsReceiptStatus.WRITTEN)
+    result = CoreResult(
+        answer="cached answer",
+        sources=[{"source": "faq-contract"}],
+        model_used="faq_cache",
+        finalization_status=FinalizationStatus.SHADOW_RECORDED,
+        producer_origin=ProducerOrigin.QUERY_GATE,
+        evidence_provenance=EvidenceProvenance.REACT_PIPELINE,
+        trusted_bypass_reason=TrustedBypassReason.DETERMINISTIC_QUERY_GATE,
+        analytics_receipt=AnalyticsReceiptStatus.WRITTEN,
+    )
+    core._process_query_core_unfinalized = AsyncMock(
+        return_value=FinalizationContext(
+            result=result,
+            producer_origin=ProducerOrigin.FAQ_CACHE,
+            analytics_receipt=AnalyticsReceiptStatus.WRITTEN,
+        )
+    )
+    scheduled: list[asyncio.Task[AnalyticsReceiptStatus]] = []
+
+    def capture_spawn(
+        coro: Any,
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task[AnalyticsReceiptStatus]:
+        task = asyncio.create_task(coro, name=name)
+        scheduled.append(task)
+        return task
+
+    with patch.object(orchestrator_core_module, "spawn", side_effect=capture_spawn) as spawn_mock:
+        finalized = await core.process_query_core(
+            query="faq query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+        serialized_once = finalized.model_dump_json().encode()
+        finalized_again = await core.finalize_result(finalized)
+
+    await asyncio.gather(*scheduled)
+
+    assert spawn_mock.call_count == 1
+    assert len(scheduled) == 1
+    assert core._log_query_analytics.await_count == 1
+    assert finalized_again.model_dump_json().encode() == serialized_once
+    assert finalized.producer_origin is ProducerOrigin.FAQ_CACHE
+    assert finalized.evidence_provenance is EvidenceProvenance.FAQ_CACHE
+    assert finalized.trusted_bypass_reason is None
+    assert finalized.analytics_receipt is AnalyticsReceiptStatus.SCHEDULED
+
+
+@pytest.mark.asyncio
+async def test_forged_empty_origin_is_recomputed_fail_visible() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+    result = CoreResult(
+        answer="future producer",
+        sources=[],
+        model_used="future-model",
+        finalization_status=FinalizationStatus.SHADOW_RECORDED,
+        producer_origin=ProducerOrigin.REACT_PIPELINE,
+        evidence_provenance=EvidenceProvenance.REACT_PIPELINE,
+        analytics_receipt=AnalyticsReceiptStatus.WRITTEN,
+    )
+
+    finalized = await core.finalize_result(result)
+
+    assert finalized.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+    assert finalized.producer_origin is ProducerOrigin.UNKNOWN
+    assert finalized.evidence_provenance is None
+    assert finalized.trusted_bypass_reason is None
+    assert finalized.analytics_receipt is AnalyticsReceiptStatus.SKIPPED
+
+
+@pytest.mark.asyncio
+async def test_clones_and_json_roundtrip_are_pure_and_cannot_duplicate_analytics() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    core._log_query_analytics = AsyncMock(return_value=AnalyticsReceiptStatus.WRITTEN)
+    context = FinalizationContext(
+        result=CoreResult(
+            answer="sourceful",
+            sources=[{"source": "faq-contract"}],
+            model_used="faq_cache",
+        ),
+        producer_origin=ProducerOrigin.FAQ_CACHE,
+    )
+    core._process_query_core_unfinalized = AsyncMock(return_value=context)
+    scheduled: list[asyncio.Task[AnalyticsReceiptStatus]] = []
+
+    def capture_spawn(
+        coro: Any,
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task[AnalyticsReceiptStatus]:
+        task = asyncio.create_task(coro, name=name)
+        scheduled.append(task)
+        return task
+
+    with patch.object(orchestrator_core_module, "spawn", side_effect=capture_spawn) as spawn_mock:
+        original = await core.process_query_core(
+            query="faq query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+        clones = [
+            original.model_copy(),
+            deepcopy(original),
+            CoreResult.model_validate_json(original.model_dump_json()),
+        ]
+        for cloned in clones:
+            assert not is_canonically_finalized(cloned)
+            finalized_clone = await core.finalize_result(cloned)
+            assert is_canonically_finalized(finalized_clone)
+            assert finalized_clone.producer_origin is ProducerOrigin.FAQ_CACHE
+            assert finalized_clone.finalization_status is FinalizationStatus.SHADOW_RECORDED
+            assert finalized_clone.analytics_receipt is AnalyticsReceiptStatus.SKIPPED
+
+    await asyncio.gather(*scheduled)
+
+    assert is_canonically_finalized(original)
+    assert spawn_mock.call_count == 1
+    assert len(scheduled) == 1
+    assert core._log_query_analytics.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_post_seal_metadata_tamper_is_restored_without_another_write() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    core._log_query_analytics = AsyncMock(return_value=AnalyticsReceiptStatus.WRITTEN)
+    core._process_query_core_unfinalized = AsyncMock(
+        return_value=FinalizationContext(
+            result=CoreResult(
+                answer="sourceful",
+                sources=[{"source": "faq-contract"}],
+                model_used="faq_cache",
+            ),
+            producer_origin=ProducerOrigin.FAQ_CACHE,
+        )
+    )
+    scheduled: list[asyncio.Task[AnalyticsReceiptStatus]] = []
+
+    def capture_spawn(
+        coro: Any,
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task[AnalyticsReceiptStatus]:
+        task = asyncio.create_task(coro, name=name)
+        scheduled.append(task)
+        return task
+
+    with patch.object(orchestrator_core_module, "spawn", side_effect=capture_spawn) as spawn_mock:
+        result = await core.process_query_core(
+            query="faq query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+        canonical_bytes = result.model_dump_json().encode()
+        canonical_metadata = (
+            result.finalization_status,
+            result.producer_origin,
+            result.evidence_provenance,
+            result.trusted_bypass_reason,
+            result.analytics_receipt,
+        )
+        result.finalization_status = FinalizationStatus.SHADOW_INCOMPLETE
+        result.producer_origin = ProducerOrigin.REACT_PIPELINE
+        result.evidence_provenance = EvidenceProvenance.REACT_PIPELINE
+        result.trusted_bypass_reason = TrustedBypassReason.DETERMINISTIC_QUERY_GATE
+        result.analytics_receipt = AnalyticsReceiptStatus.FAILED
+        assert not is_canonically_finalized(result)
+
+        restored = await core.finalize_result(result)
+
+    await asyncio.gather(*scheduled)
+
+    assert restored.model_dump_json().encode() == canonical_bytes
+    assert restored.finalization_status is canonical_metadata[0]
+    assert restored.producer_origin is canonical_metadata[1]
+    assert restored.evidence_provenance is canonical_metadata[2]
+    assert restored.trusted_bypass_reason is canonical_metadata[3]
+    assert restored.analytics_receipt is canonical_metadata[4]
+    assert is_canonically_finalized(restored)
+    assert spawn_mock.call_count == 1
+    assert core._log_query_analytics.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field_name", "producer"),
+    [
+        ("finalization_status", "faq"),
+        ("producer_origin", "faq"),
+        ("evidence_provenance", "faq"),
+        ("trusted_bypass_reason", "gate"),
+        ("analytics_receipt", "faq"),
+    ],
+)
+async def test_post_seal_equal_string_tamper_restores_exact_enum_type(
+    field_name: str,
+    producer: str,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+    result = await core.finalize_result(_producer_result(producer))
+    canonical_value = getattr(result, field_name)
+    assert canonical_value is not None
+    canonical_bytes = result.model_dump_json().encode()
+
+    setattr(result, field_name, canonical_value.value)
+
+    assert not is_canonically_finalized(result)
+    restored = await core.finalize_result(result)
+
+    assert getattr(restored, field_name) is canonical_value
+    assert restored.model_dump_json().encode() == canonical_bytes
+    assert is_canonically_finalized(restored)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field_name", "producer"),
+    [
+        ("finalization_status", "faq"),
+        ("producer_origin", "faq"),
+        ("evidence_provenance", "faq"),
+        ("trusted_bypass_reason", "gate"),
+        ("analytics_receipt", "faq"),
+    ],
+)
+async def test_post_seal_none_tamper_restores_exact_enum_type(
+    field_name: str,
+    producer: str,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+    result = await core.finalize_result(_producer_result(producer))
+    canonical_value = getattr(result, field_name)
+    assert canonical_value is not None
+    canonical_bytes = result.model_dump_json().encode()
+
+    setattr(result, field_name, None)
+
+    assert not is_canonically_finalized(result)
+    restored = await core.finalize_result(result)
+
+    assert getattr(restored, field_name) is canonical_value
+    assert restored.model_dump_json().encode() == canonical_bytes
+    assert is_canonically_finalized(restored)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tampered_model", ["security-gate", "future-gate"])
+async def test_post_seal_attribution_drift_is_fail_closed_without_io(
+    tampered_model: str,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    core._log_query_analytics = AsyncMock()
+    result = await core.finalize_result(_producer_result("faq"))
+    assert result.producer_origin is ProducerOrigin.FAQ_CACHE
+
+    result.model_used = tampered_model
+    with patch.object(orchestrator_core_module, "spawn") as spawn_mock:
+        finalized = await core.finalize_result(result)
+
+    spawn_mock.assert_not_called()
+    core._log_query_analytics.assert_not_called()
+    assert finalized.producer_origin is ProducerOrigin.UNKNOWN
+    assert finalized.trusted_bypass_reason is None
+    assert finalized.evidence_provenance is None
+    assert finalized.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+    assert finalized.analytics_receipt is AnalyticsReceiptStatus.SKIPPED
+    assert is_canonically_finalized(finalized)
+
+
+@pytest.mark.asyncio
+async def test_execution_authority_cannot_be_cloned_into_a_second_analytics_write() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    core._log_query_analytics = AsyncMock(return_value=AnalyticsReceiptStatus.WRITTEN)
+    first_context = FinalizationContext(
+        result=CoreResult(
+            answer="sourceful",
+            sources=[{"source": "faq-contract"}],
+            model_used="faq_cache",
+        ),
+        producer_origin=ProducerOrigin.FAQ_CACHE,
+    )
+    core._process_query_core_unfinalized = AsyncMock(return_value=first_context)
+    scheduled: list[asyncio.Task[AnalyticsReceiptStatus]] = []
+    captured_claims: list[Any] = []
+    original_finalize = core._finalize_process_context
+
+    def capture_spawn(
+        coro: Any,
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task[AnalyticsReceiptStatus]:
+        task = asyncio.create_task(coro, name=name)
+        scheduled.append(task)
+        return task
+
+    def capture_authority(
+        context: FinalizationContext,
+        **kwargs: Any,
+    ) -> CoreResult:
+        claim = kwargs["claim_analytics"]
+        captured_claims.extend([claim, copy(claim), deepcopy(claim)])
+        with pytest.raises((AttributeError, pickle.PicklingError, TypeError)):
+            pickle.dumps(claim)
+        return original_finalize(context, **kwargs)
+
+    core._finalize_process_context = MagicMock(side_effect=capture_authority)
+    with patch.object(orchestrator_core_module, "spawn", side_effect=capture_spawn) as spawn_mock:
+        await core.process_query_core(
+            query="faq query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+        original_claim, shallow_claim, deep_claim = captured_claims
+        assert shallow_claim is original_claim
+        assert deep_claim is original_claim
+
+        second_context = FinalizationContext(
+            result=first_context.result.model_copy(),
+            producer_origin=ProducerOrigin.FAQ_CACHE,
+        )
+        for claim, context in (
+            (original_claim, first_context),
+            (shallow_claim, first_context),
+            (deep_claim, second_context),
+        ):
+            with pytest.raises(RuntimeError, match="capability already consumed"):
+                original_finalize(
+                    context,
+                    query="faq query",
+                    user_id=None,
+                    session_id=None,
+                    claim_analytics=claim,
+                )
+
+    await asyncio.gather(*scheduled)
+
+    assert spawn_mock.call_count == 1
+    assert len(scheduled) == 1
+    assert core._log_query_analytics.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "sources",
+    [
+        [None],
+        [{}],
+        [{"source": ""}],
+        [{"source": "unknown"}],
+        [{"title": "placeholder"}],
+        ["not-a-source"],
+    ],
+)
+async def test_placeholder_sources_do_not_create_evidence_or_get_rewritten(
+    sources: list[Any],
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+    result = CoreResult(answer="cached answer", sources=deepcopy(sources), model_used="faq_cache")
+    sources_before = deepcopy(result.sources)
+
+    finalized = await core.finalize_result(result)
+
+    assert finalized.sources == sources_before
+    assert finalized.producer_origin is ProducerOrigin.FAQ_CACHE
+    assert finalized.evidence_provenance is None
+    assert finalized.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_used", "route_used"),
+    [
+        ("future-gate", None),
+        ("model", "future-gate"),
+        ("model", "invented-gate"),
+    ],
+)
+async def test_gate_like_names_outside_closed_allowlist_are_incomplete(
+    model_used: str,
+    route_used: str | None,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+
+    finalized = await core.finalize_result(
+        CoreResult(answer="untrusted", model_used=model_used, route_used=route_used)
+    )
+
+    assert finalized.producer_origin is ProducerOrigin.UNKNOWN
+    assert finalized.trusted_bypass_reason is None
+    assert finalized.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+
+
+def test_internal_context_cannot_extend_the_closed_gate_allowlist() -> None:
+    finalized = finalize_core_result(
+        CoreResult(answer="future gate", model_used="future-gate"),
+        producer_origin=ProducerOrigin.QUERY_GATE,
+        trusted_bypass_reason=TrustedBypassReason.DETERMINISTIC_QUERY_GATE,
+        analytics_receipt=AnalyticsReceiptStatus.SKIPPED,
+    )
+
+    assert finalized.producer_origin is ProducerOrigin.UNKNOWN
+    assert finalized.trusted_bypass_reason is None
+    assert finalized.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("background_error", [RuntimeError("db failed"), TimeoutError("db slow")])
+async def test_fast_path_analytics_is_non_blocking_and_failure_cannot_mutate_response(
+    background_error: Exception,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+
+    async def fail_later(**_kwargs: Any) -> AnalyticsReceiptStatus:
+        await asyncio.sleep(0)
+        raise background_error
+
+    core._log_query_analytics = fail_later
+    tasks: list[asyncio.Task[AnalyticsReceiptStatus]] = []
+
+    def capture_spawn(coro: Any, *, name: str | None = None) -> asyncio.Task[Any]:
+        task = asyncio.create_task(coro, name=name)
+        tasks.append(task)
+        return task
+
+    raw_result = _producer_result("faq")
+    core._process_query_core_unfinalized = AsyncMock(
+        return_value=FinalizationContext(
+            result=raw_result,
+            producer_origin=ProducerOrigin.FAQ_CACHE,
+        )
+    )
+    answer_before = raw_result.answer
+    abstain_before = raw_result.abstain
+    sources_before = deepcopy(raw_result.sources)
+    with patch.object(orchestrator_core_module, "spawn", side_effect=capture_spawn):
+        finalized = await asyncio.wait_for(
+            core.process_query_core(
+                query="cached query",
+                user_id=None,
+                conversation_history=None,
+                start_time=0.0,
+            ),
+            timeout=0.05,
+        )
+
+    assert finalized.analytics_receipt is AnalyticsReceiptStatus.SCHEDULED
+    assert finalized.answer == answer_before
+    assert finalized.abstain is abstain_before
+    assert finalized.sources == sources_before
+    with pytest.raises(type(background_error)):
+        await tasks[0]
+    assert finalized.answer == answer_before
+    assert finalized.abstain is abstain_before
+    assert finalized.sources == sources_before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["prepare", "spawn"])
+async def test_synchronous_analytics_scheduling_failure_is_fail_visible(
+    failure_point: str,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    raw_result = _producer_result("faq")
+    core._process_query_core_unfinalized = AsyncMock(
+        return_value=FinalizationContext(
+            result=raw_result,
+            producer_origin=ProducerOrigin.FAQ_CACHE,
+        )
+    )
+    if failure_point == "prepare":
+        core._log_query_analytics = MagicMock(side_effect=RuntimeError("prepare failed"))
+        spawn_side_effect = None
+    else:
+        core._log_query_analytics = AsyncMock()
+        spawn_side_effect = RuntimeError("spawn failed")
+
+    with patch.object(
+        orchestrator_core_module,
+        "spawn",
+        side_effect=spawn_side_effect,
+    ) as spawn_mock:
+        finalized = await core.process_query_core(
+            query="cached query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+
+    assert finalized.answer == raw_result.answer
+    assert finalized.abstain is raw_result.abstain
+    assert finalized.sources == raw_result.sources
+    assert finalized.analytics_receipt is AnalyticsReceiptStatus.FAILED
+    assert spawn_mock.call_count == (1 if failure_point == "spawn" else 0)
+
+
+@pytest.mark.asyncio
+async def test_scheduled_analytics_uses_return_time_source_and_timing_snapshots() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    raw_result = CoreResult(
+        answer="cached answer",
+        sources=[{"source": "faq-contract"}],
+        model_used="faq_cache",
+        timings={"total": 0.01},
+    )
+    core._process_query_core_unfinalized = AsyncMock(
+        return_value=FinalizationContext(
+            result=raw_result,
+            producer_origin=ProducerOrigin.FAQ_CACHE,
+        )
+    )
+    core._log_query_analytics = AsyncMock(return_value=AnalyticsReceiptStatus.WRITTEN)
+    scheduled: list[Any] = []
+
+    def capture_spawn(coro: Any, *, name: str | None = None) -> None:
+        del name
+        scheduled.append(coro)
+
+    with patch.object(orchestrator_core_module, "spawn", side_effect=capture_spawn):
+        finalized = await core.process_query_core(
+            query="cached query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+
+    raw_result.sources.append({"source": "post-return-mutation"})
+    raw_result.timings["total"] = 99.0
+
+    assert finalized.analytics_receipt is AnalyticsReceiptStatus.SCHEDULED
+    assert core._log_query_analytics.call_args.kwargs["sources"] == [{"source": "faq-contract"}]
+    assert core._log_query_analytics.call_args.kwargs["timings"] == {"total": 0.01}
+    scheduled[0].close()
+
+
+def test_finalizer_rejects_open_string_attribution_and_ambiguous_trust() -> None:
+    result = CoreResult(answer="answer")
+    with pytest.raises(TypeError, match="ProducerOrigin"):
+        finalize_core_result(
+            result,
+            producer_origin="react_pipeline",  # type: ignore[arg-type]
+            trusted_bypass_reason=None,
+            analytics_receipt=AnalyticsReceiptStatus.SKIPPED,
+        )
+    with pytest.raises(ValueError, match="allowlisted query-gate"):
+        finalize_core_result(
+            result,
+            producer_origin=ProducerOrigin.REACT_PIPELINE,
+            trusted_bypass_reason=TrustedBypassReason.DETERMINISTIC_QUERY_GATE,
+            analytics_receipt=AnalyticsReceiptStatus.SKIPPED,
+        )
+    with pytest.raises(TypeError, match="trusted_bypass_reason"):
+        finalize_core_result(
+            result,
+            producer_origin=ProducerOrigin.QUERY_GATE,
+            trusted_bypass_reason="deterministic_query_gate",  # type: ignore[arg-type]
+            analytics_receipt=AnalyticsReceiptStatus.SKIPPED,
+        )
+    with pytest.raises(TypeError, match="analytics_receipt"):
+        finalize_core_result(
+            result,
+            producer_origin=ProducerOrigin.REACT_PIPELINE,
+            trusted_bypass_reason=None,
+            analytics_receipt="written",  # type: ignore[arg-type]
+        )
+
+
+def test_finalization_enums_are_closed_to_the_reviewed_contract() -> None:
+    assert set(ProducerOrigin) == {
+        ProducerOrigin.QUERY_GATE,
+        ProducerOrigin.FAQ_CACHE,
+        ProducerOrigin.SEMANTIC_CACHE,
+        ProducerOrigin.MULTI_AGENT_COORDINATOR,
+        ProducerOrigin.SPECIALIZED_SERVICE_ROUTER,
+        ProducerOrigin.KNOWLEDGE_GRAPH,
+        ProducerOrigin.REACT_PIPELINE,
+        ProducerOrigin.UNKNOWN,
+    }
+    assert set(EvidenceProvenance) == {
+        EvidenceProvenance.FAQ_CACHE,
+        EvidenceProvenance.SEMANTIC_CACHE,
+        EvidenceProvenance.MULTI_AGENT_COORDINATOR,
+        EvidenceProvenance.SPECIALIZED_SERVICE_ROUTER,
+        EvidenceProvenance.KNOWLEDGE_GRAPH,
+        EvidenceProvenance.REACT_PIPELINE,
+    }
+    assert set(TrustedBypassReason) == {
+        TrustedBypassReason.DETERMINISTIC_QUERY_GATE,
+    }
+    assert set(AnalyticsReceiptStatus) == {
+        AnalyticsReceiptStatus.SCHEDULED,
+        AnalyticsReceiptStatus.WRITTEN,
+        AnalyticsReceiptStatus.SKIPPED,
+        AnalyticsReceiptStatus.FAILED,
+    }
+    assert set(FinalizationStatus) == {
+        FinalizationStatus.SHADOW_RECORDED,
+        FinalizationStatus.SHADOW_INCOMPLETE,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unknown_producer_is_fail_visible_instead_of_silent_react() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+    result = CoreResult(
+        answer="future producer",
+        sources=[{"source": "unattributed-but-structured"}],
+        model_used="future-model",
+        route_used="aggregate_service",
+    )
+    sources_before = deepcopy(result.sources)
+
+    finalized = await core.finalize_result(result)
+
+    assert finalized.producer_origin is ProducerOrigin.UNKNOWN
+    assert finalized.evidence_provenance is None
+    assert finalized.trusted_bypass_reason is None
+    assert finalized.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+    assert finalized.sources == sources_before
+
+
+@pytest.mark.asyncio
+async def test_known_producer_without_transferred_evidence_is_incomplete() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+    result = CoreResult(
+        answer="coordinator answer",
+        sources=[],
+        model_used="multi-agent-coordinator",
+    )
+
+    finalized = await core.finalize_result(result)
+
+    assert finalized.producer_origin is ProducerOrigin.MULTI_AGENT_COORDINATOR
+    assert finalized.evidence_provenance is None
+    assert finalized.trusted_bypass_reason is None
+    assert finalized.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+
+
+@pytest.mark.asyncio
+async def test_analytics_uses_answer_and_abstain_decision_not_source_count() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    core._log_query_analytics = AsyncMock()
+    result = CoreResult(
+        answer="I cannot answer safely.",
+        sources=[{"source": "retrieved-source"}],
+        model_used="faq_cache",
+        abstain=True,
+    )
+    core._process_query_core_unfinalized = AsyncMock(
+        return_value=FinalizationContext(
+            result=result,
+            producer_origin=ProducerOrigin.FAQ_CACHE,
+        )
+    )
+    scheduled: list[asyncio.Task[AnalyticsReceiptStatus]] = []
+
+    def capture_spawn(
+        coro: Any,
+        *,
+        name: str | None = None,
+    ) -> asyncio.Task[AnalyticsReceiptStatus]:
+        task = asyncio.create_task(coro, name=name)
+        scheduled.append(task)
+        return task
+
+    with patch.object(orchestrator_core_module, "spawn", side_effect=capture_spawn):
+        finalized = await core.process_query_core(
+            query="abstain query",
+            user_id=None,
+            conversation_history=None,
+            start_time=0.0,
+        )
+
+    await asyncio.gather(*scheduled)
+
+    assert finalized.analytics_receipt is AnalyticsReceiptStatus.SCHEDULED
+    assert core._log_query_analytics.call_args.kwargs["response_generated"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("repo_result", "repo_error", "expected_receipt"),
+    [
+        ("query-id", None, AnalyticsReceiptStatus.WRITTEN),
+        (None, None, AnalyticsReceiptStatus.FAILED),
+        (None, RuntimeError("repository failed"), AnalyticsReceiptStatus.FAILED),
+        (None, TimeoutError("repository timeout"), AnalyticsReceiptStatus.FAILED),
+    ],
+)
+async def test_canonical_analytics_receipt_reflects_repository_outcome(
+    repo_result: str | None,
+    repo_error: Exception | None,
+    expected_receipt: AnalyticsReceiptStatus,
+) -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = object()
+    repository = MagicMock()
+    repository.log_query = AsyncMock(return_value=repo_result, side_effect=repo_error)
+
+    with patch.object(
+        orchestrator_core_module,
+        "QueryAnalyticsRepository",
+        return_value=repository,
+    ):
+        receipt = await core._log_query_analytics(
+            query="analytics contract",
+            user_id=None,
+            session_id=None,
+            collections_used=set(),
+            sources=[],
+            model_used="contract-model",
+            token_usage=orchestrator_core_module.TokenUsage(),
+            timings={"total": 0.01},
+            response_generated=True,
+        )
+
+    assert receipt is expected_receipt
+    assert repository.log_query.call_args.kwargs["response_generated"] is True
+
+
+@pytest.mark.asyncio
+async def test_canonical_analytics_is_skipped_without_database_pool() -> None:
+    core = OrchestratorCore.__new__(OrchestratorCore)
+    core.db_pool = None
+
+    receipt = await core._log_query_analytics(
+        query="analytics contract",
+        user_id=None,
+        session_id=None,
+        collections_used=set(),
+        sources=[],
+        model_used="contract-model",
+        token_usage=orchestrator_core_module.TokenUsage(),
+        timings={},
+        response_generated=False,
+    )
+
+    assert receipt is AnalyticsReceiptStatus.SKIPPED
+
+
+def test_pure_finalizer_p95_is_below_ten_milliseconds() -> None:
+    durations_ns: list[int] = []
+    for _ in range(500):
+        result = CoreResult(answer="stable", sources=[{"source": "test"}])
+        started_ns = time.perf_counter_ns()
+        finalize_core_result(
+            result,
+            producer_origin=ProducerOrigin.REACT_PIPELINE,
+            trusted_bypass_reason=None,
+            analytics_receipt=AnalyticsReceiptStatus.SKIPPED,
+        )
+        durations_ns.append(time.perf_counter_ns() - started_ns)
+
+    p95_ns = sorted(durations_ns)[int(len(durations_ns) * 0.95)]
+    assert p95_ns < 10_000_000
+
+
+def test_raw_early_returns_are_sealed_behind_one_public_wrapper() -> None:
+    source = inspect.getsource(orchestrator_core_module)
+    tree = ast.parse(source)
+    core_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "OrchestratorCore"
+    )
+    methods = {
+        node.name: node
+        for node in core_class.body
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+    }
+    public = methods["process_query_core"]
+    implementation = methods["_process_query_core_unfinalized"]
+
+    public_returns = [node for node in public.body if isinstance(node, ast.Return)]
+    assert len(public_returns) == 1
+    assert "_finalize_process_context" in ast.unparse(public_returns[0])
+
+    authority_minters = [
+        method_name
+        for method_name, method in methods.items()
+        for node in ast.walk(method)
+        if isinstance(node, ast.FunctionDef) and node.name == "_claim_finalization_analytics_once"
+    ]
+    assert authority_minters == ["process_query_core"]
+
+    raw_returns = [
+        node
+        for node in ast.walk(implementation)
+        if isinstance(node, ast.Return) and node.value is not None
+    ]
+    assert raw_returns
+    assert all(
+        isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "FinalizationContext"
+        for node in raw_returns
+    ), "every user-visible early return must carry a closed internal producer context"
+
+    callers: set[str] = set()
+    for method_name, method in methods.items():
+        for node in ast.walk(method):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr == "_process_query_core_unfinalized":
+                    callers.add(method_name)
+    assert callers == {"process_query_core"}

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_finalization_spine.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_finalization_spine.py
@@ -1052,10 +1052,23 @@ def test_raw_early_returns_are_sealed_behind_one_public_wrapper() -> None:
         for node in raw_returns
     ), "every user-visible early return must carry a closed internal producer context"
 
-    callers: set[str] = set()
+    # Do not limit this to direct calls.  A future caller could first alias the
+    # private implementation (or resolve it through ``getattr``) and then call
+    # the alias, bypassing a call-only tripwire while still exposing a raw
+    # finalization context.  Any reference to the implementation belongs only
+    # in the public wrapper.
+    references: set[str] = set()
     for method_name, method in methods.items():
         for node in ast.walk(method):
-            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-                if node.func.attr == "_process_query_core_unfinalized":
-                    callers.add(method_name)
-    assert callers == {"process_query_core"}
+            if isinstance(node, ast.Attribute) and node.attr == "_process_query_core_unfinalized":
+                references.add(method_name)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[1], ast.Constant)
+                and node.args[1].value == "_process_query_core_unfinalized"
+            ):
+                references.add(method_name)
+    assert references == {"process_query_core"}

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave2.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_orchestrator_state_machine_wave2.py
@@ -36,9 +36,17 @@ if str(backend_path) not in sys.path:
 from backend.services.llm_clients.pricing import TokenUsage
 from backend.services.rag.agentic import orchestrator_core as orchestrator_core_module
 from backend.services.rag.agentic.orchestrator import AgenticRAGOrchestrator
+from backend.services.rag.agentic.orchestrator_core import OrchestratorCore
 from backend.services.rag.agentic.orchestrator_response import OrchestratorResponseBuilder
 from backend.services.rag.agentic.query_gates import QueryGates
-from backend.services.rag.agentic.schema import CoreResult
+from backend.services.rag.agentic.schema import (
+    AnalyticsReceiptStatus,
+    CoreResult,
+    EvidenceProvenance,
+    FinalizationStatus,
+    ProducerOrigin,
+    TrustedBypassReason,
+)
 from backend.services.tools.definitions import AgentState, BaseTool
 
 # ---------------------------------------------------------------------------
@@ -248,6 +256,271 @@ def orch(_mock_db_pool, _stub_final_state):
         yield orchestrator
 
 
+_FINALIZATION_FIELDS = {
+    "finalization_status",
+    "producer_origin",
+    "evidence_provenance",
+    "trusted_bypass_reason",
+    "analytics_receipt",
+}
+
+
+def _legacy_payload(result: CoreResult) -> dict:
+    return result.model_dump(exclude=_FINALIZATION_FIELDS)
+
+
+def _legacy_bytes(result: CoreResult) -> bytes:
+    return result.model_dump_json(exclude=_FINALIZATION_FIELDS).encode("utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "producer",
+    ["gate", "faq", "semantic_cache", "multi_agent", "specialized_router", "kg", "react"],
+)
+async def test_real_producer_parent_payload_is_byte_invariant_after_finalization(
+    orch,
+    producer: str,
+) -> None:
+    """Run each real outer branch and preserve the canonical parent payload.
+
+    Collaborators are deterministic doubles, but the producer branches and
+    shared wrapper are the real implementation. The explicit field snapshots
+    below are the pre-finalization shapes from parent ``b81c7b077``; the full
+    dict and JSON comparisons then prove the finalizer only adds its five fields.
+    """
+    core = orch.core
+    query = "What is a KITAS?"
+    extracted_entities = {"domain": "visa"}
+    core.db_pool = None
+    core._query_planner = None
+    core.prepare_query_context = AsyncMock(
+        return_value=(
+            {"profile": None},
+            [],
+            extracted_entities,
+            "",
+            None,
+        ),
+    )
+    core.query_gates.prompt_builder.check_greetings.return_value = None
+    core.check_faq_cache = AsyncMock(return_value=None)
+    core.check_semantic_cache = AsyncMock(return_value=None)
+    core._inject_curated_qa_grounding = AsyncMock(return_value="")
+    core._multi_agent_coordinator = None
+    core._specialized_router = None
+    core._surface_router = None
+    core.kg_langgraph_orchestrator = None
+    core._log_query_analytics = AsyncMock(return_value=AnalyticsReceiptStatus.SKIPPED)
+
+    expected_origin: ProducerOrigin
+    expected_trust: TrustedBypassReason | None = None
+    expected_provenance: EvidenceProvenance | None
+    expected_parent_fields: dict
+
+    if producer == "gate":
+        core.query_gates.prompt_builder.check_greetings.return_value = "Hello from parent"
+        expected_origin = ProducerOrigin.QUERY_GATE
+        expected_trust = TrustedBypassReason.DETERMINISTIC_QUERY_GATE
+        expected_provenance = None
+        expected_parent_fields = {
+            "answer": "Hello from parent",
+            "sources": [],
+            "model_used": "greeting-gate",
+            "route_used": None,
+            "evidence_score": 1.0,
+            "document_count": 0,
+            "workflow": None,
+            "reasoning": None,
+            "tools_called": [],
+        }
+    elif producer == "faq":
+        faq_cache = MagicMock()
+        faq_cache.get = AsyncMock(
+            return_value={
+                "answer": "FAQ parent answer",
+                "metadata": {"source": "team_qa", "domain": "visa"},
+            },
+        )
+        core.faq_cache = faq_cache
+        core.check_faq_cache = OrchestratorCore.check_faq_cache.__get__(core)
+        expected_origin = ProducerOrigin.FAQ_CACHE
+        expected_provenance = EvidenceProvenance.FAQ_CACHE
+        expected_parent_fields = {
+            "answer": "FAQ parent answer",
+            "sources": [{"type": "faq_cache", "source": "team_qa", "domain": "visa"}],
+            "model_used": "faq_cache",
+            "route_used": None,
+            "evidence_score": 0.0,
+            "document_count": 0,
+            "workflow": None,
+            "reasoning": None,
+            "tools_called": [],
+        }
+    elif producer == "semantic_cache":
+        core.semantic_cache = MagicMock()
+        core.semantic_cache.get_cached_result = AsyncMock(
+            return_value={
+                "cache_hit": "semantic",
+                "result": {
+                    "answer": "Semantic parent answer",
+                    "sources": [{"source": "semantic-parent"}],
+                },
+            },
+        )
+        core.retriever = None
+        core.check_semantic_cache = OrchestratorCore.check_semantic_cache.__get__(core)
+        expected_origin = ProducerOrigin.SEMANTIC_CACHE
+        expected_provenance = EvidenceProvenance.SEMANTIC_CACHE
+        expected_parent_fields = {
+            "answer": "Semantic parent answer",
+            "sources": [{"source": "semantic-parent"}],
+            "model_used": "cache",
+            "route_used": None,
+            "evidence_score": 0.0,
+            "document_count": 1,
+            "workflow": None,
+            "reasoning": None,
+            "tools_called": [],
+        }
+    elif producer == "multi_agent":
+        query = "How much does a KITAS cost and how long does it take?"
+        coordinator = MagicMock()
+        coordinator.process = AsyncMock(return_value={"final_answer": "MA parent answer"})
+        core._multi_agent_coordinator = coordinator
+        expected_origin = ProducerOrigin.MULTI_AGENT_COORDINATOR
+        expected_provenance = None
+        expected_parent_fields = {
+            "answer": "MA parent answer",
+            "sources": [],
+            "model_used": "multi-agent-coordinator",
+            "route_used": None,
+            "evidence_score": 0.0,
+            "document_count": 0,
+            "workflow": None,
+            "reasoning": None,
+            "tools_called": ["legal_agent", "financial_agent", "timeline_agent"],
+        }
+    elif producer == "specialized_router":
+        router = MagicMock()
+        router.detect_autonomous_research.return_value = True
+        router.route_autonomous_research = AsyncMock(
+            return_value={
+                "response": "SSR parent answer",
+                "model": "autonomous-research",
+                "category": "autonomous_research",
+                "autonomous_research": {
+                    "sources_consulted": [{"source": "nested-only"}],
+                    "confidence": 0.73,
+                },
+            },
+        )
+        core._specialized_router = router
+        expected_origin = ProducerOrigin.SPECIALIZED_SERVICE_ROUTER
+        expected_provenance = None
+        expected_parent_fields = {
+            "answer": "SSR parent answer",
+            "sources": [],
+            "model_used": "autonomous-research",
+            "route_used": None,
+            "evidence_score": 0.0,
+            "document_count": 0,
+            "workflow": None,
+            "reasoning": None,
+            "tools_called": ["autonomous_research"],
+        }
+    elif producer == "kg":
+        core._surface_router = MagicMock()
+        core._surface_router.decide.return_value = MagicMock(
+            is_kg_surface=True,
+            confidence=0.91,
+        )
+        kg_orchestrator = MagicMock()
+        kg_orchestrator.app = object()
+        kg_orchestrator.query = AsyncMock(return_value={"reasoning": "KG parent reasoning"})
+        core.kg_langgraph_orchestrator = kg_orchestrator
+        expected_origin = ProducerOrigin.KNOWLEDGE_GRAPH
+        expected_provenance = EvidenceProvenance.KNOWLEDGE_GRAPH
+        expected_parent_fields = {
+            "answer": "KG parent reasoning",
+            "sources": [
+                {
+                    "type": "kg",
+                    "source": "neo4j_knowledge_graph",
+                    "domain": "kg",
+                    "surface": "kg",
+                },
+            ],
+            "model_used": "kg_langgraph",
+            "route_used": None,
+            "evidence_score": 0.0,
+            "document_count": 0,
+            "workflow": None,
+            "reasoning": None,
+            "tools_called": ["kg_langgraph"],
+        }
+    else:
+        state = AgentState(query=query, intent_type="business_complex")
+        state.final_answer = "ReAct parent answer"
+        state.sources = []
+        state.steps = []
+        state.evidence_score = 0.8
+        state.trusted_tools_used = True
+        core.routing_manager.route_query = AsyncMock(return_value=("flash", False, state))
+        core.execute_react_loop = AsyncMock(
+            return_value=(state, "gemini-parent", TokenUsage(), 0.01),
+        )
+        expected_origin = ProducerOrigin.REACT_PIPELINE
+        expected_provenance = None
+        expected_parent_fields = {
+            "answer": "ReAct parent answer",
+            "sources": [],
+            "model_used": "gemini-parent",
+            "route_used": None,
+            "evidence_score": 0.8,
+            "document_count": 0,
+            "workflow": None,
+            "reasoning": None,
+            "tools_called": [],
+        }
+
+    with patch.object(
+        orchestrator_core_module,
+        "_MULTI_AGENT_COORDINATOR_ENABLED",
+        producer == "multi_agent",
+    ):
+        context = await core._process_query_core_unfinalized(
+            query=query,
+            user_id="contract-user",
+            conversation_history=None,
+            start_time=0.0,
+        )
+
+    assert context.producer_origin is expected_origin
+    for field, expected in expected_parent_fields.items():
+        assert getattr(context.result, field) == expected
+
+    before_dict = _legacy_payload(context.result)
+    before_bytes = _legacy_bytes(context.result)
+    answer_bytes = context.result.answer.encode("utf-8")
+    sources_before = context.result.model_dump(include={"sources"})
+    core._process_query_core_unfinalized = AsyncMock(return_value=context)
+    finalized = await core.process_query_core(
+        query=query,
+        user_id="contract-user",
+        conversation_history=None,
+        start_time=0.0,
+    )
+
+    assert _legacy_payload(finalized) == before_dict
+    assert _legacy_bytes(finalized) == before_bytes
+    assert finalized.answer.encode("utf-8") == answer_bytes
+    assert finalized.model_dump(include={"sources"}) == sources_before
+    assert finalized.producer_origin is expected_origin
+    assert finalized.evidence_provenance is expected_provenance
+    assert finalized.trusted_bypass_reason is expected_trust
+
+
 # =============================================================================
 # O2 — QueryPlanner active mode
 # =============================================================================
@@ -357,6 +630,9 @@ class TestMultiAgent:
 
         assert result.model_used == "multi-agent-coordinator"
         assert "Rp 15M" in result.answer
+        assert result.producer_origin is ProducerOrigin.MULTI_AGENT_COORDINATOR
+        assert result.evidence_provenance is None
+        assert result.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
         mock_coord.process.assert_called_once()
         # ReAct loop MUST NOT have been invoked
         orch.reasoning_engine.execute_react_loop.assert_not_called()
@@ -381,6 +657,9 @@ class TestMultiAgent:
             return_value={"final_answer": "ungrounded multi-agent answer"},
         )
         orch.core._multi_agent_coordinator = mock_coord
+        orch.core._log_query_analytics = AsyncMock(
+            return_value=AnalyticsReceiptStatus.WRITTEN,
+        )
 
         result = await orch.process_query(
             "How much does a KITAS cost and how long does it take?",
@@ -390,6 +669,13 @@ class TestMultiAgent:
         mock_coord.process.assert_not_awaited()
         assert result.model_used != "multi-agent-coordinator"
         assert "ungrounded multi-agent answer" not in result.answer
+        # Parent contract: the sync ReAct result did not populate route_used.
+        assert result.route_used is None
+        assert result.producer_origin is ProducerOrigin.REACT_PIPELINE
+        assert result.evidence_provenance is None
+        assert result.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
+        assert result.analytics_receipt is AnalyticsReceiptStatus.WRITTEN
+        assert orch.core._log_query_analytics.call_args.kwargs["response_generated"] is True
         orch.reasoning_engine.execute_react_loop.assert_called_once()
 
     async def test_multi_agent_exception_falls_back_to_react(self, orch):
@@ -444,6 +730,10 @@ class TestSpecializedRouter:
                 "response": "Research findings on KBLI 62011",
                 "model": "autonomous-research",
                 "category": "autonomous_research",
+                "autonomous_research": {
+                    "sources_consulted": 5,
+                    "confidence": 0.73,
+                },
             },
         )
         orch.core._specialized_router = ssr
@@ -452,6 +742,14 @@ class TestSpecializedRouter:
 
         assert result.model_used == "autonomous-research"
         assert "Research findings" in result.answer
+        assert result.sources == []
+        # Parent contract: nested SSR research metadata was not copied into
+        # public CoreResult fields.
+        assert result.document_count == 0
+        assert result.evidence_score == 0.0
+        assert result.producer_origin is ProducerOrigin.SPECIALIZED_SERVICE_ROUTER
+        assert result.evidence_provenance is None
+        assert result.finalization_status is FinalizationStatus.SHADOW_INCOMPLETE
         ssr.route_autonomous_research.assert_called_once()
         orch.reasoning_engine.execute_react_loop.assert_not_called()
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 689 services · 1307 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 690 services · 1308 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Cosa cambia
Introduzione della spine di finalizzazione shadow per i sette producer sincroni, con metadati additivi e analytics esattamente una volta.

## Hardening incluso
- Capability analytics lessicale, one-shot e non serializzabile.
- Invarianza del payload legacy e ripristino fail-closed dei metadati manomessi.
- Tripwire contro riferimenti indiretti al percorso non finalizzato.

## Verifica
- Matrice Stage-1: 142 passed.
- Full pre-push backend suite: verde.
- ruff, mypy sui moduli sorgente, import smoke e review LLM indipendenti: verdi.

## Limiti dichiarati
Raw ReAct streaming e i consumer WhatsApp restano fuori dallo Stage-1; questa PR non abilita una promozione universale.