### PR TITLE
research(kbli): rewrite proposals for the 25 licensing-absent kbli_documents rows (Mandate 10)

### DIFF
--- a/research/operations/2026-08-09-kbli-25refused-rewrite-pack-1-agri-finance-tech.md
+++ b/research/operations/2026-08-09-kbli-25refused-rewrite-pack-1-agri-finance-tech.md
@@ -1,0 +1,328 @@
+---
+date: 2026-08-09
+domain: operations
+topic: kbli-25refused-rewrite-pack-part1
+client_case: none — internal `kbli_documents` data-quality follow-up, Mandate 10, part 1 of 3 (agriculture/food/tech/finance/creative), requested by Zero via team-lead
+discovered_by: kbli-docs-flip subagent, Mandate 10 (team-lead directive, on Zero's request)
+sources:
+  - "Postgres `kbli_documents` (prod, via `mcp__postgres-nuzantara__query`, read-only role) — live `content`/`judul`/`metadata` for the 8 codes in this file, queried this session; byte-level check via `position(E'\\n' in content)` confirmed the stored text contains ZERO real newline characters for every code in the licensing-absent-25 population (see §0 below — a new finding, not part of the mandate's ask)"
+  - "data/source_documents/KBLI_2025_FINAL_CLEAN.json — canonical 2025 dataset; full `per_skala` (risk tier / authority / timeline) array and top-level `pma_*` fields read for all 8 codes"
+  - "apps/backend-rag/backend/scripts/kbli_documents_cure.py — the selector this mandate re-derives (`licensing_absent_codes()`) and the auto-rebuild gate it deliberately did NOT clear (`rebuild_reason()`, `CONTRADICTED_LICENSING_CLAIM_RE`) for these rows"
+  - "scripts/kbli_filiera/kbli_surface_conformance.py — SNAPSHOT_SQL query re-derived directly against prod to re-measure the population (see §0)"
+adversarial_review: codex
+---
+
+# KBLI 25-refused rewrite pack — part 1 of 3 (agriculture / food / tech / finance / creative)
+
+Mandate 10: for each code the `kbli_documents_cure.py --all-licensing-absent` selector found but refused
+to auto-rebuild (hand-written prose, not a machine-template and not matching the tool's literal
+contradiction regex), produce a card: current prose verbatim, the canonical licensing rows the channel
+doesn't serve, a contradiction verdict, and a proposed rewrite. **Proposals only — nothing in this file
+was applied to `kbli_documents`.**
+
+## §0 — Population re-measured, not assumed (2026-08-09)
+
+Re-ran the exact selector logic live against prod (SQL from `kbli_surface_conformance.py::SNAPSHOT_SQL`,
+executed via the read-only Postgres MCP role, cross-joined against the local canonical dataset — same
+computation `licensing_absent_codes()` performs): **still exactly 25 codes**, and the list is byte-identical
+to the 2026-08-02 report referenced in the mandate:
+`03231 03232 03233 56400 62900 65111 65121 74192 85102 85510 85520 85571 85572 85573 85574 85575 85579
+85693 85694 90200 90310 91122 96230 96300 96400`. No delta to declare.
+
+**Side finding, out of scope for this mandate but too material to omit**: querying live `content` for these
+25 rows, `position(E'\n' in content) = 0` for every one of them — the stored text has **zero real newline
+characters**. What WhatsApp/webchat serve today for these codes is a single run-on line where "WHAT IT
+MEANS:" and "BALI CONTEXT:" read as glued-on labels with no paragraph breaks. A broader sweep
+(`length(content) > 100 AND position(E'\n' in content) = 0`) found **312 rows** across the whole table with
+this same defect — far larger than the 25 in scope here. This is a genuine, previously-undocumented
+client-facing rendering defect (distinct from the licensing-absence question this mandate investigates) and
+is flagged to team-lead separately; it is not fixed in this pack, and the rewrite drafts below are written as
+clean prose from scratch, so they do not inherit it.
+
+## Method per code
+
+1. Quote the live `content` verbatim (it has no real newlines — quoted as stored).
+2. Summarize canonical's `per_skala` risk/authority/timeline rows, deduplicated by scale-tier (the raw JSON
+   repeats near-identical rows across `scope_uraian` sub-clauses of the same official activity).
+3. Verdict: **CONTRADICE** (the prose asserts something canonical's rows disprove), **COMPATIBILE** (prose
+   and canonical agree or the prose's claim is independently corroborated by a canonical field), or
+   **SILENTE** (prose says nothing canonical could contradict — it just never surfaces licensing at all).
+4. A rewrite draft: keeps every hand-written disambiguation/warning, adds the canonical risk/authority/
+   timeline picture, English/factual, no marketing language.
+
+---
+
+## 03231 — Pembudidayaan Ikan Bersirip (Selain Ikan Hias) dan Biota Air Payau Lainnya yang Tidak Dilindungi
+
+**Prosa attuale (verbatim, no real newlines in the stored row):**
+> KBLI 03231: BRACKISH WATER FINFISH FARMING (PEMBUDIDAYAAN IKAN BERSIRIP AIR PAYAU)nnWHAT IT MEANS:nFarming
+> fish like Milkfish (Bandeng) and Snapper in brackish water systems. Includes hatchery and nursery
+> operations.nnBALI CONTEXT:nNorth Bali (Buleleng) is the brackish water capital. Milkfish (Bandeng) are a
+> staple for the local market and vital for live bait in the tuna industry.
+
+**Canonical licensing (20 raw rows, deduplicated):** Mikro/Kecil → **Menengah Rendah**, Otomatis. Menengah/
+Besar → **Menengah Tinggi**, 3 hari. Authority spans Bupati/Walikota, Gubernur, and Menteri/Kepala Badan
+depending on scale/scope. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE.** The prose never mentions risk tier, timeline, or foreign-ownership status — it says
+nothing canonical could contradict, but a client reading it learns nothing about licensing at all.
+
+**Bozza:**
+> **What it means**: Brackish-water finfish farming (milkfish, snapper) and related non-protected species —
+> land preparation, hatchery/nursery operations, grow-out, and harvest.
+>
+> **Licensing**: Micro/Small scale — Menengah Rendah (medium-low) risk, NIB issued automatically. Medium/
+> Large scale — Menengah Tinggi (medium-high) risk, NIB + Sertifikat Standar within 3 working days. Authority
+> is shared across Bupati/Walikota, Gubernur, and central ministry depending on scale and operating area.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: North Bali (Buleleng) is the province's brackish-water aquaculture center. Milkfish
+> (bandeng) supply both the local table market and the live-bait trade for Bali's tuna fishing fleet.
+
+---
+
+## 03232 — Pembudidayaan Ikan Hias Air Payau yang Tidak Dilindungi
+
+**Prosa attuale (verbatim):**
+> KBLI 03232: PEMBUDIDAYAAN IKAN HIAS AIR PAYAU YANG TIDAK DILINDUNGInnWHAT IT MEANS:nBreeding non-protected
+> freshwater ornamental fish. This includes raising, breeding, and harvesting fish for sale or further
+> breeding in various water bodies.nnBALI CONTEXT:n
+
+**Canonical licensing (8 raw rows, deduplicated):** Mikro/Kecil → **Menengah Rendah**, Otomatis. Menengah/
+Besar → **Menengah Tinggi**, 3 hari. `pma_status = TERBUKA`.
+
+**Data-quality flag found reading the official `uraian` itself (added after adversarial review — codex,
+confirmed independently against `KBLI_2025_FINAL_CLEAN.json`):** canonical's OWN description is internally
+inconsistent on water type. The title and the second uraian sentence both say *air payau* (brackish): *"...
+menggunakan air payau sebagai media budi daya"*. But the FIRST uraian sentence says *"...pembenihan, dan
+pemanenan ikan hias **air tawar** yang tidak dilindungi"* — freshwater. This is a defect in canonical
+itself, not something this pack can resolve; the rewrite below follows the title + the media-of-cultivation
+sentence (brackish), consistent with 03231/03233's sibling framing, but this conflict should be raised with
+whoever maintains the canonical dataset rather than silently resolved here.
+
+**Verdetto: SILENTE on licensing**, plus a data-quality note: the "BALI CONTEXT" section is **empty** — the
+label is present with nothing after it, a gap the rewrite should actually fill rather than reproduce.
+
+**Bozza:**
+> **What it means**: Breeding, raising, and harvesting non-protected ornamental fish in brackish water —
+> for retail sale or further breeding stock, not for food. (Canonical's own `uraian` calls this species
+> "air tawar"/freshwater in one sentence and "air payau"/brackish in the next — flagged above; this draft
+> follows the brackish reading, matching the code's title and its sibling codes 03231/03233.)
+>
+> **Licensing**: Micro/Small — Menengah Rendah risk, automatic NIB. Medium/Large — Menengah Tinggi risk,
+> NIB + Sertifikat Standar within 3 working days.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: [genuinely no source material exists in the current row — this is an honest gap to fill
+> with real research, not invented copy; flagged here rather than silently carried forward.]
+
+---
+
+## 03233 — Pembudidayaan Tumbuhan Air Payau yang Tidak Dilindungi
+
+**Prosa attuale (verbatim):**
+> KBLI 03233: PEMBUDIDAYAAN TUMBUHAN AIR PAYAU YANG TIDAK DILINDUNGInnWHAT IT MEANS:nGrowing non-protected
+> freshwater aquatic plants such as Gracilaria spp. This includes cultivation for carbon sequestration and
+> selling carbon credits from these activities.nnBALI CONTEXT:n
+
+**Canonical licensing (4 raw rows):** Mikro/Kecil → **Menengah Rendah**, Otomatis. Menengah/Besar →
+**Menengah Tinggi**, 3 hari. `pma_status = TERBUKA`.
+
+**Verdetto revised after adversarial review (codex, independently confirmed): not plain SILENTE — the
+stored prose contains a factual error, separate from licensing.** Unlike 03232, canonical's `uraian` for
+03233 is internally CONSISTENT: it says *"air payau"* (brackish) throughout, with no "air tawar" mention
+anywhere. Yet the stored `content` calls this "**freshwater** aquatic plants" — flatly wrong against an
+unambiguous source. The original rewrite draft happened to already say "brackish-water" (a lucky accidental
+correction, not a deliberate one — the original draft never flagged that it was fixing an error). Recorded
+here explicitly rather than silently: this is a genuine content defect in the live row, not just an
+absent-licensing gap.
+
+**Bozza:**
+> **What it means**: Cultivating non-protected brackish-water aquatic plants (e.g. Gracilaria seaweed) —
+> including cultivation specifically for carbon sequestration and the sale of resulting carbon credits.
+>
+> **Licensing**: Micro/Small — Menengah Rendah risk, automatic NIB. Medium/Large — Menengah Tinggi risk,
+> NIB + Sertifikat Standar within 3 working days.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: [no source material in the current row — genuine gap, not filled with invented copy.]
+
+---
+
+## 56400 — Aktivitas Jasa Intermediasi Penyediaan Makanan dan Minuman
+
+**Prosa attuale (verbatim):**
+> KBLI 56400: AKTIVITAS JASA INTERMEDIASI PENYEDIAAN MAKANAN DANnnWHAT IT MEANS:nFood trucks and mobile
+> street food — preparing and serving food from motorized or non-motorized vehicles, carts, or mobile
+> stalls. This includes food trucks, mobile kitchens, street food carts, and pop-up food stalls that can
+> relocate. If your food operation moves on wheels or is designed to be mobile, this is your code.nnBALI
+> CONTEXT:nFood trucks are having a moment in Bali...
+
+**Canonical `uraian` (official BPS text, read in full)**: *"Kelompok ini mencakup aktivitas penyediaan jasa
+intermediasi makanan dan minuman yang mempertemukan klien dengan jasa penyedia makanan dan minuman
+berdasarkan balas jasa atau komisi, dengan penyedia jasa perantara TIDAK menyediakan makanan dan minuman
+tersebut... jasa reservasi restoran... TIDAK MENCAKUP pengoperasian platform daring yang mengizinkan orang
+untuk memesan layanan pengiriman makanan (lihat 5330)."* — this is a **commission-based intermediation
+platform that connects clients with food/beverage providers** (e.g. restaurant reservation services) and
+explicitly EXCLUDES both (a) actually preparing/serving food, and (b) online food-delivery-ordering
+platforms (that is code 53300 instead).
+
+**Canonical licensing (3 raw rows — no Mikro tier exists for this code in canonical, and all 3 rows are
+scoped to `"Selain Penyelenggara Perdagangan Melalui Sistem Elektronik (PPMSE) dan Penyelenggara Sarana
+Perantara (PSP)"`, i.e. NON-electronic-platform intermediaries only — confirmed via `scope_uraian` after
+adversarial review flagged the earlier draft for glossing over this):** Kecil/Menengah → **Menengah
+Rendah**, Otomatis. Besar → **Menengah Tinggi**, 7 hari. `pma_status = TERBUKA`.
+
+**Verdetto: CONTRADICE — not merely a licensing gap, a topic mismatch.** The stored prose describes an
+entirely different business (operating a mobile food truck) than what code 56400 actually covers (a
+commission-based matchmaking service between clients and F&B providers, e.g. table-reservation platforms).
+A food-truck operator using this code would be filing under the wrong KBLI entirely. This is the most
+severe finding in this file's group and should be prioritized.
+
+**Bozza (genuine rewrite, not a patch):**
+> **What it means**: Food and beverage intermediation services — platforms or agencies that connect clients
+> with food/beverage providers on a commission or fee basis, WITHOUT preparing or serving the food
+> themselves. Restaurant reservation services are the named example. This explicitly EXCLUDES online
+> platforms that let users order food delivery (that is code 53300) and excludes actually running a food
+> business (a food truck, a restaurant, a mobile kitchen — those are separate codes entirely).
+>
+> **Licensing**: these tiers apply only to intermediaries NOT registered as a PPMSE/PSP (Penyelenggara
+> Perdagangan Melalui Sistem Elektronik / Penyelenggara Sarana Perantara — Indonesia's electronic-trading
+> system operator status). Small/Medium scale — Menengah Rendah risk, automatic NIB. Large scale — Menengah
+> Tinggi risk, NIB + Sertifikat Standar within 7 working days. No Micro-scale entry exists in canonical for
+> this code. If the intermediation runs THROUGH a registered PPMSE/PSP electronic system, canonical has no
+> corresponding row under this code at all — that variant likely needs separate confirmation against
+> Indonesia's e-commerce/PMSE licensing framework rather than this table.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: [the removed food-truck content should be re-homed to whichever code actually covers
+> mobile food service — that research is outside this mandate's scope, but leaving it here misdirects
+> anyone reading this code.]
+
+---
+
+## 62900 — Aktivitas Jasa Teknologi Informasi dan Komputer Lainnya
+
+**Prosa attuale (verbatim):**
+> KBLI 62900: AKTIVITAS JASA TEKNOLOGI INFORMASI DAN KOMPUTER LAINNYAnnWHAT IT MEANS:nThe catch-all code for
+> IT services that don't fit anywhere else...nnBALI CONTEXT:nUse this code with caution. If you're doing app
+> development (62192), AI (62194), cybersecurity (62201), or IT consulting (62209), use those specific
+> codes...
+
+**Canonical licensing (4 raw rows):** Mikro/Kecil/Menengah → **Rendah**, Otomatis. Besar → **Menengah
+Rendah**, Otomatis. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE.** The prose's own warning against misusing this catch-all is good, accurate content —
+it names real sibling codes and correctly frames this as a residual bucket. It just never states the actual
+risk tier.
+
+**Bozza:**
+> **What it means**: The residual/catch-all code for IT and computer services not covered by a more specific
+> 62xxx code.
+>
+> **Licensing**: Micro/Small/Medium — Rendah (low) risk, automatic NIB. Large — Menengah Rendah risk,
+> automatic NIB.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Use this code with caution — app development is 62192, AI is 62194, cybersecurity is
+> 62201, IT consulting is 62209. Some Bali business consultants recommend adding 62900 as a SECONDARY code
+> alongside a specific primary code for flexibility, but it should never be your only code.
+
+---
+
+## 65111 — Asuransi Jiwa Konvensional / 65121 — Asuransi Umum Konvensional
+
+Grouped: same regulator, same PMA cap, same licensing shape — only the product line differs.
+
+**Prosa attuale, 65111 (verbatim):**
+> KBLI 65111: ASURANSI JIWA KONVENSIONALnnWHAT IT MEANS:nConventional life insurance activities...nnBALI
+> CONTEXT:n...Foreign life insurers can own up to 80% — but must meet minimum local market capitalization...
+
+**Prosa attuale, 65121 (verbatim):**
+> KBLI 65121: ASURANSI UMUM KONVENSIONALnnWHAT IT MEANS:nConventional general (non-life) insurance
+> activities...nnBALI CONTEXT:n...OJK requires minimum equity of Rp 250 billion for general insurers...
+
+**Canonical licensing (both codes, 4 raw rows each):** ALL scales → **Tinggi** (high) risk, timeline
+*"Sesuai ketentuan OJK/BI"* (per OJK/BI regulation, i.e. outside the standard OSS clock).
+`pma_status = TERBATAS`, `pma_max_asing = 80`, `pma_cap_verified = True`, official basis: *PP 14/2018 Pasal
+5(1) jo. PP 3/2020 Pasal I angka 1* — foreign ownership capped at 80% of paid-up capital, listed insurers
+(perseroan terbuka) exempt, pre-2018 holdings above 80% grandfathered.
+
+**Verdetto: COMPATIBILE — and independently verified, not just uncontradicted.** The prose's "80%" claim
+matches canonical's own `pma_max_asing` exactly, and canonical marks it `pma_cap_verified: True` with a
+named legal basis. This is well-sourced hand-written content; the rewrite below only adds the missing risk
+tier and the exact regulatory citation.
+
+**Bozza (65111):**
+> **What it means**: Conventional life insurance — term, whole life, endowment, and unit-linked products
+> covering death, disability, or survival to a specified age.
+>
+> **Licensing**: All scales — Tinggi (high) risk. Timeline and process follow OJK/BI regulation directly,
+> outside the standard OSS risk-based clock.
+>
+> **PMA**: Restricted — foreign ownership capped at 80% of paid-up capital (PP 14/2018 Pasal 5(1) jo. PP
+> 3/2020 Pasal I angka 1). Listed insurers (perseroan terbuka) are exempt from the cap; holdings above 80%
+> from before 2018 are grandfathered without further increase. **The 80% cap is not the only constraint**:
+> the operator must also separately meet OJK's minimum local capital/equity requirement (see below) —
+> clearing the ownership cap does not by itself clear the capital-adequacy bar.
+>
+> **Bali context**: Life insurance penetration in Indonesia remains under 3% of GDP. Post-Jiwasraya/AJB
+> Bumiputera, OJK has tightened capital requirements (minimum equity Rp 500 billion, rising to Rp 1 trillion
+> by 2028 under POJK 23/2023). Bali's expat community drives demand for international health and life
+> products.
+>
+> *(Fix after adversarial review: the first draft of this rewrite silently dropped the original stored
+> prose's specific claim that foreign insurers "must meet minimum local market capitalization" — folding it
+> into a generic OJK-equity citation elsewhere. Both claims are hand-authored content already present in the
+> live row; restored above rather than left merged away.)*
+
+**Bozza (65121):** same Licensing/PMA blocks as above, with:
+> **What it means**: Conventional non-life insurance — property, liability, motor vehicle, non-life health,
+> travel, cargo, and other non-life products.
+>
+> **Bali context**: Property and vehicle insurance are Bali's highest-volume general-insurance lines — fire/
+> flood/earthquake cover matters near Mount Agung and Batur. Travel insurance is required for many visa
+> applications and is largely sold through tour operators and airlines. OJK requires minimum equity of Rp
+> 250 billion for general insurers (rising to Rp 500 billion by 2028).
+
+---
+
+## 74192 — Aktivitas Desain Grafis/Komunikasi Visual
+
+**Prosa attuale (verbatim):**
+> KBLI 74192: AKTIVITAS DESAIN GRAFIS/KOMUNIKASI VISUALnnWHAT IT MEANS:nGraphic Design / Visual
+> Communication...nnBALI CONTEXT:n...KBLI 74192 provides a clean, 100% PMA-open avenue to set up a legal
+> entity...
+
+**Canonical licensing (4 raw rows):** ALL scales → **Rendah**, Otomatis. `pma_status = TERBUKA`.
+
+**Verdetto: COMPATIBILE.** The "100% PMA-open" claim matches canonical exactly; the prose is simply silent
+on the risk tier itself.
+
+**Bozza:**
+> **What it means**: Graphic design and visual-communication services — brand identity, logos, packaging,
+> infographics, UI/UX visual assets, signage, and typography. Excludes computer-based animation.
+>
+> **Licensing**: All scales — Rendah (low) risk, NIB issued automatically.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: A clean, low-risk entry point for Bali's freelance/creative expat community — no
+> physical studio required, a virtual office is sufficient. Historically confused with the more restricted
+> Advertising code (73100); keep client contracts framed as "design deliverables", not "ad placements".
+
+## Adversarial review
+
+**Seat**: `codex` (`codex exec -m gpt-5.6-sol`, reasoning effort `high`, `--sandbox read-only`), run against
+the first draft of all three parts of this pack together, independently re-querying the live table and the
+canonical dataset rather than trusting this file's quotes, and instructed to check specifically for (a) any
+rewrite that contradicts a canonical row, and (b) any rewrite that drops a hand-written warning/
+disambiguation the original prose carried. Full transcript and per-code verdicts are recorded in Part 3 of
+this pack (`2026-08-09-kbli-25refused-rewrite-pack-3-arts-personal-misc.md`), which the reviewer was run
+against as the anchor file for the whole three-part pack — cross-reference there for the complete review
+table covering all 25 codes, including the 8 in this file.

--- a/research/operations/2026-08-09-kbli-25refused-rewrite-pack-2-education.md
+++ b/research/operations/2026-08-09-kbli-25refused-rewrite-pack-2-education.md
@@ -1,0 +1,423 @@
+---
+date: 2026-08-09
+domain: operations
+topic: kbli-25refused-rewrite-pack-part2
+client_case: none — internal `kbli_documents` data-quality follow-up, Mandate 10, part 2 of 3 (education family — 11 of the 25 codes), requested by Zero via team-lead
+discovered_by: kbli-docs-flip subagent, Mandate 10 (team-lead directive, on Zero's request)
+sources:
+  - "Postgres `kbli_documents` (prod, via `mcp__postgres-nuzantara__query`, read-only role) — live `content`/`judul` for the 11 codes in this file, queried this session"
+  - "data/source_documents/KBLI_2025_FINAL_CLEAN.json — canonical 2025 dataset; full `per_skala` array (incl. `scope_uraian` sub-scope text) and top-level `pma_*` fields for all 11 codes"
+  - "apps/backend-rag/backend/scripts/kbli_documents_cure.py::CONTRADICTED_LICENSING_CLAIM_RE — the literal-phrase gate two of this file's rows evade (see 85573/85574 below); its own docstring names this as a declared limit, not a bug"
+adversarial_review: codex
+---
+
+# KBLI 25-refused rewrite pack — part 2 of 3 (education family)
+
+See Part 1 for the shared method, the re-measured population (still 25, unchanged since 2026-08-02), and
+the side-finding that all 25 rows' stored `content` has zero real newline characters. **Proposals only —
+nothing in this file was applied to `kbli_documents`.**
+
+---
+
+## 85102 — Pendidikan Taman Kanak-Kanak Umum Swasta
+
+**Prosa attuale (verbatim):**
+> KBLI 85102: PENDIDIKAN TAMAN KANAK-KANAK UMUM SWASTAnnWHAT IT MEANS:nPrivate kindergarten...nnBALI
+> CONTEXT:n...The Yayasan structure is fundamentally different from a profit-generating PT PMA...The SPK
+> framework adds another layer of approval that takes 6-12 months minimum.
+
+**Canonical licensing (16 raw rows, deduplicated):** ALL scales → **Tinggi** (high) risk, timeline *"Izin
+Kemendikbud (di luar OSS)"* — a Kemendikbud permit issued OUTSIDE the standard OSS system, for every scale.
+
+**Verdetto: COMPATIBILE — but corroboration is partial, corrected after adversarial review.** Canonical's
+"outside OSS" timeline field directly backs ONE claim: that this activity needs a special Kemendikbud
+approval process separate from a standard OSS/NIB clock. That much is confirmed. Canonical does **not**,
+however, contain a field proving the two more specific hand-written claims — that the operating structure
+must be a Yayasan (non-profit foundation) rather than a PT PMA, or that the SPK track "takes 6-12 months
+minimum". Those are real, plausible, hand-authored domain knowledge (consistent with Indonesian education
+law generally), but this pack cannot independently verify them against `KBLI_2025_FINAL_CLEAN.json` the way
+it can the risk tier and the outside-OSS fact — the original draft overstated this as fully "corroborated"
+when only part of it is.
+
+**Bozza:**
+> **What it means**: Private kindergarten — early childhood education for ages 4-6 (priority enrollment
+> 5-6), play-based and holistic.
+>
+> **Licensing**: All scales — Tinggi (high) risk. The permit is issued by Kemendikbud OUTSIDE the standard
+> OSS risk-based system — it does not follow the normal NIB timeline.
+>
+> **PMA**: Fully open on paper, but the *operating structure* is the real constraint: Indonesian kindergarten
+> law requires a non-profit Yayasan foundation, not a profit-generating PT PMA, to hold the school license.
+> The SPK (foreign-cooperation school) approval track adds 6-12 months minimum on top of that.
+>
+> **Bali context**: Rising demand from expat families in Ubud, Sanur, and Canggu. Founders who set up a
+> standard PT PMA expecting to run the school directly are the most common failure mode — the Yayasan
+> structure changes how money and control flow through the business entirely.
+
+---
+
+## 85510 — Pendidikan Olahraga dan Rekreasi
+
+**Prosa attuale (verbatim):**
+> KBLI 85510: PENDIDIKAN OLAHRAGA DAN REKREASInnWHAT IT MEANS:nSports and Recreation Education...surf
+> schools, yoga teacher training, martial arts dojos...nnBALI CONTEXT:n...they MUST possess a valid Working
+> KITAS with a proper IMTA (work permit) declaring them as 'Master Trainers'. Bali Immigration regularly
+> raids yoga studios and surf camps...
+
+**Canonical licensing (8 raw rows):** ALL scales → **Tinggi**, timeline **not specified** in canonical (empty
+string on every row — an honest gap in the SSOT itself, not something the prose can be faulted for missing).
+`pma_status = TERBUKA`.
+
+**Verdetto: COMPATIBILE.** "Completely open to foreign ownership" matches. The immigration/KITAS warning is
+valuable, real-world content canonical has no field for at all — must be preserved verbatim in substance.
+
+**Bozza:**
+> **What it means**: Non-degree training and camps in sports/recreation — explicitly includes surf schools,
+> yoga teacher training, martial arts, equestrian, swimming, and e-sports coaching by professional
+> instructors.
+>
+> **Licensing**: All scales — Tinggi (high) risk. Canonical does not specify a standard processing timeline
+> for this code — treat any quoted timeline as an estimate, not a guarantee.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: The corporate license is rarely the real obstacle — immigration and manpower law is.
+> Foreign yoga teachers or surf coaches employed under a PT PMA using this code MUST hold a Working KITAS
+> with an IMTA declaring them "Master Trainers". Bali Immigration regularly raids yoga studios and surf
+> camps specifically to catch foreigners "teaching" on tourist or investor visas without that KITAS/IMTA.
+>
+> *(Fix after adversarial review: the first draft of this rewrite diluted "regularly raids yoga studios and
+> surf camps" into the vaguer "actively enforces" — losing the frequency and the specific named targets.
+> Restored above.)*
+
+---
+
+## 85520 — Pendidikan Kebudayaan
+
+**Prosa attuale (verbatim):**
+> KBLI 85520: PENDIDIKAN KEBUDAYAANnnWHAT IT MEANS:nCultural education — non-formal education in arts,
+> drama, and music...nnBALI CONTEXT:n...The PT PMA route makes this much more accessible to foreign
+> operators than formal education...Dinas Pendidikan still requires curriculum registration, but the process
+> is lighter than for formal schools.
+
+**Canonical licensing (8 raw rows):** ALL scales → **Tinggi**, timeline not specified (empty). `pma_status =
+TERBUKA`.
+
+**Verdetto: COMPATIBILE, with a nuance worth naming explicitly.** "Lighter than formal schools" is about the
+STRUCTURE (PT PMA vs. Yayasan/SPK — genuinely lighter), not the risk CATEGORY, which canonical marks Tinggi
+same as any other education code. The rewrite should say both things so a reader doesn't conflate them.
+
+**Bozza:**
+> **What it means**: Non-formal cultural education — dance studios, music schools, art workshops, creative
+> classes. Training in creative arts, not a path to a formal academic qualification.
+>
+> **Licensing**: All scales — Tinggi (high) risk, same category as formal education codes; canonical does
+> not specify a processing timeline.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed, via a standard PT PMA — a materially lighter
+> corporate structure than the Yayasan/SPK route formal schools require, even though the RISK category
+> itself is the same "Tinggi" tier.
+>
+> **Bali context**: Dance studios, music schools, and art workshops are everywhere in Ubud and Canggu (e.g.
+> gamelan classes for tourists). Yoga teacher training programs often overlap with this code. Dinas
+> Pendidikan curriculum registration still applies.
+
+---
+
+## 85571 — Pelatihan Kerja Teknik Swasta
+
+**Prosa attuale (verbatim):**
+> KBLI 85571: PELATIHAN KERJA TEKNIK SWASTAnnWHAT IT MEANS:nPrivate technical vocational training — welding,
+> CNC machining, electrical installation...nnBALI CONTEXT:n...BNSP competency certification is increasingly
+> required by large employers. Dinas Ketenagakerjaan Bali oversees LPK (Lembaga Pelatihan Kerja) licensing.
+
+**Canonical licensing (4 raw rows):** ALL scales → **Menengah Tinggi** (medium-high), 5 hari. `pma_status =
+TERBUKA`.
+
+**Verdetto: SILENTE.** No claim in the prose to contradict; it just doesn't state the risk tier/timeline.
+
+**Bozza:**
+> **What it means**: Private technical vocational training — welding, CNC machining, electrical installation,
+> plumbing, automotive/marine mechanics, and similar trades. Training workers, not academic students.
+>
+> **Licensing**: All scales — Menengah Tinggi (medium-high) risk, NIB + Sertifikat Standar within 5 working
+> days.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Bali has an acute shortage of skilled trade workers as construction demand outpaces
+> supply. BNSP competency certification is increasingly required by large employers; Dinas Ketenagakerjaan
+> Bali oversees the LPK (Lembaga Pelatihan Kerja) licensing track alongside the NIB.
+
+---
+
+## 85572 — Pelatihan Kerja Teknologi Informasi dan Komunikasi Swasta
+
+**Prosa attuale (verbatim):**
+> KBLI 85572: PELATIHAN KERJA TEKNOLOGI INFORMASI DAN KOMUNIKASInnWHAT IT MEANS:nPrivate ICT job training —
+> ...coding bootcamps, web development courses, cybersecurity workshops...nnBALI CONTEXT:n...Le Wagon ran
+> cohorts out of Canggu...Teacher qualifications are strictly checked...
+
+**Canonical licensing (4 raw rows):** ALL scales → **Menengah Tinggi**, 5 hari. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE.**
+
+**Bozza:**
+> **What it means**: Private ICT job training — networking, technical support, cybersecurity, programming,
+> and digital skills. Skills-based training, not degree-granting education.
+>
+> **Licensing**: All scales — Menengah Tinggi risk, NIB + Sertifikat Standar within 5 working days.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Coding bootcamps have a real track record in Bali (Le Wagon ran cohorts out of Canggu),
+> fed by the digital-nomad community's demand for upskilling. Instructor qualifications are actively checked
+> by regulators — don't imply formal certification in marketing unless the school actually holds
+> accreditation.
+
+---
+
+## 85573 — Pelatihan Kerja Industri Kreatif Swasta
+
+**Prosa attuale (verbatim):**
+> KBLI 85573: PELATIHAN KERJA INDUSTRI KREATIF SWASTAnnWHAT IT MEANS:nCreative industry training...
+> nnBALI CONTEXT:n...**The absence of PP28 requirements means lower regulatory friction — for now.** Smart
+> operators will get their NIB established early and build their reputation before the full licensing
+> framework drops.
+
+**Canonical licensing (4 raw rows):** ALL scales → **Menengah Tinggi**, 5 hari, named authorities
+(Bupati/Walikota + Menteri/Kepala Badan). `pma_status = TERBUKA`. Official `uraian` (read in full — the
+first draft of this card did not quote it and, as a result, mis-scoped the rewrite below): *"...pelatihan
+kerja yang bertujuan untuk menambah ketrampilan/keahlian dalam bidang teknik ukir logam, teknik ukir kayu,
+merenda, menyulam, menenun, sablon, anyaman, teknik batik tulis, teknik batik cap, penyamakan kulit,
+finishing kulit, pembuatan produk dari kulit, menjahit, teknik bordir, teknik pola, fashion design, fashion
+technology, kecantikan kulit, kecantikan rambut..."* — this code is scoped to **traditional craft, textile,
+leather, fashion, and beauty-industry vocational training**: metalwork/woodcarving, crochet/embroidery/
+weaving, screen-printing, wickerwork, batik (tulis and cap), leather tanning/finishing/leather goods,
+sewing/pattern-making, fashion design and fashion technology, and skin/hair beauty training. It says nothing
+about yoga, surfing, photography, music, or film.
+
+**Verdetto: CONTRADICE — two independent, unrelated defects on the same code.** (1) The prose asserts *"the
+absence of PP28 requirements"* and frames the regulatory picture as still pending — but canonical already
+carries a full risk tier, a named 5-day timeline, and named authorities for every scale. This phrasing
+("absence of PP28 requirements... for now") is close to, but does not literally match, the cure tool's own
+`CONTRADICTED_LICENSING_CLAIM_RE` regex (`no PP28 data|licensing is currently minimal|no licensing data
+yet|belum ada data PP28`) — which is exactly why this row landed in the REFUSED bucket instead of being
+auto-rebuilt as a caught contradiction. Worth reporting as a near-miss of that regex, not just a one-off row
+fix. (2) **Confirmed by adversarial review, independently verified against the official `uraian` above**:
+the FIRST DRAFT of this pack's own rewrite named "Yoga teacher training, surf instructor courses,
+photography and music-production workshops" as falling under 85573 — none of which the official scope
+covers. Yoga/surf training is explicitly 85510 (this same pack's own card for 85510 already says so);
+photography and music production appear nowhere in 85573's `uraian` at all. This was this pack's own
+authoring error, not something inherited from the stored prose (the live `content`'s "BALI CONTEXT" for
+85573 is a general regulatory-friction remark, not a topic list) — caught only because an independent
+reviewer re-read the source `uraian` rather than trusting the draft.
+
+**Bozza (corrected):**
+> **What it means**: Non-degree creative-industry vocational training — traditional and modern craft skills
+> including metal/wood carving, crochet/embroidery/weaving, screen-printing, wickerwork, batik (tulis and
+> cap techniques), leather tanning/finishing/leather-goods production, sewing and pattern-making, fashion
+> design and fashion technology, and skin/hair beauty training. Teaching hands-on craft/trade skills, not
+> granting academic degrees.
+>
+> **Licensing**: All scales — Menengah Tinggi risk, NIB + Sertifikat Standar within 5 working days.
+> Authority is shared between Bupati/Walikota and the central ministry.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Bali's batik, weaving, leatherwork, silversmithing, and fashion-design ateliers regularly
+> run paid apprenticeship/training programs alongside production — this code covers that training activity
+> specifically, distinct from the production/retail business itself (which needs its own manufacturing or
+> trade code). Beauty-industry training (skin and hair) is also in scope here. Note: yoga/surf instructor
+> training is a DIFFERENT code (85510, "Pendidikan Olahraga dan Rekreasi") — don't conflate the two when
+> advising a client.
+
+---
+
+## 85574 — Pelatihan Kerja Pariwisata dan Perhotelan Swasta
+
+**Prosa attuale (verbatim):**
+> KBLI 85574: PELATIHAN KERJA PARIWISATA DAN PERHOTELAN SWASTAnnWHAT IT MEANS:nPrivate hospitality and
+> tourism training — training programs...Barista courses, hotel management training, tour guide
+> certification programs...nnBALI CONTEXT:n...**Since this is a BPS_ONLY code, the licensing details are
+> still pending** — but the opportunity is clear...
+
+**Canonical licensing (4 raw rows):** ALL scales → **Menengah Tinggi**, 5 hari, named authorities. Same
+shape as 85571-85573. `pma_status = TERBUKA`.
+
+**Verdetto: CONTRADICE — the same defect as 85573, independently occurring.** *"Licensing details are still
+pending"* is false: canonical holds a complete risk/timeline/authority row for every scale. Two codes in
+this same 855xx sibling family making the same now-false claim, in two different phrasings, both missed by
+the cure tool's literal regex — this looks like a systematic gap in that regex's phrase list rather than two
+unrelated one-offs, worth flagging to whoever maintains `_whatchanged_basis`-style pattern lists.
+
+**Bozza:**
+> **What it means**: Private hospitality and tourism job training — barista courses, hotel-management
+> training, tour-guide certification, hospitality service-excellence workshops.
+>
+> **Licensing**: All scales — Menengah Tinggi risk, NIB + Sertifikat Standar within 5 working days.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Bali's hospitality sector constantly needs trained staff across hotels, restaurants,
+> villas, and tour operators. Programs range from basic housekeeping training to professional barista
+> academies to full hospitality-management courses; growing niches include wellness-therapist and
+> mixology/bartending training.
+
+---
+
+## 85575 — Pelatihan Kerja Bisnis dan Manajemen Swasta
+
+**Prosa attuale (verbatim):**
+> KBLI 85575: PELATIHAN KERJA BISNIS DAN MANAJEMEN SWASTAnnWHAT IT MEANS:nPrivate business and management
+> training...nnBALI CONTEXT:n...wellness retreats that include 'business coaching' or 'entrepreneurship
+> workshops' often need this code...The line between 'community event' and 'educational service' gets
+> blurry...
+
+**Canonical licensing (4 raw rows):** ALL scales → **Menengah Tinggi**, 5 hari. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE.**
+
+**Bozza:**
+> **What it means**: Private business/management training — entrepreneurship, leadership, HR management,
+> marketing, and other practical business skills. Non-degree.
+>
+> **Licensing**: All scales — Menengah Tinggi risk, NIB + Sertifikat Standar within 5 working days.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Wellness retreats or co-working spaces that bundle "business coaching" or
+> "entrepreneurship workshops" alongside their core offering often need this code too — the line between a
+> community event and a chargeable educational service is where operators most often get caught out.
+
+---
+
+## 85579 — Pelatihan Kerja Swasta Lainnya
+
+**Prosa attuale (verbatim):**
+> KBLI 85579: PELATIHAN KERJA SWASTA LAINNYAnnWHAT IT MEANS:nOther Private Job Training — personal
+> development, motivational training, NLP, career development, K3 methodologies...nnBALI CONTEXT:n...KBLI
+> 85579 provides a legal, 100% foreign-owned umbrella for these personal development and NLP training
+> businesses...
+
+**Canonical licensing (52 raw rows — the largest per_skala array of the whole 25, reflecting many distinct
+`scope_uraian` sub-activities lumped into this "other" catch-all):** every row is **Menengah Tinggi** risk.
+Reading the sub-scopes in full (correction after adversarial review — the first draft's "5 to 30 working
+days" framing implied every sub-activity has SOME set timeline, which is wrong): the 52 rows are dominated
+by nuclear/radiation-safety training sub-scopes (radioactive-waste-facility officers, X-ray equipment
+testers, industrial radiography, reactor officers, radiation-protection officers, etc.) plus K3 (occupational
+health & safety) consultation, plus a residual "other vocational training outside K3" bucket. Only a MINORITY
+of these sub-scopes carry a stated timeline — **5 hari** (e.g. nuclear-installation officers, industrial
+radiation-protection officers) or **30 hari** (medical radiation-protection officers) — the rest, including
+K3 consultation itself and the general "other vocational" residual bucket, have **no timeline stated at all**
+(empty field, not zero). `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE**, with a scope caveat worth stating rather than hiding: because this is a residual
+"other" bucket, whether a timeline exists at all — let alone which number — depends entirely on which
+sub-activity applies. The prose should not quote a bounded range as if it covers every case; some legitimate
+sub-activities under this code have no stated processing timeline in canonical at all.
+
+**Bozza:**
+> **What it means**: The residual/catch-all for private, non-formal job training not classified elsewhere —
+> personal development, motivational training, NLP, career development coaching, occupational health &
+> safety (K3) methodologies, and (a large, Bali-irrelevant share of the official sub-scopes) nuclear/
+> radiation-safety officer training.
+>
+> **Licensing**: All scales — Menengah Tinggi risk. Timeline depends entirely on the specific official
+> sub-activity: some carry a stated 5 or 30 working-day timeline, but several sub-scopes — including general
+> "other vocational" training and K3 consultation itself — have NO stated timeline in canonical at all.
+> Confirm the exact sub-scope before quoting a client any number, and don't assume one exists.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Ubud's "life coach"/breathwork/corporate-wellness-retreat scene previously operated in a
+> legal gray area on tourist visas. This code gives a legal, 100% foreign-owned structure for ticketing and
+> hosting personal-development and NLP-style paid events, without needing a dedicated facility.
+
+---
+
+## 85693 — Aktivitas Sertifikasi Profesi oleh Asosiasi
+
+**Prosa attuale (verbatim):**
+> KBLI 85693: AKTIVITAS SERTIFIKASI PROFESI OLEH ASOSIASInnWHAT IT MEANS:nProfessional certification by
+> industry or professional associations...nnBALI CONTEXT:n...IAI, PII, IAPI, PERADI, PKBR...
+
+**Canonical licensing (8 raw rows, two genuinely distinct tracks — not a duplicate artifact):**
+"Seluruh, selain Lembaga Sertifikasi Profesi (LSP) Jasa Konstruksi" (everything except construction-sector
+LSPs) → **Menengah Tinggi**, **67 hari**. "Lembaga Sertifikasi Profesi (LSP) Jasa Konstruksi" specifically →
+**Menengah Tinggi**, **65 hari**. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE**, with a genuine value-add canonical holds that the prose omits entirely: a
+construction-sector carve-out with its own (slightly shorter) timeline.
+
+**Bozza:**
+> **What it means**: Professional certification issued by industry/professional associations — validating
+> member competency within their own profession (e.g. engineering bodies, medical specialist boards, legal
+> associations).
+>
+> **Licensing**: Menengah Tinggi risk across all scales. Timeline is 67 working days for all sectors EXCEPT
+> construction-services professional certification bodies (Lembaga Sertifikasi Profesi Jasa Konstruksi),
+> which run on a 65-working-day timeline.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Active associations include IAI (architects), PII (engineers), IAPI (public accountants),
+> PERADI (lawyers), and PKBR (public relations). Their certification is increasingly a prerequisite for
+> government procurement eligibility; foreign professionals need Indonesian registration in addition to
+> home-country credentials.
+
+---
+
+## 85694 — Aktivitas Sertifikasi Profesi Independen
+
+**Prosa attuale (verbatim):**
+> KBLI 85694: AKTIVITAS SERTIFIKASI PROFESI INDEPENDENnnWHAT IT MEANS:nIndependent professional certification
+> activities...nnBALI CONTEXT:n...CompTIA, PMI, Cisco...Pearson VUE and Prometric testing centers in
+> Denpasar...
+
+**Canonical licensing (4 raw rows) — corrected after adversarial review, independently confirmed against
+`scope_uraian`:** all 4 rows carry the SAME single `scope_uraian`: *"Usaha dalam kelompok ini adalah usaha
+jasa sertifikasi kompetensi tenaga teknik ketenagalistrikan"* (electrical-power-technician competency
+certification services). ALL scales → **Menengah Tinggi**, **5 hari** — but this figure is confirmed ONLY
+for electrical-technician certification. Canonical carries no separate per_skala entry for other independent
+certification activities (IT, project management, food safety, sustainability, sport, etc.) under this code
+— the first draft's blanket "All scales — Menengah Tinggi, 5 days" applied to the whole code, including
+CompTIA/PMI/Cisco-style certifiers it named, is unsupported for anything outside the electrical-technician
+sub-scope.
+
+**Verdetto: SILENTE on the electrical-technician sub-scope** (canonical states a real number, prose doesn't
+contradict it — it just never surfaces it), but the ORIGINAL rewrite draft over-generalized a narrowly-scoped
+canonical figure to the whole code — flagged and corrected below.
+
+**Bozza (corrected):**
+> **What it means**: Independent professional certification — bodies operating apart from both educational
+> institutions and professional associations, certifying skills through competency testing alone. Canonical
+> covers the *uraian*'s "independent professional certification, including in sports" activity generally,
+> but its ONLY priced sub-scope is electrical-technician competency certification specifically.
+>
+> **Licensing**: For electrical-technician competency certification specifically — all scales, Menengah
+> Tinggi risk, NIB + Sertifikat Standar within 5 working days. For other independent-certification
+> activities under this code (IT, project management, food safety, sustainability, sport, etc.), canonical
+> has no separate per_skala entry — do not assume the same 5-day/Menengah Tinggi figure applies without
+> confirming against the live OSS system for that specific activity.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Independent certifiers active locally include IT (CompTIA, PMI, Cisco via authorized
+> centers), project management (PMI PMP via Prometric), food safety (ServSafe, HACCP), and sustainability
+> (LEED, Green Globe). Pearson VUE and Prometric testing centers in Denpasar administer the exams; BNSP
+> oversight applies where a certification claims alignment with Indonesia's national qualifications
+> framework. None of these specific examples is the electrical-technician sub-scope canonical actually
+> prices — treat the licensing figure above as informative context, not a confirmed number for these
+> particular certifiers.
+
+## Adversarial review
+
+**Seat**: `codex` (`codex exec -m gpt-5.6-sol`, reasoning effort `high`, `--sandbox read-only`), run against
+the first draft of all three parts of this pack together. Full transcript and the per-code verdict table are
+recorded in Part 3 of this pack (`2026-08-09-kbli-25refused-rewrite-pack-3-arts-personal-misc.md`), the
+anchor file the reviewer was run against for the whole 25-code pack — cross-reference there for the complete
+table, including the 11 codes in this file. This file's own cards above were revised in place (85102, 85510,
+85573, 85579, 85694) to incorporate the confirmed findings for its codes; each revision states what changed
+and why, independently re-verified against `KBLI_2025_FINAL_CLEAN.json` rather than accepted on the
+reviewer's word alone.

--- a/research/operations/2026-08-09-kbli-25refused-rewrite-pack-3-arts-personal-misc.md
+++ b/research/operations/2026-08-09-kbli-25refused-rewrite-pack-3-arts-personal-misc.md
@@ -1,0 +1,368 @@
+---
+date: 2026-08-09
+domain: operations
+topic: kbli-25refused-rewrite-pack-part3
+client_case: none — internal `kbli_documents` data-quality follow-up, Mandate 10, part 3 of 3 (arts/personal-services/spa/misc — final 6 codes, plus the full 25-code summary and adversarial review), requested by Zero via team-lead
+discovered_by: kbli-docs-flip subagent, Mandate 10 (team-lead directive, on Zero's request)
+sources:
+  - "Postgres `kbli_documents` (prod, via `mcp__postgres-nuzantara__query`, read-only role) — live `content`/`judul` for the 6 codes in this file, queried this session"
+  - "data/source_documents/KBLI_2025_FINAL_CLEAN.json — canonical 2025 dataset; full `per_skala` array (incl. `scope_uraian`) and top-level `pma_*` fields for all 6 codes"
+  - "Part 1 (2026-08-09-kbli-25refused-rewrite-pack-1-agri-finance-tech.md) and Part 2 (...-2-education.md), same lane, same session — this file's summary table covers all 25 codes across all three parts"
+adversarial_review: codex
+---
+
+# KBLI 25-refused rewrite pack — part 3 of 3 (arts / personal services / spa / misc) + full summary
+
+See Part 1 for the shared method, the re-measured population (still 25, unchanged since 2026-08-02), and
+the side-finding that all 25 rows' stored `content` has zero real newline characters. **Proposals only —
+nothing in this file was applied to `kbli_documents`.**
+
+---
+
+## 90200 — Aktivitas Seni Pertunjukan
+
+**Prosa attuale (verbatim):**
+> KBLI 90200: AKTIVITAS SENI PERTUNJUKANnnWHAT IT MEANS:nPerforming arts...nnBALI CONTEXT:n...Legong,
+> Barong, Kecak, and Wayang puppet theater are UNESCO-recognized cultural treasures...traditional Balinese
+> performing arts are deeply tied to Hindu religious ceremonies — commercial use of sacred performances
+> requires cultural sensitivity and community consent.
+
+**Canonical licensing (12 raw rows):** ALL scales → **Rendah** (low) risk, Otomatis. Official `uraian`
+explicitly lists, among other things, *"pengoperasian fasilitas seni yang digunakan untuk kelompok seninya
+sendiri"* — operating an arts facility used by one's OWN performing group. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE on licensing**, but the stored prose's categorical claim needs softening — confirmed
+after adversarial review. Both the live `content` and this pack's first-draft rewrite say "this covers the
+act of performing, **not** the venue (90310)" as an absolute. Canonical's own `uraian` contradicts the
+absolute version: operating a performance facility for one's OWN troupe/group's use is explicitly INSIDE
+90200, not 90310. Only operating a venue for THIRD PARTIES (other performers, the general public) is
+exclusively 90310's territory. The distinction is who the venue serves, not "performing vs. venue" as a
+clean binary.
+
+**Bozza (corrected):**
+> **What it means**: Live performing-arts activities — dance, theater, music concerts, opera, puppetry,
+> circus, and other staged performances, including a group operating its OWN rehearsal/performance facility
+> for its own use. Also explicitly covers actors, dancers, singers/musicians, background singers,
+> conductors, models, and — per the official scope — influencers, content creators, and YouTubers appearing
+> in video/vlog content, and independent musicians/actors appearing across audiovisual content. Operating a
+> venue FOR OTHER performers or the general public (rather than one's own group) is the separate code
+> 90310.
+>
+> **Licensing**: All scales — Rendah (low) risk, NIB issued automatically.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Bali's performing-arts tradition (Legong, Barong, Kecak, Wayang puppet theater) is
+> UNESCO-recognized. The clearest opportunity for foreign artists is contemporary fusion — combining
+> Balinese dance with modern choreography or staging international festivals. Traditional Balinese
+> performing arts are deeply tied to Hindu ceremony; commercial use of sacred performances requires cultural
+> sensitivity and community consent, not just a license.
+
+---
+
+## 90310 — Aktivitas Operasional Tempat dan Fasilitas Kesenian
+
+**Prosa attuale (verbatim):**
+> KBLI 90310: AKTIVITAS OPERASIONAL TEMPAT DAN FASILITAS KESENIANnnWHAT IT MEANS:nArts venues and
+> facilities — physical spaces dedicated to displaying or hosting artistic and cultural activities. Art
+> galleries, performance halls, exhibition spaces, cultural centers, artist studios open to the public, and
+> creative coworking spaces focused on arts. You provide the space; artists and performers use it.nnBALI
+> CONTEXT:nBali's gallery scene is concentrated in Ubud (ARMA Museum, Neka Art Museum, Agung Rai Fine Art
+> Gallery) but expanding into Canggu, Seminyak, and even Tabanan...Combine with 90391 for event programming
+> and 85573 for training programs...
+
+**Canonical `uraian` (official BPS text, read in full — the first draft of this card did not quote it, and
+as a result reproduced the stored prose's scope error instead of catching it):** covers operating auditoriums
+for concerts/theater, cultural centers/**Taman Budaya** (cultural parks), facilities supporting the creation
+of visual-art works, and live-music venues/music clubs where performers perform. It then explicitly states
+what this code does **NOT** cover: *"perdagangan eceran lukisan dan patung (aktivitas komersial galeri
+kesenian), lihat 4769"* (commercial art-gallery retail — separate code 4769), *"pengoperasian berbagai jenis
+museum, lihat 9020"* (museum operation — separate code 90200's family), plus cinemas (5914) and ticket sales
+(7990). Canonical's per_skala scope for all 4 rows is literally **"Taman Budaya"**.
+
+**Canonical licensing (4 raw rows):** ALL scales → **Rendah**, Otomatis. `pma_status = TERBUKA`.
+
+**Verdetto revised after adversarial review — this is CONTRADICE, not SILENTE, and the defect is in the
+LIVE stored prose itself, not just this pack's rewrite.** The stored `content` names ARMA Museum, Neka Art
+Museum, and Agung Rai Fine Art Gallery as examples of what 90310 covers — but the official `uraian`
+EXPLICITLY EXCLUDES both commercial art galleries (→ 4769) and museums (→ 90200's family) from this code.
+Every named example in the live prose is something the code's own scope says does NOT belong here. This
+pack's first-draft rewrite reproduced the same error uncritically (kept "galleries" and the same three named
+venues) instead of catching it — caught only on independent re-reading of the official `uraian` during
+adversarial review.
+
+**Bozza (corrected):**
+> **What it means**: Arts venues and facilities — auditoriums and halls for concerts/theater, cultural
+> centers and Taman Budaya (cultural parks), facilities supporting visual-art creation, and live-music
+> venues/music clubs where performers appear. You operate the venue; performers/artists use it. This
+> code explicitly EXCLUDES commercial art-gallery retail (selling paintings/sculptures — that's code 4769)
+> and museum operation (that's part of 90200's family) — despite what the current live content says, ARMA
+> Museum, Neka Art Museum, and Agung Rai Fine Art Gallery are NOT examples of this code.
+>
+> **Licensing**: All scales — Rendah (low) risk, NIB issued automatically.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Bali's Taman Budaya (Denpasar) and various concert/theater auditoriums are the clearest
+> fit for this code. A hybrid live-music-venue-plus-café model (Ubud, Canggu, Seminyak) also fits, so long as
+> the primary activity is hosting performances rather than selling art or operating a museum. Consider
+> pairing with 90391 (event organization) and 85573 (creative-industry training) for a fuller business
+> model — but route any actual gallery/museum concept to 4769 or the museum code instead of this one.
+
+---
+
+## 91122 — Aktivitas Kearsipan Swasta
+
+**Prosa attuale (verbatim):**
+> KBLI 91122: AKTIVITAS KEARSIPAN SWASTAnnWHAT IT MEANS:nPrivate archiving services...nnBALI CONTEXT:n
+
+**Canonical licensing (8 raw rows):** ALL scales → **Rendah**, Otomatis. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE**, plus the same empty-BaliContext defect seen on 03232/03233 — the section label is
+present with zero content after it.
+
+**Bozza:**
+> **What it means**: Private archiving services — building, storing, classifying, and providing access to
+> physical or digital archive collections, run by individuals, companies, foundations, or other private
+> entities.
+>
+> **Licensing**: All scales — Rendah (low) risk, NIB issued automatically.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: [no source material in the current row — genuine gap, not filled with invented copy.]
+
+---
+
+## 96230 — Aktivitas Sante Par Aqua (SPA) Harian, Sauna, dan Pemandian Uap
+
+**Prosa attuale (verbatim):**
+> KBLI 96230: AKTIVITAS SANTE PAR AQUA (SPA) HARIAN, SAUNA, DANnnWHAT IT MEANS:nDay spas, saunas, and steam
+> baths...nnBALI CONTEXT:n...The 2025 code 96230 finally gives spas their own classification. **Since it's
+> BPS_ONLY (no PP28 licensing data yet), the detailed requirements are pending.** However, existing spa
+> operations typically need: TDUP, health/hygiene certification, trained therapists...
+
+**Canonical licensing (4 raw rows) — corrected after adversarial review, independently re-pulled with full
+`skala_usaha`/`scope_uraian` fields (the first draft's Besar-vs-rest framing conflated SCALE with a
+different, SUBJECT-MATTER split):** the real split is **Medical Spa vs. non-Medical Spa**, not "large vs.
+small". Besar-scale, `scope_uraian = "Usaha Spa yang sudah mengarah kepada Medical Spa"` → **Tinggi**
+(high) risk, 14 hari, authority listed as `["Menteri/Kepala Badan", "Menteri/Kepala Badan"]` — the SAME
+value listed twice (a data artifact, not two distinct ministries — do not read this as "two sign-offs").
+Mikro/Kecil/Menengah, `scope_uraian = "Seluruh, kecuali usaha SPA yang mengarah kepada Medical SPA"` (i.e.
+non-medical) → **Menengah Tinggi**, 14 hari, authority Gubernur + Menteri/Kepala Badan (listed in
+inconsistent order across the three rows — again likely a data-entry artifact, not a meaningful difference).
+Canonical has **no populated row** for a Besar-scale non-medical spa, nor for a Mikro/Kecil/Menengah medical
+spa — a real gap in the source, not something this pack invents an answer for. `pma_status = TERBUKA`.
+
+**Verdetto: CONTRADICE — third instance of the same near-miss pattern found in 85573/85574.** *"BPS_ONLY (no
+PP28 licensing data yet)... requirements are pending"* is false: canonical carries a complete risk tier, a
+14-day timeline, and named authorities for every scale. Same phrasing family as the two education-code
+hits, again not literally matching `CONTRADICTED_LICENSING_CLAIM_RE`'s phrase list. Three independent
+occurrences of the same evasion, across three unrelated activity domains (creative-industry training,
+hospitality training, day spas) — this reads as a systemic pattern in how this content batch was authored
+(everything using "BPS_ONLY"/"pending" language was written before PP28 per-skala data existed for these
+codes, and never revisited once it landed), not three coincidental one-offs.
+
+**Bozza (corrected):**
+> **What it means**: Day spas, saunas, and steam baths — holistic body care combining traditional and modern
+> methods: water-based treatments, herbal-preparation massage, aromatherapy, and related wellness services.
+>
+> **Licensing**: The split in canonical is by whether the operation qualifies as a "Medical Spa", not by
+> business scale alone. Non-medical spa, Micro/Small/Medium scale — Menengah Tinggi risk, NIB + Sertifikat
+> Standar within 14 working days, provincial (Gubernur) + central authority. Medical-leaning spa, Large
+> scale — Tinggi (high) risk, 14 working days, central-ministry authority. Canonical has no populated entry
+> for a large-scale non-medical spa or a small/medium-scale medical spa — confirm directly with OSS if your
+> case falls in that gap.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Bali is globally synonymous with spas, from high-end resort spas in Nusa Dua to
+> budget massage venues in Kuta. In addition to the NIB/Sertifikat Standar above, operators typically also
+> need: Tanda Daftar Usaha Pariwisata (TDUP), health/hygiene certification, therapist competency
+> certificates, and SNI spa-standard compliance. A spa marketing itself with medical-adjacent treatments
+> (e.g. aesthetic/dermatology-linked services) should confirm whether it is classified as "Medical Spa" for
+> licensing purposes before assuming the lighter non-medical tier applies.
+
+---
+
+## 96300 — Aktivitas Pemakaman dan Kegiatan Terkait
+
+**Prosa attuale (verbatim):**
+> KBLI 96300: AKTIVITAS PEMAKAMAN DAN KEGIATAN TERKAITnnWHAT IT MEANS:nFuneral and related
+> services...nnBALI CONTEXT:n...the Ngaben (cremation) ceremony is one of the most important cultural
+> practices. Commercial funeral services for the local Balinese population are virtually non-existent as a
+> PMA opportunity...
+
+**Canonical licensing (4 raw rows):** ALL scales → **Rendah**, Otomatis. `pma_status = TERBUKA`.
+
+**Verdetto: SILENTE.** The cultural/market-realism framing is valuable and non-regulatory — preserve as-is.
+
+**Bozza:**
+> **What it means**: Funeral and related services — funerals, cremation, burial preparation, cemetery
+> management, and memorial services.
+>
+> **Licensing**: All scales — Rendah (low) risk, NIB issued automatically.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: Funeral practice in Bali is deeply tied to Hindu tradition — the Ngaben cremation
+> ceremony is central to local culture, and commercial PMA funeral services for the Balinese population are
+> effectively not a realistic market (managed through Banjar and family structures instead). The realistic
+> PMA angle is serving the international community: expat memorial services, repatriation logistics, and
+> pet cremation.
+
+---
+
+## 96400 — Aktivitas Jasa Intermediasi untuk Jasa Perorangan
+
+**Prosa attuale (verbatim):**
+> KBLI 96400: AKTIVITAS JASA INTERMEDIASI UNTUK JASA PERORANGANnnWHAT IT MEANS:nPersonal services
+> intermediary — a platform that connects clients with personal service providers...nnBALI
+> CONTEXT:n...Critical tax issue...'Spa' classified as entertainment can face 40-75% PBJT (entertainment
+> tax)...
+
+**Canonical licensing (24 raw rows) — corrected after adversarial review, independently re-pulled row by
+row: this is NOT a clean two-track PPMSE/non-PPMSE split.** The first draft's "two tracks, each with its own
+risk categorization" framing is too tidy for what's actually there. The 24 rows resolve into (at least)
+FOUR overlapping groups, several duplicated near-verbatim across `scope_index` sub-clauses (this pack's own
+stated method already flags this as a known raw-data pattern, but this code's duplication is heavier than
+most): (1) PPMSE/PSP-registered operators — Mikro **Rendah**/Otomatis, but Kecil/Menengah/Besar **Tinggi**/3
+hari (risk does NOT stay constant across scale within this track); (2) non-PPMSE operators ("Selain PPMSE
+dan PSP") — Kecil/Menengah **Menengah Rendah**/Otomatis, Besar **Menengah Tinggi**/7 hari (no Mikro row
+exists in this specific sub-scope); (3) a broad "Seluruh, kecuali [PPMSE...]" bucket repeated across several
+near-identical `scope_index` entries, uniformly **Rendah**/Otomatis for Mikro/Kecil/Menengah; (4) a plain
+"Seluruh" (no PPMSE distinction at all) bucket, **Rendah**/Otomatis for ALL FOUR scales including Besar.
+Whether groups (3)/(4) are genuinely separate regulatory tracks or raw-data duplication of the same
+underlying activity is not something this pack can resolve with confidence — flagged rather than guessed.
+`pma_status = TERBUKA`.
+
+**Verdetto: SILENTE on licensing** (the stored prose makes no licensing claim to contradict), and the
+tax warning remains a DIFFERENT, non-overlapping regulatory axis (PBJT entertainment tax classification)
+that canonical's `per_skala` doesn't address at all — nothing to contradict there either. But the pack's
+OWN first-draft rewrite over-simplified a genuinely messy canonical structure into a clean binary that isn't
+supported by the raw rows — corrected below to be honest about the mess rather than paper over it.
+
+**Bozza (corrected):**
+> **What it means**: Personal-services intermediary — a platform connecting clients with personal-service
+> providers (e.g. booking a massage therapist, aggregating spa services). You are the matchmaker, not the
+> service provider.
+>
+> **Licensing**: Whether you operate as a registered PPMSE/PSP (electronic-trading system operator under
+> Indonesia's e-commerce regulation) materially affects your risk tier, but the relationship is NOT a simple
+> two-track split — canonical's data for this code is unusually complex, with risk tiers varying by BOTH
+> registration status and scale (e.g. a PPMSE-registered Mikro-scale operator is Rendah risk, but a
+> PPMSE-registered Kecil/Menengah/Besar operator is Tinggi risk). Given the complexity, confirm your specific
+> scale + registration status directly against the live OSS system rather than relying on a general rule
+> here.
+>
+> **PMA**: Fully open — 100% foreign ownership allowed.
+>
+> **Bali context**: The platform economy for beauty/wellness bookings is growing fast in Bali. Critical tax
+> issue: "spa" services classified as entertainment can face 40-75% PBJT (entertainment tax) — clarify
+> whether the platform connects users to "wellness/health" services (lower tax bracket) or "entertainment/
+> spa" services (higher bracket); the classification materially affects margins for both the platform and
+> its service providers. This tax question is entirely separate from, and does not resolve, the
+> PPMSE/scale-dependent licensing question above.
+
+---
+
+## Full summary — all 25 codes
+
+**Table below reflects the verdicts AFTER adversarial review and independent correction — see the review
+section for what changed from the first draft.**
+
+| Verdict | Count | Codes |
+|---|---|---|
+| **CONTRADICE** | 5 | 56400 (topic mismatch — "food trucks" prose on an intermediation-platform code), 85573, 85574, 96230 (all three: false "BPS_ONLY/no PP28 data yet/pending" claims on codes canonical already fully populates), 90310 (live prose names ARMA/Neka/Agung Rai as examples — official scope explicitly EXCLUDES galleries and museums from this code) |
+| **COMPATIBILE** | 6 | 65111, 65121 (80% PMA cap independently verified against canonical's own `pma_cap_verified`/official basis), 74192, 85102 (partially corroborated — the "outside OSS" fact is confirmed, the Yayasan-structure/6-12-month claims are hand-authored domain knowledge canonical doesn't independently confirm), 85510, 85520 |
+| **SILENTE** | 14 | 03231, 03232, 03233, 62900, 85571, 85572, 85575, 85579, 85693, 85694 (narrowly, electrical-technician sub-scope only), 90200 (with a scope correction, see card), 91122, 96300, 96400 |
+
+**Also flagged, not a licensing verdict**: 03233's stored prose calls its species "freshwater" when
+canonical's `uraian` is unambiguously "brackish" throughout — a factual error distinct from the
+licensing-contradiction question this mandate scopes (see card).
+
+**Cross-cutting findings, not limited to any one code:**
+
+- **The three CONTRADICE rows sharing "BPS_ONLY/pending" language (85573, 85574, 96230) are a pattern, not
+  three coincidences** — all three were evidently written before PP28 per-skala data existed for their
+  codes and never revisited once canonical was populated. `CONTRADICTED_LICENSING_CLAIM_RE` in
+  `kbli_documents_cure.py` is a literal-phrase probe by its own docstring's admission; these three phrasings
+  ("absence of PP28 requirements... for now", "the licensing details are still pending", "no PP28 licensing
+  data yet... requirements are pending") are close enough in MEANING but different enough in WORDING to all
+  evade it. Worth widening that regex's phrase list with these three as new test cases, independent of
+  whether these specific 3 rows get manually rewritten from this pack.
+- **56400 and 90310 are qualitatively different from the rest** — neither is a licensing-completeness gap;
+  both are the wrong content under the right code (56400: literally the wrong business activity; 90310:
+  named venue examples the code's own official scope explicitly excludes). These two should be triaged
+  ahead of the others — they're actively misdirecting a reader today, not merely silent.
+- **This pack's OWN first draft introduced defects that adversarial review caught, not just inherited ones**
+  — 85573's rewrite invented a topic list (yoga/surf/photography/music) that belongs to a different code
+  entirely or nowhere in this pack's scope, 90310's rewrite reproduced the live prose's gallery/museum error
+  instead of catching it, and 96230/96400's rewrites flattened genuinely messy canonical structures (a
+  subject-matter split misread as a scale split; a >20-row structure misread as a clean binary) into
+  incorrect simplifications. Lesson for future rounds of this kind of work: reading the official `uraian`
+  and the FULL raw `per_skala` array in full, every time, is not optional even when a summarized version
+  looks clean enough to trust.
+- **Two rows (03232/03233, plus 91122) have a genuinely EMPTY "BALI CONTEXT" section** — the label exists,
+  the content after it does not. Not a contradiction, but a gap this pack could not responsibly fill with
+  invented copy; flagged rather than guessed.
+- **Side-finding (Part 1 §0, repeated here for visibility): 312 rows across the whole `kbli_documents` table
+  — far beyond this mandate's 25 — have zero real newline characters in stored `content`**, rendering as a
+  run-on wall of text on WhatsApp/webchat. Out of scope for this mandate's rewrite proposals but material
+  enough that it should not be buried in a single Part-1 footnote. The adversarial reviewer, working without
+  live Postgres access, could not independently confirm the 312-row table-wide count, but confirmed that all
+  25 quoted rows in this pack are internally consistent with the artifact (visible "n" where a newline would
+  be expected).
+
+## Adversarial review
+
+**Seat**: `codex` (`codex exec -m gpt-5.6-sol`, reasoning effort `high`, `--sandbox read-only`), run against
+the first drafts of all three parts of this pack, independently re-querying the canonical dataset (no live
+Postgres access in that sandbox — the reviewer treated this pack's verbatim quotes of stored `content` as
+the claim under test, but re-derived everything canonical-side itself rather than trusting this pack's
+summaries), and asked specifically to (1) independently verify three flagship claims (56400's topic-mismatch
+finding, the 85573/85574/96230 false-"pending" pattern, and the 65111/65121 80%-cap corroboration), (2)
+judge whether each code's verdict was actually correct, and (3) check every rewrite draft for two failure
+modes: contradicting a canonical row, or dropping hand-written value from the original prose. This is the
+generator≠grader gate the mandate asked for — the reviewer never saw this pack's internal reasoning, only
+its output.
+
+**Result: the review found real, confirmed defects — this was not a rubber-stamp.** All three flagship
+claims were confirmed (56400's commission-platform scope and food-truck exclusion; 85573/85574/96230's
+fully-populated per_skala rows disproving their "pending" claims; 65111/65121's `pma_cap_verified=true`
+matching the 80% claim). But the reviewer also flagged 8 codes with substantive defects and 3 verdicts that
+needed correction — every one of which was independently re-verified against `KBLI_2025_FINAL_CLEAN.json`
+(and, for the insurance/spa/personal-intermediary rows, against live `kbli_documents.content` via a fresh
+Postgres query) **in this session, not accepted on the reviewer's word alone**, per this pack's own stated
+discipline. All were confirmed real and have been corrected in place above:
+
+| Code | Reviewer's finding | Independently confirmed? | Fix applied |
+|---|---|---|---|
+| 03232 | Verdict too weak — canonical's own `uraian` is internally inconsistent (first sentence says "air tawar"/freshwater, title + second sentence say "air payau"/brackish); the draft picked brackish without flagging the source conflict | CONFIRMED — pulled `uraian` directly | Added explicit note of the canonical inconsistency; rewrite states which reading it follows and why |
+| 03233 | The stored prose says "freshwater" but canonical is unambiguously "brackish" throughout — a real factual error the SILENTE verdict didn't name | CONFIRMED — pulled `uraian`, no "air tawar" anywhere in it | Verdict annotated to name the error explicitly, rather than let the rewrite silently fix it |
+| 56400 | Draft's licensing paragraph applied the risk tiers to "platforms or agencies" broadly, but all 3 canonical rows are scoped ONLY to non-PPMSE/PSP intermediaries | CONFIRMED — all 3 `scope_uraian` values read "Selain PPMSE dan PSP" | Added explicit non-PPMSE scoping caveat |
+| 65111 | Draft dropped the original's specific "must meet minimum local market capitalization" claim, replacing it with a differently-sourced OJK-equity citation | CONFIRMED — re-pulled live `content`; both claims are genuinely present in the original stored prose, pack's rewrite let one crowd out the other | Restored the market-capitalization claim explicitly alongside the equity citation |
+| 85102 | Verdict overstated as "corroborated" — canonical confirms the "outside OSS" fact but not the specific Yayasan-structure requirement or "6-12 months" duration | CONFIRMED — canonical's only relevant field is the outside-OSS timeline string; no field addresses ownership structure or duration | Verdict language softened to distinguish confirmed vs. hand-authored-but-plausible claims |
+| 85510 | Draft diluted "Bali Immigration regularly raids yoga studios and surf camps" into generic "actively enforces", losing frequency and named targets | CONFIRMED — re-pulled live `content`, exact phrase present | Restored the specific claim verbatim in substance |
+| 85573 | Draft's Bali-context invented a topic list (yoga, surf, photography, music/film) not in this code's official scope at all — yoga/surf is explicitly 85510 per this SAME pack's own 85510 card | CONFIRMED — official `uraian` covers only crafts/textile/leather/fashion/beauty; no mention of yoga, surf, photography, or music | Bali-context section rewritten to the actual scope, with an explicit note distinguishing this code from 85510 |
+| 85579 | Draft's "5 to 30 working days" framing implied every sub-activity has a set timeline; most of the 52 raw rows (nuclear/radiation-safety sub-scopes, K3 consultation, general "other vocational") have NO stated timeline at all | CONFIRMED — read all 52 rows' `jangka_waktu` fields; the majority are empty strings | Licensing text corrected to state that a timeline is the exception, not the rule, for most sub-scopes |
+| 85694 | Draft applied "Menengah Tinggi, 5 days" to ALL independent certification (CompTIA, PMI, food safety, sustainability); canonical's only populated sub-scope is electrical-power-technician certification specifically | CONFIRMED — all 4 rows share one identical `scope_uraian`, electrical-technician only | Licensing narrowed explicitly to the electrical-technician sub-scope; named examples (CompTIA etc.) flagged as unconfirmed for licensing purposes |
+| 90200 | Draft's "not the venue" claim was too categorical — official `uraian` explicitly includes operating an arts facility for one's OWN performing group | CONFIRMED — `uraian` lists this exact clause | Rewrite corrected: own-group venue use is included; only third-party venue operation is exclusively 90310 |
+| 90310 | Draft (and the LIVE stored prose itself) names ARMA Museum, Neka Art Museum, and Agung Rai as examples — official `uraian` explicitly EXCLUDES commercial galleries (→4769) and museums (→90200's family) from this code | CONFIRMED — `uraian`'s "tidak mencakup" clause names both exclusions verbatim; per_skala scope is literally "Taman Budaya" | Verdict upgraded from SILENTE to CONTRADICE; Bali-context section rewritten entirely around auditoriums/Taman Budaya/live-music venues, with the gallery/museum examples explicitly named as wrong |
+| 96230 | Draft's Besar-vs-rest framing conflated business SCALE with the real split, which is Medical Spa vs. non-Medical Spa; the "two distinct central-ministry sign-offs" reading of Besar's authority field is wrong — it's the identical value listed twice, not two different ministries | CONFIRMED — re-pulled full `per_skala` with `scope_uraian`; Besar row is scoped to Medical Spa specifically, Mikro/Kecil/Menengah to non-Medical Spa specifically; authority array for Besar is `["Menteri/Kepala Badan","Menteri/Kepala Badan"]`, literally duplicated | Licensing section rewritten around the medical/non-medical split; the population gap (no Besar non-medical row, no small-scale medical row) stated explicitly rather than papered over |
+| 96400 | Draft's "two clean tracks" (PPMSE vs. non-PPMSE) oversimplifies a 24-row structure with at least 4 overlapping groups and heavy near-duplication, where risk varies by scale WITHIN each track (e.g. PPMSE-registered Mikro is Rendah, but PPMSE-registered Kecil/Menengah/Besar is Tinggi) | CONFIRMED — re-pulled and read all 24 raw rows individually | Licensing text rewritten to honestly describe the complexity and recommend confirming against live OSS rather than asserting a clean two-track rule |
+
+**General objections, by severity (reviewer's framing, after independent confirmation):**
+
+1. Eight rewrite drafts contained substantive canonical-contradicting or scope-distorting errors introduced
+   BY THIS PACK's own first draft, not inherited from the stored prose — all corrected above.
+2. Two verdicts (03232, 03233) needed to be more than plain SILENTE because of a genuine content-accuracy
+   issue distinct from licensing — corrected above.
+3. One verdict (85102) overstated how much of its claim canonical actually corroborates — corrected above.
+4. Two edits (65111, 85510) silently dropped hand-authored specific claims in favor of vaguer or
+   differently-sourced substitutes — both restored.
+5. The table-wide 312-row newline-corruption count could not be independently re-verified by the reviewer
+   (no live Postgres access in its sandbox), though nothing in the 25 quoted rows here contradicts it.
+
+No code's verdict needed to move in the other direction (i.e. no reviewer objection was itself found to be
+wrong on independent re-check) — every finding the reviewer raised against this pack's first draft held up.


### PR DESCRIPTION
## Summary

Mandate 10: for each of the 25 `kbli_documents` rows the auto-cure tool
(`kbli_documents_cure.py --all-licensing-absent`) found but refused to
rebuild (hand-written prose, not a machine-template, not caught by
`CONTRADICTED_LICENSING_CLAIM_RE`), this pack produces a card: live
`content` quoted verbatim, canonical's `per_skala` licensing rows the
channel doesn't serve, a CONTRADICE/COMPATIBILE/SILENTE verdict, and a
proposed rewrite that preserves hand-written value while adding the
canonical risk/authority/timeline picture. **Proposals only — nothing
in this PR is applied to `kbli_documents`.**

Split across 3 files by topic cluster:
- Part 1 — agriculture/food/tech/finance/creative (8 codes)
- Part 2 — education family (11 codes)
- Part 3 — arts/personal-services/spa/misc (6 codes) + the full
  25-code summary + the adversarial review

## Key findings

- **Population re-measured live, not assumed**: still exactly 25 codes,
  byte-identical to the 2026-08-02 report. No delta.
- **Final tally**: 5 CONTRADICE, 6 COMPATIBILE, 14 SILENTE.
- **3 codes (85573, 85574, 96230)** carry a near-identical false
  "BPS_ONLY / no PP28 data yet / pending" licensing claim that canonical
  already fully populates — a systemic near-miss of the cure tool's
  literal-phrase regex, not 3 unrelated one-offs.
- **56400** describes a food-truck business under a code whose official
  BPS scope is actually a commission-based F&B intermediation platform
  — a topic mismatch, not a licensing gap.
- **90310** (live prose, not just this pack's draft) names ARMA Museum/
  Neka/Agung Rai as examples — official scope explicitly EXCLUDES
  commercial galleries and museums from this code.
- **Side-finding, out of this mandate's scope but material**: 312 rows
  table-wide (well beyond these 25) have zero real newline characters
  in stored `content` — a run-on wall of text on WhatsApp/webchat today.
  Flagged to team-lead separately, not fixed here.

## Adversarial review

Genuine `codex` (gpt-5.6-sol, effort high, read-only sandbox) review run
against the first drafts of all three files, independently re-deriving
every canonical fact rather than trusting this pack's quotes. It found
real defects — 12 of 25 codes needed correction, 8 of them introduced
by this pack's OWN first-draft rewrites (not inherited from the stored
prose): an invented topic list on 85573, a reproduced scope error on
90310, oversimplified canonical structures on 96230/96400, dropped
hand-written specifics on 65111/85510, an overstated corroboration on
85102, and two under-stated verdicts on 03232/03233. Every finding was
independently re-verified against `KBLI_2025_FINAL_CLEAN.json` and live
`kbli_documents.content` before being incorporated — none accepted on
the reviewer's word alone. Full transcript and per-code table in Part
3's `## Adversarial review` section.

## Test plan

- [x] `python3 scripts/check_adversarial_review.py --files <all 3>` → PASS
- [x] `npx prettier --check <all 3>` → PASS
- [x] Pre-commit/pre-push hooks passed (docs-only, backend suite
      correctly skipped via path-aware allowlist)
- [x] No edits to `kbli_documents` or `kbli-gold-content.ts` — proposals only

🤖 Generated with [Claude Code](https://claude.com/claude-code)