### PR TITLE
docs(sync): bump AI_ONBOARDING test count 1308 -> 1309 (unblocks 4 PRs)

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 690 services · 1308 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 690 services · 1309 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

One-line regen of the DOCSYNC-derived contract in `docs/AI_ONBOARDING.md`: `1308 -> 1309 tests`.

## Why

`check-docs-sync` is a **required** check, and it is red on `origin/main` itself. A merged PR added a
backend test without folding `python scripts/docs_sync.py` into the same commit — the W86 shape
(`.claude/rules/cicatrix-superscar.md` #9). Every PR opened afterwards inherits a red required check
it did not cause.

Measured, not assumed — four PRs are blocked on this single cause right now:

- #3879, #3878, #3876, #3874 — all show `check-docs-sync ... concl=FAILURE` with the identical
  payload `docs/AI_ONBOARDING.md: a3bff7bf3a64 -> 44985024fe35`.

## Proof

Verified against `origin/main` (79ffad131) in a fresh worktree, **not** against a local checkout that
could be behind (W106b — the checkout is a proxy that lies when it is stale):

```
$ git rev-parse --short HEAD && git rev-parse --short origin/main
79ffad131
79ffad131
$ python3 scripts/docs_sync.py --check ; echo RC=$?
DOCSYNC STALE — run: python scripts/docs_sync.py
  docs/AI_ONBOARDING.md: a3bff7bf3a64 -> 44985024fe35
RC=1
```

After the regen, on the same worktree:

```
$ python3 scripts/docs_sync.py --check ; echo RC=$?
DOCSYNC OK (no changes)
RC=0
```

RC captured directly, never through a pipe (W97 — `| head` masks the exit code that decides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF6j1aaCbh5fPJU41vVosc