### PR TITLE
docs: sync onboarding test count

### DIFF
--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 693 services · 1324 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 693 services · 1325 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## Summary
- update the generated onboarding test count from 1324 to 1325
- restore the docs-sync prerequisite currently failing the virtual merge for #3959

## Verification
- apps/backend-rag/.venv/bin/python scripts/docs_sync.py --check
- scripts/tests/test_docs_sync_atlas.py: 12 passed
- normal pre-commit and pre-push hooks passed

This is intentionally a standalone prerequisite from the current main branch. It does not modify #3959 or its auto-merge state.