### PR TITLE
fix(wa-mirror): announce the failure to recover, not the disconnection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -547,6 +547,33 @@ jobs:
           cd packages/core
           npx vitest --run
 
+      # wa-mirror's vitest suite had NEVER run in CI — 8 test files, 0 gates.
+      # The bridge is the organ that mirrors client WhatsApp lines, and the alert
+      # policy it now carries (announce the failure to recover, never the
+      # disconnection — apps/wa-mirror/bridge/down-alarm.ts) is exactly the kind
+      # of rule that decays silently: a mute watchdog looks identical to a healthy
+      # one. Built, never armed (cicatrix-superscar #2), and W108's lesson is that
+      # the defect only surfaces once the test runs on EVERY PR.
+      #
+      # Same reasoning as the packages/core step above for WHERE this lives: a
+      # step of the already-required `(mouth, true)` leg, because branch
+      # protection pins required contexts by NAME (W69).
+      #
+      # DECLARED LIMIT — this runs 2 of the 8 files, by name, not the suite.
+      # `apps/wa-mirror` is not an npm workspace and has NO lockfile, so the root
+      # `npm install` above does not install baileys / pino / libphonenumber-js
+      # and the other 6 files fail on the missing packages (measured locally:
+      # 2 passed, 6 failed to import, 26 tests green). These two import nothing
+      # outside node's stdlib, so they resolve vitest upward from the ROOT
+      # node_modules exactly as packages/core does. Arming the remaining 6 needs a
+      # lockfile for that package — its own PR, on the W81 ledger, NOT a silent
+      # `npm install` of floating versions inside a required check.
+      - name: Run wa-mirror bridge alert-policy tests (dependency-free files)
+        if: matrix.app == 'mouth'
+        run: |
+          cd apps/wa-mirror
+          npx vitest run tests/down-alarm.test.ts tests/telegram.test.ts
+
       - name: Upload coverage
         if: ${{ matrix.coverage && env.HAS_CODECOV_TOKEN == 'true' }}
         uses: codecov/codecov-action@v7

--- a/apps/wa-mirror/bridge/down-alarm.ts
+++ b/apps/wa-mirror/bridge/down-alarm.ts
@@ -1,0 +1,147 @@
+// down-alarm.ts — announce the FAILURE TO RECOVER, never the disconnection.
+//
+// WHY THIS EXISTS (measured, not assumed).
+//
+// research/operations/2026-08-06-telegram-messaging-study.md §5.2 paired every
+// bridge disconnection in a 29.5-day corpus with the next reconnection:
+// 718 disconnections, 718 followed by a reconnection, median 1.0 min, 81% under
+// 5 min, p90 25 min, max 358 min. Re-measured on the live spool 2026-08-08 over
+// the whole retained window (2026-07-08..2026-08-07): 741 `wa-bridge:disconnected`
+// + 725 `wa-bridge:connected` + 25 `wa-bridge:loggedout` = 1491 records, the
+// second-loudest producer on the fleet at ~24-52 events/day.
+//
+// Every one of those 1466 non-terminal lines announced a condition that healed
+// itself, usually within a minute — and the 358-minute tail, the one incident
+// shape a human actually needs, was indistinguishable from the noise. The channel
+// was reporting the SYMPTOM (a socket closed) instead of the FAULT (a line that
+// is not coming back).
+//
+// So: hold the disconnection silently, and speak only if it OUTLASTS the
+// threshold. A recovery inside the threshold says nothing at all — there is
+// nothing for a reader to do about a socket that already reconnected. A recovery
+// that closes an incident we DID announce is worth one digest line, because a
+// reader who saw the alarm needs to know it ended.
+//
+// Terminal logout is NOT this path: `index.ts` announces it p0 and stops
+// retrying, because no amount of waiting fixes a device unlinked on the phone.
+// Registering it here too would have the still-down alarm re-announce, 25 minutes
+// later, a condition already reported and already known to be terminal.
+//
+// The state is per-process and in memory: if the bridge restarts while a line is
+// down, `downSince` is lost and the clock restarts from the next close. That is
+// stated rather than hidden — a restart re-attempts the connection anyway, and a
+// line still down will re-arm the alarm on its next close.
+
+/** One account's open incident. Absent from the map == the line is up. */
+export interface DownState {
+  /** epoch ms of the first close of the CURRENT incident */
+  downSince: number;
+  /** true once the still-down alarm has fired for this incident */
+  announced: boolean;
+}
+
+export type Verdict =
+  | { speak: false }
+  | { speak: true; kind: "still-down"; downMinutes: number }
+  | { speak: true; kind: "recovered"; downMinutes: number };
+
+const DEFAULT_THRESHOLD_MINUTES = 25;
+
+/**
+ * Minutes a line may be down before the alarm speaks. Default 25 = the p90 of
+ * the measured recovery distribution, so ~10% of real incidents reach it.
+ *
+ * `WA_MIRROR_DOWN_ALERT_MINUTES=0` is a deliberate escape hatch: it restores
+ * announce-on-every-disconnection. An unparseable or negative value falls back
+ * to the default rather than silently disarming the alarm (a threshold of NaN
+ * would make every comparison false and the organ mute — the exact failure this
+ * module exists to end).
+ */
+export function thresholdMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.WA_MIRROR_DOWN_ALERT_MINUTES;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_THRESHOLD_MINUTES * 60_000;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_THRESHOLD_MINUTES * 60_000;
+  }
+  return parsed * 60_000;
+}
+
+function elapsed(state: DownState, now: number): number {
+  // A clock that moved backwards (NTP step, sleep/wake) must never produce a
+  // negative duration: it would read as "recovered instantly" and mute the tail.
+  return Math.max(0, now - state.downSince);
+}
+
+function minutes(ms: number): number {
+  return Math.round(ms / 60_000);
+}
+
+/**
+ * Record a close. Speaks at most ONCE per incident, and only when the line has
+ * been down for at least `threshold`.
+ *
+ * `terminal` lives HERE, as an argument, rather than as an `if (!terminal)` at
+ * the call site: the rule "a terminal logout never arms the still-down clock" is
+ * then part of the tested unit instead of a comment above an untested branch — a
+ * guard whose only statement is prose is a guard nobody proved (cicatrix W115).
+ * A terminal close leaves NO state behind, so a later QR re-link connects
+ * silently instead of reporting a recovery from an incident never announced.
+ */
+export function onDisconnected(
+  states: Map<string, DownState>,
+  account: string,
+  now: number,
+  threshold: number,
+  opts: { terminal?: boolean } = {},
+): Verdict {
+  if (opts.terminal) return { speak: false };
+  const state = states.get(account);
+  if (!state) {
+    states.set(account, { downSince: now, announced: false });
+    // A zero threshold means "announce immediately" — honour it on the very
+    // first close, otherwise the escape hatch would need a second close to fire.
+    if (threshold <= 0) {
+      const created = states.get(account) as DownState;
+      created.announced = true;
+      return { speak: true, kind: "still-down", downMinutes: 0 };
+    }
+    return { speak: false };
+  }
+  if (state.announced) return { speak: false };
+  const downMs = elapsed(state, now);
+  if (downMs < threshold) return { speak: false };
+  state.announced = true;
+  return { speak: true, kind: "still-down", downMinutes: minutes(downMs) };
+}
+
+/**
+ * Record an open. Speaks only to CLOSE an incident that was announced; a
+ * recovery nobody was told about is not news, and neither is the first connect
+ * after a clean start (no state == nothing was ever down).
+ */
+export function onConnected(
+  states: Map<string, DownState>,
+  account: string,
+  now: number,
+): Verdict {
+  const state = states.get(account);
+  if (!state) return { speak: false };
+  states.delete(account);
+  if (!state.announced) return { speak: false };
+  return {
+    speak: true,
+    kind: "recovered",
+    downMinutes: minutes(elapsed(state, now)),
+  };
+}
+
+/**
+ * The one shared incident map. `session.ts` (close/open) and `index.ts` (crash
+ * restart) must read the SAME state: two maps would let the crash path re-arm an
+ * incident the close path already announced, which is how a cure applied to one
+ * of several call sites reopens itself (cicatrix W107).
+ */
+export const downStates = new Map<string, DownState>();

--- a/apps/wa-mirror/bridge/index.ts
+++ b/apps/wa-mirror/bridge/index.ts
@@ -18,6 +18,7 @@ import "dotenv/config";
 
 import pino from "pino";
 
+import { downStates, onDisconnected, thresholdMs } from "./down-alarm.js";
 import { closePool } from "./pg.js";
 import { normalizePhone } from "./phone.js";
 import { SessionLoggedOutError, startSession } from "./session.js";
@@ -178,11 +179,26 @@ async function runAccountForever(account: AccountConfig): Promise<void> {
         },
         "wa-mirror session crashed; restarting with backoff",
       );
-      await sendTelegramAlert(
-        `wa-mirror disconnected: ${account.name}; reconnect_attempt=${attempt}`,
-        logger,
-        { tier: "digest", dedupKey: `wa-bridge:reconnect:${account.name}` },
+      // Same incident state as session.ts's close path (down-alarm.ts owns the
+      // one map): a crash-restart is a disconnection by another name, and it must
+      // not be able to re-announce an incident the close path already reported.
+      // This site produced ZERO records in the 30-day spool — the close path
+      // fires first — but a dormant call site left on the old behaviour is how a
+      // cure applied to one of several sites reopens itself (cicatrix W107).
+      const down = onDisconnected(
+        downStates,
+        account.name,
+        Date.now(),
+        thresholdMs(),
       );
+      if (down.speak) {
+        await sendTelegramAlert(
+          `wa-mirror DOWN: ${account.name} for ${down.downMinutes}m and not recovering ` +
+            `(crash restart; reconnect_attempt=${attempt})`,
+          logger,
+          { tier: "p0", dedupKey: `wa-bridge:down:${account.name}` },
+        );
+      }
       await sleep(delayMs);
     }
   }

--- a/apps/wa-mirror/bridge/session.ts
+++ b/apps/wa-mirror/bridge/session.ts
@@ -67,6 +67,12 @@ import type {
   MessageContextStore,
   WaMirrorAccount,
 } from "./message_capture.js";
+import {
+  downStates,
+  onConnected,
+  onDisconnected,
+  thresholdMs,
+} from "./down-alarm.js";
 import { queueMediaDownload } from "./media.js";
 import { normalizePhone, phoneDigits } from "./phone.js";
 import { sendTelegramAlert } from "./telegram.js";
@@ -504,10 +510,20 @@ async function handleConnectionUpdate(
       );
     }
     logger.info({ sessionId: ctx.sessionId }, "wa-mirror session connected");
-    await sendTelegramAlert(`wa-mirror connected: ${ctx.account.name}`, logger, {
-      tier: "digest",
-      dedupKey: `wa-bridge:connected:${ctx.account.name}`,
-    });
+    // A connect is only news if it CLOSES an incident we announced. 725 bare
+    // `connected` lines in 30 days told a reader nothing they could act on —
+    // see down-alarm.ts for the measurement.
+    const recovery = onConnected(downStates, ctx.account.name, Date.now());
+    if (recovery.speak) {
+      await sendTelegramAlert(
+        `wa-mirror recovered: ${ctx.account.name} after ${recovery.downMinutes}m down`,
+        logger,
+        {
+          tier: "digest",
+          dedupKey: `wa-bridge:recovered:${ctx.account.name}`,
+        },
+      );
+    }
 
     // CICATRIX 2026-05-25: refresh pre-keys on every connect.
     // Pre-fix: bridge initial pairing seeded ~30 prekeys, all consumed over time.
@@ -579,13 +595,27 @@ async function handleConnectionUpdate(
       },
       "wa-mirror session closed",
     );
-    await sendTelegramAlert(
-      `wa-mirror disconnected: ${ctx.account.name}; reason=${reason}; reconnect_attempt=${deps.attempt}`,
-      logger,
-      // W67: reconnect storms flood this path — dedup collapses a flap wave
-      // into one digest entry per account per 6h window.
-      { tier: "digest", dedupKey: `wa-bridge:disconnected:${ctx.account.name}` },
+    // A close is held SILENTLY and only speaks if the line stays down past the
+    // threshold (default 25m = p90 of the measured recovery distribution). The
+    // terminal case is excluded INSIDE onDisconnected (see down-alarm.ts):
+    // `index.ts` announces the logout as p0 and stops retrying, so arming the
+    // still-down clock would re-announce, 25 minutes later, a fault already
+    // reported and already known to be unrecoverable by waiting.
+    const down = onDisconnected(
+      downStates,
+      ctx.account.name,
+      Date.now(),
+      thresholdMs(),
+      { terminal },
     );
+    if (down.speak) {
+      await sendTelegramAlert(
+        `wa-mirror DOWN: ${ctx.account.name} for ${down.downMinutes}m and not recovering ` +
+          `(reason=${reason}; reconnect_attempt=${deps.attempt})`,
+        logger,
+        { tier: "p0", dedupKey: `wa-bridge:down:${ctx.account.name}` },
+      );
+    }
 
     if (terminal) {
       // Device removed from the phone's Linked Devices — needs a fresh QR.

--- a/apps/wa-mirror/tests/down-alarm.test.ts
+++ b/apps/wa-mirror/tests/down-alarm.test.ts
@@ -1,0 +1,283 @@
+// down-alarm.test.ts — guilt AND innocence for "announce the failure to
+// recover, never the disconnection".
+//
+// Guilt: a line that stays down past the threshold must speak, exactly once,
+// with the right duration, and its recovery must close the incident.
+// Innocence: the 81% of flaps that heal inside the threshold must produce ZERO
+// messages, a clean first connect must be silent, and a terminal logout must
+// never arm this clock (index.ts already reports it p0).
+//
+// Every clock value is injected. There is no timer and no sleep in this corpus:
+// a test that waits 25 real minutes would be deleted by the first person in a
+// hurry, and one that mocks Date.now() globally would not prove the module reads
+// the time it is GIVEN.
+
+import { describe, expect, it } from "vitest";
+
+import type { DownState } from "../bridge/down-alarm.js";
+import {
+  onConnected,
+  onDisconnected,
+  thresholdMs,
+} from "../bridge/down-alarm.js";
+
+const MIN = 60_000;
+const THRESHOLD = 25 * MIN;
+
+function freshStates(): Map<string, DownState> {
+  return new Map<string, DownState>();
+}
+
+describe("onDisconnected — guilt", () => {
+  it("speaks once the line has been down past the threshold, naming the duration", () => {
+    const s = freshStates();
+    const t0 = 1_000_000;
+    expect(onDisconnected(s, "ari", t0, THRESHOLD)).toEqual({ speak: false });
+    // a retry 10 minutes in: still inside the recovery distribution, still silent
+    expect(onDisconnected(s, "ari", t0 + 10 * MIN, THRESHOLD)).toEqual({
+      speak: false,
+    });
+    expect(onDisconnected(s, "ari", t0 + 26 * MIN, THRESHOLD)).toEqual({
+      speak: true,
+      kind: "still-down",
+      downMinutes: 26,
+    });
+  });
+
+  it("speaks EXACTLY once per incident, however many retries follow", () => {
+    const s = freshStates();
+    const t0 = 0;
+    onDisconnected(s, "ari", t0, THRESHOLD);
+    const first = onDisconnected(s, "ari", t0 + 30 * MIN, THRESHOLD);
+    expect(first.speak).toBe(true);
+    for (const later of [40, 55, 120, 360]) {
+      expect(onDisconnected(s, "ari", t0 + later * MIN, THRESHOLD)).toEqual({
+        speak: false,
+      });
+    }
+  });
+
+  it("fires exactly AT the threshold, not one tick later", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 0, THRESHOLD);
+    expect(onDisconnected(s, "ari", THRESHOLD - 1, THRESHOLD)).toEqual({
+      speak: false,
+    });
+    expect(onDisconnected(s, "ari", THRESHOLD, THRESHOLD)).toMatchObject({
+      speak: true,
+      kind: "still-down",
+    });
+  });
+
+  it("tracks accounts independently — one line down does not mute another", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 0, THRESHOLD);
+    onDisconnected(s, "asya", 20 * MIN, THRESHOLD);
+    expect(onDisconnected(s, "ari", 30 * MIN, THRESHOLD)).toMatchObject({
+      speak: true,
+    });
+    // asya went down 10 minutes ago, not 30 — it must stay silent
+    expect(onDisconnected(s, "asya", 30 * MIN, THRESHOLD)).toEqual({
+      speak: false,
+    });
+  });
+
+  it("re-arms for a NEW incident after a recovery", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 0, THRESHOLD);
+    expect(onDisconnected(s, "ari", 30 * MIN, THRESHOLD)).toMatchObject({
+      speak: true,
+    });
+    expect(onConnected(s, "ari", 31 * MIN)).toMatchObject({
+      speak: true,
+      kind: "recovered",
+    });
+    // second incident, hours later
+    onDisconnected(s, "ari", 200 * MIN, THRESHOLD);
+    expect(onDisconnected(s, "ari", 240 * MIN, THRESHOLD)).toMatchObject({
+      speak: true,
+      kind: "still-down",
+      downMinutes: 40,
+    });
+  });
+
+  it("honours threshold=0 as the announce-immediately escape hatch", () => {
+    const s = freshStates();
+    expect(onDisconnected(s, "ari", 5_000, 0)).toEqual({
+      speak: true,
+      kind: "still-down",
+      downMinutes: 0,
+    });
+    // and still only once — the escape hatch is not a licence to spam a wave
+    expect(onDisconnected(s, "ari", 6_000, 0)).toEqual({ speak: false });
+  });
+});
+
+describe("onDisconnected — innocence", () => {
+  it("says NOTHING about a flap that heals inside the threshold", () => {
+    const s = freshStates();
+    // the measured median: 1.0 minute
+    expect(onDisconnected(s, "ari", 0, THRESHOLD)).toEqual({ speak: false });
+    expect(onConnected(s, "ari", 1 * MIN)).toEqual({ speak: false });
+    expect(s.size).toBe(0);
+  });
+
+  it("never arms the clock on a TERMINAL close, and leaves no state behind", () => {
+    const s = freshStates();
+    expect(onDisconnected(s, "ari", 0, THRESHOLD, { terminal: true })).toEqual({
+      speak: false,
+    });
+    expect(s.size).toBe(0);
+    // 25 minutes of terminal retries would be a contradiction (retries stop),
+    // but even if they happened, this path must stay mute: index.ts owns the p0.
+    expect(
+      onDisconnected(s, "ari", 30 * MIN, THRESHOLD, { terminal: true }),
+    ).toEqual({ speak: false });
+    // and a later QR re-link connects silently, not "recovered from" an
+    // incident nobody was ever told about
+    expect(onConnected(s, "ari", 40 * MIN)).toEqual({ speak: false });
+  });
+
+  it("a terminal close AFTER an announced incident cannot re-announce", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 0, THRESHOLD);
+    expect(onDisconnected(s, "ari", 30 * MIN, THRESHOLD)).toMatchObject({
+      speak: true,
+    });
+    expect(
+      onDisconnected(s, "ari", 60 * MIN, THRESHOLD, { terminal: true }),
+    ).toEqual({ speak: false });
+  });
+});
+
+describe("onConnected", () => {
+  it("is silent on a clean first connect (nothing was ever down)", () => {
+    const s = freshStates();
+    expect(onConnected(s, "ari", 12345)).toEqual({ speak: false });
+  });
+
+  it("closes an ANNOUNCED incident with the total time down", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 0, THRESHOLD);
+    onDisconnected(s, "ari", 26 * MIN, THRESHOLD); // announces
+    expect(onConnected(s, "ari", 91 * MIN)).toEqual({
+      speak: true,
+      kind: "recovered",
+      downMinutes: 91,
+    });
+    expect(s.size).toBe(0);
+  });
+
+  it("is silent for an incident that was never announced", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 0, THRESHOLD);
+    onDisconnected(s, "ari", 5 * MIN, THRESHOLD); // still under the line
+    expect(onConnected(s, "ari", 6 * MIN)).toEqual({ speak: false });
+  });
+});
+
+describe("the shared incident map (cicatrix W107 — one cure, every call site)", () => {
+  it("the crash-restart path cannot re-announce what the close path announced", () => {
+    // session.ts (close) and index.ts (crash restart) pass the SAME map. Two
+    // maps would let the same outage speak twice.
+    const shared = freshStates();
+    onDisconnected(shared, "ari", 0, THRESHOLD); // close path arms
+    expect(onDisconnected(shared, "ari", 30 * MIN, THRESHOLD)).toMatchObject({
+      speak: true,
+    }); // close path announces
+    expect(onDisconnected(shared, "ari", 31 * MIN, THRESHOLD)).toEqual({
+      speak: false,
+    }); // crash path, same incident
+  });
+
+  it("the crash-restart path can arm an incident the close path never saw", () => {
+    const shared = freshStates();
+    expect(onDisconnected(shared, "vino", 0, THRESHOLD)).toEqual({
+      speak: false,
+    });
+    expect(onDisconnected(shared, "vino", 26 * MIN, THRESHOLD)).toMatchObject({
+      speak: true,
+      kind: "still-down",
+    });
+  });
+});
+
+describe("a clock that moves backwards", () => {
+  it("never reports a negative duration and never speaks for it", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 100 * MIN, THRESHOLD);
+    // NTP step / sleep-wake: now is EARLIER than downSince
+    expect(onDisconnected(s, "ari", 10 * MIN, THRESHOLD)).toEqual({
+      speak: false,
+    });
+    const v = onConnected(s, "ari", 10 * MIN);
+    expect(v.speak).toBe(false);
+  });
+
+  it("clamps the duration REPORTED when the recovery timestamp precedes the outage", () => {
+    // This is the one place a negative duration is observable: the incident was
+    // announced, so the recovery speaks — and it must not say "recovered after
+    // -20m". Found by mutation: with the clamp removed, every other backwards-
+    // clock assertion still passed, because a negative duration reads as "under
+    // the threshold" and the module stays silent. A guard that is only ever
+    // exercised through a silent path is not proven by the silence.
+    const s = freshStates();
+    onDisconnected(s, "ari", 0, THRESHOLD);
+    expect(onDisconnected(s, "ari", 30 * MIN, THRESHOLD)).toMatchObject({
+      speak: true,
+    });
+    expect(onConnected(s, "ari", -20 * MIN)).toEqual({
+      speak: true,
+      kind: "recovered",
+      downMinutes: 0,
+    });
+  });
+
+  it("a backwards clock does not corrupt a later honest measurement", () => {
+    const s = freshStates();
+    onDisconnected(s, "ari", 100 * MIN, THRESHOLD);
+    onDisconnected(s, "ari", 10 * MIN, THRESHOLD); // backwards, silent
+    expect(onDisconnected(s, "ari", 130 * MIN, THRESHOLD)).toEqual({
+      speak: true,
+      kind: "still-down",
+      downMinutes: 30,
+    });
+  });
+});
+
+describe("thresholdMs", () => {
+  it("defaults to 25 minutes — the p90 of the measured recovery distribution", () => {
+    expect(thresholdMs({} as NodeJS.ProcessEnv)).toBe(25 * MIN);
+    expect(
+      thresholdMs({ WA_MIRROR_DOWN_ALERT_MINUTES: "" } as NodeJS.ProcessEnv),
+    ).toBe(25 * MIN);
+    expect(
+      thresholdMs({ WA_MIRROR_DOWN_ALERT_MINUTES: "   " } as NodeJS.ProcessEnv),
+    ).toBe(25 * MIN);
+  });
+
+  it("honours a valid override, including fractional minutes", () => {
+    expect(
+      thresholdMs({ WA_MIRROR_DOWN_ALERT_MINUTES: "5" } as NodeJS.ProcessEnv),
+    ).toBe(5 * MIN);
+    expect(
+      thresholdMs({ WA_MIRROR_DOWN_ALERT_MINUTES: "0.5" } as NodeJS.ProcessEnv),
+    ).toBe(30_000);
+    expect(
+      thresholdMs({ WA_MIRROR_DOWN_ALERT_MINUTES: "0" } as NodeJS.ProcessEnv),
+    ).toBe(0);
+  });
+
+  it("falls back to the default rather than disarming on garbage", () => {
+    // NaN would make every `downMs < threshold` comparison FALSE... and every
+    // `>=` false too, so the organ would go mute. Silence is the one outcome a
+    // watchdog may never choose by accident.
+    for (const bad of ["abc", "NaN", "-5", "Infinity-ish", "1e"]) {
+      expect(
+        thresholdMs({
+          WA_MIRROR_DOWN_ALERT_MINUTES: bad,
+        } as NodeJS.ProcessEnv),
+      ).toBe(25 * MIN);
+    }
+  });
+});


### PR DESCRIPTION
The bridge's alert policy was reporting the SYMPTOM. Measured on the live
spool this turn, over its whole retained window (2026-07-08..2026-08-07):
741 `wa-bridge:disconnected` + 725 `wa-bridge:connected` + 25
`wa-bridge:loggedout` = 1491 records, the second-loudest producer on the
fleet at 24-52 events/day. The 2026-08-06 messaging study had already
paired every disconnection with the next reconnection — 718 of 718
recovered, median 1.0 min, 81% under 5 min, p90 25 min, max 358 min.

So 1466 of those lines announced a condition that healed itself, usually
within a minute, and the 358-minute tail — the one incident shape a human
needs — was indistinguishable from the noise.

The cure holds the close silently and speaks only if the outage OUTLASTS a
threshold (default 25m = the measured p90, `WA_MIRROR_DOWN_ALERT_MINUTES`):

- a flap that heals inside the threshold produces ZERO messages
- a line still down past it speaks ONCE, p0, `wa-bridge:down:<account>`
- a recovery speaks only to CLOSE an incident that was announced (digest)
- a terminal logout never arms this clock: index.ts already reports it p0
  and stops retrying, so arming it would re-announce, 25 minutes later, a
  fault already reported and already known to be unrecoverable by waiting

`terminal` is an ARGUMENT of onDisconnected rather than an `if (!terminal)`
at the call site, so that rule sits inside the tested unit instead of a
comment above an untested branch (W115). All three call sites — close,
open, crash-restart — share ONE incident map: the crash path produced zero
records in 30 days, but a dormant site left on the old behaviour is how a
cure applied to one of several sites reopens itself (W107).

ARMED, which is the other half: no workflow had ever run wa-mirror's vitest
suite — 8 files, 0 gates, on the organ that mirrors client WhatsApp lines.
The corpus now runs as a step of the already-required `Frontend Tests
(mouth, true)` leg, because branch protection pins contexts by NAME and a
new job would be born unrequired (W69). Declared limit: 2 of the 8 files —
the other 6 import baileys/pino/libphonenumber-js, which the root install
does not provide (apps/wa-mirror is not a workspace and has no lockfile).
Arming those needs a lockfile for that package: its own PR, not a silent
`npm install` of floating versions inside a required check.

Mutation-verified, 6 mutants, 0 survivors: threshold gate, terminal
exclusion, once-per-incident guard, backwards-clock clamp, garbage-threshold
fallback, and the never-announced-recovery guard each turn the corpus red.
The clamp mutant SURVIVED the first draft — a negative duration reads as
"under the threshold", so every backwards-clock assertion still passed
through a silent path; the case that observes it (an announced incident
whose recovery timestamp precedes the outage) was added because of that.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

## Measured this turn, on the live spool (counts only — no message bodies left this machine)

| what | how | result |
|---|---|---|
| this producer's whole retained window | `~/.organism/tg_spool` on Pro, 2026-07-08..2026-08-07 | 741 `wa-bridge:disconnected` + 725 `wa-bridge:connected` + 25 `wa-bridge:loggedout` = **1491** |
| the crash-restart call site's share | same census, key class `wa-bridge:reconnect` | **0 records in 30 days** — dormant, and still routed through the same map (W107) |
| offered vs delivered, fleet-wide | per-day aggregation over the spool | offered **61–185/day**, delivered **exactly 14/day** for 8 straight days (`P0_BUDGET=12` + 2 `cron-fail` reserve); the rest is spooled to the digest |
| the loudest producer, for contrast | same window | `log-size-watchdog` 68/day → **0** on 08-07 and 08-08 (its own cure landed 08-06 and both live copies on Pro carry it) |
| the lines are healthy, not silent-because-dead | `scripts/wa_session_liveness.py --json --no-alert` on Pro | 7/7 `OK`, 0 stale — so today's zero flaps are real stability, not a corpse |
| corpus | `npx vitest run tests/down-alarm.test.ts tests/telegram.test.ts` in `apps/wa-mirror` | 26 tests green with NO app-level `node_modules` (both files import only stdlib) |
| mutation | 6 cures removed one at a time | **0 survivors** (6, 1, 3, 1, 1, 3 tests red respectively) |

## Why the CI step is where it is

No workflow had ever run this app's vitest suite. The step is attached to the **already-required** `Frontend Tests (Next.js) (mouth, true)` leg rather than being its own job, because branch protection pins required contexts by NAME — a new name is born unrequired and nobody changes the setting (W69). Same reasoning the `packages/core` step above it states for itself.

**Declared limit, not hidden:** 2 of 8 files. The other 6 import `baileys`/`pino`/`libphonenumber-js`; `apps/wa-mirror` is not an npm workspace and has **no lockfile**, so the root `npm install` does not provide them (measured locally: 2 passed, 6 failed to import). Arming those needs a lockfile for that package — its own PR, on the W81 ledger, not a silent `npm install` of floating versions inside a required check.

## Deploy note (this PR is not live on merge)

The 7 bridges run `dist/bridge/index.js` from Pro's checkout, so the merge must be followed by `git pull` + `npm run build` + a rolling restart. Measured: `dist/bridge/index.js` is dated 8 Jul and that is CURRENT — **zero** commits touched `apps/wa-mirror/bridge/` since, so the rebuild ships this diff and nothing else. The prove-live is direct: a restart emits `connection: open`, which under the OLD code wrote a `wa-bridge:connected` record — if that counter does not move across 7 restarts, the code that ran is this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)