### PR TITLE
feat(visa-engine): rulepack seq-4 — Phase A gates + citizenship-conflict guard

### DIFF
--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-004.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-004.source.json
@@ -1,0 +1,7688 @@
+{
+  "created_at": "2026-08-08T12:00:00Z",
+  "created_by": "visa.oracle.sequence4.authoring",
+  "decision_domain": "IMMIGRATION_VISA",
+  "engine_contract_version": "1.0.0",
+  "engine_max_version": "1.0.0",
+  "engine_min_version": "1.0.0",
+  "environment": "PRODUCTION",
+  "hit_policy": {
+    "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+    "hard_filter": "COLLECT_ALL",
+    "human_review": "COLLECT_ALL",
+    "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+  },
+  "jurisdiction": "ID",
+  "previous_payload_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "rollback_of_payload_sha256": null,
+  "products": [
+    {
+      "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+      "product_code": "E28A",
+      "legacy_codes": ["B211"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Visa (E28A)",
+        "id": "Visa Investor (E28A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": [
+        "operational_work_beyond_management_and_ownership"
+      ],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 730,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 100,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+      "product_code": "E28B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa \u2014 Company Establishment (E28B)",
+        "id": "Visa Investor Pendirian Perusahaan (E28B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+      "product_code": "E28C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa \u2014 Capital Market (E28C)",
+        "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work", "corporate_establishment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+      "product_code": "E28D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa \u2014 Branch or Subsidiary (E28D)",
+        "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work_outside_managing_subsidiary"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+      "product_code": "E28F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa \u2014 New Capital (IKN) Subsidiary (E28F)",
+        "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+      "product_code": "E33",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa (E33)",
+        "id": "Visa Rumah Kedua (E33)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["SECOND_HOME", "TOURISM"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "guarantee_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+      "product_code": "E33A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa \u2014 Special-Expertise Government Invitation (E33A)",
+        "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+      "product_code": "E33B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa \u2014 Special-Expertise Collaboration (E33B)",
+        "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "EMPLOYMENT",
+        "BUSINESS_MEETINGS",
+        "INVESTMENT",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+      "product_code": "E33C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa \u2014 World-Figure Government Invitation (E33C)",
+        "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "INVESTMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+      "product_code": "E33E",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa \u2014 Elderly 5-Year (E33E)",
+        "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "deposit_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+      "product_code": "E33F",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa \u2014 Elderly 1-Year (E33F)",
+        "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "RETIREMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+      "product_code": "E33G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa \u2014 Remote Worker (E33G)",
+        "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "work_for_indonesian_entity",
+        "indonesian_source_compensation_including_in_kind",
+        "indonesian_company_ownership",
+        "sale_of_goods_or_services_beyond_remote_work"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+      "product_code": "A1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa-Free Tourism Visit (A1)",
+        "id": "Bebas Visa Kunjungan Wisata (A1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "TRANSIT"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+      "product_code": "B1",
+      "legacy_codes": ["B213"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa on Arrival \u2014 Tourism (B1)",
+        "id": "Visa Saat Kedatangan Wisata (B1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 30,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+      "product_code": "C1",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Tourist Visit Visa (C1)",
+        "id": "Visa Kunjungan Wisata (C1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+      "product_code": "C2",
+      "legacy_codes": ["B211B", "B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Business Visit Visa (C2)",
+        "id": "Visa Kunjungan Bisnis (C2)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+      "product_code": "C6",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Social Activity Visit Visa (C6)",
+        "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": ["paid_employment", "business_meetings"],
+      "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+      "product_code": "BRIDGING",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Bridging Visa \u2014 Transitional Stay Permit",
+        "id": "Izin Tinggal Peralihan"
+      },
+      "category": "OTHER",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": [
+        "employment_relationship",
+        "exit_terminates_permit"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "NOT_APPLICABLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": null,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+      "product_code": "E23",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa (E23)",
+        "id": "Visa Kerja (E23)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": [
+        "work_for_non_sponsor_entity",
+        "hr_personnel_positions",
+        "passive_investment_management"
+      ],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Working KITAS (Offshore)"
+      },
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+      "product_code": "E23U",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa \u2014 Foreign Diplomat House Assistant (E23U)",
+        "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_non_diplomat_employer"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+      "product_code": "E23V",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa \u2014 Trade and Economic Office (E23V)",
+        "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_standard_corporate_employers"],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+      "product_code": "E31A",
+      "legacy_codes": ["C317"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Spouse of Indonesian Citizen (E31A)",
+        "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": [],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Spouse 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+      "product_code": "E31B",
+      "legacy_codes": ["C318"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Spouse of ITAS/ITAP Holder (E31B)",
+        "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+      "product_code": "E31C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Child of Legal Mixed Marriage (E31C)",
+        "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+      "product_code": "E31D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+        "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+      "product_code": "E31E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Child of ITAS/ITAP Holder (E31E)",
+        "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+      "product_code": "E31F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Child of Indonesian Citizen Parent (E31F)",
+        "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+      "product_code": "E31G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Parent of Indonesian Citizen Child (E31G)",
+        "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+      "product_code": "E31H",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Parent of Child ITAS/ITAP Holder (E31H)",
+        "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+      "product_code": "E31J",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa \u2014 Child Joining Sibling ITAS/ITAP Holder (E31J)",
+        "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+      "product_code": "D1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Tourism \u2014 Multiple Entry (D1)",
+        "id": "Visa Kunjungan Wisata \u2014 Beberapa Kali Perjalanan (D1)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D1 Tourism (1 Year)"
+      },
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+      "product_code": "D2",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Business \u2014 Multiple Entry (D2)",
+        "id": "Visa Kunjungan Bisnis (D2)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "continuous_supervision_production_sales"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D2 Business (1 Year)"
+      },
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+      "product_code": "D12",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Pre-Investment \u2014 Multiple Entry (D12)",
+        "id": "Visa Kunjungan Pra-Investasi (D12)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 180,
+        "maximum_days": 180
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 180,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D12 Business Investigation (1 Year)"
+      },
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+      "product_code": "E30",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Education Visa (E30)",
+        "id": "Visa Pendidikan (E30)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+      "product_code": "E30A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Primary/Secondary Education Visa (E30A)",
+        "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+      "product_code": "E30B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Higher Education Visa (E30B)",
+        "id": "Visa Pendidikan Tinggi (E30B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 1460
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "31850f85-8d19-58df-bb66-b04968c9aff0"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+      "product_code": "E30E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "SEZ Education Visa (E30E)",
+        "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+      "product_code": "E30F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Student Exchange Visa (E30F)",
+        "id": "Visa Pertukaran Pelajar (E30F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hf.citizen",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "derived.has_indonesian_citizenship",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.has_indonesian_citizenship"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.citizen",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.overstay-exceeds-60-days",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 60
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "OVERSTAY_EXCEEDS_60_DAYS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.overstay-exceeds-60-days",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.calling-visa",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "intersects",
+        "fact": "person.nationalities",
+        "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CALLING_VISA_REVIEW"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+      "explanation_key": "explain.review.calling-visa",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.active-overstay",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 0
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ACTIVE_OVERSTAY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.review.active-overstay",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.a1.not-bvk-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "BN",
+            "MY",
+            "TH",
+            "SG",
+            "PH",
+            "KH",
+            "LA",
+            "MM",
+            "VN",
+            "TL",
+            "SR",
+            "CO",
+            "HK",
+            "TR",
+            "BR",
+            "PE",
+            "MO",
+            "KZ",
+            "BY"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BVK_NATIONALITY_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.hf.a1.not-bvk-nationality",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.a1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "TRANSIT"]
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "A1_BVK_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "TRANSIT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.el.a1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.b1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "B1_VOA_ELIGIBLE",
+        "covered_purposes": ["TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+      ],
+      "explanation_key": "explain.el.b1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "el.c1.tourism-family",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "FAMILY"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C1_VISIT_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c1.tourism-family",
+      "safety_critical": false,
+      "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"]
+    },
+    {
+      "rule_id": "el.c2.business",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C2_BUSINESS_ELIGIBLE",
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c2.business",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "review.c2.corporate-sponsor-type",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "C2_CORPORATE_SPONSOR_TYPE_VERIFICATION"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.c2.corporate-sponsor-type",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "el.c6.social",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C6_SOCIAL_ELIGIBLE",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c6.social",
+      "safety_critical": false,
+      "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"]
+    },
+    {
+      "rule_id": "hf.e28a.paid-capital-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.paid_up_capital_idr",
+        "value": 2500000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.paid_up_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "hf.e28a.total-investment-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.investment_capital_idr",
+        "value": 10000000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.investment_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.total-investment-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "el.e28a.investment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "investment.proposed_role",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          },
+          {
+            "op": "gte",
+            "fact": "investment.paid_up_capital_idr",
+            "value": 2500000000
+          },
+          {
+            "op": "gte",
+            "fact": "investment.investment_capital_idr",
+            "value": 10000000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.investment_capital_idr",
+        "investment.paid_up_capital_idr",
+        "investment.proposed_role",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.e28a.investment",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "review.e28b.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28b.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"]
+    },
+    {
+      "rule_id": "review.e28c.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28c.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"]
+    },
+    {
+      "rule_id": "review.e28d.usd-threshold-turnover-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28D"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"]
+    },
+    {
+      "rule_id": "review.e28f.ikn-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28F"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"]
+    },
+    {
+      "rule_id": "el.e33.deposit-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.bank_deposit_usd",
+            "value": 130000
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_at_state_bank",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_in_own_name",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.deposit-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.property-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_PROPERTY_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.property-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.guarantee-maintenance",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 130000
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.qualifying_property_value_usd",
+                "value": 1000000
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.guarantee-maintenance",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.work-rangkap-kegiatan",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33a.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33A"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33a.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "review.e33b.expertise-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33b.expertise-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "review.e33c.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33c.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "hf.e33e.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33e.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "review.e33e.age-55-59-disputed-band",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "between",
+            "fact": "derived.age_years",
+            "lower": 55,
+            "upper": 59
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33E_AGE_55_59_DISPUTED_BAND"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years", "intent.purposes"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33e.age-55-59-disputed-band",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 50000
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_at_state_bank",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_in_own_name",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "review.e33e.deposit-income-basis",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "all",
+                    "args": [
+                      {
+                        "op": "gte",
+                        "fact": "secondhome.bank_deposit_usd",
+                        "value": 50000
+                      },
+                      {
+                        "op": "eq",
+                        "fact": "secondhome.bank_deposit_at_state_bank",
+                        "value": true
+                      },
+                      {
+                        "op": "eq",
+                        "fact": "secondhome.bank_deposit_in_own_name",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "op": "not",
+                    "arg": {
+                      "op": "gte",
+                      "fact": "secondhome.passive_monthly_income_usd",
+                      "value": 3000
+                    }
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "not",
+                    "arg": {
+                      "op": "all",
+                      "args": [
+                        {
+                          "op": "gte",
+                          "fact": "secondhome.bank_deposit_usd",
+                          "value": 50000
+                        },
+                        {
+                          "op": "eq",
+                          "fact": "secondhome.bank_deposit_at_state_bank",
+                          "value": true
+                        },
+                        {
+                          "op": "eq",
+                          "fact": "secondhome.bank_deposit_in_own_name",
+                          "value": true
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.passive_monthly_income_usd",
+                    "value": 3000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33E_DEPOSIT_INCOME_BASIS_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33e.deposit-income-basis",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "hf.e33f.sponsor-required",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "family.sponsor_confirmed",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "SPONSOR_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["family.sponsor_confirmed"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e33f.sponsor-required",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "review.e33f.age-under-55",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "lt",
+            "fact": "derived.age_years",
+            "value": 55
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33F_AGE_UNDER_55_DISCRETIONARY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years", "intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33f.age-under-55",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "el.e33f.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33f.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-employer",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.employer_is_indonesian_entity",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.employer_is_indonesian_entity"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-employer",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-source-compensation",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.indonesia_source_compensation",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.indonesia_source_compensation"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-market",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-market",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-company-ownership",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-company-ownership",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.income-60k-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_INCOME_60K_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.review.e33g.income-60k-manual",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e33g.remote-work",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REMOTE_WORK_ELIGIBLE",
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.e33g.remote-work",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.bridging.offshore",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.currently_in_indonesia",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_ONSHORE_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.currently_in_indonesia"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.offshore",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.from-visit-itk",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "in",
+        "fact": "immigration.current_status_code",
+        "values": [
+          "ITK_FROM_BVK",
+          "ITK_FROM_VISIT_C",
+          "ITK_FROM_VISIT_D",
+          "A1",
+          "C1",
+          "C2",
+          "C6"
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+      ],
+      "explanation_key": "explain.hf.bridging.from-visit-itk",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.to-bridging",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.current_status_code",
+        "value": "ITK_PERALIHAN"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.to-bridging",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.t3-window-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "known",
+            "fact": "immigration.current_status_expiry"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_T3_WINDOW_MANUAL_CHECK"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.t3-window-manual",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.overstay-shield-payment",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "known",
+            "fact": "immigration.current_status_expiry"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.overstay-shield-payment",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.source-status-verify",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "known",
+            "fact": "immigration.current_status_code"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_code",
+        "immigration.currently_in_indonesia"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.source-status-verify",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.adverse-history",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "intersects",
+            "fact": "immigration.violation_history",
+            "values": [
+              "OVERSTAY",
+              "DEPORTATION",
+              "BLACKLIST",
+              "IMMIGRATION_INVESTIGATION"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_ADVERSE_HISTORY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": [
+        "immigration.currently_in_indonesia",
+        "immigration.violation_history"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.adverse-history",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.destination-stated",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "neq",
+            "fact": "intent.requested_product_code",
+            "value": "BRIDGING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_DESTINATION_STATED",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.destination-stated",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.e23-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.employer_is_indonesian_entity",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-rptka-verification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_RPTKA_APPROVAL"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-rptka-verification",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-prohibited-hr-roles",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROHIBITED_HR_ROLES_KEPMENAKER_349_2019"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-prohibited-hr-roles",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-operational-work-boundary",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "investment.proposed_role",
+            "op": "in",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": ["intent.purposes", "investment.proposed_role"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-operational-work-boundary",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-jabatan-kbli-match",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "JABATAN_MUST_MATCH_KBLI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-jabatan-kbli-match",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e23u-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23u-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "hr.e23u-diplomat-sponsor",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_DIPLOMAT_SPONSOR"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23u-diplomat-sponsor",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "hr.e23u-domestic-helper-role",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "RESTRICTED_TO_DOMESTIC_HELPER"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23u-domestic-helper-role",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "el.e23v-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23v-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hr.e23v-kdei-sponsor",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_KDEI_SPONSOR"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23v-kdei-sponsor",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hr.e23v-rptka-verification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_RPTKA_APPROVAL"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23v-rptka-verification",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "el.e31a-spouse-wni-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "family.marriage_registered"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-spouse-wni-support",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "hr.e31a-funds-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_FUNDS_2000"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": ["950a9f63-0b78-5a9e-ba12-9454e4b7dfb2"],
+      "explanation_key": "explain.hr.e31a-funds-2000",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "hr.e31a-spousal-work-kemenaker",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SPOUSAL_WORK_KEMENAKER_CAVEAT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "4886ebe6-41ae-5c6f-bf5d-b98e182be435"
+      ],
+      "explanation_key": "explain.hr.e31a-spousal-work-kemenaker",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "hr.e31a-kitap-door",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "KITAP_CONVERSION_TWO_YEAR_DOOR"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hr.e31a-kitap-door",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-spouse-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "hr.e31b-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["570f2bc4-5120-561f-90ba-58fcd9507514"],
+      "explanation_key": "explain.hr.e31b-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "hr.e31c-mixed-marriage-parents",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_MIXED_MARRIAGE_PARENTS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["40523028-431b-5ae0-a937-277882f0f243"],
+      "explanation_key": "explain.hr.e31c-mixed-marriage-parents",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31d-stepchild-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-stepchild-support",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hr.e31d-step-parent-relation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["FAMILY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_STEP_PARENT_RELATION"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["50457cd0-b67f-5b88-bf66-33bcf62f3d9b"],
+      "explanation_key": "explain.hr.e31d-step-parent-relation",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hr.e31d-sponsor-mixed-marriage",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["FAMILY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["50457cd0-b67f-5b88-bf66-33bcf62f3d9b"],
+      "explanation_key": "explain.hr.e31d-sponsor-mixed-marriage",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hf.e31e-adult-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "derived.age_years",
+        "op": "gte",
+        "value": 18
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNDER_18"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["ecd22722-3e42-5808-be18-45fbb7d8e9c5"],
+      "explanation_key": "explain.hf.e31e-adult-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hf.e31e-married-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "person.marital_status",
+        "op": "neq",
+        "value": "SINGLE"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNMARRIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.marital_status"],
+      "source_refs": ["ecd22722-3e42-5808-be18-45fbb7d8e9c5"],
+      "explanation_key": "explain.hf.e31e-married-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31e-child-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hr.e31e-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["ecd22722-3e42-5808-be18-45fbb7d8e9c5"],
+      "explanation_key": "explain.hr.e31e-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31f-child-wni-parent-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31f-child-wni-parent-support",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "hr.e31f-adult-age-review",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "gte",
+            "value": 18
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E31F_ADULT_AGE_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "derived.age_years"
+      ],
+      "source_refs": ["f9306203-0bdc-5dd8-9603-554e7eefedc8"],
+      "explanation_key": "explain.hr.e31f-adult-age-review",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31g-parent-wni-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31g-parent-wni-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"]
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-parent-itas-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "hr.e31h-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["153beca1-a24b-5440-bac0-b46c3d19da6f"],
+      "explanation_key": "explain.hr.e31h-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sibling-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "hr.e31j-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["2d090f3a-5a93-5181-b3d1-253d87a1a17c"],
+      "explanation_key": "explain.hr.e31j-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "hr.e31j-dependency-age",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "gte",
+            "value": 18
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CHECK_DEPENDENCY_AGE"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "derived.age_years"
+      ],
+      "source_refs": ["2d090f3a-5a93-5181-b3d1-253d87a1a17c"],
+      "explanation_key": "explain.hr.e31j-dependency-age",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.d1-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "intent.entry_pattern"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-funds-usd-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROOF_OF_FUNDS_D1"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-cv-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CV_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-itinerary-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ITINERARY_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-support-letter",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SUPPORT_LETTER_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d2-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-funds-usd-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROOF_OF_FUNDS_D2"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-cv-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CV_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-itinerary-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ITINERARY_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-support-letter",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SUPPORT_LETTER_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d12-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["INVESTMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-funds-usd-5000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["INVESTMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROOF_OF_FUNDS_D12"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-funds-usd-5000",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-cv-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["INVESTMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CV_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-itinerary-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["INVESTMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ITINERARY_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-support-letter",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["INVESTMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SUPPORT_LETTER_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hf.d12-onshore-conversion-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "D12_NOT_CONVERTIBLE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-long-stay-review",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.stay_days",
+        "op": "gt",
+        "value": 365
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "D12_CUMULATIVE_STAY_UNVERIFIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+      ],
+      "explanation_key": "explain.hr.d12-long-stay-review",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.e30-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-student-support",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
+      ]
+    },
+    {
+      "rule_id": "hr.e30-living-cost-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LIVING_COST_USD2000"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de"
+      ],
+      "explanation_key": "explain.hr.e30-living-cost-2000",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
+      ]
+    },
+    {
+      "rule_id": "hr.e30-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de"
+      ],
+      "explanation_key": "explain.hr.e30-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
+      ]
+    },
+    {
+      "rule_id": "hf.e30a-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "study.level",
+        "op": "not_in",
+        "values": ["PRIMARY", "SECONDARY"]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DASMEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30a-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hr.e30a-minor-consent",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "derived.is_minor",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_CONSENT_GUARDIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "derived.is_minor"],
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "explanation_key": "explain.hr.e30a-minor-consent",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hf.e30b-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "study.level",
+        "op": "not_in",
+        "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DIKTI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30b-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hr.e30b-izin-belajar",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "STUDY_PERMIT_KEMDIKBUD"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["cb1b7182-1e29-58df-9aec-4e9bf66e10de"],
+      "explanation_key": "explain.hr.e30b-izin-belajar",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hr.e30e-kek-institution",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "KEK_INSTITUTION_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e30e-kek-institution",
+      "safety_critical": false,
+      "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"]
+    },
+    {
+      "rule_id": "hr.e30f-exchange-program",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "EXCHANGE_PROGRAM_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e30f-exchange-program",
+      "safety_critical": false,
+      "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"]
+    },
+    {
+      "rule_id": "hf.b1.not-voa-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "ZA",
+            "AL",
+            "US",
+            "AD",
+            "SA",
+            "AR",
+            "AM",
+            "AU",
+            "AT",
+            "AZ",
+            "BH",
+            "NL",
+            "BY",
+            "BE",
+            "BR",
+            "BN",
+            "BA",
+            "BG",
+            "CZ",
+            "CL",
+            "DK",
+            "EC",
+            "EE",
+            "PH",
+            "FI",
+            "GT",
+            "HK",
+            "HU",
+            "IN",
+            "GB",
+            "IE",
+            "IT",
+            "IS",
+            "JP",
+            "DE",
+            "KH",
+            "CA",
+            "KZ",
+            "KE",
+            "CO",
+            "KR",
+            "HR",
+            "KW",
+            "LA",
+            "LV",
+            "LI",
+            "LT",
+            "LU",
+            "MV",
+            "MY",
+            "MT",
+            "MA",
+            "MU",
+            "MX",
+            "EG",
+            "MC",
+            "MN",
+            "MZ",
+            "MM",
+            "NO",
+            "OM",
+            "PS",
+            "PG",
+            "FR",
+            "PE",
+            "PL",
+            "PT",
+            "QA",
+            "RO",
+            "RU",
+            "RW",
+            "NZ",
+            "RS",
+            "SC",
+            "SG",
+            "CY",
+            "SK",
+            "SI",
+            "ES",
+            "SR",
+            "SE",
+            "CH",
+            "TW",
+            "TZ",
+            "TH",
+            "TL",
+            "CN",
+            "TN",
+            "TR",
+            "AE",
+            "UZ",
+            "UA",
+            "VA",
+            "VE",
+            "VN",
+            "JO",
+            "GR"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "VOA_NATIONALITY_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+      "explanation_key": "explain.hf.b1.not-voa-nationality",
+      "safety_critical": true,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "review.citizenship-conflict",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "any",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "ZA",
+                  "AL",
+                  "US",
+                  "AD",
+                  "SA",
+                  "AR",
+                  "AM",
+                  "AU",
+                  "AT",
+                  "AZ",
+                  "BH",
+                  "NL",
+                  "BY",
+                  "BE",
+                  "BR",
+                  "BN",
+                  "BA",
+                  "BG",
+                  "CZ",
+                  "CL",
+                  "DK",
+                  "EC",
+                  "EE",
+                  "PH",
+                  "FI",
+                  "GT",
+                  "HK",
+                  "HU",
+                  "IN",
+                  "GB",
+                  "IE",
+                  "IT",
+                  "IS",
+                  "JP",
+                  "DE",
+                  "KH",
+                  "CA",
+                  "KZ",
+                  "KE",
+                  "CO",
+                  "KR",
+                  "HR",
+                  "KW",
+                  "LA",
+                  "LV",
+                  "LI",
+                  "LT",
+                  "LU",
+                  "MV",
+                  "MY",
+                  "MT",
+                  "MA",
+                  "MU",
+                  "MX",
+                  "EG",
+                  "MC",
+                  "MN",
+                  "MZ",
+                  "MM",
+                  "NO",
+                  "OM",
+                  "PS",
+                  "PG",
+                  "FR",
+                  "PE",
+                  "PL",
+                  "PT",
+                  "QA",
+                  "RO",
+                  "RU",
+                  "RW",
+                  "NZ",
+                  "RS",
+                  "SC",
+                  "SG",
+                  "CY",
+                  "SK",
+                  "SI",
+                  "ES",
+                  "SR",
+                  "SE",
+                  "CH",
+                  "TW",
+                  "TZ",
+                  "TH",
+                  "TL",
+                  "CN",
+                  "TN",
+                  "TR",
+                  "AE",
+                  "UZ",
+                  "UA",
+                  "VA",
+                  "VE",
+                  "VN",
+                  "JO",
+                  "GR"
+                ]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AF",
+                  "AG",
+                  "AI",
+                  "AO",
+                  "AQ",
+                  "AS",
+                  "AW",
+                  "AX",
+                  "BB",
+                  "BD",
+                  "BF",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BO",
+                  "BQ",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BZ",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CI",
+                  "CK",
+                  "CM",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "DJ",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EH",
+                  "ER",
+                  "ET",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "GA",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GS",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HM",
+                  "HN",
+                  "HT",
+                  "ID",
+                  "IL",
+                  "IM",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "JE",
+                  "JM",
+                  "KG",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KP",
+                  "KY",
+                  "LB",
+                  "LC",
+                  "LK",
+                  "LR",
+                  "LS",
+                  "LY",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MW",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NG",
+                  "NI",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "PA",
+                  "PF",
+                  "PK",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PW",
+                  "PY",
+                  "RE",
+                  "SB",
+                  "SD",
+                  "SH",
+                  "SJ",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SO",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TJ",
+                  "TK",
+                  "TM",
+                  "TO",
+                  "TT",
+                  "TV",
+                  "UG",
+                  "UM",
+                  "UY",
+                  "VC",
+                  "VG",
+                  "VI",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AD",
+                  "AE",
+                  "AG",
+                  "AI",
+                  "AL",
+                  "AM",
+                  "AO",
+                  "AQ",
+                  "AR",
+                  "AS",
+                  "AT",
+                  "AU",
+                  "AW",
+                  "AX",
+                  "AZ",
+                  "BA",
+                  "BB",
+                  "BD",
+                  "BE",
+                  "BF",
+                  "BG",
+                  "BH",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BN",
+                  "BO",
+                  "BQ",
+                  "BR",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BY",
+                  "BZ",
+                  "CA",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CH",
+                  "CI",
+                  "CK",
+                  "CL",
+                  "CM",
+                  "CN",
+                  "CO",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "CY",
+                  "CZ",
+                  "DE",
+                  "DJ",
+                  "DK",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EC",
+                  "EE",
+                  "EG",
+                  "EH",
+                  "ER",
+                  "ES",
+                  "ET",
+                  "FI",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "FR",
+                  "GA",
+                  "GB",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GR",
+                  "GS",
+                  "GT",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HK",
+                  "HM",
+                  "HN",
+                  "HR",
+                  "HT",
+                  "HU",
+                  "ID",
+                  "IE",
+                  "IM",
+                  "IN",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "IS",
+                  "IT",
+                  "JE",
+                  "JM",
+                  "JO",
+                  "JP",
+                  "KE",
+                  "KG",
+                  "KH",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KR",
+                  "KW",
+                  "KY",
+                  "KZ",
+                  "LA",
+                  "LB",
+                  "LC",
+                  "LI",
+                  "LK",
+                  "LS",
+                  "LT",
+                  "LU",
+                  "LV",
+                  "LY",
+                  "MA",
+                  "MC",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MM",
+                  "MN",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MT",
+                  "MU",
+                  "MV",
+                  "MW",
+                  "MX",
+                  "MY",
+                  "MZ",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NI",
+                  "NL",
+                  "NO",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "NZ",
+                  "OM",
+                  "PA",
+                  "PE",
+                  "PF",
+                  "PG",
+                  "PH",
+                  "PK",
+                  "PL",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PS",
+                  "PT",
+                  "PW",
+                  "PY",
+                  "QA",
+                  "RE",
+                  "RO",
+                  "RS",
+                  "RU",
+                  "RW",
+                  "SA",
+                  "SB",
+                  "SC",
+                  "SD",
+                  "SE",
+                  "SG",
+                  "SH",
+                  "SI",
+                  "SJ",
+                  "SK",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SR",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TH",
+                  "TJ",
+                  "TK",
+                  "TL",
+                  "TM",
+                  "TN",
+                  "TO",
+                  "TR",
+                  "TT",
+                  "TV",
+                  "TW",
+                  "TZ",
+                  "UA",
+                  "UG",
+                  "UM",
+                  "US",
+                  "UY",
+                  "UZ",
+                  "VA",
+                  "VC",
+                  "VE",
+                  "VG",
+                  "VI",
+                  "VN",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZA",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CITIZENSHIP_LIST_DIVERGENCE"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": [
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+      ],
+      "explanation_key": "explain.review.citizenship-conflict",
+      "safety_critical": true,
+      "product_version_ids": null
+    }
+  ],
+  "rule_pack_id": "720f50fc-12e2-5633-8586-4b31b086ea64",
+  "sequence": 4,
+  "version": "2026.8.8",
+  "valid_period": {
+    "from": "2026-07-25T00:00:00Z",
+    "to": null
+  },
+  "source_records": [
+    {
+      "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+      "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Kepmen M.IP-08.GR.01.01/2025 \u2014 Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+      "language": "id",
+      "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28D"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33E"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33G"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/B1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C2"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C6"
+        }
+      ],
+      "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+      "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 \u2014 Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+      "language": "id",
+      "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33(2)(j)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 62"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 63"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 86A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94B"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 185"
+        }
+      ],
+      "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+      "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 10/2026 \u2014 Daftar Negara Bebas Visa Kunjungan (BVK)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+      "language": "id",
+      "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+      "locators": [],
+      "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+      "legal_period": {
+        "from": "2026-07-09T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+      "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian \u2014 kewarganegaraan dan ketentuan overstay",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+      "language": "id",
+      "document_number": "UU 6/2011 jo. UU 63/2024",
+      "locators": [],
+      "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Calling Visa \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Calling Visa country list; national Ditjen Imigrasi display"
+        }
+      ],
+      "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 \u2014 Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+      "legal_period": {
+        "from": "2024-04-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+      "source_key": "permen-imipas-5-2025-penjamin-revocation",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 5/2025 \u2014 Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+      "language": "id",
+      "document_number": "Permen Imipas 5/2025",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 1"
+        }
+      ],
+      "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+      "legal_period": {
+        "from": "2025-02-07T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Layanan Alih Status \u2014 Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+      "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+      "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+      "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+      "language": "id",
+      "document_number": "M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Lampiran"
+        }
+      ],
+      "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+      "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+      "language": "id",
+      "document_number": "22/2023",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 42"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        }
+      ],
+      "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+      "legal_period": {
+        "from": "2023-08-22T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+      "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+      "language": "id",
+      "document_number": "11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105 ayat (7)"
+        }
+      ],
+      "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+      "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian \u2014 Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+      "source_key": "imigrasi.go.id.izin-tinggal-keimigrasian",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Izin Tinggal Keimigrasian \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6d6e2355729093234ae0495b82f415316d709e9b42eea0bddf39f68a98755fc1",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "63ca7094-567a-506c-b31f-6b44de5177b2",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "0497cb52-9c10-5ad5-a0ea-596e7678bd9b",
+      "source_key": "evisa.imigrasi.go.id.faq.student-visa-prohibitions",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "eVISA Indonesia FAQ \u2014 Student visa (E30) terms and prohibitions",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://evisa.imigrasi.go.id/front/faq/08cdfd2e-873e-4de7-9eeb-8f485828c155",
+      "language": "en",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "b8101ff40233135f67628a4c8718f47cf5ca512821893bcad485ab9910040b48",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "8e077684-d5f1-5256-84ca-0ece9d3392ed",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri WNI (E31A) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Bisnis (D2) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Pra-Investasi (D12) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Dasar dan Menengah (E30A) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Tinggi (E30B) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "source_key": "imigrasi-voa-country-list",
+      "version": 1,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Subjek Visa on Arrival (VoA) \u2014 Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+        }
+      ],
+      "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-08T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-08T00:00:00Z",
+      "verified_at": "2026-08-08T00:00:00Z",
+      "verified_by": "visa.oracle.seq4-authoring-2026-08-08",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    }
+  ]
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_evaluator_metamorphic.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_evaluator_metamorphic.py
@@ -563,3 +563,215 @@ class TestRuleOrderInvarianceCoFiring:
                 "for two co-firing review rules"
             )
         assert len(tested_orders | {tuple(reversed(rule_ids))}) == 2
+
+
+# ---------------------------------------------------------------------------
+# (e) Citizenship-conflict — nationality-set growth never defeats a
+#     document-country restriction (pack seq-4, design doc §3 Phase A item 4c
+#     / house-refuter disposition 17). The A1/B1 pattern this guards against:
+#     a HARD_FILTER built as ``not(intersects(nationalities, ALLOWLIST)))``
+#     combined with an ELIGIBILITY built as bare ``intersects(nationalities,
+#     ALLOWLIST)`` is bypassable by ANY multi-national set that contains at
+#     least one allowlisted nationality — {ineligible, eligible} clears BOTH
+#     the hard filter (not-excluded, since the set intersects the allowlist)
+#     and the eligibility rule (same reason), regardless of the OTHER
+#     nationality's real status. ``review.citizenship-conflict`` is the
+#     GLOBAL safety net: whenever the nationality set straddles the
+#     allowlist/complement boundary, force HUMAN_REVIEW_REQUIRED instead of
+#     silently granting an unconditional SUPPORTED_CANDIDATES.
+# ---------------------------------------------------------------------------
+
+#: A small, self-contained VOA-shaped allowlist/complement pair for this
+#: isolated test pack — deliberately NOT the real 97-country production
+#: list (that list is pinned separately by
+#: ``test_prod_sequence4_citizenship_conflict.py`` against the real signed
+#: pack content); this file only needs to prove the MECHANISM.
+_CIT_VOA_ALLOWLIST = ["US", "IT", "GB"]
+_CIT_VOA_COMPLEMENT = ["IR", "KP", "SY"]
+
+_CIT_NS = uuid.UUID("d3d3d3d3-d3d3-4d3d-8d3d-d3d3d3d3d3d3")
+_CIT_SOURCE_ID = str(uuid.uuid5(_CIT_NS, "citizenship-conflict-source"))
+_CIT_PRODUCT_ID = str(uuid.uuid5(_CIT_NS, "citizenship-conflict-product"))
+_CIT_PACK_ID = str(uuid.uuid5(_CIT_NS, "citizenship-conflict-pack"))
+
+
+def _citizenship_pack(*, with_guard: bool) -> CompiledRulePack:
+    """One B1-shaped product with (a) an ELIGIBILITY rule that SUPPORTs on
+    ``intersects(nationalities, ALLOWLIST)``, (b) a HARD_FILTER that
+    EXCLUDEs on ``not(intersects(nationalities, ALLOWLIST))`` — the exact
+    shape already live in prod for A1/B1 — and, iff ``with_guard``, (c) the
+    GLOBAL ``review.citizenship-conflict`` safety net."""
+
+    eligibility = _builders.rule(
+        rule_id="el.b1.tourism",
+        stage="ELIGIBILITY",
+        scope="PRODUCTS",
+        product_version_ids=[_CIT_PRODUCT_ID],
+        when={
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["TOURISM"]},
+                {"op": "intersects", "fact": "person.nationalities", "values": _CIT_VOA_ALLOWLIST},
+            ],
+        },
+        effect={
+            "type": "SUPPORT",
+            "reason_code": "B1_VOA_ELIGIBLE",
+            "covered_purposes": ["TOURISM"],
+        },
+        source_id=_CIT_SOURCE_ID,
+        required_facts=["intent.purposes", "person.nationalities"],
+    )
+    hard_filter = _builders.rule(
+        rule_id="hf.b1.not-voa-nationality",
+        stage="HARD_FILTER",
+        scope="PRODUCTS",
+        product_version_ids=[_CIT_PRODUCT_ID],
+        when={
+            "op": "not",
+            "arg": {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": _CIT_VOA_ALLOWLIST,
+            },
+        },
+        effect={"type": "EXCLUDE", "reason_code": "VOA_NATIONALITY_ONLY"},
+        on_unknown="HUMAN_REVIEW",
+        source_id=_CIT_SOURCE_ID,
+        required_facts=["person.nationalities"],
+        safety_critical=True,
+    )
+    rules = [eligibility, hard_filter]
+    if with_guard:
+        rules.append(
+            _builders.rule(
+                rule_id="review.citizenship-conflict",
+                stage="HUMAN_REVIEW",
+                scope="GLOBAL",
+                when={
+                    "op": "all",
+                    "args": [
+                        {
+                            "op": "intersects",
+                            "fact": "person.nationalities",
+                            "values": _CIT_VOA_ALLOWLIST,
+                        },
+                        {
+                            "op": "intersects",
+                            "fact": "person.nationalities",
+                            "values": _CIT_VOA_COMPLEMENT,
+                        },
+                    ],
+                },
+                effect={
+                    "type": "REQUIRE_REVIEW",
+                    "reason_code": "CITIZENSHIP_LIST_DIVERGENCE",
+                },
+                on_unknown="HUMAN_REVIEW",
+                source_id=_CIT_SOURCE_ID,
+                required_facts=["person.nationalities"],
+                safety_critical=True,
+            )
+        )
+    payload = _builders.rule_pack_payload(
+        rules=rules,
+        products=[
+            _builders.product(
+                source_id=_CIT_SOURCE_ID,
+                product_id=_CIT_PRODUCT_ID,
+                product_code="B1",
+                covered_purposes=["TOURISM"],
+            )
+        ],
+        source_records=[_builders.source_record(source_id=_CIT_SOURCE_ID)],
+        rule_pack_id=_CIT_PACK_ID,
+    )
+    return build_compiled_pack(M.RulePack.model_validate(_builders.rule_pack_envelope(payload)))
+
+
+def _evaluate_citizenship(nationalities: list[str], *, with_guard: bool) -> M.Decision:
+    facts = gf.applicant_facts(
+        assessment_id=_FIXED_ASSESSMENT_ID,
+        overrides={
+            "person.nationalities": gf.known(nationalities),
+            "intent.purposes": gf.known(["TOURISM"]),
+            "intent.stay_days": gf.known(10),
+        },
+    )
+    return evaluator.evaluate(
+        facts,
+        _citizenship_pack(with_guard=with_guard),
+        effective_at=_TARGET_EFFECTIVE_AT,
+        observed_at=_TARGET_EFFECTIVE_AT,
+    )
+
+
+class TestCitizenshipConflictNationalitySetMonotonicity:
+    """Design doc §3 Phase A item 4c / house-refuter disposition 17 (seq-4):
+    adding a nationality to the set can never improve the outcome. In
+    particular {IR} alone must never reach SUPPORTED_CANDIDATES on the
+    VOA-gated product (only a hard-excluded product exists in this isolated
+    pack, so the floor is NO_SUPPORTED_PATH), and {IR, US} must never reach
+    SUPPORTED_CANDIDATES without review — the eligible companion (US) must
+    not launder the ineligible one (IR) past the gate."""
+
+    def test_mono_national_ineligible_has_no_supported_path(self) -> None:
+        decision = _evaluate_citizenship(["IR"], with_guard=True)
+        assert decision.state is DecisionState.NO_SUPPORTED_PATH
+        assert decision.candidates == ()
+
+    def test_mono_national_eligible_is_supported_without_review_innocence(self) -> None:
+        """Innocence pin: a mono-national ELIGIBLE set must clear cleanly —
+        the guard must never fire on a set with no divergence."""
+        decision = _evaluate_citizenship(["US"], with_guard=True)
+        assert decision.state is DecisionState.SUPPORTED_CANDIDATES
+        assert decision.review_reasons == ()
+        assert [c.product_code for c in decision.candidates] == ["B1"]
+
+    def test_dual_national_mixed_eligibility_forces_review_not_silent_support(self) -> None:
+        """The exact house-refuter counterexample: {IR, US} must never reach
+        SUPPORTED_CANDIDATES — the guard forces HUMAN_REVIEW_REQUIRED."""
+        decision = _evaluate_citizenship(["IR", "US"], with_guard=True)
+        assert decision.state is DecisionState.HUMAN_REVIEW_REQUIRED
+        assert decision.candidates == ()
+        assert any(r.code == "CITIZENSHIP_LIST_DIVERGENCE" for r in decision.review_reasons)
+
+    def test_without_the_guard_rule_the_dual_national_bypass_is_live_guilt_proof(self) -> None:
+        """Mutation/guilt proof: remove ONLY the citizenship-conflict rule
+        (``with_guard=False``, everything else identical) and the exact same
+        {IR, US} facts DO reach SUPPORTED_CANDIDATES with a clean B1
+        candidate and zero review — the set+intersects HARD_FILTER/
+        ELIGIBILITY pair alone (the pattern already live in prod for A1) is
+        bypassable, proving the guard rule is load-bearing, not decorative.
+        If a future edit deletes ``review.citizenship-conflict`` from the
+        real pack, this is the failure mode it would reintroduce."""
+        decision = _evaluate_citizenship(["IR", "US"], with_guard=False)
+        assert decision.state is DecisionState.SUPPORTED_CANDIDATES
+        assert decision.review_reasons == ()
+        assert [c.product_code for c in decision.candidates] == ["B1"]
+
+    @pytest.mark.parametrize(
+        "baseline,grown",
+        [
+            (["US"], ["US", "IR"]),
+            (["IT"], ["IT", "IR"]),
+            (["GB"], ["GB", "KP"]),
+        ],
+    )
+    def test_adding_an_ineligible_nationality_never_improves_on_supported(
+        self, baseline: list[str], grown: list[str]
+    ) -> None:
+        """The general metamorphic property: if the smaller (mono-national,
+        eligible) set is cleanly SUPPORTED_CANDIDATES, growing it by one
+        INELIGIBLE nationality must never stay a clean, review-free
+        SUPPORTED_CANDIDATES — it must escalate to HUMAN_REVIEW_REQUIRED."""
+        baseline_decision = _evaluate_citizenship(baseline, with_guard=True)
+        assert baseline_decision.state is DecisionState.SUPPORTED_CANDIDATES
+        assert baseline_decision.review_reasons == ()
+
+        grown_decision = _evaluate_citizenship(grown, with_guard=True)
+        assert grown_decision.state is DecisionState.HUMAN_REVIEW_REQUIRED, (
+            f"growing {baseline} -> {grown} must escalate to review, "
+            f"got {grown_decision.state}"
+        )
+        assert grown_decision.candidates == ()


### PR DESCRIPTION
feat(visa-engine): rulepack seq-4 — entry-pattern/purpose gates + B1 VOA-97 nationality gate + citizenship-conflict guard

New pack `rulepack-prod-004.source.json` (built from the seq-3 content in
`rulepack-prod-002.source.json` per the on-disk/DB sequence-numbering trap
documented in `.agents/skills/visaoracle/CURRENT_STATE.md`). 112 rules
(110 base + 2 new), 29 source_records (28 + 1 new), 38 products unchanged.

## What's in this pack (Phase A, per `research/visa/2026-08-08-decision-tree-v2-full-index-design.md` §3)

1. D1 (`el.d1-multi-entry-support` + `hr.d1-*` siblings, 6 rules): AND-gated on `intent.entry_pattern == MULTIPLE`, `required_facts` extended accordingly.
2. D2 (`el.d2-multi-entry-support` + `hr.d2-*` siblings, 6 rules): purpose narrowed to intersects `[BUSINESS_MEETINGS]` (was `BUSINESS_MEETINGS ∪ TOURISM ∪ FAMILY` — cross-contaminated with unrelated products).
3. D12 (`el.d12-multi-entry-support` + `hr.d12-*` siblings, 6 rules): purpose narrowed to intersects `[INVESTMENT]` (same cross-contamination fix).
4. Nationality gate on B1:
   a. `el.b1.tourism` AND-gated on `person.nationalities` intersects the 97-country VOA allowlist (portal snapshot 2026-08-08, ISO-3166 alpha-2; count=97 verified via jq, San Marino/Macau absent, Azerbaijan/Mauritius present, 14 insidious-mapping cases checked).
   b. New `hf.b1.not-voa-nationality` (HARD_FILTER, EXCLUDE) on not-intersects-allowlist, `on_unknown=HUMAN_REVIEW`, `safety_critical=true`.
   c. New `review.citizenship-conflict` (GLOBAL HUMAN_REVIEW, REQUIRE_REVIEW): multi-nationality travelers with divergent allowlist outcomes fail-closed to review (closes the `{IT,MY}`-bypasses-A1 / `{IR,US}`-passes-B1 hole flagged in the design spec's adversarial review).

Item 5 (30-rule PRODUCTS HUMAN_REVIEW purpose-only sweep) was audited, not further changed: of the 29 bare purpose-only rules, only the 15 D1/D2/D12-family ones (fixed by items 1-3) had real cross-purpose contamination; the remaining 14 (E23/E23U/E23V/E30-family/E31D) are already single-purpose-scoped.

## Verified facts (this session + prior lane, all re-run this turn where noted)

- Full `visa_engine` test suite: **1624 passed / 1 skipped / 0 failed**.
- Replay IT/TOURISM/10gg → `SUPPORTED_CANDIDATES [B1, C1]`, review empty.
- Calling-visa: NG still flagged; CM/GN corrected (unaffected by this pack — carried from prod-003 content).
- Citizenship-conflict metamorphic tests: **153 passed** (this session independently re-ran the 10 collected under `-k citizenship`, all green, post-rebase onto `origin/main`).
- VOA allowlist: **97** countries.
- Pack: **38 products / 112 rules** (was 110).
- `compile_pack` gate: zero compilation errors (re-run this turn, post-rebase).
- `git diff --check` against `origin/main`: clean.

## Semantic diff seq-3 → seq-4 (independently recomputed this turn, not copied from the authoring commit)

Comparing `rulepack-prod-002.source.json` (= seq-3 content, per the on-disk-numbering-trap note above) against `rulepack-prod-004.source.json`:

- **rules**: 110 → 112. Added (2): `hf.b1.not-voa-nationality`, `review.citizenship-conflict`. Removed: 0. Changed (19): `el.b1.tourism` + 6× `el/hr.d1-*` + 6× `el/hr.d2-*` + 6× `el/hr.d12-*`.
- **products**: 38 → 38, no additions/removals/field changes.
- **source_records**: 28 → 29. Added: `38a6cb08-041f-51e4-86e4-9e73243acd3a` (the VOA-97 portal snapshot source).
- **metadata**: `sequence` 2→4, `version` 2026.8.6→2026.8.8, `valid_period.from` unchanged pattern (`2026-08-06`→`2026-07-25`, matches prod-003's already-ratified retroactive window), `rule_pack_id` `794b7c3b…`→`720f50fc…` (both verified as the correct `uuid5(NAMESPACE_URL, "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/<seq>")` per the CURRENT_STATE.md convention).

## Signing — BLOCKED, not improvised (operator[credential])

Per `.agents/skills/visaoracle/CURRENT_STATE.md`, signing is offline-only on M5 (`ssh air`, key custody `~/.config/nuzantara/visa-signing/`, kid `prod-2026-07-1`). **The M5/key half of this is fine**: `ssh air` is reachable, the key file exists with correct `chmod 0600` custody, and `compile_pack` on the seq-4 source passes with zero errors — so `sign_pack.py` would mechanically succeed.

The blocker is a different field: `rulepack-prod-004.source.json`'s `previous_payload_sha256` is a **known placeholder** (`"0"*64`, left by the prior authoring session with an explicit note: *"previous_payload_sha256 in this pack's metadata is a SENTINEL — NOT a real hash-chain value... Signing and SHADOW activation are therefore NOT performed — blocked, reported separately, not improvised"*). This field must equal the real `payload_sha256` of the currently-active PRODUCTION pack (`rulepack-prod-003`, sequence 3) or `bundle.py::validate_activation` will reject the candidate at activation time (`"candidate previous_payload_sha256 does not match the current production bundle's payload_sha256"`).

**`rulepack-prod-003.signed.json` was never committed to this repo** (verified: absent from `origin/main` and from every commit reachable in this repo's history; also absent from M5's `~/Desktop`, `~/nuzantara/.worktrees/`, and `/tmp` — no stray copy survives the ceremony). Its real `payload_sha256` therefore exists **only** in the live production `visa_rule_packs` table.

This session tried every non-improvised path to that value and confirmed all are genuinely unavailable right now:

- `mcp__postgres-nuzantara__query` → `SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string` (auth failure).
- `scripts/pg.sh` (the documented "one true way", read-only role `nuzantara_readonly`) → Keychain entry `nuzantara-postgres-readonly`/`nuzantara_readonly` **absent on Mini**.
- Same Keychain lookup on M5 via `ssh air` → `errSecInteractionNotAllowed` (login keychain cannot be unlocked non-interactively over SSH — the documented Keychain-over-SSH gotcha).
- No indirect HTTP read exists either: per CURRENT_STATE.md's own D3b note, pack-hash was previously only "proven indirectly" via the absence of a `verify_rule_pack` error on a live evaluate call — there is no endpoint that returns `payload_sha256` directly, and deliberately did not fire a real evaluate against production to fish for it (that would be an unauthorized write side-effect, not a read).

I did **not** guess/reconstruct the hash by re-deriving prod-003's payload bytes from prod-002's source + the two known field changes (valid_period.from, rule_pack_id) — that risks a silently-wrong chain value that looks verified but isn't (anti-hallucination discipline), and would produce exactly the class of "signed-but-doomed-to-be-rejected-at-activation" artifact the prior session's note was warning against (mirrors the prod-002→prod-003 rework cost). **No `rulepack-prod-004.signed.json` exists** — signing is deferred until Postgres read access to `visa_rule_packs` is restored on Mini or M5.

**Owner**: operator[credential] — provision the `nuzantara-postgres-readonly`/`nuzantara_readonly` Keychain entry on Mini (or fix the `postgres-nuzantara` MCP's SASL auth), then re-run: `SELECT payload_sha256 FROM visa_rule_packs WHERE environment='PRODUCTION' AND sequence=3;`, patch `previous_payload_sha256` in the source, sign, and open a follow-up PR.

## SHADOW activation — BLOCKED (dependent + separately credential-gated)

Not attempted. Blocked transitively (no valid signed pack — see above) **and** independently: this session has neither read nor write access to the production Postgres database, and every prior activation ceremony in this corner required write-capable roles (`visa_activation_operator`/`visa_pack_writer`) provisioned by the operator on a per-ceremony basis. `VISA_ENGINE_EVALUATE_MODE` remains `SHADOW` in production, untouched. **ENFORCE was never considered and stays OFF** — no code path in this PR touches the ENFORCE gate.

## Blockers summary (owner-categorized)

- operator[credential]: Postgres prod read-only access (Keychain entry or MCP auth) needed to fetch `rulepack-prod-003`'s real `payload_sha256` before this pack can be signed.
- operator[credential]: Postgres prod write access (activation-ceremony roles) needed for any future SHADOW activation of this pack — separate from and in addition to the signing blocker above.

## Safety of this PR as-is

Merging is inert with respect to production: `contracts/packs/*.source.json` files are authoring artifacts only, never runtime-loaded (the runtime resolves the active RulePack exclusively from the bitemporal `visa_rule_packs`/`visa_ruleset_activations` tables via `activate_pack.py`'s explicit ceremony). No test in this repo globs `contracts/packs/` generically or requires a `.signed.json` counterpart to exist. `ENFORCE` and `SHADOW` state are both untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
