### PR TITLE
fix(kbli): the gold indexer's stats and dry-run sample blocks still read the nested metadata key — flat sweep, all 4 remaining sites

### DIFF
--- a/apps/backend-rag/backend/scripts/index_kbli_gold_content.py
+++ b/apps/backend-rag/backend/scripts/index_kbli_gold_content.py
@@ -368,6 +368,35 @@ async def upsert_to_qdrant(points: list[dict], qdrant_url: str, api_key: str | N
                 logger.info(f"  Upserted batch {i}-{i + len(batch)} ({len(batch)} points)")
 
 
+def field_coverage(all_points: list[dict]) -> dict[str, int]:
+    """Count how many points carry each gold field (flat payload — the
+    KBLI flat-payload golden rule; ``gold_fields`` lives directly on
+    ``point["payload"]``, never under a nested sub-dict)."""
+    fields_count: dict[str, int] = {}
+    for p in all_points:
+        for f in p["payload"].get("gold_fields", []):
+            fields_count[f] = fields_count.get(f, 0) + 1
+    return fields_count
+
+
+def tka_total(all_points: list[dict]) -> int:
+    """Count points flagged ``has_tka_info`` (flat payload)."""
+    return sum(1 for p in all_points if p["payload"]["has_tka_info"])
+
+
+def sample_lines(point: dict) -> list[str]:
+    """Human-readable preview lines for one point (dry-run sample display).
+
+    Returns plain strings — the caller is responsible for logging them.
+    """
+    payload = point["payload"]
+    return [
+        f"  Code: {payload['kode']}",
+        f"  Judul: {payload['judul'][:80]}",
+        f"  Text preview: {point['_text_to_embed'][:300]}...",
+    ]
+
+
 async def main():
     parser = argparse.ArgumentParser(description="Index KBLI gold content into kbli_2025_final")
     parser.add_argument("--dry-run", action="store_true")
@@ -423,23 +452,19 @@ async def main():
     logger.info(f"Built {len(all_points)} points to index")
 
     # Stats
-    fields_count = {}
-    for p in all_points:
-        for f in p["payload"]["metadata"].get("gold_fields", []):
-            fields_count[f] = fields_count.get(f, 0) + 1
+    fields_count = field_coverage(all_points)
     logger.info("Gold field coverage:")
     for f, n in sorted(fields_count.items(), key=lambda x: -x[1]):
         logger.info(f"  {f}: {n}/{len(all_points)} ({100 * n // len(all_points)}%)")
 
-    tka_count = sum(1 for p in all_points if p["payload"]["metadata"]["has_tka_info"])
+    tka_count = tka_total(all_points)
     logger.info(f"Codes with TKA info: {tka_count}/{len(all_points)}")
 
     if args.dry_run:
         logger.info("DRY RUN — sample points:")
         for p in all_points[:2]:
-            logger.info(f"  Code: {p['payload']['metadata']['kode']}")
-            logger.info(f"  Judul: {p['payload']['metadata']['judul'][:80]}")
-            logger.info(f"  Text preview: {p['_text_to_embed'][:300]}...")
+            for line in sample_lines(p):
+                logger.info(line)
             logger.info("")
         logger.info(f"Would upsert {len(all_points)} gold points to {COLLECTION_NAME}")
         return

--- a/apps/backend-rag/backend/tests/unit/scripts/test_kbli_only_selection.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_kbli_only_selection.py
@@ -16,7 +16,10 @@ import pytest
 from backend.scripts._kbli_repo_root import resolve_repo_root
 from backend.scripts.index_kbli_gold_content import (
     build_point,
+    field_coverage,
     filter_to_codes,
+    sample_lines,
+    tka_total,
 )
 from backend.scripts.index_kbli_gold_content import (
     parse_only_codes as parse_gold_only,
@@ -199,6 +202,87 @@ class TestBuildPoint:
         p2 = build_point("56101", self._gold(), self._base(), "2026-08-08T01:00:00+00:00")
         assert p1["id"] == p2["id"]
         assert p1["payload"]["indexed_at"] != p2["payload"]["indexed_at"]
+
+
+# ─── field_coverage / tka_total / sample_lines (gold indexer stats blocks) ──
+#
+# These are the 4 REMAINING nested-metadata crash sites that #3832 did not
+# touch (it only fixed build_point()) — never reached by any prior run since
+# build_point() crashed first. Every test here builds its points with the
+# REAL build_point() and feeds them to the REAL helper — build→stats→sample,
+# end to end on the actual production call path, per the W101-recidiva
+# symmetry lesson (a fix that only covers the site that bit you is half a
+# fix).
+
+
+class TestFieldCoverage:
+    def test_counts_fields_across_points_synthetic(self):
+        """Direct unit check on the counting logic with hand-built points."""
+        points = [
+            {"payload": {"gold_fields": ["whatItMeans", "whatYouNeed"]}},
+            {"payload": {"gold_fields": ["whatItMeans"]}},
+        ]
+        assert field_coverage(points) == {"whatItMeans": 2, "whatYouNeed": 1}
+
+    def test_end_to_end_via_real_build_point(self):
+        """Guilt: real build_point() output flows into field_coverage() —
+        this is exactly the shape that KeyError'd on `["metadata"]` at the
+        original line 428."""
+        gold = {"whatItMeans": "Restoran", "whatYouNeed": "Izin usaha mikro"}
+        base = {"judul": "Restoran", "sektor_id": "I"}
+        point = build_point("56101", gold, base, "2026-08-08T00:00:00+00:00")
+        coverage = field_coverage([point])
+        assert coverage["whatItMeans"] == 1
+        assert coverage["whatYouNeed"] == 1
+
+
+class TestTkaTotal:
+    def test_counts_flagged_points_synthetic(self):
+        points = [
+            {"payload": {"has_tka_info": True}},
+            {"payload": {"has_tka_info": False}},
+            {"payload": {"has_tka_info": True}},
+        ]
+        assert tka_total(points) == 2
+
+    def test_end_to_end_via_real_build_point(self):
+        """Guilt: real build_point() output flows into tka_total() — this is
+        exactly the shape that KeyError'd on `["metadata"]` at the original
+        line 434."""
+        gold_with_tka = {
+            "whatItMeans": "x",
+            "tka_positions": [{"en": "Engineer", "id": "Insinyur"}],
+        }
+        gold_without_tka = {"whatItMeans": "y"}
+        base = {"judul": "x", "sektor_id": "I"}
+        points = [
+            build_point("11111", gold_with_tka, base, "2026-08-08T00:00:00+00:00"),
+            build_point("22222", gold_without_tka, base, "2026-08-08T00:00:00+00:00"),
+        ]
+        assert tka_total(points) == 1
+
+
+class TestSampleLines:
+    def test_lines_shape_synthetic(self):
+        point = {
+            "payload": {"kode": "56101", "judul": "Restoran dan Penyediaan Makanan"},
+            "_text_to_embed": "preview text " * 40,
+        }
+        lines = sample_lines(point)
+        assert len(lines) == 3
+        assert any("56101" in line for line in lines)
+        assert any("Restoran dan Penyediaan Makanan" in line for line in lines)
+
+    def test_end_to_end_via_real_build_point(self):
+        """Guilt: real build_point() output flows into sample_lines() — this
+        is exactly the shape that KeyError'd on `["metadata"]` at the
+        original lines 440/441 (Code + Judul)."""
+        gold = {"whatItMeans": "Restoran"}
+        base = {"judul": "Restoran Padang Asli", "sektor_id": "I"}
+        point = build_point("56101", gold, base, "2026-08-08T00:00:00+00:00")
+        lines = sample_lines(point)
+        assert any("56101" in line for line in lines)
+        assert any("Restoran Padang Asli" in line for line in lines)
 
 
 # ─── resolve_repo_root (shared marker-walk, replaces parents[N]) ────────────


### PR DESCRIPTION
#3832 fixed the point-construction crash (`build_point()`) but never got far enough to reach 4 more sites, all in `main()`'s post-build stats/sample blocks, that made the SAME assumption — a nested `payload["metadata"]` that `build_payload()` never produces (flat payload — the KBLI flat-payload golden rule). Found on the very next dry-run after #3832 deployed: `Built 3 points to index` succeeded, then crashed on `p["payload"]["metadata"].get("gold_fields", [])`.

Full census (`grep -n "metadata"`) found exactly 4 sites — field coverage counting, TKA-info counting, and the dry-run sample's code/judul lines. All 4 now read the flat keys directly. `grep -c "metadata"` on the fixed file is **0**.

Extracted the loop bodies into 3 pure, testable helpers that `main()` calls directly (never recreated copies): `field_coverage()`, `tka_total()`, `sample_lines()`. Tests build points with the real `build_point()` and feed them to the real helpers end-to-end (build→stats→sample, the actual production path) — symmetry discipline, not just the one site that bit us this time. Mutation-verified locally: reintroduced each of the 4 original `["metadata"]` accesses one at a time and confirmed the relevant tests fail with the same `KeyError`, then restored and reconfirmed 49/49 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)