### PR TITLE
fix(immune): the retracted-claims guard flagged a ReDoS benchmark as a citation

### DIFF
--- a/infra/retracted-claims/registry.json
+++ b/infra/retracted-claims/registry.json
@@ -62,8 +62,8 @@
     {
       "id": "kim-2025-17x-error-amplification-as-cause",
       "pattern": "\\b17[.,]2\\s*(-|\\s)?\\s*[×x]|\\b4[.,]4\\s*(-|\\s)?\\s*[×x]",
-      "context_pattern": "error|amplif|peer|topolog|coordinat|Kim|2512\\.08296|Independent|Decentralized|swarm|Google|sub-?agents?|agents?|talk|hand-?off|handoff|never",
-      "context_window": 3,
+      "context_pattern": "error|amplif|peer|topolog|coordinat|Kim|2512\\.08296|Independent|Decentralized|swarm|Google|sub-?agents?|hand-?off|handoff",
+      "context_window": 0,
       "source": "arXiv:2512.08296v3 (Kim et al., Towards a Science of Scaling Agent Systems)",
       "retracted": "2026-08-02",
       "prs": ["#3509", "#3513", "#3514"],

--- a/scripts/lint_retracted_claims.py
+++ b/scripts/lint_retracted_claims.py
@@ -640,10 +640,47 @@ def run_selftest(registry_path: Optional[Path] = None) -> int:
             ("kim-2025-ranking-supports-the-no-peer-rule",
              "Independent is lowest, therefore use centralized state (2512.08296)"),
         ]
+        # The other half, and the half this guard did not have: text that
+        # contains the NUMBER and means something else entirely. `4.4x` is a
+        # bare ratio shape — a benchmark, a speedup, a regex timing — and the
+        # claim's subject is what makes it a citation.
+        #
+        # MEASURED 2026-08-09, this guard blocking a live PR (#3837): a ledger
+        # row reading `0.0049s -> 0.0216s (4.4x for 2x input, max 3.0x)` — a
+        # ReDoS timing benchmark — was flagged, because the anchor list carried
+        # the bare word `agents?` and the window was +/-3 lines, so it matched
+        # `agents` in an UNRELATED row of the same list. In an agent ledger that
+        # word is background noise, not an entity (superscar #3: the form, not
+        # the fact). The anchor is now same-line, and the generic tokens
+        # (`agents?`, `talk`, `never`) are gone — every evasion above still
+        # fires via `Google`, `error`, or `Independent`, asserted right here.
+        # Each case pins ONE half of the fix, because either half alone happens
+        # to clear the live PR — so a corpus that only replays the live text
+        # lets the other half be reverted in silence. Written after both
+        # mutations SURVIVED a first draft of this list (W116: a surviving
+        # mutant is sometimes a vacuous test, not a missing one).
+        _INNOCENTS = [
+            # pins REMOVING the generic tokens: one line, ratio + `agents`,
+            # obviously not a citation. Fires again if `agents?` returns.
+            ("generic token on the same line",
+             "the wa-mirror agents' bench went 4.4x faster after caching"),
+            # pins context_window: 0. The ratio is alone on its line; the
+            # anchor `error` sits on a NEIGHBOUR, which is exactly how an
+            # unrelated ledger row three lines away flagged #3837.
+            ("anchor bleeding from a neighbouring line",
+             "regex sweep: 0.0049s -> 0.0216s (4.4x for 2x input, max 3.0x)\n"
+             "the error budget for this lane is tracked separately\n"),
+            ("plain speedup", "throughput improved 17.2x on the new index"),
+        ]
         prod_path = registry_path or DEFAULT_REGISTRY
         if prod_path.is_file():
             pclaims, pwindow, pdirs = load_registry(prod_path)
             expect("production registry parses", len(pclaims) >= 1)
+            for label, text in _INNOCENTS:
+                expect(
+                    f"PROD INNOCENCE bare ratio is not a citation ({label})",
+                    scan_text(text + "\n", pclaims, pdirs, pwindow) == [],
+                )
             for c in pclaims:
                 probe, truth = {
                     "kim-2025-17x-error-amplification-as-cause": (


### PR DESCRIPTION
## The false positive, measured

`.claude/skills/modus/PENDING-ARMS.md:844`, a ledger row about the pre-push gate:

```
0.0049s -> 0.0216s (4.4x for 2x input, max 3.0x)
```

flagged as re-asserting `kim-2025-17x-error-amplification-as-cause`, hard-blocking
**#3837** on the required `antidotes` check.

Why it matched:

- the numeric pattern is `\b17[.,]2\s*[×x]|\b4[.,]4\s*[×x]` — `4.4x` is a **bare
  ratio shape**: a benchmark, a speedup, a regex timing.
- the context anchor carried the bare word **`agents?`** with `context_window: 3`,
  and the anchor it actually hit was `agents` **three rows away**, in an unrelated
  entry about launchd plists. In an agent ledger that word is background noise.

Superscar #3, on W113's own guard: it judged **form** (a number, a common noun
somewhere nearby) instead of **entity**.

## Why annotating was never an option

The failure message proposes adding a retraction directive near the line. That
would have written into the ledger the assertion that a ReDoS benchmark is a
citation of Kim et al. **An exemption is a claim about the document** (W109) — so
the only correct move was to fix the anchor.

## The fix

- drop `agents?`, `talk`, `never` from the anchor. Every pinned evasion in
  `_EVASIONS` still fires — via `Google`, `error`, `Independent` — and the selftest
  asserts exactly that against the **shipped** registry.
- `context_window: 0` for this claim only: a real citation puts the number and its
  subject in one sentence. The ±20 window for the retraction **directive** is a
  different mechanism and is untouched.

## The corpus, and the draft of it that was vacuous

The first `_INNOCENTS` list let **both mutations survive** — because either half of
the fix alone clears the live text, and the cases exercised neither. A surviving
mutant is sometimes a vacuous test, not a missing one (W116).

Each case now pins one half:

| case | pins | fires again if |
|---|---|---|
| `the wa-mirror agents' bench went 4.4x faster after caching` | token removal | `agents?` returns |
| ratio on one line, `error` on the **next** | `context_window: 0` | the window returns |

Mutation-verified **2/2**. Selftest **61 checks**. `--all` scans **2223 files
clean**; a real re-assertion still exits 1; the blocked ledger file is clean.

## After merge

#3837's `antidotes` ran against its own head — it needs `gh pr update-branch 3837`,
not a re-run: a re-run replays a stale merge ref (W111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)