### PR TITLE
refactor(tg): batch 2 — the 288/day poller was MUTE, and the 48/day watchdog kept a bot token in a shell variable

### DIFF
--- a/.github/workflows/tg-gateway.yml
+++ b/.github/workflows/tg-gateway.yml
@@ -130,7 +130,9 @@ jobs:
       - name: Migrated senders must REACH the gateway, not just name it
         run: |
           # The 2026-08-09 batch moved six organs (~2,350 wake-ups/day between
-          # them) off raw sendMessage. The anti-regrowth lint below proves they
+          # them) off raw sendMessage; 2026-08-10 added post_publish_poller
+          # (288/day, previously MUTE for want of a token) and
+          # runtime-reconcile (48/day). The anti-regrowth lint below proves they
           # no longer POST directly; it cannot prove the replacement WORKS —
           # a call that resolves no gateway, or resolves `python3` from a PATH
           # the sick environment just broke, satisfies the lint and still leaves

--- a/apps/bali-intel-scraper/scripts/post_publish_poller.py
+++ b/apps/bali-intel-scraper/scripts/post_publish_poller.py
@@ -548,9 +548,10 @@ def maybe_flush_all_batches(threshold: int = _FLUSH_THRESHOLD) -> bool:
     layout_ok = flush_layout_batch()
     if not img_ok or not seo_ok or not layout_ok:
         send_telegram_alert(
-            "⚠️ *Post-publish poller*\n"
+            "⚠️ Post-publish poller\n"
             f"GitHub batch flush failed (image={img_ok}, seo={seo_ok}, "
-            f"layout={layout_ok}) — see log"
+            f"layout={layout_ok}) — see log",
+            dedup_key="post-publish:github-batch-flush-failed",
         )
     return True
 
@@ -602,17 +603,61 @@ def mark_step_done(slug: str, step: str):
         log(f"  ⚠ Failed to mark step '{step}' done: {e}")
 
 
-def send_telegram_alert(message: str):
-    """Send alert to Telegram owner chat."""
-    if not TELEGRAM_BOT_TOKEN:
+_GATEWAY_VERDICT_RE = re.compile(r"^tg_notify:\s*(\S+)", re.MULTILINE)
+
+
+def _find_gateway():
+    """scripts/tg_notify.py, from the checkout this poller lives in."""
+    for cand in (
+        Path(__file__).resolve().parents[3] / "scripts" / "tg_notify.py",
+        Path.home() / "nuzantara" / "scripts" / "tg_notify.py",
+    ):
+        if cand.is_file():
+            return cand
+    return None
+
+
+def send_telegram_alert(message: str, *, dedup_key: str, tier: str = "digest"):
+    """Route an alert through the tg_notify gateway.
+
+    Tier is `digest`, not p0. This poller wakes every 300s and every one of its
+    alerts is a pipeline DEGRADATION (a batch flush that failed, a cover skipped
+    because Codex is down) — real, worth seeing, and not worth a P0 budget slot
+    each. Grouped into the digest they arrive as a handful of lines a day
+    instead of up to 288 individual messages.
+
+    It also could not speak at all before now: its LaunchAgent passes no
+    TELEGRAM_BOT_TOKEN, so the raw POST this replaces returned at the first
+    `if not TELEGRAM_BOT_TOKEN`. The gateway owns credential resolution, so
+    migrating GIVES this organ a voice — which is exactly why the tier is a
+    deliberate choice and not a default.
+
+    Messages are plain text: the old POST passed parse_mode=Markdown and the
+    gateway has none, so `*bold*` and backticks would arrive literally.
+    """
+    gateway = _find_gateway()
+    if gateway is None:
+        log(f"  ⚠ no tg_notify gateway — alert NOT sent: {message[:80]}")
         return
+    cmd = [
+        # Absolute interpreter, never PATH: the alarm must not share a failure
+        # mode with the environment it reports on (W108).
+        sys.executable,
+        str(gateway),
+        "--tier", tier,
+        "--source", "post-publish-poller",
+        "--dedup-key", dedup_key,
+        "--", message,
+    ]
     try:
-        url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
-        data = json.dumps({"chat_id": TELEGRAM_CHAT_ID, "text": message, "parse_mode": "Markdown"}).encode()
-        req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
-        urllib.request.urlopen(req, timeout=10)
-    except Exception:
-        pass  # Alert failure is not critical
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=False)
+    except (subprocess.TimeoutExpired, OSError) as e:
+        log(f"  ⚠ tg_notify unreachable: {e}")
+        return
+    # Verdict on stderr; the gateway exits 0 by design, so the exit code would
+    # read every refusal as a success (W104).
+    m = _GATEWAY_VERDICT_RE.search(proc.stderr or "")
+    log(f"  tg_notify: {m.group(1) if m else 'NESSUN verdetto rc=' + str(proc.returncode)}")
 
 
 def wait_for_ollama_free(max_wait: int = 60 * 15) -> bool:
@@ -866,7 +911,12 @@ def run_image(slug: str, category: str, title: str | None = None, article_id: st
     # Pre-flight: Codex reachable & authed? Otherwise leave queued (no cover-less publish).
     if not codex_healthy():
         log("  ⏸ Codex unavailable — leaving item queued for next tick")
-        send_telegram_alert(f"⚠️ Cover gen skipped (Codex down): {slug}")
+        send_telegram_alert(
+            f"⚠️ Cover gen skipped (Codex down): {slug}",
+            # Keyed on the CONDITION, not the slug: Codex being down skips every
+            # article in the run, and a per-slug key would mint one alert each.
+            dedup_key="post-publish:cover-skipped-codex-down",
+        )
         return False
 
     # Build the two brand-railed prompts
@@ -1171,9 +1221,10 @@ def main():
     layout_flush_ok = flush_layout_batch()
     if not img_flush_ok or not seo_flush_ok or not layout_flush_ok:
         send_telegram_alert(
-            "⚠️ *Post-publish poller*\n"
+            "⚠️ Post-publish poller\n"
             f"GitHub batch flush failed (image={img_flush_ok}, seo={seo_flush_ok}, "
-            f"layout={layout_flush_ok}) — see log"
+            f"layout={layout_flush_ok}) — see log",
+            dedup_key="post-publish:github-batch-flush-failed",
         )
 
     # Commit translations — staged + flushed via the same batch-branch/PR
@@ -1181,8 +1232,9 @@ def main():
     if translated_slugs:
         if not git_commit_and_push_translations(translated_slugs):
             send_telegram_alert(
-                "⚠️ *Post-publish poller*\n"
-                f"Translation batch flush failed for: {', '.join(translated_slugs[:5])}"
+                "⚠️ Post-publish poller\n"
+                f"Translation batch flush failed for: {', '.join(translated_slugs[:5])}",
+                dedup_key="post-publish:translation-batch-flush-failed",
             )
 
     # Mark done
@@ -1210,11 +1262,14 @@ def main():
         # Telegram alert after 2+ attempts
         if attempts >= 2:
             send_telegram_alert(
-                f"⚠️ *Post-publish pipeline*\n"
-                f"Article: `{slug}`\n"
+                f"⚠️ Post-publish pipeline\n"
+                f"Article: {slug}\n"
                 f"Failed steps: {', '.join(steps)}\n"
                 f"Attempt: {attempts}/5\n"
-                f"{'🔴 Will be dead-lettered after 5' if attempts >= 4 else '🔄 Will retry'}"
+                f"{'🔴 Will be dead-lettered after 5' if attempts >= 4 else '🔄 Will retry'}",
+                # Per-article: a stuck article is its own condition, and folding
+                # them onto one key would hide every article after the first.
+                dedup_key=f"post-publish:pipeline-failed:{slug}",
             )
 
     log("🏁 Poller completed")

--- a/infra/tg-gateway/grandfathered.json
+++ b/infra/tg-gateway/grandfathered.json
@@ -1,5 +1,5 @@
 {
-  "_doc": "Direct api.telegram.org senders grandfathered at gateway birth (2026-07-06). This list only SHRINKS: migrate a file to scripts/tg_notify.py, then remove it here (or run --prune). New files must use the gateway \u2014 the lint fails CI otherwise. 2026-07-28: the .yml/.yaml cohort below was ADDED, which looks like growth and is not: the founding census never scanned GitHub Actions, so these were day-1 members nobody counted, not new senders. The one-time enrollment is enforced by check_monotone (growth is legal only for a suffix the base register could not see); scan_suffixes exists so no future reader has to guess whether 'no senders here' meant 'nobody looked here'.",
+  "_doc": "Direct api.telegram.org senders grandfathered at gateway birth (2026-07-06). This list only SHRINKS: migrate a file to scripts/tg_notify.py, then remove it here (or run --prune). New files must use the gateway — the lint fails CI otherwise. 2026-07-28: the .yml/.yaml cohort below was ADDED, which looks like growth and is not: the founding census never scanned GitHub Actions, so these were day-1 members nobody counted, not new senders. The one-time enrollment is enforced by check_monotone (growth is legal only for a suffix the base register could not see); scan_suffixes exists so no future reader has to guess whether 'no senders here' meant 'nobody looked here'.",
   "frozen_at": "2026-07-06",
   "scan_suffixes": [
     ".bash",
@@ -68,7 +68,6 @@
     "apps/backend-rag/scripts/run_entity_linker_full.py",
     "apps/backend-rag/scripts/telegram_reviewer.py",
     "apps/backend-rag/setup_telegram_bot.sh",
-    "apps/bali-intel-scraper/scripts/post_publish_poller.py",
     "apps/bali-intel-scraper/scripts/run_intel_pipeline.py",
     "apps/bali-intel-scraper/scripts/telegram_approval.py",
     "apps/cell/cell/effectors/telegram.py",
@@ -146,7 +145,6 @@
     "scripts/post-deploy-verify.sh",
     "scripts/profile-monitor/wrapper.py",
     "scripts/ragas_eval.py",
-    "scripts/runtime-reconcile.sh",
     "scripts/sentry-quota-check.sh",
     "scripts/sota_fase0_final_check.py",
     "scripts/supervisor_autofix_tier2.sh",

--- a/scripts/runtime-reconcile.sh
+++ b/scripts/runtime-reconcile.sh
@@ -26,7 +26,6 @@ STRICT="${RUNTIME_RECONCILE_STRICT:-0}"                          # P0 default 0 
 PULL_STATE="${HOME}/.agent/decisions/state/wr2_deploy_pull.state"
 LOG="${HOME}/logs/runtime-reconcile.log"
 STATE="${HOME}/.organism/last_seen/pro.runtime_reconcile.json"
-SECRETS="${HOME}/.nuzantara-secrets.env"
 ALERT_COOLDOWN_SEC="${RUNTIME_RECONCILE_ALERT_COOLDOWN_SEC:-21600}"
 ALERT_STAMP="${HOME}/.agent/decisions/state/runtime_reconcile.alert"
 
@@ -51,15 +50,26 @@ alert() {
       return 0
     fi
   fi
-  if [[ -f "$SECRETS" ]]; then
-    local tok cid
-    tok="$(grep '^TELEGRAM_BOT_TOKEN=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"')" || true
-    cid="$(grep '^TELEGRAM_OWNER_CHAT_ID=' "$SECRETS" | head -1 | cut -d= -f2- | tr -d '"')" || true
-    if [[ -n "${tok:-}" && -n "${cid:-}" ]]; then
-      curl -s -m 10 "https://api.telegram.org/bot${tok}/sendMessage" \
-        --data-urlencode "chat_id=${cid}" \
-        --data-urlencode "text=🛟 runtime-reconcile P0 breach: ${msg}" >/dev/null 2>&1 || true
-    fi
+  # Through the tg_notify gateway (2026-08-09). Two gains, not one: this wakes
+  # every 1800s so a standing breach was up to 48 un-budgeted sends a day, AND
+  # the old path grep'd the bot token out of the secrets file into a shell
+  # variable to build a URL with it — the gateway owns credential resolution,
+  # so no secret passes through this script at all any more (superscar #4).
+  # The local cooldown above is kept: it also gates the log line.
+  local gateway py
+  gateway="$(dirname "$0")/tg_notify.py"
+  [[ -f "$gateway" ]] || gateway="$HOME/nuzantara/scripts/tg_notify.py"
+  if [[ ! -f "$gateway" ]]; then
+    log "NO GATEWAY at $gateway — alert NOT sent"
+  else
+    # Absolute interpreter, never PATH (W108).
+    for py in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+      [[ -x "$py" ]] || continue
+      "$py" "$gateway" --tier p0 --source runtime-reconcile \
+        --dedup-key "runtime-reconcile:invariant-breach" \
+        -- "🛟 runtime-reconcile P0 breach: ${msg}" >>"$LOG" 2>&1 || log "gateway send failed"
+      break
+    done
   fi
   echo "$now" > "$ALERT_STAMP"
 }

--- a/scripts/tests/test_tg_sender_migration.sh
+++ b/scripts/tests/test_tg_sender_migration.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
-# test_tg_sender_migration.sh — the six senders migrated to the gateway on
-# 2026-08-09 must actually REACH it, not merely contain its name.
+# test_tg_sender_migration.sh — the senders migrated to the gateway must
+# actually REACH it, not merely contain its name.
+#
+# Batch 1 (2026-08-09, #3913): six organs, ~2,350 wake-ups a day.
+# Batch 2 (2026-08-10): post_publish_poller.py (288/day) and
+# runtime-reconcile.sh (48/day). The poller is a special case worth naming: its
+# LaunchAgent passes no TELEGRAM_BOT_TOKEN, so its raw POST returned at the
+# first `if not TELEGRAM_BOT_TOKEN` and the organ was MUTE. Migrating it GIVES
+# it a voice, which is why its tier is `digest` by deliberate choice — five
+# pipeline-degradation alerts do not each deserve a P0 slot.
 #
 # Why this exists. Six organs that between them wake ~2,350 times a day used to
 # POST straight to Telegram: outside the tier router, outside the P0 budget,
@@ -37,6 +45,8 @@ MIGRATED=(
   "scripts/cost_breaker_deadman.sh"
   "scripts/wr2_plist_watchdog.sh"
   "scripts/supervisor_liveness_watchdog.sh"
+  "apps/bali-intel-scraper/scripts/post_publish_poller.py"
+  "scripts/runtime-reconcile.sh"
 )
 
 echo "── struttura (tutti e ${#MIGRATED[@]})"
@@ -177,9 +187,65 @@ printf '%s' "$out" | grep -q 'NOT sent' \
   || bad "intel-lake: senza gateway è muto — $(printf '%s' "$out" | tail -1)"
 mv "$FAKE/nuzantara/scripts/tg_notify.hidden" "$FAKE/nuzantara/scripts/tg_notify.py"
 
+# post_publish_poller resolves the gateway from parents[3] of its own path, so
+# the fake reproduces the REAL tree (apps/bali-intel-scraper/scripts/...) rather
+# than the convenient flat one — otherwise the assertion would exercise the
+# home-relative fallback and leave the branch that actually runs in production
+# unproven.
+POLLER_DIR="$FAKE/nuzantara/apps/bali-intel-scraper/scripts"
+mkdir -p "$POLLER_DIR"
+cp "$REPO_ROOT/apps/bali-intel-scraper/scripts/post_publish_poller.py" "$POLLER_DIR/"
+poller_drive() {
+  HOME="$FAKE" "${1:-python3}" - "$POLLER_DIR" <<'PYPOLL' 2>&1
+import importlib.util
+import sys
+spec = importlib.util.spec_from_file_location("pp", f"{sys.argv[1]}/post_publish_poller.py")
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+m.send_telegram_alert("prova", dedup_key="post-publish:cover-skipped-codex-down")
+PYPOLL
+}
+rm -f "$CALLED"
+poller_drive >/dev/null 2>&1
+if [ -f "$CALLED" ]; then
+  ok "post-publish-poller: gateway raggiunto dal layout reale (parents[3])"
+  grep -qx 'post-publish:cover-skipped-codex-down' "$CALLED" \
+    && ok "post-publish-poller: chiave = post-publish:cover-skipped-codex-down" \
+    || bad "post-publish-poller: chiave inattesa"
+  # digest, not p0 — a deliberate tier choice, so it is asserted and not assumed.
+  grep -qx 'digest' "$CALLED" \
+    && ok "post-publish-poller: tier digest" \
+    || bad "post-publish-poller: tier inatteso (atteso digest)"
+else
+  bad "post-publish-poller: il gateway NON è stato invocato"
+fi
+
+# Gateway gone: it must say it did not speak. This organ was MUTE before the
+# migration, so a silent failure here would restore exactly the state cured.
+mv "$FAKE/nuzantara/scripts/tg_notify.py" "$FAKE/nuzantara/scripts/tg_notify.hidden"
+pollout="$(poller_drive)"
+printf '%s' "$pollout" | grep -q 'NOT sent' \
+  && ok "post-publish-poller: senza gateway lascia traccia (fail-loud)" \
+  || bad "post-publish-poller: senza gateway è muto"
+mv "$FAKE/nuzantara/scripts/tg_notify.hidden" "$FAKE/nuzantara/scripts/tg_notify.py"
+
 # The shell organs: their sender function is self-contained, so it is extracted
 # and run on its own. `$HOME` points at the fake, which is the fallback branch
 # every one of them resolves to when no sibling gateway exists.
+# Extra harness lines a given sender needs to run standalone. runtime-reconcile
+# reads its own cooldown stamp and logs through a `log` helper defined outside
+# the extracted function; without these the harness dies on `set -u` and the
+# organ would be scored mute for the harness's poverty, not its own (W108).
+_extra_env() {
+  case "$1" in
+    runtime-reconcile.sh)
+      echo "ALERT_STAMP=$FAKE/rr_stamp"
+      echo "ALERT_COOLDOWN_SEC=0"
+      echo 'log() { printf "%s\n" "$*" >> "$LOG"; }'
+      ;;
+  esac
+}
+
 run_shell_sender() {
   local rel="$1" fn="$2" expect_key="$3" base
   base="$(basename "$rel")"
@@ -192,6 +258,7 @@ run_shell_sender() {
     echo 'set -uo pipefail'
     echo "LOG_FILE=$FAKE/harness.log"
     echo "LOG=$FAKE/harness.log"
+    _extra_env "$base"
     # Extract the function verbatim, from its opening line to the closing brace
     # in column 1 — running the REAL body, not a paraphrase of it.
     awk "/^${fn}\(\) \{/,/^\}/" "$REPO_ROOT/$rel"
@@ -224,6 +291,7 @@ run_shell_sender "scripts/cost_breaker_deadman.sh" "tg_alert" "cost-breaker-dead
 # only the organs it actually runs.
 run_shell_sender "scripts/intake_review_reader_liveness.sh" "send_telegram" "intake-review-reader:stalled:${HOST}"
 run_shell_sender "scripts/supervisor_liveness_watchdog.sh" "send_telegram" "supervisor-liveness:${HOST}"
+run_shell_sender "scripts/runtime-reconcile.sh" "alert" "runtime-reconcile:invariant-breach"
 
 # ── W108, proven by behaviour instead of by spelling ──────────────────────────
 # A POISONED python3 goes first on PATH. An organ that resolves its interpreter
@@ -251,6 +319,7 @@ poisoned_still_reaches() {
     echo 'set -uo pipefail'
     echo "LOG_FILE=$FAKE/harness.log"
     echo "LOG=$FAKE/harness.log"
+    _extra_env "$base"
     awk "/^${fn}\(\) \{/,/^\}/" "$REPO_ROOT/$rel"
     if [ "$fn" = "telegram_backup" ]; then
       echo "$fn 'probe:key' 'con PATH avvelenato'"
@@ -270,6 +339,7 @@ poisoned_still_reaches "scripts/wr2_plist_watchdog.sh" "_telegram"
 poisoned_still_reaches "scripts/cost_breaker_deadman.sh" "tg_alert"
 poisoned_still_reaches "scripts/intake_review_reader_liveness.sh" "send_telegram"
 poisoned_still_reaches "scripts/supervisor_liveness_watchdog.sh" "send_telegram"
+poisoned_still_reaches "scripts/runtime-reconcile.sh" "alert"
 
 # Same discriminator for the Python organs: sys.executable is absolute by
 # construction, a literal "python3" is not.
@@ -293,6 +363,12 @@ PYPOISON
   && ok "intel-lake: raggiunge il gateway anche col PATH avvelenato" \
   || bad "intel-lake: interprete risolto da PATH (W108)"
 
+rm -f "$CALLED"
+PATH="$POISON:$PATH" poller_drive "$DRIVER_PY" >/dev/null 2>&1
+[ -f "$CALLED" ] \
+  && ok "post-publish-poller: raggiunge il gateway anche col PATH avvelenato" \
+  || bad "post-publish-poller: interprete risolto da PATH (W108)"
+
 # ── fail-loud, per BRANCH ─────────────────────────────────────────────────────
 # Run each shell sender with no gateway anywhere and demand a line in its log.
 # The earlier version grep'd the file for a fail-loud phrase and survived having
@@ -310,6 +386,7 @@ shell_fail_loud() {
     echo 'set -uo pipefail'
     echo "LOG_FILE=$logf"
     echo "LOG=$logf"
+    _extra_env "$base"
     awk "/^${fn}\(\) \{/,/^\}/" "$REPO_ROOT/$rel"
     if [ "$fn" = "telegram_backup" ]; then
       echo "$fn 'probe:key' 'nessun gateway'"
@@ -330,6 +407,7 @@ shell_fail_loud "scripts/wr2_plist_watchdog.sh" "_telegram"
 shell_fail_loud "scripts/cost_breaker_deadman.sh" "tg_alert"
 shell_fail_loud "scripts/intake_review_reader_liveness.sh" "send_telegram"
 shell_fail_loud "scripts/supervisor_liveness_watchdog.sh" "send_telegram"
+shell_fail_loud "scripts/runtime-reconcile.sh" "alert"
 mv "$FAKE/nuzantara/scripts/tg_notify.hidden" "$FAKE/nuzantara/scripts/tg_notify.py"
 
 echo
@@ -338,7 +416,7 @@ echo "── il registro grandfathered si è RIDOTTO"
 # bases block each other with zero shared lines (W109b), which is why this
 # migration ships as one sequential PR per batch and never in parallel.
 count=$(python3 -c "import json;print(len(json.load(open('$REPO_ROOT/infra/tg-gateway/grandfathered.json'))['files']))")
-if [ "$count" -le 148 ]; then ok "registro a $count voci (≤148)"; else bad "registro CRESCIUTO a $count"; fi
+if [ "$count" -le 146 ]; then ok "registro a $count voci (≤146)"; else bad "registro CRESCIUTO a $count"; fi
 
 echo
 echo "════ PASS=$PASS FAIL=$FAIL"

--- a/scripts/wr2-deploy-pull.sh
+++ b/scripts/wr2-deploy-pull.sh
@@ -141,10 +141,18 @@ TG_NOTIFY_PY="${WR2_TG_NOTIFY_PY:-${SOURCE_REPO}/scripts/tg_notify.py}"
 tg_notify_or_fallback() {
   local tier="$1" key="$2" fallback_key="$3" text="$4"
   if [[ -f "$TG_NOTIFY_PY" ]]; then
-    if python3 "$TG_NOTIFY_PY" --tier "$tier" --source wr2-deploy-pull \
-        --dedup-key "$key" -- "$text" >>"$LOG" 2>&1; then
-      return 0
-    fi
+    # Absolute interpreter, never `python3` from PATH: this self-heal runs when
+    # the deploy clone is already sick, and the alarm must not share a failure
+    # mode with what it reports (W108).
+    local _py
+    for _py in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+      [[ -x "$_py" ]] || continue
+      if "$_py" "$TG_NOTIFY_PY" --tier "$tier" --source wr2-deploy-pull \
+          --dedup-key "$key" -- "$text" >>"$LOG" 2>&1; then
+        return 0
+      fi
+      break
+    done
     log "WARN: tg_notify.py failed (tier=${tier} key=${key}), falling back to send_telegram"
   fi
   send_telegram "$fallback_key" "$text"


### PR DESCRIPTION
Second and final high-frequency batch of the Telegram-sender consolidation. Two
armed organs, **336 wake-ups a day** between them. Neither is a plain plumbing swap.

## `post_publish_poller.py` — 288/day, and it could not speak at all

Its LaunchAgent passes no `TELEGRAM_BOT_TOKEN`, so every one of its five alerts
returned at the first `if not TELEGRAM_BOT_TOKEN`. The gateway owns credential
resolution, so this migration **gives the organ a voice** — which makes the tier a
decision, not a default. All five alerts are pipeline degradations (a GitHub batch
flush that failed, a cover skipped because Codex is down), so they go to `digest`:
real, worth seeing, and not worth 288 P0 slots.

- Markdown stripped at every call site — the gateway has no `parse_mode`, so `*bold*`
  and backticks would arrive literally.
- One key names the **condition**, not the article: Codex being down skips every slug
  in the run, and a per-slug key would mint one alert each.

## `runtime-reconcile.sh` — 48/day, plus a secret it no longer touches

The old path grep'd the bot token out of `~/.nuzantara-secrets.env` into a shell
variable to build a URL with it. No secret passes through this script any more
(superscar #4), and its now-unused `SECRETS` declaration is **deleted** rather than
left asserting the opposite.

## `wr2-deploy-pull.sh` — hardening only

Keeps its documented raw fallback and stays grandfathered, but its gateway call no
longer resolves `python3` from `PATH`: it self-heals a deploy clone that is already
sick, so its alarm must not share a failure mode with what it reports (W108).

## Proof

Corpus extended to **64 assertions**; the six new properties are behavioural, not
greps, and all six were **mutation-verified**:

| mutation | result |
|---|---|
| poller `sys.executable` → `"python3"` | killed (poisoned-PATH check) |
| poller tier `digest` → `p0` | killed |
| poller fail-loud deleted | killed |
| `runtime-reconcile` absolute interpreter → PATH | killed |
| `runtime-reconcile` gateway call deleted | killed (3 checks) |
| `runtime-reconcile` fail-loud deleted | killed |

6 applied, 6 killed, **0 survivors**; baseline restored 64/64.

Register 148 → 146. Sequential after #3913 by construction: two PRs shrinking a
monotone register from different bases block each other with zero shared lines (W109b).

## Measured remainder

With the anchored census (my first probe over-matched `telegram.py` against
`wa-mirror-attention-telegram.py` — the disease it was measuring): **34 armed files,
215 wake-ups/day**, of which the top three (176/day) are *already* gateway-primary
with documented fallbacks. Real un-migrated remainder after this PR: ~31 files at
~39 wake-ups/day, nearly all 1/day and fault-triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)