### PR TITLE
test(tg): make drive-watchdog subprocess fake faithful

### DIFF
--- a/scripts/tests/test_drive_watchdog_tier_ratchet.py
+++ b/scripts/tests/test_drive_watchdog_tier_ratchet.py
@@ -605,6 +605,15 @@ def test_the_condition_actually_reaches_the_dedup_key_on_the_wire(
 
     class _Result:
         returncode = 0
+        # subprocess.run(..., capture_output=True, text=True) ALWAYS returns a
+        # CompletedProcess carrying .stderr; a fake without it is not a thinner
+        # CompletedProcess, it is a different object. Adding the verdict read to
+        # _send_telegram made the gap visible: the fake raised AttributeError,
+        # the caller's `except` swallowed it, and the function reported "not
+        # sent" for a send that worked — the fake and the code were wrong
+        # together, which is why the test stayed green while the fake was unfaithful (W114).
+        stderr = "tg_notify: spooled\n"
+        stdout = ""
 
     def fake_run(cmd, **kw):
         calls.append(cmd)


### PR DESCRIPTION
## Summary
- give the drive-watchdog subprocess fake the captured `stderr` and `stdout` fields returned by `subprocess.run`
- keep the production gateway-verdict read strict and exercise the real dedup-key wire path

## Root cause
PR #3930 reads the gateway verdict from `CompletedProcess.stderr`. The regression fake only modeled `returncode`, so it raised `AttributeError`; the caller swallowed that exception and reported a successful fake send as unsent.

## Validation
- red baseline: targeted wire-key test failed on parent `53ae5fbc`
- focused file: `16 passed`
- normal pre-commit hooks: passed
- normal pre-push full backend suite: passed

Stacked on #3930.
