### PR TITLE
docs: sync onboarding test count

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 693 services · 1323 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 693 services · 1324 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary

- regenerate `docs/AI_ONBOARDING.md` with the sanctioned `scripts/docs_sync.py` compiler
- update the backend test-file count from 1323 to 1324 after PR #3954 adds one evaluator regression file
- keep this child docs-only and stacked directly on #3954

## Verification

- `python scripts/docs_sync.py --check`
- full normal pre-push backend suite
- normal pre-commit and pre-push hooks
- `git diff --check`

Parent: #3954