### PR TITLE
fix(visa-oracle): show each source's own dates, not the evaluation clock

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -1,8 +1,44 @@
 import { describe, expect, it } from "vitest";
 import { buildEngineOutcome } from "./engine-adapter";
-import { makeVisaOracleResponse } from "./visa-oracle-test-fixture";
+import { TEST_NOW, makeVisaOracleResponse } from "./visa-oracle-test-fixture";
 
 describe("Visa Oracle authoritative outcome adapter", () => {
+  it("shows each source's own dates, not the decision's evaluation clock", () => {
+    // The backend's `_build_sources_dto` stamps EVERY cited source's
+    // applicability block with `decision.effective_at`/`observed_at` — the
+    // evaluation clock — so those two fields say nothing about the document.
+    // Reading them made every source on screen claim it took legal effect at
+    // the instant the reader pressed the button.
+    //
+    // The shared fixture sets every date to TEST_NOW, so it cannot tell the
+    // right field from the wrong one: give this source dates of its own.
+    // The response contract requires these to stay mutually consistent
+    // (`retrieved_at <= verified_at`, `freshness.verified_at === verified_at`),
+    // so move the whole observation forward together — a day before TEST_NOW,
+    // inside the fixture's 86_400s freshness window.
+    const OBSERVED = "2026-08-02T05:00:00Z";
+    const response = makeVisaOracleResponse();
+    response.sources[0].legal_period_from = "2026-07-24T00:00:00Z";
+    response.sources[0].retrieved_at = OBSERVED;
+    response.sources[0].verified_at = OBSERVED;
+    response.sources[0].freshness.verified_at = OBSERVED;
+    response.sources[0].applicability.effective_at = TEST_NOW;
+    response.sources[0].applicability.observed_at = TEST_NOW;
+
+    const outcome = buildEngineOutcome(response);
+    const source = outcome.sources[0];
+    expect(source.effectiveAtIso).toBe("2026-07-24T00:00:00Z");
+    expect(source.observedAtIso).toBe(OBSERVED);
+    expect(source.effectiveAtIso).not.toBe(TEST_NOW);
+
+    // Innocence: the ASSESSMENT's own dates are legitimately the evaluation
+    // moment. This fix must not reach up and rewrite those too.
+    expect(outcome.assessment).not.toBeNull();
+    expect(outcome.assessment?.effectiveAtIso).toBe(
+      response.decision.effective_at,
+    );
+  });
+
   it.each([
     "SUPPORTED_CANDIDATES",
     "NEEDS_INPUT",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -12,24 +12,35 @@ describe("Visa Oracle authoritative outcome adapter", () => {
     //
     // The shared fixture sets every date to TEST_NOW, so it cannot tell the
     // right field from the wrong one: give this source dates of its own.
-    // The response contract requires these to stay mutually consistent
-    // (`retrieved_at <= verified_at`, `freshness.verified_at === verified_at`),
-    // so move the whole observation forward together — a day before TEST_NOW,
-    // inside the fixture's 86_400s freshness window.
-    const OBSERVED = "2026-08-02T05:00:00Z";
+    // Four DISTINCT dates, so each assertion can only be satisfied by the one
+    // field it names. In particular `retrieved_at` and `verified_at` must not
+    // share a value: they are adjacent candidates for "observed", and a test
+    // that collapses them cannot tell which one the adapter read.
+    //
+    // `decisiveSource` (engine-adapter.ts) enforces the ordering that makes a
+    // source usable as decisive evidence — `retrieved_at <= verified_at`,
+    // `freshness.verified_at === verified_at`, `verified_at <= observed_at` —
+    // so these move together, forward, inside the fixture's 86_400s window.
+    const LEGAL_FROM = "2026-07-24T00:00:00Z";
+    const RETRIEVED = "2026-08-02T04:00:00Z";
+    const VERIFIED = "2026-08-02T05:00:00Z";
     const response = makeVisaOracleResponse();
-    response.sources[0].legal_period_from = "2026-07-24T00:00:00Z";
-    response.sources[0].retrieved_at = OBSERVED;
-    response.sources[0].verified_at = OBSERVED;
-    response.sources[0].freshness.verified_at = OBSERVED;
+    response.sources[0].legal_period_from = LEGAL_FROM;
+    response.sources[0].retrieved_at = RETRIEVED;
+    response.sources[0].verified_at = VERIFIED;
+    response.sources[0].freshness.verified_at = VERIFIED;
     response.sources[0].applicability.effective_at = TEST_NOW;
     response.sources[0].applicability.observed_at = TEST_NOW;
 
     const outcome = buildEngineOutcome(response);
     const source = outcome.sources[0];
-    expect(source.effectiveAtIso).toBe("2026-07-24T00:00:00Z");
-    expect(source.observedAtIso).toBe(OBSERVED);
+    expect(source.effectiveAtIso).toBe(LEGAL_FROM);
+    expect(source.observedAtIso).toBe(VERIFIED);
+    // Name every value it must NOT be: the evaluation clock (the bug) and
+    // `retrieved_at` (the near-miss the freshness policy makes wrong).
     expect(source.effectiveAtIso).not.toBe(TEST_NOW);
+    expect(source.observedAtIso).not.toBe(TEST_NOW);
+    expect(source.observedAtIso).not.toBe(RETRIEVED);
 
     // Innocence: the ASSESSMENT's own dates are legitimately the evaluation
     // moment. This fix must not reach up and rewrite those too.

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -132,8 +132,22 @@ function outcomeSource(source: VisaOracleSourceRecord): OutcomeSource | null {
     url,
     authority: source.authority_type,
     primary: source.is_primary_authority,
-    effectiveAtIso: source.applicability.effective_at,
-    observedAtIso: source.applicability.observed_at,
+    // These two feed a line that reads "Effective X · observed Y" ABOUT THE
+    // SOURCE, so they must carry the document's own dates.
+    //
+    // They used to read `source.applicability.*`, which is not a property of
+    // the document at all: the backend writes the decision's evaluation clock
+    // into every cited source's applicability block (`_build_sources_dto` in
+    // evaluate_path.py sets effective_at/observed_at from `decision.*`, itself
+    // `now`). The result on screen was every source claiming it took legal
+    // effect at the instant the reader pressed the button — a date that reads
+    // as a freshness guarantee while carrying no information about the source.
+    //
+    // `verified_at` rather than `retrieved_at` for "observed": the freshness
+    // policy is MAX_AGE_SINCE_VERIFIED_AT, so this is the date that actually
+    // explains the freshness badge rendered next to it.
+    effectiveAtIso: source.legal_period_from,
+    observedAtIso: source.verified_at,
     freshness: source.freshness.status,
   };
 }

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -143,9 +143,13 @@ function outcomeSource(source: VisaOracleSourceRecord): OutcomeSource | null {
     // effect at the instant the reader pressed the button — a date that reads
     // as a freshness guarantee while carrying no information about the source.
     //
-    // `verified_at` rather than `retrieved_at` for "observed": the freshness
-    // policy is MAX_AGE_SINCE_VERIFIED_AT, so this is the date that actually
-    // explains the freshness badge rendered next to it.
+    // `verified_at` rather than `retrieved_at` for "observed": the only
+    // freshness policy the schema can express is MAX_AGE_SINCE_VERIFIED_AT,
+    // so this is the date that explains the freshness badge rendered beside
+    // it. Narrower than it sounds — `freshness_policy` is optional for packs
+    // signed under the older schema, and a source without one is reported
+    // UNKNOWN; there the badge has no rule to explain, and `verified_at` is
+    // simply the better of two dates rather than the one the policy names.
     effectiveAtIso: source.legal_period_from,
     observedAtIso: source.verified_at,
     freshness: source.freshness.status,


### PR DESCRIPTION
## What this fixes

Measured live on `balizero.com/visa-oracle` after seq-5 went active. Every cited source rendered:

```
Effective 10 August 2026 at 00:27 · observed 10 August 2026 at 00:27
```

Both stamps equal to the instant the reader pressed the button — on every source, on every decision.

## Cause

`outcomeSource()` read `source.applicability.effective_at/observed_at`. Those are **not** properties of the document: `_build_sources_dto` (`evaluate_path.py:752-753`) writes `decision.effective_at`/`observed_at` — the evaluation clock — into every cited source's applicability block. That block legitimately answers *"was this source applicable at evaluation time?"*; the UI label promises the document's own dates.

The effect is worse than a cosmetic slip: a reader checking how fresh a regulation is saw a timestamp that **reads as a freshness guarantee and carries no information about the source**. The VoA country list claimed to have taken legal effect today.

## Fix

The real dates were already on the wire and schema-validated (`evaluate_path.py:733-741`). Map those:

- `effectiveAtIso` ← `legal_period_from` (seq-5 VoA list: `2026-07-24`)
- `observedAtIso` ← `verified_at` (seq-5 VoA list: `2026-08-08`)

`verified_at` rather than `retrieved_at` because `MAX_AGE_SINCE_VERIFIED_AT` is the only freshness policy the schema can express — it is the date that explains the badge rendered beside it. Narrower than it sounds, and the code comment now says so: `freshness_policy` is optional for packs signed under the older schema, and a source without one is reported `UNKNOWN`, where the badge has no rule to explain.

**Untouched:** the assessment's own `effective/observed/evaluated` stamps. For the *decision*, "now" is the correct answer; an assertion pins that so this fix cannot creep upward.

## Adversarial review (Sonnet seat, ordered to refute) — one finding, real, fixed in `681e00bb7`

The review **refuted the first version of this test**, with a mutation that proves it: changing the adapter from `source.verified_at` to `source.retrieved_at` left the test **green**. It set both fields to the same value, so the assertion could not name which one the adapter had read — precisely the axis this fix's rationale rests on. A test that collapses two adjacent candidates cannot choose between them.

Fixed: four distinct dates, ordered so `decisiveSource` still accepts the source as decisive evidence, plus assertions naming what each value must **not** be.

Now mutation-verified on **both** wrong mappings:

| mutation | result |
|---|---|
| `verified_at` → `retrieved_at` | fails — `04:00` where `05:00` expected |
| `legal_period_from` → `applicability.effective_at` | fails — `2026-08-03` where `2026-07-24` expected |

Two overclaims of mine, corrected in the same commit:

1. The test comment credited the ordering invariant to "the response contract". `engine-response.ts` only validates each field parses as UTC; the ordering (`retrieved_at <= verified_at`, `freshness.verified_at === verified_at`) is enforced by `decisiveSource` in `engine-adapter.ts`. The reviewer looked where I pointed it, found nothing, and concluded the invariant did not exist — it does, and I had hit it live. The comment now names the real enforcer.
2. The code comment stated the freshness policy as universal. Corrected as described above.

The review could **not** refute the causal claim (checked `_build_sources_dto`'s single call site and the outage path, which returns `sources: []`), consumer breakage (all five readers enumerated; `decisiveSource` reads the raw record, not this view model; the date formatter is NaN-safe), or nullability (`legal_period_from` and `verified_at` are required non-null in both the Pydantic model and the generated TS contract).

Left open, declared not fixed: the label word "observed" / "diamati" now carries `verified_at`, which is a defensible but imprecise reading. Changing user-facing copy in two languages is a separate call, not smuggled into a bug fix.

## Not in scope

The backend still stamps `applicability.*` with the decision clock. That is correct for what the field means; only the frontend's use of it was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)