### PR TITLE
fix(ci): give detect-secrets measured timeout headroom

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -398,7 +398,10 @@ jobs:
   detect-secrets:
     name: Detect Secrets
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Run 31312661093 measured 19m34s in the scan alone and was cancelled at
+    # the 20m job limit after every gating step had succeeded. Keep this gate
+    # blocking, but give runner variance enough headroom to report its verdict.
+    timeout-minutes: 30
     # Re-enabled as a blocking gate now that:
     # 1. .secrets.baseline has been triaged: 920 findings auto-marked as
     #    false positives via scripts/detect_secrets_auto_triage.py (path


### PR DESCRIPTION
## Summary

- raise the blocking Detect Secrets job timeout from 20 to 30 minutes
- document the measured failure mode from run 31312661093
- preserve the scan and every security decision unchanged

## Evidence

Run 31312661093 spent 19m34s in the detect-secrets scan, completed every gating step successfully, and was then reported as cancelled at the 20-minute job limit. That false red blocked #3909 and the now-superseded #3896.

## Verification

- actionlint .github/workflows/security.yml
- python scripts/lint_workflow_timeout_floor.py — 119 jobs clean
- python -m pytest scripts/tests/test_lint_workflow_timeout_floor.py -q — 16 passed

No merge or auto-merge is armed; independent review remains required.
