### PR TITLE
feat(ci): catch silent ledger-row loss across a merge=union PR (dry-run)

### DIFF
--- a/.github/workflows/check-ledger-no-silent-loss.yml
+++ b/.github/workflows/check-ledger-no-silent-loss.yml
@@ -1,0 +1,90 @@
+# Residual arming step for the PENDING-ARMS entry opened 2026-08-02
+# ("merge=union on this ledger makes GitHub call EVERY ledger-touching PR
+# conflicted, while every git client merges it cleanly — and the documented
+# escape fails too"). Runbook: docs/runbooks/merge-queue-discipline.md
+# §6quinquies. Script: scripts/check_ledger_no_silent_loss.py.
+#
+# `.gitattributes` declares PENDING-ARMS.md `merge=union`, correct for an
+# append-only registry — but GitHub's own mergeability computation ignores
+# .gitattributes drivers and can report `mergeable: false` / DIRTY on a PR
+# that `git merge` resolves cleanly in both directions. The danger this
+# check exists for: a session reading that false DIRTY as a real conflict
+# and hand-resolving it by keeping one side, silently dropping the other
+# side's rows.
+#
+# NON-REQUIRED by design (same posture as check-kbli-dataset-sync.yml): the
+# check cannot distinguish "accidentally dropped" from "legitimately closed
+# — arming PROVEN live" using git history alone (both are just a line
+# present at merge-base and absent at HEAD). It only flags rows untouched
+# by ANY PR since the branch diverged, which narrows but does not eliminate
+# false positives on a rare legitimate closure. Promoting this to a
+# required branch-protection check is a separate, later, operator-only
+# action (repo/branch-protection settings, CLAUDE.md §13) — build first,
+# observe over a dry-run window, promote after.
+#
+# Path-scoped: only runs when the ledger, this script, or this workflow
+# changes — a PR that touches none of them has nothing to check.
+
+name: check-ledger-no-silent-loss
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".claude/skills/modus/PENDING-ARMS.md"
+      - "scripts/check_ledger_no_silent_loss.py"
+      - "scripts/pending_arms_report.py"
+      - "scripts/tests/test_check_ledger_no_silent_loss.py"
+      - ".github/workflows/check-ledger-no-silent-loss.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-ledger-no-silent-loss-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-ledger-no-silent-loss:
+    name: check-ledger-no-silent-loss
+    runs-on: ubuntu-latest
+    # Floor is the CHECKOUT, not the script (scripts/lint_workflow_timeout_floor.py).
+    timeout-minutes: 10
+    steps:
+      # Checkout base SHA (not branch HEAD), fetch full history — the same
+      # convention hot-zone-pr-gate.yml uses for merge-base-anchored diffing.
+      - name: Checkout base ref
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+
+      - name: Fetch PR head
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=200 origin "$HEAD_SHA"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: python -m pip install --quiet pytest
+
+      - name: Self-test the guard (guilt AND innocence)
+        run: |
+          set -uo pipefail
+          python -m pytest scripts/tests/test_check_ledger_no_silent_loss.py -q
+
+      - name: No silent loss across the ledger merge
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          python scripts/check_ledger_no_silent_loss.py \
+            --base-ref "$BASE_SHA" --head-ref "$HEAD_SHA"
+        continue-on-error: true # dry-run posture — see header comment

--- a/scripts/check_ledger_no_silent_loss.py
+++ b/scripts/check_ledger_no_silent_loss.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""check_ledger_no_silent_loss.py — the residual arming step for the `merge=union`
+PENDING-ARMS entry (opened 2026-08-02).
+
+`.gitattributes` declares `.claude/skills/modus/PENDING-ARMS.md merge=union`, a
+built-in git driver that keeps both sides' lines on any textual conflict —
+exactly right for an append-only registry. But GitHub's OWN mergeability
+computation does not apply `.gitattributes` merge drivers: it reports
+`mergeable: false` / `mergeStateStatus: DIRTY` on a plain three-way merge even
+when `git merge --no-commit` succeeds cleanly in both directions. The
+documented escape (`gh pr update-branch`) also fails on this file ("Cannot
+update PR branch due to conflicts"). The only path is a LOCAL `git merge
+origin/main` + push.
+
+The danger this check exists for: a session that reads GitHub's false
+`mergeable: false` as a REAL conflict and hand-resolves it by picking one
+side, silently dropping the other side's rows — exactly what `merge=union`
+was added to prevent, and exactly the kind of loss no git-level conflict
+marker would ever flag (a clean three-way merge with a wrong resolution
+produces no conflict at all).
+
+INVARIANT (deliberately narrow — see below): a row present at BOTH the
+branch's own merge-base AND on current origin/main — i.e. a row NEITHER
+this branch NOR any other PR has touched since this branch was created —
+must still be present on the branch's own HEAD. If it isn't, nothing on
+either side asked for its removal, so its disappearance can only be an
+artifact of how the branch's tree was produced (the exact "hand-resolved a
+false conflict, kept one side's whole file" incident this check exists
+for). A PR that doesn't touch the ledger at all is skipped entirely.
+
+Why not simply "every row on origin/main must be in HEAD"? Because this
+ledger's own header sanctions a real, intentional action: "Remove a line
+ONLY when the arming is PROVEN live." A PR that legitimately closes an
+existing, previously-untouched row is indistinguishable, by pure git
+history, from one that accidentally dropped it — nothing in `git diff`
+can carry that intent. Rather than either (a) blocking every legitimate
+closure or (b) trusting intent no mechanical check can verify, this stays
+a LOUD, NON-required signal (see the companion workflow) until it has been
+observed over a dry-run window — the same promotion path this repo already
+uses (`worktree_gc_universal`'s own history). Promoting it to a required
+branch-protection check is a separate, later, operator-only action
+(repo/branch-protection settings are explicitly outside session scope).
+
+Identity is (opened_date, artifact-title), not the full raw line: the
+ledger's own body fields (status, missing-step, owner, proof-of-armed) are
+legitimately edited in place as work progresses on an ALREADY-open entry
+(e.g. PR #3831, same day this check was written: the ReDoS-timing entry's
+status text changed from "NOT fixed" to "FIXED in PR #3831" without the row
+being a "different" entry) — keying on the full line would treat every such
+edit as a silent removal-plus-addition and never distinguish it from a
+genuine loss.
+
+Pure signaler: reads three git refs (origin/main, merge-base, working tree),
+prints a verdict, never writes anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+from pathlib import Path
+from typing import List, Optional, Set, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from pending_arms_report import (  # noqa: E402
+    Entry,
+    LedgerRefUnreadable,
+    _default_ledger_path,
+    _git,
+    _parse_now,
+    load_entries,
+)
+
+EntryKey = Tuple[Optional[date], str]
+
+
+def entry_key(entry: Entry) -> EntryKey:
+    return (entry.opened_date, entry.artifact.strip())
+
+
+def entry_keys(entries: List[Entry]) -> Set[EntryKey]:
+    return {entry_key(e) for e in entries}
+
+
+def _format_key(key: EntryKey) -> str:
+    opened, title = key
+    opened_str = opened.isoformat() if opened else "????-??-??"
+    return f"opened {opened_str} | {title}"
+
+
+def ledger_touched_by_branch(
+    ledger_path: Path, merge_base: str, head_ref: Optional[str] = None
+) -> bool:
+    rc, out, err = _git(
+        ["diff", "--name-only", f"{merge_base}..{head_ref or 'HEAD'}", "--", str(ledger_path.name)],
+        cwd=ledger_path.parent,
+    )
+    if rc != 0:
+        # Can't tell -> do NOT assume untouched (that would silently skip the
+        # one case this check exists for). Caller surfaces this as CANNOT-VERIFY.
+        raise LedgerRefUnreadable(f"git diff --name-only failed: {err or rc}")
+    return bool(out.strip())
+
+
+def check(
+    ledger_path: Path,
+    now: date,
+    base_ref: str = "origin/main",
+    head_ref: Optional[str] = None,
+) -> int:
+    """head_ref=None reads the physical working tree (local/dev use — what's
+    actually checked out IS the branch under test). CI passes an explicit SHA
+    when the checkout strategy pins HEAD to something other than the PR's own
+    branch tip (e.g. a base-anchored checkout, matching hot-zone-pr-gate.yml's
+    convention of checking out base.sha and fetching head.sha separately)."""
+    head_for_diff = head_ref or "HEAD"
+    rc, merge_base, err = _git(["merge-base", base_ref, head_for_diff], cwd=ledger_path.parent)
+    if rc != 0:
+        print(f"CANNOT-VERIFY: git merge-base {base_ref} {head_for_diff} failed: {err or rc}")
+        return 4
+
+    try:
+        touched = ledger_touched_by_branch(ledger_path, merge_base, head_ref=head_ref)
+    except LedgerRefUnreadable as exc:
+        print(f"CANNOT-VERIFY: {exc}")
+        return 4
+
+    if not touched:
+        print(
+            "OK: this branch does not touch "
+            f"{ledger_path.name} — nothing for this check to verify."
+        )
+        return 0
+
+    try:
+        main_entries = load_entries(ledger_path, now, ref=base_ref)
+        base_entries = load_entries(ledger_path, now, ref=merge_base)
+        head_entries = load_entries(ledger_path, now, ref=head_ref)  # None = working tree
+    except LedgerRefUnreadable as exc:
+        print(f"CANNOT-VERIFY: {exc}")
+        return 4
+
+    main_keys = entry_keys(main_entries)
+    base_keys = entry_keys(base_entries)
+    head_keys = entry_keys(head_entries)
+
+    # Untouched by ANYONE since this branch diverged: present at the branch's
+    # own starting point AND still present on current main. Nothing on either
+    # side has asked for these rows to go away.
+    stable_keys = base_keys & main_keys
+    missing = sorted(stable_keys - head_keys, key=lambda k: (k[0] or date.min, k[1]))
+
+    if missing:
+        print(
+            f"FAIL (non-blocking, dry-run — see workflow): {len(missing)} open ledger row(s) "
+            "untouched by any PR since this branch diverged (present at merge-base AND on "
+            "current origin/main) are absent from this branch's HEAD:"
+        )
+        for key in missing:
+            print(f"  - {_format_key(key)}")
+        print(
+            "\nIf this is a deliberate closure (arming PROVEN live — the ledger's own "
+            "removal rule), ignore this signal; it cannot see intent, only content. If it "
+            "is NOT deliberate, this is the exact loss the merge=union driver exists to "
+            "prevent. If GitHub reported this PR as `mergeable: false` / DIRTY on "
+            "PENDING-ARMS.md, that is EXPECTED (server-side mergeability does not apply "
+            ".gitattributes drivers) and is NOT a real conflict — do not hand-resolve. Fix: "
+            "`git merge origin/main` locally (the union driver applies correctly "
+            "client-side), then push. See the PENDING-ARMS.md entry opened 2026-08-02 "
+            "('merge=union on this ledger...') and docs/runbooks/merge-queue-discipline.md "
+            "§6quinquies."
+        )
+        return 1
+
+    print(
+        f"OK: {len(head_keys)} open row(s) on HEAD, {len(main_keys)} on origin/main, "
+        f"{len(stable_keys)} row(s) untouched-by-anyone all survived — no silent loss."
+    )
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ledger", type=Path, default=None, help="Path to PENDING-ARMS.md")
+    parser.add_argument(
+        "--now", type=str, default=None, help="Override 'today' as YYYY-MM-DD (deterministic runs/tests)."
+    )
+    parser.add_argument(
+        "--base-ref",
+        type=str,
+        default="origin/main",
+        help=(
+            "Ref/SHA to treat as 'main' (default origin/main). CI passes the PR's exact "
+            "base SHA — a symbolic origin/main may not be populated in a base-anchored "
+            "shallow checkout."
+        ),
+    )
+    parser.add_argument(
+        "--head-ref",
+        type=str,
+        default=None,
+        help=(
+            "Ref/SHA to treat as the PR's HEAD. Default reads the physical working tree "
+            "(local/dev use). CI passes the PR's exact head SHA when the checkout strategy "
+            "doesn't leave HEAD pointed at the PR branch tip."
+        ),
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    ledger_path = args.ledger or _default_ledger_path()
+    now = _parse_now(args.now)
+    return check(ledger_path, now, base_ref=args.base_ref, head_ref=args.head_ref)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_ledger_no_silent_loss.py
+++ b/scripts/tests/test_check_ledger_no_silent_loss.py
@@ -1,0 +1,146 @@
+"""Guilt AND innocence for check_ledger_no_silent_loss.py.
+
+Every test runs against a throwaway git repo under tmp_path — never the
+real PENDING-ARMS.md (W96: tests must not touch production state, and this
+repo's own conftest/immune-organ discipline exists precisely because of
+that class of bug).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_ledger_no_silent_loss import check  # noqa: E402
+from pending_arms_report import _parse_now  # noqa: E402
+
+NOW = _parse_now("2026-08-08")
+
+ENTRY_A = "- opened 2026-08-01 | **Entry A** | missing step A | me (sessione test) | proof A"
+ENTRY_B = "- opened 2026-08-01 | **Entry B** | missing step B | me (sessione test) | proof B"
+ENTRY_C = "- opened 2026-08-03 | **Entry C** | missing step C | me (sessione test) | proof C"
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-q", "-b", "main"], repo)
+    _git(["config", "user.email", "test@example.com"], repo)
+    _git(["config", "user.name", "Test"], repo)
+    return repo
+
+
+def _write_ledger(repo: Path, entries: list[str]) -> Path:
+    ledger = repo / "PENDING-ARMS.md"
+    ledger.write_text("\n\n".join(entries) + "\n", encoding="utf-8")
+    return ledger
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(["add", "-A"], repo)
+    _git(["commit", "-q", "-m", message], repo)
+
+
+def _mark_as_origin_main(repo: Path) -> None:
+    """Simulate a fetched origin/main ref without a real remote."""
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    _git(["update-ref", "refs/remotes/origin/main", sha], repo)
+
+
+def test_guilt_a_bad_resolution_silently_drops_an_untouched_row(tmp_path):
+    """The exact incident: main advances (another PR adds C), this branch's
+    'resolution' keeps only its own view of the file and drops A — A was
+    never touched by anyone, so its disappearance can only be the
+    resolution itself, not a legitimate closure.
+    """
+    repo = _init_repo(tmp_path)
+    ledger = _write_ledger(repo, [ENTRY_A, ENTRY_B])
+    _commit(repo, "seed A+B")
+    _mark_as_origin_main(repo)
+    _git(["checkout", "-q", "-b", "feature"], repo)
+
+    _git(["checkout", "-q", "main"], repo)
+    _write_ledger(repo, [ENTRY_A, ENTRY_B, ENTRY_C])
+    _commit(repo, "main: add C")
+    _mark_as_origin_main(repo)
+
+    _git(["checkout", "-q", "feature"], repo)
+    _write_ledger(repo, [ENTRY_B])  # bad "resolution": drops A, never picks up C
+    _commit(repo, "feature: bad hand-resolution")
+
+    assert check(ledger, NOW) == 1
+
+
+def test_innocence_a_clean_local_merge_carries_everything_forward(tmp_path):
+    """The correct, documented procedure (`git merge origin/main`) picks up
+    C automatically and leaves A+B untouched — no loss, no false alarm.
+    """
+    repo = _init_repo(tmp_path)
+    ledger = _write_ledger(repo, [ENTRY_A, ENTRY_B])
+    _commit(repo, "seed A+B")
+    _mark_as_origin_main(repo)
+    _git(["checkout", "-q", "-b", "feature"], repo)
+
+    _git(["checkout", "-q", "main"], repo)
+    _write_ledger(repo, [ENTRY_A, ENTRY_B, ENTRY_C])
+    _commit(repo, "main: add C")
+    _mark_as_origin_main(repo)
+
+    _git(["checkout", "-q", "feature"], repo)
+    _git(["merge", "-q", "main", "-m", "merge main"], repo)
+
+    assert check(ledger, NOW) == 0
+
+
+def test_innocence_a_legitimate_edit_in_place_is_not_a_removal(tmp_path):
+    """Editing an entry's body (status/proof text) while keeping its
+    (opened_date, title) identical must not read as a removal — this is the
+    exact shape of PR #3831's own ledger update, same session: the
+    ReDoS-timing entry's status text changed without the row being a
+    'different' entry.
+    """
+    repo = _init_repo(tmp_path)
+    ledger = _write_ledger(repo, [ENTRY_A, ENTRY_B])
+    _commit(repo, "seed A+B")
+    _mark_as_origin_main(repo)
+    _git(["checkout", "-q", "-b", "feature"], repo)
+
+    edited_a = (
+        "- opened 2026-08-01 | **Entry A** | UPDATED missing step | "
+        "me (sessione test) | UPDATED proof"
+    )
+    _write_ledger(repo, [edited_a, ENTRY_B])
+    _commit(repo, "feature: update A's status text")
+
+    assert check(ledger, NOW) == 0
+
+
+def test_innocence_a_pr_that_never_touches_the_ledger_is_skipped(tmp_path):
+    """Main independently closing A after this branch diverged must not be
+    read as THIS branch's loss — the branch never touched the file at all.
+    """
+    repo = _init_repo(tmp_path)
+    ledger = _write_ledger(repo, [ENTRY_A, ENTRY_B])
+    _commit(repo, "seed A+B")
+    _mark_as_origin_main(repo)
+    _git(["checkout", "-q", "-b", "feature"], repo)
+
+    (repo / "unrelated.txt").write_text("hi\n", encoding="utf-8")
+    _commit(repo, "feature: unrelated change")
+
+    _git(["checkout", "-q", "main"], repo)
+    _write_ledger(repo, [ENTRY_B])
+    _commit(repo, "main: legitimately closes A")
+    _mark_as_origin_main(repo)
+    _git(["checkout", "-q", "feature"], repo)
+
+    assert check(ledger, NOW) == 0


### PR DESCRIPTION
## Summary

Closes the residual "missing arming step" on the PENDING-ARMS ledger entry opened 2026-08-02 ("`merge=union` on this ledger makes GitHub call EVERY ledger-touching PR conflicted...").

- `.gitattributes` declares `.claude/skills/modus/PENDING-ARMS.md merge=union`, correct for an append-only registry — but GitHub's own mergeability computation ignores `.gitattributes` drivers and reports `mergeable: false` / `mergeStateStatus: DIRTY` on a ledger-touching PR that `git merge` resolves cleanly in both directions (measured live on PR #3527).
- The danger: a session reading that false DIRTY as a real conflict and hand-resolving it by keeping one side, silently dropping the other side's rows — exactly what `merge=union` exists to prevent, and exactly the kind of loss no git-level conflict marker would flag (a clean three-way merge with a wrong resolution produces no conflict at all).

## What this ships

`scripts/check_ledger_no_silent_loss.py` + `.github/workflows/check-ledger-no-silent-loss.yml`:

- Flags an open row present at the branch's own merge-base **and** on current `origin/main` — i.e. untouched by ANY PR since the branch diverged — that's missing from HEAD.
- Deliberately narrower than "every row on main must survive": this ledger's own header sanctions a real, intentional action ("Remove a line ONLY when the arming is PROVEN live"), and no git-history check can tell a legitimate closure apart from an accidental drop using content alone.
- Skips entirely on a PR that doesn't touch the ledger (a PR simply branched before main grew new rows is not evidence of anything).
- **Non-required by design** (`continue-on-error: true`) — same promotion path as `check-kbli-dataset-sync.yml`: build first, observe over a dry-run window, promote to a required branch-protection check later. That promotion is explicitly an operator-only action (repo/branch-protection settings, CLAUDE.md §13), not something this PR arms itself.

## Test plan

- [x] Guilt: `test_guilt_a_bad_resolution_silently_drops_an_untouched_row` — scripts the exact incident (main advances with a new row from another PR, this branch's "resolution" drops an untouched row and never picks up the new one)
- [x] Innocence ×3: a clean `git merge origin/main` carries everything forward; an in-place body edit to an existing entry (same shape as this session's own PR #3831 ledger update) is not mistaken for a removal; a PR that never touches the ledger is skipped even when main independently closes rows after it diverged
- [x] Verified guilt by disabling detection locally — reproduces the incident (red); restored (green)
- [x] Smoke-tested against the real, 355-entry PENDING-ARMS.md: zero (opened_date, title) key collisions, correctly skips when the current branch doesn't touch the file
- [x] `actionlint` clean on the new workflow
- [x] Full backend pre-push suite: passed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)