### PR TITLE
feat(imigrasi-mirror): add /berita news index as a daily page (v2 item 2)

### DIFF
--- a/scripts/imigrasi_mirror/README.md
+++ b/scripts/imigrasi_mirror/README.md
@@ -1,6 +1,6 @@
 # imigrasi.go.id scoped mirror + diff-alert
 
-**Scope: NOT a full-site copy.** ~123 pages that feed the Bali Zero visa
+**Scope: NOT a full-site copy.** ~124 pages that feed the Bali Zero visa
 engine, versioned daily/weekly, with a Telegram alert when one of them
 changes. The value is the repeated crawl + diff, not a one-off copy
 (cicatrix W90: "anche il ground-truth invecchia" — a static snapshot goes
@@ -13,6 +13,7 @@ stale the moment Imigrasi edits a list; this exists to catch that edit).
 | VoA/BVK/Calling subject lists + parent | 4 | daily | `/wna/daftar-negara-voa-bvk-calling-visa[/...]` |
 | FAQ (documented for its OWN staleness, not trusted) | 1 | daily | `/faq/visa/negara-mana-saja...e-voa` |
 | Visa catalog index | 1 | daily | `/wna/daftar-visa-indonesia` |
+| News/announcement index (v2 — removals announced here first) | 1 | daily | `/berita` |
 | Regional kanim mirrors (schema counter-proof) | 3 | daily | depok / bontang / ngurah rai |
 | Per-visa-code detail pages | 114 | weekly | `/wna/daftar-visa-indonesia/{CODE}` |
 
@@ -24,13 +25,16 @@ dependency chain so it can run standalone from cron). Re-check with:
 scripts/imigrasi_mirror/run-mirror.sh --verify-codes
 ```
 
-All 123 URLs in `urls.py` were verified live (WebFetch, 200, real content)
-on 2026-08-08 before being committed — see the module docstring.
+All 124 URLs in `urls.py` were verified live (200, real content) before being
+committed — 123 on 2026-08-08, the `/berita` v2 index on 2026-08-09. `/berita`
+was also extraction-stability probed (identical extract text across two fetches
+3s apart) so the daily diff fires only on a genuinely new headline, never on
+volatile page furniture. See the module docstring.
 
 ## Cadence (coded, NOT yet installed as cron)
 
 ```
-run-mirror.sh --tier daily     # the 9 pages that "morde" — run this one daily
+run-mirror.sh --tier daily     # the 10 pages that "morde" — run this one daily
 run-mirror.sh --tier weekly    # the 114 per-code pages — run this one weekly
 run-mirror.sh --tier all       # everything in one pass
 run-mirror.sh --select parent,voa,bvk,calling,faq-evoa   # ad-hoc subset

--- a/scripts/imigrasi_mirror/urls.py
+++ b/scripts/imigrasi_mirror/urls.py
@@ -1,13 +1,17 @@
 r"""Canonical URL catalog for the imigrasi.go.id scoped mirror.
 
-Scope v1 (Zero mandate, 2026-08-08): NOT a full-site copy. Only the pages that
+Scope (Zero mandate, 2026-08-08): NOT a full-site copy. Only the pages that
 feed the Bali Zero visa engine — the VoA/BVK/Calling subject lists, the
 per-visa-code catalog, and three regional-office mirrors as a counter-proof
-that the schema is uniform. ~123 pages total (9 "daily" + 114 "weekly").
+that the schema is uniform. v2 (2026-08-09) adds the national `/berita` news
+index as a daily page — where a subject removal (e.g. San Marino) is announced
+first, before the subject lists are edited. ~124 pages total (10 "daily" +
+114 "weekly").
 
-Every URL below was verified live (WebFetch, 200, real content — not a 404)
-on 2026-08-08 before being committed here (anti-hallucination discipline,
-CLAUDE.md §6). Do not add a URL to this file without the same verification.
+Every URL below was verified live (200, real content — not a 404) before being
+committed here (anti-hallucination discipline, CLAUDE.md §6): the v1 set on
+2026-08-08, the `/berita` v2 index on 2026-08-09. Do not add a URL to this file
+without the same verification.
 
 The ~114 per-visa-code identifiers are a COPY of the codes in the repo's own
 seed file, not a live import — this keeps the mirror module dependency-free
@@ -73,11 +77,12 @@ class Page:
     slug: str
     label: str
     tier: str  # "daily" | "weekly"
-    category: str  # "list" | "faq" | "index" | "regional" | "code"
+    category: str  # "list" | "faq" | "index" | "berita" | "regional" | "code"
 
 
-# --- daily tier: the pages that "morde" (bite) — subject lists, FAQ, index, --
-# --- and 3 regional mirrors as a schema counter-proof.                     --
+# --- daily tier: the pages that "morde" (bite) — subject lists, FAQ, visa    --
+# --- index, the /berita news index (v2), and 3 regional mirrors as a         --
+# --- schema counter-proof.                                                   --
 DAILY_PAGES: list[Page] = [
     Page(
         id="parent",
@@ -126,6 +131,14 @@ DAILY_PAGES: list[Page] = [
         label="Indice Daftar Visa Indonesia",
         tier="daily",
         category="index",
+    ),
+    Page(
+        id="berita",
+        url=f"{BASE}/berita",
+        slug="berita-index",
+        label="Indice Berita (news/annunci — dove le rimozioni si annunciano per prime)",
+        tier="daily",
+        category="berita",
     ),
     Page(
         id="regional-depok",


### PR DESCRIPTION
## What

Adds the national `/berita` news index to the imigrasi.go.id scoped mirror's **daily tier** (10th daily page, category `berita`). This is v2 item 2 of the "v2 completo, uno alla volta, prove-live ciascuno" mandate.

## Why

The daily tier watches the VoA/BVK/Calling subject lists directly. But Imigrasi announces a change (a country dropped from VoA — the San Marino class of event) on `/berita` **before** the subject lists are edited, so `/berita` is the earliest signal.

## Prove-live (real fetch through the mirror, throwaway data-root)

- **Extraction-stability probe**: `extract_text` byte-identical across two live fetches 3s apart (sha `e9c09768cdbb` both) — page uses absolute dates, no volatile furniture → the daily diff fires only on a genuinely new headline, never a false positive (W116 risk excluded).
- **Innocence**: prior snapshot identical → `diffs=0, nothing_to_commit`.
- **Guilt**: prior snapshot mutated → `diffs=1 (+0/-1)` detected → would alert.
- Captured 1005 bytes of real content (headlines + dates), not a 404.
- `--selftest` PASS (RC=0); module imports, catalog asserts pass (10 daily / 124 total).
- Independent verification (backend-verifier, generator≠grader): 5/5 PASS.

## Notes

`category` is human/telemetry metadata only — no code branches on it, so `berita` is inert to the crawl/diff/alert logic. berita rides the existing `com.nuzantara.imigrasi-mirror.daily` LaunchAgent; **nothing new to arm**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)