### PR TITLE
fix(visa-oracle): send the employer country as one code, not a set of one

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.test.ts
@@ -602,3 +602,53 @@ describe("mapOracleFactsToApplicantFacts — determinism", () => {
     );
   });
 });
+
+describe("country-code facts: one code is not a set of one", () => {
+  // `work.employer_country_code` is `KnownCountryCode` (a bare string) while
+  // `person.nationalities` is `KnownCountrySet` (an array). They were mapped
+  // by the same helper, and the resulting type error was silenced with an
+  // `as` cast — the only one in the mapper. The API answered 422
+  // `string_type`, and the interview showed that as a "Client safety hold",
+  // so every remote-work interview that named an employer country died
+  // before reaching the engine. Assert the SHAPES, side by side.
+  it("sends the employer country as a string and nationalities as an array", () => {
+    const mapped = mapFacts({
+      category: "remote",
+      nationalities: "AL",
+      remote_employer_country: "AL",
+    } as OracleFacts);
+
+    const employer = mapped.facts["work.employer_country_code"];
+    const nationalities = mapped.facts["person.nationalities"];
+    expect(employer).toEqual({ status: "KNOWN", value: "AL" });
+    expect(typeof (employer as { value: unknown }).value).toBe("string");
+    expect(Array.isArray((employer as { value: unknown }).value)).toBe(false);
+    // Same answer, different contract: this one really is a set.
+    expect(nationalities).toEqual({ status: "KNOWN", value: ["AL"] });
+  });
+
+  it("refuses more than one employer country rather than truncating", () => {
+    const mapped = mapFacts({
+      category: "remote",
+      remote_employer_country: "AL,IT",
+    } as OracleFacts);
+    expect(mapped.facts["work.employer_country_code"]).toEqual({
+      status: "UNKNOWN",
+      reason: "NOT_PROVIDED",
+    });
+  });
+
+  it("keeps the not-asked and unsure answers representable", () => {
+    expect(
+      mapFacts({ category: "remote" } as OracleFacts).facts[
+        "work.employer_country_code"
+      ],
+    ).toEqual({ status: "UNKNOWN", reason: "NOT_ASKED" });
+    expect(
+      mapFacts({
+        category: "remote",
+        remote_employer_country: "unsure",
+      } as OracleFacts).facts["work.employer_country_code"],
+    ).toEqual({ status: "UNKNOWN", reason: "UNVERIFIED" });
+  });
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/fact-mapper.ts
@@ -99,6 +99,28 @@ function enumFact<T extends string>(
     : unknownFact(NOT_PROVIDED);
 }
 
+/**
+ * A SINGLE country code — the wire type `KnownCountryCode`, whose `value` is a
+ * bare string, not a one-element array.
+ *
+ * Kept separate from `countryCodesFact` on purpose. The two shapes look alike
+ * and are not: `person.nationalities` / `family.sponsor_nationalities` are
+ * `KnownCountrySet`, while `work.employer_country_code` is `KnownCountryCode`.
+ * Sending the set shape for the singular field made the API reject the whole
+ * request (422 `string_type`), which the interview surfaced as a "Client
+ * safety hold" — so every remote-work interview that answered the employer's
+ * country died before it ever reached the engine.
+ */
+function countryCodeFact(value: string | undefined): FactValue<string> {
+  if (value === undefined) return unknownFact(NOT_ASKED);
+  if (value === "unsure") return unknownFact(UNVERIFIED);
+  const codes = value.split(",");
+  if (codes.length !== 1) return unknownFact(NOT_PROVIDED);
+  return canonicalCountryCodes(codes, false) === value
+    ? known(codes[0])
+    : unknownFact(NOT_PROVIDED);
+}
+
 function countryCodesFact(
   value: string | undefined,
   multiple: boolean,
@@ -420,10 +442,9 @@ export function mapOracleFactsToApplicantFacts(
     "intent.desired_entry_date": unknownFact(NOT_ASKED),
     "intent.entry_pattern": enumFact(facts.entry_pattern, ENTRY_PATTERNS),
     "intent.requested_product_code": unknownFact(NOT_ASKED),
-    "work.employer_country_code": countryCodesFact(
+    "work.employer_country_code": countryCodeFact(
       facts.remote_employer_country,
-      false,
-    ) as ApplicantFactsDataWire["work.employer_country_code"],
+    ),
     "work.employer_is_indonesian_entity": mapEmployerIsIndonesianEntity(facts),
     "work.serves_indonesian_clients": remoteClients.servesIndonesianClients,
     "work.indonesia_source_compensation": pairedBooleanFact(


### PR DESCRIPTION
## The bug, as the user hit it

Reported from a real interview on `balizero.com/visa-oracle`: Albanian remote worker, employer abroad, no Indonesian source, 70 days. Screen said:

> **Client safety hold** — This interview contains information the verified API cannot represent safely. **No evaluation was submitted.**

**Every remote-work interview that answered "where is your remote employer or main client registered?" died before reaching the engine.** E33G — the digital-nomad product — was unreachable end to end.

## Cause

Two lookalike wire types:

| fact | wire type | shape |
|---|---|---|
| `person.nationalities` | `KnownCountrySet` | array |
| `family.sponsor_nationalities` | `KnownCountrySet` | array |
| `work.employer_country_code` | **`KnownCountryCode`** | **bare string** |

All three were mapped by `countryCodesFact`, which returns `FactValue<string[]>`. The resulting type error on the singular field was silenced with `as ApplicantFactsDataWire["work.employer_country_code"]` — **the only such cast in the file**, sitting exactly where the two shapes diverge.

So the request carried `{"status":"KNOWN","value":["AL"]}` where the API requires `{"status":"KNOWN","value":"AL"}` → API answers `422 string_type` → `HTTP_ERROR` 4xx → client guard → "Client safety hold".

## Fix

`countryCodeFact` for the singular shape; `countryCodesFact` keeps the two genuinely set-shaped fields. The cast is gone.

## The engine was never the problem

Replaying the **same facts** with the correct shape, live against production:

```
HTTP 200
state       HUMAN_REVIEW_REQUIRED
review      E33G_INCOME_60K_MANUAL_CHECK
rule_pack   sequence 5
```

A useful answer the user could never see.

## Why 73 green tests missed it

All 73 pre-existing mapper tests passed with the bug in place. None asserted the **shape** of a fact value — only presence, keys and reason codes. That is the gap this class of bug lives in.

Three tests added: the two shapes asserted **side by side** in one case (same answer, different contract); a two-country answer refused rather than truncated; not-asked/unsure kept representable.

**Mutation-verified:** restoring the cast fails with the exact production symptom — `value: ['AL']` where `value: 'AL'` is expected.

## Not fixed here — and it is the bigger one

With the request finally arriving, a clean remote worker **still gets no option**. `review.e33g.income-60k-manual` is an unconditional `REQUIRE_REVIEW` whose `when` clause contains **no income fact** — because the engine's vocabulary has none (`work.*` has 5 facts, none about money). The rule cannot test the USD 60k requirement, so it hands every clean nomad to a human.

Zero's call: E33G should be **offered** with the 60k condition surfaced as "talk to an advisor", not hidden behind a review wall. That is a rule-pack change (seq-6) and is tracked separately. Same shape affects 11 money-threshold review rules in total (E28B/C/D/F, E33E, D1, D2, D12, E30, E31A, E33G).

🤖 Generated with [Claude Code](https://claude.com/claude-code)