### PR TITLE
chore(nb-health): flag frozen pre-gather inventory in 2026-08-09 report

### DIFF
--- a/research/nb-health/2026-08-09-health.md
+++ b/research/nb-health/2026-08-09-health.md
@@ -4,46 +4,55 @@ adversarial_review: exempt-machine-report # nb-curator daily health snapshot (ge
 
 # NB Arsenal Health Report — 2026-08-09 (daily)
 
-## Summary
-- Total live notebooks: 59 (memory index last showed 88 on 2026-06-16 — sizeable drop, likely archival/consolidation of WA-* scaffolds; NOT investigated further today, flagged below)
-- Total sources: 5,765 (+1,475 vs 2026-06-16 snapshot's 4,290)
-- Health (structural, from inventory JSON): 58 healthy / 1 empty / 0 flagged broken
-- Near-cap (500/500 NLM hard ceiling): 3 — NB-INTEL-AIResearch, NB-INTEL-Press, NB-INTEL-AIResearch-2 (overflow NB)
+## ⚠️ CRITICAL: pre-gather inventory is frozen, not fresh
+`nb-inventory-live.json` carries `generated_at: 2026-07-30T20:02:08Z` — **10 days old**, byte-identical
+in content to what the 2026-08-08 report consumed. `nb_generate_inventory.py` has not refreshed since
+2026-07-30, contradicting "generated immediately before this prompt". Matches the session-start
+organism heartbeat alert: `pro.nb_curator_daily: breathing but status=failed`. Everything below is the
+**same frozen snapshot as yesterday** — no real day-over-day delta is detectable until the pre-gather
+cron/script is fixed on Pro.
 
-## Empty (needs attention)
-- "Labor Law Research May 2025" (`bafceb4f-cd61-4922-8fc1-932852d1c054`): 0 sources. Candidate for archive or re-seed.
+## Summary (structural, from stale inventory)
+- Total notebooks: 59 (unchanged vs 2026-08-08; memory index last live count was 86-88 on 2026-06-16 —
+  still unreconciled, not re-derived here)
+- Healthy: 58 | Empty: 1 | Broken: 0
+- Near-cap (500-source NLM ceiling): 3 — AIResearch (dc5d01cd), Press (9d262101), AIResearch-2 overflow
+  (069f009c) — all saturated, unchanged since data didn't refresh
 
-## NB-INTEL snapshot
-- AIResearch: 500 **AT CAP** (overflow NB-INTEL-AIResearch-2 also at 500 → 1,000 sources across 2 NBs on this topic)
-- Press: 500 **AT CAP**, +266 vs 234 on 2026-06-16 — hit ceiling since last report
-- Tax: 205, +184 vs 21 on 2026-06-14
-- Immigration: 199, +107 vs 92 on 2026-06-15
-- Regulation: 142, +97 vs 45 on 2026-06-15
+## Empty
+- `bafceb4f-cd61-4922-8fc1-932852d1c054` "Labor Law Research May 2025" — 0 sources (long-standing scaffold).
 
-## Mode C — Press dedup/summarize proposals (Press only, daily cadence; partial title coverage ~380/500, read-budget limited)
+## Broken
+None (structural field). The real infra fault is the frozen pre-gather, flagged above — not an NB itself.
 
-### Near-dup title pairs (5, eyeballed — literal repeats, likely re-add or regional syndication)
-1. "1.274 Golden Visa diterbitkan, Indonesia raup investasi Rp52 triliun - ANTARA News Kalteng" — appears 2x
-2. "Silmy : Imigrasi tertibkan penyalahgunaan visa dan ITAS investor - ANTARA News Kupang..." — appears 3x
-3. "Golden Visa beri kemudahan pada WNA dalam berinvestasi dan berkarya - ANTARA News Kalteng" — appears 2x
-4. "Family Sponsored Visa (KITAS) in Indonesia: New 2026 Rules" — appears 2x
-5. "Pria Australia Tewas Saat Ditahan Imigrasi Bali, Keluarga Terkejut" — appears 2x
+## NB-INTEL snapshot (unchanged vs 2026-08-08)
+| NB | uuid | sources | near_cap |
+|---|---|---|---|
+| AIResearch | dc5d01cd | 500 | yes (ceiling) |
+| Regulation | a17f134e | 142 | no |
+| Press | 9d262101 | 500 | yes (ceiling) |
+| Tax | 7fb12c9c | 205 | no |
+| Immigration | 1ed02e54 | 199 | no |
+| AIResearch-2 (overflow) | 069f009c | 500 | yes (ceiling) |
 
-Proposal: keep 1 instance each, remove 7 duplicate sources. Confirm via `nlm source list <uuid> --json` (URL match) before any `nlm rm` — operator-executed only, per Article 1.
+## Part 2 — Mode C: NB-INTEL-Press dedup/summarize proposals
+### Near-dup title pairs (eyeballed on full 500-title list, capped at 5 of ~30 visible)
+1. "1.274 Golden Visa diterbitkan, Indonesia raup investasi Rp52 triliun - ANTARA News Kalteng" — exact dup.
+2. "Family Sponsored Visa (KITAS) in Indonesia: New 2026 Rules" — exact dup.
+3. "Silmy : Imigrasi tertibkan penyalahgunaan visa dan ITAS investor - ANTARA News Kupang..." — appears 3x.
+4. "Indonesia Adds 7 New Digital Tax Collectors, Including Strava" — bare vs "- News En.tempo.co" suffix variant.
+5. "How to Change Your PT PMA's KBLI Code in Indonesia | InvestinAsia" — exact dup.
+(~25 more ANTARA regional-syndication dup pairs visible, same set as 2026-08-08 — capped per instructions.)
 
-### Summarization bundle (>=10 sources/topic)
-- "Golden Visa Indonesia" cluster: ~15+ sources visible in this partial read (launch coverage, investment-figure updates, regional ANTARA syndication e.g. Kalteng/Yogyakarta/Makassar/Riau variants). Propose synthetic master doc via offline Ollama batch, remove originals after Antonello review.
-- "Visa-free entry cut 87%" cluster: ~6 sources visible here, likely crosses 10 in the unread remainder (500-380). Not proposing removal today — flag for full-file pass.
+### Summarization candidates (≥10 sources, single topic) — unchanged vs 2026-08-08
+- **PMK 37/2025 marketplace tax-collector rollout** (Shopee/Tokopedia/Blibli/Lazada/Strava PPh/PPN) — ~13-15 titles, same wire story syndicated.
+- **Golden Visa coverage** (issuance stats/investment totals by province) — ~12+ near-dup ANTARA regional syndications.
 
-### Stale (>90d)
-- Not computed — no per-source date field in the titles-only inventory view; would need `nlm source list --json` with timestamps (out of today's budget).
-
-## Notes / gaps
-- Read budget capped Press title coverage at ~380/500; Tax/Immigration/Regulation/AIResearch near-dup pass skipped by design (Press-only daily cadence per Mode C schedule).
-- Notebook count 88→59 since 2026-06-16 is unexplained in this pass — needs a dedicated reconciliation check, not a guess.
+### Stale sources (>90d)
+Not computable — inventory schema has notebook-level `updated_at` only, no per-source dates.
 
 ## Operator actions
-- [ ] Review the 5 near-dup clusters above, confirm via URL, then remove
-- [ ] Decide fate of empty "Labor Law Research May 2025" NB
-- [ ] Investigate 88→59 notebook count drop (intentional archival vs data loss?)
-- [ ] AIResearch + Press both pinned at hard 500 cap — consider overflow/offload strategy
+- [ ] **Fix `nb_generate_inventory.py` pre-gather** — frozen at 2026-07-30, feeding stale data for 10+ days; blocks any real delta detection until resolved
+- [ ] Decide AIResearch capacity: create overflow-2, or prune main+overflow (both 500/500)
+- [ ] Review PMK-37 + Golden-Visa Press clusters for synthesis (unchanged from 2026-08-08, still pending)
+- [ ] Reconcile notebook_count vs 2026-06-16 memory snapshot (86-88→59)


### PR DESCRIPTION
## Summary
- Daily nb-curator report for 2026-08-09 updated to flag that `nb-inventory-live.json` is frozen at `generated_at: 2026-07-30T20:02:08Z` (10 days stale, byte-identical to what 2026-08-08's report consumed).
- Matches the `pro.nb_curator_daily: breathing but status=failed` heartbeat alert seen at session start — the pre-gather script (`nb_generate_inventory.py`) is not refreshing.
- Report body otherwise carries the same structural counts (59 NB, 58 healthy/1 empty/0 broken, 3 near-cap) and Press dedup/summarization proposals as 2026-08-08, since the underlying data hasn't moved.

## Test plan
- [x] Pre-commit/pre-push hooks passed locally (no backend paths touched, docs-only change)
- [x] Frontmatter carries the required `adversarial_review: exempt-machine-report` R1 exemption line

🤖 Generated with [Claude Code](https://claude.com/claude-code)