### PR TITLE
feat(imigrasi-mirror): add e-Visa eVOA info page as 12th daily page (v2 item 4)

### DIFF
--- a/scripts/imigrasi_mirror/README.md
+++ b/scripts/imigrasi_mirror/README.md
@@ -1,6 +1,6 @@
 # imigrasi.go.id scoped mirror + diff-alert
 
-**Scope: NOT a full-site copy.** ~125 pages that feed the Bali Zero visa
+**Scope: NOT a full-site copy.** ~126 pages that feed the Bali Zero visa
 engine, versioned daily/weekly, with a Telegram alert when one of them
 changes. The value is the repeated crawl + diff, not a one-off copy
 (cicatrix W90: "anche il ground-truth invecchia" — a static snapshot goes
@@ -15,6 +15,7 @@ stale the moment Imigrasi edits a list; this exists to catch that edit).
 | Visa catalog index | 1 | daily | `/wna/daftar-visa-indonesia` |
 | News/announcement index (v2 — removals announced here first) | 1 | daily | `/berita` |
 | Kemenimipas Permen legal-doc listing (v2 — enacts visa rule changes) | 1 | daily | `kemenimipas.go.id/produk-hukum/peraturan-menteri-imipas` |
+| e-Visa eVOA info — applicant-facing fee/requirements/eligible countries (v2 — downstream witness to a rule change) | 1 | daily | `evisa.imigrasi.go.id/front/info/evoa` |
 | Regional kanim mirrors (schema counter-proof) | 3 | daily | depok / bontang / ngurah rai |
 | Per-visa-code detail pages | 114 | weekly | `/wna/daftar-visa-indonesia/{CODE}` |
 
@@ -37,17 +38,17 @@ dependency chain so it can run standalone from cron). Re-check with:
 scripts/imigrasi_mirror/run-mirror.sh --verify-codes
 ```
 
-All 125 URLs in `urls.py` were verified live (200, real content) before being
-committed — 123 on 2026-08-08, the `/berita` and kemenimipas Permen v2 pages on
-2026-08-09. Both v2 pages were extraction-stability probed (identical extract
-text across two fetches seconds apart) so the daily diff fires only on genuinely
-new content, never on volatile page furniture (view counters, timestamps). See
-the module docstring.
+All 126 URLs in `urls.py` were verified live (200, real content) before being
+committed — 123 on 2026-08-08, the `/berita`, kemenimipas Permen and e-Visa
+eVOA v2 pages on 2026-08-09. All three v2 pages were extraction-stability probed
+(identical extract text across two fetches seconds apart) so the daily diff
+fires only on genuinely new content, never on volatile page furniture (view
+counters, timestamps). See the module docstring.
 
 ## Cadence (coded, NOT yet installed as cron)
 
 ```
-run-mirror.sh --tier daily     # the 11 pages that "morde" — run this one daily
+run-mirror.sh --tier daily     # the 12 pages that "morde" — run this one daily
 run-mirror.sh --tier weekly    # the 114 per-code pages — run this one weekly
 run-mirror.sh --tier all       # everything in one pass
 run-mirror.sh --select parent,voa,bvk,calling,faq-evoa   # ad-hoc subset

--- a/scripts/imigrasi_mirror/urls.py
+++ b/scripts/imigrasi_mirror/urls.py
@@ -3,17 +3,19 @@ r"""Canonical URL catalog for the imigrasi.go.id scoped mirror.
 Scope (Zero mandate, 2026-08-08): NOT a full-site copy. Only the pages that
 feed the Bali Zero visa engine — the VoA/BVK/Calling subject lists, the
 per-visa-code catalog, and three regional-office mirrors as a counter-proof
-that the schema is uniform. v2 (2026-08-09) adds two more daily pages: the
+that the schema is uniform. v2 (2026-08-09) adds three more daily pages: the
 national `/berita` news index — where a subject removal (e.g. San Marino) is
-announced first, before the subject lists are edited — and the kemenimipas
+announced first, before the subject lists are edited — the kemenimipas
 Peraturan Menteri legal-doc listing (the legal instrument that enacts a visa
-rule change, feeding the Visa Oracle RulePack). ~125 pages total (11 "daily" +
-114 "weekly").
+rule change, feeding the Visa Oracle RulePack), and the applicant-facing
+e-Visa eVOA info page (fee, requirements, eligible-country list — the
+downstream-of-policy surface the client actually reads, a second independent
+witness to a rule change). ~126 pages total (12 "daily" + 114 "weekly").
 
 Every URL below was verified live (200, real content — not a 404) before being
 committed here (anti-hallucination discipline, CLAUDE.md §6): the v1 set on
-2026-08-08, the `/berita` and kemenimipas Permen v2 pages on 2026-08-09. Do not
-add a URL to this file without the same verification.
+2026-08-08, the `/berita`, kemenimipas Permen and e-Visa eVOA v2 pages on
+2026-08-09. Do not add a URL to this file without the same verification.
 
 The ~114 per-visa-code identifiers are a COPY of the codes in the repo's own
 seed file, not a live import — this keeps the mirror module dependency-free
@@ -79,7 +81,7 @@ class Page:
     slug: str
     label: str
     tier: str  # "daily" | "weekly"
-    category: str  # "list" | "faq" | "index" | "berita" | "produk-hukum" | "regional" | "code"
+    category: str  # "list" | "faq" | "index" | "berita" | "produk-hukum" | "evisa" | "regional" | "code"
     # Which extractor in extract.py handles this page's HTML. Default = the
     # generic content-block extractor; a page on a differently-structured CMS
     # (e.g. the kemenimipas Joomla legal-doc listing) names a specific one.
@@ -87,8 +89,8 @@ class Page:
 
 
 # --- daily tier: the pages that "morde" (bite) — subject lists, FAQ, visa    --
-# --- index, the /berita news index + kemenimipas Permen listing (v2), and    --
-# --- 3 regional mirrors as a schema counter-proof.                           --
+# --- index, the /berita news index + kemenimipas Permen listing + e-Visa     --
+# --- eVOA info (v2), and 3 regional mirrors as a schema counter-proof.       --
 DAILY_PAGES: list[Page] = [
     Page(
         id="parent",
@@ -162,6 +164,24 @@ DAILY_PAGES: list[Page] = [
         tier="daily",
         category="produk-hukum",
         extractor="produk_hukum",
+    ),
+    Page(
+        # evisa.imigrasi.go.id, NOT www.imigrasi.go.id — the applicant-facing
+        # e-Visa portal is a separate subdomain. This is the eVOA/Visitor-Visa
+        # info page a foreign traveller actually reads: the fee ("IDR 500.000"),
+        # the document requirements, and the full eligible-country list. It is
+        # DOWNSTREAM of the policy pages above — when a Permen changes a fee or
+        # adds a country, this is where the change surfaces to the public, so a
+        # diff here is a second, independent witness to the same rule change.
+        # Generic extractor: the page is a plain content block (extraction-
+        # stability probed 2026-08-09 — identical extract across two fetches,
+        # no volatile view counters), so no page-specific extractor is needed.
+        id="evisa-evoa-info",
+        url="https://evisa.imigrasi.go.id/front/info/evoa",
+        slug="evisa-evoa-info",
+        label="e-Visa — eVOA/Visitor Visa info (fee, requisiti, paesi eleggibili)",
+        tier="daily",
+        category="evisa",
     ),
     Page(
         id="regional-depok",


### PR DESCRIPTION
## What

v2 item 4 of the imigrasi.go.id scoped mirror: add the applicant-facing **e-Visa eVOA info page** (`evisa.imigrasi.go.id/front/info/evoa`) as the **12th daily page**. Adds only a `Page(...)` row to `urls.py` (default extractor, new `category="evisa"`) + doc updates in `README.md`. `extract.py` and `crawler.py` are untouched.

## Why

It is the surface a foreign traveller actually reads — the Visitor-Visa fee (`IDR 500.000,00`), the document requirements, and the full ~90-country eligible list. It sits **downstream** of the policy pages already mirrored (the VOA/BVK/Calling subject lists + the kemenimipas Permen listing shipped in items 2–3), so a diff here is a **second, independent witness** to the same rule change.

## No new extractor (W116 checked)

This page is a plain content block, not a Joomla `<form>` like the Permen listing. Extraction-stability probed 2026-08-09: identical extract across two fetches ~5s apart (16556 chars, sha `b797fc8`), **zero** volatile view-counters (`Dilihat`) in the extract → the generic `extract_text` is correct and immune to the false-diff class. So no `extractor=` argument, no touch to `extract.py`/`crawler.py`.

## Prove-live (throwaway data-root, real fetches — not theatre)

| check | result |
|---|---|
| first-capture (no prior) | `captured=1 diffs=0` |
| innocence (real identical prior) | `diffs=0` |
| guilt (mutated prior) | `diffs=1` → `DIFF evisa-evoa-info vs prior: +0/-1` |
| `--selftest` | 17/17 PASS |
| independent verifier (generator≠grader) | live 200, extract STABLE (sha `b797fc8` × 2), real content (49× "Visitor Visa", fee, docs list, ~90-country list), no collateral edits |

## Consumer

Rides the existing daily LaunchAgent on Mini (`com.nuzantara.imigrasi-mirror.daily`) — nothing new to arm. Post-merge the Mini main checkout is ff-only-pulled so the new page enters the daily crawl.

Counts: **12 daily / 114 weekly / 126 total.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
