### PR TITLE
test(infra): close runtime truth trust gaps

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -301,6 +301,13 @@ jobs:
           done
           exit $fail
 
+      - name: Runtime Truth meta-contract (external to runner)
+        if: steps.paths.outputs.relevant == 'true'
+        env:
+          HOME: ${{ runner.temp }}/runtime-truth-home
+          TMPDIR: ${{ runner.temp }}/runtime-truth-tmp
+        run: python -m pytest scripts/tests/test_runtime_truth_ci_gauntlet.py -q
+
       - name: Runtime Truth CI gauntlet (four incident contracts)
         if: steps.paths.outputs.relevant == 'true'
         env:

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -302,7 +302,10 @@ jobs:
           exit $fail
 
       - name: Runtime Truth meta-contract (external to runner)
-        if: steps.paths.outputs.relevant == 'true'
+        # Deliberately unconditional inside the required job. This is the
+        # fail-closed observer for the path detector and the conditional heavy
+        # runner below; gating it on that detector would let a false-negative
+        # detector self-disarm both layers while `antidotes` stayed green.
         env:
           HOME: ${{ runner.temp }}/runtime-truth-home
           TMPDIR: ${{ runner.temp }}/runtime-truth-tmp

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -309,7 +309,10 @@ jobs:
         env:
           HOME: ${{ runner.temp }}/runtime-truth-home
           TMPDIR: ${{ runner.temp }}/runtime-truth-tmp
-        run: python -m pytest scripts/tests/test_runtime_truth_ci_gauntlet.py -q
+        run: |
+          mkdir -p "$HOME" "$TMPDIR"
+          python -m pip install --quiet pytest PyYAML==6.0.3
+          python -m pytest scripts/tests/test_runtime_truth_ci_gauntlet.py -q
 
       - name: Runtime Truth CI gauntlet (four incident contracts)
         if: steps.paths.outputs.relevant == 'true'

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -61,11 +61,10 @@ jobs:
           RELEVANT=false
           # NOTE on the `.github/workflows/*` entries at the end of this list:
           # test_ci_service_images_use_mirror.py scans EVERY workflow file, so its
-          # SUBJECTS have to trigger this job too. Listing only immune-enforcement.yml
-          # left that guard armed against the one file nobody would ever un-mirror —
-          # a test in the run-loop whose subject never wakes the job is armed to
-          # nothing. The glob supersedes the old literal entry, which shellcheck
-          # correctly flagged as dead (SC2222); it was removed, not kept as decor.
+          # SUBJECTS have to trigger this job too. Runtime Truth also keeps the
+          # immune workflow as an exact self-trigger: removing or narrowing these
+          # globs must not make a change to the required workflow auto-skip its
+          # own contracts. The exact entry is therefore a deliberate overlap.
           while IFS= read -r f; do
             case "$f" in
               scripts/lint_home_fork.py|\
@@ -183,6 +182,7 @@ jobs:
               scripts/tests/test_no_import_time_chdir_in_tests.py|\
               scripts/tests/test_husky_prepush_venv_guard.py|\
               scripts/tests/test_immune_enforcement_trigger_symmetry.py|\
+              scripts/runtime_truth_ci_gauntlet.py|\
               scripts/tests/test_runtime_truth_ci_gauntlet.py|\
               scripts/drive_token_watchdog.py|\
               scripts/tests/test_drive_watchdog_fly_path.py|\
@@ -212,6 +212,7 @@ jobs:
               apps/evaluator/nlm_deep_research/nb10_pipeline.py|\
               apps/evaluator/nlm_deep_research/tests/test_run_verdict.py|\
               .claude/skills/modus/PENDING-ARMS.md|\
+              .github/workflows/immune-enforcement.yml|\
               .github/workflows/*.yml|\
               .github/workflows/*.yaml)
                 RELEVANT=true
@@ -246,7 +247,7 @@ jobs:
       - name: Unit tests (guilt + innocence per tool)
         if: steps.paths.outputs.relevant == 'true'
         run: |
-          python -m pip install --quiet pytest
+          python -m pip install --quiet pytest PyYAML==6.0.3
           fail=0
           for t in \
             scripts/tests/test_lint_home_fork.py \
@@ -305,19 +306,7 @@ jobs:
         env:
           HOME: ${{ runner.temp }}/runtime-truth-home
           TMPDIR: ${{ runner.temp }}/runtime-truth-tmp
-        run: |
-          # Fail closed: every path is mandatory, and the meta-test pins this
-          # runner to the sentinel subjects that wake it. The corpora use only
-          # temp/fake worlds; no fleet HOME, launchd state, secrets, or network.
-          set -euo pipefail
-          mkdir -p "$HOME" "$TMPDIR"
-          python -m pytest \
-            apps/evaluator/nlm_deep_research/tests/test_run_verdict.py \
-            scripts/tests/test_launchd_liveness_expected_nonzero.py \
-            scripts/tests/test_proprioception_run_wrap_exit_code.py \
-            scripts/tests/test_runtime_truth_ci_gauntlet.py \
-            -q
-          bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
+        run: python scripts/runtime_truth_ci_gauntlet.py
 
       - name: apps/zantara-media suite has a runner (replaces the garuda alert pin)
         if: steps.paths.outputs.relevant == 'true'

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -70,6 +70,7 @@ jobs:
             case "$f" in
               scripts/lint_home_fork.py|\
               scripts/proprioception.py|\
+              scripts/tests/test_proprioception_run_wrap_exit_code.py|\
               scripts/secrets_permissions_audit.py|\
               scripts/pending_arms_report.py|\
               scripts/lint_plist_keepalive.py|\
@@ -116,6 +117,7 @@ jobs:
               scripts/tests/test_lint_tcc_desktop_paths.py|\
               infra/tcc-desktop-paths/allowlist.txt|\
               scripts/launchd_liveness_detector.py|\
+              scripts/tests/test_launchd_liveness_expected_nonzero.py|\
               scripts/tests/test_launchd_liveness_exit_status_decode.py|\
               scripts/tests/test_launchd_liveness_marker_freshness.py|\
               scripts/tests/test_launchd_liveness_stale_exit_recovery.py|\
@@ -154,10 +156,12 @@ jobs:
               scripts/lib/offsite_verify.sh|\
               scripts/test_offsite_verify.sh|\
               scripts/fly-pg-backup.sh|\
+              scripts/lib/heartbeat.sh|\
               scripts/wr2-cron-wrapper.sh|\
               scripts/test_wr2_wrapper_alert.sh|\
               infra/openclaw/wr2/wr2-script-wrapper.sh|\
               scripts/test_wr2_script_wrapper_alert.sh|\
+              scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh|\
               scripts/cron-wrapper.sh|\
               scripts/cron-state.sh|\
               scripts/test_cron_state_alert.sh|\
@@ -179,6 +183,7 @@ jobs:
               scripts/tests/test_no_import_time_chdir_in_tests.py|\
               scripts/tests/test_husky_prepush_venv_guard.py|\
               scripts/tests/test_immune_enforcement_trigger_symmetry.py|\
+              scripts/tests/test_runtime_truth_ci_gauntlet.py|\
               scripts/drive_token_watchdog.py|\
               scripts/tests/test_drive_watchdog_fly_path.py|\
               scripts/tests/test_drive_watchdog_tier_ratchet.py|\
@@ -196,6 +201,16 @@ jobs:
               infra/asset-lint/public-asset-refs-config.json|\
               scripts/tests/test_intake_dsn_guard_covers_every_var.py|\
               apps/backend-rag/backend/tests/conftest.py|\
+              apps/evaluator/nlm_deep_research/run_verdict.py|\
+              apps/evaluator/nlm_deep_research/pipeline.py|\
+              apps/evaluator/nlm_deep_research/nb3_pipeline.py|\
+              apps/evaluator/nlm_deep_research/nb4_pipeline.py|\
+              apps/evaluator/nlm_deep_research/nb5_pipeline.py|\
+              apps/evaluator/nlm_deep_research/nb6_pipeline.py|\
+              apps/evaluator/nlm_deep_research/nb7_pipeline.py|\
+              apps/evaluator/nlm_deep_research/nb8_pipeline.py|\
+              apps/evaluator/nlm_deep_research/nb10_pipeline.py|\
+              apps/evaluator/nlm_deep_research/tests/test_run_verdict.py|\
               .claude/skills/modus/PENDING-ARMS.md|\
               .github/workflows/*.yml|\
               .github/workflows/*.yaml)
@@ -284,6 +299,25 @@ jobs:
             fi
           done
           exit $fail
+
+      - name: Runtime Truth CI gauntlet (four incident contracts)
+        if: steps.paths.outputs.relevant == 'true'
+        env:
+          HOME: ${{ runner.temp }}/runtime-truth-home
+          TMPDIR: ${{ runner.temp }}/runtime-truth-tmp
+        run: |
+          # Fail closed: every path is mandatory, and the meta-test pins this
+          # runner to the sentinel subjects that wake it. The corpora use only
+          # temp/fake worlds; no fleet HOME, launchd state, secrets, or network.
+          set -euo pipefail
+          mkdir -p "$HOME" "$TMPDIR"
+          python -m pytest \
+            apps/evaluator/nlm_deep_research/tests/test_run_verdict.py \
+            scripts/tests/test_launchd_liveness_expected_nonzero.py \
+            scripts/tests/test_proprioception_run_wrap_exit_code.py \
+            scripts/tests/test_runtime_truth_ci_gauntlet.py \
+            -q
+          bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
 
       - name: apps/zantara-media suite has a runner (replaces the garuda alert pin)
         if: steps.paths.outputs.relevant == 'true'

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -311,7 +311,7 @@ jobs:
           TMPDIR: ${{ runner.temp }}/runtime-truth-tmp
         run: |
           mkdir -p "$HOME" "$TMPDIR"
-          python -m pip install --quiet pytest PyYAML==6.0.3
+          python -m pip install --quiet pytest PyYAML==6.0.3 httpx==0.28.1
           python -m pytest scripts/tests/test_runtime_truth_ci_gauntlet.py -q
 
       - name: Runtime Truth CI gauntlet (four incident contracts)

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 689 services · 1306 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 689 services · 1307 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/scripts/runtime_truth_ci_gauntlet.py
+++ b/scripts/runtime_truth_ci_gauntlet.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 
 import collections
 import dataclasses
+import json
 import logging
 import os
 import pathlib
+import shutil
 import subprocess
 import sys
+import tempfile
 from collections.abc import Sequence
 from typing import Final
 
@@ -39,9 +42,11 @@ SHELL_CASES: Final[dict[str, tuple[str, ...]]] = {
         "heartbeat_self_heal",
     ),
 }
-SHELL_EVIDENCE_PROTOCOL: Final = "runtime-truth-shell-v1"
-SHELL_EVIDENCE_FD_ENV: Final = "RUNTIME_TRUTH_EVIDENCE_FD"
 PYTEST_OPTIONS: Final[tuple[str, ...]] = ("-q", "--strict-markers")
+WR2_WRAPPER_RELATIVE: Final = "scripts/wr2-cron-wrapper.sh"
+WR2_HEARTBEAT_RELATIVE: Final = "scripts/lib/heartbeat.sh"
+WR2_TEST_MODULE: Final = "some.module"
+WR2_GUARD_ORGAN_ID: Final = f"pro.wr2_wrapper_guard.{WR2_TEST_MODULE}"
 
 LOGGER = logging.getLogger("runtime-truth-ci-gauntlet")
 
@@ -123,15 +128,57 @@ class PytestEvidence:
 
 
 @dataclasses.dataclass(frozen=True)
+class ShellCaseEvidence:
+    """Outcome observed by the parent from wrapper exit state and sidecar state."""
+
+    case_id: str
+    exit_code: int
+    expected_exit_code: int
+    sidecar_status: str
+    expected_sidecar_status: str
+    precondition_exit_code: int | None = None
+    expected_precondition_exit_code: int | None = None
+    precondition_sidecar_status: str | None = None
+    expected_precondition_sidecar_status: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        return (
+            self.exit_code == self.expected_exit_code
+            and self.sidecar_status == self.expected_sidecar_status
+            and self.precondition_exit_code == self.expected_precondition_exit_code
+            and self.precondition_sidecar_status
+            == self.expected_precondition_sidecar_status
+        )
+
+
+@dataclasses.dataclass(frozen=True)
 class ShellEvidence:
-    """Case-level evidence read from a dedicated file descriptor."""
+    """Independent parent observations for every expected shell case."""
 
     target: str
-    collected: int
-    executed: int
-    passed: int
-    failed: int
-    skipped: int
+    expected_cases: tuple[str, ...]
+    cases: tuple[ShellCaseEvidence, ...]
+
+    @property
+    def collected(self) -> int:
+        return len(self.expected_cases)
+
+    @property
+    def executed(self) -> int:
+        return len(self.cases)
+
+    @property
+    def passed(self) -> int:
+        return sum(case.passed for case in self.cases)
+
+    @property
+    def failed(self) -> int:
+        return sum(not case.passed for case in self.cases)
+
+    @property
+    def skipped(self) -> int:
+        return self.collected - self.executed
 
 
 def _validate_targets(repo_root: pathlib.Path, targets: Sequence[str]) -> None:
@@ -262,53 +309,219 @@ def _prepare_hermetic_directories() -> None:
         pathlib.Path(os.environ[name]).mkdir(parents=True, exist_ok=True)
 
 
-def _parse_shell_evidence(
+def _write_executable(path: pathlib.Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _sidecar_status(path: pathlib.Path) -> str:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "<missing-or-invalid>"
+    status = payload.get("status") if isinstance(payload, dict) else None
+    return status if isinstance(status, str) else "<missing-or-invalid>"
+
+
+def _set_nc_exit(world: pathlib.Path, exit_code: int) -> None:
+    _write_executable(
+        world / "bin/nc",
+        f"#!/usr/bin/env sh\nexit {exit_code}\n",
+    )
+
+
+def _prepare_wr2_world(
     *,
+    repo_root: pathlib.Path,
+    world: pathlib.Path,
+    nc_exit: int,
+    database_url_present: bool,
+) -> tuple[pathlib.Path, pathlib.Path, dict[str, str]]:
+    """Create a hermetic wrapper world owned by the Python observer."""
+    wrapper_source = repo_root / WR2_WRAPPER_RELATIVE
+    heartbeat_source = repo_root / WR2_HEARTBEAT_RELATIVE
+    missing = [
+        path.relative_to(repo_root).as_posix()
+        for path in (wrapper_source, heartbeat_source)
+        if not path.is_file()
+    ]
+    if missing:
+        raise GauntletContractError(f"mandatory WR2 subjects missing: {missing}")
+
+    wrapper = world / "scripts/wr2-cron-wrapper.sh"
+    heartbeat = world / "repo/scripts/lib/heartbeat.sh"
+    fake_python = world / "repo/apps/backend-rag/.venv/bin/python"
+    for directory in (
+        wrapper.parent,
+        heartbeat.parent,
+        fake_python.parent,
+        world / "bin",
+        world / "logs",
+        world / "organism",
+        world / "tmp",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(wrapper_source, wrapper)
+    shutil.copy2(heartbeat_source, heartbeat)
+    _write_executable(fake_python, "#!/usr/bin/env sh\nexit 0\n")
+    _set_nc_exit(world, nc_exit)
+
+    secrets = world / "secrets.env"
+    secrets.write_text(
+        (
+            "DATABASE_URL_LOCAL=postgres://x@127.0.0.1:15432/y\n"
+            if database_url_present
+            else ""
+        ),
+        encoding="utf-8",
+    )
+    sidecar = world / f"organism/{WR2_GUARD_ORGAN_ID}.json"
+    child_env = os.environ.copy()
+    child_env.pop("RUNTIME_TRUTH_EVIDENCE_FD", None)
+    child_env.update(
+        {
+            "NUZANTARA_REPO_ROOT": str(world / "repo"),
+            "NUZANTARA_SECRETS": str(secrets),
+            "ORGANISM_LAST_SEEN_DIR": str(world / "organism"),
+            "WR2_LOG_DIR": str(world / "logs"),
+            "WR2_CRON_ALERT": "false",
+            "PATH": os.pathsep.join((str(world / "bin"), child_env.get("PATH", ""))),
+            "HOME": str(world),
+            "TMPDIR": str(world / "tmp"),
+            "RUNTIME_TRUTH_WRAPPER": str(wrapper),
+            "RUNTIME_TRUTH_MODULE": WR2_TEST_MODULE,
+        }
+    )
+    return wrapper, sidecar, child_env
+
+
+def _run_process(
+    argv: Sequence[str],
+    *,
+    cwd: pathlib.Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            list(argv),
+            cwd=cwd,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        raise GauntletContractError(
+            f"shell contract process could not start: {argv}: {exc}"
+        ) from exc
+
+
+def _observe_wr2_case(
+    *,
+    repo_root: pathlib.Path,
+    target: pathlib.Path,
+    case_id: str,
+) -> ShellCaseEvidence:
+    configurations: dict[str, tuple[int, bool, int, str]] = {
+        "pg_proxy_unreachable": (1, True, 74, "error"),
+        "database_url_local_missing": (0, False, 74, "error"),
+        "pg_proxy_reachable": (0, True, 0, "ok"),
+        "heartbeat_self_heal": (1, True, 0, "ok"),
+    }
+    if case_id not in configurations:
+        raise GauntletContractError(f"unknown WR2 shell case: {case_id}")
+    nc_exit, database_url_present, expected_exit, expected_status = configurations[
+        case_id
+    ]
+
+    temp_parent = os.environ.get("TMPDIR")
+    with tempfile.TemporaryDirectory(
+        prefix=f"runtime-truth-{case_id}-",
+        dir=temp_parent,
+    ) as raw_world:
+        world = pathlib.Path(raw_world)
+        wrapper, sidecar, child_env = _prepare_wr2_world(
+            repo_root=repo_root,
+            world=world,
+            nc_exit=nc_exit,
+            database_url_present=database_url_present,
+        )
+        precondition_exit: int | None = None
+        expected_precondition_exit: int | None = None
+        precondition_status: str | None = None
+        expected_precondition_status: str | None = None
+        if case_id == "heartbeat_self_heal":
+            precondition = _run_process(
+                ("bash", str(wrapper), WR2_TEST_MODULE),
+                cwd=repo_root,
+                env=child_env,
+            )
+            precondition_exit = precondition.returncode
+            expected_precondition_exit = 74
+            precondition_status = _sidecar_status(sidecar)
+            expected_precondition_status = "error"
+            _set_nc_exit(world, 0)
+
+        completed = _run_process(
+            ("bash", str(target), case_id),
+            cwd=repo_root,
+            env=child_env,
+        )
+        return ShellCaseEvidence(
+            case_id=case_id,
+            exit_code=completed.returncode,
+            expected_exit_code=expected_exit,
+            sidecar_status=_sidecar_status(sidecar),
+            expected_sidecar_status=expected_status,
+            precondition_exit_code=precondition_exit,
+            expected_precondition_exit_code=expected_precondition_exit,
+            precondition_sidecar_status=precondition_status,
+            expected_precondition_sidecar_status=expected_precondition_status,
+        )
+
+
+def run_shell_contract(
+    *,
+    repo_root: pathlib.Path,
     relative_path: str,
     expected_cases: Sequence[str],
-    raw_evidence: str,
-    exit_code: int,
 ) -> ShellEvidence:
-    errors: list[str] = []
+    """Run four isolated cases; the parent derives evidence from real side effects."""
+    target = repo_root / relative_path
+    if not target.is_file():
+        raise GauntletContractError(f"mandatory shell target missing: {relative_path}")
     if not expected_cases:
-        errors.append("case manifest is empty")
+        raise GauntletContractError("shell case manifest is empty")
     if len(expected_cases) != len(set(expected_cases)):
-        errors.append("case manifest contains duplicates")
+        raise GauntletContractError("shell case manifest contains duplicates")
 
-    outcomes: dict[str, str] = {}
-    for line_number, line in enumerate(raw_evidence.splitlines(), start=1):
-        parts = line.split("\t")
-        if len(parts) != 3 or parts[0] != SHELL_EVIDENCE_PROTOCOL:
-            errors.append(f"invalid evidence line {line_number}: {line!r}")
-            continue
-        _, case_id, outcome = parts
-        if not case_id or outcome not in {"passed", "failed", "skipped"}:
-            errors.append(f"invalid evidence line {line_number}: {line!r}")
-            continue
-        if case_id in outcomes:
-            errors.append(f"duplicate shell case evidence: {case_id}")
-            continue
-        outcomes[case_id] = outcome
-
-    expected = set(expected_cases)
-    actual = set(outcomes)
-    missing = sorted(expected - actual)
-    unexpected = sorted(actual - expected)
-    if missing:
-        errors.append(f"missing shell cases={missing}")
-    if unexpected:
-        errors.append(f"unexpected shell cases={unexpected}")
-
+    cases = tuple(
+        _observe_wr2_case(
+            repo_root=repo_root,
+            target=target,
+            case_id=case_id,
+        )
+        for case_id in expected_cases
+    )
     evidence = ShellEvidence(
         target=relative_path,
-        collected=len(expected_cases),
-        executed=len(outcomes),
-        passed=sum(outcome == "passed" for outcome in outcomes.values()),
-        failed=sum(outcome == "failed" for outcome in outcomes.values()),
-        skipped=sum(outcome == "skipped" for outcome in outcomes.values()),
+        expected_cases=tuple(expected_cases),
+        cases=cases,
     )
-    if exit_code != 0:
-        errors.append(f"exit_code={exit_code}")
+    errors = [
+        (
+            f"{case.case_id}: rc={case.exit_code}/{case.expected_exit_code} "
+            f"sidecar={case.sidecar_status}/{case.expected_sidecar_status} "
+            f"pre_rc={case.precondition_exit_code}/"
+            f"{case.expected_precondition_exit_code} "
+            f"pre_sidecar={case.precondition_sidecar_status}/"
+            f"{case.expected_precondition_sidecar_status}"
+        )
+        for case in evidence.cases
+        if not case.passed
+    ]
+    if tuple(case.case_id for case in evidence.cases) != tuple(expected_cases):
+        errors.append("observed shell case order differs from exact manifest")
     if not (
         evidence.collected == evidence.executed == evidence.passed
         and evidence.failed == 0
@@ -324,47 +537,6 @@ def _parse_shell_evidence(
             f"shell contract failed: {relative_path}; " + "; ".join(errors)
         )
     return evidence
-
-
-def run_shell_contract(
-    *,
-    repo_root: pathlib.Path,
-    relative_path: str,
-    expected_cases: Sequence[str],
-) -> ShellEvidence:
-    """Run one shell corpus and verify case evidence without parsing stdout."""
-    target = repo_root / relative_path
-    if not target.is_file():
-        raise GauntletContractError(f"mandatory shell target missing: {relative_path}")
-
-    read_fd, write_fd = os.pipe()
-    child_env = os.environ.copy()
-    child_env[SHELL_EVIDENCE_FD_ENV] = str(write_fd)
-    try:
-        try:
-            completed = subprocess.run(
-                ["bash", str(target)],
-                cwd=repo_root,
-                env=child_env,
-                check=False,
-                pass_fds=(write_fd,),
-            )
-        except OSError as exc:
-            os.close(read_fd)
-            raise GauntletContractError(
-                f"shell contract could not start: {relative_path}: {exc}"
-            ) from exc
-    finally:
-        os.close(write_fd)
-
-    with os.fdopen(read_fd, encoding="utf-8") as evidence_stream:
-        raw_evidence = evidence_stream.read()
-    return _parse_shell_evidence(
-        relative_path=relative_path,
-        expected_cases=expected_cases,
-        raw_evidence=raw_evidence,
-        exit_code=completed.returncode,
-    )
 
 
 def run_shell_contracts(repo_root: pathlib.Path) -> tuple[ShellEvidence, ...]:
@@ -434,6 +606,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             result.failed,
             result.skipped,
         )
+        for case in result.cases:
+            LOGGER.info(
+                "RUNTIME_TRUTH_SHELL_CASE id=%s rc=%d expected_rc=%d "
+                "sidecar=%s expected_sidecar=%s pre_rc=%s "
+                "expected_pre_rc=%s pre_sidecar=%s expected_pre_sidecar=%s",
+                case.case_id,
+                case.exit_code,
+                case.expected_exit_code,
+                case.sidecar_status,
+                case.expected_sidecar_status,
+                case.precondition_exit_code,
+                case.expected_precondition_exit_code,
+                case.precondition_sidecar_status,
+                case.expected_precondition_sidecar_status,
+            )
     return 0
 
 

--- a/scripts/runtime_truth_ci_gauntlet.py
+++ b/scripts/runtime_truth_ci_gauntlet.py
@@ -376,23 +376,21 @@ def _prepare_wr2_world(
         encoding="utf-8",
     )
     sidecar = world / f"organism/{WR2_GUARD_ORGAN_ID}.json"
-    child_env = os.environ.copy()
-    child_env.pop("RUNTIME_TRUTH_EVIDENCE_FD", None)
-    child_env.update(
+    wrapper_env = os.environ.copy()
+    wrapper_env.pop("RUNTIME_TRUTH_EVIDENCE_FD", None)
+    wrapper_env.update(
         {
             "NUZANTARA_REPO_ROOT": str(world / "repo"),
             "NUZANTARA_SECRETS": str(secrets),
             "ORGANISM_LAST_SEEN_DIR": str(world / "organism"),
             "WR2_LOG_DIR": str(world / "logs"),
             "WR2_CRON_ALERT": "false",
-            "PATH": os.pathsep.join((str(world / "bin"), child_env.get("PATH", ""))),
+            "PATH": os.pathsep.join((str(world / "bin"), wrapper_env.get("PATH", ""))),
             "HOME": str(world),
             "TMPDIR": str(world / "tmp"),
-            "RUNTIME_TRUTH_WRAPPER": str(wrapper),
-            "RUNTIME_TRUTH_MODULE": WR2_TEST_MODULE,
         }
     )
-    return wrapper, sidecar, child_env
+    return wrapper, sidecar, wrapper_env
 
 
 def _run_process(
@@ -419,7 +417,6 @@ def _run_process(
 def _observe_wr2_case(
     *,
     repo_root: pathlib.Path,
-    target: pathlib.Path,
     case_id: str,
 ) -> ShellCaseEvidence:
     configurations: dict[str, tuple[int, bool, int, str]] = {
@@ -440,7 +437,7 @@ def _observe_wr2_case(
         dir=temp_parent,
     ) as raw_world:
         world = pathlib.Path(raw_world)
-        wrapper, sidecar, child_env = _prepare_wr2_world(
+        wrapper, sidecar, wrapper_env = _prepare_wr2_world(
             repo_root=repo_root,
             world=world,
             nc_exit=nc_exit,
@@ -454,7 +451,7 @@ def _observe_wr2_case(
             precondition = _run_process(
                 ("bash", str(wrapper), WR2_TEST_MODULE),
                 cwd=repo_root,
-                env=child_env,
+                env=wrapper_env,
             )
             precondition_exit = precondition.returncode
             expected_precondition_exit = 74
@@ -463,9 +460,9 @@ def _observe_wr2_case(
             _set_nc_exit(world, 0)
 
         completed = _run_process(
-            ("bash", str(target), case_id),
+            ("bash", str(wrapper), WR2_TEST_MODULE),
             cwd=repo_root,
-            env=child_env,
+            env=wrapper_env,
         )
         return ShellCaseEvidence(
             case_id=case_id,
@@ -486,9 +483,15 @@ def run_shell_contract(
     relative_path: str,
     expected_cases: Sequence[str],
 ) -> ShellEvidence:
-    """Run four isolated cases; the parent derives evidence from real side effects."""
-    target = repo_root / relative_path
-    if not target.is_file():
+    """Observe four direct real-wrapper invocations in parent-owned fake worlds.
+
+    ``relative_path`` remains the incident-corpus label and developer entrypoint,
+    but its process is never invoked and cannot provide evidence.  The parent owns
+    case configuration, directly launches the copied production wrapper, and reads
+    only that wrapper's exit code and heartbeat sidecar.
+    """
+    contract_path = repo_root / relative_path
+    if not contract_path.is_file():
         raise GauntletContractError(f"mandatory shell target missing: {relative_path}")
     if not expected_cases:
         raise GauntletContractError("shell case manifest is empty")
@@ -498,7 +501,6 @@ def run_shell_contract(
     cases = tuple(
         _observe_wr2_case(
             repo_root=repo_root,
-            target=target,
             case_id=case_id,
         )
         for case_id in expected_cases

--- a/scripts/runtime_truth_ci_gauntlet.py
+++ b/scripts/runtime_truth_ci_gauntlet.py
@@ -27,11 +27,20 @@ PYTEST_TARGETS: Final[tuple[str, ...]] = (
     "apps/evaluator/nlm_deep_research/tests/test_run_verdict.py",
     "scripts/tests/test_launchd_liveness_expected_nonzero.py",
     "scripts/tests/test_proprioception_run_wrap_exit_code.py",
-    "scripts/tests/test_runtime_truth_ci_gauntlet.py",
 )
 SHELL_TARGETS: Final[tuple[str, ...]] = (
     "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh",
 )
+SHELL_CASES: Final[dict[str, tuple[str, ...]]] = {
+    "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh": (
+        "pg_proxy_unreachable",
+        "database_url_local_missing",
+        "pg_proxy_reachable",
+        "heartbeat_self_heal",
+    ),
+}
+SHELL_EVIDENCE_PROTOCOL: Final = "runtime-truth-shell-v1"
+SHELL_EVIDENCE_FD_ENV: Final = "RUNTIME_TRUTH_EVIDENCE_FD"
 PYTEST_OPTIONS: Final[tuple[str, ...]] = ("-q", "--strict-markers")
 
 LOGGER = logging.getLogger("runtime-truth-ci-gauntlet")
@@ -55,10 +64,17 @@ class PytestEvidence:
     skipped_by_file: collections.Counter[str] = dataclasses.field(
         default_factory=collections.Counter
     )
+    xfail_by_file: collections.Counter[str] = dataclasses.field(
+        default_factory=collections.Counter
+    )
+    xpass_by_file: collections.Counter[str] = dataclasses.field(
+        default_factory=collections.Counter
+    )
     collected_nodeids: set[str] = dataclasses.field(default_factory=set)
     executed_nodeids: set[str] = dataclasses.field(default_factory=set)
     skipped_reports: set[str] = dataclasses.field(default_factory=set)
     xfail_reports: set[str] = dataclasses.field(default_factory=set)
+    xpass_reports: set[str] = dataclasses.field(default_factory=set)
 
     def _relative_path(self, path: pathlib.Path) -> str:
         resolved = path.resolve()
@@ -98,7 +114,24 @@ class PytestEvidence:
             self.skipped_reports.add(f"{report.when}:{report.nodeid}")
             self.skipped_by_file[relative_path] += 1
         if getattr(report, "wasxfail", None):
-            self.xfail_reports.add(f"{report.when}:{report.nodeid}")
+            if report.skipped:
+                self.xfail_reports.add(f"{report.when}:{report.nodeid}")
+                self.xfail_by_file[relative_path] += 1
+            else:
+                self.xpass_reports.add(f"{report.when}:{report.nodeid}")
+                self.xpass_by_file[relative_path] += 1
+
+
+@dataclasses.dataclass(frozen=True)
+class ShellEvidence:
+    """Case-level evidence read from a dedicated file descriptor."""
+
+    target: str
+    collected: int
+    executed: int
+    passed: int
+    failed: int
+    skipped: int
 
 
 def _validate_targets(repo_root: pathlib.Path, targets: Sequence[str]) -> None:
@@ -146,16 +179,21 @@ def validate_pytest_evidence(
     if evidence.skipped_reports:
         errors.append(f"skipped={sorted(evidence.skipped_reports)}")
     if evidence.xfail_reports:
-        errors.append(f"xfail/xpass={sorted(evidence.xfail_reports)}")
+        errors.append(f"xfail={sorted(evidence.xfail_reports)}")
+    if evidence.xpass_reports:
+        errors.append(f"xpass={sorted(evidence.xpass_reports)}")
 
     for target in targets:
         collected = evidence.collected_by_file[target]
         executed = evidence.executed_by_file[target]
         skipped = evidence.skipped_by_file[target]
-        if executed != collected or skipped:
+        xfailed = evidence.xfail_by_file[target]
+        xpassed = evidence.xpass_by_file[target]
+        if executed != collected or skipped or xfailed or xpassed:
             errors.append(
                 f"per-file evidence {target}: collected={collected} "
-                f"executed={executed} skipped={skipped}"
+                f"executed={executed} skipped={skipped} "
+                f"xfail={xfailed} xpass={xpassed}"
             )
 
     if errors:
@@ -224,21 +262,124 @@ def _prepare_hermetic_directories() -> None:
         pathlib.Path(os.environ[name]).mkdir(parents=True, exist_ok=True)
 
 
-def run_shell_contracts(repo_root: pathlib.Path) -> None:
-    for relative_path in SHELL_TARGETS:
-        target = repo_root / relative_path
-        if not target.is_file():
-            raise GauntletContractError(f"mandatory shell target missing: {relative_path}")
-        completed = subprocess.run(
-            ["bash", str(target)],
-            cwd=repo_root,
-            env=os.environ.copy(),
-            check=False,
+def _parse_shell_evidence(
+    *,
+    relative_path: str,
+    expected_cases: Sequence[str],
+    raw_evidence: str,
+    exit_code: int,
+) -> ShellEvidence:
+    errors: list[str] = []
+    if not expected_cases:
+        errors.append("case manifest is empty")
+    if len(expected_cases) != len(set(expected_cases)):
+        errors.append("case manifest contains duplicates")
+
+    outcomes: dict[str, str] = {}
+    for line_number, line in enumerate(raw_evidence.splitlines(), start=1):
+        parts = line.split("\t")
+        if len(parts) != 3 or parts[0] != SHELL_EVIDENCE_PROTOCOL:
+            errors.append(f"invalid evidence line {line_number}: {line!r}")
+            continue
+        _, case_id, outcome = parts
+        if not case_id or outcome not in {"passed", "failed", "skipped"}:
+            errors.append(f"invalid evidence line {line_number}: {line!r}")
+            continue
+        if case_id in outcomes:
+            errors.append(f"duplicate shell case evidence: {case_id}")
+            continue
+        outcomes[case_id] = outcome
+
+    expected = set(expected_cases)
+    actual = set(outcomes)
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing:
+        errors.append(f"missing shell cases={missing}")
+    if unexpected:
+        errors.append(f"unexpected shell cases={unexpected}")
+
+    evidence = ShellEvidence(
+        target=relative_path,
+        collected=len(expected_cases),
+        executed=len(outcomes),
+        passed=sum(outcome == "passed" for outcome in outcomes.values()),
+        failed=sum(outcome == "failed" for outcome in outcomes.values()),
+        skipped=sum(outcome == "skipped" for outcome in outcomes.values()),
+    )
+    if exit_code != 0:
+        errors.append(f"exit_code={exit_code}")
+    if not (
+        evidence.collected == evidence.executed == evidence.passed
+        and evidence.failed == 0
+        and evidence.skipped == 0
+    ):
+        errors.append(
+            f"collected={evidence.collected} executed={evidence.executed} "
+            f"passed={evidence.passed} failed={evidence.failed} "
+            f"skipped={evidence.skipped}"
         )
-        if completed.returncode != 0:
-            raise GauntletContractError(
-                f"shell contract failed: {relative_path} exit_code={completed.returncode}"
+    if errors:
+        raise GauntletContractError(
+            f"shell contract failed: {relative_path}; " + "; ".join(errors)
+        )
+    return evidence
+
+
+def run_shell_contract(
+    *,
+    repo_root: pathlib.Path,
+    relative_path: str,
+    expected_cases: Sequence[str],
+) -> ShellEvidence:
+    """Run one shell corpus and verify case evidence without parsing stdout."""
+    target = repo_root / relative_path
+    if not target.is_file():
+        raise GauntletContractError(f"mandatory shell target missing: {relative_path}")
+
+    read_fd, write_fd = os.pipe()
+    child_env = os.environ.copy()
+    child_env[SHELL_EVIDENCE_FD_ENV] = str(write_fd)
+    try:
+        try:
+            completed = subprocess.run(
+                ["bash", str(target)],
+                cwd=repo_root,
+                env=child_env,
+                check=False,
+                pass_fds=(write_fd,),
             )
+        except OSError as exc:
+            os.close(read_fd)
+            raise GauntletContractError(
+                f"shell contract could not start: {relative_path}: {exc}"
+            ) from exc
+    finally:
+        os.close(write_fd)
+
+    with os.fdopen(read_fd, encoding="utf-8") as evidence_stream:
+        raw_evidence = evidence_stream.read()
+    return _parse_shell_evidence(
+        relative_path=relative_path,
+        expected_cases=expected_cases,
+        raw_evidence=raw_evidence,
+        exit_code=completed.returncode,
+    )
+
+
+def run_shell_contracts(repo_root: pathlib.Path) -> tuple[ShellEvidence, ...]:
+    if set(SHELL_CASES) != set(SHELL_TARGETS):
+        raise GauntletContractError(
+            "shell target manifest and case manifest do not match exactly"
+        )
+    return tuple(
+        run_shell_contract(
+            repo_root=repo_root,
+            relative_path=relative_path,
+            expected_cases=SHELL_CASES[relative_path],
+        )
+        for relative_path in SHELL_TARGETS
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -254,25 +395,44 @@ def main(argv: Sequence[str] | None = None) -> int:
             repo_root=REPO_ROOT,
             targets=PYTEST_TARGETS,
         )
-        run_shell_contracts(REPO_ROOT)
+        shell_evidence = run_shell_contracts(REPO_ROOT)
     except GauntletContractError as exc:
         LOGGER.error("RUNTIME_TRUTH_FAIL %s", exc)
         return 1
 
     LOGGER.info(
-        "RUNTIME_TRUTH_PASS files=%d collected=%d executed=%d skipped=0 shell=%d",
+        "RUNTIME_TRUTH_PASS files=%d collected=%d executed=%d skipped=0 "
+        "xfail=0 xpass=0 "
+        "shell_collected=%d shell_executed=%d shell_passed=%d "
+        "shell_failed=0 shell_skipped=0",
         len(evidence.collected_by_file),
         len(evidence.collected_nodeids),
         len(evidence.executed_nodeids),
-        len(SHELL_TARGETS),
+        sum(result.collected for result in shell_evidence),
+        sum(result.executed for result in shell_evidence),
+        sum(result.passed for result in shell_evidence),
     )
     for target in PYTEST_TARGETS:
         LOGGER.info(
-            "RUNTIME_TRUTH_FILE path=%s collected=%d executed=%d skipped=%d",
+            "RUNTIME_TRUTH_FILE path=%s collected=%d executed=%d skipped=%d "
+            "xfail=%d xpass=%d",
             target,
             evidence.collected_by_file[target],
             evidence.executed_by_file[target],
             evidence.skipped_by_file[target],
+            evidence.xfail_by_file[target],
+            evidence.xpass_by_file[target],
+        )
+    for result in shell_evidence:
+        LOGGER.info(
+            "RUNTIME_TRUTH_SHELL path=%s collected=%d executed=%d passed=%d "
+            "failed=%d skipped=%d",
+            result.target,
+            result.collected,
+            result.executed,
+            result.passed,
+            result.failed,
+            result.skipped,
         )
     return 0
 

--- a/scripts/runtime_truth_ci_gauntlet.py
+++ b/scripts/runtime_truth_ci_gauntlet.py
@@ -376,20 +376,23 @@ def _prepare_wr2_world(
         encoding="utf-8",
     )
     sidecar = world / f"organism/{WR2_GUARD_ORGAN_ID}.json"
-    wrapper_env = os.environ.copy()
-    wrapper_env.pop("RUNTIME_TRUTH_EVIDENCE_FD", None)
-    wrapper_env.update(
-        {
-            "NUZANTARA_REPO_ROOT": str(world / "repo"),
-            "NUZANTARA_SECRETS": str(secrets),
-            "ORGANISM_LAST_SEEN_DIR": str(world / "organism"),
-            "WR2_LOG_DIR": str(world / "logs"),
-            "WR2_CRON_ALERT": "false",
-            "PATH": os.pathsep.join((str(world / "bin"), wrapper_env.get("PATH", ""))),
-            "HOME": str(world),
-            "TMPDIR": str(world / "tmp"),
-        }
-    )
+    # The production wrapper sources a secrets file and otherwise inherits its
+    # launchd environment.  The contract world must prove only its four cases,
+    # never accidentally consume a developer/CI credential, proxy setting, or
+    # ambient toggle.  Keep the executable search path intentionally minimal:
+    # the fake ``nc`` wins, then only the platform's standard command paths
+    # remain for bash, mkdir, dirname, and friends.
+    wrapper_env = {
+        "NUZANTARA_REPO_ROOT": str(world / "repo"),
+        "NUZANTARA_SECRETS": str(secrets),
+        "ORGANISM_LAST_SEEN_DIR": str(world / "organism"),
+        "WR2_LOG_DIR": str(world / "logs"),
+        "WR2_CRON_ALERT": "false",
+        "PATH": os.pathsep.join((str(world / "bin"), os.defpath)),
+        "HOME": str(world),
+        "TMPDIR": str(world / "tmp"),
+        "LC_ALL": "C",
+    }
     return wrapper, sidecar, wrapper_env
 
 

--- a/scripts/runtime_truth_ci_gauntlet.py
+++ b/scripts/runtime_truth_ci_gauntlet.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Execute the four Runtime Truth incident contracts fail-closed.
+
+The workflow delegates to this harness instead of invoking pytest directly so
+the check can prove that tests were collected *and* executed.  Pytest returning
+zero is insufficient: collection-only runs, skips, importorskip, and expected
+failures all violate this contract.
+"""
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+from collections.abc import Sequence
+from typing import Final
+
+import pytest
+
+REPO_ROOT: Final = pathlib.Path(__file__).resolve().parents[1]
+
+PYTEST_TARGETS: Final[tuple[str, ...]] = (
+    "apps/evaluator/nlm_deep_research/tests/test_run_verdict.py",
+    "scripts/tests/test_launchd_liveness_expected_nonzero.py",
+    "scripts/tests/test_proprioception_run_wrap_exit_code.py",
+    "scripts/tests/test_runtime_truth_ci_gauntlet.py",
+)
+SHELL_TARGETS: Final[tuple[str, ...]] = (
+    "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh",
+)
+PYTEST_OPTIONS: Final[tuple[str, ...]] = ("-q", "--strict-markers")
+
+LOGGER = logging.getLogger("runtime-truth-ci-gauntlet")
+
+
+class GauntletContractError(RuntimeError):
+    """The runner could not prove that every incident contract executed."""
+
+
+@dataclasses.dataclass(eq=False)
+class PytestEvidence:
+    """Evidence captured from pytest hooks, independent of terminal text."""
+
+    repo_root: pathlib.Path
+    collected_by_file: collections.Counter[str] = dataclasses.field(
+        default_factory=collections.Counter
+    )
+    executed_by_file: collections.Counter[str] = dataclasses.field(
+        default_factory=collections.Counter
+    )
+    skipped_by_file: collections.Counter[str] = dataclasses.field(
+        default_factory=collections.Counter
+    )
+    collected_nodeids: set[str] = dataclasses.field(default_factory=set)
+    executed_nodeids: set[str] = dataclasses.field(default_factory=set)
+    skipped_reports: set[str] = dataclasses.field(default_factory=set)
+    xfail_reports: set[str] = dataclasses.field(default_factory=set)
+
+    def _relative_path(self, path: pathlib.Path) -> str:
+        resolved = path.resolve()
+        try:
+            return resolved.relative_to(self.repo_root.resolve()).as_posix()
+        except ValueError:
+            return resolved.as_posix()
+
+    def pytest_collection_finish(self, session: pytest.Session) -> None:
+        """Record the concrete files and node IDs pytest collected."""
+        for item in session.items:
+            relative_path = self._relative_path(pathlib.Path(item.path))
+            self.collected_by_file[relative_path] += 1
+            self.collected_nodeids.add(item.nodeid)
+
+    def pytest_collectreport(self, report: pytest.CollectReport) -> None:
+        """Capture module-level importorskip and other collection skips."""
+        if report.skipped:
+            self.skipped_reports.add(f"collection:{report.nodeid}")
+            collection_path = report.nodeid.split("::", maxsplit=1)[0]
+            if collection_path:
+                path = pathlib.Path(collection_path)
+                if not path.is_absolute():
+                    path = self.repo_root / path
+                self.skipped_by_file[self._relative_path(path)] += 1
+
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
+        """Record actual call phases and every runtime skip/xfail outcome."""
+        report_path = pathlib.Path(report.location[0])
+        if not report_path.is_absolute():
+            report_path = self.repo_root / report_path
+        relative_path = self._relative_path(report_path)
+        if report.when == "call":
+            self.executed_nodeids.add(report.nodeid)
+            self.executed_by_file[relative_path] += 1
+        if report.skipped:
+            self.skipped_reports.add(f"{report.when}:{report.nodeid}")
+            self.skipped_by_file[relative_path] += 1
+        if getattr(report, "wasxfail", None):
+            self.xfail_reports.add(f"{report.when}:{report.nodeid}")
+
+
+def _validate_targets(repo_root: pathlib.Path, targets: Sequence[str]) -> None:
+    if not targets:
+        raise GauntletContractError("pytest target manifest is empty")
+    if len(targets) != len(set(targets)):
+        raise GauntletContractError("pytest target manifest contains duplicates")
+    wildcard_targets = sorted(path for path in targets if "*" in path)
+    if wildcard_targets:
+        raise GauntletContractError(
+            f"pytest target manifest contains wildcards: {wildcard_targets}"
+        )
+    missing = sorted(path for path in targets if not (repo_root / path).is_file())
+    if missing:
+        raise GauntletContractError(f"mandatory pytest targets missing: {missing}")
+
+
+def validate_pytest_evidence(
+    evidence: PytestEvidence,
+    targets: Sequence[str],
+    exit_code: int,
+) -> None:
+    """Reject any result that does not prove every collected test executed."""
+    errors: list[str] = []
+    expected_files = set(targets)
+    collected_files = set(evidence.collected_by_file)
+
+    if exit_code != 0:
+        errors.append(f"pytest exit_code={exit_code}")
+    if not evidence.collected_nodeids:
+        errors.append("pytest collected zero tests")
+
+    missing_files = sorted(expected_files - collected_files)
+    if missing_files:
+        errors.append(f"targets with zero collected tests={missing_files}")
+
+    unexpected_files = sorted(collected_files - expected_files)
+    if unexpected_files:
+        errors.append(f"tests collected outside exact manifest={unexpected_files}")
+
+    unexecuted = sorted(evidence.collected_nodeids - evidence.executed_nodeids)
+    if unexecuted:
+        errors.append(f"collected but not executed={unexecuted}")
+
+    if evidence.skipped_reports:
+        errors.append(f"skipped={sorted(evidence.skipped_reports)}")
+    if evidence.xfail_reports:
+        errors.append(f"xfail/xpass={sorted(evidence.xfail_reports)}")
+
+    for target in targets:
+        collected = evidence.collected_by_file[target]
+        executed = evidence.executed_by_file[target]
+        skipped = evidence.skipped_by_file[target]
+        if executed != collected or skipped:
+            errors.append(
+                f"per-file evidence {target}: collected={collected} "
+                f"executed={executed} skipped={skipped}"
+            )
+
+    if errors:
+        raise GauntletContractError("; ".join(errors))
+
+
+def run_pytest_contract(
+    *,
+    repo_root: pathlib.Path,
+    targets: Sequence[str],
+    extra_options: Sequence[str] = (),
+) -> PytestEvidence:
+    """Run pytest and return evidence only after the fail-closed contract passes."""
+    _validate_targets(repo_root, targets)
+    evidence = PytestEvidence(repo_root=repo_root)
+    args = [
+        *(str((repo_root / path).resolve()) for path in targets),
+        "--rootdir",
+        str(repo_root.resolve()),
+        "-c",
+        os.devnull,
+        *PYTEST_OPTIONS,
+        *extra_options,
+    ]
+
+    previous_addopts = os.environ.get("PYTEST_ADDOPTS")
+    previous_autoload = os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD")
+    previous_pythonpath = os.environ.get("PYTHONPATH")
+    previous_sys_path = sys.path.copy()
+    os.environ["PYTEST_ADDOPTS"] = ""
+    os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    os.environ["PYTHONPATH"] = os.pathsep.join(
+        part
+        for part in (str(repo_root.resolve()), previous_pythonpath)
+        if part
+    )
+    sys.path.insert(0, str(repo_root.resolve()))
+    try:
+        exit_code = int(pytest.main(args, plugins=[evidence]))
+    finally:
+        sys.path[:] = previous_sys_path
+        if previous_addopts is None:
+            os.environ.pop("PYTEST_ADDOPTS", None)
+        else:
+            os.environ["PYTEST_ADDOPTS"] = previous_addopts
+        if previous_autoload is None:
+            os.environ.pop("PYTEST_DISABLE_PLUGIN_AUTOLOAD", None)
+        else:
+            os.environ["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = previous_autoload
+        if previous_pythonpath is None:
+            os.environ.pop("PYTHONPATH", None)
+        else:
+            os.environ["PYTHONPATH"] = previous_pythonpath
+
+    validate_pytest_evidence(evidence, targets, exit_code)
+    return evidence
+
+
+def _prepare_hermetic_directories() -> None:
+    missing_names = [name for name in ("HOME", "TMPDIR") if not os.environ.get(name)]
+    if missing_names:
+        raise GauntletContractError(
+            f"workflow must provide hermetic environment variables: {missing_names}"
+        )
+    for name in ("HOME", "TMPDIR"):
+        pathlib.Path(os.environ[name]).mkdir(parents=True, exist_ok=True)
+
+
+def run_shell_contracts(repo_root: pathlib.Path) -> None:
+    for relative_path in SHELL_TARGETS:
+        target = repo_root / relative_path
+        if not target.is_file():
+            raise GauntletContractError(f"mandatory shell target missing: {relative_path}")
+        completed = subprocess.run(
+            ["bash", str(target)],
+            cwd=repo_root,
+            env=os.environ.copy(),
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise GauntletContractError(
+                f"shell contract failed: {relative_path} exit_code={completed.returncode}"
+            )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = tuple(sys.argv[1:] if argv is None else argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    try:
+        if arguments:
+            raise GauntletContractError(
+                f"runner accepts no CLI arguments; exact manifest is internal: {arguments}"
+            )
+        _prepare_hermetic_directories()
+        evidence = run_pytest_contract(
+            repo_root=REPO_ROOT,
+            targets=PYTEST_TARGETS,
+        )
+        run_shell_contracts(REPO_ROOT)
+    except GauntletContractError as exc:
+        LOGGER.error("RUNTIME_TRUTH_FAIL %s", exc)
+        return 1
+
+    LOGGER.info(
+        "RUNTIME_TRUTH_PASS files=%d collected=%d executed=%d skipped=0 shell=%d",
+        len(evidence.collected_by_file),
+        len(evidence.collected_nodeids),
+        len(evidence.executed_nodeids),
+        len(SHELL_TARGETS),
+    )
+    for target in PYTEST_TARGETS:
+        LOGGER.info(
+            "RUNTIME_TRUTH_FILE path=%s collected=%d executed=%d skipped=%d",
+            target,
+            evidence.collected_by_file[target],
+            evidence.executed_by_file[target],
+            evidence.skipped_by_file[target],
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
+++ b/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
@@ -1,31 +1,20 @@
 #!/usr/bin/env bash
-# Runtime Truth case transport for scripts/wr2-cron-wrapper.sh.
+# Developer entrypoint for the Runtime Truth WR2 wrapper contract.
 #
-# This child deliberately emits NO pass/fail evidence. The Python gauntlet is
-# the independent observer: it builds one fake world per exact case, invokes
-# this transport once, then derives the verdict from the real wrapper's exit
-# code and heartbeat sidecar. A child that prints hardcoded PASS receipts or
-# exits zero without invoking the wrapper therefore cannot certify itself.
-#
-# Usage is internal to scripts/runtime_truth_ci_gauntlet.py:
-#   bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh <exact-case-id>
+# CI does not execute this shell process and accepts no evidence from it. The
+# Python parent owns all four fake worlds, invokes the real production wrapper
+# directly, and observes only wrapper exit codes plus heartbeat sidecars. This
+# file is intentionally only a convenient local delegator to that parent suite.
 
 set -euo pipefail
 
-case_id="${1:-}"
-case "$case_id" in
-    pg_proxy_unreachable|\
-    database_url_local_missing|\
-    pg_proxy_reachable|\
-    heartbeat_self_heal)
-        ;;
-    *)
-        printf 'unknown Runtime Truth shell case: %s\n' "$case_id" >&2
-        exit 64
-        ;;
-esac
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON_BIN="${RUNTIME_TRUTH_PYTHON:-$REPO_ROOT/apps/backend-rag/.venv/bin/python}"
 
-: "${RUNTIME_TRUTH_WRAPPER:?RUNTIME_TRUTH_WRAPPER is required}"
-: "${RUNTIME_TRUTH_MODULE:?RUNTIME_TRUTH_MODULE is required}"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+    printf 'Runtime Truth Python missing or not executable: %s\n' "$PYTHON_BIN" >&2
+    exit 69
+fi
 
-exec bash "$RUNTIME_TRUTH_WRAPPER" "$RUNTIME_TRUTH_MODULE"
+exec "$PYTHON_BIN" "$REPO_ROOT/scripts/runtime_truth_ci_gauntlet.py" "$@"

--- a/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
+++ b/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
@@ -1,166 +1,31 @@
 #!/usr/bin/env bash
-# Proof for the pg-proxy guard's success-path heartbeat in
-# scripts/wr2-cron-wrapper.sh.
+# Runtime Truth case transport for scripts/wr2-cron-wrapper.sh.
 #
-# TRAUMA (ward-round 2026-08-07, id wr2_wrapper_guard_pg_proxy_stale, upheld
-# sensor_stale). GUARD_ORGAN_ID's sidecar was write-ONLY-on-failure: both
-# guard branches (DATABASE_URL_LOCAL absent, pg-proxy unreachable) called
-# `organism_heartbeat "$GUARD_ORGAN_ID" "error" ...`, but nothing ever wrote
-# "ok" when the guard passed. A heartbeat that can only ever say "error" can
-# never clear itself — one historical trip reads as N days of ongoing outage
-# even after the very next run passes clean (superscar #2, W110-adjacent: a
-# sidecar that never speaks on the happy path is a guardian aimed at silence).
+# This child deliberately emits NO pass/fail evidence. The Python gauntlet is
+# the independent observer: it builds one fake world per exact case, invokes
+# this transport once, then derives the verdict from the real wrapper's exit
+# code and heartbeat sidecar. A child that prints hardcoded PASS receipts or
+# exits zero without invoking the wrapper therefore cannot certify itself.
 #
-# W107 family-check (done in the prose that shipped alongside this test, not
-# repeated here as code): every OTHER wrapper calling organism_heartbeat on
-# error (scripts/outbox-prune.sh, scripts/agent_worktree_cleanup_cron.sh)
-# already pairs it with an "ok" call on its success path. wr2-cron-wrapper.sh
-# was the only sibling missing it — this is a single-site fix, not a class fix.
-#
-# GUILT      — pg-proxy unreachable still writes "error" (regression guard on
-#              the branch the fix sits next to).
-# INNOCENCE  — DATABASE_URL_LOCAL absent (the OTHER guard, same organ id)
-#              still writes its own "error" and must NOT be clobbered by the
-#              new line, because that branch exits before reaching it.
-# THE FIX    — pg-proxy reachable writes "ok" with a note, before the module
-#              even runs.
-# SELF-HEAL  — a prior "error" trip is overwritten by "ok" on the next good
-#              run (heartbeat.sh's own contract: atomic overwrite, not append)
-#              — this is the actual behavior ward-round asked for: the sidecar
-#              must be able to clear itself.
-#
-# Run: bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
+# Usage is internal to scripts/runtime_truth_ci_gauntlet.py:
+#   bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh <exact-case-id>
 
-set -uo pipefail
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WRAPPER_SRC="$SCRIPT_DIR/wr2-cron-wrapper.sh"
-HEARTBEAT_SRC="$SCRIPT_DIR/lib/heartbeat.sh"
-PASS=0
-FAIL=0
-EVIDENCE_FD="${RUNTIME_TRUTH_EVIDENCE_FD:-}"
+case_id="${1:-}"
+case "$case_id" in
+    pg_proxy_unreachable|\
+    database_url_local_missing|\
+    pg_proxy_reachable|\
+    heartbeat_self_heal)
+        ;;
+    *)
+        printf 'unknown Runtime Truth shell case: %s\n' "$case_id" >&2
+        exit 64
+        ;;
+esac
 
-record_result() {  # record_result <case_id> <passed|failed>
-    [[ -n "$EVIDENCE_FD" ]] || return 0
-    printf 'runtime-truth-shell-v1\t%s\t%s\n' "$1" "$2" >&"$EVIDENCE_FD"
-}
+: "${RUNTIME_TRUTH_WRAPPER:?RUNTIME_TRUTH_WRAPPER is required}"
+: "${RUNTIME_TRUTH_MODULE:?RUNTIME_TRUTH_MODULE is required}"
 
-ok() {  # ok <case_id> <label>
-    PASS=$((PASS+1))
-    record_result "$1" passed
-    printf '  ok    %s\n' "$2"
-}
-
-bad() {  # bad <case_id> <label> <detail>
-    FAIL=$((FAIL+1))
-    record_result "$1" failed
-    printf '  FAIL  %s\n     -> %s\n' "$2" "${3:-}"
-}
-
-# ---------------------------------------------------------------- fake world
-# Real heartbeat.sh copied in (not stubbed) — the whole point of this test is
-# that the sidecar actually gets written, so a no-op stub would prove nothing.
-make_world() {  # make_world <nc_exit>
-    local nc_exit="$1"
-    W="$(mktemp -d)"
-    mkdir -p "$W/scripts/lib" "$W/repo/scripts/lib" \
-             "$W/repo/apps/backend-rag/.venv/bin" "$W/bin" "$W/logs" "$W/organism"
-    cp "$WRAPPER_SRC" "$W/scripts/wr2-cron-wrapper.sh"
-    cp "$HEARTBEAT_SRC" "$W/repo/scripts/lib/heartbeat.sh"
-
-    # Module interpreter: exits 0 (module "succeeds" — irrelevant to what
-    # this test checks, which all happens before the module ever runs).
-    printf '#!/bin/sh\nexit 0\n' > "$W/repo/apps/backend-rag/.venv/bin/python"
-    chmod +x "$W/repo/apps/backend-rag/.venv/bin/python"
-
-    printf '#!/bin/sh\nexit %s\n' "$nc_exit" > "$W/bin/nc"
-    chmod +x "$W/bin/nc"
-
-    printf 'DATABASE_URL_LOCAL=postgres://x@127.0.0.1:15432/y\n' > "$W/secrets.env"
-}
-
-run_wrapper() {
-    env NUZANTARA_REPO_ROOT="$W/repo" \
-        NUZANTARA_SECRETS="$W/secrets.env" \
-        ORGANISM_LAST_SEEN_DIR="$W/organism" \
-        WR2_LOG_DIR="$W/logs" \
-        WR2_CRON_ALERT=false \
-        PATH="$W/bin:$PATH" \
-        HOME="$W" \
-        bash "$W/scripts/wr2-cron-wrapper.sh" "$@" >"$W/stdout.txt" 2>"$W/stderr.txt"
-    echo $?
-}
-
-sidecar_status() {  # sidecar_status <organ_id>
-    python3 -c '
-import json, sys
-try:
-    print(json.load(open(sys.argv[1]))["status"])
-except Exception:
-    print("<missing>")
-' "$W/organism/$1.json" 2>/dev/null
-}
-
-ORGAN="pro.wr2_wrapper_guard.some.module"
-
-echo
-echo "wr2-cron-wrapper pg-proxy guard heartbeat"
-echo
-
-# ------------------------------------------------------------------- GUILT
-make_world 1   # nc fails: pg-proxy unreachable
-rc="$(run_wrapper some.module)"
-st="$(sidecar_status "$ORGAN")"
-if [[ "$rc" == "74" && "$st" == "error" ]]; then
-    ok pg_proxy_unreachable "GUILT: pg-proxy unreachable still writes status=error"
-else
-    bad pg_proxy_unreachable "GUILT: pg-proxy unreachable" "rc=$rc status=$st"
-fi
-
-# --------------------------------------------------------------- INNOCENCE
-# The OTHER guard on the same organ id (DATABASE_URL_LOCAL absent) exits
-# before ever reaching the new success-path line — must still read "error",
-# never silently upgraded to "ok" by a fix that sits three lines below it.
-make_world 0
-printf '' > "$W/secrets.env"   # DATABASE_URL_LOCAL absent
-rc="$(run_wrapper some.module)"
-st="$(sidecar_status "$ORGAN")"
-if [[ "$rc" == "74" && "$st" == "error" ]]; then
-    ok database_url_local_missing \
-        "INNOCENCE: DATABASE_URL_LOCAL guard (same organ id) still error, not ok"
-else
-    bad database_url_local_missing \
-        "INNOCENCE: DATABASE_URL_LOCAL guard" "rc=$rc status=$st"
-fi
-
-# ------------------------------------------------------------------ THE FIX
-make_world 0   # nc succeeds: pg-proxy reachable
-rc="$(run_wrapper some.module)"
-st="$(sidecar_status "$ORGAN")"
-if [[ "$rc" == "0" && "$st" == "ok" ]]; then
-    ok pg_proxy_reachable \
-        "FIX: pg-proxy reachable writes status=ok — the sidecar now has a voice"
-else
-    bad pg_proxy_reachable "FIX: pg-proxy reachable" "rc=$rc status=$st"
-fi
-
-# --------------------------------------------------------------- SELF-HEAL
-# The whole point: a prior error trip must clear on the next good run,
-# because heartbeat.sh overwrites atomically rather than appending.
-make_world 1
-run_wrapper some.module >/dev/null
-st1="$(sidecar_status "$ORGAN")"
-printf '#!/bin/sh\nexit 0\n' > "$W/bin/nc"; chmod +x "$W/bin/nc"
-rc="$(run_wrapper some.module)"
-st2="$(sidecar_status "$ORGAN")"
-if [[ "$st1" == "error" && "$rc" == "0" && "$st2" == "ok" ]]; then
-    ok heartbeat_self_heal \
-        "SELF-HEAL: an error sidecar clears to ok on the next good run"
-else
-    bad heartbeat_self_heal \
-        "SELF-HEAL: sidecar did not clear" "st1=$st1 rc=$rc st2=$st2"
-fi
-
-echo
-echo "  $PASS passed, $FAIL failed"
-[[ "$FAIL" -eq 0 ]] || exit 1
+exec bash "$RUNTIME_TRUTH_WRAPPER" "$RUNTIME_TRUTH_MODULE"

--- a/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
+++ b/scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh
@@ -38,9 +38,24 @@ WRAPPER_SRC="$SCRIPT_DIR/wr2-cron-wrapper.sh"
 HEARTBEAT_SRC="$SCRIPT_DIR/lib/heartbeat.sh"
 PASS=0
 FAIL=0
+EVIDENCE_FD="${RUNTIME_TRUTH_EVIDENCE_FD:-}"
 
-ok()  { PASS=$((PASS+1)); printf '  ok    %s\n' "$1"; }
-bad() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n     -> %s\n' "$1" "${2:-}"; }
+record_result() {  # record_result <case_id> <passed|failed>
+    [[ -n "$EVIDENCE_FD" ]] || return 0
+    printf 'runtime-truth-shell-v1\t%s\t%s\n' "$1" "$2" >&"$EVIDENCE_FD"
+}
+
+ok() {  # ok <case_id> <label>
+    PASS=$((PASS+1))
+    record_result "$1" passed
+    printf '  ok    %s\n' "$2"
+}
+
+bad() {  # bad <case_id> <label> <detail>
+    FAIL=$((FAIL+1))
+    record_result "$1" failed
+    printf '  FAIL  %s\n     -> %s\n' "$2" "${3:-}"
+}
 
 # ---------------------------------------------------------------- fake world
 # Real heartbeat.sh copied in (not stubbed) — the whole point of this test is
@@ -97,9 +112,9 @@ make_world 1   # nc fails: pg-proxy unreachable
 rc="$(run_wrapper some.module)"
 st="$(sidecar_status "$ORGAN")"
 if [[ "$rc" == "74" && "$st" == "error" ]]; then
-    ok "GUILT: pg-proxy unreachable still writes status=error"
+    ok pg_proxy_unreachable "GUILT: pg-proxy unreachable still writes status=error"
 else
-    bad "GUILT: pg-proxy unreachable" "rc=$rc status=$st"
+    bad pg_proxy_unreachable "GUILT: pg-proxy unreachable" "rc=$rc status=$st"
 fi
 
 # --------------------------------------------------------------- INNOCENCE
@@ -111,9 +126,11 @@ printf '' > "$W/secrets.env"   # DATABASE_URL_LOCAL absent
 rc="$(run_wrapper some.module)"
 st="$(sidecar_status "$ORGAN")"
 if [[ "$rc" == "74" && "$st" == "error" ]]; then
-    ok "INNOCENCE: DATABASE_URL_LOCAL guard (same organ id) still error, not ok"
+    ok database_url_local_missing \
+        "INNOCENCE: DATABASE_URL_LOCAL guard (same organ id) still error, not ok"
 else
-    bad "INNOCENCE: DATABASE_URL_LOCAL guard" "rc=$rc status=$st"
+    bad database_url_local_missing \
+        "INNOCENCE: DATABASE_URL_LOCAL guard" "rc=$rc status=$st"
 fi
 
 # ------------------------------------------------------------------ THE FIX
@@ -121,9 +138,10 @@ make_world 0   # nc succeeds: pg-proxy reachable
 rc="$(run_wrapper some.module)"
 st="$(sidecar_status "$ORGAN")"
 if [[ "$rc" == "0" && "$st" == "ok" ]]; then
-    ok "FIX: pg-proxy reachable writes status=ok — the sidecar now has a voice"
+    ok pg_proxy_reachable \
+        "FIX: pg-proxy reachable writes status=ok — the sidecar now has a voice"
 else
-    bad "FIX: pg-proxy reachable" "rc=$rc status=$st"
+    bad pg_proxy_reachable "FIX: pg-proxy reachable" "rc=$rc status=$st"
 fi
 
 # --------------------------------------------------------------- SELF-HEAL
@@ -136,9 +154,11 @@ printf '#!/bin/sh\nexit 0\n' > "$W/bin/nc"; chmod +x "$W/bin/nc"
 rc="$(run_wrapper some.module)"
 st2="$(sidecar_status "$ORGAN")"
 if [[ "$st1" == "error" && "$rc" == "0" && "$st2" == "ok" ]]; then
-    ok "SELF-HEAL: an error sidecar clears to ok on the next good run"
+    ok heartbeat_self_heal \
+        "SELF-HEAL: an error sidecar clears to ok on the next good run"
 else
-    bad "SELF-HEAL: sidecar did not clear" "st1=$st1 rc=$rc st2=$st2"
+    bad heartbeat_self_heal \
+        "SELF-HEAL: sidecar did not clear" "st1=$st1 rc=$rc st2=$st2"
 fi
 
 echo

--- a/scripts/tests/test_runtime_truth_ci_gauntlet.py
+++ b/scripts/tests/test_runtime_truth_ci_gauntlet.py
@@ -500,6 +500,38 @@ def test_runner_manifest_is_exact_and_contains_four_incident_corpora() -> None:
     )
 
 
+def test_wr2_contract_world_environment_is_an_explicit_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """The direct-wrapper probe must not inherit host credentials or toggles."""
+    monkeypatch.setenv("FLY_API_TOKEN", "must-not-leak")
+    monkeypatch.setenv("DATABASE_URL", "must-not-leak")
+    monkeypatch.setenv("WR2_CRON_ENABLED", "false")
+    monkeypatch.setenv("RUNTIME_TRUTH_EVIDENCE_FD", "99")
+
+    world = tmp_path / "world"
+    world.mkdir()
+    _, _, environment = gauntlet._prepare_wr2_world(
+        repo_root=REPO_ROOT,
+        world=world,
+        nc_exit=0,
+        database_url_present=True,
+    )
+
+    assert environment == {
+        "NUZANTARA_REPO_ROOT": str(world / "repo"),
+        "NUZANTARA_SECRETS": str(world / "secrets.env"),
+        "ORGANISM_LAST_SEEN_DIR": str(world / "organism"),
+        "WR2_LOG_DIR": str(world / "logs"),
+        "WR2_CRON_ALERT": "false",
+        "PATH": os.pathsep.join((str(world / "bin"), os.defpath)),
+        "HOME": str(world),
+        "TMPDIR": str(world / "tmp"),
+        "LC_ALL": "C",
+    }
+
+
 def test_workflow_steps_match_exact_structural_contract_and_order() -> None:
     text = _workflow_text()
     meta_index, meta_step = named_step(text, META_STEP_NAME)

--- a/scripts/tests/test_runtime_truth_ci_gauntlet.py
+++ b/scripts/tests/test_runtime_truth_ci_gauntlet.py
@@ -1,22 +1,26 @@
 #!/usr/bin/env python3
-"""Fail-closed wiring contract for the Runtime Truth CI gauntlet.
-
-The incident corpora are useful only if the required-safe workflow both runs
-them and wakes when either a corpus or one of its subjects changes.  This file
-pins both halves and pins itself, so a future edit cannot make the gate green by
-construction through an omitted runner path, sentinel path, or PR trigger.
-"""
+"""Structural and execution contract for the Runtime Truth CI gauntlet."""
 
 from __future__ import annotations
 
 import pathlib
 import re
+from collections.abc import Mapping
+from typing import Final
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
-WORKFLOW = REPO_ROOT / ".github" / "workflows" / "immune-enforcement.yml"
-STEP_NAME = "Runtime Truth CI gauntlet (four incident contracts)"
+import pytest
+import yaml
 
-CORPORA = frozenset(
+from scripts import runtime_truth_ci_gauntlet as gauntlet
+
+REPO_ROOT: Final = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW_RELATIVE: Final = ".github/workflows/immune-enforcement.yml"
+WORKFLOW: Final = REPO_ROOT / WORKFLOW_RELATIVE
+RUNNER_RELATIVE: Final = "scripts/runtime_truth_ci_gauntlet.py"
+META_TEST: Final = "scripts/tests/test_runtime_truth_ci_gauntlet.py"
+STEP_NAME: Final = "Runtime Truth CI gauntlet (four incident contracts)"
+
+INCIDENT_CORPORA: Final[frozenset[str]] = frozenset(
     {
         "apps/evaluator/nlm_deep_research/tests/test_run_verdict.py",
         "scripts/tests/test_launchd_liveness_expected_nonzero.py",
@@ -24,14 +28,30 @@ CORPORA = frozenset(
         "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh",
     }
 )
-META_TEST = "scripts/tests/test_runtime_truth_ci_gauntlet.py"
-RUNNER_PATHS = CORPORA | {META_TEST}
+EXPECTED_PYTEST_TARGETS: Final[tuple[str, ...]] = (
+    "apps/evaluator/nlm_deep_research/tests/test_run_verdict.py",
+    "scripts/tests/test_launchd_liveness_expected_nonzero.py",
+    "scripts/tests/test_proprioception_run_wrap_exit_code.py",
+    META_TEST,
+)
+EXPECTED_SHELL_TARGETS: Final[tuple[str, ...]] = (
+    "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh",
+)
+EXPECTED_STEP: Final[dict[str, object]] = {
+    "name": STEP_NAME,
+    "if": "steps.paths.outputs.relevant == 'true'",
+    "env": {
+        "HOME": "${{ runner.temp }}/runtime-truth-home",
+        "TMPDIR": "${{ runner.temp }}/runtime-truth-tmp",
+    },
+    "run": f"python {RUNNER_RELATIVE}",
+}
 
-# Every file whose semantics are asserted by the four corpora, plus the wiring
-# contract itself. A wildcard may cover a subject, but every subject must match
-# at least one sentinel pattern.
-TRIGGER_SUBJECTS = frozenset(
+TRIGGER_SUBJECTS: Final[frozenset[str]] = frozenset(
     {
+        WORKFLOW_RELATIVE,
+        RUNNER_RELATIVE,
+        META_TEST,
         "apps/evaluator/nlm_deep_research/run_verdict.py",
         "apps/evaluator/nlm_deep_research/pipeline.py",
         "apps/evaluator/nlm_deep_research/nb3_pipeline.py",
@@ -41,20 +61,50 @@ TRIGGER_SUBJECTS = frozenset(
         "apps/evaluator/nlm_deep_research/nb7_pipeline.py",
         "apps/evaluator/nlm_deep_research/nb8_pipeline.py",
         "apps/evaluator/nlm_deep_research/nb10_pipeline.py",
+        "apps/evaluator/nlm_deep_research/tests/test_run_verdict.py",
         "scripts/launchd_liveness_detector.py",
+        "scripts/tests/test_launchd_liveness_expected_nonzero.py",
         "scripts/proprioception.py",
+        "scripts/tests/test_proprioception_run_wrap_exit_code.py",
         "scripts/wr2-cron-wrapper.sh",
         "scripts/lib/heartbeat.sh",
+        "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh",
     }
-) | RUNNER_PATHS
+)
 
-_SENTINEL_RE = re.compile(
-    r"^\s+([A-Za-z0-9_./*-]+\.(?:py|sh|md|json|txt|yml|yaml))\|?\\?$",
+_SENTINEL_RE: Final = re.compile(
+    r"^\s+([A-Za-z0-9_./*-]+\.(?:py|sh|md|json|txt|yml|yaml))(?:\|\\|\))$",
     re.MULTILINE,
 )
-_RUNNER_LINE_RE = re.compile(
-    r"^\s+(?:bash\s+)?((?:apps|scripts)/[A-Za-z0-9_./-]+\.(?:py|sh))\s*\\?$",
-    re.MULTILINE,
+
+
+class WorkflowContractError(RuntimeError):
+    """The parsed workflow no longer matches the required runner contract."""
+
+
+class UniqueKeyLoader(yaml.BaseLoader):
+    """YAML loader that preserves `on` as text and refuses duplicate keys."""
+
+
+def _construct_unique_mapping(
+    loader: UniqueKeyLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[str, object]:
+    mapping: dict[str, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if not isinstance(key, str):
+            raise WorkflowContractError(f"non-string workflow key: {key!r}")
+        if key in mapping:
+            raise WorkflowContractError(f"duplicate workflow key: {key}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
 )
 
 
@@ -62,128 +112,177 @@ def _workflow_text() -> str:
     return WORKFLOW.read_text(encoding="utf-8")
 
 
-def gauntlet_block(text: str) -> str:
-    """Return the one named step, refusing missing or duplicate runners."""
-    marker = f"      - name: {STEP_NAME}\n"
-    assert text.count(marker) == 1, (
-        f"expected exactly one {STEP_NAME!r} step, found {text.count(marker)}"
-    )
-    start = text.index(marker)
-    next_step = text.find("\n      - name:", start + len(marker))
-    assert next_step != -1, "gauntlet must be followed by another named step"
-    return text[start:next_step]
+def parse_workflow(text: str) -> dict[str, object]:
+    document = yaml.load(text, Loader=UniqueKeyLoader)
+    if not isinstance(document, dict):
+        raise WorkflowContractError("workflow root must be a mapping")
+    return document
 
 
-def event_block(text: str) -> str:
-    """Return the top-level event block without a YAML parser dependency."""
-    start = text.index("\non:\n") + 1
-    end = text.index("\nconcurrency:\n", start)
-    return text[start:end]
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise WorkflowContractError(f"{label} must be a mapping")
+    return value
 
 
-def sentinel_patterns(text: str) -> frozenset[str]:
-    return frozenset(_SENTINEL_RE.findall(text))
+def runtime_truth_step(text: str) -> dict[str, object]:
+    document = parse_workflow(text)
+    jobs = _mapping(document.get("jobs"), "jobs")
+    antidotes = _mapping(jobs.get("antidotes"), "jobs.antidotes")
+    steps = antidotes.get("steps")
+    if not isinstance(steps, list):
+        raise WorkflowContractError("jobs.antidotes.steps must be a sequence")
+    matches = [
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == STEP_NAME
+    ]
+    if len(matches) != 1:
+        raise WorkflowContractError(
+            f"expected one {STEP_NAME!r} step, found {len(matches)}"
+        )
+    return matches[0]
 
 
-def runner_path_mentions(text: str) -> tuple[str, ...]:
-    """Active path-only command lines, never paths hidden in comments."""
-    return tuple(_RUNNER_LINE_RE.findall(gauntlet_block(text)))
+def validate_runtime_truth_step(step: Mapping[str, object]) -> None:
+    if dict(step) != EXPECTED_STEP:
+        raise WorkflowContractError(
+            f"runtime truth step differs from exact contract: {dict(step)!r}"
+        )
 
 
-def runner_paths(text: str) -> frozenset[str]:
-    return frozenset(runner_path_mentions(text))
+def sentinel_entries(text: str) -> tuple[str, ...]:
+    return tuple(_SENTINEL_RE.findall(text))
 
 
 def uncovered_subjects(
-    subjects: frozenset[str], patterns: frozenset[str]
+    subjects: frozenset[str], entries: tuple[str, ...]
 ) -> list[str]:
-    """Subjects not named exactly by the in-job sentinel."""
-    return sorted(subjects - patterns)
+    return sorted(subjects - set(entries))
 
 
-def test_apparatus_finds_one_non_vacuous_runner_and_sentinel() -> None:
-    text = _workflow_text()
-    assert runner_paths(text) == RUNNER_PATHS
-    assert len(runner_path_mentions(text)) == len(RUNNER_PATHS)
-    assert len(sentinel_patterns(text)) >= 50
+def _remove_sentinel_entry(text: str, relative_path: str) -> str:
+    pattern = re.compile(
+        rf"^\s+{re.escape(relative_path)}(?:\|\\|\))$\n?",
+        re.MULTILINE,
+    )
+    mutated, replacements = pattern.subn("", text, count=1)
+    if replacements != 1:
+        raise WorkflowContractError(
+            f"could not create sentinel mutation for {relative_path}"
+        )
+    return mutated
 
 
-def test_gauntlet_runs_exactly_the_four_corpora_and_its_meta_test() -> None:
-    text = _workflow_text()
-    assert runner_paths(text) == RUNNER_PATHS
-    assert len(runner_path_mentions(text)) == len(RUNNER_PATHS)
-    assert all("*" not in path for path in runner_path_mentions(text))
+def test_runner_manifest_is_exact_and_contains_four_incident_corpora() -> None:
+    assert gauntlet.PYTEST_TARGETS == EXPECTED_PYTEST_TARGETS
+    assert gauntlet.SHELL_TARGETS == EXPECTED_SHELL_TARGETS
+    assert frozenset(gauntlet.PYTEST_TARGETS[:-1] + gauntlet.SHELL_TARGETS) == (
+        INCIDENT_CORPORA
+    )
 
 
-def test_gauntlet_is_fail_closed_and_uses_only_runner_temp_state() -> None:
-    block = gauntlet_block(_workflow_text())
-    assert "if: steps.paths.outputs.relevant == 'true'" in block
-    assert 'HOME: ${{ runner.temp }}/runtime-truth-home' in block
-    assert 'TMPDIR: ${{ runner.temp }}/runtime-truth-tmp' in block
-    assert "set -euo pipefail" in block
-    assert "python -m pytest \\\n" in block
-    assert "bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh" in block
-    for green_by_construction in (
-        "if [ -f",
-        "continue-on-error",
-        "|| true",
-        "|| :",
-        "pytest.skip",
+def test_workflow_step_matches_exact_structural_contract() -> None:
+    step = runtime_truth_step(_workflow_text())
+    validate_runtime_truth_step(step)
+    assert step == EXPECTED_STEP
+
+
+@pytest.mark.parametrize(
+    "mutated_run",
+    (
+        "exit 0",
+        f"python {RUNNER_RELATIVE} --collect-only",
+    ),
+)
+def test_guilt_exit_zero_and_collect_only_break_step_contract(
+    mutated_run: str,
+) -> None:
+    mutated_step = dict(runtime_truth_step(_workflow_text()))
+    mutated_step["run"] = mutated_run
+    with pytest.raises(WorkflowContractError):
+        validate_runtime_truth_step(mutated_step)
+
+
+def test_runner_rejects_real_runtime_skip(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "test_runtime_skip_probe.py"
+    target.write_text(
+        "import pytest\n\ndef test_probe():\n    pytest.skip('mutant')\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(gauntlet.GauntletContractError, match="skipped="):
+        gauntlet.run_pytest_contract(
+            repo_root=tmp_path,
+            targets=(target.name,),
+        )
+
+
+def test_runner_rejects_real_importorskip(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "test_importorskip_probe.py"
+    target.write_text(
+        "import pytest\n"
+        "pytest.importorskip('runtime_truth_definitely_missing')\n\n"
+        "def test_probe():\n    assert True\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(gauntlet.GauntletContractError, match="skipped="):
+        gauntlet.run_pytest_contract(
+            repo_root=tmp_path,
+            targets=(target.name,),
+        )
+
+
+def test_runner_rejects_real_collect_only(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "test_collect_only_probe.py"
+    target.write_text("def test_probe():\n    assert True\n", encoding="utf-8")
+    with pytest.raises(
+        gauntlet.GauntletContractError,
+        match="collected but not executed",
     ):
-        assert green_by_construction not in block
+        gauntlet.run_pytest_contract(
+            repo_root=tmp_path,
+            targets=(target.name,),
+            extra_options=("--collect-only",),
+        )
 
 
-def test_every_corpus_and_subject_wakes_the_gauntlet() -> None:
+def test_every_corpus_subject_harness_and_workflow_are_exact_triggers() -> None:
+    entries = sentinel_entries(_workflow_text())
+    missing = uncovered_subjects(TRIGGER_SUBJECTS, entries)
+    assert not missing, f"runtime-truth paths missing exact triggers: {missing}"
+    assert entries.count(WORKFLOW_RELATIVE) == 1
+    assert entries.count(RUNNER_RELATIVE) == 1
+
+
+def test_workflow_self_trigger_survives_workflow_glob_removal() -> None:
     text = _workflow_text()
-    missing = uncovered_subjects(TRIGGER_SUBJECTS, sentinel_patterns(text))
-    assert not missing, (
-        "runtime-truth subjects missing from the sentinel path check; edits "
-        f"to them would skip the gauntlet: {missing}"
+    without_globs = _remove_sentinel_entry(
+        _remove_sentinel_entry(text, ".github/workflows/*.yml"),
+        ".github/workflows/*.yaml",
     )
+    assert uncovered_subjects(frozenset({WORKFLOW_RELATIVE}), sentinel_entries(without_globs)) == []
 
 
-def test_required_safe_events_run_on_every_pr_and_merge_group() -> None:
-    events = event_block(_workflow_text())
-    assert "  pull_request:\n" in events
-    assert "  merge_group:\n" in events
-    assert "  workflow_dispatch:\n" in events
-    assert not re.search(r"^\s{4}paths(?:-ignore)?:", events, re.MULTILINE)
-
-
-def test_meta_test_is_itself_run_and_triggered() -> None:
-    text = _workflow_text()
-    assert META_TEST in runner_paths(text)
+def test_guilt_removing_workflow_exact_self_trigger_is_detected() -> None:
+    mutated = _remove_sentinel_entry(_workflow_text(), WORKFLOW_RELATIVE)
     assert uncovered_subjects(
-        frozenset({META_TEST}), sentinel_patterns(text)
+        frozenset({WORKFLOW_RELATIVE}), sentinel_entries(mutated)
+    ) == [WORKFLOW_RELATIVE]
+
+
+def test_required_safe_events_are_structural_and_ungated() -> None:
+    document = parse_workflow(_workflow_text())
+    events = _mapping(document.get("on"), "on")
+    for event in ("workflow_dispatch", "pull_request", "merge_group"):
+        assert event in events
+        event_config = events[event]
+        if isinstance(event_config, Mapping):
+            assert "paths" not in event_config
+            assert "paths-ignore" not in event_config
+
+
+def test_meta_test_is_run_and_self_triggered() -> None:
+    assert META_TEST in gauntlet.PYTEST_TARGETS
+    assert uncovered_subjects(
+        frozenset({META_TEST}), sentinel_entries(_workflow_text())
     ) == []
-
-
-def test_corpora_have_no_skip_or_xfail_escape_hatches() -> None:
-    for relative_path in RUNNER_PATHS:
-        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
-        for escape_hatch in (
-            "pytest." + "skip(",
-            "pytest." + "xfail(",
-            "@pytest.mark." + "skip",
-            "@pytest.mark." + "xfail",
-        ):
-            assert escape_hatch not in source, (
-                f"{relative_path} contains {escape_hatch!r}; the gauntlet must "
-                "report zero skipped/xfail contracts"
-            )
-
-
-def test_guilt_missing_runner_path_is_detected() -> None:
-    text = _workflow_text().replace(
-        f"            {META_TEST} \\\n", "", 1
-    )
-    assert META_TEST not in runner_paths(text)
-    assert runner_paths(text) != RUNNER_PATHS
-
-
-def test_guilt_missing_trigger_path_is_detected() -> None:
-    patterns = frozenset({"scripts/proprioception.py"})
-    missing = uncovered_subjects(
-        frozenset({"scripts/lib/heartbeat.sh"}), patterns
-    )
-    assert missing == ["scripts/lib/heartbeat.sh"]

--- a/scripts/tests/test_runtime_truth_ci_gauntlet.py
+++ b/scripts/tests/test_runtime_truth_ci_gauntlet.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Fail-closed wiring contract for the Runtime Truth CI gauntlet.
+
+The incident corpora are useful only if the required-safe workflow both runs
+them and wakes when either a corpus or one of its subjects changes.  This file
+pins both halves and pins itself, so a future edit cannot make the gate green by
+construction through an omitted runner path, sentinel path, or PR trigger.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "immune-enforcement.yml"
+STEP_NAME = "Runtime Truth CI gauntlet (four incident contracts)"
+
+CORPORA = frozenset(
+    {
+        "apps/evaluator/nlm_deep_research/tests/test_run_verdict.py",
+        "scripts/tests/test_launchd_liveness_expected_nonzero.py",
+        "scripts/tests/test_proprioception_run_wrap_exit_code.py",
+        "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh",
+    }
+)
+META_TEST = "scripts/tests/test_runtime_truth_ci_gauntlet.py"
+RUNNER_PATHS = CORPORA | {META_TEST}
+
+# Every file whose semantics are asserted by the four corpora, plus the wiring
+# contract itself. A wildcard may cover a subject, but every subject must match
+# at least one sentinel pattern.
+TRIGGER_SUBJECTS = frozenset(
+    {
+        "apps/evaluator/nlm_deep_research/run_verdict.py",
+        "apps/evaluator/nlm_deep_research/pipeline.py",
+        "apps/evaluator/nlm_deep_research/nb3_pipeline.py",
+        "apps/evaluator/nlm_deep_research/nb4_pipeline.py",
+        "apps/evaluator/nlm_deep_research/nb5_pipeline.py",
+        "apps/evaluator/nlm_deep_research/nb6_pipeline.py",
+        "apps/evaluator/nlm_deep_research/nb7_pipeline.py",
+        "apps/evaluator/nlm_deep_research/nb8_pipeline.py",
+        "apps/evaluator/nlm_deep_research/nb10_pipeline.py",
+        "scripts/launchd_liveness_detector.py",
+        "scripts/proprioception.py",
+        "scripts/wr2-cron-wrapper.sh",
+        "scripts/lib/heartbeat.sh",
+    }
+) | RUNNER_PATHS
+
+_SENTINEL_RE = re.compile(
+    r"^\s+([A-Za-z0-9_./*-]+\.(?:py|sh|md|json|txt|yml|yaml))\|?\\?$",
+    re.MULTILINE,
+)
+_RUNNER_LINE_RE = re.compile(
+    r"^\s+(?:bash\s+)?((?:apps|scripts)/[A-Za-z0-9_./-]+\.(?:py|sh))\s*\\?$",
+    re.MULTILINE,
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def gauntlet_block(text: str) -> str:
+    """Return the one named step, refusing missing or duplicate runners."""
+    marker = f"      - name: {STEP_NAME}\n"
+    assert text.count(marker) == 1, (
+        f"expected exactly one {STEP_NAME!r} step, found {text.count(marker)}"
+    )
+    start = text.index(marker)
+    next_step = text.find("\n      - name:", start + len(marker))
+    assert next_step != -1, "gauntlet must be followed by another named step"
+    return text[start:next_step]
+
+
+def event_block(text: str) -> str:
+    """Return the top-level event block without a YAML parser dependency."""
+    start = text.index("\non:\n") + 1
+    end = text.index("\nconcurrency:\n", start)
+    return text[start:end]
+
+
+def sentinel_patterns(text: str) -> frozenset[str]:
+    return frozenset(_SENTINEL_RE.findall(text))
+
+
+def runner_path_mentions(text: str) -> tuple[str, ...]:
+    """Active path-only command lines, never paths hidden in comments."""
+    return tuple(_RUNNER_LINE_RE.findall(gauntlet_block(text)))
+
+
+def runner_paths(text: str) -> frozenset[str]:
+    return frozenset(runner_path_mentions(text))
+
+
+def uncovered_subjects(
+    subjects: frozenset[str], patterns: frozenset[str]
+) -> list[str]:
+    """Subjects not named exactly by the in-job sentinel."""
+    return sorted(subjects - patterns)
+
+
+def test_apparatus_finds_one_non_vacuous_runner_and_sentinel() -> None:
+    text = _workflow_text()
+    assert runner_paths(text) == RUNNER_PATHS
+    assert len(runner_path_mentions(text)) == len(RUNNER_PATHS)
+    assert len(sentinel_patterns(text)) >= 50
+
+
+def test_gauntlet_runs_exactly_the_four_corpora_and_its_meta_test() -> None:
+    text = _workflow_text()
+    assert runner_paths(text) == RUNNER_PATHS
+    assert len(runner_path_mentions(text)) == len(RUNNER_PATHS)
+    assert all("*" not in path for path in runner_path_mentions(text))
+
+
+def test_gauntlet_is_fail_closed_and_uses_only_runner_temp_state() -> None:
+    block = gauntlet_block(_workflow_text())
+    assert "if: steps.paths.outputs.relevant == 'true'" in block
+    assert 'HOME: ${{ runner.temp }}/runtime-truth-home' in block
+    assert 'TMPDIR: ${{ runner.temp }}/runtime-truth-tmp' in block
+    assert "set -euo pipefail" in block
+    assert "python -m pytest \\\n" in block
+    assert "bash scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh" in block
+    for green_by_construction in (
+        "if [ -f",
+        "continue-on-error",
+        "|| true",
+        "|| :",
+        "pytest.skip",
+    ):
+        assert green_by_construction not in block
+
+
+def test_every_corpus_and_subject_wakes_the_gauntlet() -> None:
+    text = _workflow_text()
+    missing = uncovered_subjects(TRIGGER_SUBJECTS, sentinel_patterns(text))
+    assert not missing, (
+        "runtime-truth subjects missing from the sentinel path check; edits "
+        f"to them would skip the gauntlet: {missing}"
+    )
+
+
+def test_required_safe_events_run_on_every_pr_and_merge_group() -> None:
+    events = event_block(_workflow_text())
+    assert "  pull_request:\n" in events
+    assert "  merge_group:\n" in events
+    assert "  workflow_dispatch:\n" in events
+    assert not re.search(r"^\s{4}paths(?:-ignore)?:", events, re.MULTILINE)
+
+
+def test_meta_test_is_itself_run_and_triggered() -> None:
+    text = _workflow_text()
+    assert META_TEST in runner_paths(text)
+    assert uncovered_subjects(
+        frozenset({META_TEST}), sentinel_patterns(text)
+    ) == []
+
+
+def test_corpora_have_no_skip_or_xfail_escape_hatches() -> None:
+    for relative_path in RUNNER_PATHS:
+        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        for escape_hatch in (
+            "pytest." + "skip(",
+            "pytest." + "xfail(",
+            "@pytest.mark." + "skip",
+            "@pytest.mark." + "xfail",
+        ):
+            assert escape_hatch not in source, (
+                f"{relative_path} contains {escape_hatch!r}; the gauntlet must "
+                "report zero skipped/xfail contracts"
+            )
+
+
+def test_guilt_missing_runner_path_is_detected() -> None:
+    text = _workflow_text().replace(
+        f"            {META_TEST} \\\n", "", 1
+    )
+    assert META_TEST not in runner_paths(text)
+    assert runner_paths(text) != RUNNER_PATHS
+
+
+def test_guilt_missing_trigger_path_is_detected() -> None:
+    patterns = frozenset({"scripts/proprioception.py"})
+    missing = uncovered_subjects(
+        frozenset({"scripts/lib/heartbeat.sh"}), patterns
+    )
+    assert missing == ["scripts/lib/heartbeat.sh"]

--- a/scripts/tests/test_runtime_truth_ci_gauntlet.py
+++ b/scripts/tests/test_runtime_truth_ci_gauntlet.py
@@ -59,7 +59,7 @@ EXPECTED_META_STEP: Final[dict[str, object]] = {
     },
     "run": (
         'mkdir -p "$HOME" "$TMPDIR"\n'
-        "python -m pip install --quiet pytest PyYAML==6.0.3\n"
+        "python -m pip install --quiet pytest PyYAML==6.0.3 httpx==0.28.1\n"
         f"python -m pytest {META_TEST} -q\n"
     ),
 }
@@ -454,7 +454,7 @@ def _run_exact_meta_step(
         "test -d \"$HOME\"\n"
         "test -d \"$TMPDIR\"\n"
         "printf '%s\\n' \"$*\" >> \"$RUNTIME_TRUTH_COMMAND_LOG\"\n"
-        "if [ \"$*\" = '-m pip install --quiet pytest PyYAML==6.0.3' ]; then\n"
+        "if [ \"$*\" = '-m pip install --quiet pytest PyYAML==6.0.3 httpx==0.28.1' ]; then\n"
         "  : > \"$RUNTIME_TRUTH_DEP_MARKER\"\n"
         "elif [ \"$*\" = '-m pytest scripts/tests/test_runtime_truth_ci_gauntlet.py -q' ]; then\n"
         "  test -f \"$RUNTIME_TRUTH_DEP_MARKER\"\n"
@@ -553,7 +553,7 @@ def test_exact_meta_workflow_shell_bootstraps_absent_environment_and_dependencie
         tmp_path=tmp_path,
     )
     assert commands == [
-        "-m pip install --quiet pytest PyYAML==6.0.3",
+        "-m pip install --quiet pytest PyYAML==6.0.3 httpx==0.28.1",
         f"-m pytest {META_TEST} -q",
     ]
 
@@ -562,7 +562,7 @@ def test_exact_meta_workflow_shell_bootstraps_absent_environment_and_dependencie
     "removed_line",
     (
         'mkdir -p "$HOME" "$TMPDIR"\n',
-        "python -m pip install --quiet pytest PyYAML==6.0.3\n",
+        "python -m pip install --quiet pytest PyYAML==6.0.3 httpx==0.28.1\n",
     ),
 )
 def test_guilt_meta_bootstrap_or_dependency_removal_fails_closed(

--- a/scripts/tests/test_runtime_truth_ci_gauntlet.py
+++ b/scripts/tests/test_runtime_truth_ci_gauntlet.py
@@ -57,7 +57,11 @@ EXPECTED_META_STEP: Final[dict[str, object]] = {
         "HOME": "${{ runner.temp }}/runtime-truth-home",
         "TMPDIR": "${{ runner.temp }}/runtime-truth-tmp",
     },
-    "run": f"python -m pytest {META_TEST} -q",
+    "run": (
+        'mkdir -p "$HOME" "$TMPDIR"\n'
+        "python -m pip install --quiet pytest PyYAML==6.0.3\n"
+        f"python -m pytest {META_TEST} -q\n"
+    ),
 }
 EXPECTED_RUNNER_STEP: Final[dict[str, object]] = {
     "name": RUNNER_STEP_NAME,
@@ -416,6 +420,77 @@ def _detector_result(script: str, tmp_path: pathlib.Path) -> str:
     return values[0]
 
 
+def _run_exact_meta_step(
+    *,
+    step: Mapping[str, object],
+    relevant: str,
+    tmp_path: pathlib.Path,
+) -> list[str]:
+    """Execute the parsed workflow shell from an absent-dir state.
+
+    The setup-python action guarantees the interpreter, so this probe provides a
+    tiny interpreter shim.  It refuses to launch the meta suite until the exact
+    dependency-install command ran and until the workflow shell itself created
+    HOME/TMPDIR.  Nothing in the test pre-creates those directories.
+    """
+    assert relevant in {"true", "false"}
+    assert "if" not in step
+    run = step.get("run")
+    assert isinstance(run, str)
+
+    runner_temp = tmp_path / f"runner-{relevant}"
+    home = runner_temp / "runtime-truth-home"
+    temp = runner_temp / "runtime-truth-tmp"
+    fake_bin = tmp_path / f"bin-{relevant}"
+    fake_bin.mkdir()
+    command_log = tmp_path / f"python-{relevant}.log"
+    dependency_marker = tmp_path / f"deps-{relevant}.ready"
+    python = fake_bin / "python"
+    python.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        ": \"${RUNTIME_TRUTH_COMMAND_LOG:?}\"\n"
+        ": \"${RUNTIME_TRUTH_DEP_MARKER:?}\"\n"
+        "test -d \"$HOME\"\n"
+        "test -d \"$TMPDIR\"\n"
+        "printf '%s\\n' \"$*\" >> \"$RUNTIME_TRUTH_COMMAND_LOG\"\n"
+        "if [ \"$*\" = '-m pip install --quiet pytest PyYAML==6.0.3' ]; then\n"
+        "  : > \"$RUNTIME_TRUTH_DEP_MARKER\"\n"
+        "elif [ \"$*\" = '-m pytest scripts/tests/test_runtime_truth_ci_gauntlet.py -q' ]; then\n"
+        "  test -f \"$RUNTIME_TRUTH_DEP_MARKER\"\n"
+        "else\n"
+        "  exit 97\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    python.chmod(0o755)
+    assert not home.exists()
+    assert not temp.exists()
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(home),
+            "TMPDIR": str(temp),
+            "PATH": os.pathsep.join((str(fake_bin), environment.get("PATH", ""))),
+            "RUNTIME_TRUTH_COMMAND_LOG": str(command_log),
+            "RUNTIME_TRUTH_DEP_MARKER": str(dependency_marker),
+            "RUNTIME_TRUTH_RELEVANT": relevant,
+        }
+    )
+    subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", run],
+        cwd=REPO_ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert home.is_dir()
+    assert temp.is_dir()
+    return command_log.read_text(encoding="utf-8").splitlines()
+
+
 def test_runner_manifest_is_exact_and_contains_four_incident_corpora() -> None:
     assert gauntlet.PYTEST_TARGETS == EXPECTED_PYTEST_TARGETS
     assert gauntlet.SHELL_TARGETS == EXPECTED_SHELL_TARGETS
@@ -432,6 +507,49 @@ def test_workflow_steps_match_exact_structural_contract_and_order() -> None:
     validate_exact_step(meta_step, EXPECTED_META_STEP)
     validate_exact_step(runner_step, EXPECTED_RUNNER_STEP)
     assert meta_index < runner_index
+
+
+@pytest.mark.parametrize("relevant", ("true", "false"))
+def test_exact_meta_workflow_shell_bootstraps_absent_environment_and_dependencies(
+    tmp_path: pathlib.Path,
+    relevant: str,
+) -> None:
+    _, meta_step = named_step(_workflow_text(), META_STEP_NAME)
+    commands = _run_exact_meta_step(
+        step=meta_step,
+        relevant=relevant,
+        tmp_path=tmp_path,
+    )
+    assert commands == [
+        "-m pip install --quiet pytest PyYAML==6.0.3",
+        f"-m pytest {META_TEST} -q",
+    ]
+
+
+@pytest.mark.parametrize(
+    "removed_line",
+    (
+        'mkdir -p "$HOME" "$TMPDIR"\n',
+        "python -m pip install --quiet pytest PyYAML==6.0.3\n",
+    ),
+)
+def test_guilt_meta_bootstrap_or_dependency_removal_fails_closed(
+    tmp_path: pathlib.Path,
+    removed_line: str,
+) -> None:
+    _, meta_step = named_step(_workflow_text(), META_STEP_NAME)
+    run = meta_step.get("run")
+    assert isinstance(run, str)
+    mutated_run = run.replace(removed_line, "", 1)
+    assert mutated_run != run
+    mutated_step = dict(meta_step)
+    mutated_step["run"] = mutated_run
+    with pytest.raises(subprocess.CalledProcessError):
+        _run_exact_meta_step(
+            step=mutated_step,
+            relevant="false",
+            tmp_path=tmp_path,
+        )
 
 
 def test_unconditional_meta_dynamically_proves_detector_relevant_path(
@@ -600,13 +718,19 @@ def test_runner_rejects_real_xpass(tmp_path: pathlib.Path) -> None:
         gauntlet.run_pytest_contract(repo_root=tmp_path, targets=(target.name,))
 
 
-def test_shell_contract_rejects_exit_zero_with_zero_structured_cases(
+def test_shell_contract_rejects_real_wrapper_exit_zero_with_zero_observations(
     tmp_path: pathlib.Path,
 ) -> None:
     target = _write_shell_mutant_repo(
         tmp_path,
-        "#!/usr/bin/env bash\necho '0 passed, 0 failed'\nexit 0\n",
+        (REPO_ROOT / EXPECTED_SHELL_TARGETS[0]).read_text(encoding="utf-8"),
     )
+    wrapper = tmp_path / gauntlet.WR2_WRAPPER_RELATIVE
+    wrapper.write_text(
+        "#!/usr/bin/env bash\necho '0 passed, 0 failed'\nexit 0\n",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
     with pytest.raises(gauntlet.GauntletContractError):
         gauntlet.run_shell_contract(
             repo_root=tmp_path,
@@ -636,9 +760,10 @@ def test_parent_observer_binds_exact_cases_to_real_wrapper_outcomes() -> None:
     assert evidence.failed == evidence.skipped == 0
 
 
-def test_shell_contract_rejects_four_hardcoded_pass_receipts(
+def test_shell_child_forged_receipts_are_outside_parent_evidence_path(
     tmp_path: pathlib.Path,
 ) -> None:
+    marker = tmp_path / "forged-child-ran"
     receipts = "".join(
         f"printf 'runtime-truth-shell-v1\\t{case_id}\\tpassed\\n' >&\"$fd\"\n"
         for case_id in EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]]
@@ -646,35 +771,41 @@ def test_shell_contract_rejects_four_hardcoded_pass_receipts(
     target = _write_shell_mutant_repo(
         tmp_path,
         "#!/usr/bin/env bash\n"
+        f"touch {marker}\n"
         "fd=\"${RUNTIME_TRUTH_EVIDENCE_FD:?}\"\n"
         f"{receipts}"
         "exit 0\n",
     )
-    with pytest.raises(gauntlet.GauntletContractError):
-        gauntlet.run_shell_contract(
-            repo_root=tmp_path,
-            relative_path=target.relative_to(tmp_path).as_posix(),
-            expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
-        )
+    evidence = gauntlet.run_shell_contract(
+        repo_root=tmp_path,
+        relative_path=target.relative_to(tmp_path).as_posix(),
+        expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
+    )
+    assert evidence.collected == evidence.executed == evidence.passed == 4
+    assert evidence.failed == evidence.skipped == 0
+    assert not marker.exists()
 
 
-def test_shell_contract_rejects_four_hardcoded_stdout_passes(
+def test_shell_child_noop_stdout_is_outside_parent_evidence_path(
     tmp_path: pathlib.Path,
 ) -> None:
+    marker = tmp_path / "noop-child-ran"
     receipts = "".join(
         f"printf 'runtime-truth-shell-v1\\t{case_id}\\tpassed\\n'\n"
         for case_id in EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]]
     )
     target = _write_shell_mutant_repo(
         tmp_path,
-        f"#!/usr/bin/env bash\n{receipts}exit 0\n",
+        f"#!/usr/bin/env bash\ntouch {marker}\n{receipts}exit 0\n",
     )
-    with pytest.raises(gauntlet.GauntletContractError, match="sidecar"):
-        gauntlet.run_shell_contract(
-            repo_root=tmp_path,
-            relative_path=target.relative_to(tmp_path).as_posix(),
-            expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
-        )
+    evidence = gauntlet.run_shell_contract(
+        repo_root=tmp_path,
+        relative_path=target.relative_to(tmp_path).as_posix(),
+        expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
+    )
+    assert evidence.collected == evidence.executed == evidence.passed == 4
+    assert evidence.failed == evidence.skipped == 0
+    assert not marker.exists()
 
 
 def test_every_corpus_subject_harness_and_workflow_are_exact_triggers() -> None:

--- a/scripts/tests/test_runtime_truth_ci_gauntlet.py
+++ b/scripts/tests/test_runtime_truth_ci_gauntlet.py
@@ -4,8 +4,11 @@
 from __future__ import annotations
 
 import ast
+import os
 import pathlib
 import re
+import shutil
+import subprocess
 from collections.abc import Mapping
 from typing import Final
 
@@ -22,6 +25,7 @@ RUNNER: Final = REPO_ROOT / RUNNER_RELATIVE
 META_TEST: Final = "scripts/tests/test_runtime_truth_ci_gauntlet.py"
 META_STEP_NAME: Final = "Runtime Truth meta-contract (external to runner)"
 RUNNER_STEP_NAME: Final = "Runtime Truth CI gauntlet (four incident contracts)"
+DETECTOR_STEP_NAME: Final = "Detect immune-relevant changes (sentinel path check)"
 
 INCIDENT_CORPORA: Final[frozenset[str]] = frozenset(
     {
@@ -49,7 +53,6 @@ EXPECTED_SHELL_CASES: Final[dict[str, tuple[str, ...]]] = {
 }
 EXPECTED_META_STEP: Final[dict[str, object]] = {
     "name": META_STEP_NAME,
-    "if": "steps.paths.outputs.relevant == 'true'",
     "env": {
         "HOME": "${{ runner.temp }}/runtime-truth-home",
         "TMPDIR": "${{ runner.temp }}/runtime-truth-tmp",
@@ -174,6 +177,14 @@ def runtime_truth_step(text: str) -> dict[str, object]:
     return named_step(text, RUNNER_STEP_NAME)[1]
 
 
+def detector_script(text: str) -> str:
+    _, step = named_step(text, DETECTOR_STEP_NAME)
+    script = step.get("run")
+    if not isinstance(script, str):
+        raise WorkflowContractError("path detector run must be a string")
+    return script
+
+
 def validate_exact_step(
     step: Mapping[str, object], expected: Mapping[str, object]
 ) -> None:
@@ -235,6 +246,176 @@ def _remove_sentinel_entry(text: str, relative_path: str) -> str:
     return mutated
 
 
+def _assert_main_runs_exact_contracts(
+    monkeypatch: pytest.MonkeyPatch,
+    namespace: dict[str, object],
+) -> None:
+    """External observer for ``main``: both contracts must run once, in order."""
+    calls: list[tuple[object, ...]] = []
+    pytest_evidence = gauntlet.PytestEvidence(repo_root=REPO_ROOT)
+    shell_evidence = (
+        gauntlet.ShellEvidence(
+            target=EXPECTED_SHELL_TARGETS[0],
+            expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
+            cases=tuple(
+                gauntlet.ShellCaseEvidence(
+                    case_id=case_id,
+                    exit_code=0,
+                    expected_exit_code=0,
+                    sidecar_status="ok",
+                    expected_sidecar_status="ok",
+                )
+                for case_id in EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]]
+            ),
+        ),
+    )
+
+    def prepare() -> None:
+        calls.append(("prepare",))
+
+    def run_pytest(
+        *,
+        repo_root: pathlib.Path,
+        targets: tuple[str, ...],
+    ) -> gauntlet.PytestEvidence:
+        calls.append(("pytest", repo_root, tuple(targets)))
+        return pytest_evidence
+
+    def run_shell(repo_root: pathlib.Path) -> tuple[gauntlet.ShellEvidence, ...]:
+        calls.append(("shell", repo_root))
+        return shell_evidence
+
+    monkeypatch.setitem(namespace, "_prepare_hermetic_directories", prepare)
+    monkeypatch.setitem(namespace, "run_pytest_contract", run_pytest)
+    monkeypatch.setitem(namespace, "run_shell_contracts", run_shell)
+
+    main = namespace["main"]
+    assert callable(main)
+    assert main(()) == 0
+    assert calls == [
+        ("prepare",),
+        ("pytest", namespace["REPO_ROOT"], namespace["PYTEST_TARGETS"]),
+        ("shell", namespace["REPO_ROOT"]),
+    ]
+
+
+def _runner_namespace(text: str) -> dict[str, object]:
+    parsed = ast.parse(text)
+    main_nodes = [
+        node
+        for node in parsed.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "main"
+    ]
+    assert len(main_nodes) == 1
+    namespace = dict(gauntlet.__dict__)
+    namespace["__name__"] = "runtime_truth_ci_gauntlet_mutant"
+    exec(
+        compile(ast.Module(body=main_nodes, type_ignores=[]), str(RUNNER), "exec"),
+        namespace,
+    )
+    return namespace
+
+
+def _insert_early_return_in_main(text: str) -> str:
+    module = ast.parse(text)
+    matches = [
+        node
+        for node in module.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "main"
+    ]
+    assert len(matches) == 1
+    main_node = matches[0]
+    assert main_node.body
+    lines = text.splitlines(keepends=True)
+    lines.insert(main_node.body[0].lineno - 1, "    return 0\n")
+    return "".join(lines)
+
+
+def _write_shell_mutant_repo(tmp_path: pathlib.Path, harness: str) -> pathlib.Path:
+    """Build a complete fake repo so failure comes from observation, not missing files."""
+    for relative_path in (
+        "scripts/wr2-cron-wrapper.sh",
+        "scripts/lib/heartbeat.sh",
+    ):
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / relative_path, destination)
+    target = tmp_path / EXPECTED_SHELL_TARGETS[0]
+    target.write_text(harness, encoding="utf-8")
+    target.chmod(0o755)
+    return target
+
+
+def _detector_result(script: str, tmp_path: pathlib.Path) -> str:
+    """Execute the workflow detector against a real two-commit local repository."""
+    repo = tmp_path / "detector-repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    git("init", "-q")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", "README.md")
+    git(
+        "-c",
+        "user.name=Runtime Truth",
+        "-c",
+        "user.email=runtime-truth@example.invalid",
+        "commit",
+        "-qm",
+        "base",
+    )
+    base_sha = git("rev-parse", "HEAD")
+    subject = repo / RUNNER_RELATIVE
+    subject.parent.mkdir(parents=True)
+    subject.write_text("# changed runtime truth subject\n", encoding="utf-8")
+    git("add", RUNNER_RELATIVE)
+    git(
+        "-c",
+        "user.name=Runtime Truth",
+        "-c",
+        "user.email=runtime-truth@example.invalid",
+        "commit",
+        "-qm",
+        "head",
+    )
+    head_sha = git("rev-parse", "HEAD")
+    output = tmp_path / "github-output"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "BASE_SHA": base_sha,
+            "HEAD_SHA": head_sha,
+            "GITHUB_OUTPUT": str(output),
+        }
+    )
+    subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", script],
+        cwd=repo,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    values = [
+        line.removeprefix("relevant=")
+        for line in output.read_text(encoding="utf-8").splitlines()
+        if line.startswith("relevant=")
+    ]
+    assert len(values) == 1
+    return values[0]
+
+
 def test_runner_manifest_is_exact_and_contains_four_incident_corpora() -> None:
     assert gauntlet.PYTEST_TARGETS == EXPECTED_PYTEST_TARGETS
     assert gauntlet.SHELL_TARGETS == EXPECTED_SHELL_TARGETS
@@ -253,8 +434,82 @@ def test_workflow_steps_match_exact_structural_contract_and_order() -> None:
     assert meta_index < runner_index
 
 
+def test_unconditional_meta_dynamically_proves_detector_relevant_path(
+    tmp_path: pathlib.Path,
+) -> None:
+    text = _workflow_text()
+    _, meta_step = named_step(text, META_STEP_NAME)
+    assert "if" not in meta_step
+    assert _detector_result(detector_script(text), tmp_path) == "true"
+
+
+def test_guilt_detector_relevant_true_mutated_false_is_rejected(
+    tmp_path: pathlib.Path,
+) -> None:
+    original = detector_script(_workflow_text())
+    mutated, replacements = re.subn(
+        r"^(\s+)RELEVANT=true$",
+        r"\1RELEVANT=false",
+        original,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    assert replacements == 1
+    assert _detector_result(mutated, tmp_path) == "false"
+
+
 def test_runner_entrypoint_delegates_to_main_structurally() -> None:
     assert validate_runner_entrypoint(_runner_text()) is None
+
+
+def test_external_observer_proves_main_runs_both_contracts_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_main_runs_exact_contracts(monkeypatch, gauntlet.__dict__)
+
+
+def test_guilt_early_return_inside_main_is_rejected_dynamically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mutated = _insert_early_return_in_main(_runner_text())
+    namespace = _runner_namespace(mutated)
+    with pytest.raises(AssertionError):
+        _assert_main_runs_exact_contracts(monkeypatch, namespace)
+
+
+@pytest.mark.parametrize(
+    ("failing_contract", "expected_calls"),
+    (("pytest", ["prepare", "pytest"]), ("shell", ["prepare", "pytest", "shell"])),
+)
+def test_main_fails_closed_when_either_contract_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_contract: str,
+    expected_calls: list[str],
+) -> None:
+    calls: list[str] = []
+
+    def prepare() -> None:
+        calls.append("prepare")
+
+    def run_pytest(
+        *, repo_root: pathlib.Path, targets: tuple[str, ...]
+    ) -> gauntlet.PytestEvidence:
+        del targets
+        calls.append("pytest")
+        if failing_contract == "pytest":
+            raise gauntlet.GauntletContractError("pytest mutant")
+        return gauntlet.PytestEvidence(repo_root=repo_root)
+
+    def run_shell(repo_root: pathlib.Path) -> tuple[gauntlet.ShellEvidence, ...]:
+        del repo_root
+        calls.append("shell")
+        raise gauntlet.GauntletContractError("shell mutant")
+
+    monkeypatch.setattr(gauntlet, "_prepare_hermetic_directories", prepare)
+    monkeypatch.setattr(gauntlet, "run_pytest_contract", run_pytest)
+    monkeypatch.setattr(gauntlet, "run_shell_contracts", run_shell)
+    assert gauntlet.main(()) == 1
+    assert calls == expected_calls
 
 
 def test_guilt_runner_entrypoint_early_exit_is_rejected() -> None:
@@ -348,13 +603,77 @@ def test_runner_rejects_real_xpass(tmp_path: pathlib.Path) -> None:
 def test_shell_contract_rejects_exit_zero_with_zero_structured_cases(
     tmp_path: pathlib.Path,
 ) -> None:
-    target = tmp_path / "fake_shell_contract.sh"
-    target.write_text("echo '0 passed, 0 failed'\nexit 0\n", encoding="utf-8")
-    with pytest.raises(gauntlet.GauntletContractError, match="executed=0"):
+    target = _write_shell_mutant_repo(
+        tmp_path,
+        "#!/usr/bin/env bash\necho '0 passed, 0 failed'\nexit 0\n",
+    )
+    with pytest.raises(gauntlet.GauntletContractError):
         gauntlet.run_shell_contract(
             repo_root=tmp_path,
-            relative_path=target.name,
-            expected_cases=("guilt", "innocence", "fix", "self_heal"),
+            relative_path=target.relative_to(tmp_path).as_posix(),
+            expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
+        )
+
+
+def test_parent_observer_binds_exact_cases_to_real_wrapper_outcomes() -> None:
+    expected_cases = EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]]
+    evidence = gauntlet.run_shell_contract(
+        repo_root=REPO_ROOT,
+        relative_path=EXPECTED_SHELL_TARGETS[0],
+        expected_cases=expected_cases,
+    )
+    assert tuple(case.case_id for case in evidence.cases) == expected_cases
+    assert [
+        (case.exit_code, case.sidecar_status)
+        for case in evidence.cases
+    ] == [(74, "error"), (74, "error"), (0, "ok"), (0, "ok")]
+    self_heal = evidence.cases[-1]
+    assert (
+        self_heal.precondition_exit_code,
+        self_heal.precondition_sidecar_status,
+    ) == (74, "error")
+    assert evidence.collected == evidence.executed == evidence.passed == 4
+    assert evidence.failed == evidence.skipped == 0
+
+
+def test_shell_contract_rejects_four_hardcoded_pass_receipts(
+    tmp_path: pathlib.Path,
+) -> None:
+    receipts = "".join(
+        f"printf 'runtime-truth-shell-v1\\t{case_id}\\tpassed\\n' >&\"$fd\"\n"
+        for case_id in EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]]
+    )
+    target = _write_shell_mutant_repo(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        "fd=\"${RUNTIME_TRUTH_EVIDENCE_FD:?}\"\n"
+        f"{receipts}"
+        "exit 0\n",
+    )
+    with pytest.raises(gauntlet.GauntletContractError):
+        gauntlet.run_shell_contract(
+            repo_root=tmp_path,
+            relative_path=target.relative_to(tmp_path).as_posix(),
+            expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
+        )
+
+
+def test_shell_contract_rejects_four_hardcoded_stdout_passes(
+    tmp_path: pathlib.Path,
+) -> None:
+    receipts = "".join(
+        f"printf 'runtime-truth-shell-v1\\t{case_id}\\tpassed\\n'\n"
+        for case_id in EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]]
+    )
+    target = _write_shell_mutant_repo(
+        tmp_path,
+        f"#!/usr/bin/env bash\n{receipts}exit 0\n",
+    )
+    with pytest.raises(gauntlet.GauntletContractError, match="sidecar"):
+        gauntlet.run_shell_contract(
+            repo_root=tmp_path,
+            relative_path=target.relative_to(tmp_path).as_posix(),
+            expected_cases=EXPECTED_SHELL_CASES[EXPECTED_SHELL_TARGETS[0]],
         )
 
 

--- a/scripts/tests/test_runtime_truth_ci_gauntlet.py
+++ b/scripts/tests/test_runtime_truth_ci_gauntlet.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 import pathlib
 import re
 from collections.abc import Mapping
@@ -17,8 +18,10 @@ REPO_ROOT: Final = pathlib.Path(__file__).resolve().parents[2]
 WORKFLOW_RELATIVE: Final = ".github/workflows/immune-enforcement.yml"
 WORKFLOW: Final = REPO_ROOT / WORKFLOW_RELATIVE
 RUNNER_RELATIVE: Final = "scripts/runtime_truth_ci_gauntlet.py"
+RUNNER: Final = REPO_ROOT / RUNNER_RELATIVE
 META_TEST: Final = "scripts/tests/test_runtime_truth_ci_gauntlet.py"
-STEP_NAME: Final = "Runtime Truth CI gauntlet (four incident contracts)"
+META_STEP_NAME: Final = "Runtime Truth meta-contract (external to runner)"
+RUNNER_STEP_NAME: Final = "Runtime Truth CI gauntlet (four incident contracts)"
 
 INCIDENT_CORPORA: Final[frozenset[str]] = frozenset(
     {
@@ -32,13 +35,29 @@ EXPECTED_PYTEST_TARGETS: Final[tuple[str, ...]] = (
     "apps/evaluator/nlm_deep_research/tests/test_run_verdict.py",
     "scripts/tests/test_launchd_liveness_expected_nonzero.py",
     "scripts/tests/test_proprioception_run_wrap_exit_code.py",
-    META_TEST,
 )
 EXPECTED_SHELL_TARGETS: Final[tuple[str, ...]] = (
     "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh",
 )
-EXPECTED_STEP: Final[dict[str, object]] = {
-    "name": STEP_NAME,
+EXPECTED_SHELL_CASES: Final[dict[str, tuple[str, ...]]] = {
+    "scripts/test_wr2_wrapper_pg_proxy_heartbeat.sh": (
+        "pg_proxy_unreachable",
+        "database_url_local_missing",
+        "pg_proxy_reachable",
+        "heartbeat_self_heal",
+    ),
+}
+EXPECTED_META_STEP: Final[dict[str, object]] = {
+    "name": META_STEP_NAME,
+    "if": "steps.paths.outputs.relevant == 'true'",
+    "env": {
+        "HOME": "${{ runner.temp }}/runtime-truth-home",
+        "TMPDIR": "${{ runner.temp }}/runtime-truth-tmp",
+    },
+    "run": f"python -m pytest {META_TEST} -q",
+}
+EXPECTED_RUNNER_STEP: Final[dict[str, object]] = {
+    "name": RUNNER_STEP_NAME,
     "if": "steps.paths.outputs.relevant == 'true'",
     "env": {
         "HOME": "${{ runner.temp }}/runtime-truth-home",
@@ -112,6 +131,10 @@ def _workflow_text() -> str:
     return WORKFLOW.read_text(encoding="utf-8")
 
 
+def _runner_text() -> str:
+    return RUNNER.read_text(encoding="utf-8")
+
+
 def parse_workflow(text: str) -> dict[str, object]:
     document = yaml.load(text, Loader=UniqueKeyLoader)
     if not isinstance(document, dict):
@@ -125,29 +148,67 @@ def _mapping(value: object, label: str) -> Mapping[str, object]:
     return value
 
 
-def runtime_truth_step(text: str) -> dict[str, object]:
+def antidotes_steps(text: str) -> list[object]:
     document = parse_workflow(text)
     jobs = _mapping(document.get("jobs"), "jobs")
     antidotes = _mapping(jobs.get("antidotes"), "jobs.antidotes")
     steps = antidotes.get("steps")
     if not isinstance(steps, list):
         raise WorkflowContractError("jobs.antidotes.steps must be a sequence")
+    return steps
+
+
+def named_step(text: str, name: str) -> tuple[int, dict[str, object]]:
+    steps = antidotes_steps(text)
     matches = [
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == STEP_NAME
+        (index, step)
+        for index, step in enumerate(steps)
+        if isinstance(step, dict) and step.get("name") == name
     ]
     if len(matches) != 1:
-        raise WorkflowContractError(
-            f"expected one {STEP_NAME!r} step, found {len(matches)}"
-        )
+        raise WorkflowContractError(f"expected one {name!r} step, found {len(matches)}")
     return matches[0]
 
 
-def validate_runtime_truth_step(step: Mapping[str, object]) -> None:
-    if dict(step) != EXPECTED_STEP:
+def runtime_truth_step(text: str) -> dict[str, object]:
+    return named_step(text, RUNNER_STEP_NAME)[1]
+
+
+def validate_exact_step(
+    step: Mapping[str, object], expected: Mapping[str, object]
+) -> None:
+    if dict(step) != dict(expected):
         raise WorkflowContractError(
             f"runtime truth step differs from exact contract: {dict(step)!r}"
+        )
+
+
+def validate_runner_entrypoint(text: str) -> None:
+    """Require the executable entrypoint to delegate to ``main`` structurally."""
+    try:
+        module = ast.parse(text)
+    except SyntaxError as exc:
+        raise WorkflowContractError(f"runner is not valid Python: {exc}") from exc
+
+    expected = ast.parse(
+        'if __name__ == "__main__":\n    raise SystemExit(main())\n'
+    ).body[0]
+    candidates = [
+        node
+        for node in module.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Name)
+        and node.test.left.id == "__name__"
+    ]
+    if len(candidates) != 1:
+        raise WorkflowContractError(
+            f"expected one runner __name__ entrypoint, found {len(candidates)}"
+        )
+    entrypoint = candidates[0]
+    if entrypoint is not module.body[-1] or ast.dump(entrypoint) != ast.dump(expected):
+        raise WorkflowContractError(
+            "runner entrypoint must end with raise SystemExit(main())"
         )
 
 
@@ -177,15 +238,31 @@ def _remove_sentinel_entry(text: str, relative_path: str) -> str:
 def test_runner_manifest_is_exact_and_contains_four_incident_corpora() -> None:
     assert gauntlet.PYTEST_TARGETS == EXPECTED_PYTEST_TARGETS
     assert gauntlet.SHELL_TARGETS == EXPECTED_SHELL_TARGETS
-    assert frozenset(gauntlet.PYTEST_TARGETS[:-1] + gauntlet.SHELL_TARGETS) == (
+    assert gauntlet.SHELL_CASES == EXPECTED_SHELL_CASES
+    assert frozenset(gauntlet.PYTEST_TARGETS + gauntlet.SHELL_TARGETS) == (
         INCIDENT_CORPORA
     )
 
 
-def test_workflow_step_matches_exact_structural_contract() -> None:
-    step = runtime_truth_step(_workflow_text())
-    validate_runtime_truth_step(step)
-    assert step == EXPECTED_STEP
+def test_workflow_steps_match_exact_structural_contract_and_order() -> None:
+    text = _workflow_text()
+    meta_index, meta_step = named_step(text, META_STEP_NAME)
+    runner_index, runner_step = named_step(text, RUNNER_STEP_NAME)
+    validate_exact_step(meta_step, EXPECTED_META_STEP)
+    validate_exact_step(runner_step, EXPECTED_RUNNER_STEP)
+    assert meta_index < runner_index
+
+
+def test_runner_entrypoint_delegates_to_main_structurally() -> None:
+    assert validate_runner_entrypoint(_runner_text()) is None
+
+
+def test_guilt_runner_entrypoint_early_exit_is_rejected() -> None:
+    original = _runner_text()
+    mutated = original.replace("raise SystemExit(main())", "raise SystemExit(0)")
+    assert mutated != original
+    with pytest.raises(WorkflowContractError, match="SystemExit\\(main\\(\\)\\)"):
+        validate_runner_entrypoint(mutated)
 
 
 @pytest.mark.parametrize(
@@ -201,7 +278,7 @@ def test_guilt_exit_zero_and_collect_only_break_step_contract(
     mutated_step = dict(runtime_truth_step(_workflow_text()))
     mutated_step["run"] = mutated_run
     with pytest.raises(WorkflowContractError):
-        validate_runtime_truth_step(mutated_step)
+        validate_exact_step(mutated_step, EXPECTED_RUNNER_STEP)
 
 
 def test_runner_rejects_real_runtime_skip(tmp_path: pathlib.Path) -> None:
@@ -246,6 +323,41 @@ def test_runner_rejects_real_collect_only(tmp_path: pathlib.Path) -> None:
         )
 
 
+def test_runner_rejects_real_xfail(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "test_xfail_probe.py"
+    target.write_text(
+        "import pytest\n\n@pytest.mark.xfail(reason='mutant')\n"
+        "def test_probe():\n    assert False\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(gauntlet.GauntletContractError, match="xfail="):
+        gauntlet.run_pytest_contract(repo_root=tmp_path, targets=(target.name,))
+
+
+def test_runner_rejects_real_xpass(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "test_xpass_probe.py"
+    target.write_text(
+        "import pytest\n\n@pytest.mark.xfail(reason='mutant')\n"
+        "def test_probe():\n    assert 1 == 1\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(gauntlet.GauntletContractError, match="xpass="):
+        gauntlet.run_pytest_contract(repo_root=tmp_path, targets=(target.name,))
+
+
+def test_shell_contract_rejects_exit_zero_with_zero_structured_cases(
+    tmp_path: pathlib.Path,
+) -> None:
+    target = tmp_path / "fake_shell_contract.sh"
+    target.write_text("echo '0 passed, 0 failed'\nexit 0\n", encoding="utf-8")
+    with pytest.raises(gauntlet.GauntletContractError, match="executed=0"):
+        gauntlet.run_shell_contract(
+            repo_root=tmp_path,
+            relative_path=target.name,
+            expected_cases=("guilt", "innocence", "fix", "self_heal"),
+        )
+
+
 def test_every_corpus_subject_harness_and_workflow_are_exact_triggers() -> None:
     entries = sentinel_entries(_workflow_text())
     missing = uncovered_subjects(TRIGGER_SUBJECTS, entries)
@@ -281,8 +393,12 @@ def test_required_safe_events_are_structural_and_ungated() -> None:
             assert "paths-ignore" not in event_config
 
 
-def test_meta_test_is_run_and_self_triggered() -> None:
-    assert META_TEST in gauntlet.PYTEST_TARGETS
+def test_meta_test_is_external_to_runner_and_self_triggered() -> None:
+    assert META_TEST not in gauntlet.PYTEST_TARGETS
+    meta_index, meta_step = named_step(_workflow_text(), META_STEP_NAME)
+    runner_index, _ = named_step(_workflow_text(), RUNNER_STEP_NAME)
+    validate_exact_step(meta_step, EXPECTED_META_STEP)
+    assert meta_index < runner_index
     assert uncovered_subjects(
         frozenset({META_TEST}), sentinel_entries(_workflow_text())
     ) == []


### PR DESCRIPTION
## Cosa cambia
Rende il controllo Runtime Truth fail-closed nel job CI obbligatorio `antidotes`, validando tre corpora Python e quattro casi WR2 osservati dal parent.

## Hardening incluso
- Meta-contratto esterno, incondizionato e self-triggered.
- Rifiuto di zero test, collection-only, skip, xfail e xpass.
- Ambiente WR2 in allowlist: nessuna credenziale, proxy o toggle host può contaminare il test.

## Verifica
- Meta-suite: 31 passed.
- Gauntlet: 43/43 Python e 4/4 WR2.
- Full pre-push backend suite: verde.
- Mutazioni storiche e anti-bypass, actionlint, shellcheck e review LLM indipendente: verdi.

## Limite dichiarato
Prima della promozione serve il controllo remoto GitHub Actions `antidotes` sul commit della PR.