### PR TITLE
fix(intel): promote the LIVE nb-pusher HOME fork and merge cure #3891 into it

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -663,6 +663,12 @@
       "repo": "infra/openclaw/guardian-board-report",
       "_note": "PROMOTED 2026-08-09 (organ ward-round). Was HOME-only and undeclared, invoked by plist com.nuzantara.openclaw.guardian-board (daily 08:30). Promoted together with a fix: the flat 120s subprocess timeout in run_tool() applied to every MCP tool call including guardian_risk_score (RBAC/API-contract/cache/dead-code scoring across the full codebase), which was seen degraded (timeout) 3 times in the last 15 runs. Repo canon adds a per-tool timeout override (guardian_risk_score -> 240s), all other tools stay at 120s. Live HOME copy still needs manual sync post-merge — do NOT treat this pair as aligned until the operator re-copies and sha256-verifies.",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/intel-lake-nb-pusher-standalone.py",
+      "repo": "scripts/intel-lake-nb-pusher-a2/intel-lake-nb-pusher-standalone.py",
+      "_note": "PROMOTED 2026-08-09 (organ ward-round, round 2): #3891's auth-refresh cure had landed on a file the cron never runs — LaunchAgent com.balizero.intel-lake-nb-pusher.15min -> ~/scripts/intel-lake-nb-pusher-cron.sh executes ~/scripts/intel-lake-nb-pusher-standalone.py, an undeclared HOME copy that had diverged from the repo canon by 71 lines. The HOME copy was AHEAD: it carries the _NB_UUID_REMAP/_NB_UUID_ORPHAN block (zero-profile -> default-profile UUID remap, live since 2026-06-10, plus --profile default on every nlm call) and the 'could not add url source' -> network error classification — none of that had ever reached the repo. Neither side was complete. This pair is the UNION: HOME content as the base (it is the live canon; overwriting it from the stale repo file would have been a W106b regression) with ONLY the #3891 auth-refresh startup-gate patch re-applied on top (verified by diff: union file minus HOME == exactly the auth-refresh block). Live HOME copy still needs manual sync post-merge — do NOT treat this pair as aligned until the operator re-copies and sha256-verifies.",
+      "machines": ["pro"]
     }
   ],
   "allow": [

--- a/scripts/intel-lake-nb-pusher-a2/intel-lake-nb-pusher-standalone.py
+++ b/scripts/intel-lake-nb-pusher-a2/intel-lake-nb-pusher-standalone.py
@@ -47,10 +47,11 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import asyncpg
 
@@ -62,6 +63,24 @@ logger = logging.getLogger("intel-lake-nb-pusher")
 
 METRICS_PATH = Path.home() / "logs" / "intel-lake-nb-pusher.metrics.json"
 NLM_CLI = Path.home() / ".local" / "bin" / "nlm"
+
+# ─── NB UUID remap (zero-profile UUIDs -> default-profile UUIDs, 2026-06-10) ─
+# The `zero` NLM profile is dead; the live profile is `default` whose
+# NB-INTEL notebooks have NEW UUIDs. Translate the old (stored) UUID to
+# the new one BEFORE every `nlm source add`. Orphan UUIDs (no default-side
+# equivalent) are skipped to avoid repeated NOT_FOUND churn.
+_NB_UUID_REMAP = {
+    "caec5b82-287c-464f-844f-02e2c8f04c21": "9d262101-abeb-4e15-af9c-c38e028c62fe",  # Press
+    "78b45ad8-ddce-4bd8-bdf0-3b45800897da": "7fb12c9c-4e12-4a8d-9bd1-c5b857bf310f",  # Tax
+    # Probe sandbox: zero-profile 1e33e107 -> default-profile NB-PROBE-SANDBOX-2026-05
+    # (writable, verified 2026-06-10). Remap runs BEFORE the orphan check below,
+    # so the e2e-probe (hop4) now delivers to a real default NB and passes.
+    "1e33e107-4064-48cd-b09d-f7f0a52b31ea": "7e6ae978-136c-4c96-bed5-9fab6f39176f",  # Probe sandbox
+}
+_NB_UUID_ORPHAN = {
+    "1e33e107-4064-48cd-b09d-f7f0a52b31ea",  # no default-profile equivalent
+}
+
 BATCH_SIZE = 10
 NLM_TIMEOUT_SECONDS = 60
 SLEEP_BETWEEN_ITEMS_S = 5
@@ -100,6 +119,10 @@ def _classify_nlm_error(stderr: str, stdout: str, returncode: int) -> str:
         return "timeout"
     if any(k in tl for k in ("network", "timeout", "connection", "unreachable")):
         return "network"
+    # NLM URL add failure (e.g. RFC 2606 .test TLD probe URLs, dead links,
+    # paywalls) — surface as "network" so text fallback fires.
+    if "could not add url source" in tl or "check the url is accessible" in tl:
+        return "network"
     return "unknown"
 
 
@@ -136,7 +159,7 @@ def _nlm_check_auth() -> bool:
     """Fail-fast auth check at startup."""
     try:
         result = subprocess.run(
-            [str(NLM_CLI), "login", "--check"],
+            [str(NLM_CLI), "login", "--check", "--profile", "default"],
             capture_output=True,
             text=True,
             timeout=15,
@@ -148,10 +171,17 @@ def _nlm_check_auth() -> bool:
 
 def _nlm_push_url(notebook_id: str, url: str, title: str | None = None) -> tuple[bool, str, str]:
     """Try URL push. Returns (ok, error_class, error_text)."""
+    # Remap stored (zero-profile / legacy) UUIDs to their default-profile
+    # equivalents BEFORE the orphan check, so a UUID that now has a real
+    # default NB (e.g. the probe sandbox) is delivered, not skipped.
+    notebook_id = _NB_UUID_REMAP.get(notebook_id, notebook_id)
+    if notebook_id in _NB_UUID_ORPHAN:
+        logger.info("skip orphan notebook (no default-profile UUID): %s", notebook_id)
+        return False, "not_found", "skip orphan notebook"
     cmd = [
         "/usr/bin/env",
         "timeout",
-        "--kill-after=5",
+        f"--kill-after=5",
         str(NLM_TIMEOUT_SECONDS),
         str(NLM_CLI),
         "source",
@@ -159,6 +189,8 @@ def _nlm_push_url(notebook_id: str, url: str, title: str | None = None) -> tuple
         notebook_id,
         "--url",
         url,
+        "--profile",
+        "default",
     ]
     if title:
         cmd.extend(["--title", title])
@@ -176,13 +208,20 @@ def _nlm_push_url(notebook_id: str, url: str, title: str | None = None) -> tuple
 
 def _nlm_push_text(notebook_id: str, title: str, body: str) -> tuple[bool, str, str]:
     """Fallback to text push via temp file."""
+    # Remap stored (zero-profile / legacy) UUIDs to their default-profile
+    # equivalents BEFORE the orphan check, so a UUID that now has a real
+    # default NB (e.g. the probe sandbox) is delivered, not skipped.
+    notebook_id = _NB_UUID_REMAP.get(notebook_id, notebook_id)
+    if notebook_id in _NB_UUID_ORPHAN:
+        logger.info("skip orphan notebook (no default-profile UUID): %s", notebook_id)
+        return False, "not_found", "skip orphan notebook"
     tmp = Path(f"/tmp/nlm_push_{uuid4().hex[:8]}.txt")
     try:
         tmp.write_text(body)
         cmd = [
             "/usr/bin/env",
             "timeout",
-            "--kill-after=5",
+            f"--kill-after=5",
             str(NLM_TIMEOUT_SECONDS),
             str(NLM_CLI),
             "source",
@@ -192,6 +231,8 @@ def _nlm_push_text(notebook_id: str, title: str, body: str) -> tuple[bool, str, 
             str(tmp),
             "--title",
             title[:100],
+            "--profile",
+            "default",
         ]
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=NLM_TIMEOUT_SECONDS + 10)
         if r.returncode == 0:


### PR DESCRIPTION
## The cure had landed on a file the cron never runs

Follow-up to #3891, closing the loop its PROVE-LIVE opened. Three facts:

1. **The wrapper runs the HOME copy.** `com.balizero.intel-lake-nb-pusher.15min` → `~/scripts/intel-lake-nb-pusher-cron.sh` → `~/scripts/intel-lake-nb-pusher-standalone.py`. The repo file at `scripts/intel-lake-nb-pusher-a2/` is never executed by the cron.
2. **The HOME copy was an undeclared fork, and it was AHEAD.** 71 divergent lines, all live behavior the repo lacked: the `_NB_UUID_REMAP`/`_NB_UUID_ORPHAN` block (zero-profile → default-profile UUID translation, live since 2026-06-10), the `"could not add url source"` → `network` error classification, and `--profile default` on all three `nlm` CLI invocations. Realigning HOME from repo — the reflex cure — would have been a regression (W106b).
3. **So the auth-refresh cure from #3891 was armed to nothing.** This PR builds the UNION: HOME copy as base, with the exact `8390a219a` startup-gate patch re-applied on top. Verified: `diff HOME vs promoted` = the auth-refresh hunk alone, nothing else added or dropped. The pair is now declared in `infra/home-fork/declared-pairs.json` (machines: pro), so `lint_home_fork` finally has eyes on it.

Post-merge (session-owned): re-copy repo → `~/scripts/intel-lake-nb-pusher-standalone.py`, sha256-verify, and the next 15-min cron tick is the live proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)