### PR TITLE
docs(kbli-navigator): LIVE STATE — gold full-population live, 314 codes

### DIFF
--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -43,7 +43,22 @@ session reads this corner; it does not browse `research/`.
 Also stale in `20-the-honest-map-blocked-bali-codes.md` and its `_INDEX.md` row: the blocked count
 is **518 / 33.2%**, not 465 / 29.8%, and `CHIUSO_PMA_NO_BESAR` is **7**, not 20.
 
-## 1. LIVE STATE (last update 2026-08-08 — keep current)
+## 1. LIVE STATE (last update 2026-08-09 — keep current)
+
+**🟢 2026-08-09 — GOLD FULL-POPULATION LIVE: 314 codes (from 3 pilots), G1-G5 all innocent — but only
+after G2 caught a real production bug and forced a same-day fix.** The morning attempt (314 = 322 minus
+8 phantom codes, see below) applied cleanly but POST-MEASURE found **G2 violated and reproducible**: on
+bare-code queries 3 of 10 sampled gold codes (56101/47721/85312) returned the GOLD point at rank1 with
+the BPS twin ABSENT from the top-5. Root cause: `_get_kbli_payload_from_qdrant`'s exact-code fast-path
+(`kbli_notebook.py`) scrolled Qdrant with `limit:1` and no `order_by` — with two points now sharing one
+`kode_kbli`, the winner was a per-code coin-flip on the two points' unrelated deterministic UUIDs
+(10/10 correlation confirmed empirically), zero relation to score/doc_type. Same-day rollback per a
+pre-declared contract, then the real fix: the filter now POSITIVELY selects `doc_type==kbli_bps` instead
+of excluding gold (#3863, deployed v4057, proven live in-container and on the search surface). Re-apply
+then measured G1-G5 all clean, G2 15/15 including the 3 ex-violators (#3865). Open, orthogonal:
+8 phantom codes in `kbli-gold-content.ts` with no 2025 counterpart (excluded from this apply,
+re-keying decision is `operator[business]`), and the `sektor`/`section` payload field remains unreliable
+(unscoped, tracked separately).
 
 **🟢 2026-08-08 (late evening) — THE INDEXERS CAN NOW RUN WHERE THEIR CREDENTIALS LIVE, AND THE FIRST
 THREE GOLD EDITORIAL POINTS EXIST.** Three PRs, each forced by proving the previous one: #3823


### PR DESCRIPTION
## Summary

Updates the `kbli-navigator` corner's §LIVE STATE with the 2026-08-09 arc: gold full-population is now live in prod (314 codes, up from 3 pilots), reached after the morning attempt caught a real production bug (G2 — a per-code UUID coin-flip on the exact-code fast-path's Qdrant `limit:1`/no-`order_by` scroll), a same-day rollback, the fix (#3863), and a verified clean re-apply (#3865, G1-G5 all innocent). Notes the two remaining open, orthogonal items (8 phantom gold codes, unreliable `sektor` field) for the next session to find without re-deriving.

Edits the canonical `.agents/skills/kbli-navigator/SKILL.md` (`.claude/skills/kbli-navigator` is a symlink to it).

## Test plan

- Docs-only change, pre-push correctly skipped the full backend suite (innocent allowlist).
- Diff scoped to exactly one new dated LIVE STATE entry, no other content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)