### PR TITLE
fix(kbli): remove unused pytest import

### DIFF
--- a/scripts/tests/test_sync_kbli_dataset_stale_checkout_guard.py
+++ b/scripts/tests/test_sync_kbli_dataset_stale_checkout_guard.py
@@ -26,8 +26,6 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-import pytest
-
 REPO = Path(__file__).resolve().parents[2]
 SCRIPT = REPO / "scripts" / "sync_kbli_dataset.sh"
 LIB = REPO / "scripts" / "lib" / "kbli_fleet_notice.sh"


### PR DESCRIPTION
## Summary

- remove the unused pytest import flagged by CodeQL on parent PR #3909
- keep the stacked patch intentionally limited to the single review finding

## Verification

- focused guard tests: 5 passed
- Ruff: clean
- mandatory full backend pre-push suite: passed
- repository diff check: clean

## Stack

Parent: #3909

This child requires independent review before the parent returns to the merge queue.