### PR TITLE
fix(verifier): a structured-output failure now names its cause, out of band of the message

### DIFF
--- a/apps/backend-rag/backend/llm/genai_client.py
+++ b/apps/backend-rag/backend/llm/genai_client.py
@@ -52,7 +52,105 @@ class LLMStructuredOutputError(Exception):
     Callers may catch this and fall back to legacy non-structured paths;
     `query_expansion._llm_translate` does so to keep the dictionary-only
     expansion path alive when the LLM round-trips an unparseable result.
+
+    `reason` carries the closed-vocabulary cause (see
+    `_structured_failure_reason`) OUT OF BAND of the message. The message
+    embeds the pydantic ValidationError, whose `input_value=...` can echo
+    client PII from the prompt — which is why `verification_service` refuses
+    to log `str(exc)` at all. `reason` is enum-only and therefore safe to
+    log, so a caller can name the cause without touching the unsafe text.
     """
+
+    def __init__(self, message: str = "", *, reason: str = "") -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+# `llm_cost_events.error_class` is varchar(64) and the recorder isolates its
+# sinks: an over-long value raises only on the Postgres write, so JSONL and
+# Prometheus keep the event while the SQL ledger silently loses it. Losing
+# exactly the failure rows makes the failure rate read as ZERO — a diagnostic
+# that hides what it diagnoses. Every composed error_class is clamped here.
+ERROR_CLASS_MAX_LEN = 64
+
+# Closed vocabulary for WHY a structured call produced no schema-valid JSON.
+# Values are short by construction so `LLMStructuredOutputError:<reason>` fits
+# the column with room to spare, and stable so the ledger can be grouped on
+# them. NEVER put model text in here — see _structured_failure_reason.
+STRUCTURED_FAILURE_NO_CANDIDATES = "NO_CANDIDATES"
+STRUCTURED_FAILURE_MAX_TOKENS = "MAX_TOKENS"
+STRUCTURED_FAILURE_EMPTY_TEXT = "EMPTY_TEXT"
+STRUCTURED_FAILURE_INVALID_JSON = "INVALID_JSON"
+STRUCTURED_FAILURE_BLOCKED_PREFIX = "BLOCKED_"
+
+
+def _enum_name(value: object) -> str:
+    """Best-effort short name for an SDK enum, int, or string.
+
+    google-genai returns `FinishReason.MAX_TOKENS` (an enum with `.name`), but
+    older/proto paths hand back a bare int or the fully-qualified `str()`.
+    Normalise all three so the ledger groups on one spelling.
+    """
+    if value is None:
+        return ""
+    name = getattr(value, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    text = str(value)
+    # `FinishReason.MAX_TOKENS` -> `MAX_TOKENS`; a bare int stays as-is.
+    return text.rsplit(".", 1)[-1]
+
+
+def _clamp_error_class(value: str) -> str:
+    """Keep a composed error_class inside the column. See ERROR_CLASS_MAX_LEN."""
+    return value[:ERROR_CLASS_MAX_LEN]
+
+
+def _structured_failure_reason(response: object, raw_text: str) -> str:
+    """Name why a structured call yielded nothing schema-valid.
+
+    Three causes arrive at the ledger indistinguishable today — the model was
+    safety-blocked, it hit `max_output_tokens` mid-thought, or it emitted text
+    that simply is not valid JSON — and they want three different fixes. The
+    ledger recorded only `LLMStructuredOutputError` for all of them, which is
+    why 10 live verifier failures over 7 days could not be attributed.
+
+    PII boundary (UU PDP / SYMBIOSIS Law 2, the same rule the verifier's own
+    except-block already follows): this returns ONLY enum names off the
+    response envelope. The model's text and the pydantic ValidationError —
+    both of which can echo client PII back out of the prompt — never enter
+    the returned string, and `raw_text` is inspected for emptiness only.
+    """
+    candidates = getattr(response, "candidates", None) or []
+
+    # A prompt-level block has no candidates at all; the reason lives on
+    # prompt_feedback instead, so read it before giving up on the envelope.
+    if not candidates:
+        feedback = getattr(response, "prompt_feedback", None)
+        block = getattr(feedback, "block_reason", None) if feedback else None
+        if block is not None:
+            return f"{STRUCTURED_FAILURE_BLOCKED_PREFIX}{_enum_name(block)}"
+        return STRUCTURED_FAILURE_NO_CANDIDATES
+
+    finish = _enum_name(getattr(candidates[0], "finish_reason", None))
+
+    # An abnormal termination outranks whatever text survived it. A response
+    # cut off by MAX_TOKENS or SAFETY often carries a PARTIAL answer, and
+    # partial JSON never validates — reading that stub as INVALID_JSON would
+    # name the symptom (bad shape) and bury the cause (it was cut off).
+    if finish == "MAX_TOKENS":
+        return STRUCTURED_FAILURE_MAX_TOKENS
+    # STOP with no text is not a block — it is an empty answer, and saying
+    # "BLOCKED_STOP" would invent a cause. Only non-STOP terminations name one.
+    if finish and finish not in {"STOP", "UNSPECIFIED", "FINISH_REASON_UNSPECIFIED"}:
+        return f"{STRUCTURED_FAILURE_BLOCKED_PREFIX}{finish}"
+
+    # Normal termination: the model answered and the answer was the wrong
+    # shape. Distinct from an empty envelope, and it wants a prompt/schema fix
+    # rather than a cap or safety fix.
+    if raw_text.strip():
+        return STRUCTURED_FAILURE_INVALID_JSON
+    return STRUCTURED_FAILURE_EMPTY_TEXT
 
 
 # Try to import new SDK
@@ -541,6 +639,11 @@ class GenAIClient:
 
         attempt_prompt: str | list = contents
         last_validation_err: ValidationError | None = None
+        # Bound before the loop so the failure path can attribute a cause even
+        # if the loop body never runs (max_retries < 0). A None response reads
+        # as NO_CANDIDATES, which is honest rather than a NameError.
+        response: Any = None
+        raw_text = ""
 
         t0 = time.perf_counter()
         prompt_tokens = 0
@@ -614,10 +717,30 @@ class GenAIClient:
                             else [contents, {"role": "user", "parts": [{"text": feedback}]}]
                         )
 
-            error_class = "LLMStructuredOutputError"
+            # Name the cause in the ledger, not just the symptom. `response`
+            # and `raw_text` are the LAST attempt's — the terminal state is the
+            # one worth attributing. Enum names only; see
+            # _structured_failure_reason for the PII boundary.
+            failure_reason = _structured_failure_reason(response, raw_text)
+            error_class = _clamp_error_class(f"LLMStructuredOutputError:{failure_reason}")
+            logger.warning(
+                "LLM structured call failed to validate",
+                extra={
+                    "provider": "gemini",
+                    "model": model,
+                    "schema": response_schema.__name__,
+                    "reason": failure_reason,
+                    "attempts": max_retries + 1,
+                    "completion_tokens": completion_tokens,
+                    "thinking_tokens": thinking_tokens,
+                    "max_output_tokens": max_output_tokens,
+                },
+            )
             raise LLMStructuredOutputError(
                 f"Model failed to produce {response_schema.__name__}-valid JSON "
-                f"after {max_retries + 1} attempt(s): {last_validation_err}"
+                f"after {max_retries + 1} attempt(s) [{failure_reason}]: "
+                f"{last_validation_err}",
+                reason=failure_reason,
             )
         except LLMStructuredOutputError:
             raise

--- a/apps/backend-rag/backend/services/rag/verification_service.py
+++ b/apps/backend-rag/backend/services/rag/verification_service.py
@@ -216,7 +216,7 @@ Return a JSON object with this exact structure:
                 max_output_tokens=2048,
                 endpoint="rag.verifier",
             )
-        except LLMStructuredOutputError:
+        except LLMStructuredOutputError as exc:
             # PII boundary (round-2 red-team fix, Codex — UU PDP /
             # SYMBIOSIS Law 2 is ABSOLUTE): LLMStructuredOutputError's
             # message embeds pydantic ValidationError's str(), which
@@ -224,9 +224,16 @@ Return a JSON object with this exact structure:
             # which can itself echo client PII from the verifier prompt
             # (draft_answer/context_chunks). Never log or store the raw
             # exception text.
+            #
+            # `.reason` is the closed-vocabulary cause carried out of band
+            # precisely so this line can say WHICH failure happened without
+            # crossing that boundary. Before it existed, every cause — safety
+            # block, output cap, malformed JSON — logged this same sentence,
+            # and 10 live failures over 7 days could not be told apart.
             logger.warning(
                 "🛡️ [Verifier] Model failed to produce a schema-valid verdict "
-                "— verdict unavailable",
+                "— verdict unavailable (reason=%s)",
+                getattr(exc, "reason", "") or "UNATTRIBUTED",
             )
             return VerificationResult(
                 is_valid=True,

--- a/apps/backend-rag/backend/tests/unit/llm/test_structured_failure_attribution.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_structured_failure_attribution.py
@@ -1,0 +1,193 @@
+"""A structured-output failure must name its own cause.
+
+Three different failures — the model was safety-blocked, it hit
+`max_output_tokens` mid-thought, or it answered in the wrong shape — arrived
+at `llm_cost_events` as the same string, `LLMStructuredOutputError`. Ten live
+verifier failures over seven days could not be told apart, and each of the
+three wants a different fix (loosen the cap / change the prompt / fix the
+schema).
+
+Guilt: every vocabulary member is reachable from a response that really has
+that shape. Innocence: the two ways to invent a cause — calling a normal empty
+answer a block, and calling a cut-off partial answer bad JSON — both stay shut.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.llm.genai_client import (
+    ERROR_CLASS_MAX_LEN,
+    LLMStructuredOutputError,
+    _clamp_error_class,
+    _enum_name,
+    _structured_failure_reason,
+)
+
+
+class _Enum:
+    """Stand-in for google-genai's FinishReason: has `.name`, str() is dotted."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"FinishReason.{self.name}"
+
+
+def _response(finish: object = None, *, feedback: object = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(finish_reason=finish)],
+        prompt_feedback=feedback,
+    )
+
+
+class TestGuilt:
+    """Each cause is reachable from a response that genuinely has it."""
+
+    def test_cap_bound_the_model_midthought(self):
+        assert _structured_failure_reason(_response(_Enum("MAX_TOKENS")), "") == "MAX_TOKENS"
+
+    def test_safety_block_is_named_as_a_block(self):
+        assert _structured_failure_reason(_response(_Enum("SAFETY")), "") == "BLOCKED_SAFETY"
+
+    def test_recitation_block_is_named_as_a_block(self):
+        got = _structured_failure_reason(_response(_Enum("RECITATION")), "")
+        assert got == "BLOCKED_RECITATION"
+
+    def test_prompt_level_block_has_no_candidates_at_all(self):
+        # A prompt rejected before generation carries its reason on
+        # prompt_feedback; there is no candidate to read a finish_reason off.
+        resp = SimpleNamespace(
+            candidates=[],
+            prompt_feedback=SimpleNamespace(block_reason=_Enum("PROHIBITED_CONTENT")),
+        )
+        assert _structured_failure_reason(resp, "") == "BLOCKED_PROHIBITED_CONTENT"
+
+    def test_empty_envelope_with_no_explanation_says_so(self):
+        resp = SimpleNamespace(candidates=[], prompt_feedback=None)
+        assert _structured_failure_reason(resp, "") == "NO_CANDIDATES"
+
+    def test_a_normal_answer_in_the_wrong_shape_is_invalid_json(self):
+        got = _structured_failure_reason(_response(_Enum("STOP")), "not json at all")
+        assert got == "INVALID_JSON"
+
+    def test_a_normal_termination_with_nothing_in_it_is_empty_text(self):
+        assert _structured_failure_reason(_response(_Enum("STOP")), "") == "EMPTY_TEXT"
+
+
+class TestInnocence:
+    """The two ways to invent a cause stay shut."""
+
+    def test_a_normal_empty_answer_is_never_reported_as_a_block(self):
+        # STOP means the model finished on its own. Emitting "BLOCKED_STOP"
+        # would send whoever reads the ledger hunting a safety filter that
+        # never fired.
+        for finish in (_Enum("STOP"), None, _Enum("FINISH_REASON_UNSPECIFIED")):
+            got = _structured_failure_reason(_response(finish), "")
+            assert not got.startswith("BLOCKED_"), f"{finish} was called a block"
+
+    def test_a_cutoff_partial_answer_blames_the_cutoff_not_the_shape(self):
+        # MAX_TOKENS and SAFETY both leave a partial answer behind, and partial
+        # JSON never validates. Reading that stub as INVALID_JSON would name
+        # the symptom and bury the cause.
+        partial = '{"reasoning": "the draft claims that'
+        assert _structured_failure_reason(_response(_Enum("MAX_TOKENS")), partial) == "MAX_TOKENS"
+        assert _structured_failure_reason(_response(_Enum("SAFETY")), partial) == "BLOCKED_SAFETY"
+
+    def test_whitespace_only_text_is_not_an_answer(self):
+        assert _structured_failure_reason(_response(_Enum("STOP")), "   \n\t ") == "EMPTY_TEXT"
+
+
+class TestPIIBoundary:
+    """UU PDP / SYMBIOSIS Law 2: the model's text never enters the cause."""
+
+    # These use a synthetic sentinel rather than a realistic tax/passport
+    # number on purpose. A convincing fake would trip the repo's own Law-2
+    # pre-commit gate — and the gate is right: a fixture is exactly where a
+    # real one eventually gets pasted. The sentinel proves the same property,
+    # which is that NOTHING from the model text reaches the reason.
+    LEAKY = "CLIENT_TEXT_SENTINEL_MUST_NOT_APPEAR"
+
+    def test_model_text_never_leaks_into_the_reason(self):
+        # The verifier prompt carries client questions and retrieved context,
+        # so the model's echo of it can carry PII. The reason is the one part
+        # of the failure that IS logged, so it must be enum-only.
+        for finish in (_Enum("STOP"), _Enum("MAX_TOKENS"), _Enum("SAFETY"), None):
+            got = _structured_failure_reason(_response(finish), self.LEAKY)
+            assert self.LEAKY not in got
+            # Stronger than a substring check: the whole vocabulary is known,
+            # so anything outside it is a leak we have not thought of.
+            assert got in {
+                "MAX_TOKENS",
+                "EMPTY_TEXT",
+                "INVALID_JSON",
+                "NO_CANDIDATES",
+            } or got.startswith("BLOCKED_")
+
+    def test_the_reason_rides_outside_the_message(self):
+        # The message embeds pydantic's ValidationError (input_value=... can
+        # echo PII), which is why verification_service refuses to log str(exc).
+        # `.reason` exists so the caller can name the cause anyway.
+        exc = LLMStructuredOutputError(
+            f"…input_value='{self.LEAKY}'…", reason="MAX_TOKENS"
+        )
+        assert exc.reason == "MAX_TOKENS"
+        assert self.LEAKY not in exc.reason
+        # …and the unsafe text really is still in the message, so this test
+        # would notice if the message stopped being the dangerous one.
+        assert self.LEAKY in str(exc)
+
+    def test_reason_defaults_to_empty_for_callers_that_do_not_set_it(self):
+        assert LLMStructuredOutputError("boom").reason == ""
+
+
+class TestLedgerFit:
+    """`llm_cost_events.error_class` is varchar(64) and the recorder isolates
+    its sinks: an over-long value raises only on the Postgres write. That
+    would drop exactly the failure rows and make the failure rate read ZERO —
+    a diagnostic that hides what it diagnoses."""
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "MAX_TOKENS",
+            "EMPTY_TEXT",
+            "INVALID_JSON",
+            "NO_CANDIDATES",
+            "BLOCKED_SAFETY",
+            "BLOCKED_RECITATION",
+            "BLOCKED_PROHIBITED_CONTENT",
+            "BLOCKED_SPII",
+            "BLOCKED_MALFORMED_FUNCTION_CALL",
+        ],
+    )
+    def test_every_composed_error_class_fits_the_column(self, reason):
+        composed = _clamp_error_class(f"LLMStructuredOutputError:{reason}")
+        assert len(composed) <= ERROR_CLASS_MAX_LEN
+        # …and is not clamped into ambiguity: the cause must survive intact,
+        # otherwise two different failures group together in the ledger.
+        assert composed.endswith(reason), f"{reason} was truncated to {composed!r}"
+
+    def test_an_unknown_future_enum_is_clamped_rather_than_dropping_the_row(self):
+        # A future SDK enum longer than the column is the case the clamp exists
+        # for. Losing the cause is acceptable; losing the row is not.
+        absurd = _clamp_error_class("LLMStructuredOutputError:BLOCKED_" + "X" * 200)
+        assert len(absurd) == ERROR_CLASS_MAX_LEN
+
+
+class TestEnumNormalisation:
+    """google-genai hands back an enum, a bare int, or a dotted string
+    depending on the path. The ledger must group on one spelling."""
+
+    def test_enum_with_name(self):
+        assert _enum_name(_Enum("MAX_TOKENS")) == "MAX_TOKENS"
+
+    def test_dotted_string(self):
+        assert _enum_name("FinishReason.SAFETY") == "SAFETY"
+
+    def test_bare_int_survives_as_itself(self):
+        assert _enum_name(3) == "3"
+
+    def test_none_is_empty(self):
+        assert _enum_name(None) == ""


### PR DESCRIPTION
## What

When `generate_structured()` gives up, the ledger recorded `LLMStructuredOutputError` and nothing else. Every failure looked identical, so the 22% verifier failure rate could not be split into "the cap truncated it", "the model returned no candidates", "safety blocked it" or "the JSON was malformed" — four causes with four different cures, filed under one name.

`_structured_failure_reason()` now classifies the response into a **closed vocabulary**: `NO_CANDIDATES` · `MAX_TOKENS` · `BLOCKED_<reason>` · `INVALID_JSON` · `EMPTY_TEXT`, and the reason rides on `error_class` as `LLMStructuredOutputError:<REASON>`.

## Two things that are load-bearing and easy to undo by accident

**The reason travels out of band of the message.** `LLMStructuredOutputError` gained a keyword-only `reason`; the message still embeds pydantic's `ValidationError`, whose `input_value=...` can echo the client's own text. `verification_service.py` therefore logs `getattr(exc, "reason", "") or "UNATTRIBUTED"` and **never** `str(exc)`. If a future change logs the message, this becomes a PII leak — the type-only logging there is deliberate, not laziness.

**Ordering in the classifier is the classification.** An abnormal termination outranks partial text: no candidates → `BLOCKED_<block_reason>`/`NO_CANDIDATES`; `MAX_TOKENS` → `MAX_TOKENS`; any non-`STOP` finish → `BLOCKED_<finish>`; only then does text presence decide `INVALID_JSON` vs `EMPTY_TEXT`. Reordering so that "text is present" wins would blame malformed JSON for every truncation — the exact confusion this PR exists to end.

**`error_class` is `varchar(64)`.** `_clamp_error_class()` bounds it, and this is not cosmetic: `LLMCostRecorder.record` isolates its sinks, so an over-long value drops only the Postgres row. That row is a failure row — the failure rate would read **zero** while failures continued.

## Tests

27 in `test_structured_failure_attribution.py`: guilt per vocabulary member; innocence (a `STOP` with empty text is never reported as a block; a cut-off partial blames the cutoff, not the JSON); a PII boundary test that puts a sentinel in the validation error and asserts it appears in **no** field of the closed vocabulary; ledger-fit; enum/int/dotted-string normalisation. Mutation-verified 4/4 — each cure disabled turns the corpus red.

## Scope

Diagnostic only. No retry, backoff, threshold or gate is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)