### PR TITLE
fix(verifier): the output cap governs thinking + verdict, and 2048 was truncating 23% of live verdicts

### DIFF
--- a/apps/backend-rag/backend/services/rag/verification_service.py
+++ b/apps/backend-rag/backend/services/rag/verification_service.py
@@ -63,6 +63,12 @@ class VerificationResult(BaseModel):
     verdict_available: bool = True
 
 
+# Thinking + verdict must both fit under this, not the verdict alone — see the
+# long note at the call site. Named rather than inlined so a test can assert
+# the floor instead of re-litigating the number in a comment.
+VERIFIER_MAX_OUTPUT_TOKENS = 8192
+
+
 class VerifierVerdict(BaseModel):
     """Schema the verifier LLM is constrained to via generate_structured()'s
     response_schema (JSON mode — response_mime_type="application/json",
@@ -191,13 +197,33 @@ Return a JSON object with this exact structure:
 """
 
         # Use low temperature for deterministic evaluation.
-        # Verdict JSON (status/score/reasoning/corrections/missing_citations)
-        # is small — 8192 was a leftover generation-sized cap for a
-        # judge-sized output. Trimmed to 2048 (increment-1, latency): a
-        # representative sample verdict on this exact prompt schema
-        # measured ~95 output tokens (see scripts/verifier_model_ab.py /
-        # self-correction-speed-design.md validation note), leaving ~20x
-        # headroom. generate_structured() (PR #311) forces JSON mode
+        #
+        # CORRECTED 2026-08-09, measured in production. The cap was trimmed
+        # 8192 → 2048 "for latency" on the reasoning that a representative
+        # verdict measured ~95 output tokens, "leaving ~20x headroom". The
+        # verdict is indeed ~95 tokens — but this cap does not govern the
+        # verdict. It governs THINKING + verdict, and Gemini 2.5+ thinks by
+        # default. The number measured was not the number the constant
+        # controls.
+        #
+        # What that cost, live: `rag.verifier` was failing 10 of 44 calls
+        # over 7 days with LLMStructuredOutputError — i.e. the fact-check
+        # gate silently off for ~23% of answers, since the failure path
+        # returns verdict_available=False and self-correction is skipped.
+        # The arithmetic is unambiguous once thinking tokens are recorded
+        # (they were invisible until the same day's ledger fix): failed
+        # calls report 4062 / 4064 / 4065 output tokens. Halved, that is
+        # ~2032 — generate_structured's one retry, with BOTH attempts
+        # truncated at the 2048 cap. A successful gemini-3.5-flash call
+        # in the same window reports 1661: under the cap, but only just.
+        # The incumbent was living one long chain-of-thought from failure.
+        #
+        # 8192 restored. It is not "generation-sized leftover" — it is the
+        # room a thinking judge needs. If latency must be cut, cut it by
+        # lowering effort or shortening the context, never by a ceiling
+        # that a model's own reasoning has to fit inside.
+        #
+        # generate_structured() (PR #311) forces JSON mode
         # (response_mime_type="application/json" + response_schema) — the
         # model can no longer wrap its verdict in a markdown ```json fence,
         # which is what silently killed the fact-check gate in prod (the
@@ -213,7 +239,7 @@ Return a JSON object with this exact structure:
                 response_schema=VerifierVerdict,
                 model=self.model_name,
                 temperature=0.0,
-                max_output_tokens=2048,
+                max_output_tokens=VERIFIER_MAX_OUTPUT_TOKENS,
                 endpoint="rag.verifier",
             )
         except LLMStructuredOutputError:

--- a/apps/backend-rag/backend/tests/services/rag/test_verification_service.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_verification_service.py
@@ -9,11 +9,62 @@ from pydantic import ValidationError
 
 from backend.llm.genai_client import LLMStructuredOutputError
 from backend.services.rag.verification_service import (
+    VERIFIER_MAX_OUTPUT_TOKENS,
     VerificationResult,
     VerificationService,
     VerificationStatus,
     VerifierVerdict,
 )
+
+
+class TestVerifierOutputBudget:
+    """The cap governs THINKING + verdict, not the verdict alone.
+
+    Measured in production 2026-08-09: with the cap at 2048, `rag.verifier`
+    failed 10 of 44 calls over 7 days with LLMStructuredOutputError — the
+    fact-check gate silently off for ~23% of answers, since that path returns
+    verdict_available=False and self-correction is then skipped. The failing
+    rows report 4062/4064/4065 output tokens: halved, ~2032 each, i.e.
+    generate_structured's one retry with BOTH attempts truncated at the cap.
+    A successful gemini-3.5-flash call in the same window reports 1661 —
+    under 2048, but only just.
+
+    The cap had been trimmed 8192 → 2048 "for latency" because a sample
+    verdict measured ~95 tokens, "~20x headroom". The verdict really is ~95
+    tokens. It is simply not what the constant controls.
+    """
+
+    def test_budget_leaves_room_for_a_thinking_judge(self):
+        """GUILT: 2048 is the value that was measured breaking the gate, and
+        1661 (a real successful verdict) already sits at 81% of it."""
+        assert VERIFIER_MAX_OUTPUT_TOKENS > 2048, "2048 truncated 23% of live verdicts"
+        assert VERIFIER_MAX_OUTPUT_TOKENS >= 4096, (
+            "a verdict observed at 1661 tokens needs more than 2x headroom when the "
+            "same budget also has to hold the model's chain of thought"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_budget_actually_reaches_the_model(self):
+        """A constant nothing passes is a comment. Pin the call site.
+
+        Innocence-side value: this also catches someone re-inlining a literal
+        at the call site while leaving the constant looking correct.
+        """
+        service = VerificationService()
+        mock_client = MagicMock()
+        mock_client.is_available = True
+        mock_client.generate_structured = AsyncMock(
+            return_value=VerifierVerdict(reasoning="ok", status="verified", score=0.9),
+        )
+        service._genai_client = mock_client
+
+        await service.verify_response(
+            query="What is KITAS?",
+            draft_answer="A temporary stay permit.",
+            context_chunks=["KITAS is a temporary stay permit."],
+        )
+        kwargs = mock_client.generate_structured.await_args.kwargs
+        assert kwargs["max_output_tokens"] == VERIFIER_MAX_OUTPUT_TOKENS
 
 
 class TestVerificationStatus:


### PR DESCRIPTION
## The gate is off for ~23% of answers, right now, with the current model

`max_output_tokens` on the verifier call was trimmed 8192 → 2048 "for latency", on the reasoning that a representative verdict measured ~95 output tokens, "leaving ~20x headroom".

The verdict really is ~95 tokens. **It is not what that constant controls**: the cap covers THINKING + verdict, and Gemini 2.5+ thinks by default. The number that was measured is not the number the constant governs.

## Measured, not argued

`rag.verifier`, 7 days: **10 failures out of 44** with `LLMStructuredOutputError`. That path returns `verdict_available=False`, so self-correction is skipped — the fact-check gate was silently off for ~23% of answers served to clients.

The arithmetic:

| evidence | value |
|---|---|
| failed rows, output tokens | 4062 · 4064 · 4065 |
| halved | ~2032 each — `generate_structured`'s one retry, **both attempts truncated at 2048** |
| a *successful* `gemini-3.5-flash` verdict | 1661 — under the cap, at **81%** of it |

The incumbent was living one long chain of thought away from failure.

**This was invisible until today.** The numbers are only readable because #3914 started recording thinking tokens hours earlier — the ledger fix surfaced a bug the ledger had been hiding.

## The fix

`VERIFIER_MAX_OUTPUT_TOKENS = 8192`, named so the floor can be asserted instead of re-litigated in a comment.

Two tests:
- the budget must exceed the value measured breaking the gate (1661 already sits at 81% of 2048);
- the budget must **actually reach the model** — a constant nothing passes is a comment, and this also catches a literal re-inlined at the call site under a correct-looking constant.

Mutation-verified: restoring `2048` turns the guard red (RC=1).

## Not a model choice

A 4-of-5 failure rate observed today while trialling `gemini-2.5-flash` as the judge (applied to prod, measured, reverted within 15 minutes) was very likely this same truncation rather than the model — its failed calls show the identical doubled-cap signature. That trial is now re-runnable on a cap that fits, which is the next step, not this PR.

If latency must come down: lower effort or shorten the context. Never a ceiling the model's own reasoning has to fit inside.

## PROVE-LIVE plan

Post-deploy, same query as the baseline: `rag.verifier` failure rate over a comparable window must fall from 10/44. Baseline recorded pre-change (7d): 44 calls, $1.2768, avg_in 17,912, avg latency 10,617 ms, **ko 10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)