### PR TITLE
fix(rag): the bot never told an English speaker which language to answer in

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
@@ -9,6 +9,7 @@ Contains:
 """
 
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -50,41 +51,153 @@ RECALL_TRIGGERS = [
     "yang kita bahas",
 ]
 
-# Indonesian language markers for detection
+# Indonesian language markers for detection.
+#
+# MATCHED AS WHOLE WORDS, never as bare substrings (see INDONESIAN_MARKER_RE below).
+# Measured 2026-08-10 on the real inbound WhatsApp corpus (188 messages) plus a
+# 20-question English domain corpus: the previous `marker in query_lower` scan
+# misclassified 11 of those 20 plain-English questions as Indonesian, because
+# "st(anda)rd", "m(anda)tory", "va(lu)e", "so(lu)tion", "inc(lu)de", "J(apa)n"
+# and "cap(a)city" all embed a marker mid-word. An English speaker so classified
+# is routed down the Indonesian branch and therefore receives NO language
+# instruction at all — one of the two paths to the observed reply-language drift.
 INDONESIAN_MARKERS = [
-    "apa",
-    "bagaimana",
-    "siapa",
-    "dimana",
-    "kapan",
-    "mengapa",
-    "yang",
-    "dengan",
-    "untuk",
-    "dari",
-    "saya",
+    "ada",
     "aku",
-    "kamu",
     "anda",
+    "apa",
+    "atau",
+    "bagaimana",
+    "banget",
+    "beberapa",
+    "belum",
+    "berapa",
+    "biaya",
     "bisa",
-    "mau",
-    "ingin",
-    "perlu",
-    "tolong",
-    "halo",
-    "selamat",
-    "terima kasih",
+    "boleh",
+    "buat",
+    "bulan",
+    "dari",
+    "dengan",
+    "dimana",
+    "dong",
+    "gak",
     "gimana",
     "gue",
     "gw",
-    "lu",
-    "dong",
-    "nih",
-    "banget",
+    "hari",
+    "harga",
+    "ingin",
+    "izin",
+    "jelas",
+    "jelaskan",
+    "juga",
+    "kalau",
+    "kalo",
+    "kamu",
+    "kapan",
+    "keluar",
+    "kena",
+    "kenapa",
     "keren",
+    "lagi",
+    "lu",
     "mantap",
-    "boleh",
+    "masih",
+    "mau",
+    "mengapa",
+    "mohon",
+    "nggak",
+    "nih",
+    "pajak",
+    "perlu",
+    "punya",
+    "sama",
+    "saya",
+    "selamat",
+    "siapa",
+    "sudah",
+    "tahun",
+    "terima kasih",
+    "tidak",
+    "tolong",
+    "untuk",
+    "urus",
+    "yang",
 ]
+
+# Indonesian is agglutinative on the right: "apa" legitimately appears as
+# "apakah", "harga" as "harganya", "bisa" as "bisalah". A plain \b…\b match
+# would therefore be an UNDER-match twin of the over-match it fixes — measured:
+# on the same 188-message corpus a bare word-boundary matcher LOST 12 genuine
+# Indonesian messages, 11 of them on "berapa" ("how much", i.e. the pricing
+# question). Allowing the enclitic suffixes keeps those while still refusing
+# any marker that merely sits inside a longer stem.
+_INDONESIAN_ENCLITICS = r"(?:kah|nya|lah|pun|ku|mu)?"
+
+
+def _whole_word_matcher(markers: list[str], suffix: str = "") -> re.Pattern[str]:
+    """Compile markers so they match as WORDS, never inside a longer stem."""
+    alternation = "|".join(re.escape(m) for m in sorted(markers, key=len, reverse=True))
+    return re.compile(rf"\b(?:{alternation}){suffix}\b")
+
+
+INDONESIAN_MARKER_RE = _whole_word_matcher(INDONESIAN_MARKERS, _INDONESIAN_ENCLITICS)
+
+# The same bare-substring defect lived in every Latin-script branch, and it is
+# not theoretical: "in(come) tax" reads as ITALIAN and "com(merci)al licence" as
+# FRENCH. The team beta test of 2026-07-28 recorded two English questions
+# answered wholly in Italian with correct content — this is a mechanism that
+# produces exactly that.
+#
+# Whole-word matching alone is not enough here, because two markers are also
+# ordinary ENGLISH words: Italian "come" and French "comment". A single one of
+# those is a coincidence, not a language — so they are HOMOGRAPHS and never
+# decide on their own; they only reinforce a language already named by a
+# decisive marker. To keep the recall that "come"/"comment" used to carry
+# ("come funziona…", "comment ça marche"), the decisive lists are widened with
+# the function words a real question in that language brings along.
+#
+# Order is preserved from the original (Italian → French → Spanish → German) so
+# that a query these lists genuinely disagree on resolves as it did before.
+_LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
+    (
+        "ITALIAN",
+        # Decisive — none of these is an English word. "non" is deliberately
+        # absent: \b makes it match "non-resident" / "non-profit", which this
+        # domain says constantly.
+        # "una" is deliberately absent: it is Italian AND Spanish, and Italian is
+        # tested first, so it would answer a Spanish question in Italian. A marker
+        # shared by two candidate languages decides neither.
+        ["ciao", "cosa", "voglio", "posso", "grazie", "perché", "quanto", "quale",
+         "quali", "sono", "della", "vorrei", "devo", "per favore", "il",
+         "che", "anche", "gli", "funziona", "essere"],
+        ["come"],  # homograph: English "come"
+    ),
+    (
+        "FRENCH",
+        ["bonjour", "pourquoi", "merci", "s'il vous", "combien", "quel", "quelle",
+         "est-ce", "vous", "je", "ça", "c'est", "votre", "nous", "faut", "avec",
+         "dans", "être"],
+        ["comment"],  # homograph: English "comment"
+    ),
+    ("SPANISH", ["hola", "cómo", "como estas", "gracias", "por qué"], []),
+    ("GERMAN", ["hallo", "wie geht", "danke", "warum", "können"], []),
+]
+
+LATIN_MARKER_RES: list[tuple[str, re.Pattern[str]]] = [
+    (language, _whole_word_matcher(decisive)) for language, decisive, _homographs in _LATIN_MARKERS
+]
+_BY_LANGUAGE = dict(LATIN_MARKER_RES)
+ITALIAN_MARKER_RE = _BY_LANGUAGE["ITALIAN"]
+FRENCH_MARKER_RE = _BY_LANGUAGE["FRENCH"]
+SPANISH_MARKER_RE = _BY_LANGUAGE["SPANISH"]
+GERMAN_MARKER_RE = _BY_LANGUAGE["GERMAN"]
+
+# Kept reachable so a test can assert these never decide alone.
+LATIN_HOMOGRAPHS: dict[str, list[str]] = {
+    language: homographs for language, _decisive, homographs in _LATIN_MARKERS if homographs
+}
 
 # Model Tiers
 TIER_FLASH = 0
@@ -110,9 +223,8 @@ def detect_query_language(query: str) -> str:
 
     query_lower = query.lower()
 
-    # Check Indonesian first
-    indo_count = sum(1 for marker in INDONESIAN_MARKERS if marker in query_lower)
-    if indo_count >= 1:
+    # Check Indonesian first — WHOLE WORDS (+ enclitics) only, never substrings.
+    if INDONESIAN_MARKER_RE.search(query_lower):
         return "INDONESIAN"
 
     # Chinese detection (contains Chinese characters)
@@ -129,28 +241,53 @@ def detect_query_language(query: str) -> str:
             return "UKRAINIAN"
         return "RUSSIAN"
 
-    # Italian
-    if any(
-        word in query_lower
-        for word in ["ciao", "come", "cosa", "voglio", "posso", "grazie", "perché"]
-    ):
+    # Latin-script markers, WHOLE WORDS only — see _LATIN_MARKERS for why.
+    #
+    # Written as literal returns on purpose, NOT as a loop over LATIN_MARKER_RES:
+    # `test_reasoning_stubs_language_coverage` derives the set of languages this
+    # function can emit by walking its AST for returned string constants, so that
+    # a new language cannot be added without either a translated stub or an
+    # explicit declaration. A loop returning a variable makes those four
+    # languages invisible to that guard — and it passes, quietly covering less.
+    if ITALIAN_MARKER_RE.search(query_lower):
         return "ITALIAN"
 
-    # French
-    if any(
-        word in query_lower for word in ["bonjour", "comment", "pourquoi", "merci", "s'il vous"]
-    ):
+    if FRENCH_MARKER_RE.search(query_lower):
         return "FRENCH"
 
-    # Spanish
-    if any(word in query_lower for word in ["hola", "cómo", "como estas", "gracias", "por qué"]):
+    if SPANISH_MARKER_RE.search(query_lower):
         return "SPANISH"
 
-    # German
-    if any(word in query_lower for word in ["hallo", "wie geht", "danke", "warum", "können"]):
+    if GERMAN_MARKER_RE.search(query_lower):
         return "GERMAN"
 
     return "ENGLISH"  # Default to English
+
+
+# How each detector verdict is NAMED back to the model.
+#
+# Module-level on purpose: it must cover every value `detect_query_language` can
+# return, and that invariant is only testable if the map is reachable from a
+# test. It previously lived inside the wrapper as a literal, and ENGLISH — the
+# detector's DEFAULT return, i.e. the largest bucket — was missing from it. The
+# instruction therefore read "YOUR ENTIRE RESPONSE MUST BE IN the user's
+# language": a self-reference naming no language and constraining nothing. That
+# is one of the two paths to the reply-language drift seen in prod on
+# 2026-07-30 (Indonesian question, French answer).
+#
+# "UNKNOWN" is deliberately absent: it is unreachable from the wrapper, which
+# bails on the same `len(query.strip()) < 2` condition that produces it.
+LANGUAGE_DISPLAY_NAMES = {
+    "CHINESE": "CHINESE (中文)",
+    "ARABIC": "ARABIC (العربية)",
+    "UKRAINIAN": "UKRAINIAN (Українська)",
+    "RUSSIAN": "RUSSIAN (Русский)",
+    "ITALIAN": "ITALIAN (Italiano)",
+    "FRENCH": "FRENCH (Français)",
+    "SPANISH": "SPANISH (Español)",
+    "GERMAN": "GERMAN (Deutsch)",
+    "ENGLISH": "ENGLISH",
+}
 
 
 def wrap_query_with_language_instruction(query: str) -> str:
@@ -183,17 +320,8 @@ Pertanyaan User:
 """
         return tool_instruction + query
 
-    # NOT Indonesian - add explicit instruction
-    lang_display = {
-        "CHINESE": "CHINESE (中文)",
-        "ARABIC": "ARABIC (العربية)",
-        "UKRAINIAN": "UKRAINIAN (Українська)",
-        "RUSSIAN": "RUSSIAN (Русский)",
-        "ITALIAN": "ITALIAN (Italiano)",
-        "FRENCH": "FRENCH (Français)",
-        "SPANISH": "SPANISH (Español)",
-        "GERMAN": "GERMAN (Deutsch)",
-    }.get(detected_lang, "the user's language")
+    # NOT Indonesian - add explicit instruction.
+    lang_display = LANGUAGE_DISPLAY_NAMES.get(detected_lang, "the user's language")
 
     language_instruction = f"""
 🔴 LANGUAGE: {lang_display}

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
@@ -142,6 +142,11 @@ def test_english_homographs_never_decide_a_language_on_their_own() -> None:
     One of them alone is a coincidence, not a language — so they may reinforce
     a verdict but never produce one. Guarding the property, not the instances.
     """
+    # Assert the declaration itself, or the loop below passes vacuously the
+    # moment someone empties the table — which is exactly the change it exists
+    # to catch.
+    assert LATIN_HOMOGRAPHS == {"ITALIAN": ["come"], "FRENCH": ["comment"]}
+
     for language, homographs in LATIN_HOMOGRAPHS.items():
         for word in homographs:
             assert detect_query_language(f"Please {word} on the tax filing") != language

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import ast
+import inspect
+
+import pytest
+
 from backend.services.rag.agentic.query_helpers import (
+    LANGUAGE_DISPLAY_NAMES,
+    LATIN_HOMOGRAPHS,
     build_recall_prompt,
     detect_query_language,
     format_conversation_history_for_recall,
@@ -42,6 +49,136 @@ def test_wrap_query_with_language_instruction_adds_same_language_instruction() -
     assert "LANGUAGE: ITALIAN" in wrapped
     assert "ALWAYS use vector_search FIRST" in wrapped
     assert wrap_query_with_language_instruction(" ") == " "
+
+
+# ---------------------------------------------------------------------------
+# Language-selection drift (2026-08-10). Two independent defects, one symptom:
+# an English speaker never received a binding language instruction, because
+# either (a) a bare-substring marker scan classified the question as Indonesian
+# — 11 of 20 plain-English domain questions did — or (b) it was correctly
+# classified ENGLISH and ENGLISH was missing from the display map, so the
+# instruction read "MUST BE IN the user's language", naming nothing.
+# ---------------------------------------------------------------------------
+
+# GUILT: every one of these embeds an Indonesian marker inside a longer English
+# stem. Measured against the pre-cure scan, all 11 returned "INDONESIAN".
+_ENGLISH_WITH_EMBEDDED_MARKERS = [
+    ("What is the standard corporate income tax rate?", "anda in st(anda)rd"),
+    ("Please include the value of the solution plus notary costs.", "lu in va(lu)e"),
+    ("Is a company in Japan eligible for a PT PMA?", "apa in J(apa)n"),
+    ("What are the mandatory annual reports?", "anda in m(anda)tory"),
+    ("Can I rent an apartment on a B211A visa?", "apa in (apa)rtment"),
+    ("What is the evaluation process for LKPM?", "lu in eva(lu)ation"),
+    ("Which column of the chart of accounts covers payroll?", "lu in co(lu)mn"),
+    ("Do you have a luxury property in Canggu?", "lu in (lu)xury"),
+    ("I would like a guess at the total budget.", "gue in (gue)ss"),
+    ("The lease agreement includes a plus-value clause.", "lu in p(lu)s"),
+    ("What are the capacity requirements for a restaurant licence?", "apa in c(apa)city"),
+    # Same defect, other branches: every Latin-script marker list was a bare
+    # substring scan too. These two are the ones this domain says constantly.
+    ("What is the corporate income tax rate?", "come in in(come) -> ITALIAN"),
+    ("What is the commercial licence for a PT PMA?", "merci in com(merci)al -> FRENCH"),
+    # And two homographs that ARE English words, so whole-word matching alone
+    # would not have saved them.
+    ("How did this come about?", "'come' is an English word"),
+    ("Can you comment on the LKPM deadline?", "'comment' is an English word"),
+    # \b makes a bare "non" marker match these; that is why it is not in the list.
+    ("Is a non-resident director allowed?", "non-resident must not read as Italian"),
+]
+
+
+@pytest.mark.parametrize(("query", "why"), _ENGLISH_WITH_EMBEDDED_MARKERS)
+def test_english_question_embedding_a_marker_is_not_indonesian(query: str, why: str) -> None:
+    assert detect_query_language(query) == "ENGLISH", why
+
+
+# INNOCENCE: the obvious cure — a plain \b…\b match — is an UNDER-match twin.
+# Measured on the real 188-message inbound corpus, it lost 12 genuine Indonesian
+# messages, 11 of them on "berapa" (the pricing question). These must stay.
+_REAL_INDONESIAN = [
+    "Berapa lama Hak Pakai bisa diperpanjang?",
+    "Berapa harga KITAS investor?",
+    "Apakah PT PMA wajib lapor LKPM?",
+    "Harganya berapa untuk paket tahunan?",
+    "Kenapa permohonan saya ditolak?",
+    "Zantara jelaskan visa C7A",
+    "Bisakah warga asing jadi direktur?",
+    "Saya mau urus izin usaha",
+    "Terima kasih, saya mau KITAS",
+]
+
+
+@pytest.mark.parametrize("query", _REAL_INDONESIAN)
+def test_real_indonesian_still_detected(query: str) -> None:
+    assert detect_query_language(query) == "INDONESIAN"
+
+
+# INNOCENCE for the Latin branches: demoting "come"/"comment" to homographs is
+# itself an under-match risk — these are the sentences that used to depend on
+# them, and the widened decisive lists must still carry them.
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("Come funziona il KITAS investor?", "ITALIAN"),
+        ("Ciao, quanto costa un E33G?", "ITALIAN"),
+        ("Vorrei aprire una PT PMA, cosa serve?", "ITALIAN"),
+        ("Comment ça marche, le KITAS?", "FRENCH"),
+        ("Bonjour, combien coûte le KITAS?", "FRENCH"),
+        ("Hola, gracias por la info", "SPANISH"),
+        # Cross-language collision: "una" is Italian AND Spanish, and Italian is
+        # tested first. Widening the Italian list with it answered this in
+        # Italian. A marker shared by two candidate languages decides neither.
+        ("hola cómo puedo obtener una visa?", "SPANISH"),
+        ("Hallo, wie geht es?", "GERMAN"),
+    ],
+)
+def test_real_latin_language_still_detected(query: str, expected: str) -> None:
+    assert detect_query_language(query) == expected
+
+
+def test_english_homographs_never_decide_a_language_on_their_own() -> None:
+    """`come` and `comment` are Italian/French markers AND English words.
+
+    One of them alone is a coincidence, not a language — so they may reinforce
+    a verdict but never produce one. Guarding the property, not the instances.
+    """
+    for language, homographs in LATIN_HOMOGRAPHS.items():
+        for word in homographs:
+            assert detect_query_language(f"Please {word} on the tax filing") != language
+
+
+def test_english_query_names_english_not_a_tautology() -> None:
+    """The pre-cure instruction read 'MUST BE IN the user's language' — a
+    self-reference that constrains nothing, on the detector's DEFAULT branch."""
+    wrapped = wrap_query_with_language_instruction("How long does a PT PMA take to set up?")
+
+    assert "LANGUAGE: ENGLISH" in wrapped
+    assert "the user's language" not in wrapped
+
+
+def test_every_language_the_detector_returns_is_named_in_the_instruction() -> None:
+    """Structural guard against the class, not just today's instance.
+
+    The display map lived as a literal INSIDE the wrapper, so a language could
+    be added to the detector and not to the map, and the only symptom would be
+    a vague prompt in production — exactly how ENGLISH, the detector's default
+    return, ended up unnamed. Enumerate what the detector can actually RETURN,
+    from its own source, and require the map to cover it.
+    """
+    tree = ast.parse(inspect.getsource(detect_query_language))
+    returned = {
+        node.value.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Return)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    }
+    assert "ENGLISH" in returned, "detector no longer returns ENGLISH — retarget this test"
+
+    # INDONESIAN returns before the map is consulted; UNKNOWN is unreachable
+    # from the wrapper (same len(strip()) < 2 bail that produces it).
+    missing = returned - {"INDONESIAN", "UNKNOWN"} - set(LANGUAGE_DISPLAY_NAMES)
+    assert not missing, f"detector can return {sorted(missing)} but the instruction names neither"
 
 
 def test_is_conversation_recall_query_matches_only_recall_phrases() -> None:


### PR DESCRIPTION
## What a live probe of the WhatsApp path found

Firing 12 defect-targeted questions at prod and re-rendering each answer through the
real channel chain (`_strip_kg_workflow_scaffold` → `format_rich_text(..., "whatsapp")`)
reproduced the reply-language drift: an English question answered wholly in French,
on-topic, confident, 4 sources, `evidence 0.85`.

Two independent defects in `query_helpers`, one symptom.

**1. Every marker list was scanned as a BARE SUBSTRING.** Measured against the pre-cure
code, **11 of 20** plain English domain questions came back `INDONESIAN`:

| query | marker | verdict |
|---|---|---|
| What is the **st(anda)rd** corporate income tax rate? | `anda` | INDONESIAN |
| Please include the **va(lu)e** of the solution | `lu` | INDONESIAN |
| Is a company in **J(apa)n** eligible? | `apa` | INDONESIAN |
| What are the **m(anda)tory** reports? | `anda` | INDONESIAN |

The Latin branches had it too: `in(come) tax` reads **ITALIAN**, `com(merci)al licence`
reads **FRENCH**. An English question classified Indonesian takes the branch that adds
**no language instruction at all**. The 2026-07-28 team beta recorded two English
questions answered wholly in Italian — this is a mechanism that produces exactly that.

**2. `ENGLISH` was missing from the display map, and it is the detector's DEFAULT return.**
Every query it could not place produced:

```
🔴 LANGUAGE: the user's language
🔴 YOUR ENTIRE RESPONSE MUST BE IN the user's language
```

A self-reference naming no language.

## The obvious cure is the under-match twin, so it was measured first

A bare `\b…\b` match **LOSES 12 genuine Indonesian messages** on the real 188-message
inbound corpus — 11 of them on **`berapa`** ("how much", i.e. the pricing question),
plus `kenapa` and `keluar`. Hence whole-word matching **plus** the Indonesian enclitics
(`-kah/-nya/-lah/-pun/-ku/-mu`) **plus** a vocabulary widened to what the corpus shows.

Two markers are also ordinary English words — Italian `come`, French `comment`. They are
demoted to **homographs**: they may reinforce a verdict, never produce one. `non` stays
out of the Italian list because `\b` matches `non-resident`; `una` stays out because it
is Italian **and** Spanish while Italian is tested first (that one was caught by an
existing test, not by me).

## Measured on the real corpus — 188 inbound WhatsApp messages, old vs new

```
unchanged 175   CHANGED 13
   +7  ENGLISH -> ITALIAN      genuinely Italian: all 7 carry ZERO English function
                               words, firing on sono / che / quanto / il
   +3  ENGLISH -> INDONESIAN   harganya, izin, jelaskan  ("jelaskan" is the exact
                               word of the prod French-drift exchange)
   -3  ITALIAN -> ENGLISH      the "income" / "come" false positives
    0  losses
```

No client text left the database: the comparison ran in a pipe and reports only counts
and matched marker tokens.

## Notes for review

- The Latin branches keep **literal returns** rather than looping over the marker table:
  `test_reasoning_stubs_language_coverage` derives the emittable languages from this
  function's AST, and a loop returning a variable makes four of them invisible to that
  guard **while still passing**. Caught by running that suite, not by reading it.
- The display map moves to module scope so the invariant "every language the detector can
  return is named in the instruction" is testable at all. That is the guard against the
  class, not just today's instance.
- Mutation-verified, 3 mutants, all killed: substring scan restored → 3 guilt failures;
  `ENGLISH` removed from the map → the tautology test **and** the structural test;
  homographs promoted back to decisive → guilt failure. The third exposed that the
  homograph property test passed **vacuously** when its table was emptied — fixed in the
  second commit.
- Pre-existing reds on this branch, unchanged and unrelated (verified by stashing the
  diff and re-running): 3 × `test_prompt_builder` MagicMock `TypeError`, 2 ×
  `test_reasoning_utils::TestDetectTeamQuery`.

Probe scripts are scratchpad-only and not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)