### PR TITLE
fix(notifications): exclude soft-deleted clients from the sweep — 497 of 1238 were deleted

### DIFF
--- a/apps/backend-rag/backend/app/modules/notifications/router.py
+++ b/apps/backend-rag/backend/app/modules/notifications/router.py
@@ -104,6 +104,14 @@ async def get_clients_from_db(pool, client_id: int | None = None) -> list[Client
     varying: 'lead' | 'active' | 'prospect' | 'inactive'); a notifications
     sweep for expiring passports/visas/birthdays is scoped to clients Bali
     Zero is actively serving, i.e. `status = 'active'`.
+
+    Ground truth (2026-08-08, prove-live post-#3822/#3827): the query was
+    missing a soft-delete filter — 1238 rows came back from a `status =
+    'active'` scan against 741 actually-active (non-deleted) clients. The
+    497-row gap is soft-deleted clients (`deleted_at IS NOT NULL`) whose
+    `status` was never flipped off 'active'. Without this filter, the first
+    real daily sweep (APScheduler cron, 09:00 WITA) would have emailed alerts
+    to ~497 ex-clients. `deleted_at` exists on the live `clients` table.
     """
     async with pool.acquire() as conn:
         if client_id:
@@ -129,7 +137,7 @@ async def get_clients_from_db(pool, client_id: int | None = None) -> list[Client
                     AND expiry_date IS NOT NULL
                     ORDER BY client_id, expiry_date DESC
                 ) v ON v.client_id = c.id
-                WHERE c.id = $1 AND c.status = 'active'
+                WHERE c.id = $1 AND c.status = 'active' AND c.deleted_at IS NULL
                 """,
                 client_id,
             )
@@ -156,7 +164,7 @@ async def get_clients_from_db(pool, client_id: int | None = None) -> list[Client
                     AND expiry_date IS NOT NULL
                     ORDER BY client_id, expiry_date DESC
                 ) v ON v.client_id = c.id
-                WHERE c.status = 'active'
+                WHERE c.status = 'active' AND c.deleted_at IS NULL
                 """,
             )
 

--- a/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_get_clients_from_db.py
+++ b/apps/backend-rag/backend/tests/unit/app/modules/notifications/test_get_clients_from_db.py
@@ -368,3 +368,55 @@ async def test_active_client_with_null_email_does_not_crash() -> None:
     assert len(clients) == 1
     assert clients[0].id == 123
     assert clients[0].email is None
+
+
+def test_query_excludes_soft_deleted_clients() -> None:
+    """GUILT (fix-4 of the notifications lane, found by the prove-live pass
+    after the sweep started running clean post-#3822/#3827): a `status =
+    'active'` scan alone returned 1238 rows against 741 actually-active
+    (non-deleted) clients, measured live 2026-08-08. The 497-row gap is
+    soft-deleted clients whose `status` was never flipped off 'active' —
+    `deleted_at IS NOT NULL` for all of them. Sending a birthday/passport/
+    visa-expiry alert to an ex-client is noise for the team at best, and an
+    unwanted contact with a former client at worst.
+
+    The query text must filter on `c.deleted_at IS NULL` in BOTH branches
+    (single-client and all-active-clients), not just one — a partial fix
+    would still amputate the wrong half of the book depending on call site.
+    """
+    source = _source_without_docstring(get_clients_from_db)
+    assert source.count("c.deleted_at IS NULL") == 2, (
+        "get_clients_from_db must exclude soft-deleted clients "
+        "(c.deleted_at IS NULL) in BOTH the single-client and "
+        "all-active-clients query branches — found "
+        f"{source.count('c.deleted_at IS NULL')} occurrence(s)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_client_sql_excludes_soft_deleted() -> None:
+    """GUILT (behavioral, single-client branch): the actual SQL text sent to
+    the connection for a specific client_id must carry the soft-delete
+    filter alongside the existing status filter."""
+    mock_conn = AsyncMock()
+    mock_conn.fetch.return_value = []
+
+    await get_clients_from_db(_Pool(mock_conn), client_id=42)
+
+    sql_sent = mock_conn.fetch.call_args[0][0]
+    assert "c.deleted_at IS NULL" in sql_sent
+    assert "c.status = 'active'" in sql_sent
+
+
+@pytest.mark.asyncio
+async def test_all_clients_sql_excludes_soft_deleted() -> None:
+    """GUILT (behavioral, all-active-clients branch): same filter must be
+    present in the no-client_id branch's SQL text."""
+    mock_conn = AsyncMock()
+    mock_conn.fetch.return_value = []
+
+    await get_clients_from_db(_Pool(mock_conn), client_id=None)
+
+    sql_sent = mock_conn.fetch.call_args[0][0]
+    assert "c.deleted_at IS NULL" in sql_sent
+    assert "c.status = 'active'" in sql_sent


### PR DESCRIPTION
Fourth and final layer of the notifications lane, found by the green prove-live after #3827: the sweep now runs end-to-end, but it returned **1238** clients where only **741** are actually active AND not deleted (measured live, 2026-08-08). The 497-row gap is soft-deleted clients whose `status` was never flipped off `'active'` — without this filter, the first real daily sweep in this system's history (APScheduler, 09:00 WITA tomorrow) would have generated alerts for ~497 ex-clients.

**Fix**: `AND c.deleted_at IS NULL` in both branches of `get_clients_from_db` (the column exists on the live table — it is in the whitelist guard added by #3822).

**Tests**: 11/11 on the module file — a source-level guard asserting the filter appears in BOTH branches, plus per-branch `sql_sent` assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)