### PR TITLE
fix(rag): resolve ambiguous language marker precedence

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_helpers.py
@@ -62,7 +62,9 @@ RECALL_TRIGGERS = [
 # is routed down the Indonesian branch and therefore receives NO language
 # instruction at all — one of the two paths to the observed reply-language drift.
 INDONESIAN_MARKERS = [
-    "ada",
+    # "ada" is deliberately absent: Ada is also a proper name. One ambiguous
+    # token must not route an otherwise-English client question to Indonesian;
+    # genuine Indonesian sentences containing "ada" carry another marker.
     "aku",
     "anda",
     "apa",
@@ -153,13 +155,13 @@ INDONESIAN_MARKER_RE = _whole_word_matcher(INDONESIAN_MARKERS, _INDONESIAN_ENCLI
 # Whole-word matching alone is not enough here, because two markers are also
 # ordinary ENGLISH words: Italian "come" and French "comment". A single one of
 # those is a coincidence, not a language — so they are HOMOGRAPHS and never
-# decide on their own; they only reinforce a language already named by a
-# decisive marker. To keep the recall that "come"/"comment" used to carry
+# decide on their own; they add one signal only after a decisive marker names
+# the same language. To keep the recall that "come"/"comment" used to carry
 # ("come funziona…", "comment ça marche"), the decisive lists are widened with
 # the function words a real question in that language brings along.
 #
-# Order is preserved from the original (Italian → French → Spanish → German) so
-# that a query these lists genuinely disagree on resolves as it did before.
+# Order is preserved from the original (Italian → French → Spanish → German) as
+# the tie-break after signal counting, so equal evidence resolves as before.
 _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
     (
         "ITALIAN",
@@ -169,16 +171,55 @@ _LATIN_MARKERS: list[tuple[str, list[str], list[str]]] = [
         # "una" is deliberately absent: it is Italian AND Spanish, and Italian is
         # tested first, so it would answer a Spanish question in Italian. A marker
         # shared by two candidate languages decides neither.
-        ["ciao", "cosa", "voglio", "posso", "grazie", "perché", "quanto", "quale",
-         "quali", "sono", "della", "vorrei", "devo", "per favore", "il",
-         "che", "anche", "gli", "funziona", "essere"],
+        # "il" is deliberately absent too: it is an Italian article and a French
+        # pronoun, so it cannot be decisive before the French signal check.
+        [
+            "ciao",
+            "cosa",
+            "voglio",
+            "posso",
+            "grazie",
+            "perché",
+            "quanto",
+            "quale",
+            "quali",
+            "sono",
+            "della",
+            "vorrei",
+            "devo",
+            "per favore",
+            "che",
+            "anche",
+            "gli",
+            "funziona",
+            "essere",
+            "ottenere",
+        ],
         ["come"],  # homograph: English "come"
     ),
     (
         "FRENCH",
-        ["bonjour", "pourquoi", "merci", "s'il vous", "combien", "quel", "quelle",
-         "est-ce", "vous", "je", "ça", "c'est", "votre", "nous", "faut", "avec",
-         "dans", "être"],
+        [
+            "bonjour",
+            "pourquoi",
+            "merci",
+            "s'il vous",
+            "combien",
+            "quel",
+            "quelle",
+            "est-ce",
+            "vous",
+            "je",
+            "ça",
+            "c'est",
+            "votre",
+            "nous",
+            "faut",
+            "avec",
+            "dans",
+            "être",
+            "obtenir",
+        ],
         ["comment"],  # homograph: English "comment"
     ),
     ("SPANISH", ["hola", "cómo", "como estas", "gracias", "por qué"], []),
@@ -198,6 +239,21 @@ GERMAN_MARKER_RE = _BY_LANGUAGE["GERMAN"]
 LATIN_HOMOGRAPHS: dict[str, list[str]] = {
     language: homographs for language, _decisive, homographs in _LATIN_MARKERS if homographs
 }
+LATIN_HOMOGRAPH_RES: dict[str, re.Pattern[str]] = {
+    language: _whole_word_matcher(homographs) for language, homographs in LATIN_HOMOGRAPHS.items()
+}
+
+
+def _latin_marker_score(query: str, language: str) -> int:
+    """Count distinct decisive signals, then one supported homograph signal."""
+    decisive_matches = {match.group(0) for match in _BY_LANGUAGE[language].finditer(query)}
+    if not decisive_matches:
+        return 0
+
+    homograph_re = LATIN_HOMOGRAPH_RES.get(language)
+    homograph_bonus = int(homograph_re is not None and homograph_re.search(query) is not None)
+    return len(decisive_matches) + homograph_bonus
+
 
 # Model Tiers
 TIER_FLASH = 0
@@ -242,6 +298,8 @@ def detect_query_language(query: str) -> str:
         return "RUSSIAN"
 
     # Latin-script markers, WHOLE WORDS only — see _LATIN_MARKERS for why.
+    # Compare evidence before applying the historical order: otherwise one weak
+    # early marker can mask several later signals from the actual language.
     #
     # Written as literal returns on purpose, NOT as a loop over LATIN_MARKER_RES:
     # `test_reasoning_stubs_language_coverage` derives the set of languages this
@@ -249,16 +307,24 @@ def detect_query_language(query: str) -> str:
     # a new language cannot be added without either a translated stub or an
     # explicit declaration. A loop returning a variable makes those four
     # languages invisible to that guard — and it passes, quietly covering less.
-    if ITALIAN_MARKER_RE.search(query_lower):
+    latin_scores = {
+        "ITALIAN": _latin_marker_score(query_lower, "ITALIAN"),
+        "FRENCH": _latin_marker_score(query_lower, "FRENCH"),
+        "SPANISH": _latin_marker_score(query_lower, "SPANISH"),
+        "GERMAN": _latin_marker_score(query_lower, "GERMAN"),
+    }
+    best_latin_score = max(latin_scores.values())
+
+    if best_latin_score and latin_scores["ITALIAN"] == best_latin_score:
         return "ITALIAN"
 
-    if FRENCH_MARKER_RE.search(query_lower):
+    if best_latin_score and latin_scores["FRENCH"] == best_latin_score:
         return "FRENCH"
 
-    if SPANISH_MARKER_RE.search(query_lower):
+    if best_latin_score and latin_scores["SPANISH"] == best_latin_score:
         return "SPANISH"
 
-    if GERMAN_MARKER_RE.search(query_lower):
+    if best_latin_score and latin_scores["GERMAN"] == best_latin_score:
         return "GERMAN"
 
     return "ENGLISH"  # Default to English

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_query_helpers.py
@@ -24,8 +24,7 @@ def test_detect_query_language_handles_supported_markers_and_defaults() -> None:
     assert detect_query_language("hola gracias") == "SPANISH"
     assert detect_query_language("hallo danke") == "GERMAN"
     assert (
-        detect_query_language("\u041f\u0440\u0438\u0432\u0456\u0442, \u044f\u043a?")
-        == "UKRAINIAN"
+        detect_query_language("\u041f\u0440\u0438\u0432\u0456\u0442, \u044f\u043a?") == "UKRAINIAN"
     )
     assert detect_query_language("\u041f\u0440\u0438\u0432\u0435\u0442") == "RUSSIAN"
     assert detect_query_language("\u0645\u0631\u062d\u0628\u0627") == "ARABIC"
@@ -92,6 +91,11 @@ def test_english_question_embedding_a_marker_is_not_indonesian(query: str, why: 
     assert detect_query_language(query) == "ENGLISH", why
 
 
+def test_ambiguous_indonesian_marker_does_not_override_english_context() -> None:
+    """A client name that happens to be an Indonesian word is not a verdict."""
+    assert detect_query_language("Is Ada eligible for a KITAS?") == "ENGLISH"
+
+
 # INNOCENCE: the obvious cure — a plain \b…\b match — is an UNDER-match twin.
 # Measured on the real 188-message inbound corpus, it lost 12 genuine Indonesian
 # messages, 11 of them on "berapa" (the pricing question). These must stay.
@@ -120,9 +124,12 @@ def test_real_indonesian_still_detected(query: str) -> None:
     ("query", "expected"),
     [
         ("Come funziona il KITAS investor?", "ITALIAN"),
+        ("Come ottenere un KITAS?", "ITALIAN"),
         ("Ciao, quanto costa un E33G?", "ITALIAN"),
         ("Vorrei aprire una PT PMA, cosa serve?", "ITALIAN"),
         ("Comment ça marche, le KITAS?", "FRENCH"),
+        ("Comment obtenir un KITAS ?", "FRENCH"),
+        ("Il faut combien de temps pour obtenir un KITAS ?", "FRENCH"),
         ("Bonjour, combien coûte le KITAS?", "FRENCH"),
         ("Hola, gracias por la info", "SPANISH"),
         # Cross-language collision: "una" is Italian AND Spanish, and Italian is
@@ -133,6 +140,19 @@ def test_real_indonesian_still_detected(query: str) -> None:
     ],
 )
 def test_real_latin_language_still_detected(query: str, expected: str) -> None:
+    assert detect_query_language(query) == expected
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("Comment obtenir un KITAS, ciao", "FRENCH"),
+        ("Come ottenere un KITAS, bonjour", "ITALIAN"),
+    ],
+)
+def test_supported_homograph_pair_outranks_one_conflicting_marker(
+    query: str, expected: str
+) -> None:
     assert detect_query_language(query) == expected
 
 


### PR DESCRIPTION
## Summary

- Score decisive Latin-language markers before applying the existing deterministic tie-break.
- Let shared homographs reinforce only a language already supported by decisive evidence.
- Demote ambiguous `Ada` and shared `il`; add explicit `ottenere` and `obtenir` evidence.
- Preserve the existing display-language map invariant.

## Regression coverage

- French: `Comment obtenir ...`
- Italian: `Come ottenere ...`
- English: `Is Ada ...`
- French: `Il faut combien ...`
- Conflicting homograph precedence and homograph-only English fallback

## Verification

- TDD RED: 6 targeted counterexamples failed before the implementation.
- Focused: 48 passed.
- Related agentic query-helper suite: 226 passed, 11 skipped.
- Ruff format/check and `git diff --check`: clean.
- Normal pre-push hook: full backend suite passed.
- Current `main` carries the independent docs-sync refresh from #3961; merge-ref docs-sync is checked separately.