### PR TITLE
feat(visa-oracle): say why a path is supported, in words

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -1,5 +1,8 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
-import { buildEngineOutcome } from "./engine-adapter";
+import { SUPPORT_REASON_COPY, buildEngineOutcome } from "./engine-adapter";
 import { TEST_NOW, makeVisaOracleResponse } from "./visa-oracle-test-fixture";
 
 describe("Visa Oracle authoritative outcome adapter", () => {
@@ -280,5 +283,68 @@ describe("Visa Oracle authoritative outcome adapter", () => {
       code: "intent.stay_days",
       questionId: "stay_days",
     });
+  });
+});
+
+describe("support reasons are sentences, not machine codes", () => {
+  const HERE = path.dirname(fileURLToPath(import.meta.url));
+  const PACK = path.resolve(
+    HERE,
+    "../../../../../../..",
+    "apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-005.source.json",
+  );
+
+  function supportReasonCodesInPack(): string[] {
+    const codes = new Set<string>();
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) return node.forEach(walk);
+      if (node === null || typeof node !== "object") return;
+      const record = node as Record<string, unknown>;
+      const effect = record.effect as Record<string, unknown> | undefined;
+      if (
+        effect &&
+        effect.type === "SUPPORT" &&
+        typeof effect.reason_code === "string"
+      ) {
+        codes.add(effect.reason_code);
+      }
+      Object.values(record).forEach(walk);
+    };
+    walk(JSON.parse(fs.readFileSync(PACK, "utf-8")));
+    return [...codes].sort();
+  }
+
+  function firstReasonEn(code: string): string {
+    const response = makeVisaOracleResponse();
+    response.decision.candidates[0].reason_codes = [code];
+    const outcome = buildEngineOutcome(response);
+    if (outcome.state !== "SUPPORTED_CANDIDATES")
+      throw new Error("unexpected state");
+    return outcome.candidates[0].legal.reasons[0].message.en;
+  }
+
+  it("renders a pack reason as prose, never the bare code", () => {
+    const message = firstReasonEn("B1_VOA_ELIGIBLE");
+    expect(message).not.toMatch(/^Verified reason: /);
+    expect(message).not.toContain("B1_VOA_ELIGIBLE");
+    expect(message).toContain("Visa on Arrival");
+  });
+
+  it("still surfaces an unmapped code instead of blanking it", () => {
+    // A code with no copy must stay visible: hiding it would conceal a new
+    // rule rather than reveal it.
+    expect(firstReasonEn("SOMETHING_NEW_FROM_A_FUTURE_PACK")).toBe(
+      "Verified reason: SOMETHING_NEW_FROM_A_FUTURE_PACK",
+    );
+  });
+
+  /**
+   * The tripwire: a future pack that adds a SUPPORT reason without copy would
+   * print a machine code at a real reader. Fail here first, naming the codes.
+   */
+  it("has copy for every SUPPORT reason code the live pack can emit", () => {
+    const codes = supportReasonCodesInPack();
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.filter((code) => !(code in SUPPORT_REASON_COPY))).toEqual([]);
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -52,8 +52,83 @@ const NEXT_STEPS: OutcomeNextSteps = [
 
 const PUBLIC_ID = /^[a-z0-9]{16,20}$/;
 
+/**
+ * Human-readable copy for the pack's SUPPORT reason codes — the "why this
+ * path is supported" line. Without it the UI printed the bare machine code
+ * (`Verified reason: B1_VOA_ELIGIBLE`) on every candidate of every product.
+ *
+ * Each sentence is derived from the rule's own `when` clause and may claim
+ * NOTHING the rule did not test. `PURPOSE_PRODUCT_MATCH` is deliberately
+ * generic: 16 rules share that one code — employment, six family relations,
+ * D1/D2/D12 multi-entry and study — so any specific sentence would be false
+ * for fifteen of them.
+ *
+ * Unknown codes keep the existing `Verified reason: <code>` form rather than
+ * degrading to a generic sentence: a code we have not written copy for is
+ * still information, and silently blanking it would hide a new rule instead
+ * of surfacing it. (The REVIEW map above chooses the opposite fallback on
+ * purpose — there, a wrong-sounding specific is worse than a safe generic.)
+ */
+export const SUPPORT_REASON_COPY: Record<string, LocalizedText> = {
+  A1_BVK_ELIGIBLE: text(
+    "Your nationality is on the visa-free (BVK) list for tourism or transit, and your stay is 30 days or less.",
+    "Kewarganegaraan Anda ada dalam daftar bebas visa (BVK) untuk wisata atau transit, dan masa tinggal Anda 30 hari atau kurang.",
+  ),
+  B1_VOA_ELIGIBLE: text(
+    "Your nationality is on the Visa on Arrival list for tourism, and your stay is 30 days or less.",
+    "Kewarganegaraan Anda ada dalam daftar Visa on Arrival untuk wisata, dan masa tinggal Anda 30 hari atau kurang.",
+  ),
+  C1_VISIT_ELIGIBLE: text(
+    "A tourism or family visit with a stay of 60 days or less.",
+    "Kunjungan wisata atau keluarga dengan masa tinggal 60 hari atau kurang.",
+  ),
+  C2_BUSINESS_ELIGIBLE: text(
+    "Business meetings or investment, with a confirmed sponsor and a stay of 60 days or less.",
+    "Pertemuan bisnis atau investasi, dengan penjamin terkonfirmasi dan masa tinggal 60 hari atau kurang.",
+  ),
+  C6_SOCIAL_ELIGIBLE: text(
+    "A social or other stated purpose, with a confirmed sponsor and a stay of 60 days or less.",
+    "Tujuan sosial atau lainnya, dengan penjamin terkonfirmasi dan masa tinggal 60 hari atau kurang.",
+  ),
+  E28A_INVESTMENT_ELIGIBLE: text(
+    "You committed to a PT PMA as shareholder-director or shareholder-commissioner, with paid-up capital of IDR 2.5 billion or more.",
+    "Anda berkomitmen pada PT PMA sebagai pemegang saham-direktur atau pemegang saham-komisaris, dengan modal disetor minimal Rp 2,5 miliar.",
+  ),
+  E33E_RETIREMENT_ELIGIBLE: text(
+    "Retirement, age 55 or over, with a deposit of USD 50,000 or more held in your own name at a state bank.",
+    "Pensiun, usia 55 tahun ke atas, dengan deposito minimal USD 50.000 atas nama sendiri di bank BUMN.",
+  ),
+  E33F_RETIREMENT_ELIGIBLE: text(
+    "Retirement with passive income of USD 3,000 per month or more and a confirmed sponsor.",
+    "Pensiun dengan penghasilan pasif minimal USD 3.000 per bulan dan penjamin terkonfirmasi.",
+  ),
+  E33_DEPOSIT_BASIS_ELIGIBLE: text(
+    "Second Home on the deposit basis: USD 130,000 or more held in your own name at a state bank.",
+    "Rumah Kedua berbasis deposito: minimal USD 130.000 atas nama sendiri di bank BUMN.",
+  ),
+  E33_PROPERTY_BASIS_ELIGIBLE: text(
+    "Second Home on the property basis: qualifying property valued at USD 1,000,000 or more.",
+    "Rumah Kedua berbasis properti: properti memenuhi syarat senilai minimal USD 1.000.000.",
+  ),
+  REMOTE_WORK_ELIGIBLE: text(
+    "You work remotely for a non-Indonesian employer, serve no Indonesian clients, and take no Indonesian-source compensation.",
+    "Anda bekerja jarak jauh untuk pemberi kerja non-Indonesia, tidak melayani klien Indonesia, dan tidak menerima kompensasi dari sumber Indonesia.",
+  ),
+  BRIDGING_DESTINATION_STATED: text(
+    "You named a destination status other than the bridging permit itself, so a bridging route can be assessed.",
+    "Anda menyebut status tujuan selain izin peralihan itu sendiri, sehingga jalur peralihan dapat dinilai.",
+  ),
+  PURPOSE_PRODUCT_MATCH: text(
+    "Your stated purpose and the circumstances you confirmed match what this visa covers.",
+    "Tujuan yang Anda nyatakan dan keadaan yang Anda konfirmasi sesuai dengan cakupan visa ini.",
+  ),
+};
+
 function reasonMessage(code: string): LocalizedText {
-  return text(`Verified reason: ${code}`, `Alasan terverifikasi: ${code}`);
+  return (
+    SUPPORT_REASON_COPY[code] ??
+    text(`Verified reason: ${code}`, `Alasan terverifikasi: ${code}`)
+  );
 }
 
 function reason(


### PR DESCRIPTION
## What a reader sees today

Every supported candidate, on every product:

> Why this path is supported
> **Verified reason: B1_VOA_ELIGIBLE**

A machine code. Observed live on `balizero.com/visa-oracle` during team testing.

A curated copy map already existed — but only for HUMAN_REVIEW reasons. SUPPORT reasons went through `reasonMessage`, which interpolated the bare code and nothing else (`engine-adapter.ts:56`).

## Change

`SUPPORT_REASON_COPY`, covering **all 13** SUPPORT reason codes the live seq-5 pack can emit. Each sentence is derived from that rule's own `when` clause and claims nothing the rule did not test — B1 names the VoA list *and* the 30-day ceiling, because the rule tests both.

Before → after:

| code | now reads |
|---|---|
| `B1_VOA_ELIGIBLE` | Your nationality is on the Visa on Arrival list for tourism, and your stay is 30 days or less. |
| `REMOTE_WORK_ELIGIBLE` | You work remotely for a non-Indonesian employer, serve no Indonesian clients, and take no Indonesian-source compensation. |
| `E33_DEPOSIT_BASIS_ELIGIBLE` | Second Home on the deposit basis: USD 130,000 or more held in your own name at a state bank. |

## Two deliberate choices

**`PURPOSE_PRODUCT_MATCH` stays generic.** Sixteen rules share that one code — employment, six family relations, D1/D2/D12 multi-entry, study. Any specific sentence would be false for fifteen of them. *That one code carrying sixteen distinct situations is a real granularity gap in the pack.* It is not fixed here, and the generic wording is the honest reading of it.

**Unknown codes keep `Verified reason: <code>`** rather than degrading to a generic sentence — the opposite of the REVIEW map's fallback, on purpose. A code we have not written copy for is still information; blanking it would conceal a new rule instead of surfacing it.

## Tests

- a pack code renders as prose and does not contain its own code;
- an unmapped code still surfaces verbatim (no silent blanking);
- **a tripwire that reads the live pack from disk** and fails if any SUPPORT reason code lacks copy — so the next pack cannot quietly ship a machine code to a reader.

**Mutation-verified:** dropping the map lookup fails with `expected 'Verified reason: B1_VOA_ELIGIBLE' not to match /^Verified reason: /`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)