### PR TITLE
chore(ci): surface pytest per-test durations — backend-growth triage (round-3 L3)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -296,18 +296,33 @@ jobs:
           REDIS_URL: redis://localhost:6379
         run: |
           cd apps/backend-rag
+          set -o pipefail
           PYTHONPATH=.:../crm-cell pytest \
             backend/tests/ \
             tests/test_sentry_lazy_import.py \
             tests/test_sentry_pii_redaction.py \
             tests/kb/test_politics_hierarchical.py \
-            -q -ra --no-header --durations=10 \
+            -q -ra --no-header --durations=50 \
             --ignore=backend/tests/e2e \
             --cov=backend \
             --cov-branch \
             --cov-report=xml:coverage.xml \
             --junit-xml=test-results-unit.xml \
-            --tb=short -x
+            --tb=short -x 2>&1 | tee pytest-output.log
+          PYTEST_RC=$?
+          # Measurement-only (round-3 queue-acceleration plan, L3): the
+          # "Run unit tests" step is the confirmed grown step (July→August
+          # median +5.4min). --durations=50 (was 10) + this summary tail
+          # surfaces the slowest tests directly in the run's Job Summary
+          # so the next lever can be picked with evidence, without a
+          # separate artifact download. No test selection/step is changed.
+          {
+            echo '## Slowest test durations (top 50)'
+            echo '```'
+            awk '/slowest durations/,0' pytest-output.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$PYTEST_RC"
 
       - name: Check coverage threshold
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -308,18 +308,33 @@ jobs:
             --cov-branch \
             --cov-report=xml:coverage.xml \
             --junit-xml=test-results-unit.xml \
-            --tb=short -x 2>&1 | tee pytest-output.log
-          PYTEST_RC=$?
+            --tb=short -x 2>&1 | tee pytest-output.log || PYTEST_RC=$?
           # Measurement-only (round-3 queue-acceleration plan, L3): the
           # "Run unit tests" step is the confirmed grown step (July→August
           # median +5.4min). --durations=50 (was 10) + this summary tail
           # surfaces the slowest tests directly in the run's Job Summary
           # so the next lever can be picked with evidence, without a
           # separate artifact download. No test selection/step is changed.
+          #
+          # errexit-immune capture (house W101 antidote): `run:` steps
+          # execute under `bash -e`. A bare `PYTEST_RC=$?` on the line
+          # right after a failing pipe is dead code — errexit aborts the
+          # script ON that failing pipeline before the next line ever
+          # runs, so the RC capture, the summary tail, and the final
+          # `exit` would all be skipped on exactly the red runs where the
+          # durations are wanted most (proven locally: a failing pytest
+          # under `bash -e -c` never reaches the line after the pipe).
+          # `|| PYTEST_RC=$?` keeps errexit from tripping on the pipeline
+          # itself; `set -o pipefail` (kept, above) still makes tee's own
+          # rc=0 not mask a red suite. `awk` pattern tolerates the count
+          # pytest sandwiches into the header (`slowest 50 durations`,
+          # not `slowest durations`) — verified against real pytest
+          # --durations=50 output.
+          PYTEST_RC=${PYTEST_RC:-0}
           {
             echo '## Slowest test durations (top 50)'
             echo '```'
-            awk '/slowest durations/,0' pytest-output.log
+            awk '/slowest [0-9]+ durations|slowest durations/,0' pytest-output.log
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$PYTEST_RC"


### PR DESCRIPTION
## Summary
- Backend Tests grew 18→25.7 min median in 3.5 weeks. Measured per-step across 16 real runs (July vs August cohorts): the growth is ENTIRELY inside the pytest step (+5.4 min; every other step flat ±6s). Measurement-only PR: no step removed/reordered/conditioned.
- `--durations=10` → `--durations=50`, and the slowest-durations block is tailed into `$GITHUB_STEP_SUMMARY` so the next lever (attacking named slow tests) is picked with evidence.

## Hardening (review round, 2 findings fixed in the follow-up commit)
- awk pattern tolerates the count pytest sandwiches into the header (`slowest 50 durations`) — the naive pattern extracted NOTHING; proven against real pytest output, both pass and fail cases.
- errexit-immune RC capture (`|| PYTEST_RC=$?`, W101 antidote): the durations summary now lands even on red runs — precisely where it's most wanted — while pipefail still keeps tee's rc from masking a red suite.

## Explicitly rejected
- xdist/sharding as the fix: measured non-lever (1.16× at -n8 on 14 cores; CI has 4 vCPU — 2026-07-17 investigation). The durations data this PR produces is the input for the real lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)