### PR TITLE
fix(nlm): read the stream the CLI actually writes to — 15 failures logged nothing for 3 months

### DIFF
--- a/apps/evaluator/nlm_deep_research/cross_notebook_correlator.py
+++ b/apps/evaluator/nlm_deep_research/cross_notebook_correlator.py
@@ -40,6 +40,7 @@ import time
 import urllib.request
 from dataclasses import dataclass, field
 from typing import Any
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +186,7 @@ def _query_notebook_sync(notebook_id: str, query: str) -> tuple[str | None, str 
             timeout=NLM_QUERY_TIMEOUT,
         )
         if result.returncode != 0:
-            return None, result.stderr.strip()[:200]
+            return None, nlm_error_reason(result)
         return result.stdout.strip(), None
     except subprocess.TimeoutExpired:
         return None, f"timeout after {NLM_QUERY_TIMEOUT}s"

--- a/apps/evaluator/nlm_deep_research/db_to_nlm_sync.py
+++ b/apps/evaluator/nlm_deep_research/db_to_nlm_sync.py
@@ -52,6 +52,7 @@ from apps.evaluator.nlm_deep_research.db_nlm_templates import (
     render_tax_compliance,
     render_team_activity,
 )
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -437,7 +438,7 @@ def _nlm_source_add(
             timeout=timeout,
         )
         if result.returncode != 0:
-            logger.error("nlm source add failed: %s", result.stderr.strip())
+            logger.error("nlm source add failed: %s", nlm_error_reason(result))
             return None
 
         output = result.stdout.strip()
@@ -497,7 +498,7 @@ def _nlm_source_delete(
             cmd, capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
-            logger.warning("nlm source delete failed: %s", result.stderr.strip())
+            logger.warning("nlm source delete failed: %s", nlm_error_reason(result))
             return False
         logger.info("Source deleted: %s", source_id)
         return True

--- a/apps/evaluator/nlm_deep_research/freshness_monitor.py
+++ b/apps/evaluator/nlm_deep_research/freshness_monitor.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 from apps.evaluator.nlm_deep_research.gap_scanner import DOMAIN_TOPICS
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +147,7 @@ def _trigger_nlm_research(notebook_id: str, query: str, mode: str = "fast", time
             capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
-            logger.error("nlm research start failed: %s", result.stderr.strip()[:200])
+            logger.error("nlm research start failed: %s", nlm_error_reason(result))
             return False
         logger.info("Research triggered for notebook %s: %s", notebook_id[:8], query[:60])
         return True

--- a/apps/evaluator/nlm_deep_research/gap_scanner.py
+++ b/apps/evaluator/nlm_deep_research/gap_scanner.py
@@ -29,6 +29,7 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +180,7 @@ def _query_notebook(notebook_id: str, query: str, timeout: int = NLM_QUERY_TIMEO
             capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
-            logger.error("nlm query failed for %s: %s", notebook_id, result.stderr.strip()[:200])
+            logger.error("nlm query failed for %s: %s", notebook_id, nlm_error_reason(result))
             return None
         return result.stdout.strip() or None
     except subprocess.TimeoutExpired:
@@ -600,7 +601,7 @@ def _add_source_to_notebook(notebook_id: str, title: str, content: str, timeout:
             capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
-            logger.error("nlm source add failed for %s: %s", notebook_id[:8], result.stderr.strip()[:200])
+            logger.error("nlm source add failed for %s: %s", notebook_id[:8], nlm_error_reason(result))
             return False
         logger.info("Added source '%s' to notebook %s", title[:50], notebook_id[:8])
         return True

--- a/apps/evaluator/nlm_deep_research/nlm_bridge.py
+++ b/apps/evaluator/nlm_deep_research/nlm_bridge.py
@@ -10,11 +10,49 @@ Usage:
 
 import json
 import logging
+import re
 import subprocess
 import time
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# The `nlm` CLI writes its diagnostics to STDOUT and leaves stderr EMPTY.
+# Measured on Pro 2026-08-09: with an expired session `nlm notebook list`
+# exits 1, writes 0 bytes to stderr, and prints to stdout
+#   ✗ Authentication Error
+#     Authentication expired. Run 'nlm login' in your terminal to re-authenticate.
+# Every call site in this package that logged `result.stderr.strip()` therefore
+# logged NOTHING: ~/logs/cron-tmp/nlm-nb3-pipeline.log carries 68 lines reading
+# "nlm source add failed: " with the reason after the colon simply missing,
+# going back to 2026-05-04. The condition behind them is real and current — NB-3
+# is 7-for-7 failed in August against 22-of-23 succeeded in July — but no reader
+# could tell the new total outage from the old intermittent one, because both
+# print the same empty sentence. Same family as W104 (`redis-cli` exits 0 and
+# puts NOAUTH on stdout): judge the REPLY, not the exit code, and read the
+# stream the tool actually writes to.
+_AUTH_EXPIRED_RE = re.compile(
+    r"authentication (error|expired)|expired.*re-?authenticate|run ['\"]?nlm login",
+    re.IGNORECASE,
+)
+
+
+def nlm_error_reason(result: subprocess.CompletedProcess, limit: int = 200) -> str:
+    """Why an `nlm` invocation failed, from whichever stream carries the reason.
+
+    Order is stderr (some failures do use it), then stdout, then the exit code —
+    so the returned string is never empty and a log line never ends in a colon.
+    An expired session is prefixed so the message names its own cure instead of
+    leaving the reader to find `nlm login` themselves.
+    """
+    stderr = (result.stderr or "").strip()
+    stdout = (result.stdout or "").strip()
+    reason = stderr or stdout or f"nlm exited with code {result.returncode} (no output)"
+    reason = " ".join(reason.split())
+    if _AUTH_EXPIRED_RE.search(reason):
+        reason = f"AUTH_EXPIRED (operator: run `nlm login` on Pro) — {reason}"
+    return reason[:limit]
+
 
 # NLM CLI path — installed via: npm install -g notebooklm-mcp
 NLM_CLI = "nlm"
@@ -43,7 +81,7 @@ def _run_nlm_once(cmd: list, timeout: int, conversation_id: Optional[str]) -> di
         )
 
         if result.returncode != 0:
-            error_msg = result.stderr.strip() or f"nlm exited with code {result.returncode}"
+            error_msg = nlm_error_reason(result)
             return {"status": "error", "error": error_msg, "_retryable": True}
 
         output = result.stdout.strip()

--- a/apps/evaluator/nlm_deep_research/ops_intelligence.py
+++ b/apps/evaluator/nlm_deep_research/ops_intelligence.py
@@ -24,6 +24,7 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +112,7 @@ def _query_notebook(notebook_id: str, query: str, timeout: int = NLM_QUERY_TIMEO
             capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
-            logger.error("nlm query failed for %s: %s", notebook_id, result.stderr.strip())
+            logger.error("nlm query failed for %s: %s", notebook_id, nlm_error_reason(result))
             return None
         return result.stdout.strip()
     except subprocess.TimeoutExpired:

--- a/apps/evaluator/nlm_deep_research/persona_engine.py
+++ b/apps/evaluator/nlm_deep_research/persona_engine.py
@@ -32,6 +32,7 @@ import time
 import urllib.request
 from pathlib import Path
 from typing import Any
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ def _nlm_source_list(notebook_id: str) -> list[dict[str, str]]:
             capture_output=True, text=True, timeout=60,
         )
         if result.returncode != 0:
-            logger.warning("nlm source list failed for %s: %s", notebook_id, result.stderr.strip())
+            logger.warning("nlm source list failed for %s: %s", notebook_id, nlm_error_reason(result))
             return []
         data = json.loads(result.stdout)
         # Handle multiple response shapes
@@ -116,7 +117,7 @@ def _nlm_source_add(notebook_id: str, title: str, content: str, timeout: int = 9
             capture_output=True, text=True, timeout=timeout,
         )
         if result.returncode != 0:
-            logger.error("nlm source add failed: %s", result.stderr.strip())
+            logger.error("nlm source add failed: %s", nlm_error_reason(result))
             return None
         # Parse source ID from output
         for line in result.stdout.splitlines():
@@ -159,7 +160,7 @@ def _nlm_chat_configure(notebook_id: str, goal: str, custom_prompt: str) -> bool
             cmd += ["--prompt", custom_prompt]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
-            logger.warning("chat configure failed for %s: %s", notebook_id, result.stderr.strip())
+            logger.warning("chat configure failed for %s: %s", notebook_id, nlm_error_reason(result))
             return False
         return True
     except Exception as exc:

--- a/apps/evaluator/nlm_deep_research/source_snapshot.py
+++ b/apps/evaluator/nlm_deep_research/source_snapshot.py
@@ -23,6 +23,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ def _run_nlm_command(
     )
 
     if result.returncode != 0:
-        error_msg = result.stderr.strip() or f"nlm exited with code {result.returncode}"
+        error_msg = nlm_error_reason(result)
         raise RuntimeError(f"nlm CLI error: {error_msg}")
 
     return result

--- a/apps/evaluator/nlm_deep_research/synthesis_roller.py
+++ b/apps/evaluator/nlm_deep_research/synthesis_roller.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import httpx
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -336,7 +337,7 @@ def nlm_source_list(notebook_id: str, timeout: int = NLM_TIMEOUT) -> list[dict]:
             timeout=timeout + 30,
         )
         if result.returncode != 0:
-            logger.error("nlm source list failed: %s", result.stderr[:300])
+            logger.error("nlm source list failed: %s", nlm_error_reason(result, limit=300))
             return []
 
         output = result.stdout.strip()
@@ -382,7 +383,7 @@ def nlm_source_delete(
             timeout=timeout + 30,
         )
         if result.returncode != 0:
-            logger.error("nlm source delete failed: %s", result.stderr[:300])
+            logger.error("nlm source delete failed: %s", nlm_error_reason(result, limit=300))
             return False
         return True
     except subprocess.TimeoutExpired:

--- a/apps/evaluator/nlm_deep_research/t4_monitor.py
+++ b/apps/evaluator/nlm_deep_research/t4_monitor.py
@@ -21,11 +21,14 @@ import math
 import os
 import re
 import signal
+import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional
+
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 if TYPE_CHECKING:
     from apps.evaluator.nlm_deep_research.t4_state import T4State
@@ -1091,11 +1094,23 @@ class T4Monitor:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            _, stderr = await asyncio.wait_for(
+            stdout, stderr = await asyncio.wait_for(
                 proc.communicate(), timeout=timeout_seconds
             )
             if proc.returncode != 0:
-                logger.error("nlm CLI error: %s", stderr.decode()[:200])
+                # stdout was being thrown away here — and stdout is where this
+                # CLI puts the reason (see nlm_error_reason).
+                logger.error(
+                    "nlm CLI error: %s",
+                    nlm_error_reason(
+                        subprocess.CompletedProcess(
+                            cmd,
+                            proc.returncode,
+                            stdout.decode(errors="replace"),
+                            stderr.decode(errors="replace"),
+                        )
+                    ),
+                )
             return proc.returncode == 0
         except asyncio.TimeoutError:
             logger.error(

--- a/apps/evaluator/nlm_deep_research/tests/test_nlm_error_reason.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_nlm_error_reason.py
@@ -1,0 +1,137 @@
+"""An `nlm` failure must arrive with its reason attached (2026-08-09).
+
+TRAUMA, measured on Pro: `nlm notebook list` on an expired session exits 1,
+writes **0 bytes to stderr**, and prints to STDOUT
+
+    ✗ Authentication Error
+      Authentication expired. Run 'nlm login' in your terminal to re-authenticate.
+
+Fourteen call sites in this package logged `result.stderr.strip()` as the
+reason, so for three months the logs read "nlm source add failed: " with
+nothing after the colon. `~/logs/cron-tmp/nlm-nb3-pipeline.log` holds 68 such
+lines going back to 2026-05-04.
+
+That empty sentence is what let a real regression hide: NB-3 is **7-for-7
+failed in August** against 22-of-23 succeeded in July, but the August total
+outage and the old ~40% intermittency print the identical line, so no reader
+could tell them apart. Same family as W104 (`redis-cli` exits 0 and puts NOAUTH
+on stdout): judge the REPLY, and read the stream the tool actually writes to.
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
+
+PKG = Path(__file__).resolve().parent.parent
+
+
+def _proc(returncode=1, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["nlm"], returncode=returncode,
+                                       stdout=stdout, stderr=stderr)
+
+
+# ── guilt ────────────────────────────────────────────────────────────────────
+
+def test_the_measured_reply_is_surfaced_not_swallowed():
+    """The exact bytes Pro produced on 2026-08-09, stderr empty."""
+    reason = nlm_error_reason(_proc(
+        stdout="\n✗ Authentication Error\n  Authentication expired. Run 'nlm login' "
+               "in your terminal to re-authenticate.\n",
+        stderr="",
+    ))
+    assert "Authentication expired" in reason
+    assert reason != ""
+
+
+def test_an_expired_session_names_its_own_cure():
+    reason = nlm_error_reason(_proc(stdout="✗ Authentication Error\n  Authentication expired."))
+    assert reason.startswith("AUTH_EXPIRED")
+    assert "nlm login" in reason
+
+
+def test_a_silent_failure_still_says_something():
+    """Both streams empty must not produce a log line ending in a colon."""
+    reason = nlm_error_reason(_proc(returncode=7))
+    assert reason.strip()
+    assert "7" in reason
+
+
+def test_the_reason_is_one_line_and_bounded():
+    reason = nlm_error_reason(_proc(stdout="a\n\n   b\tc" + "x" * 500), limit=40)
+    assert "\n" not in reason and "\t" not in reason
+    assert reason.startswith("a b c")
+    assert len(reason) == 40
+
+
+# ── innocence ────────────────────────────────────────────────────────────────
+
+def test_stderr_still_wins_when_the_tool_does_use_it():
+    reason = nlm_error_reason(_proc(stdout="progress noise", stderr="connection refused"))
+    assert reason == "connection refused"
+
+
+def test_an_ordinary_failure_gets_no_auth_prefix():
+    reason = nlm_error_reason(_proc(stderr="notebook 933509f9 not found"))
+    assert not reason.startswith("AUTH_EXPIRED")
+    assert reason == "notebook 933509f9 not found"
+
+
+def test_a_success_shaped_result_is_not_special_cased():
+    """The helper only ever runs on a failure — it must not invent one."""
+    reason = nlm_error_reason(_proc(returncode=0, stdout="ok"))
+    assert reason == "ok"
+
+
+# ── the class, not just the instance (W107) ──────────────────────────────────
+
+def test_no_nlm_failure_in_this_package_reports_from_stderr_alone():
+    """Every logger call that NAMES nlm must not take its reason from stderr only.
+
+    Anchored on the message text naming the tool, so the Gemini-CLI call sites
+    in freshness_monitor/gap_scanner — which legitimately do use stderr — are
+    out of scope. DECLARED LIMIT: this sees logger calls whose format string is
+    a literal; a message built elsewhere is invisible to it.
+    """
+    offenders = []
+    for path in sorted(PKG.glob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in {"error", "warning", "info", "critical"}:
+                continue
+            if not node.args or not isinstance(node.args[0], ast.Constant):
+                continue
+            msg = str(node.args[0].value)
+            if "nlm " not in msg.lower():
+                continue
+            for arg in node.args[1:]:
+                src = ast.unparse(arg)
+                if "stderr" in src and "nlm_error_reason" not in src:
+                    offenders.append(f"{path.name}:{node.lineno}: {msg[:48]!r} <- {src}")
+    assert not offenders, "nlm failures reporting from stderr alone:\n  " + "\n  ".join(offenders)
+
+
+@pytest.mark.parametrize("module", [
+    "cross_notebook_correlator", "db_to_nlm_sync", "freshness_monitor", "gap_scanner",
+    "nlm_bridge", "ops_intelligence", "persona_engine", "source_snapshot",
+    "synthesis_roller", "yt_monitor",
+])
+def test_every_rewired_module_can_reach_the_shared_reader(module):
+    """The import must not break its host AND must actually bind the name.
+
+    The first attempt at this rewiring inserted the import INSIDE a
+    parenthesised multi-line import block in db_to_nlm_sync.py — a SyntaxError.
+    A second failure mode is subtler and silent: the module imports fine while
+    the name never binds, so every rewired call site would raise NameError only
+    on the failure path, i.e. exactly when it is needed.
+    """
+    import importlib
+
+    mod = importlib.import_module(f"apps.evaluator.nlm_deep_research.{module}")
+    assert getattr(mod, "nlm_error_reason", None) is nlm_error_reason

--- a/apps/evaluator/nlm_deep_research/yt_monitor.py
+++ b/apps/evaluator/nlm_deep_research/yt_monitor.py
@@ -21,6 +21,7 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from apps.evaluator.nlm_deep_research.nlm_bridge import nlm_error_reason
 
 logger = logging.getLogger(__name__)
 
@@ -257,7 +258,7 @@ def ingest_video(notebook_id: str, video_url: str, dry_run: bool = False) -> boo
             _enqueue_to_intel_lake(video_url, notebook_id)
             return True
         else:
-            logger.error("nlm ingest failed: %s", result.stderr[:200])
+            logger.error("nlm ingest failed: %s", nlm_error_reason(result))
             return False
     except subprocess.TimeoutExpired:
         logger.error("nlm ingest timeout for %s", video_url)


### PR DESCRIPTION
## What this is

`nlm` on an expired session **exits 1, writes 0 bytes to stderr**, and prints to
**stdout**:

```
✗ Authentication Error
  Authentication expired. Run 'nlm login' in your terminal to re-authenticate.
```

Fifteen call sites in `apps/evaluator/nlm_deep_research/` logged
`result.stderr.strip()` as the reason. For three months the logs read
`nlm source add failed:` with **nothing after the colon** —
`~/logs/cron-tmp/nlm-nb3-pipeline.log` holds 68 such lines going back to
2026-05-04.

That empty sentence is what let a real regression hide: NB-3 was **7-for-7 failed
in August** against 22-of-23 succeeded in July, and the August total outage and
the old ~40% intermittency print the **identical line**. No reader could tell
them apart.

Same family as **W104** (`redis-cli` exits 0 and puts `NOAUTH` on stdout): judge
the REPLY, and read the stream the tool actually writes to.

## The cure

- `nlm_bridge.nlm_error_reason()` — one shared reader: stderr, else stdout, else
  `exited with code N`; collapses whitespace, bounds the length, and prefixes
  `AUTH_EXPIRED (operator: run 'nlm login' on Pro)` when the reply says so, so
  the log line names its own remedy.
- 15 sites rewired across 11 modules. `t4_monitor.py` was async and **discarding
  stdout entirely** — it now captures both streams.
- `multimodal_pipeline.py` already did it right and is untouched: it is the
  pattern the others were copied from badly. Gemini-CLI call sites in
  `freshness_monitor`/`gap_scanner` legitimately use stderr and are out of scope.

## Tests — 18, guilt + innocence + the class

`tests/test_nlm_error_reason.py`. Guilt uses the **exact bytes measured on Pro**.
Innocence: stderr still wins when the tool does use it; an ordinary failure gets
no AUTH prefix.

The class guard (W107 — cure the class, not the instance) is an **AST sweep**:
every `logger.{error,warning,info,critical}` in the package whose message names
`nlm ` must not take its reason from stderr alone. A sixteenth site added
tomorrow fails here. Its blind spot is declared in the docstring: it sees only
literal format strings.

The per-module check asserts the helper is **actually bound** (`is
nlm_error_reason`), not merely importable — the first draft of this rewiring
inserted the import *inside* a parenthesised import block (SyntaxError), and the
subtler twin failure is a module that imports fine while the name never binds,
so every rewired site would raise `NameError` **only on the failure path**.

## Status of the underlying outage

The credential itself was dead. Zero ran `nlm login`, and I verified **read and
write** end-to-end on Pro with a self-cleaning probe: `notebook create` → `source
add` → `source list` → `notebook delete`, all `rc=0`, zero residue. This PR does
not fix the credential; it makes the next expiry legible in one line instead of
three months of blank colons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)