### PR TITLE
fix(mouth): make Vercel builds reproducible and harden article rendering

### DIFF
--- a/apps/mouth/scripts/assert-public-login-bundle.mjs
+++ b/apps/mouth/scripts/assert-public-login-bundle.mjs
@@ -11,6 +11,14 @@ const MANIFEST_PATH = path.join(
   "login-upgraded",
   "page_client-reference-manifest.js",
 );
+const ROUTE_CHUNK_DIRECTORY = path.join(
+  ".next",
+  "static",
+  "chunks",
+  "app",
+  "portal",
+  "login-upgraded",
+);
 
 // Public authentication may reveal its own endpoints. Every other API route is
 // denied by default so adding a new internal domain cannot silently bypass a
@@ -56,16 +64,30 @@ if (!clientEntry) {
   fail(`client entry ${CLIENT_ENTRY_SUFFIX} is absent from route manifest`);
 }
 
-const chunkEntries = clientEntry[1]?.chunks;
-if (!Array.isArray(chunkEntries)) {
+const clientEntryChunks = clientEntry[1]?.chunks;
+if (!Array.isArray(clientEntryChunks)) {
   fail(`client entry ${CLIENT_ENTRY_SUFFIX} has no chunk list`);
 }
 
-const chunkPaths = chunkEntries.filter(
+let chunkPaths = clientEntryChunks.filter(
   (entry) => typeof entry === "string" && entry.endsWith(".js"),
 );
+
+// Vercel can deduplicate the page module and leave its manifest chunk list
+// empty even though Next.js emitted the route entry. The route-specific entry
+// is the narrow fallback; scanning every clientModules entry would include
+// chunks from unrelated authenticated routes.
+if (chunkPaths.length === 0 && fs.existsSync(ROUTE_CHUNK_DIRECTORY)) {
+  chunkPaths = fs
+    .readdirSync(ROUTE_CHUNK_DIRECTORY)
+    .filter((entry) => /^page-[A-Za-z0-9]+\.js$/.test(entry))
+    .map((entry) =>
+      path.join("static", "chunks", "app", "portal", "login-upgraded", entry),
+    );
+}
+
 if (chunkPaths.length === 0) {
-  fail(`client entry ${CLIENT_ENTRY_SUFFIX} resolves to no JavaScript chunks`);
+  fail(`route ${ROUTE} resolves to no JavaScript chunks`);
 }
 
 const violations = [];

--- a/apps/mouth/src/app/api/auth/login/route.test.ts
+++ b/apps/mouth/src/app/api/auth/login/route.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/lib/logger", () => ({
   logger: {
     info: vi.fn(),
+    warn: vi.fn(),
     error: vi.fn(),
   },
 }));
@@ -30,16 +31,17 @@ describe("POST /api/auth/login", () => {
       vi.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        json: async () => ({
-          success: true,
-          message: "Login successful",
-          data: {
-            token: " token-with-newline\n",
-            csrfToken: " csrf-with-newline\n",
-            expiresIn: 3600,
-            user: { email: "ops@balizero.com" },
-          },
-        }),
+        text: async () =>
+          JSON.stringify({
+            success: true,
+            message: "Login successful",
+            data: {
+              token: " token-with-newline\n",
+              csrfToken: " csrf-with-newline\n",
+              expiresIn: 3600,
+              user: { email: "ops@balizero.com" },
+            },
+          }),
       }),
     );
   });
@@ -135,5 +137,58 @@ describe("POST /api/auth/login", () => {
     });
     expect(JSON.stringify(payload)).not.toContain("private-backend");
     expect(JSON.stringify(payload)).not.toContain("ECONNREFUSED");
+  });
+
+  it("preserves an upstream error status when its response body is empty", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "",
+    } as Response);
+
+    const { POST } = await import("./route");
+    const response = await POST(makeLoginRequest());
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      message: "Login service unavailable",
+    });
+  });
+
+  it("returns bad gateway when a successful upstream response is incomplete", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    } as Response);
+
+    const { POST } = await import("./route");
+    const response = await POST(makeLoginRequest());
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      message: "Invalid response from login service",
+    });
+  });
+
+  it("does not expose a malformed upstream response body", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: async () => "<html>private upstream failure</html>",
+    } as Response);
+
+    const { POST } = await import("./route");
+    const response = await POST(makeLoginRequest());
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload).toEqual({
+      success: false,
+      message: "Login service unavailable",
+    });
+    expect(JSON.stringify(payload)).not.toContain("private upstream");
   });
 });

--- a/apps/mouth/src/app/api/auth/login/route.ts
+++ b/apps/mouth/src/app/api/auth/login/route.ts
@@ -14,6 +14,38 @@ function getBackendUrl(): string {
 }
 const BACKEND_URL = getBackendUrl();
 
+interface LoginUpstreamPayload {
+  message?: string;
+  data?: {
+    token?: unknown;
+    csrfToken?: unknown;
+    expiresIn?: number;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+async function parseUpstreamPayload(
+  upstream: Response,
+): Promise<LoginUpstreamPayload | null> {
+  const responseBody = await upstream.text();
+
+  if (!responseBody.trim()) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(responseBody) as LoginUpstreamPayload;
+  } catch {
+    logger.warn("Login upstream returned a non-JSON response", {
+      component: "LoginRoute",
+      action: "parseUpstreamResponse",
+      code: upstream.status,
+    });
+    return null;
+  }
+}
+
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
     const body = await req.json();
@@ -25,10 +57,26 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       body: JSON.stringify(body),
     });
 
-    const data = await upstream.json();
+    const data = await parseUpstreamPayload(upstream);
 
-    if (!upstream.ok || !data?.data?.token) {
-      return NextResponse.json(data, { status: upstream.status });
+    if (!upstream.ok) {
+      return NextResponse.json(
+        data ?? {
+          success: false,
+          message: "Login service unavailable",
+        },
+        { status: upstream.status },
+      );
+    }
+
+    if (!data?.data?.token) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Invalid response from login service",
+        },
+        { status: 502 },
+      );
     }
 
     const { expiresIn } = data.data;

--- a/apps/mouth/src/components/blog/MDXContent.tsx
+++ b/apps/mouth/src/components/blog/MDXContent.tsx
@@ -56,6 +56,7 @@ const mdxComponents = {
   AskZantara,
   ConfidenceMeter,
   Checklist,
+  CheckList: Checklist,
   InfoCard,
   GlossaryTerm,
   AnswerBox,

--- a/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
+++ b/apps/mouth/src/components/blog/MDXContentRSC.test.tsx
@@ -21,6 +21,28 @@ const strataTitleArticles = [
   "src/content/articles/property/strata-title-explained.ru.mdx",
 ];
 
+const productionArticleRegressions = [
+  "src/content/articles/business/export-import-business-guide.mdx",
+  "src/content/articles/business/ota-data-crackdown-bali-2026.mdx",
+  "src/content/articles/business/capital-requirements-guide.mdx",
+  "src/content/articles/business/restaurant-business-guide.mdx",
+  "src/content/articles/business/business-licenses-overview.mdx",
+  "src/content/articles/business/contracts-indonesian-law.mdx",
+  "src/content/articles/business/due-diligence-indonesia.mdx",
+  "src/content/articles/business/labor-law-guide.mdx",
+  "src/content/articles/business/manufacturing-business-guide.mdx",
+  "src/content/articles/business/hiring-indonesian-employees.mdx",
+  "src/content/articles/immigration/airport-procedures.mdx",
+  "src/content/articles/immigration/golden-visa-indonesia-complete-guide.mdx",
+  "src/content/articles/property/property-investment-guide.mdx",
+  "src/content/articles/property/villa-investment-guide.mdx",
+  "src/content/articles/business/pt-pma-first-year-compliance.mdx",
+  "src/content/articles/business/pt-pma-registration-guide.mdx",
+  "src/content/articles/digital-nomad/freelancing-legally-indonesia.mdx",
+  "src/content/articles/tax/freelancer-tax-guide.mdx",
+  "src/content/articles/business/bali-2026-eco-luxury-villas-and-the-new-american-expat-playbook.id.mdx",
+];
+
 describe("renderMDXBody", () => {
   it("server-renders the driving license article interactive MDX body", async () => {
     const articlePath = path.join(
@@ -92,4 +114,18 @@ describe("renderMDXBody", () => {
     expect(html).toContain("PPN raised to 12%");
     expect(html).not.toContain("Cannot read properties of undefined");
   });
+
+  it.each(productionArticleRegressions)(
+    "server-renders an article observed failing in production: %s",
+    async (article) => {
+      const articlePath = path.join(process.cwd(), article);
+      const articleFile = fs.readFileSync(articlePath, "utf8");
+      const { content } = matter(articleFile);
+
+      const mdxBody = await renderMDXBody(stripImports(content));
+      const html = renderToString(<>{mdxBody}</>);
+
+      expect(html).toContain("mdx-content");
+    },
+  );
 });

--- a/apps/mouth/src/components/blog/interactive/CalculatorRSC.tsx
+++ b/apps/mouth/src/components/blog/interactive/CalculatorRSC.tsx
@@ -73,11 +73,16 @@ function inferFormat(
   value: number,
   currency?: string,
 ): CalculatorResult["format"] {
-  if (currency) {
+  if (normalizeCurrencyCode(currency)) {
     return "currency";
   }
 
   return Math.abs(value) <= 1 ? "percentage" : "number";
+}
+
+function normalizeCurrencyCode(currency?: string): string | undefined {
+  const normalized = currency?.trim().toUpperCase();
+  return normalized && /^[A-Z]{3}$/.test(normalized) ? normalized : undefined;
 }
 
 function normalizeLegacyResult(
@@ -87,15 +92,17 @@ function normalizeLegacyResult(
     return result;
   }
 
-  const currency = result.currency;
+  const currency = normalizeCurrencyCode(result.currency);
   const breakdown = (result.breakdown ?? []).map((item) => {
     const value = item.amount ?? item.value ?? 0;
+
+    const itemCurrency = normalizeCurrencyCode(item.currency) ?? currency;
 
     return {
       label: item.label,
       value,
-      format: item.format ?? inferFormat(value, item.currency ?? currency),
-      currency: item.currency ?? currency,
+      format: item.format ?? inferFormat(value, itemCurrency),
+      currency: itemCurrency,
       description: item.description,
       isTotal: item.isTotal,
       highlight: item.highlight,
@@ -145,16 +152,20 @@ function calculateStaticResults({
 
 function formatValue(result: CalculatorResult): string {
   if (result.format === "currency") {
-    const currency = result.currency ?? "IDR";
+    const currency = normalizeCurrencyCode(result.currency) ?? "IDR";
 
     if (currency === "IDR") {
       return `Rp ${result.value.toLocaleString("id-ID")}`;
     }
 
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency,
-    }).format(result.value);
+    try {
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency,
+      }).format(result.value);
+    } catch {
+      return result.value.toLocaleString("en-US");
+    }
   }
 
   if (result.format === "percentage") {

--- a/apps/mouth/src/components/blog/interactive/Checklist.tsx
+++ b/apps/mouth/src/components/blog/interactive/Checklist.tsx
@@ -19,23 +19,41 @@ import { cn } from "@/lib/utils";
 // ============================================================================
 
 export interface ChecklistItem {
+  id?: string;
+  label?: string;
+  /** Legacy MDX alias for label */
+  text?: string;
+  /** Legacy MDX details */
+  subItems?: string[];
+  description?: string;
+  required?: boolean;
+  /** Group/category */
+  group?: string;
+  /** Legacy MDX alias for group */
+  category?: string;
+}
+
+interface NormalizedChecklistItem {
   id: string;
   label: string;
   description?: string;
   required?: boolean;
-  /** Group/category */
   group?: string;
 }
 
 export interface ChecklistProps {
   /** Unique ID for saving progress */
-  id: string;
+  id?: string;
   /** Title */
   title: string;
   /** Subtitle */
   subtitle?: string;
+  /** Legacy MDX alias for subtitle */
+  description?: string;
   /** Items */
-  items: ChecklistItem[];
+  items?: ChecklistItem[];
+  /** Legacy MDX storage key */
+  persistKey?: string;
   /** Persist to localStorage */
   persist?: boolean;
   /** Allow download as PDF */
@@ -54,16 +72,31 @@ export function Checklist({
   id,
   title,
   subtitle,
+  description,
   items,
+  persistKey,
   persist = true,
   allowDownload = true,
   allowPrint = true,
   className,
 }: ChecklistProps) {
   const hasValidItems = Array.isArray(items);
-  const checklistItems = hasValidItems ? items : [];
+  const checklistItems: NormalizedChecklistItem[] = Array.isArray(items)
+    ? items.map((item, index) => ({
+        id: item.id || `item-${index + 1}`,
+        label: item.label || item.text || `Item ${index + 1}`,
+        description:
+          item.description ||
+          (Array.isArray(item.subItems) ? item.subItems.join(" ") : undefined),
+        required: item.required,
+        group: item.group || item.category,
+      }))
+    : [];
+  const effectiveId =
+    id || persistKey || title.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const effectiveSubtitle = subtitle || description;
 
-  const storageKey = `checklist-${id}`;
+  const storageKey = `checklist-${effectiveId}`;
 
   // Initialize checked items
   const [checked, setChecked] = useState<Set<string>>(() => {
@@ -117,7 +150,10 @@ export function Checklist({
   };
 
   // Calculate progress
-  const progress = (checked.size / checklistItems.length) * 100;
+  const progress =
+    checklistItems.length > 0
+      ? (checked.size / checklistItems.length) * 100
+      : 0;
   const requiredItems = checklistItems.filter((i) => i.required);
   const requiredComplete = requiredItems.filter((i) =>
     checked.has(i.id),
@@ -132,7 +168,7 @@ export function Checklist({
       acc[group] = checklistItems.filter((i) => (i.group || "Items") === group);
       return acc;
     },
-    {} as Record<string, ChecklistItem[]>,
+    {} as Record<string, NormalizedChecklistItem[]>,
   );
 
   // Handle print
@@ -158,8 +194,10 @@ export function Checklist({
               <h3 className="font-serif text-xl font-semibold text-white">
                 {title}
               </h3>
-              {subtitle && (
-                <p className="text-white/60 text-sm mt-0.5">{subtitle}</p>
+              {effectiveSubtitle && (
+                <p className="text-white/60 text-sm mt-0.5">
+                  {effectiveSubtitle}
+                </p>
               )}
             </div>
           </div>
@@ -206,7 +244,7 @@ export function Checklist({
         <div className="mt-4">
           <div className="flex items-center justify-between text-xs mb-1">
             <span className="text-white/60">
-              {checked.size} of {items.length} completed
+              {checked.size} of {checklistItems.length} completed
             </span>
             <span className="text-white/40">
               {requiredItems.length > 0 &&

--- a/apps/mouth/src/components/blog/interactive/ConfidenceMeter.tsx
+++ b/apps/mouth/src/components/blog/interactive/ConfidenceMeter.tsx
@@ -18,13 +18,19 @@ export interface ConfidenceItem {
 
 export interface ConfidenceMeterProps {
   /** Items to show */
-  items: ConfidenceItem[];
+  items?: ConfidenceItem[];
   /** Title */
   title?: string;
   /** Show legend */
   showLegend?: boolean;
   /** Variant */
   variant?: "compact" | "detailed";
+  /** Legacy single-value format used by older MDX articles */
+  level?: "low" | "medium" | "high";
+  /** Legacy source metadata */
+  source?: string;
+  /** Legacy update metadata */
+  lastUpdated?: string;
   /** Custom class */
   className?: string;
 }
@@ -85,9 +91,27 @@ export function ConfidenceMeter({
   title = "Data Reliability",
   showLegend = true,
   variant = "detailed",
+  level,
+  source,
+  lastUpdated,
   className,
 }: ConfidenceMeterProps) {
   const isCompact = variant === "compact";
+  const legacyValue = level
+    ? { low: 25, medium: 50, high: 90 }[level]
+    : undefined;
+  const displayItems = Array.isArray(items)
+    ? items
+    : legacyValue !== undefined
+      ? [
+          {
+            label: "Overall confidence",
+            value: legacyValue,
+            source,
+            note: lastUpdated ? `Updated ${lastUpdated}` : undefined,
+          },
+        ]
+      : [];
 
   return (
     <div
@@ -107,7 +131,7 @@ export function ConfidenceMeter({
 
       {/* Items */}
       <div className={cn("space-y-3", isCompact && "space-y-2")}>
-        {items.map((item, index) => {
+        {displayItems.map((item, index) => {
           const colors = getConfidenceColor(item.value);
           const Icon = colors.icon;
 

--- a/apps/mouth/src/components/blog/interactive/InfoCard.tsx
+++ b/apps/mouth/src/components/blog/interactive/InfoCard.tsx
@@ -27,9 +27,11 @@ export type InfoCardVariant =
   | "note"
   | "highlight";
 
+type LegacyInfoCardVariant = InfoCardVariant | "danger";
+
 export interface InfoCardProps {
   /** Variant determines color and icon */
-  variant?: InfoCardVariant;
+  variant?: LegacyInfoCardVariant;
   /** Custom title (optional, uses default based on variant) */
   title?: string;
   /** Content */
@@ -151,7 +153,8 @@ export function InfoCard({
   className,
 }: InfoCardProps) {
   const [isCollapsed, setIsCollapsed] = React.useState(defaultCollapsed);
-  const styles = variantStyles[variant];
+  const normalizedVariant = variant === "danger" ? "error" : variant;
+  const styles = variantStyles[normalizedVariant] ?? variantStyles.info;
   const Icon = styles.icon;
   const displayTitle = title || styles.defaultTitle;
 

--- a/apps/mouth/src/content/articles/business/business-licenses-overview.mdx
+++ b/apps/mouth/src/content/articles/business/business-licenses-overview.mdx
@@ -96,7 +96,8 @@ Since the **Job Creation Law (Omnibus Law)**, Indonesia uses the **OSS RBA** (Ri
 - Receive **NIB** (Nomor Induk Berusaha)
 - Risk level determines further requirements
 - Sectoral licenses integrated into OSS
-  </InfoCard>
+
+</InfoCard>
 
 ## License Categories
 
@@ -369,7 +370,8 @@ Most businesses need environmental approval:
 - Large projects
 - Full environmental impact study
 - Public consultation required
-  </InfoCard>
+
+</InfoCard>
 
 ---
 

--- a/apps/mouth/src/content/articles/business/capital-requirements-guide.mdx
+++ b/apps/mouth/src/content/articles/business/capital-requirements-guide.mdx
@@ -287,7 +287,8 @@ Some business classifications (KBLI codes) have specific capital requirements ab
 - Appraisal report submitted to notary
 - Assets must be transferred to company
 - Documented in company deed
-  </InfoCard>
+
+</InfoCard>
 
 ### Appraisal Process
 
@@ -353,7 +354,8 @@ Some business classifications (KBLI codes) have specific capital requirements ab
 - Some special zones may have different rules
 - Representative office doesn't require capital but can't trade
 - Consider PT PMDN (domestic company) if eligible
-  </InfoCard>
+
+</InfoCard>
 
 | Question                   | Answer                            |
 | -------------------------- | --------------------------------- |

--- a/apps/mouth/src/content/articles/business/contracts-indonesian-law.mdx
+++ b/apps/mouth/src/content/articles/business/contracts-indonesian-law.mdx
@@ -330,7 +330,8 @@ Example clause should specify:
 - Location
 - Number of arbitrators
 - Language
-  </InfoCard>
+
+</InfoCard>
 
 ---
 

--- a/apps/mouth/src/content/articles/business/due-diligence-indonesia.mdx
+++ b/apps/mouth/src/content/articles/business/due-diligence-indonesia.mdx
@@ -515,7 +515,8 @@ Tax issues can exceed purchase price. Always do thorough tax DD!
 6. **Environmental non-compliance** - No permits, violations
 7. **Undisclosed liabilities** - Hidden debts, guarantees
 8. **IP not registered** - Trademark, patent gaps
-   </InfoCard>
+
+</InfoCard>
 
 ---
 
@@ -560,6 +561,7 @@ Tax issues can exceed purchase price. Always do thorough tax DD!
 ### Indemnification
 
 <InfoCard variant="tip" title="Protect Yourself">
+
 **For identified risks:**
 
 - Specific indemnities in sale agreement

--- a/apps/mouth/src/content/articles/business/export-import-business-guide.mdx
+++ b/apps/mouth/src/content/articles/business/export-import-business-guide.mdx
@@ -157,7 +157,8 @@ Trading PT PMA requires: - Minimum **IDR 10 billion** investment - Paid-up
 capital **IDR 2.5 billion** - Proper warehouse facilities (for certain goods)
 
 - Registered import/export codes
-  </InfoCard>
+
+</InfoCard>
 
 ---
 
@@ -430,11 +431,14 @@ Work with established forwarders who can:
 ## Common Mistakes
 
 <InfoCard variant="error" title="Avoid These Errors">
-  1. **Wrong API type** - API-U vs API-P must match activity 2. **Ignoring
-  product regulations** - Some goods need special permits 3. **Undervaluing
-  goods** - Customs penalties are severe 4. **No proper documentation** - Delays
-  and extra costs 5. **Wrong HS code** - Different duties, potential penalties
-  6. **Ignoring quotas/restrictions** - Some products limited
+
+1. **Wrong API type** - API-U vs API-P must match activity
+2. **Ignoring product regulations** - Some goods need special permits
+3. **Undervaluing goods** - Customs penalties are severe
+4. **No proper documentation** - Delays and extra costs
+5. **Wrong HS code** - Different duties, potential penalties
+6. **Ignoring quotas/restrictions** - Some products limited
+
 </InfoCard>
 
 ---

--- a/apps/mouth/src/content/articles/business/hiring-indonesian-employees.mdx
+++ b/apps/mouth/src/content/articles/business/hiring-indonesian-employees.mdx
@@ -350,7 +350,8 @@ Hiring in Indonesia requires understanding local requirements. Here's your step-
 - Spouse
 - Up to 3 children
 - Additional family members: +1% each
-  </InfoCard>
+
+</InfoCard>
 
 ### BPJS Ketenagakerjaan (Employment)
 
@@ -420,7 +421,8 @@ Hiring in Indonesia requires understanding local requirements. Here's your step-
 
 - Probation NOT allowed
 - Any probation clause is void
-  </InfoCard>
+
+</InfoCard>
 
 ---
 

--- a/apps/mouth/src/content/articles/business/labor-law-guide.mdx
+++ b/apps/mouth/src/content/articles/business/labor-law-guide.mdx
@@ -264,10 +264,13 @@ Violation: Contract automatically becomes PKWTT (permanent).
 
 <InfoCard variant="note" title="Minimum Wage Notes">
 
-- UMR is minimum for permanent employees - Updated annually (usually January)
-- Sectoral minimums may apply - Components: basic salary can be 75%,
-  allowances 25% - PKWT workers entitled to same minimums
-  </InfoCard>
+- UMR is minimum for permanent employees
+- Updated annually (usually January)
+- Sectoral minimums may apply
+- Components: basic salary can be 75%, allowances 25%
+- PKWT workers entitled to same minimums
+
+</InfoCard>
 
 ---
 

--- a/apps/mouth/src/content/articles/business/manufacturing-business-guide.mdx
+++ b/apps/mouth/src/content/articles/business/manufacturing-business-guide.mdx
@@ -439,11 +439,14 @@ processing - Better security
 
 <InfoCard variant="warning" title="Labor Laws Favor Workers">
 
-Indonesian labor law provides strong worker protections: - Difficult to
-terminate permanent employees - Severance can be substantial (up to 35 months)
+Indonesian labor law provides strong worker protections:
 
-- Unions are common in manufacturing - Strikes are protected
-  </InfoCard>
+- Difficult to terminate permanent employees
+- Severance can be substantial (up to 35 months)
+- Unions are common in manufacturing
+- Strikes are protected
+
+</InfoCard>
 
 ### Foreign Workers
 

--- a/apps/mouth/src/content/articles/business/ota-data-crackdown-bali-2026.mdx
+++ b/apps/mouth/src/content/articles/business/ota-data-crackdown-bali-2026.mdx
@@ -93,11 +93,12 @@ If you own rental property listed on Airbnb, Booking.com, or other platforms in 
 
 <InfoCard variant="error" title="Quick Facts">
 
-- **What:** Governor Koster summons OTAs to share tax data and remove
-  unlicensed listings - **Who's affected:** 39,000+ Airbnb listings (most
-  without proper licenses) - **When:** March 31, 2026 compliance deadline -
-  **Risk Level:** **VERY HIGH** for unlicensed properties
-  </InfoCard>
+- **What:** Governor Koster summons OTAs to share tax data and remove unlicensed listings
+- **Who's affected:** 39,000+ Airbnb listings (most without proper licenses)
+- **When:** March 31, 2026 compliance deadline
+- **Risk Level:** **VERY HIGH** for unlicensed properties
+
+</InfoCard>
 
 ---
 

--- a/apps/mouth/src/content/articles/business/restaurant-business-guide.mdx
+++ b/apps/mouth/src/content/articles/business/restaurant-business-guide.mdx
@@ -340,7 +340,7 @@ discovered, you can lose everything. Use proper PT PMA structure.
 
 <JourneyMap
   title="Restaurant Setup Journey"
-  description: "From idea to opening"
+  description="From idea to opening"
   estimatedTotal="4-6 months"
   steps={[
     {

--- a/apps/mouth/src/content/articles/immigration/airport-procedures.mdx
+++ b/apps/mouth/src/content/articles/immigration/airport-procedures.mdx
@@ -268,7 +268,7 @@ You may still be randomly checked in green channel.
 
 <JourneyMap
   title="Airport Departure Steps"
-  description: "Leaving Indonesia"
+  description="Leaving Indonesia"
   estimatedTotal="60-120 minutes"
   steps={[
     {

--- a/apps/mouth/src/content/articles/immigration/golden-visa-indonesia-complete-guide.mdx
+++ b/apps/mouth/src/content/articles/immigration/golden-visa-indonesia-complete-guide.mdx
@@ -202,7 +202,7 @@ Companies investing in Indonesia can also apply for Golden Visa sponsorship for 
   ]}
   calculateResult={(values) => {
     const amount = Number(values.amount);
-    const tier = values.tier as string;
+    const tier = String(values.tier);
 
     const thresholds = {
       "5year": 350000000,

--- a/apps/mouth/src/content/articles/tax/freelancer-tax-guide.mdx
+++ b/apps/mouth/src/content/articles/tax/freelancer-tax-guide.mdx
@@ -171,12 +171,12 @@ If you're a tax resident freelancing for **international clients only**:
   calculateResult={(values) => {
     const income = Number(values.annual);
     const expenses = Number(values.expenses);
-    const net = income - expenses;
+    const netIncome = income - expenses;
 
     const ptkpMap = { 'TK0': 54000000, 'K0': 58500000, 'K1': 63000000, 'K2': 67500000 };
     const ptkp = ptkpMap[values.status];
 
-    let taxable = Math.max(0, net - ptkp);
+    let taxable = Math.max(0, netIncome - ptkp);
     let tax = 0;
     let remaining = taxable;
 
@@ -186,14 +186,14 @@ If you're a tax resident freelancing for **international clients only**:
     if (remaining > 0) { const b4 = Math.min(remaining, 4500000000); tax += b4 * 0.30; remaining -= b4; }
     if (remaining > 0) { tax += remaining * 0.35; }
 
-    const effectiveRate = net > 0 ? ((tax / net) * 100).toFixed(1) : 0;
+    const effectiveRate = netIncome > 0 ? ((tax / netIncome) * 100).toFixed(1) : 0;
 
     return {
       total: tax,
       breakdown: [
         { label: "Gross Income", amount: income },
         { label: "Expenses", amount: -expenses },
-        { label: "Net Income", amount: net },
+        { label: "Net Income", amount: netIncome },
         { label: "PTKP Deduction", amount: -ptkp },
         { label: "Taxable Income", amount: taxable },
         { label: "Annual Tax", amount: tax }

--- a/apps/mouth/vercel.json
+++ b/apps/mouth/vercel.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
   "framework": "nextjs",
-  "buildCommand": "next build --webpack",
-  "installCommand": "npm install --include=dev"
+  "buildCommand": "npm run build",
+  "installCommand": "cd ../.. && npm ci --include=dev"
 }


### PR DESCRIPTION
## Summary
- use the root lockfile for Vercel installs and run the complete mouth build
- safely handle empty or malformed login upstream responses
- fix invalid MDX and support legacy article component props
- support the deduplicated login bundle manifest emitted by Vercel

## Why
The frontend deployment was not guaranteed to use the repository lockfile, while production logs exposed invalid MDX, incomplete login response parsing, and legacy article props that could crash rendering. The first PR Preview also exposed a Vercel-specific empty chunk list in the post-build login bundle check; the route-specific emitted chunk is now used as a safe fallback.

## Verification
- npm run typecheck
- npx vitest run src/app/api/auth/login/route.test.ts src/components/blog/MDXContentRSC.test.tsx — 34 tests passed
- npm run build — 1,755 static pages generated
- Vercel Preview dpl_DV1n2d3SJqyqb4wyNxiPmNRCG5M8 — READY
- authenticated smoke test of login and all 13 affected article routes — no browser or Vercel runtime errors

Original commit 9f2633217 was rebased onto current main as a0172d750 without content changes.