### PR TITLE
fix(antidotes): the retracted-claims guard judged form, not entity — `4.4x` is a homograph

### DIFF
--- a/infra/retracted-claims/registry.json
+++ b/infra/retracted-claims/registry.json
@@ -62,7 +62,7 @@
     {
       "id": "kim-2025-17x-error-amplification-as-cause",
       "pattern": "\\b17[.,]2\\s*(-|\\s)?\\s*[×x]|\\b4[.,]4\\s*(-|\\s)?\\s*[×x]",
-      "context_pattern": "error|amplif|peer|topolog|coordinat|Kim|2512\\.08296|Independent|Decentralized|swarm|Google|sub-?agents?|agents?|talk|hand-?off|handoff|never",
+      "context_pattern": "error|amplif|peer|topolog|coordinat|Kim|2512\\.08296|Independent|Decentralized|swarm|Google|talk|hand-?off|handoff",
       "context_window": 3,
       "source": "arXiv:2512.08296v3 (Kim et al., Towards a Science of Scaling Agent Systems)",
       "retracted": "2026-08-02",

--- a/scripts/lint_retracted_claims.py
+++ b/scripts/lint_retracted_claims.py
@@ -640,6 +640,24 @@ def run_selftest(registry_path: Optional[Path] = None) -> int:
             ("kim-2025-ranking-supports-the-no-peer-rule",
              "Independent is lowest, therefore use centralized state (2512.08296)"),
         ]
+        # The mirror of _EVASIONS: real repo prose that CARRIES the relic number
+        # and is NOT the claim. `4.4x` is a homograph — a wall-clock ratio is the
+        # commonest way a number-followed-by-x appears in an ops ledger — so the
+        # context_pattern is the only thing standing between the guard and a false
+        # accusation. It failed on 2026-08-09 (PR #3837, blocked for a ReDoS timing
+        # measurement) because the pattern carried `agents?` and `never`: tokens
+        # present in 556 and 834 tracked .md files respectively, i.e. satisfied by
+        # ambient prose in a repo about agents. Verbatim, so a future widening of
+        # the context re-opens this loudly instead of on someone else's PR.
+        _HOMOGRAPHS = [
+            ("kim-2025-17x-error-amplification-as-cause",
+             "promote the plist into `infra/launchagents/`, and check whether the other wr2 agents' plists\n"
+             "are in the same state | proof-of-armed: the tracked copy is byte-identical to the loaded one\n"
+             "the suite then failed at 96% on `test_redos_anchor_patterns.py`: `0.0049s -> 0.0216s "
+             "(4.4x for 2x input, max 3.0x)`, and again at 3.8x when re-run alone at load average 9-11\n"
+             "**Deliberately NOT fixed by widening the allowlist**: unblocking my own push by relaxing\n"
+             "the gate that blocked it is the generator grading its own diff, and it must never be done"),
+        ]
         prod_path = registry_path or DEFAULT_REGISTRY
         if prod_path.is_file():
             pclaims, pwindow, pdirs = load_registry(prod_path)
@@ -683,6 +701,13 @@ def run_selftest(registry_path: Optional[Path] = None) -> int:
                     expect(
                         f"PROD GUILT `{c.id}` catches the evasive form: {text[:46]}...",
                         len(scan_text(text + "\n", [c], pdirs, pwindow)) == 1,
+                    )
+                for hid, text in _HOMOGRAPHS:
+                    if hid != c.id:
+                        continue
+                    expect(
+                        f"PROD INNOCENCE `{c.id}` a homograph of the relic number is not the claim",
+                        scan_text(text + "\n", [c], pdirs, pwindow) == [],
                     )
                 if c.require_marker:
                     expect(


### PR DESCRIPTION
## The bug

`antidotes` is a required check and it is blocking **PR #3837** for this line:

```
`0.0049s -> 0.0216s (4.4x for 2x input, max 3.0x)`
```

That is a ReDoS timing measurement. It has nothing to do with Kim et al.

The `kim-2025-17x-error-amplification-as-cause` entry carried a `context_pattern` containing
`agents?` and `never`. Measured on tracked markdown in this repo:

| token    | tracked `.md` files containing it |
|----------|-----------------------------------|
| `agents` | 556                               |
| `never`  | 834                               |

In a repo *about agents*, those are ambient prose. The context stopped discriminating, so the
whole verdict fell onto the numeric pattern — and `4.4x` is a perfect homograph, because a
wall-clock ratio is the commonest way "number followed by x" appears in an ops ledger. The
3-line window around the offending line was completed by `agents'` (wr2 plists, 4 occurrences)
three lines up.

Superscar #3, and the irony is that this is W113's own guard biting an innocent record.

**Annotating the ledger line was not an option.** `RETRACTED[<id>]` is an assertion *about the
text*, and that text does not discuss the claim — writing it there would put a false statement
into the ledger to buy a green check (W109: an exemption is a claim, not a formality).

## The cure

Dropped exactly the two ambient tokens. Kept every token that NAMES the claim — including
`Google`, `talk`, `hand-off`, which is what catches the evasive form already pinned in
`_EVASIONS` ("Google's 17.2x finding is why agents must never talk to each other").

Measured across the 85 real repo lines carrying the relic number, rather than argued:

| variant                      | guilt | evasive form | PR #3837 line |
|------------------------------|-------|--------------|---------------|
| current                      | 81/85 | CAUGHT       | FIRES (bug)   |
| drop `agents?` only          | 81/85 | CAUGHT       | FIRES (bug)   |
| **drop `agents?` + `never`** | **81/85** | **CAUGHT** | **clean**   |
| drop all weak tokens         | 81/85 | MISSED       | clean         |

**Zero guilt lost** — the 4 lines it misses were already missed before this diff.

## The regression is pinned, and the pin can go red

`_HOMOGRAPHS` is the mirror of `_EVASIONS`: real repo prose that carries the relic number and
is not the claim, verbatim, so a future widening of the context re-opens this in the selftest
instead of on someone else's PR.

Mutation-verified, because a check that cannot fail is decorative (W116):

- cured registry    → `SELFTEST OK — 59 checks`
- original registry → `SELFTEST FAILED — 1/59`, and the failing check is exactly
  `PROD INNOCENCE ... a homograph of the relic number is not the claim`

Also verified: `--all` green over 2224 files; the real #3837 file passes with the cured
registry and still FAILS with the original one (the probe can say yes).

generator ≠ grader: #3837 is another session's diff (M5); this is Pro grading it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF6j1aaCbh5fPJU41vVosc