### PR TITLE
feat(ci): arm a changed-files prettier gate, retire the decorative black check

### DIFF
--- a/.github/workflows/intel-router-tests.yml
+++ b/.github/workflows/intel-router-tests.yml
@@ -110,10 +110,21 @@ jobs:
         run: |
           pip install flake8 black isort mypy
 
-      - name: Check code formatting
-        working-directory: apps/backend-rag
-        run: |
-          black --check backend/services/intel/ backend/app/routers/intel.py || echo "Formatting check skipped"
+      # Removed 2026-08-09 (PENDING-ARMS.md ledger, opened 2026-07-27 — "the
+      # prettier rule is enforced by nothing that can see the whole repo" also
+      # named this step's twin shape). This step ran
+      # `black --check ... || echo "Formatting check skipped"` — the bare
+      # `|| echo` swallows every non-zero exit, so the step could never go red
+      # and certified nothing (same decorative shape as the W104 antibody that
+      # trusted an exit code instead of the reply). Measured before removing
+      # it, not assumed: `black --check backend/services/intel/
+      # backend/app/routers/intel.py` against this same scope goes RED today
+      # (file count in the PR body that removed this step) — arming the bare
+      # `||` would have broken every future intel-router PR on a pre-existing
+      # backlog this PR did not create. `isort`'s step right below
+      # (`|| echo "Import check skipped"`) has the identical decorative shape
+      # and is deliberately NOT touched here — left as a ledgered follow-up,
+      # not silently inherited as "fixed" alongside this one.
 
       - name: Check imports
         working-directory: apps/backend-rag

--- a/.github/workflows/prettier-changed-files.yml
+++ b/.github/workflows/prettier-changed-files.yml
@@ -1,0 +1,155 @@
+name: Prettier (changed files)
+
+# WHY THIS EXISTS (2026-08-09 — ledger .claude/skills/modus/PENDING-ARMS.md, lines
+# opened 2026-07-27 twice over: "the repo's prettier gate is declared in three
+# places and armed in none of CI" + "the prettier rule is enforced by nothing
+# that can see the whole repo").
+#
+# prettier is declared THREE times in this repo — package.json's `format` /
+# `format:check` / `lint:check` scripts, package.json's `lint-staged` config,
+# and .husky/pre-commit's own inline `npx prettier --check` on staged files —
+# and until this workflow, armed in NONE of CI (grep over .github/workflows/
+# returned nothing). The local pre-commit hook only ever sees files staged on
+# the machine that commits, so a file nobody commits locally, or a merge that
+# carries someone else's pre-existing drift, trips the rule invisibly until a
+# later merge stumbles over it. Measured live 2026-07-27: 515 tracked files on
+# main already violate the rule the repo's own pre-commit hook enforces
+# locally (44 under apps/mouth/src/lib alone, using the ts/tsx glob).
+#
+# This workflow does NOT attempt that backlog — a repo-wide `format:check`
+# would fail on all 515 at once, and a single reformat commit conflicts with
+# every open branch. It only stops the bleeding: no NEW unformatted file may
+# land through a PR. The 515 retire area by area, on their own schedule.
+#
+# SCOPE matches the repo's OWN declared rule, not a broader one: package.json's
+# format/format:check/lint:check globs are `{ts,js,json,md,yml,yaml}` — no
+# tsx/jsx (the local pre-commit hook's LINT_FILES regex is broader and DOES
+# include tsx/jsx; that pre-existing inconsistency between the hook and the
+# npm scripts is not fixed here — out of scope for a changed-files CI gate).
+#
+# SENTINEL PATTERN (mirrors frontend-typecheck.yml / immune-enforcement.yml):
+# triggers on EVERY pull request, no `paths:` filter — a required check gated
+# by `paths:` leaves innocent PRs permanently "expected but never ran" (W84).
+# Relevance (did this PR touch a prettier-formattable file at all) is decided
+# INSIDE the job, and the expensive steps (npm ci + prettier) are skipped when
+# nothing in scope changed.
+#
+# The changed-file set is enumerated from the MERGE-BASE via the existing
+# scripts/ci/hotzone_changed_files.sh, never a two-dot `git diff BASE HEAD`:
+# `pull_request.base.sha` is main's CURRENT tip, so a branch behind main would
+# be blamed for every file main gained since the branch point (W102, which
+# hard-blocked innocent PR #3057). That helper exits 3 when it cannot
+# determine the changed set — this job treats that as FAILURE, never as
+# "nothing changed" (a blind-empty read would be a disarmed gate that still
+# reports green, superscar #2 "esiste ≠ armato").
+#
+# `.prettierignore` handling — VERIFIED EMPIRICALLY 2026-08-09, not assumed
+# (W114 "mai per contratto immaginato"): does `prettier --check <path>` honor
+# `.prettierignore` when the path is passed explicitly rather than via a glob?
+# Tested against `.claude/skills/modus/PENDING-ARMS.md` — a file BOTH
+# declared-ignored AND independently known to be non-conformant (it is in
+# .prettierignore precisely because prettier corrupts literal tokens in it).
+# Default invocation (ignore file auto-discovered from cwd): reports clean, 0
+# files matched. The identical invocation with `--ignore-path /dev/null`
+# (bypassing the ignore file): correctly flags it, exit 1. Confirmed: prettier
+# DOES respect .prettierignore for explicit paths, so the enumerated file list
+# is passed straight through below — no manual pre-filter against the ignore
+# file is needed or added.
+
+on:
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prettier-changed-files-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prettier:
+    name: prettier --check (changed files)
+    runs-on: ubuntu-latest
+    # Floor is the CHECKOUT + npm ci, not the prettier run itself
+    # (scripts/lint_workflow_timeout_floor.py convention used across sibling gates).
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Enumerate changed files (merge-base anchored, fail-loud)
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          if [ ! -f scripts/ci/hotzone_changed_files.sh ]; then
+            echo "::error::enumerator missing — refusing to guess the changed set"
+            exit 1
+          fi
+          if ! CHANGED="$(bash scripts/ci/hotzone_changed_files.sh "$BASE_SHA" "$HEAD_SHA" "$PR_NUMBER")"; then
+            echo "::error::could not determine the changed set — failing rather than skipping"
+            exit 1
+          fi
+
+          # Restrict to prettier's own declared scope (package.json
+          # format/format:check/lint:check): ts, js, json, md, yml, yaml.
+          # Deletions/renames-away are dropped by the `[ -f ]` check below —
+          # nothing to check in a file that no longer exists in this tree.
+          CANDIDATES="$(printf '%s\n' "$CHANGED" | grep -E '\.(ts|js|json|md|ya?ml)$' || true)"
+          RELEVANT=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ -f "$f" ] && RELEVANT="$RELEVANT
+          $f"
+          done <<< "$CANDIDATES"
+          RELEVANT="$(printf '%s\n' "$RELEVANT" | sed '/^$/d')"
+
+          {
+            echo "files<<PRETTIER_EOF"
+            echo "$RELEVANT"
+            echo "PRETTIER_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          COUNT="$(printf '%s\n' "$RELEVANT" | grep -c . || true)"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "::notice::prettier-changed-files: $COUNT candidate file(s) in this diff"
+
+      - name: Setup Node.js
+        if: steps.diff.outputs.count != '0'
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspaces (npm ci, lockfile-bound)
+        if: steps.diff.outputs.count != '0'
+        run: npm ci --no-audit --no-fund
+
+      - name: prettier --check (this PR's files only)
+        if: steps.diff.outputs.count != '0'
+        env:
+          FILES: ${{ steps.diff.outputs.files }}
+        run: |
+          set -uo pipefail
+          echo "--- Checking ---"
+          echo "$FILES"
+          echo "----------------"
+          # .prettierignore is auto-discovered from cwd and honored even for
+          # explicit paths (verified empirically — see header comment), so the
+          # enumerated list is passed straight through with no pre-filter.
+          if ! echo "$FILES" | xargs npx --no-install prettier --check --ignore-unknown; then
+            echo "::error::one or more changed files are not prettier-formatted — run 'npx prettier --write <file>' locally, or 'npx prettier --write <file>' per file listed above"
+            exit 1
+          fi
+
+      - name: Not a prettier-scoped change
+        if: steps.diff.outputs.count == '0'
+        run: echo "::notice::no ts/js/json/md/yml/yaml file in this diff; prettier check skipped"


### PR DESCRIPTION
## Summary

PENDING-ARMS.md ledger (opened 2026-07-27, two entries) records that prettier
is declared in **three** places — `package.json`'s `format` / `format:check` /
`lint:check` scripts, `package.json`'s `lint-staged` config, and
`.husky/pre-commit`'s own inline `npx prettier --check` on staged files — and
was armed in **none** of CI (grep over `.github/workflows/` returned nothing).
The local pre-commit hook only ever sees files staged on the machine that
commits, so a file nobody commits locally, or a merge that carries someone
else's pre-existing drift, trips the rule invisibly. Measured live
2026-07-27: **515 tracked files** on main already violate the rule the
repo's own pre-commit hook enforces locally.

This PR does not touch that backlog — a repo-wide `format:check` would fail
on all 515 at once, and one reformat commit would conflict with every open
branch. It only stops the bleeding: no *new* unformatted file can land
through a PR from here on. The 515 retire area by area, on their own
schedule (ledgered).

- **`.github/workflows/prettier-changed-files.yml`** (new): sentinel-pattern
  gate — triggers on every PR, no `paths:` filter (a required check gated by
  `paths:` leaves innocent PRs permanently "expected but never ran", W84).
  Enumerates the PR's own changed files via the existing merge-base-anchored
  `scripts/ci/hotzone_changed_files.sh` (never a two-dot `git diff BASE HEAD`
  — that already hard-blocked an innocent PR once, W102/#3057), restricts to
  the repo's *own declared* prettier scope (`ts,js,json,md,yml,yaml` — same
  glob as `format:check`/`lint:check`, deliberately not the broader
  `tsx,jsx` the local pre-commit hook also covers), and runs
  `prettier --check` only on those files. The enumerator's own exit-3
  ("cannot determine the changed set") is treated as job failure, never as
  "nothing changed."

  **Verified empirically, not assumed (W114)**: does `prettier --check
  <path>` honor `.prettierignore` when the path is passed explicitly rather
  than via a glob? Tested against `.claude/skills/modus/PENDING-ARMS.md` — a
  file that is both declared-ignored *and* independently known
  non-conformant (it's ignored precisely because prettier corrupts literal
  tokens in it). Default run: clean, 0 files matched. Same invocation with
  `--ignore-path /dev/null` (bypassing the ignore file): correctly flags it,
  exit 1. Confirmed prettier respects the ignore file for explicit paths —
  no manual pre-filter was needed or added. Full end-to-end rehearsal run
  locally (bad file / good file / two ignored files mixed in one `--check`
  invocation) before pushing: bad file flagged, good + both ignored files
  passed silently.

- **`.github/workflows/intel-router-tests.yml`**: removed the "Check code
  formatting" step. It ran
  `black --check backend/services/intel/ backend/app/routers/intel.py ||
  echo "Formatting check skipped"` — the bare `|| echo` swallows every
  non-zero exit, so the step could never go red and certified nothing (same
  decorative shape as the W104 antibody that trusted an exit code instead of
  the reply).

  **Measured before removing, not assumed**: ran `black --check` against the
  exact same two paths locally (black 26.5.1, since the workflow installs
  `black` unpinned from PyPI). Result: **RED** — `3 of 22` files would be
  reformatted:
  - `backend/services/intel/trend_hunter/orchestrator.py`
  - `backend/services/intel/intel_lake_router.py`
  - `backend/services/intel/trend_hunter/adapters.py`

  Per the red branch of the ledger's own prescribed cure: remove the step
  (arming the bare `||` instead would have broken every future
  `intel-router-tests` PR on a pre-existing backlog this PR did not create).
  `isort`'s twin step right below (`|| echo "Import check skipped"`) has the
  identical decorative shape and is **deliberately not touched here** —
  ledgered as its own follow-up, not silently inherited as "fixed."

## Out of scope (ledgered as follow-ups, not done here)

- The 515-file prettier backlog on main (retires area-by-area, own decision).
- `isort`'s identical `|| echo "Import check skipped"` decorative twin.
- Adding this new check to branch-protection `required_status_checks` —
  matches existing precedent: `frontend-typecheck.yml` (merged 2026-08-07,
  same sentinel pattern) is *also* not yet in the required-checks list on
  `main`, so a new gate landing un-required first, with "make it required"
  as a distinct follow-up decision, is this repo's established practice
  (see `hot-zone-pr-gate.yml`'s own header: "Phase 2b: flip + add to
  required_status_checks, separate PR, after monitor-mode data").

## Proof-of-armed (comes next, per the ledger's own criterion)

After this PR merges: a probe PR with one deliberately mis-formatted tracked
file (must go RED) and an innocence check touching only pre-existing legacy
files (must stay GREEN) — then, and only then, the PENDING-ARMS.md lines
(opened 2026-07-27 ×2) flip to closed in a separate docs commit.

## Test plan

- [x] `actionlint` clean on both changed workflow files (individually, exit 0)
- [x] `python3 scripts/lint_workflow_timeout_floor.py` — repo-wide clean (118 jobs, floor 10m)
- [x] `python3 scripts/lint_workflow_errexit_decap.py` — repo-wide clean (90 files, 409 run-blocks, errexit-immune)
- [x] `pytest scripts/tests/test_lint_workflow_errexit_decap.py scripts/tests/test_lint_workflow_timeout_floor.py` — 29 passed
- [x] Local end-to-end rehearsal of the new gate's final step (bad/good/ignored files mixed) — correct red/green/skip
- [x] `black --check` measured locally against the removed step's exact scope — 3/22 red, cited above
- [x] husky pre-commit + pre-push — both green on this branch

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>