### PR TITLE
fix(wa-attention): a standing condition is news once, then it is a reminder

### DIFF
--- a/scripts/tests/test_wa_attention_episode_tier.py
+++ b/scripts/tests/test_wa_attention_episode_tier.py
@@ -1,0 +1,274 @@
+"""wa-attention: a persistent condition is news ONCE, then it is a reminder.
+
+Zero's ruling, 2026-08-08, on a measurement of the live spool: over 32 days the
+organism delivered 390 immediate (P0) Telegram alerts — 12.2/day against a
+12/day budget, i.e. saturated every single day — and `wa-attention` was **165
+of them, 42.3%**, for NINE recurring conditions re-raised about every 11 hours.
+Those repeats were not extra news. Because the budget is a race rather than a
+triage, they were pushing other sources' genuine P0s into the digest.
+
+The rule now: first entry into HIGH → p0 · condition persists → digest · a NEW
+critical reason → p0 again.
+
+The load-bearing test in here is `test_reasons_improving_does_not_fire_a_p0`.
+The old state key was `f"{phone}:{sorted(critical)[0]}"`, so a contact whose
+reasons went from ["audit","deadline"] to ["deadline"] changed key, read as a
+brand-new contact, and would have bought a P0 — **an alert fired by things
+getting better**. Keying the episode on the phone alone is what closes that,
+and without this test the obvious phone+reason implementation looks correct.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "scripts" / "wa-mirror-attention-telegram.py"
+
+
+@pytest.fixture(scope="module")
+def wa(tmp_path_factory):
+    """Import the hyphenated script by path, in a throwaway world (W96).
+
+    Same shape as test_wa_attention_pii_envelope.py: the module does real work
+    at import (reads ~/.wa-mirror.env, mkdirs ~/.cache), and the state file it
+    would touch is the LIVE alert ledger.
+    """
+    home = tmp_path_factory.mktemp("home")
+    prev = {k: os.environ.get(k) for k in ("HOME", "WA_MIRROR_DATABASE_URL")}
+    os.environ["HOME"] = str(home)
+    os.environ["WA_MIRROR_DATABASE_URL"] = "postgresql://test/none"
+    try:
+        spec = importlib.util.spec_from_file_location("wa_attention_tier", SRC)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["wa_attention_tier"] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except ImportError as exc:  # asyncpg absent on a bare runner
+            pytest.skip(f"dependency missing: {exc}")
+        assert Path(mod.STATE_PATH).is_relative_to(home), (
+            f"the import escaped the throwaway HOME: {mod.STATE_PATH}")
+        yield mod
+    finally:
+        for k, v in prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+@pytest.fixture(autouse=True)
+def clean_state(wa):
+    """Every test starts with no episode history."""
+    Path(wa.STATE_PATH).unlink(missing_ok=True)
+    yield
+    Path(wa.STATE_PATH).unlink(missing_ok=True)
+
+
+def _item(phone: str, reasons: list[str], n_high: int = 2, crm_id: int | None = 7):
+    return {
+        "phone": phone,
+        "reasons": reasons,
+        "n_high": n_high,
+        "crm_id": crm_id,
+        "crm_name": "Test Contact" if crm_id else None,
+    }
+
+
+class _FakeAcquire:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakePool:
+    def acquire(self):
+        return _FakeAcquire()
+
+    async def close(self):
+        return None
+
+
+def _run(wa, monkeypatch, items, force=False):
+    """Run one scan; return the list of (tier, dedup_key, text) sent."""
+    sent: list[tuple[str, str, str]] = []
+
+    async def fake_create_pool(*_a, **_k):
+        return _FakePool()
+
+    async def fake_fetch(_conn):
+        return items
+
+    def fake_send(text, tier="p0", dedup_key=""):
+        sent.append((tier, dedup_key, text))
+        return True
+
+    monkeypatch.setattr(wa.asyncpg, "create_pool", fake_create_pool)
+    monkeypatch.setattr(wa, "fetch_high_unresolved", fake_fetch)
+    monkeypatch.setattr(wa, "send_telegram", fake_send)
+    asyncio.run(wa.cmd_realtime(force=force))
+    return sent
+
+
+def _age_state(wa, hours: float):
+    """Push every stored episode timestamp into the past."""
+    state = json.loads(Path(wa.STATE_PATH).read_text())
+    past = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    for ep in state.get("episodes", {}).values():
+        ep["ts"] = past
+    Path(wa.STATE_PATH).write_text(json.dumps(state))
+
+
+# --------------------------------------------------------------------- guilt
+
+
+def test_first_entry_into_high_is_a_p0(wa, monkeypatch):
+    sent = _run(wa, monkeypatch, [_item("6281000000001", ["deadline"])])
+    assert [t for t, _, _ in sent] == ["p0"], sent
+
+
+def test_the_same_condition_a_second_time_is_a_digest_not_a_p0(wa, monkeypatch):
+    """THE defect: 165 of 390 delivered P0s in 32 days were this repeat."""
+    items = [_item("6281000000001", ["deadline"])]
+    _run(wa, monkeypatch, items)
+    _age_state(wa, hours=12)
+    sent = _run(wa, monkeypatch, items)
+    assert [t for t, _, _ in sent] == ["digest"], sent
+
+
+def test_a_repeat_inside_the_window_sends_nothing_at_all(wa, monkeypatch):
+    """The scan runs every 10 minutes. Without this, a persisting contact would
+    write 144 spool records a day — the digest collapses to one LINE, but the
+    spool would still carry every event."""
+    items = [_item("6281000000001", ["deadline"])]
+    _run(wa, monkeypatch, items)
+    sent = _run(wa, monkeypatch, items)  # no ageing: still inside DEDUP_WINDOW
+    assert sent == [], sent
+
+
+def test_a_new_critical_reason_earns_a_fresh_p0(wa, monkeypatch):
+    """Genuinely worse, not merely still true."""
+    _run(wa, monkeypatch, [_item("6281000000001", ["deadline"])])
+    sent = _run(wa, monkeypatch, [_item("6281000000001", ["deadline", "lawyer"])])
+    assert [t for t, _, _ in sent] == ["p0"], sent
+
+
+def test_a_resolved_contact_who_returns_is_a_fresh_p0(wa, monkeypatch):
+    """Episode END is what makes 'first entry' mean first entry, not first
+    ever. Without pruning, a real new problem would be filed as 'already told
+    you' forever."""
+    items = [_item("6281000000001", ["deadline"])]
+    _run(wa, monkeypatch, items)
+    _run(wa, monkeypatch, [])  # resolved: leaves the HIGH-unresolved set
+    sent = _run(wa, monkeypatch, items)  # comes back
+    assert [t for t, _, _ in sent] == ["p0"], sent
+
+
+# ----------------------------------------------------------------- innocence
+
+
+def test_reasons_improving_does_not_fire_a_p0(wa, monkeypatch):
+    """The case the obvious implementation gets wrong.
+
+    Old key was `phone:sorted(critical)[0]`. Going from ["audit","deadline"] to
+    ["deadline"] changes that key, so the contact reads as brand new and buys a
+    P0 — an alert fired BY THINGS GETTING BETTER. Episodes key on phone alone.
+    """
+    _run(wa, monkeypatch, [_item("6281000000001", ["audit", "deadline"])])
+    _age_state(wa, hours=12)
+    sent = _run(wa, monkeypatch, [_item("6281000000001", ["deadline"])])
+    assert [t for t, _, _ in sent] == ["digest"], (
+        f"an improvement was announced as new news: {sent}")
+
+
+def test_migration_from_the_legacy_state_does_not_fire_a_burst(wa, monkeypatch):
+    """First run after deploy reads ~9 live contacts. If the old `last_alerted`
+    shape were ignored, every one would look like a first entry and fire the
+    exact P0 burst this change exists to end."""
+    Path(wa.STATE_PATH).write_text(json.dumps({
+        "last_alerted": {
+            "6281000000001:deadline": datetime.now(timezone.utc).isoformat(),
+            "6281000000002:refund": datetime.now(timezone.utc).isoformat(),
+        }
+    }))
+    sent = _run(wa, monkeypatch, [
+        _item("6281000000001", ["deadline"]),
+        _item("6281000000002", ["refund"]),
+    ])
+    assert [t for t, _, _ in sent] != ["p0"], f"legacy state fired a P0 burst: {sent}"
+
+
+def test_a_genuinely_new_contact_still_cuts_through(wa, monkeypatch):
+    """The whole point is not silence. A contact nobody has heard of must still
+    reach the phone immediately, even while others are merely persisting."""
+    _run(wa, monkeypatch, [_item("6281000000001", ["deadline"])])
+    _age_state(wa, hours=12)
+    sent = _run(wa, monkeypatch, [
+        _item("6281000000001", ["deadline"]),          # persisting
+        _item("6281000000002", ["refund"], crm_id=None),  # brand new lead
+    ])
+    tiers = sorted(t for t, _, _ in sent)
+    assert tiers == ["digest", "p0"], f"expected one of each tier, got {sent}"
+
+
+def test_force_still_surfaces_a_persisting_contact(wa, monkeypatch):
+    items = [_item("6281000000001", ["deadline"])]
+    _run(wa, monkeypatch, items)
+    sent = _run(wa, monkeypatch, items, force=True)
+    assert [t for t, _, _ in sent] == ["digest"], sent
+
+
+def test_a_contact_with_no_critical_reason_is_never_alerted(wa, monkeypatch):
+    sent = _run(wa, monkeypatch, [_item("6281000000001", ["greeting"])])
+    assert sent == [], sent
+
+
+# ------------------------------------------------------------------ envelope
+
+
+def test_the_reminder_does_not_wear_the_alarm_banner(wa, monkeypatch):
+    """A '🚨 HIGH attention' banner on the fourth reminder of the same contact
+    is how a reader learns to stop reading the banner."""
+    items = [_item("6281000000001", ["deadline"])]
+    _run(wa, monkeypatch, items)
+    _age_state(wa, hours=12)
+    sent = _run(wa, monkeypatch, items)
+    text = sent[0][2]
+    assert "still unresolved" in text, text
+    assert "🚨" not in text, f"the reminder is dressed as an alarm: {text}"
+
+
+def test_the_reminder_keeps_the_pii_envelope(wa, monkeypatch):
+    """The new digest path is a new rendering site, and the last defect in this
+    file was a rendering site that printed a number in the clear."""
+    items = [_item("6281000000001", ["deadline"], crm_id=None)]
+    _run(wa, monkeypatch, items)
+    _age_state(wa, hours=12)
+    sent = _run(wa, monkeypatch, items)
+    text = sent[0][2]
+    assert "6281000000001" not in text, f"full number in the reminder: {text}"
+    assert "****" in text, text
+
+
+def test_the_two_tiers_never_share_a_dedup_key(wa, monkeypatch):
+    """Same contact set, two tiers: colliding keys would make the gateway
+    swallow the second as a duplicate of the first."""
+    _run(wa, monkeypatch, [_item("6281000000001", ["deadline"])])
+    _age_state(wa, hours=12)
+    sent = _run(wa, monkeypatch, [
+        _item("6281000000001", ["deadline"]),
+        _item("6281000000002", ["refund"]),
+    ])
+    keys = [k for _, k, _ in sent]
+    assert len(keys) == len(set(keys)), keys
+    assert all(k.startswith("wa-attention:") for k in keys), keys

--- a/scripts/tests/test_wa_attention_pii_envelope.py
+++ b/scripts/tests/test_wa_attention_pii_envelope.py
@@ -131,9 +131,17 @@ def test_every_fstring_that_renders_a_phone_goes_through_a_masker(wa):
     Grepping for the line shape that had already been found could only ever
     re-find it. This walks the AST instead and asks a question about the
     ENTITY: does anything named `phone` reach an f-string without passing a
-    masker? The one permitted exception is the LOCAL 4h dedup state key, which
-    never leaves the machine — Law 2 draws the line at output, not at local
-    processing, and that boundary is declared in the source.
+    masker?
+
+    TIGHTENED 2026-08-08: there used to be ONE declared exception — the local
+    4h dedup state key `f"{phone}:{sorted(critical)[0]}"`, which never left the
+    machine (Law 2 draws the line at output, not at local processing). The
+    episode-tier change removed that f-string: episodes are keyed on the phone
+    value directly, so the exception no longer exists and the invariant is now
+    absolute. The count assertion below moved from `== 1` to `== 0` because the
+    exception went away, NOT because it was waived — and it is kept, rather
+    than deleted, so that reintroducing an undeclared local-state f-string
+    still has to come past this test and be argued for.
     """
     allowed = ("mask", "contact_label", "distinct_phones", "phone[:4]", "phone[-4:]")
     offenders = []
@@ -146,12 +154,12 @@ def test_every_fstring_that_renders_a_phone_goes_through_a_masker(wa):
             rendered = ast.unparse(value.value)
             if "phone" in rendered and not any(a in rendered for a in allowed):
                 offenders.append((node.lineno, rendered))
-    # line 228-ish: the local state key, declared in the source as deliberate.
     local_state = [o for o in offenders if o[1] == "phone"]
     leaks = [o for o in offenders if o not in local_state]
     assert not leaks, f"an unmasked phone reaches a message: {leaks}"
-    assert len(local_state) == 1, (
-        f"the local-state exception moved or multiplied: {local_state}")
+    assert local_state == [], (
+        "a bare-phone f-string is back; if it is genuinely local-only state, "
+        f"declare it in the source and in this docstring first: {local_state}")
 
 
 # ----------------------------------------------------------------- innocence

--- a/scripts/wa-mirror-attention-telegram.py
+++ b/scripts/wa-mirror-attention-telegram.py
@@ -226,9 +226,42 @@ async def fetch_digest_metrics(conn: asyncpg.Connection) -> dict:
     return {**dict(row), "new_leads_24h": new_leads}
 
 
+def _load_episodes(state: dict) -> dict:
+    """Read episode state, migrating the pre-2026-08-08 `last_alerted` shape.
+
+    Old shape: {"<phone>:<reason>": "<iso ts>"} — one entry per contact+reason,
+    the value a bare timestamp. New shape is keyed on PHONE alone and carries
+    the reason set that has already bought a P0:
+
+        {"<phone>": {"ts": "<iso>", "reasons": ["deadline", ...]}}
+
+    Keyed on phone, NOT on phone+reason, and that is the whole point: the old
+    key embedded `sorted(critical)[0]`, so a contact whose reasons IMPROVED
+    from ["audit","deadline"] to ["deadline"] would change key, look brand new,
+    and buy a fresh P0 — an alert fired by things getting better.
+
+    Migration treats a legacy entry as an episode ALREADY in progress. That is
+    the quiet direction on purpose: the loud alternative would read every one
+    of the ~9 live contacts as a first entry and fire a P0 burst on the first
+    run after deploy, which is the exact failure this change exists to end.
+    """
+    raw = state.get("episodes")
+    if isinstance(raw, dict):
+        return raw
+    migrated: dict = {}
+    for key, ts in (state.get("last_alerted") or {}).items():
+        if not isinstance(key, str):
+            continue
+        phone, _, reason = key.partition(":")
+        ep = migrated.setdefault(phone, {"ts": ts if isinstance(ts, str) else "", "reasons": []})
+        if reason and reason not in ep["reasons"]:
+            ep["reasons"].append(reason)
+    return migrated
+
+
 async def cmd_realtime(force: bool = False):
     state = load_state()
-    last_alerted = state.get("last_alerted", {})
+    episodes = _load_episodes(state)
     now = datetime.now(timezone.utc)
 
     pool = await asyncpg.create_pool(DB_URL, min_size=1, max_size=2, ssl=False)
@@ -238,17 +271,35 @@ async def cmd_realtime(force: bool = False):
     finally:
         await pool.close()
 
-    # PASS 1 — decide WHO is due, without sending anything yet. A scan that
-    # finds N due contacts used to send N separate P0s: on 2026-07-26 that was
-    # 8 messages in 60 seconds, which ate the gateway's whole daily P0 budget
-    # (12) by 02:01 and pushed every later alert of the day into the 12h
-    # digest. One scan is one event — it gets ONE message.
-    due = []
+    # PASS 1 — decide WHO is due and AT WHICH TIER, without sending anything
+    # yet. A scan that finds N due contacts used to send N separate P0s: on
+    # 2026-07-26 that was 8 messages in 60 seconds, which ate the gateway's
+    # whole daily P0 budget (12) by 02:01. One scan is one message per tier.
+    #
+    # Tier rule (Zero, 2026-08-08). Measured on the live spool that day:
+    # wa-attention was 165 of the 390 P0s the whole organism delivered in 32
+    # days — 42.3% of every immediate alert — for NINE recurring conditions
+    # re-raised roughly every 11 hours. The budget is 12/day and ran fully
+    # consumed every single day, so those repeats were not "extra" news: they
+    # were pushing OTHER sources' genuine P0s into the digest.
+    #
+    #   first entry into HIGH  → p0   (news)
+    #   condition persists     → digest (already told you; the digest groups by
+    #                            source, so all of it costs ONE line)
+    #   a NEW critical reason  → p0   (genuinely worse, not merely still true)
+    #
+    # An episode ENDS when the contact leaves the HIGH-unresolved set; the
+    # pruning below is what makes "first entry" mean first entry rather than
+    # first ever.
+    first_or_worse: list = []
+    persisting: list = []
+    live_phones: set = set()
     for it in items:
         critical = [r for r in (it["reasons"] or []) if r in CRITICAL_REASONS]
         if not critical:
             continue
         phone = it["phone"]
+        live_phones.add(phone)
         # DELIBERATE, not an oversight: this key is the LOCAL 4h dedup state in
         # ~/.cache/wa-mirror-attention-state.json. It never reaches Telegram and
         # never reaches the gateway spool — the wire key is the sha256 set
@@ -256,54 +307,90 @@ async def cmd_realtime(force: bool = False):
         # OUTPUT, not at local processing: "il processing PII resta
         # locale-sovrano sul Pro". Recorded here so the next reader can tell a
         # considered boundary from a missed one.
-        key = f"{phone}:{sorted(critical)[0]}"
-        last_ts_str = last_alerted.get(key)
-        if last_ts_str and not force:
-            try:
-                last_ts = datetime.fromisoformat(last_ts_str)
-                if now - last_ts < DEDUP_WINDOW:
-                    continue  # dedup — per contact, unchanged
-            except Exception:
-                pass
-        due.append((key, it, sorted(critical)))
+        cur = sorted(critical)
+        ep = episodes.get(phone)
+        if ep is None:
+            first_or_worse.append((phone, it, cur))
+            continue
+        already = set(ep.get("reasons") or [])
+        if set(cur) - already:
+            # A reason we have never alerted on for this open episode.
+            first_or_worse.append((phone, it, cur))
+            continue
+        # Still true, nothing new. Goes to the digest, rate-limited by the same
+        # window as before so a 10-minute scan cannot write 144 spool records a
+        # day per contact — the digest collapses to one LINE, not one EVENT.
+        if force:
+            persisting.append((phone, it, cur))
+            continue
+        try:
+            if now - datetime.fromisoformat(ep.get("ts") or "") >= DEDUP_WINDOW:
+                persisting.append((phone, it, cur))
+        except (TypeError, ValueError):
+            # Unparseable stored timestamp: treat as due rather than sit silent.
+            persisting.append((phone, it, cur))
 
-    # PASS 2 — one message for the whole scan. The per-contact 4h dedup window
-    # above is untouched: grouping changes HOW MANY messages carry the news,
-    # never WHICH contacts are considered due.
+    # PASS 2 — at most one message per tier for the whole scan.
     alerted = 0
-    if due:
-        msg = _compose_realtime_alert(due)
+    messages = 0
+
+    def _emit(batch: list, tier: str, prefix: str) -> bool:
         # Keyed on the exact set of contacts, so a scan repeating the same set
         # collapses into a counter at the gateway instead of a new message.
-        sig = hashlib.sha256(",".join(sorted(k for k, _, _ in due)).encode()).hexdigest()[:12]
-        if send_telegram(msg, tier="p0", dedup_key=f"wa-attention:set:{sig}"):
-            for key, _, _ in due:
-                last_alerted[key] = now.isoformat()
-            alerted = len(due)
+        sig = hashlib.sha256(",".join(sorted(p for p, _, _ in batch)).encode()).hexdigest()[:12]
+        msg = _compose_realtime_alert([(p, it, c) for p, it, c in batch], tier=tier)
+        return send_telegram(msg, tier=tier, dedup_key=f"wa-attention:{prefix}:{sig}")
 
-    state["last_alerted"] = last_alerted
+    if first_or_worse and _emit(first_or_worse, "p0", "new"):
+        for phone, _, cur in first_or_worse:
+            ep = episodes.setdefault(phone, {"reasons": []})
+            ep["ts"] = now.isoformat()
+            ep["reasons"] = sorted(set(ep.get("reasons") or []) | set(cur))
+        alerted += len(first_or_worse)
+        messages += 1
+
+    if persisting and _emit(persisting, "digest", "still"):
+        for phone, _, _ in persisting:
+            episodes.setdefault(phone, {"reasons": []})["ts"] = now.isoformat()
+        messages += 1
+
+    # An episode ends when the contact drops out of the HIGH-unresolved set.
+    # Without this the state grows forever and, worse, a contact who is
+    # resolved and later comes back would be read as "already told you" and
+    # never earn the P0 that a genuinely new problem deserves.
+    episodes = {p: v for p, v in episodes.items() if p in live_phones}
+
+    state["episodes"] = episodes
+    state.pop("last_alerted", None)
     save_state(state)
-    print(json.dumps({"alerted": alerted, "messages": 1 if alerted else 0,
-                      "high_open": len(items), "ts": now.isoformat()}))
+    print(json.dumps({"alerted": alerted, "messages": messages,
+                      "persisting": len(persisting), "high_open": len(items),
+                      "ts": now.isoformat()}))
 
 
-def _compose_realtime_alert(due: list) -> str:
+def _compose_realtime_alert(due: list, tier: str = "p0") -> str:
     """One contact keeps the full detail; several become a compact roster.
 
     Same OSINT envelope as before either way: display name, masked phone,
     reason codes, unresolved count, dashboard link. No free text ever.
+
+    `tier` only changes the HEADLINE, never the envelope. A digest batch is a
+    reminder about something already reported, and it has to SAY so — a
+    "🚨 HIGH attention" banner on the fourth reminder of the same contact is
+    how a reader learns to stop reading the banner.
     """
+    banner = "🚨 HIGH attention" if tier == "p0" else "🔔 still unresolved"
     if len(due) == 1:
         _, it, critical = due[0]
         crm_tag = f"CRM #{it['crm_id']}" if it["crm_id"] else "new lead"
         return (
-            "🚨 HIGH attention\n"
+            f"{banner}\n"
             f"{contact_label(it)}\n"
             f"{crm_tag} · {it['n_high']} unresolved msg\n"
             f"Reasons: {', '.join(critical)}\n"
             f"→ {DASHBOARD_URL}"
         )
-    lines = [f"🚨 HIGH attention — {len(due)} contacts"]
+    lines = [f"{banner} — {len(due)} contacts"]
     for _, it, critical in due:
         crm_tag = f"CRM #{it['crm_id']}" if it["crm_id"] else "new lead"
         lines.append(


### PR DESCRIPTION
A standing condition is news once. After that it is a reminder, and it should
look like one.

## Zero's ruling (2026-08-08, Legge 5)

How loudly an unresolved client may nag is a business call, so it was asked and
answered: **first entry into HIGH = immediate p0 · while the condition stands the
repeats go to the digest · a genuine worsening may re-arm the p0 once.**

## What this actually buys, measured honestly

The obvious framing for this PR would be "`wa-attention` is 165 of 390 delivered
P0s, 42.2% of everything". That figure is arithmetically correct and it would be
misleading, so here is what the spool really says (measured today on Pro,
`~/.organism/tg_spool`):

- `archive-p0.jsonl` is the **delivered** log — 390 rows, all carrying `sent`,
  none carrying an overflow marker. It is capped: `TG_P0_BUDGET=12` plus the
  2-slot `cron-fail` reserve, and the observed rate is **exactly 14/day for
  twelve consecutive days**. Ranking producers off it ranks them by who won a
  race, not by who is loud.
- True demand, from the per-day spool: **39-49 P0-intent events/day** in August.
  Confirmed independently from the gateway's own `state.json` at 06:59 today —
  `sent: 10, overflow: 19`.
- By **demand** over Aug 1-8, `wa-attention` is **sixth**, not first:
  `dlq-autopilot` 45 · `sentinel` 34 · `tech-orchestrator` 33 · `system-doctor`
  31 · `compliance-ops` 20 · `wa-attention` 20. Its delivered share is
  front-loaded — 8/day through 07-26, 1/day from 07-27, 0 on 08-07 and 08-08.

So **this PR is not a 42% volume cut**, and claiming so would be building the
next session's plan on a number that describes July. What it is:

1. **A correctness fix that no gateway window can make.** The old state key was
   `f"{phone}:{sorted(critical)[0]}"`. A contact whose reasons *improved* from
   `["audit","deadline"]` to `["deadline"]` changed key, read as brand new, and
   bought a fresh P0 — **an alert fired by things getting better**. Keying the
   episode on the phone alone is what closes that, and the gateway cannot: from
   outside, `phone:audit` and `phone:deadline` are two different conditions.
   `test_reasons_improving_does_not_fire_a_p0` is the load-bearing test; without
   it the obvious phone+reason implementation looks correct.
2. **The first instance of the escalator the organism already knows it is
   missing.** `discovery_dedup_was_never_the_volume_driver_2026_08_07` names it
   in as many words: *"a standing condition wants one line per day and a P0 only
   on state CHANGE … that escalator does not exist yet — it is the piece to
   build."* This builds it, for one producer.
3. **A reminder that stops wearing the alarm's clothes.** The fourth repeat of
   the same contact no longer carries `🚨 HIGH attention`; it says
   `🔔 still unresolved`. W116: an alarm that fires on the correct outcome is an
   alarm nobody reads, and that is how the next true one gets missed.

## Declared, not fixed here (W107)

There are **~12 near-daily producers** repeating a standing condition. This
cures one. Curing one producer of twelve does not cut the risk — it moves which
alert dies in silence. The remaining eleven need this at the source, because the
gateway cannot supply it for them: it can only mute a repeat, never tell a
worsening from a persistence.

A correction I made while writing this, kept because it is the reusable part:
I first wrote here that `sentinel` still keys on `md5(whole message)` with a
counter inside, citing the comment in `tg_notify.py`. **That comment describes a
state that ended on 2026-08-06** — the producer now passes `sentinel:<condition>`
or no key at all. Measured strictly after the transition (found in the DATA: the
last bare-`sentinel:<md5>` key is 08-06 14:26, not the merge date): **0** bare-md5
keys, and sentinel is down from 12.9 to 6.3 msgs/day. Citing a code comment as
evidence of current state is the same error as citing a stale measurement, and my
first bucketing (`>= 08-06`) straddled the cure and reported it as incomplete.

Also declared: the gateway's repeat ladder (`TG_REPEAT_LADDER_H`, landed
2026-08-07) claims `wa-attention 20.45 -> 1.49` in its own comment. **Only 4 of
390 delivered rows carry a `streak` field** — that number is a replay projection
over the old corpus, not an observed effect. It is not evidence that this PR is
redundant, and it is not evidence that it is necessary.

## Implementation

`last_alerted` (a flat `phone:reason -> timestamp` map) becomes `episodes`, keyed
on the **phone**, carrying the reasons seen so far. An episode ends when the
contact leaves the HIGH-unresolved set, so "first entry" means first entry into
*this* episode, not first ever — without that, a real new problem would be filed
as "already told you" forever. Legacy state is migrated in place, so the first
run after deploy does not read nine live contacts as nine first entries and fire
exactly the burst this change exists to end.

## Verification

20 tests (13 new + the 7 PII-envelope ones), all passing, and 4 mutations:

| mutation | result |
|---|---|
| worsening compared with `!=` instead of a set difference | 1 failed |
| everything left at p0 | 5 failed |
| episodes never pruned | 1 failed |
| legacy state ignored | 1 failed |

The PII sweep was **tightened, not waived**. It used to allow exactly one
declared bare-phone f-string — the old dedup key, local-only state, which Law 2
permits because it draws the line at output. That f-string is gone, so the
assertion moved from `== 1` to `== []` and the invariant is now absolute. The
tightened pin was proven still to bite by injecting a leak (`_leak = f"{phone}"`)
and watching `test_every_fstring_that_renders_a_phone_goes_through_a_masker`
fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
