### PR TITLE
fix(rag): the PT PMA capital step told clients to deposit the investment-plan figure

### DIFF
--- a/apps/backend-rag/backend/services/rag/kg_subgraph_company.py
+++ b/apps/backend-rag/backend/services/rag/kg_subgraph_company.py
@@ -42,7 +42,15 @@ class CompanyState(TypedDict, total=False):
     # Company-specific fields
     company_type: str | None  # "pt_pma", "perorangan", "cv", "pt_lokal"
     is_foreign_investor: bool
-    capital_amount: int | None  # in IDR
+    # Two DIFFERENT figures, and conflating them is client-facing misinformation:
+    # `capital_amount` is the INVESTMENT PLAN value (nilai investasi, >10bn per
+    # KBLI per location for a PT PMA — assets and working capital, land and
+    # buildings excluded), while `paid_up_amount` is the money that must actually
+    # be DEPOSITED and shown in the deed (modal disetor, 2.5bn since BKPM 5/2025).
+    # Telling a founder to "prepare minimum capital: Rp 10,000,000,000" reads as
+    # the second and is wrong by a factor of four.
+    capital_amount: int | None  # in IDR — investment plan value, NOT paid-up
+    paid_up_amount: int | None  # in IDR — modal disetor, the cash actually deposited
     kbli_codes: list[str]  # Business classification codes
     licensing_requirements: list[dict]  # NIB, OSS, sector licenses
     shareholders: list[dict]  # For PT PMA
@@ -389,10 +397,19 @@ async def get_capital_requirements_node(state: CompanyState, db_pool: asyncpg.Po
     # Hardcoded knowledge (can be queried from KG)
     capital_reqs = {
         "pt_pma": {
-            "min_capital": 10_000_000_000,  # 10B IDR
-            "paid_up_min": 2_500_000_000,  # 2.5B IDR
+            # NOT stale, and NOT the same number: >10bn is the investment PLAN
+            # value required per KBLI per location, 2.5bn is the capital that must
+            # be paid up. Perka BKPM 5/2025 abrogated 4/2021 and set paid-up at
+            # 2.5bn while leaving the >10bn investment threshold in force. A blind
+            # sweep replacing "10 billion" with "2.5 billion" is therefore WRONG.
+            "min_capital": 10_000_000_000,  # 10B IDR — investment plan, per KBLI per location
+            "paid_up_min": 2_500_000_000,  # 2.5B IDR — modal disetor (Perka BKPM 5/2025)
             "currency": "IDR",
-            "notes": "Foreign investment minimum as per BKPM regulations",
+            "notes": (
+                "PT PMA: investment plan value above IDR 10bn per KBLI per location "
+                "(land and buildings excluded); paid-up capital IDR 2.5bn "
+                "(Perka BKPM 5/2025, which abrogated 4/2021)"
+            ),
         },
         "pt_lokal": {
             "min_capital": 50_000_000,  # 50M IDR
@@ -424,9 +441,12 @@ async def get_capital_requirements_node(state: CompanyState, db_pool: asyncpg.Po
     )
 
     state["capital_amount"] = requirements.get("min_capital")
+    state["paid_up_amount"] = requirements.get("paid_up_min")
 
     logger.info(
-        f"✅ [Company Subgraph] Capital requirements: {requirements.get('min_capital', 'N/A')} IDR",
+        "✅ [Company Subgraph] Capital requirements: investment plan "
+        f"{requirements.get('min_capital', 'N/A')} IDR, paid-up "
+        f"{requirements.get('paid_up_min', 'N/A')} IDR",
     )
 
     return state
@@ -459,6 +479,7 @@ async def synthesize_company_workflow_node(state: CompanyState) -> CompanyState:
     company_type = state.get("company_type", "unknown")
     is_foreign = state.get("is_foreign_investor", False)
     capital = state.get("capital_amount")
+    paid_up = state.get("paid_up_amount")
 
     steps = []
 
@@ -475,16 +496,32 @@ async def synthesize_company_workflow_node(state: CompanyState) -> CompanyState:
         },
     )
 
-    # Step 2: Capital preparation
+    # Step 2: Capital preparation.
+    #
+    # This string is read by clients: the whatsapp/web answer quotes the workflow
+    # verbatim. "Prepare minimum capital: Rp 10,000,000,000" names the INVESTMENT
+    # PLAN value but reads as cash to deposit, which is 2.5bn (BKPM 5/2025) — a
+    # 4x overstatement on the single number a founder budgets against. Both
+    # figures are in `capital_reqs` two functions up; only one was ever surfaced.
     if capital:
+        action = f"Plan a total investment value of at least Rp {capital:,}"
+        if paid_up:
+            action += f", of which Rp {paid_up:,} must be paid up (modal disetor)"
         steps.append(
             {
                 "step": 2,
-                "action": f"Prepare minimum capital: Rp {capital:,}",
+                "action": action,
                 "entity_id": "capital_requirement",
                 "details": {
-                    "amount": capital,
+                    "investment_plan_amount": capital,
+                    "paid_up_amount": paid_up,
                     "currency": "IDR",
+                    # Kept unchanged as a non-breaking precaution, NOT because a
+                    # reader was found: grepping the backend turns up no consumer
+                    # of this key, and the renderer at orchestrator_core.py:906
+                    # reads only `action` plus requirement/location/processing_time.
+                    # Whatever it meant, it was always the investment plan value.
+                    "amount": capital,
                 },
             },
         )

--- a/apps/backend-rag/backend/tests/unit/services/rag/test_kg_subgraph_company.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/test_kg_subgraph_company.py
@@ -54,6 +54,7 @@ def _base_state(**overrides):
         "company_type": None,
         "is_foreign_investor": False,
         "capital_amount": None,
+        "paid_up_amount": None,
         "kbli_codes": [],
         "licensing_requirements": [],
         "shareholders": [],
@@ -510,6 +511,18 @@ class TestGetCapitalRequirements:
         assert req["details"]["min_capital"] == 10_000_000_000
 
     @pytest.mark.asyncio
+    async def test_pt_pma_carries_the_paid_up_figure_not_only_the_investment_plan(
+        self, mock_db_pool
+    ):
+        """The dict always held both; only `min_capital` was copied into state,
+        so the paid-up figure could never reach the client-facing workflow."""
+        state = _base_state(company_type="pt_pma", is_foreign_investor=True)
+        result = await get_capital_requirements_node(state, mock_db_pool)
+
+        assert result["capital_amount"] == 10_000_000_000
+        assert result["paid_up_amount"] == 2_500_000_000
+
+    @pytest.mark.asyncio
     async def test_pt_lokal_capital(self, mock_db_pool):
         state = _base_state(company_type="pt_lokal")
         result = await get_capital_requirements_node(state, mock_db_pool)
@@ -558,6 +571,74 @@ class TestSynthesizeCompanyWorkflow:
         assert len(wf["steps"]) == 5
         assert wf["confidence"] > 0
         assert "confidence_breakdown" in wf
+
+    @pytest.mark.asyncio
+    async def test_capital_step_does_not_present_the_investment_plan_as_cash(self):
+        """GUILT — this string reaches clients verbatim through the KG workflow.
+
+        It used to read "Prepare minimum capital: Rp 10,000,000,000". Both
+        figures live side by side in `capital_reqs`; only the investment-plan
+        one was surfaced, and "prepare capital" reads as money to deposit —
+        4x the real paid-up requirement (IDR 2.5bn, Perka BKPM 5/2025).
+        """
+        state = _base_state(
+            company_type="pt_pma",
+            is_foreign_investor=True,
+            capital_amount=10_000_000_000,
+            paid_up_amount=2_500_000_000,
+            kbli_codes=["kbli:62011"],
+        )
+        result = await synthesize_company_workflow_node(state)
+        capital_step = next(
+            s for s in result["workflow"]["steps"] if s["entity_id"] == "capital_requirement"
+        )
+
+        assert "Prepare minimum capital" not in capital_step["action"]
+        # Both numbers present, each named for what it is.
+        assert "10,000,000,000" in capital_step["action"]
+        assert "2,500,000,000" in capital_step["action"]
+        assert "investment" in capital_step["action"].lower()
+        assert "paid up" in capital_step["action"].lower()
+        assert capital_step["details"]["paid_up_amount"] == 2_500_000_000
+        assert capital_step["details"]["investment_plan_amount"] == 10_000_000_000
+
+    @pytest.mark.asyncio
+    async def test_the_10bn_investment_threshold_is_not_stale_and_must_survive(self):
+        """INNOCENCE — the sibling error is deleting the 10bn as 'outdated'.
+
+        Perka BKPM 5/2025 changed the PAID-UP figure to 2.5bn and left the
+        >10bn investment-plan threshold per KBLI per location in force. A sweep
+        that rewrites every "10 billion" to "2.5 billion" breaks this.
+        """
+        state = _base_state(
+            company_type="pt_pma",
+            is_foreign_investor=True,
+            capital_amount=10_000_000_000,
+            paid_up_amount=2_500_000_000,
+        )
+        result = await synthesize_company_workflow_node(state)
+        capital_step = next(
+            s for s in result["workflow"]["steps"] if s["entity_id"] == "capital_requirement"
+        )
+        assert "10,000,000,000" in capital_step["action"]
+
+    @pytest.mark.asyncio
+    async def test_capital_step_survives_a_missing_paid_up_figure(self):
+        """A company type with an investment floor but no paid-up rule must not
+        crash, and must not invent one."""
+        state = _base_state(
+            company_type="pt_lokal",
+            is_foreign_investor=False,
+            capital_amount=50_000_000,
+            paid_up_amount=None,
+        )
+        result = await synthesize_company_workflow_node(state)
+        capital_step = next(
+            s for s in result["workflow"]["steps"] if s["entity_id"] == "capital_requirement"
+        )
+        assert "50,000,000" in capital_step["action"]
+        assert "paid up" not in capital_step["action"].lower()
+        assert capital_step["details"]["paid_up_amount"] is None
 
     @pytest.mark.asyncio
     async def test_cv_workflow_no_capital_step(self):


### PR DESCRIPTION
## What the client was told

The company KG subgraph's capital step rendered one sentence for both numbers:

> Prepare minimum capital of Rp 10,000,000,000

`10bn` is the **investment plan value per KBLI per location** (Perka BKPM 5/2025, still in force). The money that actually has to be **paid up** is **Rp 2,500,000,000** (modal disetor, Permen Investasi 5/2025, which repealed 4/2021). Presented as "prepare minimum capital", the 10bn reads as cash to deposit — a 4× overstatement of what a client must actually wire.

This is a **labelling** defect, not a stale number: the 10bn is correct and must survive. The blind "10 billion → 2.5 billion" sweep is the #3720 error and this PR does the opposite of it — a test pins that 10bn is still named.

## The cure

`kg_subgraph_company.py`:
- `CompanyState` gains `paid_up_amount`; the capital node reads `requirements["paid_up_min"]` alongside the existing plan figure.
- Step 2's `action` now names both roles explicitly:
  `Plan a total investment value of at least Rp 10,000,000,000, of which Rp 2,500,000,000 must be paid up (modal disetor)`
- `details` carries `investment_plan_amount` / `paid_up_amount` / `currency`, keeping the legacy `amount` key so no existing reader breaks.
- `notes` for `pt_pma` names both thresholds and their sources.

Verified the renderer consumes only `action`, so the sentence above is the whole client-facing surface.

## Tests

`test_kg_subgraph_company.py`: guilt (the old "prepare minimum capital of 10bn" sentence must not come back), innocence (10bn must still be named — this is the anti-#3720 pin), the no-paid-up case (sentence stays single-figure), and that the node exposes both figures in `details`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)