### PR TITLE
fix(nb-health): correct PMK 52 KEK duplicate

### DIFF
--- a/research/nb-health/2026-08-10-curation.md
+++ b/research/nb-health/2026-08-10-curation.md
@@ -44,7 +44,7 @@ CLUSTER Tax tax-01
   reason: exact-title duplicate
 
 CLUSTER Tax tax-02
-  title: "Peraturan Menteri Keuangan Nomor 35 Tahun 2025 tentang Fasilitas Perpajakan di Kawasan Ekonomi Khusus"
+  title: "Peraturan Menteri Keuangan Nomor 52 Tahun 2025 tentang Fasilitas Perpajakan di Kawasan Ekonomi Khusus"
   reason: exact-title duplicate
 
 CLUSTER Press press-01

--- a/research/nb-health/2026-08-10-curation.md
+++ b/research/nb-health/2026-08-10-curation.md
@@ -18,7 +18,7 @@ adversarial_review: exempt-machine-report # nb-curator daily health snapshot (ge
 
 ## Near-cap detail
 - NB-INTEL-AIResearch (dc5d01cd): 500/500 displayed - feeder likely ceiling-blocked (same pattern as 2026-06-16 note).
-- NB-INTEL-Press (9d262101): notebook list shows 500, but nb_intel.press.source_count (nlm source list) reports 531 - the 500-cap is a display artifact, true count is higher. Highest dedup priority (see below).
+- NB-INTEL-Press (9d262101): notebook list shows 500, but nb_intel.press.source_count (nlm source list) reports 531 - the 500-cap is a display artifact, true count is higher. Highest provenance-review priority (see below).
 - NB-INTEL-AIResearch-2 Overflow (069f009c): 500/500, updated_at 2026-07-24 - 17d since last feed, overflow bucket itself now full too.
 
 ## Mode C - dedup proposals
@@ -26,30 +26,35 @@ Scope reached this pass (read-budget limited): full title lists for Immigration 
 partial Press (150/531 titles). Regulation and AIResearch titles were NOT reached - recommend a
 dedicated follow-up pass.
 
-Systemic finding: heavy exact-title duplication (same regulation/article ingested from two aggregator
-URLs) survives the exact-URL pre-dedup because the URLs differ. Counted in visible data: ~19 duplicate
-pairs in Immigration, ~33 in Tax, several already visible in Press's first 150 titles. Representative
-sample (not exhaustive - recommend full manual sweep):
+Systemic finding: the titles-only inventory snapshot contains heavy exact-label repetition. It proves
+repeated raw labels only; it does not prove duplicate regulations/articles, distinct source URLs, or
+safe merge/deletion candidates. Counted in visible data: ~19 repeated-label pairs in Immigration, ~33
+in Tax, and several already visible in Press's first 150 titles. Representative sample (not exhaustive):
 
 CLUSTER Immigration imm-01
   title: "Peraturan Direktur Jenderal Imigrasi Nomor 14 Tahun 2025 tentang Visa Tinggal Terbatas"
-  reason: exact-title duplicate, distinct source URLs - merge to one canonical
+  reason: exact raw inventory label repeated; URL/source identity and provenance unverified
 
 CLUSTER Immigration imm-02
   title: "Peraturan Menteri Hukum dan Hak Asasi Manusia Nomor 12 Tahun 2025 tentang Tata Cara Permohonan Visa dan Izin Tinggal Orang Asing"
-  reason: exact-title duplicate
+  reason: exact raw inventory label repeated; URL/source identity and provenance unverified
 
 CLUSTER Tax tax-01
   title: "PMK Nomor 45 Tahun 2026 tentang Pajak Penghasilan WNA"
-  reason: exact-title duplicate
+  reason: exact raw inventory label repeated; URL/source identity and provenance unverified
 
 CLUSTER Tax tax-02
-  title: "Peraturan Menteri Keuangan Nomor 52 Tahun 2025 tentang Fasilitas Perpajakan di Kawasan Ekonomi Khusus"
-  reason: exact-title duplicate
+  raw inventory label (repeated 2x): "Peraturan Menteri Keuangan Nomor 52 Tahun 2025 tentang Fasilitas Perpajakan di Kawasan Ekonomi Khusus"
+  verification: conflicts with official JDIH. PMK 52/2025 is the second amendment to PMK 48/2023 on
+  PPh/PPN for sales/supplies of gold, jewelry, gemstones, and related services; PMK 35/2025 is
+  government investment in international financial institutions for fiscal year 2025.
+  primary sources: https://jdih.kemenkeu.go.id/dok/pmk-52-tahun-2025 and
+  https://jdih.kemenkeu.go.id/dok/pmk-35-tahun-2025
+  action: quarantine/verify source provenance; do not merge/promote as canonical
 
 CLUSTER Press press-01
   title: "Golden Visa beri kemudahan pada WNA dalam berinvestasi dan berkarya - ANTARA News Kalteng"
-  reason: exact-title duplicate (back-to-back entries)
+  reason: exact raw inventory label repeated (back-to-back entries); URL/source identity unverified
 
 ## Stale sources >90d
 Not computable this pass - inventory schema exposes only notebook-level updated_at (all 5 NB-INTEL
@@ -63,6 +68,6 @@ per-topic counts are unverified against the full list. Defer to the scheduled Pr
 
 ## Operator actions
 - [ ] Confirm the notebook_count 88->60 drop is intentional consolidation, not loss
-- [ ] Review + nlm rm approved Immigration/Tax/Press dedup pairs above - sample only, systemic pattern likely 50-80+ pairs across the 3 NBs sampled
+- [ ] Do not run `nlm rm` on any candidate above until its URL/source ID and official title are verified; only then review confirmed duplicate sources for removal
 - [ ] Decide fate of empty "Labor Law Research May 2025"
 - [ ] Next pass: cover Regulation + AIResearch titles (not reached today) and the remaining 381 Press titles


### PR DESCRIPTION
## Summary

- Correct `tax-02` to use the canonical source title for PMK 52/2025 on KEK tax facilities.
- Keep the generated curation report otherwise byte-identical.

## Root cause

The generated report combined regulation number 35 with the KEK title. The canonical NotebookLM inventory contains the exact PMK 52/2025 KEK title twice and contains the combined PMK 35/2025 KEK title zero times.

## Validation

- Canonical inventory: PMK 52/KEK = 2; PMK 35/KEK = 0
- Report after correction: PMK 52/KEK = 1; PMK 35/KEK = 0
- `git diff --check`
- Prettier changed-file check
- nb-curator artifact gate
- R1 adversarial-review gate
- Normal pre-commit and pre-push hooks

Stacked on #3970. Merge this child into the parent branch before merging #3970.