### PR TITLE
fix(sentinel): escalations queue never forgets a resolved job (net-pending)

### DIFF
--- a/scripts/modus_enqueue.py
+++ b/scripts/modus_enqueue.py
@@ -87,11 +87,18 @@ def enqueue_task(
 
 
 def _already_pending(job: str) -> bool:
-    """True if the queue already has a pending entry for this job."""
-    for entry in escalations.read_all_escalations(include_resolved=False):
-        if entry.get("job") == job and entry.get("status") == "pending":
-            return True
-    return False
+    """True if the queue's LATEST record for this job is still open (pending).
+
+    Delegates to escalations.is_job_open() — a naive per-entry status scan
+    over read_all_escalations(include_resolved=False) sees the job's
+    ORIGINAL pending entry forever, because mark_resolved() appends a new
+    resolved record rather than mutating it (append-only queue). Without
+    the collapse-to-latest step, a job that fails once, gets resolved, then
+    fails again months later would never re-enqueue: this function would
+    keep reporting "already pending" against the ancient, since-resolved
+    entry.
+    """
+    return escalations.is_job_open(job)
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:

--- a/scripts/sentinel_lib/escalations.py
+++ b/scripts/sentinel_lib/escalations.py
@@ -136,3 +136,29 @@ def mark_resolved(job_id: str) -> int:
         return 0
     write_escalation({"job": job_id, "status": "resolved", "resolved_at": time.time()})
     return len(pending)
+
+
+def is_job_open(job_id: str) -> bool:
+    """True if job_id's LATEST record (by ts) is a pending entry.
+
+    The queue is append-only: mark_resolved() appends a NEW {"status":
+    "resolved", ...} record rather than mutating the original pending one
+    (see write_escalation/mark_resolved docstrings). A naive
+    ``any(e["status"] == "pending" for e in ... if e["job"] == job_id)``
+    scan therefore finds the ORIGINAL pending entry and reports "open"
+    forever, even after resolution — cicatrix #2 Esiste≠Armato / #9
+    state-schema drift (a resolved marker is state a naive reader ignores).
+    Collapse to the newest record per job before checking status, mirroring
+    scripts/hooks/escalations_alert_sessionstart.sh's net-pending logic and
+    modus_autoloop.py's _collapse_by_job — the correct behavior already
+    existed in two consumers; this promotes it into the shared library so
+    every consumer of read_all_escalations() gets it, not just those two.
+
+    A recurring job (escalate → resolve → escalate again) reads OPEN again,
+    because the newest record is the new pending one.
+    """
+    entries = [e for e in read_all_escalations(include_resolved=True) if e.get("job") == job_id]
+    if not entries:
+        return False
+    latest = max(entries, key=lambda e: e.get("ts", 0))
+    return latest.get("status") != "resolved"

--- a/scripts/tests/test_modus_enqueue.py
+++ b/scripts/tests/test_modus_enqueue.py
@@ -91,6 +91,11 @@ def test_reenqueue_of_pending_job_does_not_double_write(fake_queue: list[dict]) 
 
 
 def test_reenqueue_after_resolution_is_allowed(fake_queue: list[dict]) -> None:
+    """The queue is append-only: resolution APPENDS a new record, it never
+    mutates the original pending one (matches sentinel_lib.escalations'
+    real mark_resolved() semantics — see test_reenqueue_after_ancient_
+    resolution_is_allowed below for why a fake that mutates in place would
+    hide the actual production bug this guards against)."""
     kwargs = dict(
         job="resolvable-job",
         source="regulatory-watcher",
@@ -101,7 +106,29 @@ def test_reenqueue_after_resolution_is_allowed(fake_queue: list[dict]) -> None:
     modus_enqueue.enqueue_task(**kwargs)
     assert len(fake_queue) == 1
 
-    fake_queue[0]["status"] = "resolved"
+    fake_queue.append({"job": "resolvable-job", "status": "resolved", "ts": 2})
 
     modus_enqueue.enqueue_task(**kwargs)
-    assert len(fake_queue) == 2  # not pending anymore, so a new entry is allowed
+    assert len(fake_queue) == 3  # not pending anymore, so a new entry is allowed
+
+
+def test_reenqueue_after_ancient_resolution_is_allowed(fake_queue: list[dict]) -> None:
+    """Regression test for the append-only staleness bug: an OLD pending
+    entry for a job must not block re-enqueue once a LATER resolved marker
+    exists for that same job — even though the old pending entry's own
+    'status' field still literally reads 'pending' forever (immutable log).
+    Pre-fix, _already_pending() did a naive per-entry status scan and would
+    see the ancient pending entry and refuse to re-enqueue, silently
+    swallowing every future recurrence of an already-fixed job."""
+    fake_queue.append({"job": "flaky-job", "status": "pending", "ts": 1})
+    fake_queue.append({"job": "flaky-job", "status": "resolved", "ts": 2})
+    assert len(fake_queue) == 2
+
+    modus_enqueue.enqueue_task(
+        job="flaky-job",
+        source="regulatory-watcher",
+        mandate="recurred after being fixed once",
+        klass="green",
+        perimeter="research/**",
+    )
+    assert len(fake_queue) == 3  # new pending record written, not skipped

--- a/scripts/tests/test_sentinel_lib_escalations.py
+++ b/scripts/tests/test_sentinel_lib_escalations.py
@@ -1,0 +1,70 @@
+"""Tests for scripts/sentinel_lib/escalations.py::is_job_open().
+
+Direct unit coverage for the net-pending collapse-by-job logic, isolated
+from any consumer (see test_modus_enqueue.py for the _already_pending()
+consumer-level regression). Uses a real on-disk JSONL under tmp_path so the
+append-only O_APPEND write path (write_escalation) is exercised for real,
+not faked.
+
+Run:
+    cd ~/nuzantara
+    source apps/backend-rag/.venv/bin/activate
+    python -m pytest scripts/tests/test_sentinel_lib_escalations.py -v
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sentinel_lib import escalations  # noqa: E402
+
+
+@pytest.fixture
+def isolated_queue(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point the module at a throwaway JSONL so this test can never collide
+    with a sibling session's live shared/escalations_pro.jsonl (scar #5)."""
+    path = tmp_path / "escalations_pro.jsonl"
+    monkeypatch.setattr(escalations, "_MACHINE_FILES", {"pro": path})
+    monkeypatch.setattr(escalations, "_current_machine", lambda: "pro")
+    monkeypatch.setenv("ESCALATIONS_USE_SQLITE", "false")
+    return path
+
+
+def test_no_entries_reads_not_open(isolated_queue: Path) -> None:
+    assert escalations.is_job_open("never-escalated-job") is False
+
+
+def test_pending_only_reads_open(isolated_queue: Path) -> None:
+    escalations.write_escalation({"job": "job-a", "status": "pending"})
+    assert escalations.is_job_open("job-a") is True
+
+
+def test_ancient_pending_with_later_resolution_reads_closed(isolated_queue: Path) -> None:
+    """The bug this function exists to fix: a pending entry's own status
+    field never changes (immutable log) — only a LATER resolved record for
+    the same job, collapsed by ts, makes the job read as closed."""
+    escalations.write_escalation({"job": "job-b", "status": "pending", "ts": 100})
+    escalations.write_escalation({"job": "job-b", "status": "resolved", "ts": 200})
+    assert escalations.is_job_open("job-b") is False
+
+
+def test_recurring_job_after_resolution_reads_open_again(isolated_queue: Path) -> None:
+    """escalate -> resolve -> escalate again must read OPEN — the newest
+    record wins the collapse, not 'any resolution ever happened'."""
+    escalations.write_escalation({"job": "job-c", "status": "pending", "ts": 100})
+    escalations.write_escalation({"job": "job-c", "status": "resolved", "ts": 200})
+    escalations.write_escalation({"job": "job-c", "status": "pending", "ts": 300})
+    assert escalations.is_job_open("job-c") is True
+
+
+def test_unrelated_job_resolution_does_not_leak(isolated_queue: Path) -> None:
+    """A resolution for job-x must never close job-y."""
+    escalations.write_escalation({"job": "job-x", "status": "pending", "ts": 100})
+    escalations.write_escalation({"job": "job-y", "status": "pending", "ts": 100})
+    escalations.write_escalation({"job": "job-x", "status": "resolved", "ts": 200})
+    assert escalations.is_job_open("job-x") is False
+    assert escalations.is_job_open("job-y") is True


### PR DESCRIPTION
## Summary
- `shared/escalations_*.jsonl` is append-only: `mark_resolved()` appends a new `{"status": "resolved", ...}` record, it never mutates the original pending entry.
- `scripts/hooks/escalations_alert_sessionstart.sh` (2026-07-16 "board-honesty" fix) and `modus_autoloop.py`'s `_collapse_by_job()` both already knew this and collapse to the newest record per job before judging status — but that logic lived in two consumers, not in the shared library.
- `read_all_escalations()` itself, and `modus_enqueue.py`'s `_already_pending()`, still did a naive per-entry status scan, so a job's ancient pending entry reads "pending" forever even after resolution.
- Concrete symptom measured live on `shared/escalations_pro.jsonl` this session: 6 `dropbox_intake` pending entries from 2026-07-08..23, three `mark_resolved()` calls appended 2026-07-24/25 — every one of the 6 still reads pending today. All 26 "pending" NORMAL escalations on the board were stale in this same way; every underlying job's current receipt was verified healthy.
- Real consequence for `modus_enqueue.py`: a job that fails once, gets resolved, then genuinely fails again later would silently never re-enqueue, because `_already_pending()` finds the old (never-mutated) pending record and refuses.

## Fix
- Adds `sentinel_lib.escalations.is_job_open(job_id)` — collapse-by-newest-ts per job, matching the hook's and `modus_autoloop`'s already-correct logic.
- Points `modus_enqueue.py`'s `_already_pending()` at it.

## Test plan
- [x] New direct unit tests for `is_job_open()` (`test_sentinel_lib_escalations.py`): no-entries, pending-only, ancient-pending-with-later-resolution, recurring-job-reopens, no cross-job leakage.
- [x] `test_modus_enqueue.py`: fixed the resolution test to APPEND a resolved marker instead of mutating in place (matching real append-only semantics — the old fixture's in-place mutation hid the actual bug), plus a new regression test for the ancient-pending case.
- [x] Verified guilt: reverted `_already_pending()` to the old naive scan locally, confirmed both the updated and new tests go red; restored the fix, confirmed green.
- [x] Full backend suite passed on push (pre-existing, unrelated `test_redos_anchor_patterns.py` flake on the first attempt was a load-induced false-red per the open PENDING-ARMS ledger note on that test — machine had 3 concurrent pre-push suites contending; retry after the lock cleared passed clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)