### PR TITLE
fix(kbli): the gold indexer crashed on every code since birth — flat indexed_at per the KBLI flat-payload golden rule

### DIFF
--- a/apps/backend-rag/backend/scripts/index_kbli_gold_content.py
+++ b/apps/backend-rag/backend/scripts/index_kbli_gold_content.py
@@ -320,6 +320,22 @@ def deterministic_uuid(code: str) -> str:
     return str(uuid.UUID(hashlib.md5(key.encode()).hexdigest()))
 
 
+def build_point(code: str, gold: dict, base: dict, indexed_at: str) -> dict:
+    """Build one Qdrant point (id + flat payload + text-to-embed) for a gold code.
+
+    Extracted from the main() loop so it can be exercised directly by tests —
+    never a recreated copy of the production logic (Codex review on #3817).
+    """
+    embedding_text = build_embedding_text(code, gold, base)
+    payload = build_payload(code, gold, base, embedding_text)
+    payload["indexed_at"] = indexed_at  # flat payload (KBLI flat-payload golden rule)
+    return {
+        "id": deterministic_uuid(code),
+        "payload": payload,
+        "_text_to_embed": embedding_text,
+    }
+
+
 async def embed_texts(texts: list[str], client) -> list[list[float]]:
     """Embed texts using OpenAI."""
     all_embeddings = []
@@ -402,17 +418,7 @@ async def main():
 
     for code, gold in sorted(gold_entries.items()):
         base = base_data.get(code, {"judul": "", "sektor_id": ""})
-        embedding_text = build_embedding_text(code, gold, base)
-        payload = build_payload(code, gold, base, embedding_text)
-        payload["metadata"]["indexed_at"] = indexed_at
-
-        all_points.append(
-            {
-                "id": deterministic_uuid(code),
-                "payload": payload,
-                "_text_to_embed": embedding_text,
-            },
-        )
+        all_points.append(build_point(code, gold, base, indexed_at))
 
     logger.info(f"Built {len(all_points)} points to index")
 

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_only_selection.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_only_selection.py
@@ -15,6 +15,7 @@ import pytest
 
 from backend.scripts._kbli_repo_root import resolve_repo_root
 from backend.scripts.index_kbli_gold_content import (
+    build_point,
     filter_to_codes,
 )
 from backend.scripts.index_kbli_gold_content import (
@@ -157,6 +158,47 @@ class TestFilterEntriesToCodes:
             filter_entries_to_codes(self._entries(), ["99999", "88888"])
         msgs = [r.getMessage() for r in caplog.records]
         assert any("99999" in m and "88888" in m for m in msgs)
+
+
+# ─── build_point (gold indexer — flat payload, KBLI flat-payload golden rule) ──
+
+
+class TestBuildPoint:
+    """build_point() is the exact function main() calls per code — never a
+    recreated copy of the production logic (Codex review on #3817). It crashed
+    on every code since birth (`payload["metadata"]["indexed_at"]` against a
+    payload that has no "metadata" key at all — build_payload() is flat)."""
+
+    def _gold(self) -> dict:
+        return {"whatItMeans": "Restoran dan penyediaan makanan."}
+
+    def _base(self) -> dict:
+        return {"judul": "Restoran", "sektor_id": "I", "pma_status": "TERBUKA"}
+
+    def test_indexed_at_is_flat_not_nested(self):
+        """Guilt: the point actually produced sets payload['indexed_at'] and
+        carries NO 'metadata' key — this is what crashed unconditionally
+        before the fix."""
+        point = build_point("56101", self._gold(), self._base(), "2026-08-08T00:00:00+00:00")
+        assert point["payload"]["indexed_at"] == "2026-08-08T00:00:00+00:00"
+        assert "metadata" not in point["payload"]
+
+    def test_point_shape(self):
+        """Innocence: the rest of the point shape (id + text-to-embed +
+        existing flat fields) is unchanged by the extraction."""
+        point = build_point("56101", self._gold(), self._base(), "2026-08-08T00:00:00+00:00")
+        assert set(point.keys()) == {"id", "payload", "_text_to_embed"}
+        assert point["payload"]["kode_kbli"] == "56101"
+        assert point["payload"]["doc_type"] == "kbli_gold"
+        assert point["_text_to_embed"]
+
+    def test_deterministic_id_across_calls(self):
+        """Innocence: id stays deterministic (idempotent upserts) — the
+        extraction must not perturb deterministic_uuid's inputs."""
+        p1 = build_point("56101", self._gold(), self._base(), "2026-08-08T00:00:00+00:00")
+        p2 = build_point("56101", self._gold(), self._base(), "2026-08-08T01:00:00+00:00")
+        assert p1["id"] == p2["id"]
+        assert p1["payload"]["indexed_at"] != p2["payload"]["indexed_at"]
 
 
 # ─── resolve_repo_root (shared marker-walk, replaces parents[N]) ────────────


### PR DESCRIPTION
Every run of `index_kbli_gold_content.py` has crashed since it was born: `build_payload()` returns a flat dict (no `metadata` key — the KBLI flat-payload golden rule), but `main()` did `payload["metadata"]["indexed_at"] = indexed_at`, which `KeyError`s on the very first code. Found while running #3823's post-deploy apply — 0 `doc_type=kbli_gold` points currently exist in `kbli_2025_final_hybrid`.

The canonical indexer (`reindex_kbli_2025_final.py:579`) already does this correctly (`payload["indexed_at"] = indexed_at  # flat payload`); this PR brings the gold indexer in line with that template.

Also extracts the per-code loop body into `build_point(code, gold, base, indexed_at) -> dict`, the exact function `main()` now calls — not a recreated copy of the production logic (per the #3817 Codex review lesson). Added guilt (asserts flat `indexed_at`, no `metadata` key — the shape that crashed) + innocence (point shape, deterministic id) tests, and mutation-verified locally that reintroducing the original bug makes the new tests fail with the same `KeyError: 'metadata'` before restoring the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)