### PR TITLE
feat(imigrasi-mirror): watch kemenimipas Permen legal-doc listing (v2 item 3)

### DIFF
--- a/scripts/imigrasi_mirror/README.md
+++ b/scripts/imigrasi_mirror/README.md
@@ -1,6 +1,6 @@
 # imigrasi.go.id scoped mirror + diff-alert
 
-**Scope: NOT a full-site copy.** ~124 pages that feed the Bali Zero visa
+**Scope: NOT a full-site copy.** ~125 pages that feed the Bali Zero visa
 engine, versioned daily/weekly, with a Telegram alert when one of them
 changes. The value is the repeated crawl + diff, not a one-off copy
 (cicatrix W90: "anche il ground-truth invecchia" — a static snapshot goes
@@ -14,8 +14,20 @@ stale the moment Imigrasi edits a list; this exists to catch that edit).
 | FAQ (documented for its OWN staleness, not trusted) | 1 | daily | `/faq/visa/negara-mana-saja...e-voa` |
 | Visa catalog index | 1 | daily | `/wna/daftar-visa-indonesia` |
 | News/announcement index (v2 — removals announced here first) | 1 | daily | `/berita` |
+| Kemenimipas Permen legal-doc listing (v2 — enacts visa rule changes) | 1 | daily | `kemenimipas.go.id/produk-hukum/peraturan-menteri-imipas` |
 | Regional kanim mirrors (schema counter-proof) | 3 | daily | depok / bontang / ngurah rai |
 | Per-visa-code detail pages | 114 | weekly | `/wna/daftar-visa-indonesia/{CODE}` |
+
+**The Permen listing needs a page-specific extractor** (`extract_produk_hukum`
+in `extract.py`, selected by `Page.extractor="produk_hukum"`). The generic
+`extract_text` is wrong for it two ways, both verified live: the regulation
+table is wrapped in a Joomla `<form>` that the generic extractor strips (so it
+would silently watch the footer menu — the WRONG signal), and each row carries
+a volatile `Dilihat: N` view counter that would fire a false diff on every
+crawl. The custom extractor pulls only the title links, so a new Permen = a new
+line and nothing else moves. It lives on the NEW ministry domain
+`kemenimipas.go.id` (the immigration legal portal moved there —
+`imigrasi.go.id/produk-hukum` is a 404).
 
 The 114 codes are a **copy** of `apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py`,
 not a live import (keeps this module free of the backend-rag app's
@@ -25,16 +37,17 @@ dependency chain so it can run standalone from cron). Re-check with:
 scripts/imigrasi_mirror/run-mirror.sh --verify-codes
 ```
 
-All 124 URLs in `urls.py` were verified live (200, real content) before being
-committed — 123 on 2026-08-08, the `/berita` v2 index on 2026-08-09. `/berita`
-was also extraction-stability probed (identical extract text across two fetches
-3s apart) so the daily diff fires only on a genuinely new headline, never on
-volatile page furniture. See the module docstring.
+All 125 URLs in `urls.py` were verified live (200, real content) before being
+committed — 123 on 2026-08-08, the `/berita` and kemenimipas Permen v2 pages on
+2026-08-09. Both v2 pages were extraction-stability probed (identical extract
+text across two fetches seconds apart) so the daily diff fires only on genuinely
+new content, never on volatile page furniture (view counters, timestamps). See
+the module docstring.
 
 ## Cadence (coded, NOT yet installed as cron)
 
 ```
-run-mirror.sh --tier daily     # the 10 pages that "morde" — run this one daily
+run-mirror.sh --tier daily     # the 11 pages that "morde" — run this one daily
 run-mirror.sh --tier weekly    # the 114 per-code pages — run this one weekly
 run-mirror.sh --tier all       # everything in one pass
 run-mirror.sh --select parent,voa,bvk,calling,faq-evoa   # ad-hoc subset

--- a/scripts/imigrasi_mirror/crawler.py
+++ b/scripts/imigrasi_mirror/crawler.py
@@ -26,7 +26,7 @@ from urllib import robotparser
 
 import httpx
 
-from extract import extract_text
+from extract import extract_for
 from urls import Page
 
 USER_AGENT = "BaliZero-visa-mirror/1.0 (+https://balizero.com; contact: zero@balizero.com)"
@@ -112,7 +112,7 @@ async def _fetch_one(
             continue
 
         if resp.status_code == 200:
-            text = extract_text(resp.text)
+            text = extract_for(page.extractor, resp.text)
             return FetchResult(page, True, 200, text, None, len(resp.content))
 
         if resp.status_code in RETRYABLE_STATUS:

--- a/scripts/imigrasi_mirror/extract.py
+++ b/scripts/imigrasi_mirror/extract.py
@@ -73,3 +73,45 @@ def extract_text(html: str) -> str:
     lines = [ln.strip() for ln in text.splitlines()]
     lines = [ln for ln in lines if ln]
     return "\n".join(lines)
+
+
+def extract_produk_hukum(html: str) -> str:
+    """Kemenimipas legal-document listing (Joomla category view).
+
+    `extract_text` is WRONG for this page for two independent reasons, both
+    verified live 2026-08-09:
+
+    1. The regulation table lives inside `<form id="adminForm">` (Joomla's
+       sort/filter form). `extract_text` strips every `<form>` as boilerplate,
+       so the whole listing is destroyed and the "largest block" it keeps is
+       the footer menu (386 chars of ministry address + category links) —
+       stable, but the WRONG signal: a new Permen would never be detected
+       (cicatrix family #3 UNDER-match / W99 — a guard that looks green while
+       watching nothing).
+    2. Every row carries a volatile `Dilihat: N` view counter that changes on
+       every crawl — diffing the full rendered row would fire an alert every
+       run (W116, an alarm nobody reads).
+
+    So extract ONLY the regulation title links (`table.category td.list-title
+    a`): "Permenimipas No 15 Tahun 2025 tentang ...", one per line, newest
+    first (document order). A new regulation = a new line; view counters and
+    footer never appear. If the Joomla theme ever changes, the selector stops
+    matching and this returns "" — which diffs LOUDLY against the prior
+    (all rows removed) rather than silently watching nothing.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    titles = [a.get_text(strip=True) for a in soup.select("table.category td.list-title a")]
+    return "\n".join(t for t in titles if t)
+
+
+# Per-page extractor registry. `Page.extractor` selects one; unknown names
+# (and the default) fall back to the generic `extract_text`.
+_EXTRACTORS = {
+    "default": extract_text,
+    "produk_hukum": extract_produk_hukum,
+}
+
+
+def extract_for(name: str, html: str) -> str:
+    """Dispatch to the page's declared extractor (default: generic)."""
+    return _EXTRACTORS.get(name, extract_text)(html)

--- a/scripts/imigrasi_mirror/run.py
+++ b/scripts/imigrasi_mirror/run.py
@@ -252,7 +252,7 @@ def selftest() -> int:
     """No-network unit checks (guilt+innocence pairs, tg_notify convention)."""
     import tempfile
 
-    from extract import extract_text
+    from extract import extract_produk_hukum, extract_text
 
     failures: list[str] = []
 
@@ -281,6 +281,41 @@ def selftest() -> int:
     text2 = extract_text(html_no_main)
     check("fallback body keeps real content", "Real content here" in text2)
     check("fallback body strips nav (innocence of a bare-body world)", "Menu" not in text2)
+
+    # --- extract_produk_hukum: kemenimipas Joomla legal-doc listing ---------
+    # The listing table lives inside <form id="adminForm"> (which extract_text
+    # strips) and each row carries a volatile "Dilihat: N" view counter (which
+    # extract_text would false-diff on). extract_produk_hukum pulls ONLY the
+    # title links, so it survives the form and drops the counter.
+    ph_html = """
+    <html><body>
+      <form id="adminForm">
+        <table class="category table table-bordered"><tbody>
+          <tr class="cat-list-row0"><td class="list-title">
+            <a href="/x/15">Permenimipas No 15 Tahun 2025 tentang Politeknik</a>
+          </td><td class="list-hits">Dilihat: 2720</td></tr>
+          <tr class="cat-list-row1"><td class="list-title">
+            <a href="/x/10">Permenimipas No 10 Tahun 2025 tentang penambahan daftar negara bebas visa</a>
+          </td><td class="list-hits">Dilihat: 2994</td></tr>
+        </tbody></table>
+      </form>
+      <footer>KEMENTERIAN IMIGRASI DAN PEMASYARAKATAN — Jakarta Selatan</footer>
+    </body></html>
+    """
+    ph = extract_produk_hukum(ph_html)
+    check("produk-hukum captures BOTH regulation titles (guilt)",
+          "Permenimipas No 15 Tahun 2025" in ph and "Permenimipas No 10 Tahun 2025" in ph)
+    check("produk-hukum drops the volatile view counter (innocence — no false diff)",
+          "Dilihat" not in ph and "2720" not in ph)
+    check("produk-hukum drops the footer menu (innocence — watches the list, not chrome)",
+          "KEMENTERIAN IMIGRASI" not in ph)
+    # a page WITHOUT the category table -> "" (loud empty diff, never a crash):
+    ph_empty = extract_produk_hukum("<html><body><div>no listing here</div></body></html>")
+    check("produk-hukum on a table-less page -> empty (loud, not a crash)", ph_empty == "")
+    # and generic extract_text is BLIND to this listing (proves why we need the
+    # custom one): the <form> is stripped, so the titles never survive.
+    check("generic extract_text is blind to the form-wrapped listing (why custom exists)",
+          "Permenimipas No 15" not in extract_text(ph_html))
 
     # --- compute_diff --------------------------------------------------------
     old = "line1\nline2\nline3"

--- a/scripts/imigrasi_mirror/urls.py
+++ b/scripts/imigrasi_mirror/urls.py
@@ -3,15 +3,17 @@ r"""Canonical URL catalog for the imigrasi.go.id scoped mirror.
 Scope (Zero mandate, 2026-08-08): NOT a full-site copy. Only the pages that
 feed the Bali Zero visa engine — the VoA/BVK/Calling subject lists, the
 per-visa-code catalog, and three regional-office mirrors as a counter-proof
-that the schema is uniform. v2 (2026-08-09) adds the national `/berita` news
-index as a daily page — where a subject removal (e.g. San Marino) is announced
-first, before the subject lists are edited. ~124 pages total (10 "daily" +
+that the schema is uniform. v2 (2026-08-09) adds two more daily pages: the
+national `/berita` news index — where a subject removal (e.g. San Marino) is
+announced first, before the subject lists are edited — and the kemenimipas
+Peraturan Menteri legal-doc listing (the legal instrument that enacts a visa
+rule change, feeding the Visa Oracle RulePack). ~125 pages total (11 "daily" +
 114 "weekly").
 
 Every URL below was verified live (200, real content — not a 404) before being
 committed here (anti-hallucination discipline, CLAUDE.md §6): the v1 set on
-2026-08-08, the `/berita` v2 index on 2026-08-09. Do not add a URL to this file
-without the same verification.
+2026-08-08, the `/berita` and kemenimipas Permen v2 pages on 2026-08-09. Do not
+add a URL to this file without the same verification.
 
 The ~114 per-visa-code identifiers are a COPY of the codes in the repo's own
 seed file, not a live import — this keeps the mirror module dependency-free
@@ -77,12 +79,16 @@ class Page:
     slug: str
     label: str
     tier: str  # "daily" | "weekly"
-    category: str  # "list" | "faq" | "index" | "berita" | "regional" | "code"
+    category: str  # "list" | "faq" | "index" | "berita" | "produk-hukum" | "regional" | "code"
+    # Which extractor in extract.py handles this page's HTML. Default = the
+    # generic content-block extractor; a page on a differently-structured CMS
+    # (e.g. the kemenimipas Joomla legal-doc listing) names a specific one.
+    extractor: str = "default"
 
 
 # --- daily tier: the pages that "morde" (bite) — subject lists, FAQ, visa    --
-# --- index, the /berita news index (v2), and 3 regional mirrors as a         --
-# --- schema counter-proof.                                                   --
+# --- index, the /berita news index + kemenimipas Permen listing (v2), and    --
+# --- 3 regional mirrors as a schema counter-proof.                           --
 DAILY_PAGES: list[Page] = [
     Page(
         id="parent",
@@ -139,6 +145,23 @@ DAILY_PAGES: list[Page] = [
         label="Indice Berita (news/annunci — dove le rimozioni si annunciano per prime)",
         tier="daily",
         category="berita",
+    ),
+    Page(
+        # kemenimipas.go.id, NOT imigrasi.go.id — the legal-documents portal
+        # moved to the new ministry domain (imigrasi.go.id/produk-hukum is 404).
+        # The Permen Imipas listing is where a visa rule change (e.g. Permen
+        # 9 & 10/2025 added visa-free countries — the San Marino class — and
+        # 14/2025 the zero-tariff services) is enacted, feeding the Visa Oracle
+        # RulePack thresholds. Custom extractor: the listing lives inside a
+        # Joomla <form> the generic extractor strips, with volatile view
+        # counters the generic extractor would false-diff on — see extract.py.
+        id="produk-hukum-permen",
+        url="https://kemenimipas.go.id/produk-hukum/peraturan-menteri-imipas",
+        slug="produk-hukum-permen",
+        label="Kemenimipas — Peraturan Menteri (produk hukum, alimenta soglie RulePack)",
+        tier="daily",
+        category="produk-hukum",
+        extractor="produk_hukum",
     ),
     Page(
         id="regional-depok",


### PR DESCRIPTION
## What

Adds the **Peraturan Menteri Imipas** listing as an 11th daily page — the legal instrument that ENACTS a visa rule change (Permen 9 & 10/2025 added visa-free countries — the San Marino class — and 14/2025 the zero-tariff services), feeding the Visa Oracle RulePack thresholds. On the NEW ministry domain `kemenimipas.go.id` (`imigrasi.go.id/produk-hukum` is a 404).

## Design — per-page extractor registry

The generic `extract_text` is wrong for this page two ways (both verified live 2026-08-09):
1. The regulation table is wrapped in a Joomla `<form id="adminForm">`, which `extract_text` strips as boilerplate → it would silently keep the footer menu (the WRONG signal; a new Permen would never be detected — the W99 / family-#3 "green while watching nothing" trap).
2. Each row carries a volatile `Dilihat: N` view counter that would fire a false diff on every crawl (W116, an alarm nobody reads).

So: `extract.py` gains `extract_produk_hukum` (pulls ONLY `table.category td.list-title a` — the title links) + an `_EXTRACTORS` registry + `extract_for()` dispatcher (default + unknown names fall back to `extract_text`); `Page` gains an optional `extractor` field (default `"default"` — every existing page unchanged); `crawler.py` calls `extract_for(page.extractor, resp.text)`. If the Joomla theme changes, the selector stops matching and it returns `""` — which diffs LOUDLY (all rows removed) rather than silently watching nothing.

## Prove-live (real fetch through the mirror, throwaway data-root)

- extraction-stability probe: 1389-char extract identical across two fetches, **zero `Dilihat` counters**, 10 real Permen titles.
- **innocence**: identical prior → `diffs=0, nothing_to_commit`.
- **guilt**: mutated prior (simulated new Permen 16) → `diffs=1` detected → would alert.
- `--selftest` 17/17 PASS incl. 5 new guilt+innocence produk-hukum checks; generic `extract_text` confirmed blind to the form-wrapped listing.
- Independent verification (backend-verifier, generator≠grader): 4/4 PASS, no regression to `extract_text`.

Rides the existing `com.nuzantara.imigrasi-mirror.daily` cron; **nothing new to arm**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)