### PR TITLE
fix(ledger): give the report a read-only way to see main, instead of prescribing a forbidden pull

### DIFF
--- a/scripts/pending_arms_report.py
+++ b/scripts/pending_arms_report.py
@@ -90,9 +90,23 @@ reply, never assume success" discipline as _ledger_freshness (W104): an
 unverifiable ref just doesn't count toward merged_pr_refs, it does not crash
 the report and it is not silently promoted to "merged" either.
 
+READING MAIN FROM A CHECKOUT THAT IS BEHIND (--ref, added 2026-08-08): this ledger is
+read out of a working tree, and on m5 the main checkout is deliberately left behind
+origin/main (pulling it races live worktrees), so the rows can be genuinely stale.
+The freshness line has always SAID so — but until now it prescribed "pull", which is
+exactly what m5 must not do and what `worktree_isolation.py` refuses for any agent
+session in the main checkout. A prescription only a nonexistent lane can carry out
+trains its reader to ignore the probe, and the next one that matters gets ignored too.
+`--ref origin/main` reads the ledger with `git show`: no pull, no fetch, no write, so
+it works from the main checkout as well. It is deliberately FATAL when the ref cannot
+be read — silently answering with the working tree would let a caller believe it is
+looking at main while it looks at its own stale copy, which is the lie the flag exists
+to end. Default (no --ref) still reads the working tree, so a session that has just
+written its own line still sees it.
+
 Usage:
-    python3 scripts/pending_arms_report.py [--ledger PATH] [--now YYYY-MM-DD] [--json]
-                                           [--strict] [--strict-phantom]
+    python3 scripts/pending_arms_report.py [--ledger PATH] [--ref GITREF] [--now YYYY-MM-DD]
+                                           [--json] [--strict] [--strict-phantom]
 
 Exit codes:
     0   always, by default (pure signaler — a report is not a failure)
@@ -560,8 +574,62 @@ def parse_entry(raw: str, now: date) -> Entry:
     )
 
 
-def load_entries(ledger_path: Path, now: date) -> List[Entry]:
-    text = ledger_path.read_text(encoding="utf-8")
+def _git(argv: List[str], *, cwd: Path, timeout: int = 15) -> tuple[int, str, str]:
+    """Run a read-only git command. Returns (rc, stdout, stderr), never raises.
+
+    A spawn failure is reported as a non-zero rc with the reason in stderr, so
+    every caller decides on the same three values and none of them has to
+    remember that "no output" might mean "git is missing".
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(cwd), *argv], capture_output=True, text=True, timeout=timeout
+        )
+    except FileNotFoundError:
+        return 127, "", "git not on PATH"
+    except (subprocess.SubprocessError, OSError) as exc:
+        return 1, "", f"git invocation failed: {type(exc).__name__}"
+    return proc.returncode, (proc.stdout or "").strip(), (proc.stderr or "").strip()
+
+
+class LedgerRefUnreadable(RuntimeError):
+    """`--ref` was given and could not be honoured.
+
+    Deliberately fatal rather than a fallback. Silently reading the working
+    tree after being asked for a ref is the worst possible outcome: the caller
+    believes it is looking at main and is looking at its own stale checkout —
+    the same class of lie the ref option exists to end.
+    """
+
+
+def _ledger_text_at_ref(ledger_path: Path, ref: str) -> str:
+    """Read the ledger as of `ref`, without touching the working tree.
+
+    Read-only by construction: `git show` writes nothing, changes no branch and
+    fetches nothing. `origin/main` is therefore only as fresh as the last fetch
+    — stated in the freshness line rather than papered over with a fetch, so
+    this stays a pure signaler (offline is a natural state, Law 6).
+    """
+    repo = ledger_path.parent
+    rc, top, err = _git(["rev-parse", "--show-toplevel"], cwd=repo)
+    if rc != 0:
+        raise LedgerRefUnreadable(f"not a git repository at {repo}: {err or f'git exited {rc}'}")
+    try:
+        rel = ledger_path.resolve().relative_to(Path(top).resolve())
+    except ValueError as exc:  # ledger outside the repo — nothing to resolve against
+        raise LedgerRefUnreadable(f"{ledger_path} is not inside {top}") from exc
+    rc, out, err = _git(["show", f"{ref}:{rel.as_posix()}"], cwd=repo)
+    if rc != 0:
+        raise LedgerRefUnreadable(f"cannot read {rel.as_posix()} at {ref!r}: {err or f'git exited {rc}'}")
+    if not out.strip():
+        # Empty is not a ledger. Zero entries is a claim, and a claim this tool
+        # must not make on the strength of an empty read.
+        raise LedgerRefUnreadable(f"{rel.as_posix()} at {ref!r} is empty")
+    return out
+
+
+def load_entries(ledger_path: Path, now: date, ref: Optional[str] = None) -> List[Entry]:
+    text = _ledger_text_at_ref(ledger_path, ref) if ref else ledger_path.read_text(encoding="utf-8")
     return [parse_entry(raw, now) for raw in extract_open_entries(text)]
 
 
@@ -684,12 +752,26 @@ def compute_counts(entries: List[Entry], check_pr_refs: bool = False) -> Dict[st
     return counts
 
 
-def _freshness_line(freshness: Optional[Dict[str, Any]]) -> str:
+def _freshness_line(freshness: Optional[Dict[str, Any]], ref: Optional[str] = None) -> str:
     """One line, always printed. Silence about freshness is what made this necessary."""
     if not freshness:
         return "- ledger-freshness: not checked"
     state = freshness.get("state")
     detail = freshness.get("detail", "")
+    if ref:
+        # The rows below came from `ref`, so how far the WORKING TREE has fallen
+        # behind cannot make them wrong. Still reported, because it is the number
+        # a reader would otherwise have to go and measure.
+        behind = freshness.get("behind")
+        gap = (
+            f"this checkout is {behind} commit(s) behind on this file"
+            if isinstance(behind, int) and behind > 0
+            else f"checkout gap {state}"
+        )
+        return (
+            f"- ledger-freshness: read at `{ref}` — {gap}, which does NOT affect the rows "
+            f"below (`{ref}` is itself only as fresh as your last fetch)"
+        )
     if state == "stale":
         return f"- ⚠️ ledger-freshness: **STALE** — {detail}"
     if state == "current":
@@ -703,13 +785,15 @@ def render_report(
     entries: List[Entry],
     freshness: Optional[Dict[str, Any]] = None,
     check_pr_refs: bool = False,
+    ref: Optional[str] = None,
 ) -> str:
     counts = compute_counts(entries, check_pr_refs=check_pr_refs)
     lines: List[str] = []
     lines.append("# PENDING-ARMS reconciliation report")
     lines.append("")
-    lines.append(f"- ledger: `{ledger_path}`")
-    lines.append(_freshness_line(freshness))
+    source = f"`{ledger_path}` @ `{ref}`" if ref else f"`{ledger_path}`"
+    lines.append(f"- ledger: {source}")
+    lines.append(_freshness_line(freshness, ref))
     lines.append(
         f"- now: {now.isoformat()} (day-precision dates; overdue = age_days >= "
         f"{OVERDUE_AGE_DAYS}, the closest day-precision proxy for >48h)"
@@ -910,8 +994,10 @@ def _ledger_freshness(ledger_path: Path) -> Dict[str, Any]:
         "behind": behind,
         "detail": (
             f"origin/main has {behind} commit(s) to this ledger that this checkout lacks — "
-            "rows shown as open may already be closed on main; pull before trusting this report "
-            "(and note origin/main itself is only as fresh as your last fetch)"
+            "rows shown as open may already be closed on main. Re-run with `--ref origin/main` "
+            "to read main's ledger: read-only, no pull and no write, so it works from the main "
+            "checkout too, where a session is (correctly) forbidden to mutate git. "
+            "(origin/main is itself only as fresh as your last fetch.)"
         ),
     }
 
@@ -936,6 +1022,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Path to PENDING-ARMS.md (default: <repo-root>/.claude/skills/modus/PENDING-ARMS.md)",
+    )
+    parser.add_argument(
+        "--ref",
+        type=str,
+        default=None,
+        metavar="GITREF",
+        help=(
+            "Read the ledger as of a git ref (e.g. origin/main) instead of the working "
+            "tree. Read-only: no pull, no fetch, no write — the way to see main's ledger "
+            "from a checkout that is behind. Fatal if the ref cannot be read; it never "
+            "falls back to the working tree."
+        ),
     )
     parser.add_argument(
         "--now",
@@ -1008,7 +1106,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         )
         return 2
 
-    entries = load_entries(ledger_path, now)
+    try:
+        entries = load_entries(ledger_path, now, ref=args.ref)
+    except LedgerRefUnreadable as exc:
+        # Fail loud. A caller who asked for a ref and silently got the working
+        # tree would draw conclusions about main from its own stale checkout.
+        print(f"pending_arms_report: --ref {args.ref!r} unreadable: {exc}", file=sys.stderr)
+        return 2
     if args.check_pr_refs:
         annotate_pr_refs(entries)
     freshness = _ledger_freshness(ledger_path)
@@ -1022,7 +1126,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         )
     else:
         print(
-            render_report(ledger_path, now, entries, freshness, check_pr_refs=args.check_pr_refs),
+            render_report(ledger_path, now, entries, freshness, check_pr_refs=args.check_pr_refs, ref=args.ref),
             end="",
         )
 

--- a/scripts/tests/test_pending_arms_ref.py
+++ b/scripts/tests/test_pending_arms_ref.py
@@ -1,0 +1,175 @@
+"""`--ref`: read the ledger from a git ref without mutating anything.
+
+Why this exists (2026-08-08): the report's freshness line used to end in "pull
+before trusting this report". On m5 the main checkout is deliberately behind
+origin/main, and `worktree_isolation.py` refuses any mutating git there for an
+agent session — so the only documented way to follow that advice was to disarm
+the guard. A prescription whose only executor is a lane that does not exist
+teaches its reader to ignore the probe.
+
+The corpus is built around the one failure that would be worse than the disease:
+asking for a ref, not getting it, and being handed the working tree anyway. A
+caller in that position believes it is reading main and is reading its own stale
+copy — so `--ref` is fatal on failure, and `test_unreadable_ref_never_falls_back`
+is the load-bearing case here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "pending_arms_report.py"
+
+OLD_LINE = (
+    "- opened 2026-01-01 | **only on the old commit** | missing arming step: none "
+    "| owner: me (test) | proof-of-armed: none\n"
+)
+NEW_LINE = (
+    "- opened 2026-01-02 | **only in the working tree** | missing arming step: none "
+    "| owner: me (test) | proof-of-armed: none\n"
+)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args], capture_output=True, text=True, timeout=120
+    )
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True, timeout=60
+    )
+
+
+@pytest.fixture()
+def repo_with_two_ledgers(tmp_path: Path) -> tuple[Path, Path]:
+    """A throwaway repo whose committed ledger differs from its working tree.
+
+    Committed on `oldref`: OLD_LINE. Working tree: NEW_LINE. Anything that
+    confuses the two is visible as a wrong entry title, not as a subtle count.
+    """
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "skills" / "modus").mkdir(parents=True)
+    ledger = repo / ".claude" / "skills" / "modus" / "PENDING-ARMS.md"
+    _git(repo.parent, "init", "-q", str(repo))
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    ledger.write_text(OLD_LINE, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "old ledger")
+    _git(repo, "branch", "-f", "oldref")
+    ledger.write_text(NEW_LINE, encoding="utf-8")  # uncommitted: working tree only
+    return repo, ledger
+
+
+def test_guilt_ref_reads_the_committed_ledger_not_the_working_tree(repo_with_two_ledgers):
+    """--ref must answer with the REF's content, or it is decoration."""
+    _, ledger = repo_with_two_ledgers
+    proc = _run("--ledger", str(ledger), "--ref", "oldref", "--now", "2026-02-01")
+    assert proc.returncode == 0, proc.stderr
+    assert "only on the old commit" in proc.stdout
+    assert "only in the working tree" not in proc.stdout
+
+
+def test_innocence_no_ref_still_reads_the_working_tree(repo_with_two_ledgers):
+    """The default must not move.
+
+    A session that has just written its own ledger line has to keep seeing it —
+    switching the default to origin/main would make its own work vanish from the
+    report, which is the twin bug of the one being fixed.
+    """
+    _, ledger = repo_with_two_ledgers
+    proc = _run("--ledger", str(ledger), "--now", "2026-02-01")
+    assert proc.returncode == 0, proc.stderr
+    assert "only in the working tree" in proc.stdout
+    assert "only on the old commit" not in proc.stdout
+
+
+def test_unreadable_ref_never_falls_back(repo_with_two_ledgers):
+    """The case that would be worse than the disease.
+
+    Silently serving the working tree after being asked for a ref lets a caller
+    conclude things about main from its own stale checkout. Must be fatal, must
+    name the ref, and must not print a report.
+    """
+    _, ledger = repo_with_two_ledgers
+    proc = _run("--ledger", str(ledger), "--ref", "no/such/ref", "--now", "2026-02-01")
+    assert proc.returncode == 2, f"expected fatal, got {proc.returncode}: {proc.stdout}"
+    assert "no/such/ref" in proc.stderr
+    assert "only in the working tree" not in proc.stdout
+    assert "only on the old commit" not in proc.stdout
+
+
+def test_empty_ledger_at_ref_is_refused_not_reported_as_zero_entries(tmp_path: Path):
+    """Zero entries is a claim; an empty read is not evidence for it."""
+    repo = tmp_path / "repo"
+    (repo / ".claude" / "skills" / "modus").mkdir(parents=True)
+    ledger = repo / ".claude" / "skills" / "modus" / "PENDING-ARMS.md"
+    _git(repo.parent, "init", "-q", str(repo))
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    ledger.write_text("", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "empty ledger")
+    _git(repo, "branch", "-f", "emptyref")
+    ledger.write_text(NEW_LINE, encoding="utf-8")
+
+    proc = _run("--ledger", str(ledger), "--ref", "emptyref", "--now", "2026-02-01")
+    assert proc.returncode == 2, proc.stdout
+    assert "empty" in proc.stderr.lower()
+
+
+def test_ref_run_writes_nothing(repo_with_two_ledgers):
+    """`git show` reads; it must not touch the tree, the index, or the branch.
+
+    Asserted on observable state rather than trusted from the docstring: the
+    working-tree bytes, `git status --porcelain` and HEAD are all unchanged.
+    """
+    repo, ledger = repo_with_two_ledgers
+    before_bytes = ledger.read_bytes()
+    before_status = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"], capture_output=True, text=True
+    ).stdout
+    before_head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True, text=True
+    ).stdout
+
+    assert _run("--ledger", str(ledger), "--ref", "oldref", "--now", "2026-02-01").returncode == 0
+
+    assert ledger.read_bytes() == before_bytes
+    after_status = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"], capture_output=True, text=True
+    ).stdout
+    after_head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True, text=True
+    ).stdout
+    assert after_status == before_status
+    assert after_head == before_head
+
+
+def test_stale_advice_no_longer_prescribes_a_pull():
+    """The prescription itself is the finding — assert on the shipped string.
+
+    Read from the module rather than from a run, because reproducing a stale
+    checkout in a fixture would test the fixture. What must never come back is
+    advice a session is forbidden to follow.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    start = src.index('"state": "stale"')
+    detail = src[start : start + 1200]
+    assert "pull before trusting" not in detail
+    assert "--ref origin/main" in detail
+
+
+def test_report_names_its_source_when_a_ref_is_used(repo_with_two_ledgers):
+    """A reader must never have to guess which ledger produced the rows."""
+    _, ledger = repo_with_two_ledgers
+    proc = _run("--ledger", str(ledger), "--ref", "oldref", "--now", "2026-02-01")
+    assert "@ `oldref`" in proc.stdout
+    assert "read at `oldref`" in proc.stdout


### PR DESCRIPTION
Closes the ledger line opened in #3816 earlier today, rather than leaving it for a follow-up lane.

## The finding

#3723 correctly stopped `git_alignment` from telling m5 to pull its main checkout (it is behind **by design** — pulling races live worktrees). Then its *actionable* half prescribed:

```
git checkout origin/main -- .claude/skills/modus/PENDING-ARMS.md   # in the main checkout
```

**No agent session may run that.** `worktree_isolation.py` blocks mutating git in the main checkout — verified this session: the `git checkout` was refused, while read-only git in the same directory passed several times, so the block is verb-selective and working as designed. The only documented way past it is `AGENT_WORKTREE_ENFORCEMENT=false`, which disarms the guard wholesale.

`pending_arms_report.py` carried the same dead advice in its own freshness line: *"pull before trusting this report"*.

With *"there is no operator lane"* in force, a prescription whose only executor does not exist is §6's disease one floor down — a probe that recommends something forbidden teaches its reader to ignore it, and the next one that matters gets ignored too.

## The fix: remove the need for the write, don't authorise it

`--ref GITREF` reads the ledger with `git show`. No pull, no fetch, no write — so it works **from the main checkout too**.

Measured on the real main checkout (210 behind), same command, one flag:

| | result |
|---|---|
| without `--ref` | `STALE`, **total=312**, does **not** contain the ledger line #3816 just merged |
| with `--ref origin/main` | **total=346**, contains it |
| after both runs | ledger dirty entries **0**, still **210** behind — nothing written |

**34 entries** were missing from that view.

## Two design choices that are the actual substance

**The default does not move.** Making `origin/main` the default would make a session's own freshly-written ledger line vanish from its own report — the twin bug of the one being fixed. No `--ref` still reads the working tree.

**`--ref` is fatal when the ref cannot be read.** Silently serving the working tree to a caller who asked for main is *worse than the disease*: they conclude things about main from their own stale copy. Same reason an empty read is refused rather than reported as zero entries — zero is a claim, and an empty read is not evidence for it.

## Verification

- **7 tests**, guilt + innocence + the never-fall-back case + a no-write assertion on *observable* state (working-tree bytes, `git status --porcelain`, HEAD) rather than on the docstring's promise.
- **Mutation-verified**: silent fallback → 2 red · `--ref` ignored → 3 red · the old `"pull"` advice restored → 1 red · all 7 green on restore.
- Existing suite **98/98**, unchanged.
- The stale-advice test asserts on the **shipped string** rather than reproducing a stale checkout in a fixture — a fixture there would test the fixture. What must never come back is advice a session is forbidden to follow.

## Not in this diff, measured while doing it

`agent_start.py --release` judges "merged into main" by **ancestor**, so it refuses a squash-merged branch (`ERROR: branch … not merged into main`), while `branch_graveyard_cleanup.sh::content_on_main()` — the cure for exactly that (W88) — judges by content. Two tools that must agree on "is this on main" give opposite answers. Verified by hand here (blob-per-file, then confirming each apparently-unique line has a counterpart on main; one had been *closed* by another lane, so the branch carried the pre-rewrite form). Noted, not fixed in this PR.