### PR TITLE
docs(infra): sync worktree-gc-universal plist comment with live M5 copy

### DIFF
--- a/infra/launchagents/com.nuzantara.worktree-gc-universal.daily.plist
+++ b/infra/launchagents/com.nuzantara.worktree-gc-universal.daily.plist
@@ -1,42 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Universal worktree garbage collector — daily 08:30 WITA
-Covers ALL git worktrees (not just WR2/broker lanes). 3-LLM panel 2026-05-29.
-Script: scripts/worktree_gc_universal.py (merged PR #925)
+Universal worktree garbage collector — daily 00:30 local (WITA)
+Covers ALL git worktrees (not just WR2/broker lanes). Armed on M5 2026-07-18
+(Zero: "auto reap anche su m5 e mini") after the W88 reap-gate cure (PR #2738).
+Script: scripts/worktree_gc_universal.py (branch-ref-preserving; live-cwd +
+age + quarantine guards; heartbeat sidecar carries reap counters).
 
-ENFORCING since 2026-05-30: the apply flag was added after ~50h dry-run
-observation (panel recommended 48h). Dry-run logs 2026-05-29→30 showed
-correct decisions (KEEP on unpushed commits, quarantine-before-remove on
-dirty). Per W62 RESOLVED. To revert to report-only: remove the apply
-argument line in ProgramArguments below.
+This file is HOME-fork-scoped by nature (paths are per-machine under
+/Users/<user>/); install/update it on each machine's own
+~/Library/LaunchAgents/ via `scripts/lint_home_fork.py` declared-pairs
+discipline — do not assume this tracked copy is symlinked live. PATH
+includes /usr/sbin (defense-in-depth for the script's lsof-based
+live-cwd guard; the primary fix is _resolve_lsof_path() in the script,
+independent of PATH).
 
-Kill switch (without removing plist):
-    set WORKTREE_GC_ENABLED=false in EnvironmentVariables (already true here)
-
-TRACKED 2026-07-18 (cicatrix #1 HOME-fork cure): this plist previously lived
-ONLY on Pro's live LaunchAgents dir, untracked in the repo — closing the
-"no plist references worktree_gc_universal.py" gap. ProgramArguments,
-schedule, and paths below are byte-identical to Pro's live copy pulled
-2026-07-18 (same day the daily cron's "reaps 0 for days" bug — the
-unpushed-commit hard-KEEP gate, W88-inflated — was cured in the script);
-this comment block only was reworded to drop a literal double-hyphen that
-was silently-invalid XML inside a comment (macOS `plutil -lint` is lenient
-about it, Python's expat parser used by `scripts/lint_plist_keepalive.py`
-is not — same class of bug the "day-1" fix on branch-cleanup.weekly.plist
-already corrected once). This file is HOME-fork-scoped by nature (paths are
-per-machine under /Users/nuzantara/); install/update it on each machine's
-own ~/Library/LaunchAgents/ via `scripts/lint_home_fork.py` declared-pairs
-discipline, do not assume this tracked copy is symlinked live.
-
-ROUND-2 FIX 2026-07-18 (BLOCKER A): PATH below gained a trailing
-`:/usr/sbin` — on both M5 and Pro, `lsof` (used by the script's live-cwd
-guard) lives ONLY at /usr/sbin/lsof, which this PATH did not previously
-include, so a bare `lsof` invocation raised FileNotFoundError under this
-exact cron every run and the guard was silently inert (scar #2). The
-PRIMARY fix is in the script (_resolve_lsof_path() resolves an absolute
-path independent of PATH); this PATH edit is defense-in-depth only. The
-INSTALLED copy on Pro's ~/Library/LaunchAgents/ needs this same edit
-applied at deploy time — this tracked copy alone does not update it live.
+Kill switch (without removing plist): set WORKTREE_GC_ENABLED=false below.
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">


### PR DESCRIPTION
## Summary
- proprioception `launchagent_canon` flagged `com.nuzantara.worktree-gc-universal.daily.plist` as repo-divergent from what's actually installed on M5.
- Diffed both: functional payload (ProgramArguments, schedule, PATH incl. `/usr/sbin`, env vars, RunAtLoad/KeepAlive) is byte-identical apart from the expected per-machine path prefix (HOME-fork-scoped by design). The only real divergence was the comment block — repo canon still narrated the 2026-05-29/30 dry-run period (PR #925) plus an absorbed 2026-07-18 PATH-fix note, while M5's live copy already carries a shorter, current comment referencing the real, merged PR #2738.
- Ported the current M5 comment into the repo canon. No functional change.

## Test plan
- [x] `plutil -lint` on the edited plist → OK
- [x] `scripts/lint_plist_keepalive.py` → 0 new findings
- [x] pre-commit/pre-push hooks passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)