### PR TITLE
probe(ci): guilt check for prettier-changed-files.yml — DO NOT MERGE

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "ms-python.python",
+      "ms-python.python",
     "ms-python.vscode-pylance",
     "ms-python.debugpy",
     "charliermarsh.ruff",


### PR DESCRIPTION
Throwaway proof-of-armed probe for `.github/workflows/prettier-changed-files.yml` (#3848).

One tracked file in scope, `.vscode/extensions.json`, was already prettier-conformant on `main` — this PR deliberately mis-indents its first array entry (verified locally with `prettier --check` before pushing: exit 1, file flagged).

Expect: `prettier --check (changed files)` goes RED, naming `.vscode/extensions.json` in the log.

**No auto-merge armed. This PR will be closed without merging and the branch deleted once the check result is confirmed.**