### PR TITLE
fix(arsenal): strip ambient CLAUDE_CODE_OAUTH_TOKEN before probing claude seat

### DIFF
--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -437,6 +437,19 @@ def probe_claude(timeout: float, env_overrides: Optional[dict] = None) -> tuple[
     # while reporting it as the MAX seat — strip both for a clean MAX-context probe.
     env.pop("ANTHROPIC_AUTH_TOKEN", None)
     env.pop("ANTHROPIC_BASE_URL", None)
+    # Strip a bare, AMBIENT CLAUDE_CODE_OAUTH_TOKEN before applying the slot-1
+    # fallback below (2026-08-08 live incident: this probe, run from Bash
+    # inside an interactive Claude Code session, inherited that session's own
+    # token — stale from an earlier /login cycle — and reported claude
+    # AUTH_DEAD while the actual on-disk credential the `claude` binary
+    # resolves by default was perfectly LIVE; unsetting the env var and
+    # re-probing flipped AUTH_DEAD -> LIVE instantly. Same class the
+    # ANTHROPIC_AUTH_TOKEN/BASE_URL strip above already guards against for
+    # GLM: a probe must test the SEAT's own credential, not whatever the
+    # calling shell happens to be carrying. A deliberate caller that wants to
+    # test one SPECIFIC token still can, via env_overrides below — that path
+    # is unaffected and remains the only sanctioned way to inject one.
+    env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
     # Headless/cron callers (launchd, sshd) often carry only the slotted
     # CLAUDE_CODE_OAUTH_TOKEN_{1,2,3} vars, never the bare one the `claude`
     # binary actually reads — same fallback already established in
@@ -444,7 +457,7 @@ def probe_claude(timeout: float, env_overrides: Optional[dict] = None) -> tuple[
     # CLI-subprocess auth path). Without this the probe reports a false
     # UNKNOWN_ERR ("Not logged in") even when the MAX-plan session backing
     # slot 1 is perfectly alive.
-    if not env.get("CLAUDE_CODE_OAUTH_TOKEN") and env.get("CLAUDE_CODE_OAUTH_TOKEN_1"):
+    if env.get("CLAUDE_CODE_OAUTH_TOKEN_1"):
         env["CLAUDE_CODE_OAUTH_TOKEN"] = env["CLAUDE_CODE_OAUTH_TOKEN_1"]
     if env_overrides:
         env.update(env_overrides)

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -502,22 +502,45 @@ def test_probe_claude_falls_back_to_oauth_token_slot_1(monkeypatch):
     assert captured_env.get("CLAUDE_CODE_OAUTH_TOKEN") == "slot1-token-value"
 
 
-def test_probe_claude_never_overrides_explicit_oauth_token(monkeypatch):
-    # innocence: a bare CLAUDE_CODE_OAUTH_TOKEN already set (interactive/agent
-    # session shape) must survive untouched — the slot-1 fallback is a
-    # last-resort, never a clobber.
+def test_probe_claude_strips_ambient_oauth_token_2026_08_08(monkeypatch):
+    # guilt: this is the live incident. A bare CLAUDE_CODE_OAUTH_TOKEN already
+    # present in the environment (the shape of an interactive Claude Code
+    # session probing its own seat) must be STRIPPED, not preserved — it may
+    # be stale from an earlier /login cycle and shadow a perfectly valid
+    # on-disk credential. Without stripping it, the calling shell's own token
+    # reaches the claude binary verbatim and a revoked one produces a false
+    # AUTH_DEAD read of a live seat (measured 2026-08-08 on M5: unsetting the
+    # var and re-probing flipped AUTH_DEAD -> LIVE with no other change).
     captured_env = {}
 
     def fake_run(cmd, **kwargs):
         captured_env.update(kwargs.get("env") or {})
         return _FakeProc(0, "PONG\n", "")
 
-    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "explicit-token-value")
-    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "slot1-token-value")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "ambient-session-token-possibly-stale")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN_1", raising=False)
     monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
     monkeypatch.setattr(ap.subprocess, "run", fake_run)
     ap.probe_claude(timeout=5)
-    assert captured_env.get("CLAUDE_CODE_OAUTH_TOKEN") == "explicit-token-value"
+    assert "CLAUDE_CODE_OAUTH_TOKEN" not in captured_env
+
+
+def test_probe_claude_explicit_override_still_wins(monkeypatch):
+    # innocence: a caller that deliberately wants to test ONE specific token
+    # still can, via the env_overrides parameter — the only sanctioned
+    # injection path (nothing in the codebase calls it today, but the
+    # capability must survive the ambient-token strip above).
+    captured_env = {}
+
+    def fake_run(cmd, **kwargs):
+        captured_env.update(kwargs.get("env") or {})
+        return _FakeProc(0, "PONG\n", "")
+
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "ambient-token-must-be-ignored")
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/opt/homebrew/bin/claude", True))
+    monkeypatch.setattr(ap.subprocess, "run", fake_run)
+    ap.probe_claude(timeout=5, env_overrides={"CLAUDE_CODE_OAUTH_TOKEN": "deliberately-injected-token"})
+    assert captured_env.get("CLAUDE_CODE_OAUTH_TOKEN") == "deliberately-injected-token"
 
 
 def test_probe_claude_binary_absent_is_not_installed(monkeypatch):


### PR DESCRIPTION
## Summary

- `arsenal_probe.py::probe_claude()` already stripped `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` before probing (to stop a stray GLM-session env from silently probing z.ai while reporting it as the MAX seat), but deliberately preserved a bare ambient `CLAUDE_CODE_OAUTH_TOKEN` if one was already set.
- That's the same shadowing hazard, unguarded, on the one credential the whole function exists to verify: run the probe from inside an interactive Claude Code session and it inherits that session's own (possibly stale/revoked) token instead of resolving the real on-disk credential the `claude` binary would use by default.
- Live-caught today: a fresh full-seat probe reported `claude: AUTH_DEAD "401 OAuth access token has been revoked"` for a seat that was actually LIVE — confirmed instantly by re-running with `env -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY`.

## Fix

`probe_claude()` now unconditionally pops `CLAUDE_CODE_OAUTH_TOKEN` from the subprocess env before applying the `_1`-slot fallback — matching the treatment already given to the other three vars. The `env_overrides` parameter remains the sanctioned path for a caller that deliberately wants to test one specific token.

## Test plan

- [x] Replaced `test_probe_claude_never_overrides_explicit_oauth_token` (encoded the old, buggy behavior as correct) with `test_probe_claude_strips_ambient_oauth_token_2026_08_08` (guilt: ambient bare token with no `_1` fallback set → must be stripped from the subprocess env)
- [x] Added `test_probe_claude_explicit_override_still_wins` (innocence: `env_overrides={"CLAUDE_CODE_OAUTH_TOKEN": ...}` still wins over an ambient token)
- [x] Verified guilt by reverting the fix locally → new test failed red; restored → green
- [x] Full suite: 145/145 passed (includes the full backend-tests pre-push gate, ran clean under shared-lock contention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)