### PR TITLE
fix(nlm): seven of eight pipelines still call their calendar skip a failure

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -216,6 +216,7 @@ jobs:
               apps/evaluator/nlm_deep_research/nb8_pipeline.py|\
               apps/evaluator/nlm_deep_research/nb10_pipeline.py|\
               apps/evaluator/nlm_deep_research/tests/test_run_verdict.py|\
+              apps/evaluator/nlm_deep_research/tests/test_calendar_skip_marker_class.py|\
               .claude/skills/modus/PENDING-ARMS.md|\
               .github/workflows/immune-enforcement.yml|\
               .github/workflows/*.yml|\
@@ -492,6 +493,25 @@ jobs:
           # run_peraturan_ingestion.sh runs from crontab with NO wrapper, so an
           # unconditional deferral would have made it mute.
           bash scripts/test_cron_single_voice.sh
+
+      - name: Pipeline run-verdict corpora (a deliberate skip is not a failure)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # test_run_verdict.py landed with #3742 and was named in the path filter
+          # above but executed by NO workflow — 0 pytest invocations across
+          # .github/workflows. That is why #3742's own gap survived: it taught
+          # verdict() that a calendar skip exits 0 and wired the marker into ONE
+          # of the eight pipelines, and the corpus that would have said so never
+          # ran (W108 — an unarmed test is decorative).
+          #
+          # Measured live on Pro 2026-08-09, both runs correct, one shouting:
+          #   nb2 (marked)   -> WRAPPER_RC=0, zero sends
+          #   nb3 (unmarked) -> exit 1 + P0 "NB-3 ... pipeline FAILED (exit 1)"
+          python -m pip install --quiet pytest
+          PYTHONPATH=. python -m pytest \
+            apps/evaluator/nlm_deep_research/tests/test_run_verdict.py \
+            apps/evaluator/nlm_deep_research/tests/test_calendar_skip_marker_class.py \
+            -q
 
       - name: Connectome alert honesty corpus (freshness + truncation + delivery)
         if: steps.paths.outputs.relevant == 'true'

--- a/apps/evaluator/nlm_deep_research/nb10_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb10_pipeline.py
@@ -305,6 +305,7 @@ class NB10Pipeline:
             if not preflight_ok:
                 self._phase = PipelinePhase.HALTED
                 summary["halted_at"] = "preflight"
+                summary["halt_reason"] = getattr(self, "_halt_reason", None)
                 return summary
 
             if not self.circuit_breakers.nlm.should_allow_request():
@@ -416,6 +417,10 @@ class NB10Pipeline:
         is_sunday = now_wita.weekday() == 6
         if is_sunday and not self.dry_run and not self.force:
             logger.info("Sunday — NB-10 pipeline skipped")
+            # Intentional calendar skip, not a failure. Without this marker
+            # run_verdict.verdict() reads the bare False as a dead run and the
+            # wrapper fires a P0 saying FAILED — measured live 2026-08-09.
+            self._halt_reason = "skip:sunday"
             return False
         checks.append(("not_sunday", not is_sunday or self.dry_run or self.force))
 

--- a/apps/evaluator/nlm_deep_research/nb3_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb3_pipeline.py
@@ -284,6 +284,7 @@ class NB3Pipeline:
             if not preflight_ok:
                 self._phase = PipelinePhase.HALTED
                 summary["halted_at"] = "preflight"
+                summary["halt_reason"] = getattr(self, "_halt_reason", None)
                 return summary
 
             if not self.circuit_breakers.nlm.should_allow_request():
@@ -394,6 +395,10 @@ class NB3Pipeline:
         is_sunday = now_wita.weekday() == 6
         if is_sunday and not self.dry_run and not self.force:
             logger.info("Sunday — NB-3 pipeline skipped")
+            # Intentional calendar skip, not a failure. Without this marker
+            # run_verdict.verdict() reads the bare False as a dead run and the
+            # wrapper fires a P0 saying FAILED — measured live 2026-08-09.
+            self._halt_reason = "skip:sunday"
             return False
         checks.append(("not_sunday", not is_sunday or self.dry_run or self.force))
 

--- a/apps/evaluator/nlm_deep_research/nb4_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb4_pipeline.py
@@ -271,6 +271,7 @@ class NB4Pipeline:
             if not preflight_ok:
                 self._phase = PipelinePhase.HALTED
                 summary["halted_at"] = "preflight"
+                summary["halt_reason"] = getattr(self, "_halt_reason", None)
                 return summary
 
             if not self.circuit_breakers.nlm.should_allow_request():
@@ -390,6 +391,10 @@ class NB4Pipeline:
         is_sunday = now_wita.weekday() == 6
         if is_sunday and not self.dry_run and not self.force:
             logger.info("Sunday — NB-4 pipeline skipped")
+            # Intentional calendar skip, not a failure. Without this marker
+            # run_verdict.verdict() reads the bare False as a dead run and the
+            # wrapper fires a P0 saying FAILED — measured live 2026-08-09.
+            self._halt_reason = "skip:sunday"
             return False
         checks.append(("not_sunday", not is_sunday or self.dry_run or self.force))
 

--- a/apps/evaluator/nlm_deep_research/nb5_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb5_pipeline.py
@@ -275,6 +275,7 @@ class NB5Pipeline:
             if not preflight_ok:
                 self._phase = PipelinePhase.HALTED
                 summary["halted_at"] = "preflight"
+                summary["halt_reason"] = getattr(self, "_halt_reason", None)
                 return summary
 
             if not self.circuit_breakers.nlm.should_allow_request():
@@ -386,6 +387,10 @@ class NB5Pipeline:
         is_sunday = now_wita.weekday() == 6
         if is_sunday and not self.dry_run and not self.force:
             logger.info("Sunday — NB-5 pipeline skipped")
+            # Intentional calendar skip, not a failure. Without this marker
+            # run_verdict.verdict() reads the bare False as a dead run and the
+            # wrapper fires a P0 saying FAILED — measured live 2026-08-09.
+            self._halt_reason = "skip:sunday"
             return False
         checks.append(("not_sunday", not is_sunday or self.dry_run or self.force))
 

--- a/apps/evaluator/nlm_deep_research/nb6_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb6_pipeline.py
@@ -286,6 +286,7 @@ class NB6Pipeline:
             if not preflight_ok:
                 self._phase = PipelinePhase.HALTED
                 summary["halted_at"] = "preflight"
+                summary["halt_reason"] = getattr(self, "_halt_reason", None)
                 return summary
 
             if not self.circuit_breakers.nlm.should_allow_request():
@@ -397,6 +398,10 @@ class NB6Pipeline:
         is_sunday = now_wita.weekday() == 6
         if is_sunday and not self.dry_run and not self.force:
             logger.info("Sunday — NB-6 pipeline skipped")
+            # Intentional calendar skip, not a failure. Without this marker
+            # run_verdict.verdict() reads the bare False as a dead run and the
+            # wrapper fires a P0 saying FAILED — measured live 2026-08-09.
+            self._halt_reason = "skip:sunday"
             return False
         checks.append(("not_sunday", not is_sunday or self.dry_run or self.force))
 

--- a/apps/evaluator/nlm_deep_research/nb7_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb7_pipeline.py
@@ -273,6 +273,7 @@ class NB7Pipeline:
             if not preflight_ok:
                 self._phase = PipelinePhase.HALTED
                 summary["halted_at"] = "preflight"
+                summary["halt_reason"] = getattr(self, "_halt_reason", None)
                 return summary
 
             if not self.circuit_breakers.nlm.should_allow_request():
@@ -384,6 +385,10 @@ class NB7Pipeline:
         is_sunday = now_wita.weekday() == 6
         if is_sunday and not self.dry_run and not self.force:
             logger.info("Sunday — NB-7 pipeline skipped")
+            # Intentional calendar skip, not a failure. Without this marker
+            # run_verdict.verdict() reads the bare False as a dead run and the
+            # wrapper fires a P0 saying FAILED — measured live 2026-08-09.
+            self._halt_reason = "skip:sunday"
             return False
         checks.append(("not_sunday", not is_sunday or self.dry_run or self.force))
 

--- a/apps/evaluator/nlm_deep_research/nb8_pipeline.py
+++ b/apps/evaluator/nlm_deep_research/nb8_pipeline.py
@@ -300,6 +300,7 @@ class NB8Pipeline:
             if not preflight_ok:
                 self._phase = PipelinePhase.HALTED
                 summary["halted_at"] = "preflight"
+                summary["halt_reason"] = getattr(self, "_halt_reason", None)
                 return summary
 
             if not self.circuit_breakers.nlm.should_allow_request():
@@ -411,6 +412,10 @@ class NB8Pipeline:
         is_sunday = now_wita.weekday() == 6
         if is_sunday and not self.dry_run and not self.force:
             logger.info("Sunday — NB-8 pipeline skipped")
+            # Intentional calendar skip, not a failure. Without this marker
+            # run_verdict.verdict() reads the bare False as a dead run and the
+            # wrapper fires a P0 saying FAILED — measured live 2026-08-09.
+            self._halt_reason = "skip:sunday"
             return False
         checks.append(("not_sunday", not is_sunday or self.dry_run or self.force))
 

--- a/apps/evaluator/nlm_deep_research/run_verdict.py
+++ b/apps/evaluator/nlm_deep_research/run_verdict.py
@@ -30,8 +30,20 @@ copies of a corrected line.
 
 WHAT COUNTS AS FAILURE, and what deliberately does not:
 
-  - `halt_reason == "weekend"` → 0. An intentional calendar skip is a healthy
-    no-op, not a death; this rule already existed in pipeline.py and is kept.
+  - an intentional calendar skip → 0. A healthy no-op is not a death.
+    Recognised as `halt_reason == "weekend"` (the literal pipeline.py has
+    written since #3742, kept so a half-deployed fleet cannot regress) **or
+    any reason prefixed `skip:`**.
+
+    The prefix, rather than a set of accepted words, is the whole point.
+    #3742 built this module for all eight pipelines but wired the marker into
+    only ONE — the one that had bitten — so on 2026-08-09 nb2's Saturday skip
+    exited 0 in silence while nb3's Sunday skip still exited 1 and fired a P0
+    reading "NB-3 Company Setup pipeline FAILED (exit 1)". Both runs were
+    correct; one of them shouted. A word-list would have to be edited again
+    for the ninth pipeline, or for `skip:holiday`; a namespace cannot be
+    forgotten, and `test_calendar_skip_marker_class.py` refuses to let a
+    pipeline declare a marker this function does not honour.
   - pre-flight failed → 1 (the only case the old line got right).
   - `halted_at` set → 1. This is the case that was exiting 0.
   - any `status` starting with "error" anywhere in the summary → 1. This is
@@ -52,7 +64,22 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["verdict", "error_markers"]
+__all__ = ["verdict", "error_markers", "is_intentional_skip", "SKIP_PREFIX"]
+
+SKIP_PREFIX = "skip:"
+
+#: The one literal that predates the namespace. pipeline.py has written it
+#: since #3742 and it is deployed on Pro right now; dropping it here would
+#: make a mid-deploy fleet (new verdict.py, old pipeline.py) alarm on every
+#: Saturday skip — the exact regression this file exists to prevent.
+LEGACY_SKIP_REASONS = frozenset({"weekend"})
+
+
+def is_intentional_skip(halt_reason: Any) -> bool:
+    """True when the pipeline deliberately did not run. See module docstring."""
+    if not isinstance(halt_reason, str):
+        return False
+    return halt_reason in LEGACY_SKIP_REASONS or halt_reason.startswith(SKIP_PREFIX)
 
 
 def error_markers(node: Any, path: str = "") -> list[str]:
@@ -84,8 +111,9 @@ def verdict(summary: Any) -> tuple[int, str]:
         # rather than treating an unreadable summary as a clean run.
         return 1, "pipeline returned no usable summary"
 
-    if summary.get("halt_reason") == "weekend":
-        return 0, "weekend skip (intentional no-op)"
+    halt_reason = summary.get("halt_reason")
+    if is_intentional_skip(halt_reason):
+        return 0, f"{halt_reason} (intentional no-op)"
 
     phases = summary.get("phases")
     preflight = phases.get("preflight") if isinstance(phases, dict) else None

--- a/apps/evaluator/nlm_deep_research/tests/test_calendar_skip_marker_class.py
+++ b/apps/evaluator/nlm_deep_research/tests/test_calendar_skip_marker_class.py
@@ -1,0 +1,181 @@
+"""A pipeline that deliberately did not run must not report a failure (2026-08-09).
+
+TRAUMA. #3742 replaced eight copies of `sys.exit(0 if preflight passed else 1)`
+with one shared `verdict()`, and taught it that an intentional calendar skip is
+a healthy no-op. It wired the marker into **one** of the eight — `pipeline.py`
+(nb2), the one that had bitten. Measured live on Pro the morning this was
+written, both runs correct, one of them shouting:
+
+    nb2, Sunday, weekend guard   -> WRAPPER_RC=0, zero Telegram sends
+    nb3, Sunday, sunday guard    -> exit 1, P0 "NB-3 Company Setup pipeline
+                                    FAILED (exit 1) — check <log>"
+
+Before #3742 that same false exit fed the whole chain: on 2026-07-11 and
+2026-07-18 — two Saturdays whose nb2 log contains nothing but "nlm CLI
+available", all breakers CLOSED, "Weekend — pipeline skipped" — the DLQ
+autopilot spent three repair attempts on a pipeline with nothing wrong with it
+and then declared `TERMINAL`. Three alerts each Saturday for a healthy no-op.
+
+The seven Sunday guards are cron-unreachable today (`45 2 * * 1-6` is Mon–Sat),
+which is exactly why nobody noticed: the defect is latent until someone runs a
+catch-up by hand, or moves one schedule to `* * *`. Latent is not absent.
+
+This file is the class guard, not seven fixes: superscar #2/W107 — "I cured ONE
+wrapper out of FIVE and called the disease closed". It reads the real modules,
+so a ninth pipeline copied from any of these fails here until its skip is
+marked with something `verdict()` actually honours.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from apps.evaluator.nlm_deep_research.run_verdict import (
+    SKIP_PREFIX,
+    is_intentional_skip,
+    verdict,
+)
+
+PKG = Path(__file__).resolve().parent.parent
+
+#: Every module that owns a pipeline `run()`. Derived from disk rather than
+#: hardcoded: a list is a thing you forget to extend, which is the defect.
+PIPELINES = sorted(
+    p.name
+    for p in PKG.glob("*pipeline*.py")
+    if "_preflight" in p.read_text() and "class " in p.read_text()
+)
+
+
+def _tree(name: str) -> ast.Module:
+    return ast.parse((PKG / name).read_text(), filename=name)
+
+
+def _skip_branch_reasons(tree: ast.Module) -> list[str | None]:
+    """The literal assigned to `self._halt_reason` inside each calendar-skip
+    branch — `None` where the branch sets nothing at all.
+
+    Anchored on the `logger.*("... pipeline skipped")` call that IS the branch,
+    not on a weekday expression: `weekday()`, `is_sunday` and `is_weekend` are
+    three spellings of one intent, and matching the spelling is how a guard
+    starts judging form instead of entity (superscar #3).
+    """
+    out: list[str | None] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        calls = [n for n in ast.walk(node) if isinstance(n, ast.Call)]
+        announces_skip = any(
+            isinstance(c.func, ast.Attribute)
+            and c.args
+            and isinstance(c.args[0], ast.Constant)
+            and isinstance(c.args[0].value, str)
+            and "pipeline skipped" in c.args[0].value
+            for c in calls
+        )
+        if not announces_skip:
+            continue
+        reason: str | None = None
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Assign) or not isinstance(sub.value, ast.Constant):
+                continue
+            for tgt in sub.targets:
+                if (
+                    isinstance(tgt, ast.Attribute)
+                    and tgt.attr == "_halt_reason"
+                    and isinstance(tgt.value, ast.Name)
+                    and tgt.value.id == "self"
+                ):
+                    reason = sub.value.value
+        out.append(reason)
+    return out
+
+
+# ── the class: every pipeline, read from disk ────────────────────────────────
+
+
+def test_the_class_is_not_empty():
+    """A discovery bug that finds nothing would make every test below vacuous."""
+    assert len(PIPELINES) >= 8, PIPELINES
+
+
+@pytest.mark.parametrize("module", PIPELINES)
+def test_every_calendar_skip_is_marked_and_the_verdict_honours_it(module):
+    reasons = _skip_branch_reasons(_tree(module))
+    assert reasons, f"{module}: no calendar-skip branch found — did the anchor move?"
+    for reason in reasons:
+        assert reason is not None, (
+            f"{module}: its calendar-skip branch returns False without setting "
+            f"self._halt_reason, so verdict() reads a deliberate no-op as a dead "
+            f"run and the wrapper fires a P0 saying FAILED."
+        )
+        assert is_intentional_skip(reason), (
+            f"{module}: marks its skip {reason!r}, which verdict() does not "
+            f"honour — use the {SKIP_PREFIX!r} namespace."
+        )
+
+
+@pytest.mark.parametrize("module", PIPELINES)
+def test_every_pipeline_carries_the_marker_into_its_summary(module):
+    """Setting `_halt_reason` is useless if `run()` never puts it in the summary.
+
+    verdict() only ever sees the summary; a module that marks the skip and drops
+    it on the floor exits 1 exactly as before, and both halves look correct in
+    isolation.
+    """
+    src = (PKG / module).read_text()
+    assert '"halt_reason"' in src, (
+        f"{module}: sets no summary['halt_reason'], so the marker never reaches verdict()"
+    )
+
+
+# ── the rule itself: guilt and innocence ─────────────────────────────────────
+
+
+def _halted(reason):
+    """The summary shape run() returns when pre-flight stops it."""
+    return {"phases": {"preflight": {"passed": False}}, "halted_at": "preflight",
+            "halt_reason": reason}
+
+
+@pytest.mark.parametrize("reason", ["skip:sunday", "skip:weekend", "skip:holiday", "weekend"])
+def test_an_intentional_skip_exits_zero(reason):
+    code, why = verdict(_halted(reason))
+    assert code == 0, why
+    assert reason in why, "the verdict must name its own reason"
+
+
+@pytest.mark.parametrize("reason", ["l1_circuit_open", "nlm_unavailable", "", None])
+def test_a_real_halt_still_fails(reason):
+    """Innocence. These are reasons this repo's pipelines genuinely emit, not
+    strings invented here — an innocence check built from your own new objects
+    confirms your convention, not reality (W116)."""
+    code, why = verdict(_halted(reason))
+    assert code == 1, why
+    assert "pre-flight failed" in why
+
+
+def test_a_skip_shaped_string_in_the_wrong_field_does_not_excuse_a_failure():
+    """`skip:` is only meaningful as the halt_reason. A phase that happens to
+    contain the word must not buy a green run."""
+    summary = {"phases": {"preflight": {"passed": False}, "l1": {"note": "skip:sunday"}},
+               "halted_at": "preflight"}
+    assert verdict(summary)[0] == 1
+
+
+def test_a_completed_run_is_unaffected():
+    summary = {"phases": {"preflight": {"passed": True}}}
+    assert verdict(summary) == (0, "completed")
+
+
+def test_an_error_marker_still_beats_a_clean_preflight():
+    summary = {"phases": {"preflight": {"passed": True}, "add": {"status": "error_nlm_add"}}}
+    code, why = verdict(summary)
+    assert code == 1 and "error_nlm_add" in why
+
+
+def test_is_intentional_skip_rejects_non_strings():
+    for value in (None, 0, 1, True, [], {}, object()):
+        assert is_intentional_skip(value) is False


### PR DESCRIPTION
## Measured live on Pro, 2026-08-09 — both runs correct, one of them shouts

| pipeline | guard | marked? | result |
|---|---|---|---|
| nb2 (`pipeline.py`) | weekend | ✅ | `WRAPPER_RC=0`, **zero Telegram sends** |
| nb3 | sunday | ❌ | `exit 1` + P0 `"NB-3 Company Setup pipeline FAILED (exit 1)"` |

**#3742** replaced eight copies of `sys.exit(0 if preflight passed else 1)` with one
shared `verdict()` and taught it that an intentional calendar skip is a healthy
no-op. It wired the marker into **one** of the eight — the one that had bitten.
`_halt_reason` count across the family before this PR: `pipeline.py` 2, everything
else **0**.

## What that false exit used to cost

On **2026-07-11** and **2026-07-18**, nb2's entire Saturday log is:

```
nlm CLI available: nlm version 0.8.3
Loaded pipeline state: COMPLETE
Circuit breakers loaded: NLM=CLOSED SOURCE=CLOSED INTEGRATION=CLOSED
=== PRE-FLIGHT CHECKLIST ===
Weekend — pipeline skipped (use --force to override)
Saved pipeline state: HALTED
```

Nothing wrong. Each of those Saturdays cost **three alerts** — a sentinel
`cli-failed` digest, a DLQ escalation, and `TERMINAL: reached 3 autopilot attempts
with no fix`. The autopilot spent three repair attempts on a pipeline that was
working as designed.

**Not claimed**: that #3742 ended that cascade. The nb2 alerts stop on **07-25**,
two weeks before #3742 merged — what silenced them then is not established. What
#3742 guarantees, and what this PR extends to the other seven, is that the skip
cannot re-enter that chain.

## Honest reachability

The seven Sunday guards are **cron-unreachable today** (`45 2 * * 1-6` is Mon–Sat),
so this costs **0 messages/day** right now. It fires on any hand-run catch-up —
that is how it was found — and becomes seven false P0s a week the day one schedule
moves to `* * *`. Latent is not absent.

## The cure

- the seven set `_halt_reason = "skip:sunday"` and carry it into the summary.
  Both halves are needed and both are asserted: marking without propagating leaves
  the exit code exactly as it was, and each half looks correct alone.
- `verdict()` honours the `skip:` **namespace**, not a word-list — a list has to be
  edited again for the ninth pipeline or for `skip:holiday`. `"weekend"` stays
  accepted so a half-deployed fleet (new `verdict.py`, old `pipeline.py`) cannot
  regress on a Saturday.
- `test_calendar_skip_marker_class.py` derives the class **from disk**, anchored on
  the `"... pipeline skipped"` log call rather than on a weekday expression
  (`weekday()`, `is_sunday`, `is_weekend` are three spellings of one intent, and
  matching the spelling is how a guard starts judging form). A ninth pipeline
  copied from any of these fails here.
- mutation-verified **3/3**: drop the marker from one module · revert `verdict()`
  to the single literal · mark the skip but never put it in the summary.

## Why the gap survived

`tests/test_run_verdict.py` — #3742's own corpus — was named in
`immune-enforcement.yml`'s path filter and executed by **no workflow**: 0 pytest
invocations across `.github/`. Both corpora now run there. A path filter that names
a test is not a workflow that runs it (W108).

## Out of scope, measured

5 pre-existing failures in `test_cross_notebook_correlator.py` — identical with
this diff stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)