### PR TITLE
feat(imigrasi-mirror): add TPI entry-point list (122 checkpoints) as 13th daily page (v2 item 5)

### DIFF
--- a/scripts/imigrasi_mirror/README.md
+++ b/scripts/imigrasi_mirror/README.md
@@ -1,6 +1,6 @@
 # imigrasi.go.id scoped mirror + diff-alert
 
-**Scope: NOT a full-site copy.** ~126 pages that feed the Bali Zero visa
+**Scope: NOT a full-site copy.** ~127 pages that feed the Bali Zero visa
 engine, versioned daily/weekly, with a Telegram alert when one of them
 changes. The value is the repeated crawl + diff, not a one-off copy
 (cicatrix W90: "anche il ground-truth invecchia" — a static snapshot goes
@@ -11,6 +11,7 @@ stale the moment Imigrasi edits a list; this exists to catch that edit).
 | Category | Count | Tier | Examples |
 |---|---|---|---|
 | VoA/BVK/Calling subject lists + parent | 4 | daily | `/wna/daftar-negara-voa-bvk-calling-visa[/...]` |
+| TPI entry-point list — 122 checkpoints where VoA is issued (v2 — WHERE vs the subject lists' WHO) | 1 | daily | `.../titik-masuk-bagi-pemegang-e-voa` |
 | FAQ (documented for its OWN staleness, not trusted) | 1 | daily | `/faq/visa/negara-mana-saja...e-voa` |
 | Visa catalog index | 1 | daily | `/wna/daftar-visa-indonesia` |
 | News/announcement index (v2 — removals announced here first) | 1 | daily | `/berita` |
@@ -38,17 +39,17 @@ dependency chain so it can run standalone from cron). Re-check with:
 scripts/imigrasi_mirror/run-mirror.sh --verify-codes
 ```
 
-All 126 URLs in `urls.py` were verified live (200, real content) before being
-committed — 123 on 2026-08-08, the `/berita`, kemenimipas Permen and e-Visa
-eVOA v2 pages on 2026-08-09. All three v2 pages were extraction-stability probed
-(identical extract text across two fetches seconds apart) so the daily diff
-fires only on genuinely new content, never on volatile page furniture (view
-counters, timestamps). See the module docstring.
+All 127 URLs in `urls.py` were verified live (200, real content) before being
+committed — 123 on 2026-08-08, the `/berita`, kemenimipas Permen, e-Visa eVOA
+and TPI entry-point v2 pages on 2026-08-09. All four v2 pages were
+extraction-stability probed (identical extract text across two fetches seconds
+apart) so the daily diff fires only on genuinely new content, never on volatile
+page furniture (view counters, timestamps). See the module docstring.
 
 ## Cadence (coded, NOT yet installed as cron)
 
 ```
-run-mirror.sh --tier daily     # the 12 pages that "morde" — run this one daily
+run-mirror.sh --tier daily     # the 13 pages that "morde" — run this one daily
 run-mirror.sh --tier weekly    # the 114 per-code pages — run this one weekly
 run-mirror.sh --tier all       # everything in one pass
 run-mirror.sh --select parent,voa,bvk,calling,faq-evoa   # ad-hoc subset

--- a/scripts/imigrasi_mirror/urls.py
+++ b/scripts/imigrasi_mirror/urls.py
@@ -3,19 +3,22 @@ r"""Canonical URL catalog for the imigrasi.go.id scoped mirror.
 Scope (Zero mandate, 2026-08-08): NOT a full-site copy. Only the pages that
 feed the Bali Zero visa engine — the VoA/BVK/Calling subject lists, the
 per-visa-code catalog, and three regional-office mirrors as a counter-proof
-that the schema is uniform. v2 (2026-08-09) adds three more daily pages: the
+that the schema is uniform. v2 (2026-08-09) adds four more daily pages: the
 national `/berita` news index — where a subject removal (e.g. San Marino) is
 announced first, before the subject lists are edited — the kemenimipas
 Peraturan Menteri legal-doc listing (the legal instrument that enacts a visa
-rule change, feeding the Visa Oracle RulePack), and the applicant-facing
+rule change, feeding the Visa Oracle RulePack), the applicant-facing
 e-Visa eVOA info page (fee, requirements, eligible-country list — the
 downstream-of-policy surface the client actually reads, a second independent
-witness to a rule change). ~126 pages total (12 "daily" + 114 "weekly").
+witness to a rule change), and the TPI entry-point list — the 122 immigration
+checkpoints (airports / seaports / land-border posts) where VoA is actually
+granted, the operational counterpart to the subject lists (WHO may get VoA vs
+WHERE it is issued). ~127 pages total (13 "daily" + 114 "weekly").
 
 Every URL below was verified live (200, real content — not a 404) before being
 committed here (anti-hallucination discipline, CLAUDE.md §6): the v1 set on
-2026-08-08, the `/berita`, kemenimipas Permen and e-Visa eVOA v2 pages on
-2026-08-09. Do not add a URL to this file without the same verification.
+2026-08-08, the `/berita`, kemenimipas Permen, e-Visa eVOA and TPI entry-point
+v2 pages on 2026-08-09. Do not add a URL to this file without the same verification.
 
 The ~114 per-visa-code identifiers are a COPY of the codes in the repo's own
 seed file, not a live import — this keeps the mirror module dependency-free
@@ -81,16 +84,17 @@ class Page:
     slug: str
     label: str
     tier: str  # "daily" | "weekly"
-    category: str  # "list" | "faq" | "index" | "berita" | "produk-hukum" | "evisa" | "regional" | "code"
+    category: str  # "list" | "faq" | "index" | "berita" | "produk-hukum" | "evisa" | "tpi" | "regional" | "code"
     # Which extractor in extract.py handles this page's HTML. Default = the
     # generic content-block extractor; a page on a differently-structured CMS
     # (e.g. the kemenimipas Joomla legal-doc listing) names a specific one.
     extractor: str = "default"
 
 
-# --- daily tier: the pages that "morde" (bite) — subject lists, FAQ, visa    --
-# --- index, the /berita news index + kemenimipas Permen listing + e-Visa     --
-# --- eVOA info (v2), and 3 regional mirrors as a schema counter-proof.       --
+# --- daily tier: the pages that "morde" (bite) — subject lists, the TPI       --
+# --- entry-point list, FAQ, visa index, the /berita news index + kemenimipas  --
+# --- Permen listing + e-Visa eVOA info (v2), and 3 regional mirrors as a      --
+# --- schema counter-proof.                                                    --
 DAILY_PAGES: list[Page] = [
     Page(
         id="parent",
@@ -123,6 +127,23 @@ DAILY_PAGES: list[Page] = [
         label="Lista Calling Visa",
         tier="daily",
         category="list",
+    ),
+    Page(
+        # The operational counterpart to the subject lists above: WHO may get
+        # VoA (the subject lists) vs WHERE it is actually issued (this list of
+        # 122 immigration checkpoints — 16 airports, 11 land-border posts, 95
+        # seaports — "titik masuk bagi pemegang e-VOA" = entry points for e-VOA
+        # holders). A checkpoint added/removed here changes where a Bali Zero
+        # client can physically land on VoA. Sibling of the VoA/BVK/Calling
+        # section. Generic extractor: a plain "name, province" text list, no
+        # form-wrapper and no volatile counters (extraction-stability probed
+        # 2026-08-09 — identical extract sha d42f566c across two fetches).
+        id="tpi-evoa-entry-points",
+        url=f"{BASE}/wna/daftar-negara-voa-bvk-calling-visa/titik-masuk-bagi-pemegang-e-voa",
+        slug="tpi-evoa-entry-points",
+        label="TPI — 122 checkpoint d'ingresso e-VOA (aeroporti/porti/PLBN, dove il VoA è emesso)",
+        tier="daily",
+        category="tpi",
     ),
     Page(
         id="faq-evoa",


### PR DESCRIPTION
## What

v2 item 5 (final) of the imigrasi.go.id scoped mirror: add the **TPI entry-point list** — `/wna/daftar-negara-voa-bvk-calling-visa/titik-masuk-bagi-pemegang-e-voa` ("titik masuk bagi pemegang e-VOA" = entry points for e-VOA holders) — as the **13th daily page**. Adds only a `Page(...)` row to `urls.py` (default extractor, new `category="tpi"`) + doc updates in `README.md`. `extract.py`, `crawler.py`, `run.py` are byte-identical to `origin/main`.

## Why

It is the operational counterpart to the subject lists already mirrored: **WHO** may get VoA (the VoA/BVK/Calling subject lists) vs **WHERE** it is issued — the **122 immigration checkpoints** (16 airports, 11 land-border posts, 95 seaports) where VoA is actually granted. A checkpoint added/removed here changes where a Bali Zero client can physically land on VoA.

## No new extractor (W116 checked)

Plain "name, province" text list (3 category headers + 122 entries), not a form-wrapped table. Extraction-stability probed 2026-08-09: identical extract across two fetches ~5s apart (3267 chars, sha `d42f566c`), **zero** volatile view counters (`Dilihat`) → generic `extract_text` is correct and immune to the false-diff class. Default extractor; no touch to `extract.py`/`crawler.py`/`run.py`.

## Prove-live (throwaway data-root, real fetches — not theatre)

| check | result |
|---|---|
| first-capture (no prior) | `captured=1 diffs=0` (124-line snapshot, 3 category headers + 122 entries) |
| innocence (real identical prior) | `diffs=0` |
| guilt (mutated prior) | `diffs=1` → `DIFF tpi-evoa-entry-points vs prior: +0/-1` |
| `--selftest` | 17/17 PASS |
| independent verifier (generator≠grader) | live 200, extract STABLE (sha `d42f566c` × 2), 122 checkpoints across 3 correctly-labelled categories (Ngurah Rai / Soekarno Hatta / Tanjung Priok present), 0 volatile markers, no collateral edits |

## Consumer

Rides the existing daily LaunchAgent on Mini (`com.nuzantara.imigrasi-mirror.daily`) — nothing new to arm. Post-merge the Mini main checkout is ff-only-pulled so the new page enters the daily crawl.

Counts: **13 daily / 114 weekly / 127 total.** This completes the v2 roadmap (self-health, berita, produk-hukum, evisa, TPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
