### PR TITLE
fix(connectome): a retirement is also declared by MOVING the plist, not only by renaming it

### DIFF
--- a/scripts/tests/test_connectome_retirement_markers.py
+++ b/scripts/tests/test_connectome_retirement_markers.py
@@ -167,3 +167,123 @@ def test_a_missing_live_directory_does_not_crash_and_still_reads_the_repo(dirs, 
     monkeypatch.setattr(vc, "LAUNCHAGENTS_DIR", Path("/nonexistent/LaunchAgents"))
     (repo / "com.x.job.plist.retired").write_text("<plist/>")
     assert vc.plist_intentionally_disabled("com.x.job") == "com.x.job.plist.retired"
+
+
+# ── the SECOND idiom: retirement declared by moving the plist into a dated dir ──
+#
+# Found by PROVE-LIVE of the suffix cure above, hours after it merged. PR #3891
+# retired `com.balizero.nextdns-tamper-detect.weekly` with "bootout + plist moved
+# to `.retired-2026-08-09/`" — the file keeps its exact name, so the suffix glob
+# is structurally blind to it and that label was left as the one remaining
+# REGRESSED on Pro. Curing one idiom of two does not halve the false alarms; it
+# only changes WHICH deliberate retirement gets mistaken for a silent death (W107).
+
+def test_a_plist_moved_into_a_retirement_directory_is_a_declaration(dirs):
+    """The live nextdns case: same filename, one level down, dir name declares it."""
+    live, _ = dirs
+    retired = live / ".retired-2026-08-09"
+    retired.mkdir()
+    (retired / "com.x.job.plist").write_text("<plist/>")
+    assert (
+        vc.plist_intentionally_disabled("com.x.job")
+        == ".retired-2026-08-09/com.x.job.plist"
+    )
+
+
+def test_a_retirement_directory_in_the_repo_counts_too(dirs):
+    """Symmetry with the suffix idiom: either place may hold the declaration."""
+    _, repo = dirs
+    retired = repo / "retired-2026-07-14"
+    retired.mkdir()
+    (retired / "com.x.job.plist").write_text("<plist/>")
+    assert (
+        vc.plist_intentionally_disabled("com.x.job")
+        == "retired-2026-07-14/com.x.job.plist"
+    )
+
+
+def test_the_real_nextdns_shape_with_a_backup_beside_it_resolves(dirs):
+    """Verbatim from Pro: the retirement dir holds the plist AND a TCC-era backup.
+
+    The exact-name file is the declaration; the `bak-*` beside it must not
+    distract the resolution into returning None.
+    """
+    live, _ = dirs
+    retired = live / ".retired-2026-08-09"
+    retired.mkdir()
+    (retired / "com.x.job.plist").write_text("<plist/>")
+    (retired / "com.x.job.plist.bak-tcc-20260716").write_text("<plist/>")
+    assert (
+        vc.plist_intentionally_disabled("com.x.job")
+        == ".retired-2026-08-09/com.x.job.plist"
+    )
+
+
+def test_an_active_plist_beats_a_copy_sitting_in_a_retirement_directory(dirs):
+    """Guilt, unchanged by the new idiom: a loaded-but-dead job still REGRESSES.
+
+    Someone archiving a copy must never silence the live label — this is the one
+    promise the whole function makes (W94).
+    """
+    live, _ = dirs
+    (live / "com.x.job.plist").write_text("<plist/>")
+    retired = live / ".retired-2026-08-09"
+    retired.mkdir()
+    (retired / "com.x.job.plist").write_text("<plist/>")
+    assert vc.plist_intentionally_disabled("com.x.job") is None
+
+
+@pytest.mark.parametrize("dirname", ["wrappers", "templates", "bin", "com.x.job"])
+def test_an_ordinary_subdirectory_is_not_a_retirement(dirs, dirname):
+    """`infra/launchagents/wrappers/` is REAL and must never read as a firebreak.
+
+    The directory NAME is judged by the marker vocabulary, exactly as a suffix is —
+    not the path, and not the mere fact of being nested (W105: the entity, not the
+    form). `com.x.job` as a directory name is included because a directory named
+    after the label is the most tempting thing to mistake for a declaration.
+    """
+    live, _ = dirs
+    sub = live / dirname
+    sub.mkdir()
+    (sub / "com.x.job.plist").write_text("<plist/>")
+    assert vc.plist_intentionally_disabled("com.x.job") is None
+
+
+def test_a_retirement_directory_does_not_excuse_a_neighbouring_label(dirs):
+    """The dir declares a retirement for what is IN it, not for everything."""
+    live, _ = dirs
+    retired = live / ".retired-2026-08-09"
+    retired.mkdir()
+    (retired / "com.x.job2.plist").write_text("<plist/>")
+    assert vc.plist_intentionally_disabled("com.x.job") is None
+
+
+def test_declared_limit_only_one_level_deep(dirs):
+    """DECLARED, not accidental: nesting deeper than one level is not searched.
+
+    Every retirement idiom measured on this fleet is exactly one level down, and a
+    recursive walk of `~/Library/LaunchAgents` would be both a cost and a surprise.
+    If a third idiom ever buries a plist deeper, this test is where it should be
+    changed on purpose rather than discovered as a silent miss.
+    """
+    live, _ = dirs
+    deep = live / ".retired-2026-08-09" / "older"
+    deep.mkdir(parents=True)
+    (deep / "com.x.job.plist").write_text("<plist/>")
+    assert vc.plist_intentionally_disabled("com.x.job") is None
+
+
+def test_declared_limit_a_bare_backup_inside_a_retirement_directory_still_reads_unknown(
+    dirs,
+):
+    """DECLARED: the dir name alone does not upgrade a `bak-*` into a declaration.
+
+    Consistent with `test_a_backup_is_not_a_retirement` above — a backup is
+    ambiguous wherever it sits, and the cure for these is to declare the
+    retirement, never to widen the predicate.
+    """
+    live, _ = dirs
+    retired = live / ".retired-2026-08-09"
+    retired.mkdir()
+    (retired / "com.x.job.plist.bak-tcc-20260716").write_text("<plist/>")
+    assert vc.plist_intentionally_disabled("com.x.job") is None

--- a/scripts/verify_connectome.py
+++ b/scripts/verify_connectome.py
@@ -152,6 +152,15 @@ def plist_intentionally_disabled(label: str) -> str | None:
 
     Nobody saw it: both of its P0s were dropped `p0_overflow`, so the false alarm
     was invisible AND the channel was proven unable to carry a true one.
+
+    TWO IDIOMS as well as two places (added 2026-08-09, hours after the above went
+    live and left exactly one label still REGRESSED). A retirement is recorded
+    EITHER by renaming the plist with a marker suffix OR by moving the untouched
+    plist into a marker-named directory — `com.balizero.nextdns-tamper-detect.weekly`
+    was retired by PR #3891 with "bootout + plist moved to `.retired-2026-08-09/`",
+    where the file still carries its exact name. Covering one idiom does not halve
+    the false alarms; it only changes WHICH deliberate retirement is mistaken for a
+    silent death (W107).
     """
     if not label.startswith("com."):
         return None
@@ -164,6 +173,36 @@ def plist_intentionally_disabled(label: str) -> str | None:
         for f in sorted(directory.glob(f"{prefix}*")):
             if _asserts_retirement(f.name[len(prefix):]):
                 return f.name
+
+    # TWO IDIOMS, not one (found by PROVE-LIVE of the suffix cure above, same day).
+    # The suffix rename is only how SOME retirements are recorded. The other way this
+    # organism retires a LaunchAgent is to MOVE the untouched plist into a dated
+    # directory: PR #3891 retired `com.balizero.nextdns-tamper-detect.weekly` with
+    # "bootout + plist moved to `.retired-2026-08-09/`", so on disk the file is still
+    # named exactly `<label>.plist` and `glob("<label>.plist.*")` cannot see it. The
+    # first cure shipped, went live on Pro, and left that label as the one remaining
+    # REGRESSED — a guardian still alarming every morning on a deliberate retirement,
+    # which is the exact disease the first cure existed to end (W116). Curing one
+    # idiom of two does not halve the noise; it only changes WHICH intentional
+    # retirement is mistaken for a regression (W107).
+    #
+    # The directory NAME is judged by the same marker vocabulary as a suffix, never
+    # the path as a whole: a label may itself contain "retired", and `infra/launchagents`
+    # holds a legitimate `wrappers/` subdirectory that must never read as a firebreak
+    # (W105 — the entity, not the form). Immediate children only: a recursive walk of
+    # an unknown tree would be both a cost and a surprise, and every retirement idiom
+    # measured on this fleet is exactly one level deep.
+    for directory in (LAUNCHAGENTS_DIR, REPO_LAUNCHAGENTS_DIR):
+        if not directory.is_dir():
+            continue
+        for sub in sorted(p for p in directory.iterdir() if p.is_dir()):
+            if not _asserts_retirement(sub.name):
+                continue
+            if (sub / f"{label}.plist").exists():
+                return f"{sub.name}/{label}.plist"
+            for f in sorted(sub.glob(f"{prefix}*")):
+                if _asserts_retirement(f.name[len(prefix):]):
+                    return f"{sub.name}/{f.name}"
     return None
 
 


### PR DESCRIPTION
## What PROVE-LIVE found that review did not

#3900 merged at 10:02 today and I deployed it to Pro's runtime worktree (which was 10 commits behind — *merged ≠ live*). The verifier went **REGRESSED 2 → 1**: `com.balizero.wr2.newsletter` is now correctly `DISABLED`, and one label was left behind.

That survivor, `com.balizero.nextdns-tamper-detect.weekly`, is **not undeclared**. PR #3891 retired it with *"bootout + plist moved to `.retired-2026-08-09/`"* — so on disk the file still carries its exact name, one directory down, and `glob("<label>.plist.*")` is **structurally blind** to it.

**This organism has TWO retirement idioms and #3900 covered the one I happened to find first:**

| idiom | shape | covered by |
|---|---|---|
| rename with a marker suffix | `<label>.plist.disabled-…` | #3900 |
| move the untouched plist into a marker-named directory | `.retired-2026-08-09/<label>.plist` | **this PR** |

Curing one of two does not halve the false alarms — it changes *which* deliberate retirement is mistaken for a silent death. That is W107's class-audit lesson landing on my own diff hours after it merged, and it left the guardian-of-the-guardians still due to alarm at 07:30 on a correct state, which is the exact disease #3900 existed to end (W116).

## The predicate judges the ENTITY, not the form

The directory **name** is judged by the same marker vocabulary as a suffix — never the path as a whole, and never the mere fact of being nested (W105):

- `infra/launchagents/` holds a real `wrappers/` subdirectory that must not read as a firebreak
- a directory named *after the label* is the most tempting thing to mistake for a declaration
- immediate children only, and that limit is **declared in a test** rather than left as an accident

Guilt preserved: an **active** plist still REGRESSES even with a copy archived in a retirement directory. That is the one promise this function makes (W94).

## Verification

**11 new tests, 27 total, mutation-verified:**

| mutation | tests killed |
|---|---|
| delete the directory block | 3 |
| accept any subdirectory (drop the name judgment) | 4 (`wrappers` / `templates` / `bin` / `com.x.job`) |
| recurse instead of one level | 1 (the declared-limit test) |

**Proven against Pro's real directories before shipping** (probe run from `/tmp`, with the repo dir repaired — relocating the module breaks its own `__file__`-derived path, which nearly had me report a phantom regression, W108 GOTCHA-2):

```
com.balizero.nextdns-tamper-detect.weekly  -> .retired-2026-08-09/com.balizero.nextdns-tamper-detect.weekly.plist
com.balizero.wr2.newsletter                -> com.balizero.wr2.newsletter.plist.disabled-2026-07-15-superseded-by-fly-daily-task
com.nuzantara.agent-worktree-cleanup.daily -> None   # active plist; its .plist.example does NOT excuse it
```

Takes Pro to **REGRESSED 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)