### PR TITLE
feat(ops): scoped versioned mirror of imigrasi.go.id visa pages + Telegram diff-alert

### DIFF
--- a/scripts/imigrasi_mirror/README.md
+++ b/scripts/imigrasi_mirror/README.md
@@ -1,0 +1,126 @@
+# imigrasi.go.id scoped mirror + diff-alert
+
+**Scope: NOT a full-site copy.** ~123 pages that feed the Bali Zero visa
+engine, versioned daily/weekly, with a Telegram alert when one of them
+changes. The value is the repeated crawl + diff, not a one-off copy
+(cicatrix W90: "anche il ground-truth invecchia" — a static snapshot goes
+stale the moment Imigrasi edits a list; this exists to catch that edit).
+
+## What it watches
+
+| Category | Count | Tier | Examples |
+|---|---|---|---|
+| VoA/BVK/Calling subject lists + parent | 4 | daily | `/wna/daftar-negara-voa-bvk-calling-visa[/...]` |
+| FAQ (documented for its OWN staleness, not trusted) | 1 | daily | `/faq/visa/negara-mana-saja...e-voa` |
+| Visa catalog index | 1 | daily | `/wna/daftar-visa-indonesia` |
+| Regional kanim mirrors (schema counter-proof) | 3 | daily | depok / bontang / ngurah rai |
+| Per-visa-code detail pages | 114 | weekly | `/wna/daftar-visa-indonesia/{CODE}` |
+
+The 114 codes are a **copy** of `apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py`,
+not a live import (keeps this module free of the backend-rag app's
+dependency chain so it can run standalone from cron). Re-check with:
+
+```
+scripts/imigrasi_mirror/run-mirror.sh --verify-codes
+```
+
+All 123 URLs in `urls.py` were verified live (WebFetch, 200, real content)
+on 2026-08-08 before being committed — see the module docstring.
+
+## Cadence (coded, NOT yet installed as cron)
+
+```
+run-mirror.sh --tier daily     # the 9 pages that "morde" — run this one daily
+run-mirror.sh --tier weekly    # the 114 per-code pages — run this one weekly
+run-mirror.sh --tier all       # everything in one pass
+run-mirror.sh --select parent,voa,bvk,calling,faq-evoa   # ad-hoc subset
+```
+
+**No LaunchAgent/cron is installed by this change.** Arming a schedule is a
+follow-up decision for the operator after reviewing the dry-run output
+below (Zero mandate 2026-08-08: code + dry-run only, this run).
+
+## Where the data lives
+
+A **separate git repo**, not this monorepo (avoids repo bloat from daily
+snapshot commits):
+
+```
+~/nuzantara-imigrasi-mirror/
+  snapshots/
+    2026-08-08/
+      voa-subjects.txt
+      bvk-subjects.txt
+      ...
+```
+
+Each run writes `snapshots/<date>/<slug>.txt` and commits. **Git history IS
+the version log** — no separate versioning mechanism. Override the path
+with `--data-root` or `IMIGRASI_MIRROR_DATA_ROOT` (used by `--selftest`'s
+hermetic fixtures, never the real path).
+
+## How the diff+alert works
+
+1. For each page, extract clean readable text (`extract.py` strips
+   nav/header/footer/script/style, tries a priority list of CMS
+   content-selectors, falls back to `<body>` — the goal is diffing what a
+   human reader sees, not markup churn).
+2. Find the most recent **prior** snapshot for that page's slug (searches
+   back through however many days it takes — a weekly-tier page's
+   "previous" may be ~7 days old, not just yesterday).
+3. If content differs, build a unified-diff excerpt (capped at 25 lines,
+   **always states `N of M` when truncated** — W97: no silent caps) and
+   send ONE Telegram alert per changed page.
+
+## Telegram: routed through `tg_notify.py`, not a direct call
+
+This module shells out to `scripts/tg_notify.py` (repo's ONE Telegram
+gateway, born 2026-07-06 after ~240 files each got secret-handling wrong in
+its own way) instead of calling the Bot API directly. Concretely this
+avoids re-introducing:
+
+- **W104** — judging `redis-cli`-style bare exit codes instead of the reply.
+  `tg_notify` already does the HTTP+JSON handling correctly.
+- **W115** — passing message content on argv, readable by any `ps` on the
+  box. This module pipes the message over **stdin**.
+- **W55** — a single-attempt send that drops silently on failure. `tg_notify`
+  spools unsendable P0s (`p0_unsent`) instead of losing them.
+
+Tier used: `p0` (a country added/removed from VoA/BVK/Calling is a real,
+actionable change for the visa engine — not routine noise). Dedup key is an
+**explicit content hash of the new snapshot**, not `tg_notify`'s default
+text-derived identity — the default strips numbers, which would treat two
+genuinely different diffs on the same page as "the same condition" and mute
+the second one. A content-hash key means: identical repeat send → deduped
+correctly; different diff → never falsely muted.
+
+## Guardrails actually enforced in code
+
+- Async `httpx`, never `requests` (Golden Rule #4).
+- Honest User-Agent: `BaliZero-visa-mirror/1.0 (+https://balizero.com; contact: zero@balizero.com)`.
+- Global rate limit ≥2s between request **dispatches**, on top of (not
+  instead of) a `--concurrency` cap (default 4 in flight).
+- Bounded retries (default 3, exponential backoff) on transient errors only
+  (timeout/5xx/429) — a 404/403 is not retried.
+- **Overall wall-clock deadline** per run (tier-scaled: 600s daily / 1800s
+  weekly / 2400s all) — never an unbounded crawl loop (the `fs_usage`
+  firehose lesson). Anything not reached by the deadline is reported as
+  `skipped_deadline`, never silently dropped.
+- `robots.txt` honored per host, cached once per run, **fail-open** on a
+  fetch/parse error (a robots.txt hiccup must not black out a public
+  government list page — verified live 2026-08-08: `imigrasi.go.id/robots.txt`
+  is `Allow: /` anyway).
+
+## Tests
+
+```
+scripts/imigrasi_mirror/run-mirror.sh --selftest    # no network
+scripts/imigrasi_mirror/run-mirror.sh --verify-codes
+```
+
+`--selftest` covers `extract_text` (guilt: script/nav stripped; innocence:
+real content survives, including the body-fallback path when no CMS
+selector matches), `compute_diff` (counts, and that a large diff DOES
+truncate with an explicit `N of M` note), and `find_previous_snapshot`
+(finds the most recent prior date, searches past simple d-1 gaps, and
+returns `None` — not a false diff — on a genuinely first capture).

--- a/scripts/imigrasi_mirror/crawler.py
+++ b/scripts/imigrasi_mirror/crawler.py
@@ -1,0 +1,160 @@
+"""Bounded, gentle, async crawler for the imigrasi.go.id scoped mirror.
+
+Guardrails (Zero mandate + fs_usage firehose lesson, CLAUDE.md host rules):
+  - httpx async (Golden Rule #4), never requests / sync sockets.
+  - Honest User-Agent naming us + a contact address.
+  - Global rate limit: no more than one request DISPATCHED every
+    `rate_limit_s` seconds, even with several requests in flight
+    (`--concurrency` caps how many are in flight at once; the limiter caps
+    how fast new ones start — the two combine, they don't substitute).
+  - Per-request timeout + bounded retries with backoff on transient errors
+    only (timeouts, 5xx, 429) — a permanent error (404/403) is not retried.
+  - An OVERALL wall-clock deadline bounds the whole crawl. Anything not
+    reached by the deadline is reported as skipped, never silently dropped
+    (W97: "no silent caps" — a truncated result must say N of M).
+  - robots.txt is honored per-host, fail-OPEN on a fetch/parse error (a
+    public government list page must not go dark because robots.txt itself
+    timed out) — cached once per host per run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from urllib import robotparser
+
+import httpx
+
+from extract import extract_text
+from urls import Page
+
+USER_AGENT = "BaliZero-visa-mirror/1.0 (+https://balizero.com; contact: zero@balizero.com)"
+
+RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+@dataclass
+class FetchResult:
+    page: Page
+    ok: bool
+    status_code: int | None
+    text: str | None
+    error: str | None
+    content_bytes: int
+
+
+class RateLimiter:
+    """Serializes request DISPATCH to at least `min_interval_s` apart, globally."""
+
+    def __init__(self, min_interval_s: float):
+        self._min = max(0.0, min_interval_s)
+        self._lock = asyncio.Lock()
+        self._last = 0.0
+
+    async def wait(self) -> None:
+        async with self._lock:
+            now = time.monotonic()
+            delta = now - self._last
+            if delta < self._min:
+                await asyncio.sleep(self._min - delta)
+            self._last = time.monotonic()
+
+
+class RobotsCache:
+    """Per-host robots.txt, fetched once per run. Fail-open on any error."""
+
+    def __init__(self, client: httpx.AsyncClient):
+        self._client = client
+        self._cache: dict[str, robotparser.RobotFileParser | None] = {}
+
+    async def allowed(self, url: str) -> bool:
+        u = httpx.URL(url)
+        origin = f"{u.scheme}://{u.host}"
+        if origin not in self._cache:
+            parsed: robotparser.RobotFileParser | None = None
+            try:
+                resp = await self._client.get(f"{origin}/robots.txt", timeout=10.0)
+                if resp.status_code == 200 and resp.text.strip():
+                    rp = robotparser.RobotFileParser()
+                    rp.parse(resp.text.splitlines())
+                    parsed = rp
+            except Exception:
+                parsed = None  # fail-open: a robots.txt hiccup must not black out a public gov page
+            self._cache[origin] = parsed
+        rp = self._cache[origin]
+        if rp is None:
+            return True
+        return rp.can_fetch(USER_AGENT, url)
+
+
+async def _fetch_one(
+    client: httpx.AsyncClient,
+    limiter: RateLimiter,
+    robots: RobotsCache,
+    page: Page,
+    *,
+    retries: int,
+    timeout_s: float,
+) -> FetchResult:
+    if not await robots.allowed(page.url):
+        return FetchResult(page, False, None, None, "robots_disallowed", 0)
+
+    last_err: str | None = None
+    for attempt in range(1, retries + 1):
+        await limiter.wait()
+        try:
+            resp = await client.get(page.url, timeout=timeout_s)
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            last_err = f"{type(exc).__name__}: {exc}"
+            if attempt < retries:
+                await asyncio.sleep(2**attempt)
+            continue
+
+        if resp.status_code == 200:
+            text = extract_text(resp.text)
+            return FetchResult(page, True, 200, text, None, len(resp.content))
+
+        if resp.status_code in RETRYABLE_STATUS:
+            last_err = f"http_{resp.status_code}"
+            if attempt < retries:
+                await asyncio.sleep(2**attempt)
+            continue
+
+        # Permanent client error (404, 403, ...) — retrying will not help.
+        return FetchResult(page, False, resp.status_code, None, f"http_{resp.status_code}", 0)
+
+    return FetchResult(page, False, None, None, last_err or "unknown_error", 0)
+
+
+async def crawl(
+    pages: list[Page],
+    *,
+    concurrency: int = 4,
+    rate_limit_s: float = 2.0,
+    timeout_s: float = 30.0,
+    retries: int = 3,
+    overall_timeout_s: float = 1200.0,
+) -> tuple[list[FetchResult], list[Page]]:
+    """Returns (results, skipped_due_to_deadline). `results` covers every
+    page NOT skipped — including failed fetches, so callers can report them
+    rather than lose them silently."""
+    limiter = RateLimiter(rate_limit_s)
+    sem = asyncio.Semaphore(max(1, concurrency))
+    deadline = time.monotonic() + overall_timeout_s
+    skipped: list[Page] = []
+
+    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, follow_redirects=True) as client:
+        robots = RobotsCache(client)
+
+        async def worker(page: Page) -> FetchResult | None:
+            async with sem:
+                if time.monotonic() > deadline:
+                    skipped.append(page)
+                    return None
+                return await _fetch_one(client, limiter, robots, page, retries=retries, timeout_s=timeout_s)
+
+        done = await asyncio.gather(*(worker(p) for p in pages))
+
+    results = [r for r in done if r is not None]
+    return results, skipped

--- a/scripts/imigrasi_mirror/diff_alert.py
+++ b/scripts/imigrasi_mirror/diff_alert.py
@@ -1,0 +1,85 @@
+"""Snapshot diff + Telegram alert, routed through the ONE gateway.
+
+Reuse, not reinvent (reuse-first discipline + scar family #4/#8): every
+Telegram send in this repo goes through `scripts/tg_notify.py` — born
+2026-07-06 specifically because ~240 files used to send Telegram directly,
+each getting secret-handling/dedup/budget/argv-safety wrong in its own way
+(W104 NOAUTH-on-stdout, W115 message-on-argv visible to `ps`, W55
+single-attempt drop). This module shells out to it rather than re-deriving
+any of that.
+
+Dedup key design (matters — see the comment on CONTENT_HASH_LEN below):
+tg_notify's DEFAULT identity-from-text strips numbers/hashes, which is
+exactly wrong here — two DIFFERENT diffs on the same page are two distinct
+newsworthy events, not one repeating condition to mute. So every diff alert
+gets an EXPLICIT dedup key keyed on a content hash of the NEW snapshot: same
+new content -> same key -> a duplicate send dedupes correctly; different new
+content -> different key -> never falsely muted.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TG_NOTIFY = REPO_ROOT / "scripts" / "tg_notify.py"
+
+CONTENT_HASH_LEN = 12
+DEFAULT_MAX_DIFF_LINES = 25
+
+
+def compute_diff(old_text: str, new_text: str, max_lines: int = DEFAULT_MAX_DIFF_LINES) -> tuple[str, int, int, bool]:
+    """Returns (excerpt, added_lines, removed_lines, truncated)."""
+    raw = list(
+        difflib.unified_diff(old_text.splitlines(), new_text.splitlines(), lineterm="", n=1)
+    )
+    body = [ln for ln in raw if not (ln.startswith("---") or ln.startswith("+++"))]
+    added = sum(1 for ln in body if ln.startswith("+"))
+    removed = sum(1 for ln in body if ln.startswith("-"))
+    truncated = len(body) > max_lines
+    excerpt_lines = body[:max_lines]
+    if truncated:
+        excerpt_lines.append(f"… ({len(body)} righe totali di diff, mostrate {max_lines})")
+    return "\n".join(excerpt_lines), added, removed, truncated
+
+
+def content_hash(text: str) -> str:
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()
+
+
+def _tg_notify(tier: str, source: str, dedup_key: str, text: str) -> str:
+    """Ships `text` to tg_notify.py over STDIN (never argv — W115: an
+    argument is readable by any `ps` on the box; the tg_notify gateway
+    already reads stdin when no positional text is given)."""
+    if not TG_NOTIFY.is_file():
+        return "gateway_missing"
+    cmd = [sys.executable, str(TG_NOTIFY), "--tier", tier, "--source", source, "--dedup-key", dedup_key]
+    try:
+        proc = subprocess.run(cmd, input=text, capture_output=True, text=True, timeout=20)
+    except Exception as exc:  # never let an alert failure break the crawl
+        return f"error:{exc}"
+    combined = (proc.stderr or "") + "\n" + (proc.stdout or "")
+    for line in combined.splitlines():
+        line = line.strip()
+        if line.startswith("tg_notify:"):
+            return line.split("tg_notify:", 1)[1].strip()
+    return f"exit_{proc.returncode}"
+
+
+def send_diff_alert(page_label: str, url: str, diff_excerpt: str, new_content_hash: str) -> str:
+    """`new_content_hash` must be content_hash(new_snapshot_text) — computed
+    ONCE by the caller (run.py already needs it to persist in the diff
+    record) and passed through, never re-derived here from something else."""
+    msg = f"🇮🇩 imigrasi.go.id — {page_label} è cambiata\n{url}\n\n{diff_excerpt}"
+    key = f"imigrasi-diff:{new_content_hash[:CONTENT_HASH_LEN]}"
+    return _tg_notify("p0", "imigrasi-mirror", key, msg)
+
+
+def send_status_note(text: str, dedup_key: str) -> str:
+    """One-off informational message (e.g. the mandatory dry-run test alert),
+    NOT a page-change event — separate dedup namespace from diff alerts."""
+    return _tg_notify("p0", "imigrasi-mirror", dedup_key, text)

--- a/scripts/imigrasi_mirror/extract.py
+++ b/scripts/imigrasi_mirror/extract.py
@@ -1,0 +1,75 @@
+"""HTML -> clean readable text, for diffing CONTENT rather than markup.
+
+The goal is to diff the same signal a human reading the page would see
+(country list changed) — not whitespace/attribute/script churn a raw-HTML
+diff would drown it in. Best-effort main-content selection: imigrasi.go.id
+and the regional kanim mirrors run on different CMS themes (W... none yet,
+but expect drift), so this tries a priority list of common content
+selectors and falls back to <body> minus boilerplate tags.
+"""
+
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+# Tags that are never content, regardless of which CMS rendered the page.
+_STRIP_TAGS = ("script", "style", "noscript", "svg", "iframe", "form", "button", "template")
+# Structural boilerplate, stripped globally before content-candidate
+# selection. `aside` covers the left-nav sidebar this site family renders as
+# `<aside id="sidebar">` — measured live 2026-08-08: without it, the sidebar's
+# ~35 menu items outweighed the real Calling Visa list (6 countries) and both
+# ended up in the same "largest block" (the list survived, buried in noise).
+_BOILERPLATE_TAGS = ("nav", "header", "footer", "aside")
+
+# Tried in order; the first one whose extracted text exceeds the threshold
+# wins. Covers WordPress-family themes (entry-content/post-content), generic
+# semantic HTML5 (main/article), and common CMS content-div id/class names
+# seen across imigrasi.go.id + the regional kanim mirrors.
+_CONTENT_SELECTORS = (
+    "main",
+    "article",
+    ".entry-content",
+    ".post-content",
+    "#content",
+    ".content",
+    "#main-content",
+    ".main-content",
+    ".container",
+)
+_MIN_CONTENT_CHARS = 200
+
+
+def extract_text(html: str) -> str:
+    """Return clean, newline-joined readable text from a page's HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    for tag in soup(_STRIP_TAGS):
+        tag.decompose()
+    # Boilerplate everywhere on this site family — strip BEFORE candidate
+    # selection (not only in the body fallback), so a decorative notice bar
+    # that happens to sit inside one of these never gets a chance to win.
+    for tag in soup.find_all(_BOILERPLATE_TAGS):
+        tag.decompose()
+
+    # Evaluate EVERY match of EVERY selector and keep the single LARGEST text
+    # block — not "first selector, first match past the threshold". A
+    # first-match rule is exactly the guard-over-match trap (cicatrix family
+    # #3): imigrasi.go.id's real VOA/BVK/Calling list lives in
+    # `div.container.my-5.px-4.content` (946 chars), but the page's generic
+    # "secure .go.id website" notice banner is ALSO `div.container...` and
+    # comes first in document order at 452 chars — a first-match rule landed
+    # on the banner every time (measured live 2026-08-08, all 5 dry-run
+    # snapshots were byte-identical 458-byte banner text, zero real content).
+    best = None
+    best_len = 0
+    for selector in _CONTENT_SELECTORS:
+        for candidate in soup.select(selector):
+            length = len(candidate.get_text(strip=True))
+            if length > best_len:
+                best, best_len = candidate, length
+
+    root = best if best is not None and best_len > _MIN_CONTENT_CHARS else (soup.body or soup)
+    text = root.get_text(separator="\n")
+    lines = [ln.strip() for ln in text.splitlines()]
+    lines = [ln for ln in lines if ln]
+    return "\n".join(lines)

--- a/scripts/imigrasi_mirror/requirements.txt
+++ b/scripts/imigrasi_mirror/requirements.txt
@@ -1,0 +1,2 @@
+httpx>=0.28
+beautifulsoup4>=4.12

--- a/scripts/imigrasi_mirror/run-mirror.sh
+++ b/scripts/imigrasi_mirror/run-mirror.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+# Wrapper: bootstraps a local venv (pattern per scripts/wa-audit-bot/run-bot.sh)
+# and runs the mirror. Telegram credentials are resolved by tg_notify.py
+# itself (env or ~/.nuzantara-secrets.env) — nothing to source here.
+#
+# NOT wired into cron/launchd by this change. Manual/dry-run invocation only
+# until the operator decides to arm a schedule (Zero mandate, 2026-08-08).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+VENV="$HERE/.venv"
+
+if [[ ! -d "$VENV" ]]; then
+    echo "[imigrasi-mirror] creating venv..." >&2
+    python3 -m venv "$VENV"
+    "$VENV/bin/pip" install -q -r "$HERE/requirements.txt"
+fi
+
+exec "$VENV/bin/python" "$HERE/run.py" "$@"

--- a/scripts/imigrasi_mirror/run.py
+++ b/scripts/imigrasi_mirror/run.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""imigrasi.go.id scoped mirror — crawl, snapshot, diff, alert.
+
+Usage:
+    run.py --tier daily              # 9 pages: 4 subject lists + FAQ + index + 3 regional
+    run.py --tier weekly             # 114 per-visa-code pages
+    run.py --tier all                # everything
+    run.py --select parent,voa,bvk,calling,faq-evoa   # ad-hoc subset (dry-run scope)
+    run.py --selftest                # no network — unit-check extract/diff/snapshot logic
+    run.py --verify-codes            # cross-check urls.CODES against the repo's seed file
+
+Data lives in a SEPARATE git repo (not this monorepo — avoids repo bloat from
+daily snapshots): default `~/nuzantara-imigrasi-mirror`, override with
+`--data-root` or `IMIGRASI_MIRROR_DATA_ROOT`. Each run writes
+`snapshots/<date>/<slug>.txt` and commits — git history IS the version log.
+
+NOT installed as a cron/LaunchAgent by this change (Zero mandate: code +
+dry-run only, arming is a follow-up decision after the dry-run is reviewed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from crawler import crawl
+from diff_alert import compute_diff, content_hash, send_diff_alert, send_status_note
+from urls import ALL_PAGES, Page, pages_for_select, pages_for_tier
+
+DEFAULT_DATA_ROOT = os.environ.get("IMIGRASI_MIRROR_DATA_ROOT") or str(Path.home() / "nuzantara-imigrasi-mirror")
+
+# Overall wall-clock budget scales with how many pages a tier touches — a
+# 9-page daily run and a 114-page weekly run should not share one constant
+# (guardrail: bounded, but "bounded" must still fit the job).
+OVERALL_TIMEOUT_BY_TIER = {"daily": 600.0, "weekly": 1800.0, "all": 2400.0}
+DEFAULT_OVERALL_TIMEOUT = 900.0
+
+
+# --------------------------------------------------------------------------- snapshot IO
+def snapshot_dir(data_root: Path, date: str) -> Path:
+    return data_root / "snapshots" / date
+
+
+def find_previous_snapshot(data_root: Path, slug: str, before_date: str) -> tuple[str, Path] | None:
+    """Most recent prior snapshot for `slug`, searched back through however
+    many days it takes (a weekly-tier page's "previous" may be ~7 days old —
+    searching only d-1 would treat every weekly run as a first capture)."""
+    snapshots_root = data_root / "snapshots"
+    if not snapshots_root.is_dir():
+        return None
+    dates = sorted(
+        (d.name for d in snapshots_root.iterdir() if d.is_dir() and d.name < before_date),
+        reverse=True,
+    )
+    for d in dates:
+        candidate = snapshots_root / d / f"{slug}.txt"
+        if candidate.is_file():
+            return d, candidate
+    return None
+
+
+def git_commit(data_root: Path, message: str) -> str:
+    """Commits everything new/changed under data_root. Returns a short status
+    string; 'nothing_to_commit' is not an error (e.g. a page fetched identical
+    to what's already on disk for today, on a re-run)."""
+    subprocess.run(["git", "add", "-A"], cwd=data_root, check=True, capture_output=True)
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=data_root, check=True, capture_output=True, text=True
+    )
+    if not status.stdout.strip():
+        return "nothing_to_commit"
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=data_root, check=True, capture_output=True)
+    return "committed"
+
+
+# --------------------------------------------------------------------------- main flow
+async def run(args: argparse.Namespace) -> dict:
+    if args.select:
+        ids = [s.strip() for s in args.select.split(",") if s.strip()]
+        pages = pages_for_select(ids)
+        tier_label = f"select({len(pages)})"
+    else:
+        pages = pages_for_tier(args.tier)
+        tier_label = args.tier
+
+    overall_timeout = args.overall_timeout_s or OVERALL_TIMEOUT_BY_TIER.get(args.tier, DEFAULT_OVERALL_TIMEOUT)
+
+    results, skipped = await crawl(
+        pages,
+        concurrency=args.concurrency,
+        rate_limit_s=args.rate_limit_s,
+        timeout_s=args.timeout_s,
+        overall_timeout_s=overall_timeout,
+    )
+
+    date = args.date or time.strftime("%Y-%m-%d", time.localtime())
+    data_root = Path(args.data_root).expanduser()
+    out_dir = snapshot_dir(data_root, date)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    captured: list[Page] = []
+    failed: list[tuple[Page, str, int | None]] = []
+    diffs: list[dict] = []
+    total_bytes = 0
+
+    for r in results:
+        if not r.ok or r.text is None:
+            failed.append((r.page, r.error or "unknown_error", r.status_code))
+            continue
+
+        out_path = out_dir / f"{r.page.slug}.txt"
+        out_path.write_text(r.text, encoding="utf-8")
+        total_bytes += len(r.text.encode("utf-8"))
+        captured.append(r.page)
+
+        prev = find_previous_snapshot(data_root, r.page.slug, date)
+        if prev is None:
+            continue  # first capture — nothing to diff against yet
+        prev_date, prev_path = prev
+        prev_text = prev_path.read_text(encoding="utf-8")
+        if prev_text == r.text:
+            continue  # unchanged
+
+        excerpt, added, removed, truncated = compute_diff(prev_text, r.text)
+        diffs.append(
+            {
+                "page": r.page,
+                "prev_date": prev_date,
+                "added": added,
+                "removed": removed,
+                "truncated": truncated,
+                "excerpt": excerpt,
+                "hash": content_hash(r.text),
+            }
+        )
+
+    commit_status = "skipped_dry_write" if args.no_commit else git_commit(
+        data_root, f"chore(snapshot): {date} tier={tier_label} {len(captured)} pages, {len(diffs)} diffs"
+    )
+
+    alert_results: list[tuple[str, str]] = []
+    if not args.no_alert:
+        for d in diffs:
+            status = send_diff_alert(d["page"].label, d["page"].url, d["excerpt"], d["hash"])
+            alert_results.append((d["page"].id, status))
+
+    summary = {
+        "date": date,
+        "tier": tier_label,
+        "pages_requested": len(pages),
+        "captured": len(captured),
+        "failed": [(p.id, err, code) for p, err, code in failed],
+        "skipped_deadline": [p.id for p in skipped],
+        "total_bytes": total_bytes,
+        "diffs": [
+            {"id": d["page"].id, "label": d["page"].label, "prev_date": d["prev_date"],
+             "added": d["added"], "removed": d["removed"]}
+            for d in diffs
+        ],
+        "alert_results": alert_results,
+        "commit_status": commit_status,
+        "data_root": str(data_root),
+    }
+    return summary
+
+
+def print_summary(summary: dict) -> None:
+    print(f"[imigrasi-mirror] date={summary['date']} tier={summary['tier']}")
+    print(f"  requested={summary['pages_requested']} captured={summary['captured']} "
+          f"failed={len(summary['failed'])} skipped_deadline={len(summary['skipped_deadline'])}")
+    print(f"  total_bytes={summary['total_bytes']} diffs={len(summary['diffs'])} commit={summary['commit_status']}")
+    for pid, err, code in summary["failed"]:
+        print(f"  FAILED {pid}: {err} (http={code})")
+    for pid in summary["skipped_deadline"]:
+        print(f"  SKIPPED (deadline) {pid}")
+    for d in summary["diffs"]:
+        print(f"  DIFF {d['id']} vs {d['prev_date']}: +{d['added']}/-{d['removed']}")
+    for pid, status in summary["alert_results"]:
+        print(f"  ALERT {pid}: {status}")
+    print(f"  data_root={summary['data_root']}")
+
+
+def verify_codes() -> int:
+    """Best-effort cross-check of urls.CODES against the seed file this
+    catalog was derived from. Skips (exit 0, loud note) if the monorepo
+    isn't reachable from here — this module must not hard-depend on it."""
+    import re
+
+    seed = Path(__file__).resolve().parent.parent.parent / (
+        "apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py"
+    )
+    if not seed.is_file():
+        print(f"[verify-codes] seed file not reachable at {seed} — skipping (not an error, this "
+              f"module is designed to run standalone)")
+        return 0
+    text = seed.read_text(encoding="utf-8")
+    live_codes = sorted(set(re.findall(r'"code":\s*"([^"]+)"', text)))
+    from urls import CODES
+
+    catalog_codes = sorted(set(CODES))
+    if live_codes == catalog_codes:
+        print(f"[verify-codes] OK — {len(live_codes)} codes match the seed file")
+        return 0
+    added = sorted(set(live_codes) - set(catalog_codes))
+    removed = sorted(set(catalog_codes) - set(live_codes))
+    print(f"[verify-codes] DRIFT — seed has {len(live_codes)} codes, catalog has {len(catalog_codes)}")
+    if added:
+        print(f"  in seed but not in urls.CODES: {added}")
+    if removed:
+        print(f"  in urls.CODES but not in seed: {removed}")
+    return 1
+
+
+def selftest() -> int:
+    """No-network unit checks (guilt+innocence pairs, tg_notify convention)."""
+    import tempfile
+
+    from extract import extract_text
+
+    failures: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        print(("  ok  " if cond else "  FAIL") + f" {name}")
+        if not cond:
+            failures.append(name)
+
+    # --- extract_text: strips boilerplate, keeps content -------------------
+    html = """
+    <html><head><script>var x=1;</script></head>
+    <body>
+      <nav>Home | About</nav>
+      <main><h1>Daftar Negara VOA</h1><p>Australia</p><p>Japan</p></main>
+      <footer>Copyright 2026</footer>
+    </body></html>
+    """
+    text = extract_text(html)
+    check("main content kept", "Australia" in text and "Japan" in text)
+    check("script stripped (guilt)", "var x=1" not in text)
+    check("nav/footer stripped when main selector wins", "About" not in text and "Copyright" not in text)
+
+    # innocence: no recognizable main container -> falls back to body, but
+    # nav/header/footer boilerplate is still stripped from the fallback.
+    html_no_main = "<html><body><nav>Menu</nav><div>Real content here padded out to exceed the minimum threshold so the fallback body extraction path is exercised honestly rather than trivially, still real content.</div><footer>Copy</footer></body></html>"
+    text2 = extract_text(html_no_main)
+    check("fallback body keeps real content", "Real content here" in text2)
+    check("fallback body strips nav (innocence of a bare-body world)", "Menu" not in text2)
+
+    # --- compute_diff --------------------------------------------------------
+    old = "line1\nline2\nline3"
+    new = "line1\nline2-changed\nline3\nline4"
+    excerpt, added, removed, truncated = compute_diff(old, new)
+    check("diff counts additions", added >= 2)  # line2-changed + line4
+    check("diff counts removals", removed >= 1)  # line2
+    check("diff not truncated for a small diff", not truncated)
+
+    long_old = "\n".join(f"l{i}" for i in range(100))
+    long_new = "\n".join(f"l{i}x" for i in range(100))
+    _, _, _, truncated_big = compute_diff(long_old, long_new, max_lines=5)
+    check("large diff IS truncated (never a silent cap — must say so)", truncated_big)
+
+    # --- find_previous_snapshot ----------------------------------------------
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        for d, content in [("2026-08-01", "old"), ("2026-08-05", "newer"), ("2026-08-08", "today")]:
+            sd = root / "snapshots" / d
+            sd.mkdir(parents=True)
+            (sd / "voa-subjects.txt").write_text(content)
+        prev = find_previous_snapshot(root, "voa-subjects", "2026-08-08")
+        check("finds most recent PRIOR snapshot, skipping today", prev is not None and prev[0] == "2026-08-05")
+
+        prev_gap = find_previous_snapshot(root, "voa-subjects", "2026-08-20")
+        check("searches back further than d-1 (weekly-tier gap)", prev_gap is not None and prev_gap[0] == "2026-08-08")
+
+        none_case = find_previous_snapshot(root, "never-seen-slug", "2026-08-08")
+        check("no prior snapshot -> None (first capture, not a false diff)", none_case is None)
+
+    print("SELFTEST", "PASS" if not failures else f"FAIL ({failures})")
+    return 0 if not failures else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--tier", choices=["daily", "weekly", "all"], default="daily")
+    ap.add_argument("--select", default="", help="comma-separated page ids, overrides --tier")
+    ap.add_argument("--data-root", default=DEFAULT_DATA_ROOT)
+    ap.add_argument("--date", default="", help="override YYYY-MM-DD (default: today, local time)")
+    ap.add_argument("--concurrency", type=int, default=4)
+    ap.add_argument("--rate-limit-s", type=float, default=2.0)
+    ap.add_argument("--timeout-s", type=float, default=30.0)
+    ap.add_argument("--overall-timeout-s", type=float, default=0.0, help="0 = tier-based default")
+    ap.add_argument("--no-alert", action="store_true", help="skip Telegram sends (still diffs+commits)")
+    ap.add_argument("--no-commit", action="store_true", help="skip git commit (still writes files)")
+    ap.add_argument("--announce", default="", help="send ONE status note after the run, e.g. for a dry-run channel check")
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--verify-codes", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+    if args.verify_codes:
+        return verify_codes()
+
+    summary = asyncio.run(run(args))
+    print_summary(summary)
+
+    if args.announce:
+        n_diffs = len(summary["diffs"])
+        text = args.announce.format(
+            captured=summary["captured"], diffs=n_diffs, failed=len(summary["failed"]), date=summary["date"]
+        )
+        status = send_status_note(text, dedup_key=f"imigrasi-mirror-announce:{summary['tier']}")
+        print(f"  ANNOUNCE: {status}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/imigrasi_mirror/urls.py
+++ b/scripts/imigrasi_mirror/urls.py
@@ -1,0 +1,189 @@
+r"""Canonical URL catalog for the imigrasi.go.id scoped mirror.
+
+Scope v1 (Zero mandate, 2026-08-08): NOT a full-site copy. Only the pages that
+feed the Bali Zero visa engine — the VoA/BVK/Calling subject lists, the
+per-visa-code catalog, and three regional-office mirrors as a counter-proof
+that the schema is uniform. ~123 pages total (9 "daily" + 114 "weekly").
+
+Every URL below was verified live (WebFetch, 200, real content — not a 404)
+on 2026-08-08 before being committed here (anti-hallucination discipline,
+CLAUDE.md §6). Do not add a URL to this file without the same verification.
+
+The ~114 per-visa-code identifiers are a COPY of the codes in the repo's own
+seed file, not a live import — this keeps the mirror module dependency-free
+from the backend-rag app (no sqlalchemy/pydantic import chain for a crawler
+script that must also run standalone via cron). That makes this a
+state-schema fork by construction (cicatrix family #9): if the seed file
+gains/loses codes, this list goes stale silently unless re-checked.
+
+Source of truth:
+    apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py
+
+Regenerate/verify with:
+    grep -oP '"code":\s*"\K[^"]+' \
+        apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py \
+        | sort -u
+
+`run.py --verify-codes` re-runs that grep (when the monorepo is reachable
+from this checkout) and fails loudly on drift instead of silently mirroring
+a stale catalog.
+
+Extracted 2026-08-08: 114 codes, A1..SKTT.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+BASE = "https://www.imigrasi.go.id"
+
+# --- 114 codes, verbatim from the seed file (see docstring for provenance) --
+CODES: list[str] = [
+    "A1", "A4", "A36", "A37",
+    "B1", "B4",
+    "C1", "C2", "C3", "C4", "C5", "C5A", "C6", "C7", "C7A", "C7B", "C7C",
+    "C8", "C8A", "C8B", "C9", "C9A", "C9B", "C10", "C10A", "C11", "C11A",
+    "C12", "C13", "C14", "C15", "C16", "C17", "C18", "C19", "C20", "C21",
+    "C22", "C22A", "C22B",
+    "D1", "D2", "D3", "D4", "D7", "D8", "D12", "D14", "D17",
+    "E23", "E23-FREELANCE", "E23A", "E23U", "E23V", "E23X", "E23Y",
+    "E25", "E25A", "E25B", "E25C", "E25D", "E25E", "E25F",
+    "E26", "E27",
+    "E28", "E28A", "E28B", "E28C", "E28D", "E28E", "E28F", "E28G",
+    "E29",
+    "E30", "E30A", "E30B", "E30E", "E30F",
+    "E31", "E31A", "E31B", "E31C", "E31D", "E31E", "E31F", "E31G", "E31H", "E31J",
+    "E32", "E32A", "E32B", "E32C", "E32D", "E32E", "E32F", "E32G", "E32H",
+    "E33", "E33A", "E33B", "E33C", "E33D", "E33E", "E33F", "E33G",
+    "E34",
+    "E35", "E35A",
+    "EPO", "ERP",
+    "F1", "F4",
+    "SKTT",
+]
+
+assert len(CODES) == 114, f"expected 114 codes, got {len(CODES)} — catalog drifted, re-derive from the seed file"
+assert len(set(CODES)) == len(CODES), "duplicate code in CODES"
+
+
+@dataclass(frozen=True)
+class Page:
+    id: str
+    url: str
+    slug: str
+    label: str
+    tier: str  # "daily" | "weekly"
+    category: str  # "list" | "faq" | "index" | "regional" | "code"
+
+
+# --- daily tier: the pages that "morde" (bite) — subject lists, FAQ, index, --
+# --- and 3 regional mirrors as a schema counter-proof.                     --
+DAILY_PAGES: list[Page] = [
+    Page(
+        id="parent",
+        url=f"{BASE}/wna/daftar-negara-voa-bvk-calling-visa",
+        slug="voa-bvk-calling-parent",
+        label="Elenco padre VoA/BVK/Calling",
+        tier="daily",
+        category="list",
+    ),
+    Page(
+        id="voa",
+        url=f"{BASE}/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+        slug="voa-subjects",
+        label="Lista VOA (Visa on Arrival)",
+        tier="daily",
+        category="list",
+    ),
+    Page(
+        id="bvk",
+        url=f"{BASE}/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+        slug="bvk-subjects",
+        label="Lista BVK (Bebas Visa Kunjungan)",
+        tier="daily",
+        category="list",
+    ),
+    Page(
+        id="calling",
+        url=f"{BASE}/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+        slug="calling-visa-subjects",
+        label="Lista Calling Visa",
+        tier="daily",
+        category="list",
+    ),
+    Page(
+        id="faq-evoa",
+        url=f"{BASE}/faq/visa/negara-mana-saja-yang-terdaftar-dalam-daftar-electronic-visa-on-arrival-e-voa",
+        slug="faq-evoa-countries",
+        label="FAQ — Paesi e-VOA (documentata per la sua staleness, W90)",
+        tier="daily",
+        category="faq",
+    ),
+    Page(
+        id="visa-index",
+        url=f"{BASE}/wna/daftar-visa-indonesia",
+        slug="visa-index",
+        label="Indice Daftar Visa Indonesia",
+        tier="daily",
+        category="index",
+    ),
+    Page(
+        id="regional-depok",
+        url="https://depok.imigrasi.go.id/47666-2/",
+        slug="regional-depok-list",
+        label="Kanim Depok — lista VoA/BVK/Calling",
+        tier="daily",
+        category="regional",
+    ),
+    Page(
+        id="regional-bontang",
+        url="https://bontang.imigrasi.go.id/layanan-publik/kategori/wna/sub/daftar-subjek-voa-bvk-calling-visa",
+        slug="regional-bontang-list",
+        label="Kanim Bontang — lista VoA/BVK/Calling",
+        tier="daily",
+        category="regional",
+    ),
+    Page(
+        id="regional-ngurahrai",
+        url="https://ngurahrai.imigrasi.go.id/layanan-wna/",
+        slug="regional-ngurahrai-list",
+        label="Kanim Ngurah Rai — lista VoA/BVK/Calling",
+        tier="daily",
+        category="regional",
+    ),
+]
+
+# --- weekly tier: the ~114 per-visa-code detail pages -----------------------
+WEEKLY_PAGES: list[Page] = [
+    Page(
+        id=f"code-{code}",
+        url=f"{BASE}/wna/daftar-visa-indonesia/{code}",
+        slug=f"code-{code}",
+        label=f"Visa {code}",
+        tier="weekly",
+        category="code",
+    )
+    for code in CODES
+]
+
+ALL_PAGES: list[Page] = DAILY_PAGES + WEEKLY_PAGES
+
+_BY_ID = {p.id: p for p in ALL_PAGES}
+assert len(_BY_ID) == len(ALL_PAGES), "duplicate page id in catalog"
+
+
+def pages_for_tier(tier: str) -> list[Page]:
+    if tier == "daily":
+        return list(DAILY_PAGES)
+    if tier == "weekly":
+        return list(WEEKLY_PAGES)
+    if tier == "all":
+        return list(ALL_PAGES)
+    raise ValueError(f"unknown tier {tier!r} — expected daily|weekly|all")
+
+
+def pages_for_select(ids: list[str]) -> list[Page]:
+    missing = [i for i in ids if i not in _BY_ID]
+    if missing:
+        raise ValueError(f"unknown page id(s): {missing} — known ids: {sorted(_BY_ID)}")
+    return [_BY_ID[i] for i in ids]


### PR DESCRIPTION
## Scope

**NOT a full-site copy.** ~123 imigrasi.go.id pages that feed the Bali Zero visa engine, versioned daily/weekly with a Telegram alert when one changes. Value is in the repeated crawl + diff (cicatrix W90: "anche il ground-truth invecchia"), not a one-off snapshot.

| Category | Count | Tier |
|---|---|---|
| VoA/BVK/Calling subject lists + parent | 4 | daily |
| FAQ (tracked for its OWN staleness) | 1 | daily |
| Visa catalog index | 1 | daily |
| Regional kanim mirrors (depok/bontang/ngurah rai — schema counter-proof) | 3 | daily |
| Per-visa-code detail pages | 114 | weekly |

All 123 URLs verified live (WebFetch, 200, real content) 2026-08-08 before being committed to `urls.py`. The 114 per-code identifiers are copied (checked, not imported) from `apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py` — `run.py --verify-codes` cross-checks against it; 0 drift measured.

## Cadence (coded, NOT installed)

```
scripts/imigrasi_mirror/run-mirror.sh --tier daily     # 9 pages
scripts/imigrasi_mirror/run-mirror.sh --tier weekly    # 114 pages
scripts/imigrasi_mirror/run-mirror.sh --tier all
```

**No LaunchAgent/cron installed by this PR.** Arming a schedule is a follow-up operator decision after reviewing the dry-run below (per mandate).

## Guardrails

- Async `httpx` (Golden Rule #4), honest User-Agent, global ≥2s rate limit + concurrency=4 cap, bounded retries w/ backoff on transient errors only, per-tier overall wall-clock deadline (never unbounded — the `fs_usage` firehose lesson), `robots.txt` honored per-host (fail-open on fetch error; `imigrasi.go.id/robots.txt` is `Allow: /` anyway, verified live).
- Telegram routed through the repo's existing `scripts/tg_notify.py` gateway, not a direct Bot API call — avoids re-deriving W104 (exit-code vs reply), W115 (message-on-argv, `ps`-visible), W55 (single-attempt silent drop). Message piped over **stdin**, never argv.
- Dedup key is an explicit content-hash of the new snapshot (tg_notify's default text-derived identity strips numbers, which would wrongly treat two *different* diffs on the same page as one repeating condition to mute).
- Snapshot data lives in a **separate git repo** (`~/nuzantara-imigrasi-mirror` on Mini) — avoids monorepo bloat; git history IS the version log.

## A real bug found + fixed mid-build

First extraction pass used a "first selector, first match past a length threshold" rule for locating each page's main content. On the real site, that landed on the generic "you're on a secure .go.id site" notice banner every time — a textbook guard-over-match (cicatrix family #3): all 5 first dry-run snapshots were byte-identical 458-byte boilerplate, zero real country-list content. Fixed to "largest text block across every candidate selector" instead of first-match, plus stripping `<aside id="sidebar">` after a second pass surfaced the same failure mode on the Calling Visa page (~35 nav items nearly burying a 6-country list). Verified against real fetched HTML for every page category (subject lists, FAQ, index, 3 regional CMSes, 114-catalog incl. the hyphenated `E23-FREELANCE` code and 2 codes imigrasi.go.id itself hasn't published yet — genuine "Data Belum Tersedia" content, exactly the future-diff signal this exists for) before shipping.

## Dry-run (mandatory scope: 4 subject lists + FAQ)

- 5/5 pages captured, 4305 bytes, 0 diffs (first capture — expected)
- 1 Telegram test alert delivered via `tg_notify` (`archive-p0.jsonl`: `"sent": true`); a second identical status note correctly **deduped** rather than re-spamming — the gateway working as designed
- Data committed to `~/nuzantara-imigrasi-mirror` (separate repo, not this one)
- Broader spot-check (8 pages across per-code/regional/index categories) run to a scratch data-root, `--no-commit --no-alert`, confirmed extraction quality before the real run

## Tests

`scripts/imigrasi_mirror/run-mirror.sh --selftest` (12 checks, no network) + `--verify-codes` (114/114 match) both green.

## Infra note (unrelated to the mirror itself, found while shipping)

`git push` over SSH died with SIGPIPE 4/4 times specifically after the pre-push hook's full ~8-minute pytest run (new files, not on the innocent allowlist) completed cleanly — but a fast allowlisted push succeeded instantly. No `Host github.com` block exists in `~/.ssh/config` (unlike `pro`/`air`, which both already carry `ServerAliveInterval`) — matches an idle-connection timeout during the long hook. Worked around per-invocation with `git -c core.sshCommand="ssh -o ServerAliveInterval=20 -o ServerAliveCountMax=15" push ...` (no config file touched — `~/.ssh/config` is correctly host-boundary-protected, operator-only). Surfacing for awareness; a persistent fix (adding that Host block) is an operator call, not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)