### PR TITLE
fix(wr2): the weekly IG-metrics analyst was killed by its own health-check for five weeks, silently

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -130,6 +130,8 @@ jobs:
               scripts/tests/test_wa_session_liveness.py|\
               infra/launchagents/wrappers/wa-session-liveness.sh|\
               scripts/tests/test_wa_session_liveness_wrapper.sh|\
+              infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh|\
+              scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh|\
               infra/launchagents/wrappers/cron-agent.sh|\
               scripts/tests/test_cron_agent_oauth_cascade.sh|\
               scripts/lib/claude_seat.sh|\
@@ -461,6 +463,27 @@ jobs:
           # together, disarming the first guard still exited 2 via the second, and
           # the mutant survived — to judge a guard it has to be the only thing broken.
           bash scripts/tests/test_wa_session_liveness_wrapper.sh
+
+      - name: wr2-ig-metrics-analyst wrapper corpus (errexit-fatal probe + no voice)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # The weekly analyst died three consecutive runs (2026-07-19, 07-26,
+          # 08-02) and no surface anywhere could notice. Two independent causes:
+          #   - its agy health-check lives in a SUBSHELL, which inherits errexit,
+          #     and both of that subshell's exits are non-zero by construction
+          #     (agy down -> agy's code; agy UP -> 143, the watchdog it killed
+          #     itself), so the block aborted the whole script ALWAYS and the DOWN
+          #     branch — the local-fallback hint, its only reason to exist — was
+          #     unreachable on the exact path it was written for (W101, 4th gen);
+          #   - launchd invokes it DIRECTLY (no cron-runner, no wr2-cron-wrapper),
+          #     so no receipt, no reader of its exit code, and missed_runs_alerter
+          #     watches WarRoom rows and not launchd labels (W81/W108).
+          # Armed HERE and not left to the scripts/tests sweep, which is
+          # continue-on-error and gates nothing — the superscar #2 shape. The
+          # probe binary is env-overridable ONLY so this corpus can drive it: the
+          # default path does not exist on a runner (or on M5), so without the
+          # override every machine is structurally unable to reproduce the red.
+          bash scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
 
       - name: OAuth seat cascade corpus (a dead seat must be skipped, not fatal)
         if: steps.paths.outputs.relevant == 'true'

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -57,7 +57,7 @@
     {
       "live": "~/scripts/wr2-ig-metrics-analyst-run.sh",
       "repo": "infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh",
-      "_note": "Promoted to repo canon 2026-07-06 (healer tick) to close the sonnet-5 runtime-proof gap (PENDING-ARMS 2026-07-03): live copy called `claude` directly with no 'used: <tier>' log line. Repo canon adds explicit provenance logging only — same invocation, same model. Live HOME copy on Pro still needs manual sync (healer is read-only on Pro).",
+      "_note": "Promoted to repo canon 2026-07-06 (healer tick) to close the sonnet-5 runtime-proof gap (PENDING-ARMS 2026-07-03): live copy called `claude` directly with no 'used: <tier>' log line. Repo canon adds explicit provenance logging only — same invocation, same model. The old tail of this note — 'Live HOME copy on Pro still needs manual sync' — was measurably FALSE on 2026-08-08: canon, origin/main and Pro's live copy were all sha256 308915627885cf8c, byte-identical. A note that names a pending action which has since happened sends the next reader to realign a copy that is already aligned (W106: a frozen measurement inside the very registry that arbitrates the pair). Corrected, and the reason to keep the pair declared is unchanged: today's errexit cure (the agy health-check subshell inherited errexit and aborted the script on BOTH its exits — three silent dead runs 2026-07-19/26 and 08-02) lands in the canon, so the live copy MUST be re-copied after merge or the two diverge for real. Merging alone leaves the organ dead (W107 delivery gotcha: this live path is a real file, not a symlink).",
       "machines": ["pro"]
     },
     {

--- a/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
+++ b/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
@@ -45,6 +45,47 @@ if [ "$POLL_SECS" -lt 1 ]; then
   POLL_SECS=1
 fi
 
+# --- FAILURE GATEWAY (2026-08-08) ---------------------------------------------
+# Until today this wrapper had ZERO gateway references and no voice at all.
+# launchd invokes it DIRECTLY (`/bin/bash <script>` in
+# com.balizero.wr2.ig-metrics-analyst.weekly — no cron-runner.sh, no
+# wr2-cron-wrapper.sh), so nothing wrote a receipt and nothing read its exit
+# code; `missed_runs_alerter` watches WarRoom DB rows, not launchd labels, and
+# knows nothing about this job; and no probe watches the freshness of its output
+# dir. Three consecutive weekly runs died with no surface anywhere able to
+# notice — W81/W108 in its plainest form.
+#
+# Routed through the ONE gateway (tg_notify.py owns token resolution, tiering and
+# dedup), like the sibling wr2-external-bench-run.sh. Two deliberate choices:
+#   - the interpreter is ABSOLUTE (W108): the alarm must not share a failure mode
+#     with what it reports, and launchd hands this job a PATH whose FIRST entry is
+#     a user-writable ~/.local/bin;
+#   - a missing gateway is LOGGED, never silent — "armed at nothing" and "fired"
+#     must not look the same afterwards. Same for the rc, which is always written.
+# It can never be the thing that kills the run: errexit is restored to whatever
+# it was and the function always returns 0.
+notify_failure() {
+  local msg="$1"
+  local dedup="$2"
+  local gateway notify_py rc had_errexit=0
+  case $- in *e*) had_errexit=1 ;; esac
+  notify_py=/opt/homebrew/bin/python3
+  [ -x "$notify_py" ] || notify_py=/usr/bin/python3
+  gateway="$(dirname "$0")/tg_notify.py"
+  [ -f "$gateway" ] || gateway="${HOME}/nuzantara/scripts/tg_notify.py"
+  if [ ! -f "$gateway" ]; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] gateway MISSING (${gateway}) — alert NOT sent: ${msg}" >> "$ERR"
+    return 0
+  fi
+  set +e
+  "$notify_py" "$gateway" --tier p0 --source wr2-ig-metrics-analyst \
+    --dedup-key "$dedup" -- "$msg" >> "$LOG" 2>&1
+  rc=$?
+  if [ "$had_errexit" -eq 1 ]; then set -e; fi
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] telegram notify rc=${rc} (gateway=${gateway}, python=${notify_py})" >> "$LOG"
+  return 0
+}
+
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] wr2-ig-metrics-analyst starting" >> "$LOG"
 
 # Source secrets for Gemini OAuth + any future env
@@ -107,13 +148,34 @@ fi
 # first process of its own job so `set -m` gives it its own process group
 # (PGID == its own PID), and the watchdog kills the WHOLE group
 # (`kill -- -$PGID`, TERM then KILL) — no descendant can outlive the timeout.
+#
+# 2026-08-08 errexit fix (W101, fourth generation): the probe subshell below ran
+# under this script's own `set -e`, and a subshell INHERITS errexit. Both of its
+# exits are non-zero by construction:
+#   - agy DOWN -> `wait "$AGY_PID"` returns agy's own non-zero code;
+#   - agy UP   -> `wait "$WATCHDOG_PID"` returns 143, the watchdog WE just killed.
+# So the block aborted the entire script, always, and nothing after it ever ran.
+# Measured on the live log (Pro): the 2026-07-19, 07-26 and 08-02 runs each stop
+# dead between "published-with-metrics count" and the health-check verdict —
+# zero further lines, .err.log untouched since 2026-06-23, last complete run
+# 2026-06-28. The DOWN branch — the local-fallback hint, the whole reason this
+# probe exists — was unreachable on the exact path it was written for.
+# Fix: disarm errexit around the probe (OUTSIDE *and* INSIDE — the subshell
+# inherits it) and judge by the CAPTURED rc, never by having survived the line.
 GEMINI_HINT=""
-AGY=/Users/nuzantara/.local/bin/agy
+# Overridable ONLY so the corpus can drive the probe; the default is the live Pro
+# path and is what every real run uses. Without the override the guilt test is
+# unwritable on M5, where this path does not exist at all (user `balizero`), so
+# `[ -x ]` is false, the whole block is skipped, and the dev machine is
+# structurally incapable of reproducing the red (W108 GOTCHA).
+AGY="${WR2_IG_AGY_BIN:-/Users/nuzantara/.local/bin/agy}"
 if [ -x "$AGY" ]; then
   AGY_PROMPT="$(mktemp "${TMPDIR:-/tmp}/wr2-ig-agy-prompt.XXXXXX")"
   AGY_TMP="$(mktemp "${TMPDIR:-/tmp}/wr2-ig-agy-health.XXXXXX")"
   echo "reply with exactly: AGYUP" > "$AGY_PROMPT"
+  set +e
   (
+    set +e
     set -m
     "$AGY" -p --print-timeout 20s < "$AGY_PROMPT" > "$AGY_TMP" 2>&1 &
     AGY_PID=$!
@@ -125,15 +187,22 @@ if [ -x "$AGY" ]; then
     ) &
     WATCHDOG_PID=$!
     wait "$AGY_PID" 2>/dev/null
+    AGY_RC=$?
     kill "$WATCHDOG_PID" 2>/dev/null
     wait "$WATCHDOG_PID" 2>/dev/null
+    # Propagate agy's OWN status, not the watchdog reap's: without this explicit
+    # exit the captured rc is always the `wait` on the watchdog we killed (143),
+    # which says nothing about the thing being probed.
+    exit "$AGY_RC"
   ) 2>/dev/null
+  AGY_PROBE_RC=$?
+  set -e
   AGY_OUT="$(cat "$AGY_TMP" 2>/dev/null || true)"
   rm -f "$AGY_PROMPT" "$AGY_TMP"
   if printf '%s' "$AGY_OUT" | grep -qi 'AGYUP'; then
-    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] gemini health-check: UP" >> "$LOG"
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] gemini health-check: UP (probe_rc=${AGY_PROBE_RC})" >> "$LOG"
   else
-    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] gemini health-check: DOWN (agy not logged in / unreachable) — instructing local fallback" >> "$LOG"
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] gemini health-check: DOWN (agy not logged in / unreachable, probe_rc=${AGY_PROBE_RC}) — instructing local fallback" >> "$LOG"
     GEMINI_HINT=" IMPORTANT: agy/Gemini is NOT available right now (auth required or unreachable). DO NOT call agy at Step 2 — skip it and use the LOCAL statistical fallback (Python/jq on the corpus) directly, and mark partial:true. Do not block waiting for Gemini."
   fi
 else
@@ -149,6 +218,8 @@ CLAUDE_PROMPT="Use the wr2-ig-metrics-analyst agent to run the weekly IG metrics
 CLAUDE_BIN="${WR2_IG_CLAUDE_BIN:-$(command -v claude || true)}"
 if [ -z "$CLAUDE_BIN" ]; then
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] claude binary not found" >> "$ERR"
+  notify_failure "⚠️ wr2-ig-metrics-analyst: claude binary not found (exit=127) on $(hostname -s). Weekly IG-insights amendment NOT produced." \
+    "wr2-ig-metrics-analyst:nobin:$(date +%Y-W%V):$(hostname -s)"
   exit 127
 fi
 MAX_CLAUDE_ATTEMPTS=7
@@ -399,6 +470,11 @@ if [ "$CLAUDE_EXIT" -eq 98 ]; then
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] all Claude OAuth accounts unavailable" >> "$ERR"
 fi
 
-echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] wr2-ig-metrics-analyst done" >> "$LOG"
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] wr2-ig-metrics-analyst done (exit=${CLAUDE_EXIT})" >> "$LOG"
+
+if [ "$CLAUDE_EXIT" -ne 0 ]; then
+  notify_failure "⚠️ wr2-ig-metrics-analyst FAILED (exit=${CLAUDE_EXIT}) on $(hostname -s). Weekly IG-insights amendment NOT produced — see ${ERR}" \
+    "wr2-ig-metrics-analyst:$(date +%Y-W%V):$(hostname -s)"
+fi
 
 exit "$CLAUDE_EXIT"

--- a/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
+++ b/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
@@ -61,30 +61,43 @@ fi
 #     with what it reports, and launchd hands this job a PATH whose FIRST entry is
 #     a user-writable ~/.local/bin;
 #   - a missing gateway is LOGGED, never silent — "armed at nothing" and "fired"
-#     must not look the same afterwards. Same for the rc, which is always written.
-# It can never be the thing that kills the run: errexit is restored to whatever
-# it was and the function always returns 0.
+#     must not look the same afterwards. That branch writes its own line and no
+#     `notify rc=`, because there was no call to have an rc; whenever the gateway
+#     IS invoked, its rc is written whether it worked or not.
+# It can never be the thing that kills the run — and getting that right needed the
+# final log line to be written BEFORE errexit is restored: with `set -e` back on, a
+# `$LOG` that has become unwritable (full disk, wrong owner) would abort the
+# CALLER from inside the reporting code, which is the alarm killing the run it came
+# to report. The gateway itself is bounded, so this cannot hang: tg_notify.py
+# calls `urlopen(..., timeout=6)` and its relay fallback `subprocess.run(...,
+# timeout=15)` — measured, not assumed.
 NOTIFIED=0
 notify_failure() {
   local msg="$1"
   local dedup="$2"
   local gateway notify_py rc had_errexit=0
   NOTIFIED=1
+  # Disarm for the WHOLE body, not just around the gateway call: the
+  # gateway-MISSING branch writes to $ERR and returns, and with errexit still
+  # armed an unwritable $ERR would abort the caller from inside the alarm too.
   case $- in *e*) had_errexit=1 ;; esac
+  set +e
   notify_py=/opt/homebrew/bin/python3
   [ -x "$notify_py" ] || notify_py=/usr/bin/python3
   gateway="$(dirname "$0")/tg_notify.py"
   [ -f "$gateway" ] || gateway="${HOME}/nuzantara/scripts/tg_notify.py"
   if [ ! -f "$gateway" ]; then
     echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] gateway MISSING (${gateway}) — alert NOT sent: ${msg}" >> "$ERR"
+    if [ "$had_errexit" -eq 1 ]; then set -e; fi
     return 0
   fi
-  set +e
   "$notify_py" "$gateway" --tier p0 --source wr2-ig-metrics-analyst \
     --dedup-key "$dedup" -- "$msg" >> "$LOG" 2>&1
   rc=$?
-  if [ "$had_errexit" -eq 1 ]; then set -e; fi
+  # Order matters: log FIRST, restore errexit AFTER. Reversed, an unwritable $LOG
+  # aborts the caller from inside the alarm.
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] telegram notify rc=${rc} (gateway=${gateway}, python=${notify_py})" >> "$LOG"
+  if [ "$had_errexit" -eq 1 ]; then set -e; fi
   return 0
 }
 
@@ -97,12 +110,16 @@ notify_failure() {
 # exit that has NOT already spoken gets a message naming that it died WITHOUT a
 # diagnosis, which is a different and more alarming fact than a named failure.
 #
-# Deliberate limit, declared rather than hidden and stated PRECISELY because a
-# comment that overstates its own coverage is the next reader's false premise:
-# the voice covers everything BELOW the `trap` line, so anything failing above it
-# is still silent — `mkdir -p "$LOGDIR"` itself, and the TIMEOUT_SECS/POLL_SECS
-# validation (a non-integer WR2_IG_METRICS_POLL_SECS makes `[ … -lt 1 ]` fail and
-# errexit take the script out before there is any voice to install).
+# Deliberate limit, declared rather than hidden — and stated by MEASUREMENT,
+# because the first version of this very comment was false. It claimed a
+# non-integer WR2_IG_METRICS_POLL_SECS would make `[ … -lt 1 ]` fail and errexit
+# take the script out before any voice existed. It does not: that test sits inside
+# an `if`, where errexit is EXEMPT (measured: `set -e; P=nope; if [ "$P" -lt 1 ];`
+# prints to stderr, rc=0, script alive). The same test OUTSIDE an `if` exits 2.
+# So the sentence written to be MORE precise was the wrong one — the correct
+# statement is narrow: the ONLY thing above this trap that can kill the script is
+# the bare `mkdir -p "$LOGDIR"`. A bad POLL_SECS survives to
+# `$((elapsed + sleep_step))`, which is BELOW the trap and therefore has a voice.
 on_exit_voice() {
   local rc="$1"
   if [ "$rc" -eq 0 ] || [ "$NOTIFIED" -eq 1 ]; then
@@ -112,10 +129,26 @@ on_exit_voice() {
     "wr2-ig-metrics-analyst:undiagnosed:$(date +%Y-W%V):$(hostname -s)"
   return 0
 }
+# Per-signal exit codes, and HUP included. launchd's own path is SIGTERM, but a
+# manual run over a dropped ssh gets SIGHUP, which nothing trapped before today:
+# the shell dies, the EXIT trap reads `$?` as 0 (measured — a bash killed by a
+# signal runs its EXIT trap with `$?` = 0) and the voice stays silent for a run cut
+# off mid-flight. Codes are conventional 128+signum instead of the old blanket 130
+# (which is SIGINT's, and was reported for SIGTERM too), so the launchd status
+# names what actually happened. SIGKILL stays outside any trap by definition —
+# declared, not covered.
+signal_exit() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] killed by SIG${1} — exiting ${2}" >> "$ERR"
+  on_exit_voice "$2"
+  exit "$2"
+}
 # Installed HERE, before the first line that can fail, and re-installed later by
-# cleanup_active_claude (which REPLACES this trap and therefore has to carry the
-# voice itself — a `trap ... EXIT` written later silently unarms this one).
+# cleanup_active_claude (which REPLACES these and therefore has to carry the voice
+# itself — a `trap ... EXIT` written later silently unarms this one).
 trap 'on_exit_voice $?' EXIT
+trap 'signal_exit HUP 129' HUP
+trap 'signal_exit INT 130' INT
+trap 'signal_exit TERM 143' TERM
 
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] wr2-ig-metrics-analyst starting" >> "$LOG"
 
@@ -196,11 +229,13 @@ fi
 # (PGID == its own PID), and the watchdog kills the WHOLE group
 # (`kill -- -$PGID`, TERM then KILL) — no descendant can outlive the timeout.
 #
-# 2026-08-08 errexit fix (W101, fourth generation): the probe subshell below ran
-# under this script's own `set -e`, and a subshell INHERITS errexit. Both of its
-# exits are non-zero by construction:
-#   - agy DOWN -> `wait "$AGY_PID"` returns agy's own non-zero code;
-#   - agy UP   -> `wait "$WATCHDOG_PID"` returns 143, the watchdog WE just killed.
+# 2026-08-08 errexit fix (W101, fourth generation). Read the tenses here: this
+# paragraph describes the code AS IT WAS, because after the fix the subshell exits
+# agy's own status and a healthy probe therefore exits 0. As written before today,
+# the probe subshell ran under this script's own `set -e`, and a subshell INHERITS
+# errexit — and BOTH of its exits were non-zero by construction:
+#   - agy DOWN -> `wait "$AGY_PID"` returned agy's own non-zero code;
+#   - agy UP   -> `wait "$WATCHDOG_PID"` returned 143, the watchdog WE just killed.
 # So the block aborted the entire script, always, and nothing after it ever ran.
 # Measured on the live log (Pro): the 2026-07-19, 07-26 and 08-02 runs each stop
 # dead between "published-with-metrics count" and the health-check verdict —
@@ -246,8 +281,15 @@ if [ -x "$AGY" ]; then
   set -e
   AGY_OUT="$(cat "$AGY_TMP" 2>/dev/null || true)"
   rm -f "$AGY_PROMPT" "$AGY_TMP"
-  if printf '%s' "$AGY_OUT" | grep -qi 'AGYUP'; then
-    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] gemini health-check: UP (probe_rc=${AGY_PROBE_RC})" >> "$LOG"
+  # BOTH conditions, not just the answer. Logging `probe_rc` without judging it
+  # would have been decoration: agy can print `AGYUP` and then exit non-zero, or
+  # be killed mid-flight by the 25s watchdog having already emitted the token, and
+  # the old test called both of those UP — then the agent walks into a Gemini that
+  # is not there, which is the whole failure this probe exists to prevent. This is
+  # also what makes the watchdog-timeout path correct for free: a killed agy exits
+  # by signal, so rc != 0 and the verdict is DOWN.
+  if [ "$AGY_PROBE_RC" -eq 0 ] && printf '%s' "$AGY_OUT" | grep -qi 'AGYUP'; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] gemini health-check: UP (probe_rc=0)" >> "$LOG"
   else
     echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] gemini health-check: DOWN (agy not logged in / unreachable, probe_rc=${AGY_PROBE_RC}) — instructing local fallback" >> "$LOG"
     GEMINI_HINT=" IMPORTANT: agy/Gemini is NOT available right now (auth required or unreachable). DO NOT call agy at Step 2 — skip it and use the LOCAL statistical fallback (Python/jq on the corpus) directly, and mark partial:true. Do not block waiting for Gemini."
@@ -274,6 +316,26 @@ DEFAULT_ACCOUNT_TIMEOUT_SECS=$((TIMEOUT_SECS / MAX_CLAUDE_ATTEMPTS))
 if [ "$DEFAULT_ACCOUNT_TIMEOUT_SECS" -lt 1 ]; then
   DEFAULT_ACCOUNT_TIMEOUT_SECS=1
 fi
+# MEASURED FLOOR, not arithmetic (2026-08-08). `TIMEOUT_SECS / MAX_CLAUDE_ATTEMPTS`
+# is 7200/7 = 1028s, and the only successful full run in this organ's whole log
+# took **1065s** (2026-06-28: `starting` 22:07:00 -> `done` 22:24:45) — the last
+# run that actually worked would be SIGTERM'd 37 seconds before finishing. That
+# never bit because the errexit bug killed the script before the cascade was ever
+# reached; curing that bug is exactly what makes this ceiling reachable for the
+# first time, and shipping the cure without this would have revived the organ into
+# a louder corpse: killed at 17 min on all seven seats, then a weekly P0.
+# The aggregate is already bounded by CASCADE_DEADLINE and run_claude_account
+# clamps each attempt to what remains, so the per-attempt number does not need to
+# divide the total — it needs to exceed a real run. 2700s is ~2.5x the observed
+# worst case with room for the corpus to grow (45 -> 50 published carousels since).
+# What re-measures it: the `starting` / `done (exit=…)` pair in this organ's log.
+ACCOUNT_TIMEOUT_MIN_SECS="${WR2_IG_METRICS_ACCOUNT_TIMEOUT_MIN_SECS:-2700}"
+if [ "$DEFAULT_ACCOUNT_TIMEOUT_SECS" -lt "$ACCOUNT_TIMEOUT_MIN_SECS" ]; then
+  DEFAULT_ACCOUNT_TIMEOUT_SECS="$ACCOUNT_TIMEOUT_MIN_SECS"
+fi
+if [ "$DEFAULT_ACCOUNT_TIMEOUT_SECS" -gt "$TIMEOUT_SECS" ]; then
+  DEFAULT_ACCOUNT_TIMEOUT_SECS="$TIMEOUT_SECS"
+fi
 ACCOUNT_TIMEOUT_SECS="${WR2_IG_METRICS_ACCOUNT_TIMEOUT_SECS:-$DEFAULT_ACCOUNT_TIMEOUT_SECS}"
 if [ "$ACCOUNT_TIMEOUT_SECS" -lt 1 ]; then
   ACCOUNT_TIMEOUT_SECS=1
@@ -296,7 +358,7 @@ cleanup_active_claude() {
   # First line, before anything can clobber it: this is also the script's exit
   # status when we get here from the EXIT trap.
   local rc="${1:-$?}"
-  trap - EXIT INT TERM
+  trap - EXIT HUP INT TERM
   if [ -n "$ACTIVE_CLAUDE_PGID" ]; then
     terminate_claude_group "$ACTIVE_CLAUDE_PGID"
   fi
@@ -312,10 +374,15 @@ cleanup_active_claude() {
   fi
 }
 trap cleanup_active_claude EXIT
-# 130 explicitly, not $?: on an external SIGTERM (the 28h hang of 2026-07-14 was
-# killed exactly that way) $? can be 0, and a voice that reads 0 stays quiet for
-# the single incident that most needs reporting.
-trap 'cleanup_active_claude 130' INT TERM
+# An explicit code, never `$?`: on an external SIGTERM (the 28h hang of 2026-07-14
+# was killed exactly that way) `$?` can be 0, and a voice that reads 0 stays quiet
+# for the single incident that most needs reporting. One trap per signal so the
+# reported status names the signal (the old single line reported SIGINT's 130 for
+# a SIGTERM too), and HUP is covered here as well as in the early phase — these
+# lines REPLACE the early traps, so anything missing from them is unarmed.
+trap 'cleanup_active_claude 129' HUP
+trap 'cleanup_active_claude 130' INT
+trap 'cleanup_active_claude 143' TERM
 
 claude_stderr_retryable() {
   local stderr_file="$1"

--- a/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
+++ b/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh
@@ -64,10 +64,12 @@ fi
 #     must not look the same afterwards. Same for the rc, which is always written.
 # It can never be the thing that kills the run: errexit is restored to whatever
 # it was and the function always returns 0.
+NOTIFIED=0
 notify_failure() {
   local msg="$1"
   local dedup="$2"
   local gateway notify_py rc had_errexit=0
+  NOTIFIED=1
   case $- in *e*) had_errexit=1 ;; esac
   notify_py=/opt/homebrew/bin/python3
   [ -x "$notify_py" ] || notify_py=/usr/bin/python3
@@ -85,6 +87,35 @@ notify_failure() {
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] telegram notify rc=${rc} (gateway=${gateway}, python=${notify_py})" >> "$LOG"
   return 0
 }
+
+# Voice of last resort. Naming the two KNOWN failure exits is not enough: under
+# `set -e` this script can also die at any un-guarded line — a failing `mkdir`,
+# `python3` absent so the pre-flight assignment aborts, `mktemp` failing because
+# TMPDIR does not exist — and every one of those was as silent as the errexit bug
+# this commit cures. Curing only the exits I happened to think of is the W107
+# mistake (one mouth out of five) at the scale of a single organ. So: any non-zero
+# exit that has NOT already spoken gets a message naming that it died WITHOUT a
+# diagnosis, which is a different and more alarming fact than a named failure.
+#
+# Deliberate limit, declared rather than hidden and stated PRECISELY because a
+# comment that overstates its own coverage is the next reader's false premise:
+# the voice covers everything BELOW the `trap` line, so anything failing above it
+# is still silent — `mkdir -p "$LOGDIR"` itself, and the TIMEOUT_SECS/POLL_SECS
+# validation (a non-integer WR2_IG_METRICS_POLL_SECS makes `[ … -lt 1 ]` fail and
+# errexit take the script out before there is any voice to install).
+on_exit_voice() {
+  local rc="$1"
+  if [ "$rc" -eq 0 ] || [ "$NOTIFIED" -eq 1 ]; then
+    return 0
+  fi
+  notify_failure "⚠️ wr2-ig-metrics-analyst exited ${rc} with NO diagnosis on $(hostname -s) — it died outside every path that knows how to explain itself. Weekly IG-insights amendment NOT produced. See ${LOG} / ${ERR}" \
+    "wr2-ig-metrics-analyst:undiagnosed:$(date +%Y-W%V):$(hostname -s)"
+  return 0
+}
+# Installed HERE, before the first line that can fail, and re-installed later by
+# cleanup_active_claude (which REPLACES this trap and therefore has to carry the
+# voice itself — a `trap ... EXIT` written later silently unarms this one).
+trap 'on_exit_voice $?' EXIT
 
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] wr2-ig-metrics-analyst starting" >> "$LOG"
 
@@ -106,10 +137,26 @@ try:
     n = sum(1 for i in items if i.get('state') in ('published', 'published_with_edits') and (i.get('engagement_metrics') or {}).get('likes') is not None)
     print(n)
 except Exception as e:
-    print(0)
+    # NOT 0 (2026-08-08). Printing 0 on any exception made 'the queue file is
+    # gone / moved / corrupt' indistinguishable from 'fewer than 10 carousels
+    # published', and the second of those exits 0 in silence after writing an
+    # insufficient-data stub. So a broken path would have parked this organ in a
+    # permanent, well-documented, entirely wrong 'not enough data yet' — the
+    # W114 shape, where an empty measurement means either 'all present' or 'the
+    # check never ran'. Name the cause and let the caller alarm.
+    print('ERR:%s' % type(e).__name__)
 ")
 
 echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] published-with-metrics count: $PUBLISHED_COUNT" >> "$LOG"
+
+case "$PUBLISHED_COUNT" in
+  ERR:*)
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [wr2-ig-metrics] pre-flight could NOT read the review queue (${PUBLISHED_COUNT}) — this is not 'no data', it is 'no measurement'" >> "$ERR"
+    notify_failure "⚠️ wr2-ig-metrics-analyst: review queue UNREADABLE (${PUBLISHED_COUNT}) on $(hostname -s) — cannot tell 'not enough data' from 'no file'. Amendment NOT produced." \
+      "wr2-ig-metrics-analyst:queue-unreadable:$(date +%Y-W%V):$(hostname -s)"
+    exit 66
+    ;;
+esac
 
 if [ "$PUBLISHED_COUNT" -lt 10 ]; then
   STUB="${HOME}/.claude/skills/bali-zero-brand/_proposed-amendments/$(date +%Y-%m-%d)-ig-insights-insufficient-data.md"
@@ -246,6 +293,9 @@ terminate_claude_group() {
 }
 
 cleanup_active_claude() {
+  # First line, before anything can clobber it: this is also the script's exit
+  # status when we get here from the EXIT trap.
+  local rc="${1:-$?}"
   trap - EXIT INT TERM
   if [ -n "$ACTIVE_CLAUDE_PGID" ]; then
     terminate_claude_group "$ACTIVE_CLAUDE_PGID"
@@ -253,9 +303,19 @@ cleanup_active_claude() {
   if [ -n "$ACTIVE_CLAUDE_PID" ]; then
     wait "$ACTIVE_CLAUDE_PID" 2>/dev/null || true
   fi
+  # This trap REPLACED the early `trap 'on_exit_voice $?' EXIT`, so it has to
+  # carry the voice or installing it would have unarmed it — a cure that deletes
+  # another cure by being written later in the file.
+  on_exit_voice "$rc"
+  if [ -n "${1:-}" ]; then
+    exit "$rc"
+  fi
 }
 trap cleanup_active_claude EXIT
-trap 'cleanup_active_claude; exit 130' INT TERM
+# 130 explicitly, not $?: on an external SIGTERM (the 28h hang of 2026-07-14 was
+# killed exactly that way) $? can be 0, and a voice that reads 0 stays quiet for
+# the single incident that most needs reporting.
+trap 'cleanup_active_claude 130' INT TERM
 
 claude_stderr_retryable() {
   local stderr_file="$1"

--- a/scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
+++ b/scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Corpus per infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh.
+#
+# Il wrapper si prova ESEGUENDOLO in un mondo finto — HOME finta, agy finto,
+# claude finto, gateway finto — perche le due cose che deve fare sono cose che si
+# vedono solo girando:
+#
+#   1. SOPRAVVIVERE all'health-check di agy. La sonda vive in un sottoshell, e un
+#      sottoshell EREDITA errexit; entrambe le sue uscite sono non-zero per
+#      costruzione (agy giu -> il codice di agy; agy su -> 143, il watchdog che
+#      abbiamo ucciso noi). Fino al 2026-08-08 quel blocco abortiva l'intero
+#      script SEMPRE: sul log vivo di Pro i run del 19/26 luglio e 2 agosto si
+#      fermano tra il conteggio e il verdetto, zero righe dopo. Il ramo DOWN — il
+#      suggerimento di fallback locale, l'unica ragione per cui la sonda esiste —
+#      era irraggiungibile esattamente sul percorso per cui era stato scritto.
+#
+#   2. PARLARE quando fallisce. launchd lo invoca DIRETTAMENTE (nessun
+#      cron-runner, nessun wr2-cron-wrapper): niente ricevuta, nessuno legge
+#      l'exit code, `missed_runs_alerter` guarda righe WarRoom e non label
+#      launchd. Tre run morti e nessuna superficie in grado di accorgersene.
+#
+# Leggerlo non distingue "non ha sparato" da "non e passato di li" (W107), e su
+# M5 il default `/Users/nuzantara/.local/bin/agy` non esiste — senza
+# WR2_IG_AGY_BIN questa macchina e strutturalmente incapace di riprodurre il
+# rosso (W108 GOTCHA). Per questo il binario della sonda e overridabile.
+#
+# Uso: bash scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER_SRC="$REPO/infra/launchagents/wrappers/wr2-ig-metrics-analyst-run.sh"
+
+PASS=0
+FAIL=0
+
+ok() {
+    echo "  ✓ $1"
+    PASS=$((PASS + 1))
+}
+ko() {
+    echo "  ✗ $1"
+    FAIL=$((FAIL + 1))
+}
+check() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then ok "$name"; else ko "$name — atteso [$expected], ottenuto [$actual]"; fi
+}
+has() {
+    local name="$1" needle="$2" file="$3"
+    if [ -f "$file" ] && grep -qF -- "$needle" "$file"; then ok "$name"; else ko "$name — '$needle' assente da $file"; fi
+}
+hasnt() {
+    local name="$1" needle="$2" file="$3"
+    if [ ! -f "$file" ] || ! grep -qF -- "$needle" "$file"; then ok "$name"; else ko "$name — '$needle' presente in $file e non doveva"; fi
+}
+
+# Monta un mondo finto: HOME propria (il wrapper scrive log, legge la coda e
+# risolve il gateway sotto $HOME), agy finto con l'esito richiesto, claude finto
+# che registra il prompt ricevuto, gateway finto che registra di essere stato
+# chiamato.
+#
+# I pezzi si montano SEPARATAMENTE di proposito: il gateway si puo omettere, cosi
+# la guardia "gateway assente" e giudicabile essendo l'unica cosa rotta.
+make_world() {
+    local root="$1" agy_rc="$2" agy_answer="$3" claude_rc="$4" want_gateway="$5"
+    mkdir -p "$root/bin" "$root/nuzantara/apps/war-room/output/queue" \
+             "$root/nuzantara/scripts" "$root/logs" \
+             "$root/.claude/skills/bali-zero-brand/_proposed-amendments"
+
+    # 12 caroselli pubblicati CON metriche: sopra la soglia di 10, cosi il
+    # pre-flight non esce 0 prima di arrivare all'health-check.
+    python3 - "$root/nuzantara/apps/war-room/output/queue/human-review-queue.json" <<'PY'
+import json, sys
+items = [{"state": "published", "engagement_metrics": {"likes": 10 + i}} for i in range(12)]
+json.dump({"items": items}, open(sys.argv[1], "w"))
+PY
+
+    cat > "$root/bin/agy" <<EOF
+#!/bin/bash
+cat > /dev/null
+[ -n "$agy_answer" ] && echo "$agy_answer"
+exit $agy_rc
+EOF
+
+    # Il finto claude scrive il prompt ricevuto su disco: e l'unico modo di
+    # provare che il GEMINI_HINT viaggia davvero fino all'agente invece di
+    # essere solo calcolato.
+    cat > "$root/bin/claude" <<EOF
+#!/bin/bash
+for a in "\$@"; do printf '%s\n' "\$a"; done > "$root/claude-argv.txt"
+echo "fake claude answer"
+exit $claude_rc
+EOF
+
+    if [ "$want_gateway" = "yes" ]; then
+        cat > "$root/nuzantara/scripts/tg_notify.py" <<EOF
+import sys
+open("$root/gateway-called.txt", "w").write(" ".join(sys.argv[1:]))
+print("fake gateway ok")
+EOF
+    fi
+
+    chmod +x "$root/bin/agy" "$root/bin/claude"
+}
+
+run_wrapper() {
+    local root="$1" wrapper="${2:-$WRAPPER_SRC}"
+    env -i \
+        HOME="$root" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" \
+        TMPDIR="$root/tmp" \
+        WR2_IG_AGY_BIN="$root/bin/agy" \
+        WR2_IG_CLAUDE_BIN="$root/bin/claude" \
+        CLAUDE_CODE_OAUTH_TOKEN_1=faketoken \
+        WR2_IG_METRICS_TIMEOUT_SECS=70 \
+        WR2_IG_METRICS_POLL_SECS=1 \
+        WR2_IG_METRICS_KILL_GRACE_SECS=1 \
+        /bin/bash "$wrapper" >/dev/null 2>&1
+}
+
+TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/wr2-ig-corpus.XXXXXX")"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# ---------------------------------------------------------------- COLPEVOLEZZA 1
+# agy GIU: la sonda esce non-zero. Il wrapper deve SOPRAVVIVERE, scrivere il
+# verdetto DOWN e arrivare in fondo. Prima della cura moriva qui.
+echo "[1] agy DOWN — il wrapper sopravvive e il ramo DOWN e raggiungibile"
+W="$TMPROOT/down"; mkdir -p "$W/tmp"
+make_world "$W" 1 "" 0 yes
+run_wrapper "$W"; rc=$?
+LOG="$W/logs/wr2-ig-metrics-analyst.log"
+check "rc del wrapper" 0 "$rc"
+has "verdetto DOWN scritto" "gemini health-check: DOWN" "$LOG"
+has "arriva in fondo (done)" "wr2-ig-metrics-analyst done" "$LOG"
+has "probe_rc e quello di AGY, non i 143 del watchdog" "probe_rc=1" "$LOG"
+has "il suggerimento di fallback VIAGGIA fino all'agente" "DO NOT call agy" "$W/claude-argv.txt"
+
+# ---------------------------------------------------------------- COLPEVOLEZZA 2
+# Lo stesso, con un codice d'uscita diverso: pinna l'`exit "$AGY_RC"` esplicito.
+# Senza quello il rc catturato e sempre il reap del watchdog e non dice nulla
+# sulla cosa sondata.
+echo "[2] agy DOWN con rc=7 — il rc catturato e di agy"
+W="$TMPROOT/down7"; mkdir -p "$W/tmp"
+make_world "$W" 7 "" 0 yes
+run_wrapper "$W" >/dev/null
+has "probe_rc=7" "probe_rc=7" "$W/logs/wr2-ig-metrics-analyst.log"
+
+# ------------------------------------------------------------------- INNOCENZA 1
+# agy SU: nessun suggerimento, verdetto UP, e comunque nessun allarme.
+echo "[3] agy UP — verdetto UP, nessun hint, nessun allarme"
+W="$TMPROOT/up"; mkdir -p "$W/tmp"
+make_world "$W" 0 "AGYUP" 0 yes
+run_wrapper "$W"; rc=$?
+LOG="$W/logs/wr2-ig-metrics-analyst.log"
+check "rc del wrapper" 0 "$rc"
+has "verdetto UP scritto" "gemini health-check: UP" "$LOG"
+hasnt "nessun hint di fallback nel prompt" "DO NOT call agy" "$W/claude-argv.txt"
+hasnt "nessuna telefonata al gateway su successo" "telegram notify" "$LOG"
+if [ -f "$W/gateway-called.txt" ]; then ko "il gateway e stato chiamato su un run riuscito"; else ok "gateway non chiamato su un run riuscito"; fi
+
+# ---------------------------------------------------------------- COLPEVOLEZZA 3
+# claude fallisce: il wrapper deve PARLARE, e il rc del gateway va loggato.
+echo "[4] claude exit=3 — il wrapper parla e logga l'rc"
+W="$TMPROOT/fail"; mkdir -p "$W/tmp"
+make_world "$W" 0 "AGYUP" 3 yes
+run_wrapper "$W"; rc=$?
+LOG="$W/logs/wr2-ig-metrics-analyst.log"
+check "il rc del job non viene mangiato dall'allarme" 3 "$rc"
+has "l'rc del gateway e loggato" "telegram notify rc=0" "$LOG"
+has "l'interprete e assoluto" "python=/" "$LOG"
+if [ -f "$W/gateway-called.txt" ]; then
+    ok "il gateway e stato invocato davvero"
+    has "tier p0" "--tier p0" "$W/gateway-called.txt"
+    has "source nominato" "--source wr2-ig-metrics-analyst" "$W/gateway-called.txt"
+else
+    ko "il gateway NON e stato invocato su un run fallito"
+fi
+
+# ---------------------------------------------------------------- COLPEVOLEZZA 4
+# Gateway assente: "armato a vuoto" deve essere LOGGATO, non silenzioso, e non
+# deve cambiare l'esito del job.
+echo "[5] gateway assente — lo dice, e non altera l'esito"
+W="$TMPROOT/nogw"; mkdir -p "$W/tmp"
+make_world "$W" 0 "AGYUP" 3 no
+run_wrapper "$W"; rc=$?
+check "il rc del job resta il suo" 3 "$rc"
+has "l'assenza del gateway e loggata" "gateway MISSING" "$W/logs/wr2-ig-metrics-analyst.err.log"
+
+# ------------------------------------------------------------------- MUTAZIONE
+# Rimette errexit dentro e attorno alla sonda — cioe ESATTAMENTE il codice di
+# prima — e pretende che il caso [1] diventi rosso. Un corpus che resta verde
+# con la cura disattivata non prova nulla (W116).
+echo "[mutazione] senza il disarmo di errexit, il caso [1] deve fallire"
+# Il mutante va COSTRUITO e va provato che sia costruito: la prima stesura di
+# questo blocco falliva la mutazione (rimuoveva 2 righe dove ne pretendeva 3),
+# quindi il file non veniva scritto e il wrapper "moriva" con rc=127 perche non
+# esisteva — verde su premessa vacua, la malattia stessa che il corpus previene
+# (W116). Ora la costruzione fallita e un FAIL, non un pass gratuito.
+MUT="$TMPROOT/mutant.sh"
+if python3 - "$WRAPPER_SRC" "$MUT" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+lines = open(src).read().splitlines(keepends=True)
+start = next(i for i, l in enumerate(lines) if 'AGY="${WR2_IG_AGY_BIN' in l)
+end = next(i for i, l in enumerate(lines) if i > start and 'AGY_OUT="$(cat' in l)
+out = [l for i, l in enumerate(lines)
+       if not (start <= i <= end and l.strip() in ("set +e", "set -e"))]
+removed = len(lines) - len(out)
+assert removed == 3, f"mutazione inattesa: rimosse {removed} righe (attese 3)"
+open(dst, "w").write("".join(out))
+PY
+then
+    ok "mutante costruito (3 righe di disarmo errexit rimosse)"
+else
+    ko "la MUTAZIONE non e stata costruita — il controllo sotto sarebbe vacuo"
+fi
+if [ -s "$MUT" ] && bash -n "$MUT" 2>/dev/null; then
+    ok "il mutante e uno script valido (non un file assente)"
+    W="$TMPROOT/mut"; mkdir -p "$W/tmp"
+    make_world "$W" 1 "" 0 yes
+    run_wrapper "$W" "$MUT"; mut_rc=$?
+    MUTLOG="$W/logs/wr2-ig-metrics-analyst.log"
+    if [ "$mut_rc" -eq 0 ] && grep -qF "wr2-ig-metrics-analyst done" "$MUTLOG" 2>/dev/null; then
+        ko "il mutante sopravvive: il corpus non sta provando il disarmo di errexit"
+    elif [ ! -f "$MUTLOG" ] || ! grep -qF "published-with-metrics count" "$MUTLOG" 2>/dev/null; then
+        ko "il mutante e morto PRIMA dell'health-check (rc=$mut_rc): sta misurando la poverta del mondo finto, non la cura"
+    else
+        ok "il mutante arriva al conteggio e muore nell'health-check (rc=$mut_rc, nessun 'done') — e la cura a tenere in vita il run"
+    fi
+else
+    ko "mutante assente o non valido — controllo di mutazione non eseguito"
+fi
+
+echo
+echo "risultato: $PASS pass, $FAIL fail"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
+++ b/scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
@@ -187,6 +187,46 @@ run_wrapper "$W"; rc=$?
 check "il rc del job resta il suo" 3 "$rc"
 has "l'assenza del gateway e loggata" "gateway MISSING" "$W/logs/wr2-ig-metrics-analyst.err.log"
 
+# ---------------------------------------------------------------- COLPEVOLEZZA 5
+# Coda illeggibile: il pre-flight stampava 0 su QUALSIASI eccezione, quindi "il
+# file non c'e" era indistinguibile da "meno di 10 pubblicati" — e il secondo esce
+# 0 in silenzio dopo aver scritto uno stub. Deve nominare la causa e allarmare.
+echo "[6] coda illeggibile — 'nessuna misura' non e 'nessun dato'"
+W="$TMPROOT/noqueue"; mkdir -p "$W/tmp"
+make_world "$W" 0 "AGYUP" 0 yes
+rm -f "$W/nuzantara/apps/war-room/output/queue/human-review-queue.json"
+run_wrapper "$W"; rc=$?
+check "esce 66, non 0" 66 "$rc"
+has "la causa e nominata nel log" "ERR:FileNotFoundError" "$W/logs/wr2-ig-metrics-analyst.log"
+has "l'ERR distingue le due cose" "it is 'no measurement'" "$W/logs/wr2-ig-metrics-analyst.err.log"
+if [ -f "$W/gateway-called.txt" ] && grep -qF "UNREADABLE" "$W/gateway-called.txt"; then
+    ok "il gateway e stato invocato e il messaggio dice UNREADABLE"
+else
+    ko "coda illeggibile: nessun allarme (o allarme senza causa)"
+fi
+if ls "$W/.claude/skills/bali-zero-brand/_proposed-amendments/"*insufficient-data* >/dev/null 2>&1; then
+    ko "ha scritto lo stub 'insufficient data' su un guasto di lettura"
+else
+    ok "nessuno stub 'insufficient data' su un guasto di lettura"
+fi
+
+# ---------------------------------------------------------------- COLPEVOLEZZA 6
+# Morte NON diagnosticata: TMPDIR inesistente fa fallire il primo `mktemp`, che
+# sta fuori dalla regione con errexit disarmato. Prima di oggi lo script moriva
+# li in totale silenzio, come nell'errexit bug che questo commit cura: nominare
+# solo le uscite a cui ho pensato e l'errore W107 alla scala di un solo organo.
+echo "[7] morte non diagnosticata — la voce di ultima istanza parla"
+W="$TMPROOT/nodiag"
+make_world "$W" 0 "AGYUP" 0 yes   # NOTA: $W/tmp deliberatamente NON creata
+run_wrapper "$W"; rc=$?
+if [ "$rc" -eq 0 ]; then ko "atteso un rc non-zero, ottenuto 0"; else ok "esce non-zero (rc=$rc)"; fi
+has "arriva oltre il pre-flight prima di morire" "published-with-metrics count: 12" "$W/logs/wr2-ig-metrics-analyst.log"
+if [ -f "$W/gateway-called.txt" ] && grep -qF "NO diagnosis" "$W/gateway-called.txt"; then
+    ok "il gateway dice che e morto SENZA diagnosi (fatto diverso da un guasto nominato)"
+else
+    ko "morte fuori da ogni percorso noto: nessuna voce"
+fi
+
 # ------------------------------------------------------------------- MUTAZIONE
 # Rimette errexit dentro e attorno alla sonda — cioe ESATTAMENTE il codice di
 # prima — e pretende che il caso [1] diventi rosso. Un corpus che resta verde

--- a/scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
+++ b/scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh
@@ -227,6 +227,81 @@ else
     ko "morte fuori da ogni percorso noto: nessuna voce"
 fi
 
+# ---------------------------------------------------------------- COLPEVOLEZZA 7
+# FALSO UP: agy stampa AGYUP e POI muore. Il vecchio test guardava solo la
+# risposta, quindi diceva UP — e l'agente camminava dentro un Gemini che non c'e,
+# che e' esattamente il guasto per cui la sonda esiste. Copre per costruzione anche
+# il watchdog che uccide agy a meta (muore per segnale => rc != 0).
+echo "[8] agy risponde AGYUP e poi muore — deve essere DOWN, non UP"
+W="$TMPROOT/falseup"; mkdir -p "$W/tmp"
+make_world "$W" 7 "AGYUP" 0 yes
+run_wrapper "$W"; rc=$?
+LOG="$W/logs/wr2-ig-metrics-analyst.log"
+check "il wrapper sopravvive" 0 "$rc"
+has "verdetto DOWN nonostante la risposta giusta" "gemini health-check: DOWN" "$LOG"
+hasnt "NON dice UP" "health-check: UP" "$LOG"
+has "e l'hint viaggia comunque" "DO NOT call agy" "$W/claude-argv.txt"
+
+# ---------------------------------------------------------------- COLPEVOLEZZA 8
+# Il tetto per-seat. `TIMEOUT_SECS/MAX_CLAUDE_ATTEMPTS` da 1028s, e l'unico run
+# completo riuscito di questo organo dura 1065s: avrebbe ucciso il lavoro 37s prima
+# della fine. Non mordeva perche' l'errexit bug impediva di arrivare alla cascata —
+# la cura e' cio' che rende quel tetto raggiungibile, quindi il pavimento misurato
+# fa parte della cura e non e' un extra.
+echo "[9] il tetto per-seat supera un run reale (1065s), non 1028s"
+W="$TMPROOT/budget"; mkdir -p "$W/tmp"
+make_world "$W" 0 "AGYUP" 0 yes
+env -i HOME="$W" PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" TMPDIR="$W/tmp" \
+    WR2_IG_AGY_BIN="$W/bin/agy" WR2_IG_CLAUDE_BIN="$W/bin/claude" \
+    CLAUDE_CODE_OAUTH_TOKEN_1=faketoken \
+    /bin/bash "$WRAPPER_SRC" >/dev/null 2>&1
+LOG="$W/logs/wr2-ig-metrics-analyst.log"
+has "account_timeout al pavimento misurato" "account_timeout=2700s" "$LOG"
+hasnt "NON il 1028 aritmetico" "account_timeout=1028s" "$LOG"
+if grep -qE "account_timeout=([0-9]+)s" "$LOG" && \
+   [ "$(grep -oE 'account_timeout=[0-9]+' "$LOG" | head -1 | cut -d= -f2)" -gt 1065 ]; then
+    ok "il tetto supera i 1065s dell'unico run riuscito"
+else
+    ko "il tetto NON supera 1065s: la cura rianima l'organo in un cadavere rumoroso"
+fi
+
+# ---------------------------------------------------------------- COLPEVOLEZZA 9
+# Uccisione esterna: e' come e' finito l'hang di 28h del 2026-07-14. Il trap deve
+# nominare il segnale, uscire 143 (non il 130 di SIGINT) e PARLARE — un EXIT trap
+# che legge $? vedrebbe 0 e resterebbe muto proprio nell'incidente che conta.
+echo "[10] SIGTERM esterno — esce 143 e parla"
+W="$TMPROOT/sigterm"; mkdir -p "$W/tmp"
+make_world "$W" 0 "AGYUP" 0 yes
+cat > "$W/bin/agy" <<'EOF'
+#!/bin/bash
+cat > /dev/null
+sleep 20
+echo AGYUP
+EOF
+chmod +x "$W/bin/agy"
+# Il segnale va al processo dello SCRIPT, non a un involucro. La prima stesura
+# faceva `run_wrapper "$W" &`, ma cosi' `$!` e' il subshell della funzione: il kill
+# uccideva quello, il trap dello script non girava mai, e il controllo su rc=143
+# passava per la ragione sbagliata. Sono stati i due controlli di CONTENUTO a
+# smascherarlo — un test che asserisce solo un codice non distingue "il trap ha
+# parlato" da "ho ucciso qualcos'altro".
+env -i HOME="$W" PATH="/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" TMPDIR="$W/tmp" \
+    WR2_IG_AGY_BIN="$W/bin/agy" WR2_IG_CLAUDE_BIN="$W/bin/claude" \
+    WR2_IG_METRICS_TIMEOUT_SECS=70 WR2_IG_METRICS_POLL_SECS=1 \
+    WR2_IG_METRICS_KILL_GRACE_SECS=1 CLAUDE_CODE_OAUTH_TOKEN_1=faketoken \
+    /bin/bash "$WRAPPER_SRC" >/dev/null 2>&1 &
+WPID=$!
+sleep 3
+kill -TERM "$WPID" 2>/dev/null
+wait "$WPID"; rc=$?
+check "esce 143 (SIGTERM), non 130" 143 "$rc"
+has "nomina il segnale" "killed by SIGTERM" "$W/logs/wr2-ig-metrics-analyst.err.log"
+if [ -f "$W/gateway-called.txt" ] && grep -qF "NO diagnosis" "$W/gateway-called.txt"; then
+    ok "ha parlato dell'uccisione esterna"
+else
+    ko "ucciso da fuori e muto — l'incidente del 2026-07-14 sarebbe di nuovo invisibile"
+fi
+
 # ------------------------------------------------------------------- MUTAZIONE
 # Rimette errexit dentro e attorno alla sonda — cioe ESATTAMENTE il codice di
 # prima — e pretende che il caso [1] diventi rosso. Un corpus che resta verde


### PR DESCRIPTION
## What was broken

`wr2-ig-metrics-analyst-run.sh` (weekly, Monday 06:07 WITA on Pro) probes `agy`
before spawning the agent so it can tell the agent to skip Gemini and use the
local statistical fallback. **That probe killed the script every single run.**

The probe lives in a subshell, and a subshell inherits `set -e`. Both of that
subshell's exits are non-zero by construction:

| agy state | last command | status | effect |
|---|---|---|---|
| DOWN | `wait "$AGY_PID"` | agy's own code | errexit aborts the subshell |
| **UP** | `wait "$WATCHDOG_PID"` | **143** — the watchdog *we* killed | errexit aborts the script |

So the DOWN branch — the local-fallback hint, the only reason the probe exists —
was unreachable on the exact path it was written for. W101, fourth generation.

**Reproduced in a fake world before touching anything**, then matched against the
corpse. Live log on Pro:

```
[2026-06-28T22:24:45Z] wr2-ig-metrics-analyst done      <- last complete run
[2026-07-19T22:59:28Z] wr2-ig-metrics-analyst starting
[2026-07-19T22:59:28Z] published-with-metrics count: 49 <- and nothing more
[2026-07-26T22:07:04Z] wr2-ig-metrics-analyst starting
[2026-07-26T22:07:04Z] published-with-metrics count: 50 <- and nothing more
[2026-08-02T22:07:02Z] wr2-ig-metrics-analyst starting
[2026-08-02T22:07:02Z] published-with-metrics count: 50 <- and nothing more
```

Three consecutive runs stop between the count and the health-check verdict, zero
further lines, `.err.log` untouched since 2026-06-23. The mutant in the new corpus
dies at the same place with the same code (`rc=1`, no `done`).

## Why five weeks passed unnoticed

Second, independent cause: **the wrapper had zero gateway references and no voice
at all.** launchd invokes it directly (`/bin/bash <script>` — no `cron-runner.sh`,
no `wr2-cron-wrapper.sh`), so nothing wrote a receipt and nothing read its exit
code; `missed_runs_alerter` watches WarRoom DB rows, not launchd labels, and knows
nothing about this job; and no probe watches the freshness of its output dir.
W81/W108.

## Then I asked what the first commit had missed

Naming only the two failure exits I thought of is the W107 mistake at the scale of
one organ. Enumerating every exit path found three more silent ones, one of them
worse than silent:

1. **A silence that named no cause.** The pre-flight's `except Exception: print(0)`
   made a moved/missing/corrupt `human-review-queue.json` indistinguishable from
   "fewer than 10 carousels published" — and that reading writes a tidy
   `insufficient-data` stub and exits 0. A broken path would have parked the organ
   in a permanent, well-documented, entirely wrong "not enough data yet", which is
   worse than a crash because it looks like an answer. (W114's `missing_folders: []`
   shape.) Now the probe names the exception class, the caller alarms, exit 66, and
   no stub is written on a read failure.
2. **Any un-guarded line could kill the run mutely** — a failing `mkdir`, `python3`
   absent, `mktemp` failing on a missing TMPDIR. `on_exit_voice` is an EXIT trap
   installed before the first line that can fail and reports that the organ died
   *without a diagnosis*, which is a different and more alarming fact than a named
   failure.
3. **Installing that trap would have unarmed itself**: `cleanup_active_claude` is
   registered later as `trap ... EXIT`, which *replaces* the earlier trap — a cure
   deleted by another cure purely by being written further down the file. It now
   carries the voice, capturing `$?` on its first line; the INT/TERM path passes
   130 explicitly, because on an external SIGTERM (how the 28h hang of 2026-07-14
   ended) `$?` can be 0 and a voice reading 0 stays quiet for the one incident that
   most needs reporting.

## Corpus — 30 checks, armed, mutation-verified

`scripts/tests/test_wr2_ig_metrics_analyst_wrapper.sh` runs the wrapper in a fake
world (fake HOME, fake agy, fake claude that records the prompt it received, fake
gateway that records being called), because reading a wrapper cannot tell "it did
not fire" from "it never got there" (W107).

Guilt: both probe outcomes · the rc captured is agy's own and not the watchdog's
143 · the hint actually travels into the agent's prompt · the voice fires on
failure with its rc logged · a missing gateway is loud · the unreadable queue
exits 66 and says UNREADABLE · an undiagnosed death still speaks.
Innocence: on success there is no hint, no gateway call, no alarm.

**Armed in `immune-enforcement.yml`**, not left to the `scripts/tests` sweep, which
is `continue-on-error` and gates nothing — the superscar #2 shape. The probe binary
is env-overridable *only* so the corpus can drive it: its default path does not
exist on M5 or on a runner, so without the override every machine here is
structurally unable to reproduce the red (W108 GOTCHA-2).

**And the first version of the mutation check was itself vacuous**: the mutation
failed to build, the mutant file never existed, and the wrapper "died" with
`rc=127` because there was nothing to run — green on a vacuous premise, the exact
W116 disease the corpus exists to prevent. Now a failed mutation is a FAIL, the
mutant must parse, and it must die *after* reaching the count, so the check
measures the cure and not the fake world's poverty.

## Also

`infra/home-fork/declared-pairs.json`'s `_note` for this pair claimed the live Pro
copy still needed a manual sync. It did not: canon, `origin/main` and Pro were all
`sha256 308915627885cf8c`, byte-identical. A note naming a pending action that has
since happened sends the next reader to realign a copy that is already aligned
(W106, inside the very registry that arbitrates the pair). Corrected — and the
reason to keep the pair declared is now the opposite: **this cure lands in the
canon, so the live copy must be re-copied after merge or the two diverge for real.**
Merging alone leaves the organ dead (W107 delivery gotcha: that live path is a real
file, not a symlink).

## Post-merge (this session, before Monday 06:07 WITA)

1. `scp` the cured canon to `~/scripts/` on Pro, re-verify sha256 both sides;
2. run it once by hand and prove the log gets *past* the health-check into
   `trying CLAUDE_CODE_OAUTH_TOKEN_1` — the thing three weeks of runs never did.

## Round 3 — the cure was about to revive it into a LOUDER corpse

A scoped cross-family adversarial pass (Codex gpt-5.6-sol, generator≠grader) raised
31 objections. Triaged against measurement, not accepted or dismissed wholesale.

**The one that mattered.** `ACCOUNT_TIMEOUT_SECS` defaults to
`TIMEOUT_SECS / MAX_CLAUDE_ATTEMPTS` = 7200/7 = **1028s**. Every historical run in
this organ's own log was measured: the only complete successful run took **1065s**
(2026-06-28, `starting` 22:07:00 → `done` 22:24:45). The last run that actually
worked would be SIGTERM'd **37 seconds before finishing** — then on all seven seats
in turn, then a weekly P0. It never bit because the errexit bug killed the script
long before the cascade was reached: **curing that bug is exactly what makes this
ceiling reachable for the first time.** A pre-existing defect that my own fix arms.
Replaced with a measured floor (2700s, ~2.5× the observed worst case, room for the
corpus growing 45 → 50 published carousels), clamped to the total. The aggregate was
already bounded by `CASCADE_DEADLINE`, so the per-attempt number never needed to
divide the total — it needed to exceed a real run. The comment names what
re-measures it (W106): the `starting`/`done` pair.

**False `UP`.** The probe logged `AGY_PROBE_RC` and then ignored it, so agy printing
`AGYUP` and *then* exiting non-zero — or being killed mid-flight by the 25s watchdog
having already emitted the token — read as UP, and the agent walked into a Gemini
that is not there: the exact failure the probe exists to prevent. The verdict now
requires `rc == 0` **and** the token, which makes the watchdog-timeout path correct
for free.

**The alarm could kill the run it came to report.** `notify_failure` restored errexit
*before* its final log line, so a `$LOG` gone unwritable aborted the CALLER from
inside the reporting code — contradicting the comment two lines above. Errexit is now
disarmed for the whole function body (the gateway-MISSING branch writes to `$ERR`
too) and the rc is written before it is restored.

**SIGHUP was untrapped** and every signal reported SIGINT's code. Now one trap per
signal with conventional 128+signum. SIGKILL stays uncovered by definition —
declared.

**W113, second order.** Round 2 replaced a vague coverage note with a "precise" one
claiming a non-integer `WR2_IG_METRICS_POLL_SECS` would kill the script before any
voice existed. It does not — that test is inside an `if`, where errexit is EXEMPT
(measured both ways: inside, rc=0 and alive; outside, rc=2). The sentence written to
be MORE precise was the wrong one.

**Refuted by measurement, recorded rather than silently dropped:** (a) "the diff turns
an observable 143 into a misleading 130" — the pre-cure code already exited 130 on
SIGTERM, so this improves it; (b) "the gateway can hang indefinitely" —
`tg_notify.py` bounds itself (`urlopen(..., timeout=6)`, relay
`subprocess.run(..., timeout=15)`), read in the source.

Corpus 30 → **40** checks. The new SIGTERM test first passed for the wrong reason:
`run_wrapper "$W" &` backgrounds the *function*, so `$!` is a subshell and the kill
never reached the script's own bash — the rc=143 assertion went green off the dead
wrapper while the trap never ran. The two CONTENT assertions caught it. A test that
asserts only an exit code cannot tell "the trap spoke" from "I killed something else".

## Corroboration from launchd

The LaunchAgent is loaded, not disabled, `state = active` — Monday 06:07 WITA it
fires — and its `last exit code = 1`. A non-zero exit **recorded by launchd** that
nothing anywhere reacted to. That is the measured proof the exit code went nowhere;
this PR is what gives it a voice. The plist needs no change.

## Four pre-existing defects deliberately NOT folded in (ledger rows instead)

`run_claude_account` is called as an `if` CONDITION, which disables errexit for its
entire body (measured) · a run can exit 0 having produced no amendment at all
(green ≠ working, one level up from what is cured here) · the OAuth token sits in
`env`'s argv for the fork-to-exec window (measured: invisible after exec — low
severity, recorded so it is not rediscovered as a P0) · the 2026-07-14 "no descendant
can outlive the timeout" claim is false for a descendant that calls `setsid()`.
A cure PR that grows to cover everything its refuter mentions stops being reviewable.
