### PR TITLE
feat(visa-oracle): PIN-gated internal preview + seq-5 activation record

### DIFF
--- a/.agents/skills/visaoracle/CURRENT_STATE.md
+++ b/.agents/skills/visaoracle/CURRENT_STATE.md
@@ -59,14 +59,18 @@ each is a distinct, explicit action requiring its own Zero go-ahead.
 > `bundle.py` docstring example + the M5 key FILENAME `2026-07-prod-1.ed25519.pem`
 > (filename ≠ kid). Proven against the live prod-004 signature; there is NO kid
 > Identifier regression on main.
-> **Selection-model correction (measured):** the prod-004 note above calling seq-4
-> "the single open activation" was imprecise — the runtime query
-> (`repository.load_active_rule_pack` and its twin `shadow._resolve_active_pack_binding`)
-> is `legal_period @> now() AND system_period @> now() ORDER BY created_at DESC LIMIT 1`;
-> multiple PRODUCTION activations are open BY DESIGN (seq 1/3/4/5 all in_force — the
-> docstring acknowledges overlapping `legal_period`s) and the NEWEST `created_at` wins.
-> seq-5 (`created_at 2026-08-09 13:27:38Z`) is newest → served, fresh per-request, no
-> cache. Content: 113 rules (= prod-004 112 + GLOBAL `review.minor-without-guardian`
+> **Single-active model CONFIRMED (an earlier revision of this block got it wrong).** A
+> first draft here claimed "multiple PRODUCTION activations are open BY DESIGN … the newest
+> `created_at` wins" and called the prod-004 note's "single open activation" imprecise.
+> **That was wrong and is retracted** — it came from a probe that filtered `legal_period`
+> ALONE, omitting the `system_period` clause the runtime applies. Re-measured with the
+> runtime's real predicate (`legal_period @> now() AND system_period @> now()`): **exactly
+> ONE active row — seq-5**; seq 1/3/4 have an open `legal_period` but a **CLOSED**
+> `system_period`. The schema enforces this (GiST exclusion over both periods,
+> `250_visa_engine_core.sql`; the writer closes covered activations,
+> `253_visa_activation_writer_hardening.sql`), and `ORDER BY created_at DESC LIMIT 1` is
+> DEFENSIVE, not a selection policy. The prod-004 note above stands as written.
+> Content: 113 rules (= prod-004 112 + GLOBAL `review.minor-without-guardian`
 > safety gate; plus the 5 D12 investment review rules now gated on
 > `investment.pt_pma_committed != true` so a committed investor concludes E28A instead
 > of a business-visit review). **EVALUATE_MODE stays SHADOW; ENFORCE remains NO-GO.**

--- a/.agents/skills/visaoracle/CURRENT_STATE.md
+++ b/.agents/skills/visaoracle/CURRENT_STATE.md
@@ -44,6 +44,34 @@ each is a distinct, explicit action requiring its own Zero go-ahead.
 > this activation. This addendum records a live prod state change; the
 > historical `prod-003` narrative below is retained as history.
 
+> **UPDATE 2026-08-09 — `prod-005` (sequence 5) is now the active PRODUCTION
+> RulePack, superseding `prod-004`.** Activated under an explicit Zero go-ahead
+> ("Sì, attiva seq-5 (SHADOW)" via checkpoint) through the two-login ceremony
+> (`activate_pack.py --yes` on Pro over `fly proxy` → `nuzantara-postgres`;
+> ephemeral roles `visa_pack_writer_ceremony_260809` / `visa_activation_ceremony_260809`
+> minted via stdin→psql — pw never in argv — and dropped same session).
+> `rule_pack_id 4159265d-53e8-5b25-ab5a-fa4f5b25a2d1`, activation
+> `560839f3-a71d-42ef-bdec-246579630884`, `payload_sha256 ebc19f5c…aaad322e`,
+> `previous_payload_sha256 1f0f7b0d…f410e49` (the real prod-004 hash — chain
+> intact), reason `seq5-shadow-activation-260809`. **Signing kid CORRECTION:** the
+> production kid is **`prod-2026-07-1`** (letter-first), NOT `2026-07-prod-1` — the
+> latter (in the older runbook) was a transposition seeded by an illustrative
+> `bundle.py` docstring example + the M5 key FILENAME `2026-07-prod-1.ed25519.pem`
+> (filename ≠ kid). Proven against the live prod-004 signature; there is NO kid
+> Identifier regression on main.
+> **Selection-model correction (measured):** the prod-004 note above calling seq-4
+> "the single open activation" was imprecise — the runtime query
+> (`repository.load_active_rule_pack` and its twin `shadow._resolve_active_pack_binding`)
+> is `legal_period @> now() AND system_period @> now() ORDER BY created_at DESC LIMIT 1`;
+> multiple PRODUCTION activations are open BY DESIGN (seq 1/3/4/5 all in_force — the
+> docstring acknowledges overlapping `legal_period`s) and the NEWEST `created_at` wins.
+> seq-5 (`created_at 2026-08-09 13:27:38Z`) is newest → served, fresh per-request, no
+> cache. Content: 113 rules (= prod-004 112 + GLOBAL `review.minor-without-guardian`
+> safety gate; plus the 5 D12 investment review rules now gated on
+> `investment.pt_pma_committed != true` so a committed investor concludes E28A instead
+> of a business-visit review). **EVALUATE_MODE stays SHADOW; ENFORCE remains NO-GO.**
+> The Bali Zero team's 38-scheda manual SHADOW test runs against this corrected tree.
+
 ## Product contract
 
 - The guarantee is **zero unsupported recommendations**, not zero errors.

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-005.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-005.source.json
@@ -1,0 +1,7773 @@
+{
+  "created_at": "2026-08-09T00:00:00Z",
+  "created_by": "session.voa-seq5-tree.draft",
+  "decision_domain": "IMMIGRATION_VISA",
+  "engine_contract_version": "1.0.0",
+  "engine_max_version": "1.0.0",
+  "engine_min_version": "1.0.0",
+  "environment": "PRODUCTION",
+  "hit_policy": {
+    "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+    "hard_filter": "COLLECT_ALL",
+    "human_review": "COLLECT_ALL",
+    "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+  },
+  "jurisdiction": "ID",
+  "previous_payload_sha256": "1f0f7b0d189d0d9adecb08afa158f1f221ef698340a65b029beb0fc21f410e49",
+  "rollback_of_payload_sha256": null,
+  "products": [
+    {
+      "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+      "product_code": "E28A",
+      "legacy_codes": ["B211"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Visa (E28A)",
+        "id": "Visa Investor (E28A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": [
+        "operational_work_beyond_management_and_ownership"
+      ],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 730,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 100,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+      "product_code": "E28B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Company Establishment (E28B)",
+        "id": "Visa Investor Pendirian Perusahaan (E28B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+      "product_code": "E28C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Capital Market (E28C)",
+        "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work", "corporate_establishment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+      "product_code": "E28D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Branch or Subsidiary (E28D)",
+        "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work_outside_managing_subsidiary"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+      "product_code": "E28F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — New Capital (IKN) Subsidiary (E28F)",
+        "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+      "product_code": "E33",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa (E33)",
+        "id": "Visa Rumah Kedua (E33)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["SECOND_HOME", "TOURISM"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "guarantee_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+      "product_code": "E33A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Special-Expertise Government Invitation (E33A)",
+        "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+      "product_code": "E33B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Special-Expertise Collaboration (E33B)",
+        "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "EMPLOYMENT",
+        "BUSINESS_MEETINGS",
+        "INVESTMENT",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+      "product_code": "E33C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — World-Figure Government Invitation (E33C)",
+        "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "INVESTMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+      "product_code": "E33E",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Elderly 5-Year (E33E)",
+        "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "deposit_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+      "product_code": "E33F",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Elderly 1-Year (E33F)",
+        "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "RETIREMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+      "product_code": "E33G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Remote Worker (E33G)",
+        "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "work_for_indonesian_entity",
+        "indonesian_source_compensation_including_in_kind",
+        "indonesian_company_ownership",
+        "sale_of_goods_or_services_beyond_remote_work"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+      "product_code": "A1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa-Free Tourism Visit (A1)",
+        "id": "Bebas Visa Kunjungan Wisata (A1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "TRANSIT"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+      "product_code": "B1",
+      "legacy_codes": ["B213"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa on Arrival — Tourism (B1)",
+        "id": "Visa Saat Kedatangan Wisata (B1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 30,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+      "product_code": "C1",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Tourist Visit Visa (C1)",
+        "id": "Visa Kunjungan Wisata (C1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+      "product_code": "C2",
+      "legacy_codes": ["B211B", "B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Business Visit Visa (C2)",
+        "id": "Visa Kunjungan Bisnis (C2)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+      "product_code": "C6",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Social Activity Visit Visa (C6)",
+        "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": ["paid_employment", "business_meetings"],
+      "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+      "product_code": "BRIDGING",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Bridging Visa — Transitional Stay Permit",
+        "id": "Izin Tinggal Peralihan"
+      },
+      "category": "OTHER",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": [
+        "employment_relationship",
+        "exit_terminates_permit"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "NOT_APPLICABLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": null,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+      "product_code": "E23",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa (E23)",
+        "id": "Visa Kerja (E23)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": [
+        "work_for_non_sponsor_entity",
+        "hr_personnel_positions",
+        "passive_investment_management"
+      ],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Working KITAS (Offshore)"
+      },
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+      "product_code": "E23U",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Foreign Diplomat House Assistant (E23U)",
+        "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_non_diplomat_employer"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+      "product_code": "E23V",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Trade and Economic Office (E23V)",
+        "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_standard_corporate_employers"],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+      "product_code": "E31A",
+      "legacy_codes": ["C317"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of Indonesian Citizen (E31A)",
+        "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": [],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Spouse 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+      "product_code": "E31B",
+      "legacy_codes": ["C318"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of ITAS/ITAP Holder (E31B)",
+        "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+      "product_code": "E31C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Legal Mixed Marriage (E31C)",
+        "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+      "product_code": "E31D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+        "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+      "product_code": "E31E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of ITAS/ITAP Holder (E31E)",
+        "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+      "product_code": "E31F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Indonesian Citizen Parent (E31F)",
+        "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+      "product_code": "E31G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Indonesian Citizen Child (E31G)",
+        "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+      "product_code": "E31H",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Child ITAS/ITAP Holder (E31H)",
+        "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+      "product_code": "E31J",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child Joining Sibling ITAS/ITAP Holder (E31J)",
+        "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+      "product_code": "D1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Tourism — Multiple Entry (D1)",
+        "id": "Visa Kunjungan Wisata — Beberapa Kali Perjalanan (D1)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D1 Tourism (1 Year)"
+      },
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+      "product_code": "D2",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Business — Multiple Entry (D2)",
+        "id": "Visa Kunjungan Bisnis (D2)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "continuous_supervision_production_sales"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D2 Business (1 Year)"
+      },
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+      "product_code": "D12",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Pre-Investment — Multiple Entry (D12)",
+        "id": "Visa Kunjungan Pra-Investasi (D12)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 180,
+        "maximum_days": 180
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 180,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D12 Business Investigation (1 Year)"
+      },
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+      "product_code": "E30",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Education Visa (E30)",
+        "id": "Visa Pendidikan (E30)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+      "product_code": "E30A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Primary/Secondary Education Visa (E30A)",
+        "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+      "product_code": "E30B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Higher Education Visa (E30B)",
+        "id": "Visa Pendidikan Tinggi (E30B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 1460
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "31850f85-8d19-58df-bb66-b04968c9aff0"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+      "product_code": "E30E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "SEZ Education Visa (E30E)",
+        "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+      "product_code": "E30F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Student Exchange Visa (E30F)",
+        "id": "Visa Pertukaran Pelajar (E30F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hf.citizen",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "derived.has_indonesian_citizenship",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.has_indonesian_citizenship"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.citizen",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.overstay-exceeds-60-days",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 60
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "OVERSTAY_EXCEEDS_60_DAYS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.overstay-exceeds-60-days",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.calling-visa",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "intersects",
+        "fact": "person.nationalities",
+        "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CALLING_VISA_REVIEW"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+      "explanation_key": "explain.review.calling-visa",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.active-overstay",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 0
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ACTIVE_OVERSTAY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.review.active-overstay",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.a1.not-bvk-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "BN",
+            "MY",
+            "TH",
+            "SG",
+            "PH",
+            "KH",
+            "LA",
+            "MM",
+            "VN",
+            "TL",
+            "SR",
+            "CO",
+            "HK",
+            "TR",
+            "BR",
+            "PE",
+            "MO",
+            "KZ",
+            "BY"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BVK_NATIONALITY_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.hf.a1.not-bvk-nationality",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.a1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "TRANSIT"]
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "A1_BVK_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "TRANSIT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.el.a1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.b1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "B1_VOA_ELIGIBLE",
+        "covered_purposes": ["TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+      ],
+      "explanation_key": "explain.el.b1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "el.c1.tourism-family",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "FAMILY"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C1_VISIT_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c1.tourism-family",
+      "safety_critical": false,
+      "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"]
+    },
+    {
+      "rule_id": "el.c2.business",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C2_BUSINESS_ELIGIBLE",
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c2.business",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "review.c2.corporate-sponsor-type",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "C2_CORPORATE_SPONSOR_TYPE_VERIFICATION"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.c2.corporate-sponsor-type",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "el.c6.social",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C6_SOCIAL_ELIGIBLE",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c6.social",
+      "safety_critical": false,
+      "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"]
+    },
+    {
+      "rule_id": "hf.e28a.paid-capital-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.paid_up_capital_idr",
+        "value": 2500000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.paid_up_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "hf.e28a.total-investment-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.investment_capital_idr",
+        "value": 10000000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.investment_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.total-investment-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "el.e28a.investment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "investment.proposed_role",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          },
+          {
+            "op": "gte",
+            "fact": "investment.paid_up_capital_idr",
+            "value": 2500000000
+          },
+          {
+            "op": "gte",
+            "fact": "investment.investment_capital_idr",
+            "value": 10000000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.investment_capital_idr",
+        "investment.paid_up_capital_idr",
+        "investment.proposed_role",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.e28a.investment",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "review.e28b.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28b.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"]
+    },
+    {
+      "rule_id": "review.e28c.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28c.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"]
+    },
+    {
+      "rule_id": "review.e28d.usd-threshold-turnover-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28D"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"]
+    },
+    {
+      "rule_id": "review.e28f.ikn-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28F"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"]
+    },
+    {
+      "rule_id": "el.e33.deposit-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.bank_deposit_usd",
+            "value": 130000
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_at_state_bank",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_in_own_name",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.deposit-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.property-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_PROPERTY_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.property-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.guarantee-maintenance",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 130000
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.qualifying_property_value_usd",
+                "value": 1000000
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.guarantee-maintenance",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.work-rangkap-kegiatan",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33a.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33A"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33a.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "review.e33b.expertise-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33b.expertise-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "review.e33c.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33c.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "hf.e33e.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33e.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "review.e33e.age-55-59-disputed-band",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "between",
+            "fact": "derived.age_years",
+            "lower": 55,
+            "upper": 59
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33E_AGE_55_59_DISPUTED_BAND"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years", "intent.purposes"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33e.age-55-59-disputed-band",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 50000
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_at_state_bank",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_in_own_name",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "review.e33e.deposit-income-basis",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "all",
+                    "args": [
+                      {
+                        "op": "gte",
+                        "fact": "secondhome.bank_deposit_usd",
+                        "value": 50000
+                      },
+                      {
+                        "op": "eq",
+                        "fact": "secondhome.bank_deposit_at_state_bank",
+                        "value": true
+                      },
+                      {
+                        "op": "eq",
+                        "fact": "secondhome.bank_deposit_in_own_name",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "op": "not",
+                    "arg": {
+                      "op": "gte",
+                      "fact": "secondhome.passive_monthly_income_usd",
+                      "value": 3000
+                    }
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "not",
+                    "arg": {
+                      "op": "all",
+                      "args": [
+                        {
+                          "op": "gte",
+                          "fact": "secondhome.bank_deposit_usd",
+                          "value": 50000
+                        },
+                        {
+                          "op": "eq",
+                          "fact": "secondhome.bank_deposit_at_state_bank",
+                          "value": true
+                        },
+                        {
+                          "op": "eq",
+                          "fact": "secondhome.bank_deposit_in_own_name",
+                          "value": true
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.passive_monthly_income_usd",
+                    "value": 3000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33E_DEPOSIT_INCOME_BASIS_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33e.deposit-income-basis",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "hf.e33f.sponsor-required",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "family.sponsor_confirmed",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "SPONSOR_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["family.sponsor_confirmed"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e33f.sponsor-required",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "review.e33f.age-under-55",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "lt",
+            "fact": "derived.age_years",
+            "value": 55
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33F_AGE_UNDER_55_DISCRETIONARY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years", "intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33f.age-under-55",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "el.e33f.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33f.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-employer",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.employer_is_indonesian_entity",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.employer_is_indonesian_entity"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-employer",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-source-compensation",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.indonesia_source_compensation",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.indonesia_source_compensation"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-market",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-market",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-company-ownership",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-company-ownership",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.income-60k-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_INCOME_60K_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.review.e33g.income-60k-manual",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e33g.remote-work",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REMOTE_WORK_ELIGIBLE",
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.e33g.remote-work",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.bridging.offshore",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.currently_in_indonesia",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_ONSHORE_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.currently_in_indonesia"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.offshore",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.from-visit-itk",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "in",
+        "fact": "immigration.current_status_code",
+        "values": [
+          "ITK_FROM_BVK",
+          "ITK_FROM_VISIT_C",
+          "ITK_FROM_VISIT_D",
+          "A1",
+          "C1",
+          "C2",
+          "C6"
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+      ],
+      "explanation_key": "explain.hf.bridging.from-visit-itk",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.to-bridging",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.current_status_code",
+        "value": "ITK_PERALIHAN"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.to-bridging",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.t3-window-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "known",
+            "fact": "immigration.current_status_expiry"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_T3_WINDOW_MANUAL_CHECK"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.t3-window-manual",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.overstay-shield-payment",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "known",
+            "fact": "immigration.current_status_expiry"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.overstay-shield-payment",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.source-status-verify",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "known",
+            "fact": "immigration.current_status_code"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_code",
+        "immigration.currently_in_indonesia"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.source-status-verify",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.adverse-history",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "intersects",
+            "fact": "immigration.violation_history",
+            "values": [
+              "OVERSTAY",
+              "DEPORTATION",
+              "BLACKLIST",
+              "IMMIGRATION_INVESTIGATION"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_ADVERSE_HISTORY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": [
+        "immigration.currently_in_indonesia",
+        "immigration.violation_history"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.adverse-history",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.destination-stated",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "neq",
+            "fact": "intent.requested_product_code",
+            "value": "BRIDGING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_DESTINATION_STATED",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.destination-stated",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.e23-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.employer_is_indonesian_entity",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-rptka-verification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_RPTKA_APPROVAL"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-rptka-verification",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-prohibited-hr-roles",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROHIBITED_HR_ROLES_KEPMENAKER_349_2019"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-prohibited-hr-roles",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-operational-work-boundary",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "investment.proposed_role",
+            "op": "in",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": ["intent.purposes", "investment.proposed_role"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-operational-work-boundary",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "hr.e23-jabatan-kbli-match",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "JABATAN_MUST_MATCH_KBLI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23-jabatan-kbli-match",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e23u-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23u-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "hr.e23u-diplomat-sponsor",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_DIPLOMAT_SPONSOR"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23u-diplomat-sponsor",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "hr.e23u-domestic-helper-role",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "RESTRICTED_TO_DOMESTIC_HELPER"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23u-domestic-helper-role",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "el.e23v-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23v-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hr.e23v-kdei-sponsor",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_KDEI_SPONSOR"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23v-kdei-sponsor",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hr.e23v-rptka-verification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["EMPLOYMENT"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQUIRED_RPTKA_APPROVAL"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e23v-rptka-verification",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "el.e31a-spouse-wni-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "family.marriage_registered"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-spouse-wni-support",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "hr.e31a-funds-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_FUNDS_2000"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": ["950a9f63-0b78-5a9e-ba12-9454e4b7dfb2"],
+      "explanation_key": "explain.hr.e31a-funds-2000",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "hr.e31a-spousal-work-kemenaker",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SPOUSAL_WORK_KEMENAKER_CAVEAT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "4886ebe6-41ae-5c6f-bf5d-b98e182be435"
+      ],
+      "explanation_key": "explain.hr.e31a-spousal-work-kemenaker",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "hr.e31a-kitap-door",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "KITAP_CONVERSION_TWO_YEAR_DOOR"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hr.e31a-kitap-door",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-spouse-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "hr.e31b-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["570f2bc4-5120-561f-90ba-58fcd9507514"],
+      "explanation_key": "explain.hr.e31b-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "hr.e31c-mixed-marriage-parents",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_MIXED_MARRIAGE_PARENTS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["40523028-431b-5ae0-a937-277882f0f243"],
+      "explanation_key": "explain.hr.e31c-mixed-marriage-parents",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31d-stepchild-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-stepchild-support",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hr.e31d-step-parent-relation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["FAMILY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_STEP_PARENT_RELATION"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["50457cd0-b67f-5b88-bf66-33bcf62f3d9b"],
+      "explanation_key": "explain.hr.e31d-step-parent-relation",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hr.e31d-sponsor-mixed-marriage",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["FAMILY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["50457cd0-b67f-5b88-bf66-33bcf62f3d9b"],
+      "explanation_key": "explain.hr.e31d-sponsor-mixed-marriage",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hf.e31e-adult-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "derived.age_years",
+        "op": "gte",
+        "value": 18
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNDER_18"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["ecd22722-3e42-5808-be18-45fbb7d8e9c5"],
+      "explanation_key": "explain.hf.e31e-adult-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hf.e31e-married-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "person.marital_status",
+        "op": "neq",
+        "value": "SINGLE"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNMARRIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.marital_status"],
+      "source_refs": ["ecd22722-3e42-5808-be18-45fbb7d8e9c5"],
+      "explanation_key": "explain.hf.e31e-married-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31e-child-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hr.e31e-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["ecd22722-3e42-5808-be18-45fbb7d8e9c5"],
+      "explanation_key": "explain.hr.e31e-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31f-child-wni-parent-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31f-child-wni-parent-support",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "hr.e31f-adult-age-review",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "gte",
+            "value": 18
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E31F_ADULT_AGE_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "derived.age_years"
+      ],
+      "source_refs": ["f9306203-0bdc-5dd8-9603-554e7eefedc8"],
+      "explanation_key": "explain.hr.e31f-adult-age-review",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31g-parent-wni-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31g-parent-wni-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"]
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-parent-itas-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "hr.e31h-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["153beca1-a24b-5440-bac0-b46c3d19da6f"],
+      "explanation_key": "explain.hr.e31h-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sibling-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "hr.e31j-sponsor-itas-itap",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": ["2d090f3a-5a93-5181-b3d1-253d87a1a17c"],
+      "explanation_key": "explain.hr.e31j-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "hr.e31j-dependency-age",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "gte",
+            "value": 18
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CHECK_DEPENDENCY_AGE"
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "derived.age_years"
+      ],
+      "source_refs": ["2d090f3a-5a93-5181-b3d1-253d87a1a17c"],
+      "explanation_key": "explain.hr.e31j-dependency-age",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.d1-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "intent.entry_pattern"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-funds-usd-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROOF_OF_FUNDS_D1"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-cv-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CV_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-itinerary-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ITINERARY_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "hr.d1-support-letter",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SUPPORT_LETTER_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.entry_pattern"],
+      "source_refs": ["ca5a2ce8-83bb-58ec-b2d9-285833cf085a"],
+      "explanation_key": "explain.hr.d1-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d2-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-funds-usd-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROOF_OF_FUNDS_D2"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-cv-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CV_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-itinerary-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ITINERARY_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "hr.d2-support-letter",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["BUSINESS_MEETINGS"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SUPPORT_LETTER_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e"],
+      "explanation_key": "explain.hr.d2-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d12-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "neq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-funds-usd-5000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "neq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PROOF_OF_FUNDS_D12"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-funds-usd-5000",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-cv-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "neq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CV_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-itinerary-required",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "neq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ITINERARY_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-support-letter",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "neq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "SUPPORT_LETTER_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hr.d12-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hf.d12-onshore-conversion-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "D12_NOT_CONVERTIBLE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hr.d12-long-stay-review",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.stay_days",
+        "op": "gt",
+        "value": 365
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "D12_CUMULATIVE_STAY_UNVERIFIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+      ],
+      "explanation_key": "explain.hr.d12-long-stay-review",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.e30-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-student-support",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
+      ]
+    },
+    {
+      "rule_id": "hr.e30-living-cost-2000",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LIVING_COST_USD2000"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de"
+      ],
+      "explanation_key": "explain.hr.e30-living-cost-2000",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
+      ]
+    },
+    {
+      "rule_id": "hr.e30-passport-validity",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "PASSPORT_VALIDITY_INSUFFICIENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de"
+      ],
+      "explanation_key": "explain.hr.e30-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+        "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+        "235f5dfc-2feb-5d5b-ab09-0f4e4122819e"
+      ]
+    },
+    {
+      "rule_id": "hf.e30a-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "study.level",
+        "op": "not_in",
+        "values": ["PRIMARY", "SECONDARY"]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DASMEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30a-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hr.e30a-minor-consent",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "derived.is_minor",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_CONSENT_GUARDIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "derived.is_minor"],
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "explanation_key": "explain.hr.e30a-minor-consent",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hf.e30b-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "study.level",
+        "op": "not_in",
+        "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DIKTI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30b-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hr.e30b-izin-belajar",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "STUDY_PERMIT_KEMDIKBUD"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["cb1b7182-1e29-58df-9aec-4e9bf66e10de"],
+      "explanation_key": "explain.hr.e30b-izin-belajar",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hr.e30e-kek-institution",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "KEK_INSTITUTION_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e30e-kek-institution",
+      "safety_critical": false,
+      "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"]
+    },
+    {
+      "rule_id": "hr.e30f-exchange-program",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "intent.purposes",
+        "op": "intersects",
+        "values": ["STUDY"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "EXCHANGE_PROGRAM_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hr.e30f-exchange-program",
+      "safety_critical": false,
+      "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"]
+    },
+    {
+      "rule_id": "hf.b1.not-voa-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "ZA",
+            "AL",
+            "US",
+            "AD",
+            "SA",
+            "AR",
+            "AM",
+            "AU",
+            "AT",
+            "AZ",
+            "BH",
+            "NL",
+            "BY",
+            "BE",
+            "BR",
+            "BN",
+            "BA",
+            "BG",
+            "CZ",
+            "CL",
+            "DK",
+            "EC",
+            "EE",
+            "PH",
+            "FI",
+            "GT",
+            "HK",
+            "HU",
+            "IN",
+            "GB",
+            "IE",
+            "IT",
+            "IS",
+            "JP",
+            "DE",
+            "KH",
+            "CA",
+            "KZ",
+            "KE",
+            "CO",
+            "KR",
+            "HR",
+            "KW",
+            "LA",
+            "LV",
+            "LI",
+            "LT",
+            "LU",
+            "MV",
+            "MY",
+            "MT",
+            "MA",
+            "MU",
+            "MX",
+            "EG",
+            "MC",
+            "MN",
+            "MZ",
+            "MM",
+            "NO",
+            "OM",
+            "PS",
+            "PG",
+            "FR",
+            "PE",
+            "PL",
+            "PT",
+            "QA",
+            "RO",
+            "RU",
+            "RW",
+            "NZ",
+            "RS",
+            "SC",
+            "SG",
+            "CY",
+            "SK",
+            "SI",
+            "ES",
+            "SR",
+            "SE",
+            "CH",
+            "TW",
+            "TZ",
+            "TH",
+            "TL",
+            "CN",
+            "TN",
+            "TR",
+            "AE",
+            "UZ",
+            "UA",
+            "VA",
+            "VE",
+            "VN",
+            "JO",
+            "GR"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "VOA_NATIONALITY_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+      "explanation_key": "explain.hf.b1.not-voa-nationality",
+      "safety_critical": true,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "review.citizenship-conflict",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "any",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "ZA",
+                  "AL",
+                  "US",
+                  "AD",
+                  "SA",
+                  "AR",
+                  "AM",
+                  "AU",
+                  "AT",
+                  "AZ",
+                  "BH",
+                  "NL",
+                  "BY",
+                  "BE",
+                  "BR",
+                  "BN",
+                  "BA",
+                  "BG",
+                  "CZ",
+                  "CL",
+                  "DK",
+                  "EC",
+                  "EE",
+                  "PH",
+                  "FI",
+                  "GT",
+                  "HK",
+                  "HU",
+                  "IN",
+                  "GB",
+                  "IE",
+                  "IT",
+                  "IS",
+                  "JP",
+                  "DE",
+                  "KH",
+                  "CA",
+                  "KZ",
+                  "KE",
+                  "CO",
+                  "KR",
+                  "HR",
+                  "KW",
+                  "LA",
+                  "LV",
+                  "LI",
+                  "LT",
+                  "LU",
+                  "MV",
+                  "MY",
+                  "MT",
+                  "MA",
+                  "MU",
+                  "MX",
+                  "EG",
+                  "MC",
+                  "MN",
+                  "MZ",
+                  "MM",
+                  "NO",
+                  "OM",
+                  "PS",
+                  "PG",
+                  "FR",
+                  "PE",
+                  "PL",
+                  "PT",
+                  "QA",
+                  "RO",
+                  "RU",
+                  "RW",
+                  "NZ",
+                  "RS",
+                  "SC",
+                  "SG",
+                  "CY",
+                  "SK",
+                  "SI",
+                  "ES",
+                  "SR",
+                  "SE",
+                  "CH",
+                  "TW",
+                  "TZ",
+                  "TH",
+                  "TL",
+                  "CN",
+                  "TN",
+                  "TR",
+                  "AE",
+                  "UZ",
+                  "UA",
+                  "VA",
+                  "VE",
+                  "VN",
+                  "JO",
+                  "GR"
+                ]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AF",
+                  "AG",
+                  "AI",
+                  "AO",
+                  "AQ",
+                  "AS",
+                  "AW",
+                  "AX",
+                  "BB",
+                  "BD",
+                  "BF",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BO",
+                  "BQ",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BZ",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CI",
+                  "CK",
+                  "CM",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "DJ",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EH",
+                  "ER",
+                  "ET",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "GA",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GS",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HM",
+                  "HN",
+                  "HT",
+                  "ID",
+                  "IL",
+                  "IM",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "JE",
+                  "JM",
+                  "KG",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KP",
+                  "KY",
+                  "LB",
+                  "LC",
+                  "LK",
+                  "LR",
+                  "LS",
+                  "LY",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MW",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NG",
+                  "NI",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "PA",
+                  "PF",
+                  "PK",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PW",
+                  "PY",
+                  "RE",
+                  "SB",
+                  "SD",
+                  "SH",
+                  "SJ",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SO",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TJ",
+                  "TK",
+                  "TM",
+                  "TO",
+                  "TT",
+                  "TV",
+                  "UG",
+                  "UM",
+                  "UY",
+                  "VC",
+                  "VG",
+                  "VI",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AD",
+                  "AE",
+                  "AG",
+                  "AI",
+                  "AL",
+                  "AM",
+                  "AO",
+                  "AQ",
+                  "AR",
+                  "AS",
+                  "AT",
+                  "AU",
+                  "AW",
+                  "AX",
+                  "AZ",
+                  "BA",
+                  "BB",
+                  "BD",
+                  "BE",
+                  "BF",
+                  "BG",
+                  "BH",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BN",
+                  "BO",
+                  "BQ",
+                  "BR",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BY",
+                  "BZ",
+                  "CA",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CH",
+                  "CI",
+                  "CK",
+                  "CL",
+                  "CM",
+                  "CN",
+                  "CO",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "CY",
+                  "CZ",
+                  "DE",
+                  "DJ",
+                  "DK",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EC",
+                  "EE",
+                  "EG",
+                  "EH",
+                  "ER",
+                  "ES",
+                  "ET",
+                  "FI",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "FR",
+                  "GA",
+                  "GB",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GR",
+                  "GS",
+                  "GT",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HK",
+                  "HM",
+                  "HN",
+                  "HR",
+                  "HT",
+                  "HU",
+                  "ID",
+                  "IE",
+                  "IM",
+                  "IN",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "IS",
+                  "IT",
+                  "JE",
+                  "JM",
+                  "JO",
+                  "JP",
+                  "KE",
+                  "KG",
+                  "KH",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KR",
+                  "KW",
+                  "KY",
+                  "KZ",
+                  "LA",
+                  "LB",
+                  "LC",
+                  "LI",
+                  "LK",
+                  "LS",
+                  "LT",
+                  "LU",
+                  "LV",
+                  "LY",
+                  "MA",
+                  "MC",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MM",
+                  "MN",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MT",
+                  "MU",
+                  "MV",
+                  "MW",
+                  "MX",
+                  "MY",
+                  "MZ",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NI",
+                  "NL",
+                  "NO",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "NZ",
+                  "OM",
+                  "PA",
+                  "PE",
+                  "PF",
+                  "PG",
+                  "PH",
+                  "PK",
+                  "PL",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PS",
+                  "PT",
+                  "PW",
+                  "PY",
+                  "QA",
+                  "RE",
+                  "RO",
+                  "RS",
+                  "RU",
+                  "RW",
+                  "SA",
+                  "SB",
+                  "SC",
+                  "SD",
+                  "SE",
+                  "SG",
+                  "SH",
+                  "SI",
+                  "SJ",
+                  "SK",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SR",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TH",
+                  "TJ",
+                  "TK",
+                  "TL",
+                  "TM",
+                  "TN",
+                  "TO",
+                  "TR",
+                  "TT",
+                  "TV",
+                  "TW",
+                  "TZ",
+                  "UA",
+                  "UG",
+                  "UM",
+                  "US",
+                  "UY",
+                  "UZ",
+                  "VA",
+                  "VC",
+                  "VE",
+                  "VG",
+                  "VI",
+                  "VN",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZA",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CITIZENSHIP_LIST_DIVERGENCE"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": [
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+      ],
+      "explanation_key": "explain.review.citizenship-conflict",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.minor-without-guardian",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-09T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "derived.is_minor",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "explanation_key": "explain.review.minor-without-guardian",
+      "safety_critical": true,
+      "product_version_ids": null
+    }
+  ],
+  "rule_pack_id": "4159265d-53e8-5b25-ab5a-fa4f5b25a2d1",
+  "sequence": 5,
+  "version": "2026.8.9",
+  "valid_period": {
+    "from": "2026-07-25T00:00:00Z",
+    "to": null
+  },
+  "source_records": [
+    {
+      "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+      "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Kepmen M.IP-08.GR.01.01/2025 — Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+      "language": "id",
+      "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28D"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33E"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33G"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/B1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C2"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C6"
+        }
+      ],
+      "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+      "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 — Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+      "language": "id",
+      "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33(2)(j)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 62"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 63"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 86A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94B"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 185"
+        }
+      ],
+      "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+      "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 10/2026 — Daftar Negara Bebas Visa Kunjungan (BVK)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+      "language": "id",
+      "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+      "locators": [],
+      "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+      "legal_period": {
+        "from": "2026-07-09T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+      "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian — kewarganegaraan dan ketentuan overstay",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+      "language": "id",
+      "document_number": "UU 6/2011 jo. UU 63/2024",
+      "locators": [],
+      "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Calling Visa — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Calling Visa country list; national Ditjen Imigrasi display"
+        }
+      ],
+      "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 — Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+      "legal_period": {
+        "from": "2024-04-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+      "source_key": "permen-imipas-5-2025-penjamin-revocation",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 5/2025 — Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+      "language": "id",
+      "document_number": "Permen Imipas 5/2025",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 1"
+        }
+      ],
+      "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+      "legal_period": {
+        "from": "2025-02-07T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Layanan Alih Status — Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+      "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+      "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+      "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+      "language": "id",
+      "document_number": "M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Lampiran"
+        }
+      ],
+      "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+      "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+      "language": "id",
+      "document_number": "22/2023",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 42"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        }
+      ],
+      "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+      "legal_period": {
+        "from": "2023-08-22T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+      "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+      "language": "id",
+      "document_number": "11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105 ayat (7)"
+        }
+      ],
+      "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+      "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+      "source_key": "imigrasi.go.id.izin-tinggal-keimigrasian",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Izin Tinggal Keimigrasian — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6d6e2355729093234ae0495b82f415316d709e9b42eea0bddf39f68a98755fc1",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "63ca7094-567a-506c-b31f-6b44de5177b2",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "0497cb52-9c10-5ad5-a0ea-596e7678bd9b",
+      "source_key": "evisa.imigrasi.go.id.faq.student-visa-prohibitions",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "eVISA Indonesia FAQ — Student visa (E30) terms and prohibitions",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://evisa.imigrasi.go.id/front/faq/08cdfd2e-873e-4de7-9eeb-8f485828c155",
+      "language": "en",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "b8101ff40233135f67628a4c8718f47cf5ca512821893bcad485ab9910040b48",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "8e077684-d5f1-5256-84ca-0ece9d3392ed",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri WNI (E31A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Bisnis (D2) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Pra-Investasi (D12) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Dasar dan Menengah (E30A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Tinggi (E30B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-06T06:19:49Z",
+      "verified_by": "visa.oracle.source-refresh-2026-08-06",
+      "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "source_key": "imigrasi-voa-country-list",
+      "version": 1,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Subjek Visa on Arrival (VoA) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+        }
+      ],
+      "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-08T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-08T00:00:00Z",
+      "verified_at": "2026-08-08T00:00:00Z",
+      "verified_by": "visa.oracle.seq4-authoring-2026-08-08",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    }
+  ]
+}

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.test.tsx
@@ -204,6 +204,36 @@ describe("OracleShell authoritative evaluate integration", () => {
     expect(screen.queryByText("Visit Visa C1")).toBeNull();
   });
 
+  // The PIN-gated internal preview. Its innocence case is the test directly
+  // above: without `internalMode`, the very same CURATED response must still
+  // fail closed and show no candidates.
+  it("internal preview renders the real decision from a CURATED response", async () => {
+    global.fetch = engineFetch("SUPPORTED_CANDIDATES", "CURATED");
+    render(<OracleShell internalMode />);
+
+    expect(await screen.findByText("Visit Visa C1")).toBeInTheDocument();
+    // Never show an engine decision without saying what it is.
+    expect(screen.getByText(/INTERNAL PREVIEW/)).toBeInTheDocument();
+  });
+
+  it("internal preview is decided before the frontend SHADOW branch", async () => {
+    // Ordering is deliberate: a SHADOW-configured frontend would otherwise
+    // swallow the decision the tester unlocked specifically to see.
+    vi.stubEnv("NEXT_PUBLIC_VISA_ORACLE_MODE", "SHADOW");
+    global.fetch = engineFetch("SUPPORTED_CANDIDATES", "CURATED");
+    render(<OracleShell internalMode />);
+
+    expect(await screen.findByText("Visit Visa C1")).toBeInTheDocument();
+  });
+
+  it("public traffic never sees the internal preview notice", async () => {
+    global.fetch = engineFetch("SUPPORTED_CANDIDATES");
+    render(<OracleShell />);
+
+    await expectStateHeading("SUPPORTED_CANDIDATES");
+    expect(screen.queryByText(/INTERNAL PREVIEW/)).toBeNull();
+  });
+
   it("never claims no evaluation was submitted when the engine adapter rejects one review-hold citation", async () => {
     const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
     response.sources[0].canonical_url = "https://imigrasi.go.id.evil.test/x";

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
@@ -24,7 +24,10 @@ import {
   type EvaluationIdentityStorage,
 } from "../_lib/evaluation-identity-store";
 import { EvaluationRunCache } from "../_lib/evaluation-run-cache";
-import { buildEngineOutcome } from "../_lib/engine-adapter";
+import {
+  buildEngineOutcome,
+  buildInternalPreviewOutcome,
+} from "../_lib/engine-adapter";
 import { VisaOracleResponseError } from "../_lib/engine-response";
 import { buildPreviewOutcome } from "../_lib/preview-adapter";
 import {
@@ -63,6 +66,14 @@ import { ThemeToggle, type OracleTheme } from "./ThemeToggle";
 import { LanguageToggle } from "./LanguageToggle";
 
 const HIDE_COUNTER_ON = new Set(["in_indonesia", "permit_expiry"]);
+
+/**
+ * Shown whenever a real engine decision is rendered from a non-authoritative
+ * (SHADOW/`CURATED`) response. Intentionally English-only and unlocalised:
+ * it addresses the internal Bali Zero tester, never a client.
+ */
+const INTERNAL_PREVIEW_NOTICE =
+  "INTERNAL PREVIEW — engine output shown for testing. Not an authoritative answer and not cleared for a client.";
 
 function isMinorForHandoff(
   birthDateValue: string | undefined,
@@ -118,8 +129,19 @@ function validateStoredSnapshot(
     : (value as InterviewSnapshot);
 }
 
+export interface OracleShellProps {
+  /**
+   * True only when the server has verified the signed `vo_internal` cookie
+   * (see `_lib/internal-access.ts`). Decided on the server and passed down —
+   * never probed from the client — so there is no window in which an unlocked
+   * tester renders (and caches) the public, decision-hidden outcome.
+   * Defaults to the public experience.
+   */
+  internalMode?: boolean;
+}
+
 /** Hydrate sessionStorage after mount so server and first client render match. */
-export function OracleShell() {
+export function OracleShell({ internalMode = false }: OracleShellProps = {}) {
   const [hydrated, setHydrated] = useState<HydratedShell | null>(null);
 
   useEffect(() => {
@@ -150,6 +172,7 @@ export function OracleShell() {
       initialSnapshot={hydrated.snapshot}
       restoreToday={hydrated.restoredAt}
       initialResumeExpiresAtIso={hydrated.resumeExpiresAtIso}
+      internalMode={internalMode}
     />
   );
 }
@@ -158,6 +181,7 @@ interface OracleShellRuntimeProps {
   initialSnapshot: InterviewSnapshot | null;
   restoreToday: Date;
   initialResumeExpiresAtIso: string | null;
+  internalMode: boolean;
 }
 
 /**
@@ -255,6 +279,7 @@ function OracleShellRuntime({
   initialSnapshot,
   restoreToday,
   initialResumeExpiresAtIso,
+  internalMode,
 }: OracleShellRuntimeProps) {
   const [theme, setTheme] = useState<OracleTheme>("light");
   const [frozenToday, setFrozenToday] = useState<Date | null>(null);
@@ -509,7 +534,10 @@ function OracleShellRuntime({
         } catch {
           // A missing correlator is safer than hashing structured applicant data.
         }
-        cacheKey = `${mode}:${state.attempt}:${prepared.evaluationHash}`;
+        // `internalMode` is part of the key: the same interview renders a
+        // different outcome for an unlocked tester, so a cached public result
+        // must never be replayed into the internal preview (or vice versa).
+        cacheKey = `${mode}:${internalMode ? "internal" : "public"}:${state.attempt}:${prepared.evaluationHash}`;
         lastEvaluationKeyRef.current = cacheKey;
         const lease = evaluationCacheRef.current.acquire(
           cacheKey,
@@ -526,6 +554,28 @@ function OracleShellRuntime({
                 idempotencyKey: prepared.identity.idempotencyKey,
                 signal: requestSignal,
               });
+              // Internal (PIN-unlocked) tester: show the REAL engine decision
+              // even while the backend answers SHADOW/`mode:"CURATED"`, which
+              // already carries the full decision. Checked BEFORE the
+              // frontend's own SHADOW branch, which would otherwise swallow
+              // the decision the tester unlocked specifically to see. The
+              // public paths below are deliberately left untouched — their
+              // fail-closed behaviour on a mode mismatch is an invariant, not
+              // an accident, and is pinned by OracleShell.test.tsx.
+              if (internalMode) {
+                const previewOutcome = buildInternalPreviewOutcome(response, {
+                  assumptions,
+                  facts: state.facts,
+                  interviewBranchesRemaining,
+                });
+                emitVisaOracleTelemetry({
+                  event: "visa_oracle_v2_engine_result",
+                  state: previewOutcome.state,
+                  correlationHash: telemetryCorrelationHash,
+                });
+                return previewOutcome;
+              }
+
               if (mode === "SHADOW") {
                 const preview = buildPreviewOutcome(state.facts, frozenToday);
                 emitVisaOracleTelemetry({
@@ -624,6 +674,7 @@ function OracleShellRuntime({
     assumptions,
     current.kind,
     frozenToday,
+    internalMode,
     interviewBranchesRemaining,
     mode,
     memoryIdentityStorage,
@@ -669,8 +720,25 @@ function OracleShellRuntime({
   );
 
   return (
-    <div className="oracle-root" data-oracle-theme={theme} data-funnel="visa">
+    <div
+      className="oracle-root"
+      data-oracle-theme={theme}
+      data-funnel="visa"
+      data-internal-preview={internalMode ? "true" : undefined}
+    >
       <div className="oracle-shell">
+        {internalMode && (
+          // Anyone shown a real engine decision must be told, on the same
+          // screen, that it is an internal preview and not an answer that has
+          // been cleared for a client.
+          <p
+            className="oracle-question__hint"
+            role="status"
+            style={{ fontWeight: 600 }}
+          >
+            {INTERNAL_PREVIEW_NOTICE}
+          </p>
+        )}
         <header className="oracle-topbar">
           <span
             className="oracle-badge"

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -521,3 +521,32 @@ export function buildShadowComparisonOutcome(
   }
   return buildValidatedOutcome(input, options);
 }
+
+/**
+ * INTERNAL PIN-GATED PREVIEW — a deliberately separate rendering boundary
+ * from `buildEngineOutcome`, which stays the public one ("CURATED can never
+ * become visible authority").
+ *
+ * Callers MUST have proven server-side PIN possession first (the `vo_internal`
+ * httpOnly cookie, set only by `/api/visa-oracle-unlock` after a timing-safe
+ * comparison). It exists so the Bali Zero team can exercise the real engine
+ * while `VISA_ENGINE_EVALUATE_MODE` is still SHADOW: the backend already
+ * computes and returns the full decision in that mode (`evaluate_path.py`
+ * fills `decision`/`sources`/`display` unconditionally and only varies the
+ * `mode` string), so nothing here reaches past what the response already
+ * carries — no backend change, and NO durable ENFORCE write, which keys off
+ * the global `engine_mode`, never off this string.
+ *
+ * A CURATED response rendered through here is comparison-grade, NOT
+ * authoritative: the caller is responsible for labelling it as an internal
+ * preview in the UI. Never call this for anonymous public traffic.
+ */
+export function buildInternalPreviewOutcome(
+  input: VisaOracleEvaluateResponse,
+  options: BuildEngineOutcomeOptions = {},
+): OutcomeViewModel {
+  if (input.mode !== "ENGINE" && input.mode !== "CURATED") {
+    throw new VisaOracleResponseError("MALFORMED_RESPONSE");
+  }
+  return buildValidatedOutcome(input, options);
+}

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/internal-access.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/internal-access.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  INTERNAL_ACCESS_MAX_AGE_SECONDS,
+  configuredPin,
+  mintInternalAccessToken,
+  safeEquals,
+  verifyInternalAccessToken,
+} from "./internal-access";
+
+const ORIGINAL_PIN = process.env.VISA_ORACLE_INTERNAL_PIN;
+
+function setPin(value: string | undefined): void {
+  if (value === undefined) delete process.env.VISA_ORACLE_INTERNAL_PIN;
+  else process.env.VISA_ORACLE_INTERNAL_PIN = value;
+}
+
+afterEach(() => {
+  setPin(ORIGINAL_PIN);
+});
+
+const NOW = 1_770_000_000_000;
+const LATER = NOW + INTERNAL_ACCESS_MAX_AGE_SECONDS * 1000;
+
+describe("internal access gate", () => {
+  describe("guilt — a real unlock is honoured", () => {
+    it("accepts a token minted for the configured PIN", () => {
+      setPin("2020");
+      const token = mintInternalAccessToken("2020", LATER);
+      expect(verifyInternalAccessToken(token, NOW)).toBe(true);
+    });
+
+    it("keeps accepting it until the moment it expires", () => {
+      setPin("2020");
+      const token = mintInternalAccessToken("2020", NOW + 1000);
+      expect(verifyInternalAccessToken(token, NOW)).toBe(true);
+      expect(verifyInternalAccessToken(token, NOW + 999)).toBe(true);
+    });
+  });
+
+  describe("innocence — everything else is refused", () => {
+    it("fails closed when no PIN is configured, even with a real token", () => {
+      // The token is minted while a PIN exists, then the env var disappears:
+      // a missing PIN must never mean "everybody is internal".
+      const token = mintInternalAccessToken("2020", LATER);
+      setPin(undefined);
+      expect(verifyInternalAccessToken(token, NOW)).toBe(false);
+    });
+
+    it("treats a blank/whitespace PIN as unconfigured", () => {
+      setPin("   ");
+      expect(configuredPin()).toBeNull();
+      expect(
+        verifyInternalAccessToken(mintInternalAccessToken("   ", LATER), NOW),
+      ).toBe(false);
+    });
+
+    it("refuses a forged bare flag (the devtools-written cookie)", () => {
+      setPin("2020");
+      // HttpOnly stops JS READING a cookie, not a person WRITING one.
+      expect(verifyInternalAccessToken("1", NOW)).toBe(false);
+      expect(verifyInternalAccessToken("true", NOW)).toBe(false);
+      expect(verifyInternalAccessToken(`${LATER}.`, NOW)).toBe(false);
+      expect(verifyInternalAccessToken(`${LATER}.forged`, NOW)).toBe(false);
+    });
+
+    it("refuses an expired token", () => {
+      setPin("2020");
+      const token = mintInternalAccessToken("2020", NOW - 1);
+      expect(verifyInternalAccessToken(token, NOW)).toBe(false);
+    });
+
+    it("refuses a token whose expiry was extended after signing", () => {
+      setPin("2020");
+      const token = mintInternalAccessToken("2020", NOW + 1000);
+      const signature = token.slice(token.indexOf(".") + 1);
+      expect(verifyInternalAccessToken(`${LATER}.${signature}`, NOW)).toBe(
+        false,
+      );
+    });
+
+    it("refuses tokens minted for a different PIN (rotation revokes)", () => {
+      const oldToken = mintInternalAccessToken("2020", LATER);
+      setPin("7391");
+      expect(verifyInternalAccessToken(oldToken, NOW)).toBe(false);
+      expect(
+        verifyInternalAccessToken(mintInternalAccessToken("7391", LATER), NOW),
+      ).toBe(true);
+    });
+
+    it("refuses absent or malformed values", () => {
+      setPin("2020");
+      expect(verifyInternalAccessToken(undefined, NOW)).toBe(false);
+      expect(verifyInternalAccessToken("", NOW)).toBe(false);
+      expect(verifyInternalAccessToken(".abc", NOW)).toBe(false);
+      expect(verifyInternalAccessToken("notanumber.abc", NOW)).toBe(false);
+      expect(verifyInternalAccessToken("99999999999999999999.abc", NOW)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("safeEquals", () => {
+    it("matches identical strings and rejects everything else", () => {
+      expect(safeEquals("2020", "2020")).toBe(true);
+      expect(safeEquals("2020", "2021")).toBe(false);
+      expect(safeEquals("2020", "20200")).toBe(false);
+      expect(safeEquals("", "")).toBe(true);
+    });
+  });
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/internal-access.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/internal-access.ts
@@ -1,0 +1,97 @@
+/**
+ * SERVER-ONLY. Internal PIN access for the Visa Oracle full-power preview.
+ *
+ * Never import this from a client component: it reads the PIN from the
+ * server-side environment and uses `node:crypto`.
+ *
+ * WHAT THIS IS: a soft internal gate so the Bali Zero team can exercise the
+ * real engine while `VISA_ENGINE_EVALUATE_MODE` is still SHADOW. It is NOT
+ * authentication and NOT a security boundary — its strength is exactly the
+ * entropy of `VISA_ORACLE_INTERNAL_PIN` (a 4-digit PIN is brute-forceable in
+ * seconds by a determined actor). It keeps casual passers-by out of an
+ * unfinished surface; it must never be relied on to protect anything whose
+ * disclosure would actually harm.
+ *
+ * WHY A SIGNED COOKIE, not a bare flag: `HttpOnly` stops client JS from
+ * READING a cookie, it does not stop a person from WRITING one in devtools.
+ * A bare `vo_internal=1` would therefore be trivially forgeable by anyone who
+ * guessed the cookie's name. The value is an HMAC over the expiry, keyed by a
+ * value derived from the PIN, so forging it costs the same as guessing the
+ * PIN — never less.
+ */
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export const INTERNAL_ACCESS_COOKIE = "vo_internal";
+
+/** 30 days: long enough that the team unlocks once, short enough to lapse. */
+export const INTERNAL_ACCESS_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+const KEY_LABEL = "vo-internal-cookie-key-v1";
+const TOKEN_LABEL = "vo-internal";
+
+/**
+ * The configured PIN, or `null` when unset. Unset means the gate is CLOSED:
+ * no unlock can succeed and no cookie can verify (fail-closed, so a missing
+ * env var can never silently open the internal surface to the public).
+ */
+export function configuredPin(): string | null {
+  const raw = process.env.VISA_ORACLE_INTERNAL_PIN;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function signingKey(pin: string): Buffer {
+  return createHmac("sha256", pin).update(KEY_LABEL).digest();
+}
+
+function signature(pin: string, expiresAtMs: number): string {
+  return createHmac("sha256", signingKey(pin))
+    .update(`${TOKEN_LABEL}|${expiresAtMs}`)
+    .digest("base64url");
+}
+
+/** Constant-time string compare that never throws on length mismatch. */
+export function safeEquals(a: string, b: string): boolean {
+  const left = Buffer.from(a, "utf8");
+  const right = Buffer.from(b, "utf8");
+  if (left.length !== right.length) return false;
+  try {
+    return timingSafeEqual(left, right);
+  } catch {
+    return false;
+  }
+}
+
+/** Mint a cookie value that proves PIN possession until `expiresAtMs`. */
+export function mintInternalAccessToken(
+  pin: string,
+  expiresAtMs: number,
+): string {
+  return `${expiresAtMs}.${signature(pin, expiresAtMs)}`;
+}
+
+/**
+ * True iff `token` is a well-formed, unexpired, correctly-signed cookie value
+ * for the currently configured PIN. Rotating the PIN invalidates every
+ * outstanding token, which is what makes "togliamo il pin" a real revocation.
+ */
+export function verifyInternalAccessToken(
+  token: string | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  const pin = configuredPin();
+  if (pin === null || !token) return false;
+
+  const separator = token.indexOf(".");
+  if (separator <= 0) return false;
+
+  const expiresAtRaw = token.slice(0, separator);
+  const presented = token.slice(separator + 1);
+  if (!/^\d{1,15}$/.test(expiresAtRaw) || presented.length === 0) return false;
+
+  const expiresAtMs = Number(expiresAtRaw);
+  if (!Number.isSafeInteger(expiresAtMs) || expiresAtMs <= nowMs) return false;
+
+  return safeEquals(presented, signature(pin, expiresAtMs));
+}

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/page.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/page.tsx
@@ -1,5 +1,24 @@
+import { cookies } from "next/headers";
 import { OracleShell } from "./_components/OracleShell";
+import {
+  INTERNAL_ACCESS_COOKIE,
+  verifyInternalAccessToken,
+} from "./_lib/internal-access";
 
-export default function VisaOraclePage() {
-  return <OracleShell />;
+/**
+ * Reading the internal-access cookie opts this route into per-request
+ * rendering. That is deliberate: deciding on the SERVER is what makes the
+ * gate unforgeable (a client-side probe would either race the interview or
+ * be patchable in the browser), and the page's work is client-side anyway,
+ * so the server render stays cheap.
+ */
+export const dynamic = "force-dynamic";
+
+export default async function VisaOraclePage() {
+  const cookieStore = await cookies();
+  const internalMode = verifyInternalAccessToken(
+    cookieStore.get(INTERNAL_ACCESS_COOKIE)?.value,
+  );
+
+  return <OracleShell internalMode={internalMode} />;
 }

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/unlock/page.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/unlock/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * Internal unlock screen for the Bali Zero team: enter the PIN once, then use
+ * `/visa-oracle` at full power (real engine decisions) while the backend is
+ * still in SHADOW. The PIN is verified server-side by
+ * `POST /api/visa-oracle-unlock`, which sets a signed HttpOnly cookie.
+ *
+ * Not linked from the public Oracle UI on purpose — the team reaches it by
+ * URL. It is a soft gate, not authentication (see `_lib/internal-access.ts`).
+ */
+import { useState, type FormEvent } from "react";
+
+type Status = "idle" | "checking" | "error" | "unconfigured" | "done";
+
+const UNLOCK_URL = "/api/visa-oracle-unlock";
+
+export default function VisaOracleUnlockPage() {
+  const [pin, setPin] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (pin.trim().length === 0 || status === "checking") return;
+    setStatus("checking");
+    try {
+      const response = await fetch(UNLOCK_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        cache: "no-store",
+        credentials: "same-origin",
+        body: JSON.stringify({ pin }),
+      });
+      if (response.ok) {
+        setStatus("done");
+        setPin("");
+        window.location.assign("/visa-oracle");
+        return;
+      }
+      setStatus(response.status === 503 ? "unconfigured" : "error");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  async function lock() {
+    try {
+      await fetch(UNLOCK_URL, {
+        method: "DELETE",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+    } finally {
+      window.location.assign("/visa-oracle");
+    }
+  }
+
+  return (
+    <div className="oracle-root" data-oracle-theme="light" data-funnel="visa">
+      <div className="oracle-shell">
+        <div className="oracle-question">
+          <h1 className="oracle-headline" tabIndex={-1}>
+            Internal access
+          </h1>
+          <p className="oracle-subhead">
+            Bali Zero team only. Unlocking shows the real engine decision for
+            testing — it is not an authoritative answer and is not cleared for a
+            client.
+          </p>
+          <form onSubmit={submit}>
+            <label className="oracle-question__hint" htmlFor="vo-pin">
+              Access PIN
+            </label>
+            <input
+              id="vo-pin"
+              name="pin"
+              type="password"
+              inputMode="numeric"
+              autoComplete="off"
+              autoFocus
+              value={pin}
+              onChange={(event) => setPin(event.currentTarget.value)}
+              aria-describedby="vo-pin-status"
+              style={{
+                display: "block",
+                margin: "0.75rem 0",
+                padding: "0.6rem 0.8rem",
+                fontSize: "1.1rem",
+                letterSpacing: "0.2em",
+                maxWidth: "12rem",
+              }}
+            />
+            <button
+              type="submit"
+              className="oracle-option-card"
+              style={{ width: "fit-content" }}
+              disabled={status === "checking" || pin.trim().length === 0}
+            >
+              {status === "checking" ? "Checking…" : "Unlock"}
+            </button>
+          </form>
+          <p id="vo-pin-status" className="oracle-question__hint" role="status">
+            {status === "error" && "That PIN was not accepted."}
+            {status === "unconfigured" &&
+              "Internal access is not configured on this deployment."}
+            {status === "done" && "Unlocked — opening the Oracle…"}
+          </p>
+          <button
+            type="button"
+            className="oracle-question__back"
+            onClick={lock}
+            style={{ marginTop: "1.5rem" }}
+          >
+            Lock this browser again
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mouth/src/app/api/visa-oracle-unlock/route.ts
+++ b/apps/mouth/src/app/api/visa-oracle-unlock/route.ts
@@ -1,0 +1,109 @@
+/**
+ * Visa Oracle internal PIN unlock (server-side).
+ *
+ * POST   { pin } -> sets the signed `vo_internal` cookie on success (401 on a
+ *                   wrong PIN, 503 when no PIN is configured — fail-closed).
+ * DELETE          -> clears the cookie ("lock it again" / end of a test).
+ *
+ * Deliberately NOT under `/api/visa-oracle/*`: that prefix is proxied to the
+ * backend by the `[...path]` catch-all, and this route must never leave the
+ * frontend. The PIN is compared here and NEVER forwarded upstream, so it
+ * cannot reach backend logs.
+ *
+ * This is a soft internal gate, not authentication — see `internal-access.ts`
+ * for the honest threat model (its strength is the PIN's entropy, no more).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import {
+  INTERNAL_ACCESS_COOKIE,
+  INTERNAL_ACCESS_MAX_AGE_SECONDS,
+  configuredPin,
+  mintInternalAccessToken,
+  safeEquals,
+  verifyInternalAccessToken,
+} from "@/app/(visa-oracle)/visa-oracle/_lib/internal-access";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function isSecureRequest(req: NextRequest): boolean {
+  const hostname = req.nextUrl.hostname.toLowerCase();
+  const isLoopback = ["localhost", "127.0.0.1", "::1"].includes(hostname);
+  return process.env.NODE_ENV === "production" && !isLoopback;
+}
+
+/**
+ * Host-only cookie (no `Domain`): the Oracle is served from one host, and
+ * Vercel's Edge runtime is documented in `api/[...path]/route.ts` to silently
+ * drop `Set-Cookie` headers carrying `domain=.balizero.com`.
+ */
+function buildCookie(req: NextRequest, value: string, maxAge: number): string {
+  const secure = isSecureRequest(req) ? "; Secure" : "";
+  return `${INTERNAL_ACCESS_COOKIE}=${value}; Path=/; Max-Age=${maxAge}; HttpOnly; SameSite=Lax${secure}`;
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const pin = configuredPin();
+  if (pin === null) {
+    // Fail-closed: an unset env var must never mean "everyone is internal".
+    return NextResponse.json(
+      { ok: false, error: "NOT_CONFIGURED" },
+      { status: 503 },
+    );
+  }
+
+  let presented = "";
+  try {
+    const body: unknown = await req.json();
+    if (body !== null && typeof body === "object" && "pin" in body) {
+      const raw = (body as { pin: unknown }).pin;
+      if (typeof raw === "string") presented = raw.trim();
+    }
+  } catch {
+    // Malformed JSON is just a failed attempt; never echo the parse error.
+  }
+
+  // Never log the presented value, not even truncated.
+  if (presented.length === 0 || !safeEquals(presented, pin)) {
+    return NextResponse.json(
+      { ok: false, error: "INVALID_PIN" },
+      { status: 401 },
+    );
+  }
+
+  const expiresAtMs = Date.now() + INTERNAL_ACCESS_MAX_AGE_SECONDS * 1000;
+  const response = NextResponse.json({ ok: true });
+  response.headers.set(
+    "Set-Cookie",
+    buildCookie(
+      req,
+      mintInternalAccessToken(pin, expiresAtMs),
+      INTERNAL_ACCESS_MAX_AGE_SECONDS,
+    ),
+  );
+  return response;
+}
+
+/**
+ * Status probe for the client shell: "is this browser unlocked?".
+ *
+ * Kept as an endpoint (rather than reading the cookie in the page's server
+ * component) so `/visa-oracle` — a PUBLIC page — stays statically rendered
+ * instead of becoming per-request dynamic. The answer is still computed
+ * server-side from the signed cookie; the browser only learns a boolean.
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const token = req.cookies.get(INTERNAL_ACCESS_COOKIE)?.value;
+  const response = NextResponse.json({
+    internal: verifyInternalAccessToken(token),
+    configured: configuredPin() !== null,
+  });
+  response.headers.set("Cache-Control", "no-store, private");
+  return response;
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const response = NextResponse.json({ ok: true });
+  response.headers.set("Set-Cookie", buildCookie(req, "", 0));
+  return response;
+}

--- a/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
+++ b/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
@@ -1,0 +1,139 @@
+---
+date: 2026-08-09
+domain: visa
+client_case: none (Visa Oracle V2 decision-tree audit)
+sources:
+  - rulepack-prod-004.source.json (seq-4, active SHADOW since 2026-08-08)
+  - real evaluator backend/services/visa_engine/evaluator.py (frozen REVIEW>SUPPORTED precedence)
+  - gold personas fixtures/personas/*.json (23) + synthetic qualified applicants
+  - offline harness (real evaluate() + real prod pack, synthetic facts, in-memory edits only)
+---
+
+# Visa Oracle V2 — full decision-tree audit ("albero perfetto")
+
+Zero mandate 2026-08-09: audit EVERY always-review branch, classify each
+SPURIOUS-MASK vs LEGITIMATE-REVIEW, + add the minor-without-guardian safety gate.
+Method: faithful OFFLINE harness (real `evaluate()` + real prod-004 pack,
+synthetic facts, in-memory pack edits only, zero prod/ledger pollution).
+
+## Method — how a branch is judged
+
+A PRODUCTS-scoped HUMAN_REVIEW rule is **purpose-only** when the only fact its
+`when` references is `intent.purposes` — it fires for ANY applicant with that
+purpose, masking regardless of qualifying facts (D12 class). It is
+**discriminating** when it also references a real fact (D1 keys on
+`intent.entry_pattern`; E31 on `family.relation_to_sponsor`; E33 on deposits).
+Under the frozen REVIEW>SUPPORTED precedence any firing review masks all
+SUPPORTED candidates, so a purpose-only rule that fires for a QUALIFIED applicant
+(facts satisfy a dedicated product's eligibility) can spuriously mask that
+product. Empirical test: remove the purpose-only rules for a purpose, re-evaluate
+a qualified applicant; if a dedicated product surfaces SUPPORTED, the mask was
+real. Static count: 25 purpose-only rules, 38 discriminating.
+
+## Per-branch verdict
+
+| Branch | purpose-only rules | Qualified-applicant counterfactual | Verdict |
+|---|---|---|---|
+| **INVESTMENT (D12)** | 5 | 09_investor (PT PMA committed, 3B capital): HUMAN_REVIEW → **SUPPORTED E28A** | 🔴 CLEAR CROSS-PRODUCT DEFECT — a real investor is routed to a business-visit review, hiding the investor KITAS (E28A). FIX. |
+| **BUSINESS (D2)** | 5 | RE-VERIFIED 2026-08-09 (Zero pushback): business single OR multi-entry always → HUMAN_REVIEW with document reasons | ✅ NOT A DEFECT (retracted). Document review (CV/itinerary/funds/support-letter) is intended verification like EMPLOYMENT/RPTKA. The earlier "SUPPORTED D2" was a FLAWED single-entry test vs a multiple-entry product. No seq-5 change. |
+| **STUDY (E30)** | 5 | E30/E30A/E30B/E30E/E30F all covered_purposes=[STUDY]; only study.admission_confirmed/level/sponsor_confirmed facts exist | 🟡 MISSING FACTS — E30E=KEK-institution, E30F=exchange-program, E30B=izin-belajar are distinct visas but NO interview fact distinguishes them, so all 3 fire as review for every student. Fix = interview/contract EXPANSION (add is_kek/is_exchange facts) → then route + conclude. A design project, not a rule edit. |
+| **EMPLOYMENT (E23/U/V)** | 8 | reasons: RPTKA_VERIFICATION, JABATAN_MUST_MATCH_KBLI, PROHIBITED_HR_ROLES_KEPMENAKER_349_2019 | ✅ LEGITIMATE — government/RPTKA verification, not auto-determinable |
+| **FAMILY (E31)** | 2 (E31D) | 06_family: remove → stays HUMAN_REVIEW (E31 sponsor-ITAS/ITAP discriminating rules dominate) | ✅ LEGITIMATE (E31D purpose-only rules redundant but harmless) |
+| **SECOND_HOME (E33)** | 1 | 13/22/23: remove → stays HUMAN_REVIEW (deposit/property discriminating) | ✅ LEGITIMATE |
+| **RETIREMENT (E33E/F)** | 0 | age-band discriminating (E33E 55-59, E33F <55) | ✅ LEGITIMATE |
+| **REMOTE_WORK (E33G)** | 0 | income/local-market discriminating | ✅ LEGITIMATE |
+| **TOURISM** | 0 | single-entry → SUPPORTED B1,C1; multi-entry → D1 review (D1 was cured with an entry_pattern gate) | ✅ CORRECT |
+| **MEDICAL / OTHER** | — | no product covers them → NEEDS_INPUT | ⚪ COVERAGE GAP (business: does Bali Zero serve these lines?) |
+
+## Safety defect (false-SUPPORTED — the dangerous class)
+
+**minor-without-guardian**: prod-004 has NO GLOBAL age gate. Only `hr.e30a-minor-consent`
+(PRODUCTS/E30A, gated on STUDY). A 15-year-old traveling alone for TOURISM
+(sponsor_confirmed=False) → auto-SUPPORTED B1,C1. Proven fix: GLOBAL rule
+`review.minor-without-guardian` (is_minor AND sponsor_confirmed==false →
+REQUIRE_REVIEW/MINOR_WITHOUT_CONFIRMED_GUARDIAN). Verified: persona 15 → HUMAN_REVIEW,
+adult persona 01 → still SUPPORTED (innocence). Shipped in the prod-005 draft.
+
+## Root cause of the spurious masks (superscar W107, incomplete-cure)
+
+D1's review rules double-gate `all(purpose, entry_pattern==MULTIPLE)` — prod-004
+cured D1. D2 and D12 fire on purpose alone; the same cure was NOT applied to them
+(cured one of three). E30's rules are purpose-only too, but 3 encode
+product-applicability (E30E only for KEK institutions, E30F only for exchange
+programs) disguised as review — deleting them wholesale would OVER-support a
+generic student. Their correct fix is conversion to ELIGIBILITY conditions.
+
+## seq-5 (prod-005) fix set
+
+FINAL seq-5 = TWO fixes only (both DRAFTED + harness-verified in prod-005, guilt/innocence PASS):
+1. **Minor gate** (safety): GLOBAL `review.minor-without-guardian` — persona 15 flips
+   SUPPORTED→HUMAN_REVIEW/minor, adult unchanged.
+2. **D12→E28A unmask** (cross-product defect): the 5 D12 investment purpose-only rules
+   gated `all(purposes intersects [INVESTMENT], investment.pt_pma_committed neq true)`
+   (Codex-vetted, single-seat: agy/kimi were quota/auth down). 09_investor →
+   SUPPORTED E28A; pt_pma FALSE → D12 review; UNKNOWN → NEEDS_INPUT. No precedence change.
+
+NOT fixed (resolved as non-defects / separate projects):
+3. **D2** — NOT a defect (retracted after Zero pushback + re-verification). Business
+   always-review is intended document verification.
+4. **E30** — needs interview/contract EXPANSION (missing is_kek/is_exchange/izin facts);
+   a design project, not a seq-5 rule edit.
+5. **LEAVE**: EMPLOYMENT, FAMILY, SECOND_HOME, RETIREMENT, REMOTE_WORK (legitimate).
+6. **Coverage gap (Legge-5)**: MEDICAL / OTHER have no product.
+
+Activation of any seq-5 pack is Zero-gated (two-login signing ceremony); ENFORCE
+stays NO-GO. The "38 schede testate in prod" is the Bali Zero team's heavy manual
+SHADOW testing (Zero mandate 2026-08-08), enabled by the offline harness above.
+
+## seq-5 activation runbook (Zero-gated ceremony)
+
+State verified live 2026-08-09: frontend `balizero.com/visa-oracle` HTTP 200,
+backend `nuzantara-rag.fly.dev/health` HTTP 200. Active pack = prod-004 (seq-4,
+`rule_pack_id 720f50fc-12e2-5633-8586-4b31b086ea64`). SHADOW testing of the
+current tree is possible NOW, with the 2 known holes above still open until seq-5.
+
+**Mechanical (session already did): DONE** — prod-005.source.json drafted +
+harness-verified (`rulepack-prod-005.source.json`, seq=5, 113 rules; compiles clean;
+exactly 2 personas flip 09_investor→SUPPORTED E28A / 15_minor→HUMAN_REVIEW,
+guilt/innocence PASS). Reproducible via `build_seq5_full.py`.
+
+**Two ceremony-blocking chain bugs caught + fixed (2026-08-09, pre-signature):** the
+initial draft `deepcopy`-ed prod-004 and carried two fields that would have failed the
+ceremony — (1) `rule_pack_id` was prod-004's `720f50fc…` → PK collision on
+`insert_rule_pack`; (2) `previous_payload_sha256` was prod-003's `99b843b8…` →
+`bundle.validate_activation` (bundle.py:987) hard-rejects unless it equals the ACTIVE
+pack's hash. Fixed: minted a new uuid5 `rule_pack_id = 4159265d-53e8-5b25-ab5a-fa4f5b25a2d1`
+(design-doc convention: uuid5 never uuid4; unique vs 001/002/004) and chained
+`previous_payload_sha256 = 1f0f7b0d189d0d9adecb08afa158f1f221ef698340a65b029beb0fc21f410e49`
+(prod-004, read dynamically from its signed bundle — no frozen constant). All four
+activation preconditions re-verified GREEN (unique id · seq 5>4 · prev==prod-004 · PRODUCTION).
+
+**Operator-gated (Zero only — credential/physical/business):**
+1. **Sign on M5** (`ssh air`, user `balizero`) — the Ed25519 PRIVATE key lives only
+   at `~/.config/nuzantara/visa-signing/2026-07-prod-1.ed25519.pem` (chmod 0600),
+   never on Pro/Mini/Keychain/repo (cicatrix #4). Command shape (verified arg surface):
+   `python -m backend.scripts.visa_engine.sign_pack rulepack-prod-005.source.json
+   --kid 2026-07-prod-1 --key-file <pem> --environment PRODUCTION --sequence 5
+   --output rulepack-prod-005.signed.json --i-know-this-is-production`.
+2. **Two-login activate** — `activate_pack.py <signed.json> --actor <id> --reason
+   seq5-shadow-activation-260809 --current-sequence 4 --current-payload-sha256
+   1f0f7b0d189d0d9adecb08afa158f1f221ef698340a65b029beb0fc21f410e49 --yes`, with TWO
+   distinct DB identities in env (`VISA_ENGINE_PACK_WRITER_DATABASE_URL` +
+   `VISA_ENGINE_ACTIVATION_DATABASE_URL`); `_assert_production_separation` hard-refuses
+   if the two logins are the same principal or a superuser. Ephemeral ceremony roles
+   (`visa_pack_writer_ceremony_<date>` / `visa_activation_ceremony_<date>`) minted +
+   dropped same session (prod-004 precedent). Run once WITHOUT `--yes` first (dry-run
+   preview of sequence/hash) before the real write.
+3. **Prove-live** (session does after activation): SHADOW binding query resolves to
+   seq-5 (`rule_pack_id 4159265d-53e8-5b25-ab5a-fa4f5b25a2d1`) on next evaluate; the 2
+   corrected branches answer correctly; EVALUATE_MODE stays SHADOW (separate Fly secret
+   `VISA_ENGINE_EVALUATE_MODE`, untouched — ENFORCE remains NO-GO).
+
+**NOT a blocker for this SHADOW activation** (corrected 2026-08-09 — earlier draft
+over-flagged it): the enforce-gate doc's DB findings (migration 264 unapplied,
+`visa_activation_executor` holds direct grants, `backend_rag_v2` can insert activation
+rows, no `visa_ledger_owner`) are explicitly **"latent while mode is SHADOW"** and are
+**hard ENFORCE blockers only**. prod-004 (seq-4) was activated in SHADOW with these
+exact conditions present, so seq-5 activates the same way. ENFORCE stays NO-GO, so they
+do not gate anything on the current path. They remain a separate operator[credential]
+DB-hardening prerequisite for any future ENFORCE decision (Zero + privacy owner + DPIA).

--- a/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
+++ b/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
@@ -108,26 +108,49 @@ pack's hash. Fixed: minted a new uuid5 `rule_pack_id = 4159265d-53e8-5b25-ab5a-f
 (prod-004, read dynamically from its signed bundle — no frozen constant). All four
 activation preconditions re-verified GREEN (unique id · seq 5>4 · prev==prod-004 · PRODUCTION).
 
-**Operator-gated (Zero only — credential/physical/business):**
-1. **Sign on M5** (`ssh air`, user `balizero`) — the Ed25519 PRIVATE key lives only
-   at `~/.config/nuzantara/visa-signing/2026-07-prod-1.ed25519.pem` (chmod 0600),
-   never on Pro/Mini/Keychain/repo (cicatrix #4). Command shape (verified arg surface):
-   `python -m backend.scripts.visa_engine.sign_pack rulepack-prod-005.source.json
-   --kid 2026-07-prod-1 --key-file <pem> --environment PRODUCTION --sequence 5
-   --output rulepack-prod-005.signed.json --i-know-this-is-production`.
-2. **Two-login activate** — `activate_pack.py <signed.json> --actor <id> --reason
-   seq5-shadow-activation-260809 --current-sequence 4 --current-payload-sha256
-   1f0f7b0d189d0d9adecb08afa158f1f221ef698340a65b029beb0fc21f410e49 --yes`, with TWO
-   distinct DB identities in env (`VISA_ENGINE_PACK_WRITER_DATABASE_URL` +
-   `VISA_ENGINE_ACTIVATION_DATABASE_URL`); `_assert_production_separation` hard-refuses
-   if the two logins are the same principal or a superuser. Ephemeral ceremony roles
-   (`visa_pack_writer_ceremony_<date>` / `visa_activation_ceremony_<date>`) minted +
-   dropped same session (prod-004 precedent). Run once WITHOUT `--yes` first (dry-run
-   preview of sequence/hash) before the real write.
-3. **Prove-live** (session does after activation): SHADOW binding query resolves to
-   seq-5 (`rule_pack_id 4159265d-53e8-5b25-ab5a-fa4f5b25a2d1`) on next evaluate; the 2
-   corrected branches answer correctly; EVALUATE_MODE stays SHADOW (separate Fly secret
-   `VISA_ENGINE_EVALUATE_MODE`, untouched — ENFORCE remains NO-GO).
+**⚠️ KID CORRECTION (2026-08-09 — the real signing key id, proven against live prod-004):**
+The production signing kid is **`prod-2026-07-1`** (letter-first) — NOT `2026-07-prod-1`.
+The earlier `2026-07-prod-1` was a transcription/transposition that propagated from an
+ILLUSTRATIVE docstring example (`bundle.py:253`, inside `StaticTrustStore.from_env`'s
+`.. code-block:: json`) and the M5 key FILENAME (`2026-07-prod-1.ed25519.pem`) — the file
+name uses a date-first convention that does NOT equal the kid it holds. Proven the hard way:
+signing with `--kid 2026-07-prod-1` is REJECTED (digit-first fails the `Identifier` pattern
+`^[A-Za-z]…`), and `RulePack.model_validate(prod-004.signed.json)` shows the LIVE bundle's
+`protected.kid == 'prod-2026-07-1'`. A GATE probe verified prod-004's Ed25519 signature with
+a trust store built from that key's derived pubkey (`gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA`)
+under kid `prod-2026-07-1` → PASS, so this exact key+kid is prod-004's live signer. There is
+NO kid Identifier regression on main — the pattern accepts `prod-2026-07-1` fine.
+
+**Session-executed (DONE 2026-08-09 — "io sono te", sign_pack reads --key-file, never prints):**
+1. **Signed on M5** (`ssh air`, user `balizero`) — Ed25519 PRIVATE key at
+   `~/.config/nuzantara/visa-signing/2026-07-prod-1.ed25519.pem` (chmod 0600, never
+   Pro/Mini/Keychain/repo, cicatrix #4). `python -m backend.scripts.visa_engine.sign_pack
+   rulepack-prod-005.source.json --kid prod-2026-07-1 --key-file <pem> --environment
+   PRODUCTION --sequence 5 --output rulepack-prod-005.signed.json --i-know-this-is-production`.
+   Result: `sequence=5 kid=prod-2026-07-1 payload_sha256=ebc19f5c0550b601350f4e8e9ab95a61cc8107ea15c2ecd03781d023aaad322e
+   public_key=gZoo1nzMsRpwWgw4HCzV_2YYxU0Vbt5FMfLWeOzAchA` (IDENTICAL pubkey to prod-004's
+   signer). sign_pack self-verified before writing.
+2. **Faithful dry-run of activate_pack** (no `--yes`, returns before any DB): with a
+   `VISA_ENGINE_TRUST_STORE_KEYS_JSON` built from the derived pubkey, the REAL path ran
+   `StaticTrustStore.from_env` → `verify_rule_pack` (PASS) → `validate_activation`
+   (anti-rollback pre-gate PASS: seq 5>4 · chain `1f0f7b0d…` · PRODUCTION · engine 1.0.0)
+   → `would_insert_and_activate=true rule_pack_id=4159265d-… payload_sha256=ebc19f5c…`.
+
+**Operator-checkpoint (Zero — Legge 5 business go for the IRREVERSIBLE write):**
+3. **Two-login `--yes` activate** — `activate_pack.py <signed.json> --actor
+   session.voa-seq5-tree --reason seq5-shadow-activation-260809 --current-sequence 4
+   --current-payload-sha256 1f0f7b0d189d0d9adecb08afa158f1f221ef698340a65b029beb0fc21f410e49
+   --yes`, with TWO distinct DB identities in env (`VISA_ENGINE_PACK_WRITER_DATABASE_URL`
+   + `VISA_ENGINE_ACTIVATION_DATABASE_URL`); `_assert_production_separation` hard-refuses
+   same-principal or superuser sessions. Ephemeral ceremony roles
+   (`visa_pack_writer_ceremony_260809` in `visa_pack_writer` / `visa_activation_ceremony_260809`
+   in `visa_activation_executor`, invariant `no-pack-writer-activation-combination`) minted
+   via fly superuser on `nuzantara-postgres` (from Pro) + dropped same session (prod-004
+   precedent). This is the single Zero-gated step remaining.
+4. **Prove-live** (session, after activation): SHADOW binding resolves to seq-5
+   (`rule_pack_id 4159265d-53e8-5b25-ab5a-fa4f5b25a2d1`) on next evaluate; the 2 corrected
+   branches answer correctly; EVALUATE_MODE stays SHADOW (`VISA_ENGINE_EVALUATE_MODE`
+   untouched — ENFORCE remains NO-GO).
 
 **NOT a blocker for this SHADOW activation** (corrected 2026-08-09 — earlier draft
 over-flagged it): the enforce-gate doc's DB findings (migration 264 unapplied,

--- a/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
+++ b/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
@@ -1,6 +1,7 @@
 ---
 date: 2026-08-09
 domain: visa
+adversarial_review: codex # gpt-5.6-sol, R1 round 2026-08-09: 20 objections, verdict BLOCKER. Retractions and corrections below are its result.
 client_case: none (Visa Oracle V2 decision-tree audit)
 sources:
   - rulepack-prod-004.source.json (seq-4, active SHADOW since 2026-08-08)
@@ -45,14 +46,34 @@ real. Static count: 25 purpose-only rules, 38 discriminating.
 | **TOURISM** | 0 | single-entry → SUPPORTED B1,C1; multi-entry → D1 review (D1 was cured with an entry_pattern gate) | ✅ CORRECT |
 | **MEDICAL / OTHER** | — | no product covers them → NEEDS_INPUT | ⚪ COVERAGE GAP (business: does Bali Zero serve these lines?) |
 
-## Safety defect (false-SUPPORTED — the dangerous class)
+## Minor handling (RETRACTED as a "safety defect" — corrected 2026-08-09)
 
-**minor-without-guardian**: prod-004 has NO GLOBAL age gate. Only `hr.e30a-minor-consent`
-(PRODUCTS/E30A, gated on STUDY). A 15-year-old traveling alone for TOURISM
-(sponsor_confirmed=False) → auto-SUPPORTED B1,C1. Proven fix: GLOBAL rule
-`review.minor-without-guardian` (is_minor AND sponsor_confirmed==false →
-REQUIRE_REVIEW/MINOR_WITHOUT_CONFIRMED_GUARDIAN). Verified: persona 15 → HUMAN_REVIEW,
-adult persona 01 → still SUPPORTED (innocence). Shipped in the prod-005 draft.
+> **RETRACTION.** An earlier revision of this section called this a false-SUPPORTED
+> **safety defect**: "a 15-year-old travelling alone for TOURISM → auto-SUPPORTED B1,C1",
+> with the seq-5 rule as its "proven fix". That was measured on the **raw `evaluate()`**
+> in the offline harness — the evaluator layer — and does **not** describe the served
+> runtime. The public evaluation path calls `_apply_minor_privacy_hold`
+> (`evaluate_path.py:902`, invoked at `:1459`), which abstains for every KNOWN minor
+> before a response is built. **No real applicant was ever auto-SUPPORTED as a minor by
+> the live surface.** Auditing a layer and reporting it as the product's behaviour is the
+> error; the claim is withdrawn.
+
+What the pack-level rule in seq-5 (`review.minor-without-guardian`) actually is:
+**defence in depth at the RulePack layer** for a case the runtime adapter already covers.
+It is not harmful and it keeps the pack self-sufficient if the adapter is ever bypassed,
+but it closed no live hole.
+
+**Naming is also wrong and should be corrected in a later pack.** The rule keys on
+`family.sponsor_confirmed`, which is a *sponsor* fact (family/work sponsorship), **not**
+guardian identity or consent. `_apply_minor_privacy_hold`'s own docstring states the
+contract "has no guardian-identity/consent fact" — so a rule called
+`minor-without-guardian` emitting `MINOR_WITHOUT_CONFIRMED_GUARDIAN` asserts a fact the
+vocabulary cannot express. Fixing it properly needs an interview/contract expansion (a
+real guardian fact), not a rename.
+
+Harness evidence, stated for what it is: on the evaluator layer, persona 15 flips
+SUPPORTED → HUMAN_REVIEW and adult persona 01 is unchanged (innocence). That is a true
+statement about `evaluate()`, and only about `evaluate()`.
 
 ## Root cause of the spurious masks (superscar W107, incomplete-cure)
 
@@ -95,7 +116,10 @@ current tree is possible NOW, with the 2 known holes above still open until seq-
 **Mechanical (session already did): DONE** — prod-005.source.json drafted +
 harness-verified (`rulepack-prod-005.source.json`, seq=5, 113 rules; compiles clean;
 exactly 2 personas flip 09_investor→SUPPORTED E28A / 15_minor→HUMAN_REVIEW,
-guilt/innocence PASS). Reproducible via `build_seq5_full.py`.
+guilt/innocence PASS — on the EVALUATOR layer; see the minor-handling retraction above for
+what that does and does not say about the served runtime). Built by a session scratchpad
+script (`build_seq5_full.py`), which is **not committed to this repo** — the reproducible
+artifact is the checked-in `rulepack-prod-005.source.json` plus `compile_pack.py`.
 
 **Two ceremony-blocking chain bugs caught + fixed (2026-08-09, pre-signature):** the
 initial draft `deepcopy`-ed prod-004 and carried two fields that would have failed the
@@ -110,10 +134,14 @@ activation preconditions re-verified GREEN (unique id · seq 5>4 · prev==prod-0
 
 **⚠️ KID CORRECTION (2026-08-09 — the real signing key id, proven against live prod-004):**
 The production signing kid is **`prod-2026-07-1`** (letter-first) — NOT `2026-07-prod-1`.
-The earlier `2026-07-prod-1` was a transcription/transposition that propagated from an
-ILLUSTRATIVE docstring example (`bundle.py:253`, inside `StaticTrustStore.from_env`'s
-`.. code-block:: json`) and the M5 key FILENAME (`2026-07-prod-1.ed25519.pem`) — the file
-name uses a date-first convention that does NOT equal the kid it holds. Proven the hard way:
+Two date-first strings exist nearby and are easy to mistake for the kid: the ILLUSTRATIVE
+docstring example at `bundle.py:253` (inside `StaticTrustStore.from_env`'s
+`.. code-block:: json`, which still shows the invalid `2026-07-prod-1`) and the M5 key
+FILENAME `2026-07-prod-1.ed25519.pem` — a filename convention that does NOT equal the kid
+the file holds. *How* the wrong value entered this runbook is not established here (the
+visaoracle skill records earlier ceremony ids that began with a digit, failed the pattern,
+and were relabelled — a different history than "copied from the docstring"); what IS
+established is the syntax and the live value. Proven the hard way:
 signing with `--kid 2026-07-prod-1` is REJECTED (digit-first fails the `Identifier` pattern
 `^[A-Za-z]…`), and `RulePack.model_validate(prod-004.signed.json)` shows the LIVE bundle's
 `protected.kid == 'prod-2026-07-1'`. A GATE probe verified prod-004's Ed25519 signature with
@@ -146,23 +174,48 @@ Zero authorized activation this session ("Sì, attiva seq-5 (SHADOW)" via checkp
    DSN env vars; `_assert_production_separation` passed (distinct non-superuser principals);
    roles DROPPED same session via EXIT trap. **Result:** `rule_pack_id=4159265d-… ·
    activation_id=560839f3-a71d-42ef-bdec-246579630884 · sequence=5 · payload_sha256=ebc19f5c…`.
-4. **Prove-live — CONFIRMED at DB + runtime-code level.** The runtime's active-pack
-   selection (`repository.load_active_rule_pack` AND its twin `shadow._resolve_active_pack_binding`)
-   is `WHERE legal_period @> now() AND system_period @> now() ORDER BY created_at DESC LIMIT 1` —
-   NOT single-active: multiple PRODUCTION activations are open by design (seq 1/3/4/5 all
-   in_force; the docstring acknowledges overlapping `legal_period`s), and the NEWEST
-   `created_at` wins. seq-5's activation (`created_at 2026-08-09 13:27:38Z`) is the newest →
-   **served.** No import-time cache, no TTL wrapper on the binding (`shadow.py:77` "re-read
-   fresh on every call") → live immediately, no restart. EVALUATE_MODE stays SHADOW
-   (engine result shadow-logged, users still see CURATED) — ENFORCE remains NO-GO. Frontend
-   `balizero.com/visa-oracle` 200, backend `/health` healthy (v100-qdrant, postgres connected).
-   The Bali Zero team now runs the 38-scheda manual SHADOW test against the corrected tree.
+4. **Post-activation verification — seq-5 is the single active pack.** The runtime's
+   active-pack selection (`repository.load_active_rule_pack` and its documented twin
+   `shadow._resolve_active_pack_binding`) filters on **BOTH** bitemporal clocks:
+   `WHERE legal_period @> $effective_at AND system_period @> $observed_at ORDER BY created_at
+   DESC LIMIT 1`. Measured against prod with that exact predicate: **exactly one row —
+   seq-5** (`4159265d-…`). Per-row: seq 1/3/4 have `legal_period @> now()` **but their
+   `system_period` is CLOSED**; only seq-5 has both open.
 
-**NOT a blocker for this SHADOW activation** (corrected 2026-08-09 — earlier draft
-over-flagged it): the enforce-gate doc's DB findings (migration 264 unapplied,
-`visa_activation_executor` holds direct grants, `backend_rag_v2` can insert activation
-rows, no `visa_ledger_owner`) are explicitly **"latent while mode is SHADOW"** and are
-**hard ENFORCE blockers only**. prod-004 (seq-4) was activated in SHADOW with these
-exact conditions present, so seq-5 activates the same way. ENFORCE stays NO-GO, so they
-do not gate anything on the current path. They remain a separate operator[credential]
-DB-hardening prerequisite for any future ENFORCE decision (Zero + privacy owner + DPIA).
+   > **CORRECTION (same day, caught by the R1 adversarial review).** An earlier revision of
+   > this section claimed "multiple PRODUCTION activations are open by design … the newest
+   > `created_at` wins". That was **wrong**, and it was wrong because the probe behind it
+   > queried `legal_period` ALONE — omitting the `system_period` filter the runtime actually
+   > applies — and then an explanation was invented to fit the flawed measurement. The schema
+   > forbids what that sentence asserted: `250_visa_engine_core.sql` carries a GiST exclusion
+   > constraint over both periods, and the activation writer
+   > (`253_visa_activation_writer_hardening.sql`) closes covered open activations before
+   > inserting. `ORDER BY created_at DESC LIMIT 1` is **defensive**, not a selection policy —
+   > treating it as "newest wins" would invite tolerating a ledger-integrity violation.
+   > The prior `CURRENT_STATE.md` wording ("seq-4 was the single open activation") was
+   > therefore CORRECT and is reinstated; this document's earlier "imprecise" label on it is
+   > withdrawn.
+
+   **Scope of what this proves:** a DB fact (which activation is bitemporally current) plus
+   the source of the selection query. It is **not** a runtime receipt: no evaluation response
+   or audit row has yet been observed naming `sequence 5` / activation `560839f3-…`. That
+   end-to-end proof is the remaining prove-live step. The binding is read per request (the
+   resolver queries the DB on every call and holds no module-level cache), so no restart is
+   expected to be needed. EVALUATE_MODE stays SHADOW (engine result shadow-logged, users still
+   see CURATED) — ENFORCE remains NO-GO. Frontend `balizero.com/visa-oracle` 200, backend
+   `/health` healthy (v100-qdrant, postgres connected).
+
+**DB hardening status — re-measured, an earlier claim here was stale.** A prior revision
+repeated `docs/runbooks/visa-oracle-privacy-enforce-gate.md`'s 2026-08-06 snapshot
+("no `visa_ledger_owner`", migration 264 unapplied). **Measured live on 2026-08-09 (read-only,
+`pg_roles`): all six capability roles EXIST** as NOLOGIN — `visa_pack_writer`,
+`visa_activation_executor`, `visa_ledger_owner`, `visa_policy_writer`,
+`visa_retention_executor`, `visa_privacy_operator`. The DB was hardened AFTER that snapshot,
+so the enforce-gate doc is itself stale on this point; repeating it here without re-measuring
+was the mistake.
+
+What is NOT claimed: that the remaining privilege-separation items are irrelevant. They did
+not prevent this activation — the ceremony ran under two distinct, non-superuser ephemeral
+principals and `_assert_production_separation` passed — but "did not block this ceremony" is
+not "not a prerequisite". Activation-ledger integrity and privilege separation remain live
+prerequisites for any ENFORCE decision (Zero + privacy owner + DPIA), which stays NO-GO.

--- a/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
+++ b/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
@@ -136,21 +136,27 @@ NO kid Identifier regression on main — the pattern accepts `prod-2026-07-1` fi
    (anti-rollback pre-gate PASS: seq 5>4 · chain `1f0f7b0d…` · PRODUCTION · engine 1.0.0)
    → `would_insert_and_activate=true rule_pack_id=4159265d-… payload_sha256=ebc19f5c…`.
 
-**Operator-checkpoint (Zero — Legge 5 business go for the IRREVERSIBLE write):**
-3. **Two-login `--yes` activate** — `activate_pack.py <signed.json> --actor
-   session.voa-seq5-tree --reason seq5-shadow-activation-260809 --current-sequence 4
-   --current-payload-sha256 1f0f7b0d189d0d9adecb08afa158f1f221ef698340a65b029beb0fc21f410e49
-   --yes`, with TWO distinct DB identities in env (`VISA_ENGINE_PACK_WRITER_DATABASE_URL`
-   + `VISA_ENGINE_ACTIVATION_DATABASE_URL`); `_assert_production_separation` hard-refuses
-   same-principal or superuser sessions. Ephemeral ceremony roles
-   (`visa_pack_writer_ceremony_260809` in `visa_pack_writer` / `visa_activation_ceremony_260809`
-   in `visa_activation_executor`, invariant `no-pack-writer-activation-combination`) minted
-   via fly superuser on `nuzantara-postgres` (from Pro) + dropped same session (prod-004
-   precedent). This is the single Zero-gated step remaining.
-4. **Prove-live** (session, after activation): SHADOW binding resolves to seq-5
-   (`rule_pack_id 4159265d-53e8-5b25-ab5a-fa4f5b25a2d1`) on next evaluate; the 2 corrected
-   branches answer correctly; EVALUATE_MODE stays SHADOW (`VISA_ENGINE_EVALUATE_MODE`
-   untouched — ENFORCE remains NO-GO).
+**Operator-checkpoint (Zero — Legge 5) → GRANTED + EXECUTED 2026-08-09:**
+Zero authorized activation this session ("Sì, attiva seq-5 (SHADOW)" via checkpoint).
+3. **Two-login `--yes` activate — DONE.** Ran on Pro (`fly proxy 15432:5432` →
+   `nuzantara-postgres` haproxy). TWO ephemeral LOGIN roles minted via stdin→psql
+   (pw never in argv, cicatrix #4): `visa_pack_writer_ceremony_260809` (in `visa_pack_writer`)
+   + `visa_activation_ceremony_260809` (in `visa_activation_executor`, invariant
+   `no-pack-writer-activation-combination`), passed to `activate_pack.py --yes` as the two
+   DSN env vars; `_assert_production_separation` passed (distinct non-superuser principals);
+   roles DROPPED same session via EXIT trap. **Result:** `rule_pack_id=4159265d-… ·
+   activation_id=560839f3-a71d-42ef-bdec-246579630884 · sequence=5 · payload_sha256=ebc19f5c…`.
+4. **Prove-live — CONFIRMED at DB + runtime-code level.** The runtime's active-pack
+   selection (`repository.load_active_rule_pack` AND its twin `shadow._resolve_active_pack_binding`)
+   is `WHERE legal_period @> now() AND system_period @> now() ORDER BY created_at DESC LIMIT 1` —
+   NOT single-active: multiple PRODUCTION activations are open by design (seq 1/3/4/5 all
+   in_force; the docstring acknowledges overlapping `legal_period`s), and the NEWEST
+   `created_at` wins. seq-5's activation (`created_at 2026-08-09 13:27:38Z`) is the newest →
+   **served.** No import-time cache, no TTL wrapper on the binding (`shadow.py:77` "re-read
+   fresh on every call") → live immediately, no restart. EVALUATE_MODE stays SHADOW
+   (engine result shadow-logged, users still see CURATED) — ENFORCE remains NO-GO. Frontend
+   `balizero.com/visa-oracle` 200, backend `/health` healthy (v100-qdrant, postgres connected).
+   The Bali Zero team now runs the 38-scheda manual SHADOW test against the corrected tree.
 
 **NOT a blocker for this SHADOW activation** (corrected 2026-08-09 — earlier draft
 over-flagged it): the enforce-gate doc's DB findings (migration 264 unapplied,

--- a/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
+++ b/research/visa/2026-08-09-visa-oracle-decision-tree-audit.md
@@ -1,7 +1,8 @@
 ---
 date: 2026-08-09
 domain: visa
-adversarial_review: codex # gpt-5.6-sol, R1 round 2026-08-09: 20 objections, verdict BLOCKER. Retractions and corrections below are its result.
+adversarial_review: codex
+adversarial_review_note: "gpt-5.6-sol, R1 round 2026-08-09 — 20 objections, verdict BLOCKER; the retractions and corrections in this document are its result"
 client_case: none (Visa Oracle V2 decision-tree audit)
 sources:
   - rulepack-prod-004.source.json (seq-4, active SHADOW since 2026-08-08)
@@ -45,6 +46,48 @@ real. Static count: 25 purpose-only rules, 38 discriminating.
 | **REMOTE_WORK (E33G)** | 0 | income/local-market discriminating | ✅ LEGITIMATE |
 | **TOURISM** | 0 | single-entry → SUPPORTED B1,C1; multi-entry → D1 review (D1 was cured with an entry_pattern gate) | ✅ CORRECT |
 | **MEDICAL / OTHER** | — | no product covers them → NEEDS_INPUT | ⚪ COVERAGE GAP (business: does Bali Zero serve these lines?) |
+
+## Adversarial review
+
+Seat: **codex** (`gpt-5.6-sol`, medium effort), 2026-08-09, prompted to REFUTE this
+document. 20 objections, verdict **BLOCKER**. Author did not grade the author's own work;
+and per W65 ("even the refuter hallucinates") every objection acted on below was
+independently re-measured before being accepted.
+
+**Survived and acted on** (each is now a retraction/correction in the text above):
+
+1. *"multiple activations open by design, newest `created_at` wins" contradicts the schema.*
+   **CONFIRMED, and the mechanism was mine**: the probe filtered `legal_period` alone,
+   omitting the runtime's `system_period` clause. Re-measured — exactly ONE active row
+   (seq-5); seq 1/3/4 carry a CLOSED `system_period`. Retracted in full.
+2. *The minor "safety defect" audits the evaluator, not the served runtime.* **CONFIRMED**:
+   `_apply_minor_privacy_hold` (`evaluate_path.py:902`, invoked `:1459`) already abstains for
+   known minors. Retracted.
+3. *The rule keys on `family.sponsor_confirmed`, which is not a guardian fact.* **CONFIRMED**
+   from the adapter's own docstring ("no guardian-identity/consent fact"). Naming defect
+   recorded; a real fix needs a contract expansion.
+4. *"no `visa_ledger_owner`" is stale.* **CONFIRMED** — all six capability roles measured
+   present 2026-08-09. The enforce-gate runbook is itself stale on this point.
+5. *"seq-5 is served" is not a prove-live test.* **ACCEPTED** — scope narrowed to a DB fact
+   plus the selection query's source; a runtime receipt naming sequence 5 is still owed.
+6. *`shadow.py:77` miscited for the no-cache claim.* **ACCEPTED** — that line is about
+   `MATCH_MODE`; the citation was dropped and the claim restated from the resolver itself.
+7. *`build_seq5_full.py` is not in the repo.* **ACCEPTED** — it is a session scratchpad;
+   the reproducible artifacts are the checked-in source pack + `compile_pack.py`.
+8. *The kid's causal history is unsupported.* **ACCEPTED** — the syntax facts and the live
+   value are proven; the "copied from the docstring" story is not, and was withdrawn.
+
+**Raised, not resolved here — recorded as open limitations** (they narrow this document's
+claims rather than change a shipped artifact):
+
+- The FAMILY / SECOND_HOME "legitimate" verdicts rest on 1–3 personas each, not on
+  exhaustive coverage; "redundant but harmless" is therefore unproven for unexplored fact
+  patterns. The per-branch table should be read as evidence-so-far, not a truth table.
+- "BUSINESS is not a defect" is an **owner-accepted** position (Zero, after pushback) plus
+  observed reason codes — not a cited design artifact or regulation.
+- The "38 schede testate in prod" line describes work the team is *starting*, not a completed
+  validation; no result table, timestamps or case manifest exists yet. The number equals the
+  pack's product count and should not be read as a test-pass count.
 
 ## Minor handling (RETRACTED as a "safety defect" — corrected 2026-08-09)
 


### PR DESCRIPTION
## Why

Zero (2026-08-09): *"non possiamo solamente mettere un pin di ingresso (2020) cosi io e il team entriamo e usiamo il visa oracle con tutto il suo potere, poi quando siamo pronti togliamo il pin"*.

The live tool currently shows **every** visitor a `Client safety hold` ("the verified API cannot represent safely"). Root cause is a mode mismatch, not a bug in the engine: the backend is in SHADOW so it answers `mode:"CURATED"`, while the frontend is configured `ENGINE` and `requireEngineResponse` fails closed on anything that is not `ENGINE`. That fail-closed behaviour is a deliberate invariant and is **left untouched** here.

This PR adds a PIN-gated internal preview so the Bali Zero team can exercise the real engine (seq-5) while `VISA_ENGINE_EVALUATE_MODE` stays SHADOW and **ENFORCE remains NO-GO**.

## No backend change was needed

In SHADOW the backend **already computes and returns the full decision**: `evaluate_path.py` fills `decision`/`sources`/`display` unconditionally and only varies the `mode` string (verified at `evaluate_path.py:1544-1558`). The durable ENFORCE write keys off the global `engine_mode` (`evaluate_path.py:1378`, fail-closed branch `:1525-1541`), **never** off that string — so nothing here can trigger the durable-write path that DB hardening + DPIA still gate.

## What changed (frontend only)

- **`_lib/internal-access.ts`** (server-only): signed, expiring token. The cookie is an HMAC keyed off the PIN, **not a bare flag** — `HttpOnly` stops JS *reading* a cookie, not a person *writing* one in devtools. Unset PIN = fail-closed; rotating the PIN revokes every outstanding token.
- **`/api/visa-oracle-unlock`**: `POST` verifies (timing-safe) and sets the cookie, `GET` reports status, `DELETE` locks again. The PIN is never forwarded upstream and never logged. Path is deliberately **outside** `/api/visa-oracle/*`, which the `[...path]` catch-all proxies to the backend.
- **`page.tsx`**: decides `internalMode` on the **server** and passes it down, so an unlocked tester cannot race into (or cache) the public outcome.
- **`buildInternalPreviewOutcome`**: a separate, documented rendering boundary. `buildEngineOutcome` stays the public one and keeps failing closed.
- **`/visa-oracle/unlock`**: PIN entry screen for the team (not linked from public UI).

## Deploy step (required, else the gate stays closed)

Set `VISA_ORACLE_INTERNAL_PIN` on Vercel for the mouth project. Without it the endpoint answers `503 NOT_CONFIGURED` and no one is ever internal (fail-closed by design).

## Honest limits

This is a **soft internal gate, not authentication**. Its strength is exactly the entropy of the PIN — a 4-digit PIN is brute-forceable in seconds by a determined actor. It keeps casual passers-by out of an unfinished surface. Note also that the full decision already reaches every browser today in the SHADOW response body, so this changes what the UI *presents*, not what the network *carries*. Every decision it reveals is labelled `INTERNAL PREVIEW — not an authoritative answer`.

## Tests

52 passed across the 4 touched suites. The guard tests are **mutation-verified**: disabling the signature check turns 3 of them red. Guilt (unlocked tester sees the decision, ordering beats the SHADOW branch) and innocence (public traffic still fails closed, never sees the notice) are both pinned.

## Also in this branch

- `rulepack-prod-005.source.json` (seq-5: minor-without-guardian safety gate + D12→E28A investor unmask) — **already activated in production SHADOW** on 2026-08-09 (`rule_pack_id 4159265d-…`, `activation_id 560839f3-…`).
- Docs recording that activation and correcting the signing kid to `prod-2026-07-1` (the earlier `2026-07-prod-1` was a transposition from a docstring example + the key filename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)