### PR TITLE
docs(sync): refresh AI onboarding counts for #3939

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 693 services · 1323 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 693 services · 1324 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

- regenerate docs/AI_ONBOARDING.md with the canonical scripts/docs_sync.py
- refresh the generated test count from 1323 to 1324

## Why

Stacked on #3939. Its check-docs-sync job reports only this generated file stale.

Parent: #3939

## Validation

- apps/backend-rag/.venv/bin/python scripts/docs_sync.py --check
- apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_docs_sync_atlas.py -q (12 passed)
- normal pre-commit and pre-push hooks