### PR TITLE
fix(infra): Fly config audit — honest cost guard, standby-aware detector, docs-only deploy skip

### DIFF
--- a/.github/workflows/cron-fly-cost-alert.yml
+++ b/.github/workflows/cron-fly-cost-alert.yml
@@ -1,7 +1,9 @@
 name: cron - fly cost alert (weekly Mon 09:00 WITA)
 
 # Migrated from Pro crontab `0 9 * * 1 fly-cost-alert.sh` (2026-04-26).
-# Weekly check of Fly.io billing; Telegram alert if monthly projection exceeds threshold.
+# Weekly resource-inventory guard. Fly.io does not expose a supported billing
+# alert/API, so direct spend must be reviewed in Cost Explorer. This workflow
+# must never report a fabricated $0 when billing data is unavailable.
 
 on:
   schedule:
@@ -17,58 +19,125 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      THRESHOLD_CENTS: "6000" # $60.00 monthly cap
+      EXPECTED_APPS: "nuzantara-rag,nuzantara-postgres"
+      MAX_TOTAL_MACHINES: "6"
+      MAX_TOTAL_VOLUME_GB: "60"
+      MAX_DEDICATED_IPV4: "1"
     steps:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Check Fly.io billing
+      - name: Inventory billable Fly.io resources
         id: check
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          set -uo pipefail
-          INVOICE=$(flyctl bills view --json 2>/dev/null || echo '{}')
-          if [ "$INVOICE" = '{}' ]; then
-            echo "WARNING: could not fetch billing; falling back to machine count"
-            TOTAL=0
-            for app in nuzantara-rag nuzantara-postgres; do
-              COUNT=$(flyctl status --app "$app" 2>/dev/null | grep -c "started" || echo "0")
-              TOTAL=$((TOTAL + COUNT))
-            done
-            echo "Active machines: $TOTAL (manual cost check recommended)"
-            echo "alert=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          TOTAL_CENTS=$(echo "$INVOICE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('total_cents', d.get('amount', 0)))" 2>/dev/null || echo "0")
-          TOTAL_DOLLARS=$(python3 -c "print(f'{${TOTAL_CENTS}/100:.2f}')")
-          THRESHOLD_DOLLARS=$(python3 -c "print(f'{${THRESHOLD_CENTS}/100:.2f}')")
-          echo "Current month cost: \$$TOTAL_DOLLARS (threshold: \$$THRESHOLD_DOLLARS)"
-          if [ "$TOTAL_CENTS" -gt "$THRESHOLD_CENTS" ]; then
-            ALERT="💰 <b>Fly.io Cost Alert</b>
-          Current: \$${TOTAL_DOLLARS}
-          Threshold: \$${THRESHOLD_DOLLARS}
-          Check: flyctl bills view"
-            {
-              echo "alert<<EOF"
-              echo "$ALERT"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-            echo "::warning::Fly.io cost \$$TOTAL_DOLLARS exceeds threshold \$$THRESHOLD_DOLLARS"
-          else
-            echo "Cost within budget ✅"
-            echo "alert=" >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          python3 <<'PY'
+          import json
+          import os
+          import subprocess
+
+
+          def fly_json(*args):
+              result = subprocess.run(
+                  ["flyctl", *args, "--json"],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+              return json.loads(result.stdout)
+
+
+          expected = {
+              name.strip()
+              for name in os.environ["EXPECTED_APPS"].split(",")
+              if name.strip()
+          }
+          apps = fly_json("apps", "list")
+          app_names = {app.get("Name") or app.get("ID") for app in apps}
+          app_names.discard(None)
+
+          machine_count = 0
+          started_count = 0
+          volume_gb = 0
+          dedicated_ipv4 = 0
+          inventory_errors = []
+
+          for app in sorted(app_names):
+              try:
+                  status = fly_json("status", "--app", app)
+                  machines = status.get("Machines") or []
+                  machine_count += len(machines)
+                  started_count += sum(m.get("state") == "started" for m in machines)
+              except Exception as exc:
+                  inventory_errors.append(f"{app}:status:{type(exc).__name__}")
+
+              try:
+                  volumes = fly_json("volumes", "list", "--app", app)
+                  volume_gb += sum(int(v.get("size_gb") or 0) for v in volumes)
+              except Exception as exc:
+                  inventory_errors.append(f"{app}:volumes:{type(exc).__name__}")
+
+              try:
+                  addresses = fly_json("ips", "list", "--app", app)
+                  dedicated_ipv4 += sum(ip.get("Type") == "v4" for ip in addresses)
+              except Exception as exc:
+                  inventory_errors.append(f"{app}:ips:{type(exc).__name__}")
+
+          unexpected_apps = sorted(app_names - expected)
+          missing_apps = sorted(expected - app_names)
+          limits = {
+              "machines": int(os.environ["MAX_TOTAL_MACHINES"]),
+              "volume_gb": int(os.environ["MAX_TOTAL_VOLUME_GB"]),
+              "dedicated_ipv4": int(os.environ["MAX_DEDICATED_IPV4"]),
+          }
+          findings = []
+          if unexpected_apps:
+              findings.append("unexpected apps=" + ",".join(unexpected_apps))
+          if missing_apps:
+              findings.append("missing apps=" + ",".join(missing_apps))
+          if machine_count > limits["machines"]:
+              findings.append(f"machines {machine_count}>{limits['machines']}")
+          if volume_gb > limits["volume_gb"]:
+              findings.append(f"volumes {volume_gb}GB>{limits['volume_gb']}GB")
+          if dedicated_ipv4 > limits["dedicated_ipv4"]:
+              findings.append(
+                  f"dedicated IPv4 {dedicated_ipv4}>{limits['dedicated_ipv4']}"
+              )
+          if inventory_errors:
+              findings.append("inventory errors=" + ",".join(inventory_errors))
+
+          report = (
+              f"Apps: {len(app_names)} | Machines: {started_count}/{machine_count} started | "
+              f"Volumes: {volume_gb} GB | Dedicated IPv4: {dedicated_ipv4}"
+          )
+          alert = "\n".join(findings)
+          output_path = os.environ["GITHUB_OUTPUT"]
+          with open(output_path, "a", encoding="utf-8") as output:
+              output.write("report<<EOF\n" + report + "\nEOF\n")
+              output.write("alert<<EOF\n" + alert + "\nEOF\n")
+
+          print(report)
+          if findings:
+              print("::warning::Fly resource guard: " + "; ".join(findings))
+          PY
 
       - name: Telegram alert
-        if: steps.check.outputs.alert != ''
+        if: always() && steps.check.outputs.report != ''
         env:
           BOT: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           CHAT: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
           ALERT: ${{ steps.check.outputs.alert }}
+          REPORT: ${{ steps.check.outputs.report }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           [ -z "$BOT" ] || [ -z "$CHAT" ] && { echo "Telegram secrets missing"; exit 0; }
-          TEXT="${ALERT}
+          FINDINGS=""
+          [ -n "${ALERT:-}" ] && FINDINGS="⚠️ <b>Findings</b>: ${ALERT}"$'\n'
+          TEXT="💰 <b>Fly.io weekly resource guard</b>
+          ${REPORT}
+          ${FINDINGS}Direct spend cannot be queried through a supported Fly billing API. Review Cost Explorer:
+          https://fly.io/dashboard/bali-zero/billing/cost-explorer
           Run: ${RUN_URL}"
           curl -sS -m 10 -X POST \
             "https://api.telegram.org/bot${BOT}/sendMessage" \

--- a/.github/workflows/cron-fly-restart-detector.yml
+++ b/.github/workflows/cron-fly-restart-detector.yml
@@ -60,9 +60,11 @@ jobs:
 
           should_alert() {
             local key="$1"
-            local last=$(grep "^${key}:" "$STATE" 2>/dev/null | tail -1 | cut -d: -f2)
+            local last
+            last=$(grep "^${key}:" "$STATE" 2>/dev/null | tail -1 | cut -d: -f2)
             if [ -z "$last" ]; then return 0; fi
-            local age=$(( NOW - last ))
+            local age
+            age=$(( NOW - last ))
             [ "$age" -ge "$COOLDOWN_SECONDS" ]
           }
 
@@ -90,7 +92,23 @@ jobs:
           machines = d.get("Machines", []) or []
           total = len(machines)
           started = sum(1 for m in machines if m.get("state") == "started")
-          bad = [m.get("state", "?") for m in machines if m.get("state") != "started"]
+          expected_stopped = sum(
+              1
+              for m in machines
+              if m.get("state") == "stopped"
+              and (m.get("config") or {}).get("standbys")
+          )
+          unexpected_stopped = sum(
+              1
+              for m in machines
+              if m.get("state") == "stopped"
+              and not (m.get("config") or {}).get("standbys")
+          )
+          bad = [
+              m.get("state", "?")
+              for m in machines
+              if m.get("state") not in ("started", "stopped")
+          ]
           unhealthy = 0
           for m in machines:
               for c in (m.get("checks") or []):
@@ -133,9 +151,20 @@ jobs:
                       oom.append(f"{machine_id}:{group}:{event_sig}")
                   if last_exit is None and "exit_code" in ee and ee.get("exit_code") is not None:
                       last_exit = exit_code
-              if m.get("state") == "stopped" and last_exit is not None and str(last_exit) != "0":
+              is_expected_standby = bool((m.get("config") or {}).get("standbys"))
+              if (
+                  m.get("state") == "stopped"
+                  and not is_expected_standby
+                  and last_exit is not None
+                  and str(last_exit) != "0"
+              ):
                   crashed.append(machine_id)
-          print(f"total={total}|started={started}|bad={','.join(bad) or 'none'}|unhealthy={unhealthy}|crashed={','.join(crashed) or 'none'}|oom={','.join(oom) or 'none'}")
+          print(
+              f"total={total}|started={started}|expected_stopped={expected_stopped}|"
+              f"unexpected_stopped={unexpected_stopped}|bad={','.join(bad) or 'none'}|"
+              f"unhealthy={unhealthy}|crashed={','.join(crashed) or 'none'}|"
+              f"oom={','.join(oom) or 'none'}"
+          )
           PY
           )
             echo "[$app] $SUMMARY"
@@ -146,15 +175,15 @@ jobs:
               fi
               continue
             fi
-            STARTED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^started= | cut -d= -f2)
-            TOTAL=$(echo "$SUMMARY" | tr '|' '\n' | grep ^total= | cut -d= -f2)
+            EXPECTED_STOPPED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^expected_stopped= | cut -d= -f2)
+            UNEXPECTED_STOPPED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^unexpected_stopped= | cut -d= -f2)
             BAD=$(echo "$SUMMARY" | tr '|' '\n' | grep ^bad= | cut -d= -f2)
             UNHEALTHY=$(echo "$SUMMARY" | tr '|' '\n' | grep ^unhealthy= | cut -d= -f2)
             CRASHED=$(echo "$SUMMARY" | tr '|' '\n' | grep ^crashed= | cut -d= -f2)
             OOM=$(echo "$SUMMARY" | tr '|' '\n' | grep ^oom= | cut -d= -f2)
-            if [ "${STARTED:-0}" -lt "${TOTAL:-1}" ]; then
+            if [ "${UNEXPECTED_STOPPED:-0}" -gt 0 ] || [ "${BAD:-none}" != "none" ]; then
               if should_alert "${app}_state"; then
-                ALERTS="${ALERTS}🔴 <b>${app}</b>: $((TOTAL-STARTED))/${TOTAL} machines NOT started (${BAD})"$'\n'
+                ALERTS="${ALERTS}🔴 <b>${app}</b>: unexpected stopped=${UNEXPECTED_STOPPED:-0}, bad states=${BAD}; expected standbys=${EXPECTED_STOPPED:-0}"$'\n'
                 mark_alerted "${app}_state"
               fi
             fi

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,7 +5,13 @@ on:
     branches: [main]
     paths:
       - "apps/backend-rag/**"
-      - "!apps/backend-rag/**/*.md"
+      # Docs-class .md only. A blanket "!**/*.md" would also skip runtime-read
+      # markdown baked into the image (training-data/*.md — Dockerfile COPY,
+      # consumed by conversation_trainer), stranding merged content undeployed.
+      - "!apps/backend-rag/docs/**"
+      - "!apps/backend-rag/**/README.md"
+      - "!apps/backend-rag/AGENTS.md"
+      - "!apps/backend-rag/CLAUDE.md"
       - "!apps/backend-rag/**/tests/**"
       - "!apps/backend-rag/**/test_*.py"
       - "!apps/backend-rag/**/*_test.py"

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - "apps/backend-rag/**"
+      - "!apps/backend-rag/**/*.md"
+      - "!apps/backend-rag/**/tests/**"
+      - "!apps/backend-rag/**/test_*.py"
+      - "!apps/backend-rag/**/*_test.py"
       - ".github/workflows/fly-deploy.yml"
   workflow_dispatch: # allow manual retrigger (e.g. after a secret rotation)
 
@@ -109,12 +113,6 @@ jobs:
           CVE_EXCEPTIONS_PATH=${{ github.workspace }}/.security/exceptions.yaml \
             python ${{ github.workspace }}/scripts/filter_safety_findings.py \
             safety-deploy-report.json
-
-      - name: Check migration status (informational)
-        run: |
-          echo "Checking for pending migrations..."
-          flyctl ssh console --app nuzantara-rag -C "cd /app && python -m backend.db.migrate status" || echo "⚠️ Migration check skipped (non-blocking)"
-        continue-on-error: true
 
       - name: Upload gate test results
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Hooks (`~/.claude/hooks/`) sono il backstop quando il system prompt non basta. A
 
 ## 11. Deploy Lifecycle
 
-**Fly.io 2 apps**: `nuzantara-rag` (shared-2x, 2GB, always-on, EventBus) + `nuzantara-postgres` (postgres-flex 17.2, `repmgr` HA — NOT Stolon; doc-drift corrected 2026-06-12 G3, backup → Tigris daily). Frontend on Vercel (auto-deploy on `git push origin main`).
+**Fly.io 2 apps**: `nuzantara-rag` (shared-2x, 2GB, always-on, EventBus) + `nuzantara-postgres` (postgres-flex 17.7, `repmgr` HA — NOT Stolon; rolling-upgraded 17.2→17.7 on 2026-08-09 after an isolated restore proof; backup → Tigris daily — WAL archiving re-enabled same day: a legacy override had disabled it, so "DONE" backups were not actually restorable). Frontend on Vercel (auto-deploy on `git push origin main`).
 
 **Pre-deploy** (run sequentially):
 ```bash

--- a/scripts/tests/test_fly_deploy_workflow.py
+++ b/scripts/tests/test_fly_deploy_workflow.py
@@ -7,9 +7,23 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "fly-deploy.yml"
 
 
-def test_deploy_ignores_test_and_markdown_only_changes() -> None:
+def test_deploy_ignores_test_and_docs_only_changes() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert '"!apps/backend-rag/**/tests/**"' in workflow
-    assert '"!apps/backend-rag/**/*.md"' in workflow
+    assert '"!apps/backend-rag/docs/**"' in workflow
+    assert '"!apps/backend-rag/**/README.md"' in workflow
     assert "Check migration status (informational)" not in workflow
+
+
+def test_deploy_never_excludes_runtime_markdown() -> None:
+    # A blanket "!**/*.md" exclusion would also skip runtime-read markdown
+    # baked into the image (training-data/*.md is COPY'd by the Dockerfile and
+    # read by conversation_trainer), stranding merged content undeployed
+    # (merged-is-not-live, scar family #2/W86). Only docs-class paths may be
+    # excluded, each named explicitly.
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert '"!apps/backend-rag/**/*.md"' not in workflow
+    assert "!apps/backend-rag/training-data" not in workflow
+    assert "!apps/backend-rag/backend" not in workflow

--- a/scripts/tests/test_fly_deploy_workflow.py
+++ b/scripts/tests/test_fly_deploy_workflow.py
@@ -1,0 +1,15 @@
+"""Regression tests for Fly.io production deploy triggers."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "fly-deploy.yml"
+
+
+def test_deploy_ignores_test_and_markdown_only_changes() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert '"!apps/backend-rag/**/tests/**"' in workflow
+    assert '"!apps/backend-rag/**/*.md"' in workflow
+    assert "Check migration status (informational)" not in workflow

--- a/scripts/tests/test_fly_workflow_guards.py
+++ b/scripts/tests/test_fly_workflow_guards.py
@@ -1,0 +1,146 @@
+"""Regression tests for Fly.io workflow honesty and standby handling."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _embedded_python(workflow: str) -> str:
+    text = (WORKFLOWS / workflow).read_text(encoding="utf-8")
+    marker = "python3 <<'PY'"
+    start = text.index(marker) + len(marker)
+    lines = text[start:].splitlines()[1:]
+    body = []
+    for line in lines:
+        if line.strip() == "PY":
+            break
+        body.append(line[10:] if line.startswith("          ") else line)
+    return "\n".join(body) + "\n"
+
+
+def test_restart_detector_treats_configured_standby_as_expected() -> None:
+    script = _embedded_python("cron-fly-restart-detector.yml")
+    machines = {
+        "Machines": [
+            {"id": "active", "state": "started", "config": {}, "events": []},
+            {
+                "id": "standby",
+                "state": "stopped",
+                "config": {"standbys": ["active"]},
+                "events": [
+                    {"request": {"exit_event": {"exit_code": 1}}},
+                ],
+            },
+        ]
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "RAW": json.dumps(machines)},
+    )
+
+    assert "expected_stopped=1" in result.stdout
+    assert "unexpected_stopped=0" in result.stdout
+    assert "bad=none" in result.stdout
+    assert "crashed=none" in result.stdout
+
+
+def test_restart_detector_keeps_unexpected_crash_recovery() -> None:
+    script = _embedded_python("cron-fly-restart-detector.yml")
+    machines = {
+        "Machines": [
+            {
+                "id": "crashed",
+                "state": "stopped",
+                "config": {},
+                "events": [
+                    {"request": {"exit_event": {"exit_code": 1}}},
+                ],
+            }
+        ]
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "RAW": json.dumps(machines)},
+    )
+
+    assert "expected_stopped=0" in result.stdout
+    assert "unexpected_stopped=1" in result.stdout
+    assert "crashed=crashed" in result.stdout
+
+
+def test_cost_guard_reports_resource_drift_without_fake_billing(tmp_path: Path) -> None:
+    workflow = (WORKFLOWS / "cron-fly-cost-alert.yml").read_text(encoding="utf-8")
+    assert "flyctl bills view" not in workflow
+    assert "Current month cost" not in workflow
+
+    fake_flyctl = tmp_path / "flyctl"
+    fake_flyctl.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+app = args[args.index("--app") + 1] if "--app" in args else None
+if args[:2] == ["apps", "list"]:
+    data = [
+        {"Name": "nuzantara-rag"},
+        {"Name": "nuzantara-postgres"},
+        {"Name": "fly-builder-legacy"},
+    ]
+elif args[0] == "status":
+    counts = {
+        "nuzantara-rag": ["started", "started", "started", "stopped"],
+        "nuzantara-postgres": ["started", "started"],
+        "fly-builder-legacy": ["stopped"],
+    }
+    data = {"Machines": [{"state": state} for state in counts[app]]}
+elif args[:2] == ["volumes", "list"]:
+    sizes = {"nuzantara-rag": [1, 1], "nuzantara-postgres": [25, 25], "fly-builder-legacy": [50]}
+    data = [{"size_gb": size} for size in sizes[app]]
+elif args[:2] == ["ips", "list"]:
+    data = [{"Type": "v4"}] if app == "nuzantara-rag" else []
+else:
+    raise SystemExit(f"unexpected flyctl args: {args}")
+print(json.dumps(data))
+""",
+        encoding="utf-8",
+    )
+    fake_flyctl.chmod(fake_flyctl.stat().st_mode | stat.S_IXUSR)
+    output = tmp_path / "github-output"
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        "EXPECTED_APPS": "nuzantara-rag,nuzantara-postgres",
+        "MAX_TOTAL_MACHINES": "6",
+        "MAX_TOTAL_VOLUME_GB": "60",
+        "MAX_DEDICATED_IPV4": "1",
+        "GITHUB_OUTPUT": str(output),
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", _embedded_python("cron-fly-cost-alert.yml")],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    github_output = output.read_text(encoding="utf-8")
+
+    assert "Apps: 3 | Machines: 5/7 started | Volumes: 102 GB" in result.stdout
+    assert "unexpected apps=fly-builder-legacy" in github_output
+    assert "machines 7>6" in github_output
+    assert "volumes 102GB>60GB" in github_output


### PR DESCRIPTION
## What

Grafts the Fly config-audit branch authored by the Codex seat (2 commits: honest resource-inventory cost guard replacing the fabricated-\$0 billing check; standby-aware restart detector; deploy skip for non-runtime changes; +4 regression tests) plus two commits from this session's independent review:

1. **fix(ci): narrow deploy `.md` exclusion to docs-class paths only** — the blanket `!apps/backend-rag/**/*.md` would also skip runtime-read markdown baked into the image (`training-data/*.md` is COPY'd by the Dockerfile and consumed by `conversation_trainer`, an exposed MCP tool): a merge touching only those files would never deploy (scar family #2/W86, merged-is-not-live). Only explicitly-named docs-class paths are excluded now, and a guard test fails if a blanket `.md` exclusion reappears.
2. **docs(deploy): PG is 17.7** — records the restore-proven 2026-08-09 rolling upgrade and the WAL-archiving re-enable in CLAUDE.md §11.

## Adversarial review (generator≠grader)

- Authors: Codex Opus 4.8 seat (commits a25da15ee4, 91a9a134d2). Grader: this session (Fable 5), independent verification:
  - `flyctl` JSON key names probed against the live API this session: `size_gb` ✅, IP `Type` values are `v6`/`shared_v4`/`v4` so counting `== "v4"` correctly counts dedicated-only ✅.
  - Standby detection via `config.standbys` matches the live machine schema ✅.
  - Guard tests execute the embedded workflow Python on guilt+innocence fixtures (5/5 pass locally).
  - One real defect found (the blanket `.md` exclusion above) — fixed in this PR, invariant pinned by test.

## Verification

- `python3 -m pytest scripts/tests/test_fly_deploy_workflow.py scripts/tests/test_fly_workflow_guards.py -q` → 5 passed.
- Cost-guard expected-apps list will correctly flag the three temporary `nuzantara-pg-restore-*` apps if they outlive their restore-proof purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)