### PR TITLE
fix(ci): vercel should-build guard — URL fallback when the build container has no origin remote

### DIFF
--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -72,6 +72,7 @@ REF="${VERCEL_GIT_COMMIT_REF:-}"
 BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
 
 log() { printf 'should-build: %s\n' "$1" >&2; }
+one_line() { printf '%s' "$1" | tr '\n' ' ' | cut -c1-200; }
 
 if [ -z "$BASE" ]; then
   # No previous deployment on this ref — this is the case that matters. Measured on the real
@@ -117,19 +118,42 @@ if [ -z "$BASE" ]; then
   fi
 
   # (3) Only now pay for the network — and keep the error, which is the whole point.
+  #
+  # The named remote is tried first, but it is NOT how this resolves on Vercel: measured live
+  # on 2026-08-10 (deployment C1BqEsSc…, branch agent/air-m5/ops/tg-senders-batch2), the build
+  # container's clone has no usable `origin` at all —
+  #     fatal: 'origin' does not appear to be a git repository
+  # — so every first deployment fell through to fail-open and bought a full 1,755-page build:
+  # the exact 89%-of-waste case this block exists to close, inert for a second reason after
+  # the 2026-07-30 rework fixed the first. The cure is to fetch the production branch straight
+  # from the repository URL that Vercel itself advertises in the build env
+  # (VERCEL_GIT_REPO_OWNER/SLUG; the repo is public, an anonymous fetch suffices).
+  # SHOULD_BUILD_FETCH_URL overrides the constructed URL — test seam and emergency lever.
+  # Every failure still exits 1 (BUILD), with each attempt's actual error named.
   if [ -z "$BASE" ]; then
+    fetched=
     if fetch_err=$(git fetch --no-tags --depth=200 origin "$PROD_BRANCH" 2>&1); then
-      if BASE=$(git merge-base FETCH_HEAD HEAD 2>/dev/null) && [ -n "$BASE" ]; then
-        log "fetched $PROD_BRANCH -> merge-base ${BASE:0:9}"
-      else
-        BASE=
-        log "fetched $PROD_BRANCH but no merge-base (shallow clone?) -> BUILD (fail-open)"
+      fetched=origin
+    else
+      FETCH_URL="${SHOULD_BUILD_FETCH_URL:-}"
+      if [ -z "$FETCH_URL" ] && [ -n "${VERCEL_GIT_REPO_OWNER:-}" ] && [ -n "${VERCEL_GIT_REPO_SLUG:-}" ]; then
+        FETCH_URL="https://github.com/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}.git"
+      fi
+      if [ -z "$FETCH_URL" ]; then
+        log "cannot fetch $PROD_BRANCH (no origin, no repo env to build a URL) -> BUILD (fail-open). git said: $(one_line "$fetch_err")"
         exit 1
       fi
+      if url_err=$(git fetch --no-tags --depth=200 "$FETCH_URL" "$PROD_BRANCH" 2>&1); then
+        fetched=$FETCH_URL
+      else
+        log "cannot fetch $PROD_BRANCH from origin or URL -> BUILD (fail-open). origin: $(one_line "$fetch_err") | url: $(one_line "$url_err")"
+        exit 1
+      fi
+    fi
+    if BASE=$(git merge-base FETCH_HEAD HEAD 2>/dev/null) && [ -n "$BASE" ]; then
+      log "fetched $PROD_BRANCH from $fetched -> merge-base ${BASE:0:9}"
     else
-      # One line, truncated: enough to diagnose auth vs network vs missing remote, without
-      # dumping a wall of git output into every build log.
-      log "cannot fetch $PROD_BRANCH -> BUILD (fail-open). git said: $(printf '%s' "$fetch_err" | tr '\n' ' ' | cut -c1-200)"
+      log "fetched $PROD_BRANCH from $fetched but no merge-base (shallow clone?) -> BUILD (fail-open)"
       exit 1
     fi
   fi

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -188,6 +188,32 @@ VERCEL_GIT_COMMIT_REF=docs/ledger VERCEL_GIT_PREVIOUS_SHA="$PREV" \
   run BUILD "second deploy, frontend delta"
 
 echo
+echo "=== NO-ORIGIN CONTAINER: Vercel's clone has no usable origin at all (measured 2026-08-10)"
+# The live failure was not an unreachable origin but a MISSING one: `fatal: 'origin' does not
+# appear to be a git repository` on every first deployment, so the fail-open bought a full
+# build each time. These cases delete the remote AND the tracking ref, so a SKIP can only come
+# from the URL-fallback fetch (SHOULD_BUILD_FETCH_URL stands in for the constructed GitHub URL).
+git -C "$WORK" checkout -q -b docs/noorigin main
+commit "research/operations/no-origin-note.md" "docs only, container without origin"
+git -C "$WORK" update-ref -d refs/remotes/origin/main
+git -C "$WORK" remote remove origin
+VERCEL_GIT_COMMIT_REF=docs/noorigin VERCEL_GIT_PREVIOUS_SHA= SHOULD_BUILD_FETCH_URL="$UPSTREAM" \
+  run SKIP "no origin remote, URL fallback resolves -> docs-only skips"
+
+git -C "$WORK" checkout -q -b feat/noorigin main
+commit "apps/mouth/app/no-origin.tsx" "frontend, container without origin"
+VERCEL_GIT_COMMIT_REF=feat/noorigin VERCEL_GIT_PREVIOUS_SHA= SHOULD_BUILD_FETCH_URL="$UPSTREAM" \
+  run BUILD "no origin remote, URL fallback resolves, frontend delta (guilt)"
+
+git -C "$WORK" checkout -q -b docs/nourl main
+commit "docs/no-url.md" "docs only, and nothing fetchable at all"
+VERCEL_GIT_COMMIT_REF=docs/nourl VERCEL_GIT_PREVIOUS_SHA= SHOULD_BUILD_FETCH_URL="$ROOT/does-not-exist.git" \
+  run BUILD "no origin remote and dead URL -> BUILD (fail-open)"
+
+git -C "$WORK" remote add origin "$UPSTREAM"
+git -C "$WORK" fetch -q origin main:refs/remotes/origin/main
+
+echo
 echo "=== THE EXIT CONTRACT: nothing may leave this script with a status other than 0 or 1"
 # Vercel reads exit 0 as skip and exit 1 as build. Every OTHER status fails the deployment
 # outright — which is what happened on 2026-07-29, 9 deployments in ERROR, because a missing


### PR DESCRIPTION
## Summary
- The Vercel Ignored Build Step guard (`scripts/ci/vercel_should_build.sh`) existed but was INERT in production: the build container's clone has **no usable `origin` remote** (measured: `fatal: 'origin' does not appear to be a git repository`), so path (3) `git fetch origin` always failed → every deployment fell open to BUILD → ~\$153/cycle of build CPU on non-frontend branches. Family #2 (esiste≠armato) at second depth: the guard ran, and could never say SKIP.
- Fix: when `git fetch origin` fails, fall back to fetching main via an explicit URL constructed from `VERCEL_GIT_REPO_OWNER`/`VERCEL_GIT_REPO_SLUG` (override seam `SHOULD_BUILD_FETCH_URL` for tests + emergencies). Every failure path still exits 1 (BUILD) with the attempt's error named — fail-open direction unchanged (exit 0=SKIP, 1=BUILD, anything else=deployment error).

## Verification
- Corpus extended with a NO-ORIGIN CONTAINER block (remote AND tracking ref deleted so SKIP can only come from the URL fallback): guilt (frontend delta → BUILD), innocence (docs-only → SKIP), fail-open (dead URL → BUILD). **27/27 pass.**
- Mutation check: `FETCH_URL=""` → exactly the new SKIP case fails (26/1) — the fallback is load-bearing, not decorative.

## Post-merge PROVE-LIVE (owned by this session)
Read a real Vercel build log of a non-frontend branch containing this commit: must show `fetched main from https://github.com/...` + the SKIP verdict (CANCELED deployment). Reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)