### PR TITLE
feat(kbli): --only per-code selection for both Qdrant indexers

### DIFF
--- a/apps/backend-rag/backend/scripts/index_kbli_gold_content.py
+++ b/apps/backend-rag/backend/scripts/index_kbli_gold_content.py
@@ -51,6 +51,59 @@ KBLI_DATA_FILE = (
     Path(__file__).resolve().parents[4] / "apps" / "kbli-navigator" / "data" / "kbli-2025.json"
 )
 
+# 5-digit KBLI codes (e.g. "56101")
+_CODE_RE = re.compile(r"^\d{5}$")
+
+
+def parse_only_codes(raw: str | None) -> list[str] | None:
+    """Parse the --only flag value into a list of validated 5-digit codes.
+
+    Returns ``None`` when *raw* is falsy (flag not given).  Raises
+    ``argparse.ArgumentTypeError`` on any malformed token so argparse surfaces
+    a clean error — the caller never sees junk.
+    """
+    if not raw:
+        return None
+    codes: list[str] = []
+    for token in raw.split(","):
+        code = token.strip()
+        if not _CODE_RE.match(code):
+            raise argparse.ArgumentTypeError(
+                f"invalid KBLI code {code!r} in --only — expected 5-digit numeric",
+            )
+        codes.append(code)
+    if not codes:
+        raise argparse.ArgumentTypeError("--only received no codes")
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for c in codes:
+        if c not in seen:
+            seen.add(c)
+            unique.append(c)
+    return unique
+
+
+def filter_to_codes(
+    entries: dict[str, dict],
+    only_codes: list[str] | None,
+) -> dict[str, dict]:
+    """Filter *entries* to *only_codes*, erroring on any absent code.
+
+    A silent skip would report success over nothing (esiste≠armato), so we exit
+    nonzero naming every missing code instead.
+    """
+    if only_codes is None:
+        return entries
+    missing = [c for c in only_codes if c not in entries]
+    if missing:
+        logger.error(
+            "--only requested code(s) absent from parsed gold: %s",
+            ", ".join(missing),
+        )
+        sys.exit(1)
+    return {c: entries[c] for c in only_codes}
+
 
 def parse_gold_content_ts(filepath: Path) -> dict[str, dict]:
     """
@@ -297,6 +350,14 @@ async def main():
     parser = argparse.ArgumentParser(description="Index KBLI gold content into kbli_2025_final")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--qdrant-url", type=str, default="")
+    parser.add_argument(
+        "--only",
+        type=parse_only_codes,
+        default=None,
+        metavar="CODE[,CODE...]",
+        help="Comma-separated 5-digit KBLI codes — index ONLY these codes "
+        "(errors out if any requested code is absent from the parsed gold).",
+    )
     args = parser.parse_args()
 
     qdrant_url = args.qdrant_url or os.getenv("QDRANT_URL", "http://localhost:6333")
@@ -313,7 +374,15 @@ async def main():
     # Parse gold content
     logger.info("Parsing gold content from TypeScript...")
     gold_entries = parse_gold_content_ts(GOLD_CONTENT_FILE)
-    logger.info(f"Parsed {len(gold_entries)} gold entries")
+    total_parsed = len(gold_entries)
+    logger.info(f"Parsed {total_parsed} gold entries")
+
+    # Per-code selection (--only): filter BEFORE building points.
+    gold_entries = filter_to_codes(gold_entries, args.only)
+    if args.only:
+        logger.info(
+            "%d of %d gold entries selected via --only", len(gold_entries), total_parsed
+        )
 
     # Load base KBLI data for enrichment
     base_data = {}

--- a/apps/backend-rag/backend/scripts/reindex_kbli_2025_final.py
+++ b/apps/backend-rag/backend/scripts/reindex_kbli_2025_final.py
@@ -26,6 +26,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -58,6 +59,64 @@ DELETE_BATCH_SIZE = 100
 SOURCE_FILE = (
     Path(__file__).resolve().parents[4] / "source_documents" / "KBLI_2025_FINAL_CLEAN.json"
 )
+
+# 5-digit KBLI codes (e.g. "56101")
+_CODE_RE = re.compile(r"^\d{5}$")
+
+
+def parse_only_codes(raw: str | None) -> list[str] | None:
+    """Parse the --only flag value into a list of validated 5-digit codes.
+
+    Returns ``None`` when *raw* is falsy (flag not given).  Raises
+    ``argparse.ArgumentTypeError`` on any malformed token so argparse surfaces
+    a clean error — the caller never sees junk.
+    """
+    if not raw:
+        return None
+    codes: list[str] = []
+    for token in raw.split(","):
+        code = token.strip()
+        if not _CODE_RE.match(code):
+            raise argparse.ArgumentTypeError(
+                f"invalid KBLI code {code!r} in --only — expected 5-digit numeric",
+            )
+        codes.append(code)
+    if not codes:
+        raise argparse.ArgumentTypeError("--only received no codes")
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for c in codes:
+        if c not in seen:
+            seen.add(c)
+            unique.append(c)
+    return unique
+
+
+def filter_entries_to_codes(
+    entries: list[dict],
+    only_codes: list[str] | None,
+) -> list[dict]:
+    """Filter *entries* to *only_codes*, erroring on any absent code.
+
+    A silent skip would report success over nothing (esiste≠armato), so we exit
+    nonzero naming every missing code instead.
+    """
+    if only_codes is None:
+        return entries
+    lookup: dict[str, dict] = {}
+    for e in entries:
+        code = e.get("kode_kbli_2025", "")
+        if code:
+            lookup[code] = e
+    missing = [c for c in only_codes if c not in lookup]
+    if missing:
+        logger.error(
+            "--only requested code(s) absent from source data: %s",
+            ", ".join(missing),
+        )
+        sys.exit(1)
+    return [lookup[c] for c in only_codes]
 
 
 def deterministic_uuid(code: str) -> str:
@@ -452,6 +511,17 @@ async def main():
     )
     parser.add_argument("--skip-delete", action="store_true", help="Skip deleting old points")
     parser.add_argument("--limit", type=int, default=0, help="Limit number of codes (0=all)")
+    parser.add_argument(
+        "--only",
+        type=parse_only_codes,
+        default=None,
+        metavar="CODE[,CODE...]",
+        help="Comma-separated 5-digit KBLI codes — re-index ONLY these codes. "
+        "Errors out if any requested code is absent from the source data. "
+        "When set, the delete step is SKIPPED automatically (upsert-only path): "
+        "deterministic UUIDs overwrite the old points for those codes anyway, "
+        "and the collection-wide delete would wipe codes you did NOT select.",
+    )
     args = parser.parse_args()
 
     qdrant_url = args.qdrant_url or os.getenv("QDRANT_URL", "http://localhost:6333")
@@ -477,8 +547,14 @@ async def main():
 
     version = source["metadata"]["version"]
     entries = source["data"]
+    total_codes = len(entries)
     logger.info(f"Version: {version}")
-    logger.info(f"Total codes: {len(entries)}")
+    logger.info(f"Total codes: {total_codes}")
+
+    # Per-code selection (--only): filter BEFORE building points.
+    entries = filter_entries_to_codes(entries, args.only)
+    if args.only:
+        logger.info("%d of %d codes selected via --only", len(entries), total_codes)
 
     if args.limit > 0:
         entries = entries[: args.limit]
@@ -575,9 +651,15 @@ async def main():
     # Step 3: Ensure payload indexes (delete/verify filters depend on them), then delete old points
     logger.info(f"\nStep 3: Ensuring payload indexes on {COLLECTION_NAME}...")
     await ensure_payload_indexes(qdrant_url, qdrant_api_key)
-    if not args.skip_delete:
+    # --only forces skip-delete: the collection-wide delete would wipe codes
+    # we did NOT select, and deterministic UUIDs overwrite the old points for
+    # the selected codes anyway (upsert-only path).
+    effective_skip_delete = args.skip_delete or args.only is not None
+    if not effective_skip_delete:
         logger.info(f"Step 3: Deleting old OSS_RBA_API points from {COLLECTION_NAME}...")
         await delete_old_points(qdrant_url, qdrant_api_key)
+    elif args.only is not None:
+        logger.info("Step 3: Delete skipped (--only implies upsert-only)")
     else:
         logger.info("Step 3: Delete skipped (--skip-delete)")
 

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_only_selection.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_only_selection.py
@@ -1,0 +1,155 @@
+"""Tests for the --only per-code selection logic added to both Qdrant indexers.
+
+Pure-function tests only — no network, no Qdrant, no OpenAI.  We exercise the
+two pure helpers each script exposes: ``parse_only_codes`` (flag parsing +
+validation) and the entry-filter function (``filter_to_codes`` for the gold
+indexer, ``filter_entries_to_codes`` for the BPS re-indexer).
+"""
+
+import argparse
+
+import pytest
+
+from backend.scripts.index_kbli_gold_content import (
+    filter_to_codes,
+)
+from backend.scripts.index_kbli_gold_content import (
+    parse_only_codes as parse_gold_only,
+)
+from backend.scripts.reindex_kbli_2025_final import (
+    filter_entries_to_codes,
+)
+from backend.scripts.reindex_kbli_2025_final import (
+    parse_only_codes as parse_bps_only,
+)
+
+# ─── parse_only_codes (shared semantics, two copies) ───────────────────────
+
+
+class TestParseOnlyCodes:
+    """Both copies share identical semantics — parametrise over both."""
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_none_when_flag_absent(self, parser):
+        assert parser(None) is None
+        assert parser("") is None
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_single_code(self, parser):
+        assert parser("56101") == ["56101"]
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_multiple_codes(self, parser):
+        assert parser("56101,56210,61108") == ["56101", "56210", "61108"]
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_strips_whitespace(self, parser):
+        assert parser(" 56101 , 56210 ") == ["56101", "56210"]
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_deduplicates_preserving_order(self, parser):
+        assert parser("56101,56210,56101") == ["56101", "56210"]
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_rejects_too_short(self, parser):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid KBLI code"):
+            parser("5610")
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_rejects_too_long(self, parser):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid KBLI code"):
+            parser("561011")
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_rejects_alpha(self, parser):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid KBLI code"):
+            parser("5610a")
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_rejects_empty_token(self, parser):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid KBLI code"):
+            parser("56101,,56210")
+
+    @pytest.mark.parametrize("parser", [parse_gold_only, parse_bps_only])
+    def test_rejects_junk(self, parser):
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid KBLI code"):
+            parser("hello")
+
+
+# ─── filter_to_codes (gold indexer — dict input) ───────────────────────────
+
+
+class TestFilterToCodes:
+    def _entries(self) -> dict[str, dict]:
+        return {
+            "56101": {"whatItMeans": "Restoran"},
+            "56210": {"whatItMeans": "Katering"},
+            "61108": {"whatItMeans": "Telekomunikasi"},
+        }
+
+    def test_passthrough_when_none(self):
+        entries = self._entries()
+        assert filter_to_codes(entries, None) is entries
+
+    def test_selects_subset(self):
+        result = filter_to_codes(self._entries(), ["56101", "61108"])
+        assert set(result.keys()) == {"56101", "61108"}
+
+    def test_preserves_requested_order(self):
+        result = filter_to_codes(self._entries(), ["61108", "56101"])
+        assert list(result.keys()) == ["61108", "56101"]
+
+    def test_single_code(self):
+        result = filter_to_codes(self._entries(), ["56210"])
+        assert list(result.keys()) == ["56210"]
+
+    def test_errors_on_missing_code(self):
+        with pytest.raises(SystemExit) as exc_info:
+            filter_to_codes(self._entries(), ["56101", "99999"])
+        assert exc_info.value.code == 1
+
+    def test_errors_name_all_missing(self, caplog):
+        with pytest.raises(SystemExit):
+            filter_to_codes(self._entries(), ["99999", "88888"])
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("99999" in m and "88888" in m for m in msgs)
+
+
+# ─── filter_entries_to_codes (BPS re-indexer — list input) ──────────────────
+
+
+class TestFilterEntriesToCodes:
+    def _entries(self) -> list[dict]:
+        return [
+            {"kode_kbli_2025": "56101", "judul": "Restoran"},
+            {"kode_kbli_2025": "56210", "judul": "Katering"},
+            {"kode_kbli_2025": "61108", "judul": "Telekomunikasi"},
+        ]
+
+    def test_passthrough_when_none(self):
+        entries = self._entries()
+        assert filter_entries_to_codes(entries, None) is entries
+
+    def test_selects_subset(self):
+        result = filter_entries_to_codes(self._entries(), ["56101", "61108"])
+        assert [e["kode_kbli_2025"] for e in result] == ["56101", "61108"]
+
+    def test_preserves_requested_order(self):
+        result = filter_entries_to_codes(self._entries(), ["61108", "56101"])
+        assert [e["kode_kbli_2025"] for e in result] == ["61108", "56101"]
+
+    def test_single_code(self):
+        result = filter_entries_to_codes(self._entries(), ["56210"])
+        assert len(result) == 1
+        assert result[0]["kode_kbli_2025"] == "56210"
+
+    def test_errors_on_missing_code(self):
+        with pytest.raises(SystemExit) as exc_info:
+            filter_entries_to_codes(self._entries(), ["56101", "99999"])
+        assert exc_info.value.code == 1
+
+    def test_errors_name_all_missing(self, caplog):
+        with pytest.raises(SystemExit):
+            filter_entries_to_codes(self._entries(), ["99999", "88888"])
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("99999" in m and "88888" in m for m in msgs)


### PR DESCRIPTION
## What

Both Qdrant indexers (`index_kbli_gold_content.py` and `reindex_kbli_2025_final.py`) lacked per-code selection — any small editorial change forced a full re-embed (or worse, was skipped). This adds an `--only CODE[,CODE...]` flag to both.

## Changes

### `index_kbli_gold_content.py` (gold editorial indexer)
- New `--only` flag: comma-separated 5-digit KBLI codes, validated via `argparse` type function
- Filters parsed gold entries to exactly those codes **before** building points
- **Errors out** (exit 1, naming absent codes) if any requested code is missing from the parsed gold — a silent skip would report success over nothing (esiste≠armato)
- Logs `"N of M gold entries selected via --only"`

### `reindex_kbli_2025_final.py` (BPS 1,563-code re-indexer)
- Same `--only` flag + same validation + same error-on-absent-code wall
- Filters source entries to selected codes before building points
- **`--only` forces `--skip-delete`** (upsert-only path): the collection-wide delete would wipe codes NOT selected, and deterministic UUIDs overwrite old points for the selected codes anyway. Documented in the `--help` text.

### Tests
- `backend/tests/unit/scripts/test_kbli_only_selection.py` — 32 pure-function tests (no network/Qdrant/OpenAI):
  - `parse_only_codes`: None on absent flag, single/multiple codes, whitespace stripping, dedup, rejects too-short/too-long/alpha/empty/junk
  - `filter_to_codes` (gold indexer, dict input): passthrough, subset selection, order preservation, error on missing code naming all missing
  - `filter_entries_to_codes` (BPS re-indexer, list input): same coverage

## Usage

```bash
# Re-embed just 2 gold codes instead of all ~40
PYTHONPATH=. python backend/scripts/index_kbli_gold_content.py --only 56101,56210

# Re-embed just 3 BPS codes instead of all 1,563
PYTHONPATH=. python backend/scripts/reindex_kbli_2025_final.py --only 61108,61210,61301
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)