### PR TITLE
fix(ci): cover prettier-changed-files.yml in main-push-failure-watch

### DIFF
--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -162,6 +162,18 @@ on:
       # exact shape of superscar #2 — the queue's own ejection detector going
       # silently dead would be invisible.
       - merge-queue-watch
+      # Added 2026-08-09: prettier-changed-files.yml (built #3848) triggers
+      # only on pull_request/merge_group — same shape as `actionlint` and
+      # `hot-zone-enforcement` above, which are already in this list despite
+      # never firing a push/schedule-on-main workflow_run event either. The
+      # `alert` job's `if:` below can therefore never match a completed run
+      # of this workflow, same as for those two — that is not a gap this
+      # entry needs to solve: check_watcher_coverage.py's contract is pure
+      # name-set membership against this file's declared `name:` (see its
+      # own docstring), not reachability of the alert path, and this file's
+      # header comment already states the list is deliberately
+      # over-inclusive for exactly this reason.
+      - Prettier (changed files)
     types: [completed]
   # Task #41 (2026-07-26): see the `verdict-liveness` job below for why this
   # exists — a reactive workflow_run watcher structurally cannot see the


### PR DESCRIPTION
## Summary

`scripts/check_watcher_coverage.py`'s self-conformance check (found as the non-required "check" job while working PR #3855) flagged `Prettier (changed files)` (built #3848) as missing from `main-push-failure-watch.yml`'s `workflows:` list — family #2 (esiste≠armato): the gate exists but nothing watches for it failing on a main-targeting run.

## Investigation before touching (per the instruction: mirror the found convention, don't invent one)

Read `check_watcher_coverage.py`'s contract first: it's pure name-set equality between every workflow's top-level `name:` and the watcher's declared `workflows:` list — nothing about trigger type or reachability.

Then checked whether `prettier-changed-files.yml`'s trigger shape (`pull_request` + `merge_group` only, no `push`/`schedule`) makes coverage meaningless here — the watcher's `alert` job only fires on `workflow_run.event in (push, schedule)` on `main`, so a `merge_group`-only workflow's runs can never satisfy that filter. Checked whether this is a NEW problem or an existing accepted shape: `actionlint` and `hot-zone-enforcement` are already in the watched list with the exact same `merge_group`+`pull_request`-only trigger, and the watcher's own header comment says the list is deliberately over-inclusive for exactly this reason (list membership avoids a push/schedule judgment call; real filtering lives in the job `if:`). So this is a purely mechanical addition matching an established, already-shipped convention — not a case that needed a stop-and-report.

## Change

- `.github/workflows/main-push-failure-watch.yml`: appended `Prettier (changed files)` to `on.workflow_run.workflows:`, with a comment explaining the trigger-shape non-issue (mirrors the existing convention, doesn't invent new prose).

## Verification

- `python3 scripts/check_watcher_coverage.py` (local, `pyyaml` in an isolated venv): `✓ watcher-coverage: all 90 live workflow(s) covered by main-push-failure-watch.yml`, RC=0 (was 1 violation before this change).
- `actionlint .github/workflows/main-push-failure-watch.yml`: clean.

## Test plan

- [x] `check_watcher_coverage.py` reports 0 violations locally
- [x] `actionlint` clean
- [ ] The non-required "Watcher coverage (main-push-failure-watch self-conformance)" check goes green on this PR
- [ ] `actionlint` + `Hot-zone enforcement` required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)