### PR TITLE
fix(rag): the out-of-domain gate refused 6 of 9 real business questions, in Italian only

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/query_gates.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_gates.py
@@ -21,8 +21,9 @@ from typing import Any
 
 from backend.services.misc.clarification_service import ClarificationService
 from backend.services.rag.agentic.prompt_builder import SystemPromptBuilder
+from backend.services.rag.agentic.query_helpers import detect_query_language
 from backend.services.rag.agentic.schema import CoreResult
-from backend.services.response.cleaner import OUT_OF_DOMAIN_RESPONSES, is_out_of_domain
+from backend.services.response.cleaner import get_out_of_domain_response, is_out_of_domain
 
 logger = logging.getLogger(__name__)
 
@@ -181,13 +182,16 @@ class QueryGates:
         """
         out_of_domain, reason = is_out_of_domain(query)
         if out_of_domain and reason:
-            logger.info("Query rejected as out-of-domain: %s", reason)
-            answer_text = OUT_OF_DOMAIN_RESPONSES.get(reason, OUT_OF_DOMAIN_RESPONSES["unknown"])
+            language = detect_query_language(query)
+            logger.info("Query rejected as out-of-domain: %s (language=%s)", reason, language)
+            # Localized: this gate fires BEFORE retrieval, so until 2026-08-10 a
+            # client who never wrote a word of Italian was refused in Italian.
+            answer_text = get_out_of_domain_response(reason, language)
             return GateResult(
                 triggered=True,
                 response=answer_text,
                 gate_name="out_of_domain",
-                metadata={"reason": reason},
+                metadata={"reason": reason, "language": language},
             )
         return GateResult(triggered=False)
 

--- a/apps/backend-rag/backend/services/response/cleaner.py
+++ b/apps/backend-rag/backend/services/response/cleaner.py
@@ -9,29 +9,268 @@ logger = logging.getLogger(__name__)
 # OUT-OF-DOMAIN DETECTION
 # ============================================================================
 
-OUT_OF_DOMAIN_RESPONSES = {
-    "personal_data": (
-        "Non ho accesso a dati personali di terze persone come codici fiscali, "
-        "numeri di telefono o indirizzi privati. Posso aiutarti con informazioni "
-        "su visa, business setup o questioni legali in Indonesia?"
-    ),
-    "realtime_info": (
-        "Non ho accesso a informazioni in tempo reale come meteo, news o risultati sportivi. "
-        "Per queste informazioni ti consiglio di consultare fonti aggiornate. "
-        "Posso invece aiutarti con visa, KITAS, o business in Indonesia?"
-    ),
-    "off_topic": (
-        f"Questo argomento è fuori dalla mia area di competenza. Sono Zantara, "
-        f"l'assistente AI di {settings.COMPANY_NAME}, specializzato in visa, immigrazione, "
-        "setup aziendale (PT PMA) e questioni legali per stranieri in Indonesia. "
-        "Come posso aiutarti in questi ambiti?"
-    ),
-    "unknown": (
-        "Non ho informazioni specifiche su questo argomento. "
-        "Posso aiutarti con visa, KITAS, setup PT PMA/Lokal, "
-        "o altre questioni business in Indonesia?"
-    ),
+# These four strings were ITALIAN-ONLY until 2026-08-10, on a gate that fires
+# BEFORE retrieval on every channel: an English or Indonesian client asking a
+# blocked question read a refusal in a language they had not written in.
+#
+# `{company}` is filled at call time, so a test can move COMPANY_NAME without
+# re-importing this module.
+#
+# WHY A SECOND TABLE AND NOT `_reasoning_stubs.STUB_MESSAGES`: that module is the
+# refusal-copy SSOT and would be the right home, but `cleaner` cannot import it.
+# `query_gates` imports THIS module, and reaching `backend.services.rag.agentic.
+# _reasoning_stubs` executes that package's `__init__`, which pulls the
+# orchestrator and lands back here mid-import. So the COPY is duplicated by
+# necessity while the LANGUAGE SET is not: `test_out_of_domain_language_coverage`
+# imports `PROTOCOL_LANGUAGES` from that same SSOT and derives the detector's
+# vocabulary from its AST, exactly as the stub table's own test does. Adding a
+# language to `detect_query_language` fails both tables or neither.
+_OUT_OF_DOMAIN_BY_LANGUAGE: dict[str, dict[str, str]] = {
+    "personal_data": {
+        "ITALIAN": (
+            "Non ho accesso a dati personali di terze persone come codici fiscali, "
+            "numeri di telefono o indirizzi privati. Posso aiutarti con informazioni "
+            "su visa, business setup o questioni legali in Indonesia?"
+        ),
+        "ENGLISH": (
+            "I don't have access to other people's personal data — tax codes, phone "
+            "numbers or private addresses. I can help with visas, business setup or "
+            "legal questions in Indonesia. What do you need?"
+        ),
+        "INDONESIAN": (
+            "Saya tidak punya akses ke data pribadi orang lain seperti NPWP, nomor "
+            "telepon, atau alamat pribadi. Saya bisa bantu soal visa, pendirian usaha, "
+            "atau pertanyaan hukum di Indonesia. Ada yang bisa saya bantu?"
+        ),
+        "RUSSIAN": (
+            "У меня нет доступа к персональным данным третьих лиц — налоговым номерам, "
+            "телефонам или домашним адресам. Могу помочь с визами, открытием компании "
+            "или юридическими вопросами в Индонезии. Что вас интересует?"
+        ),
+        "UKRAINIAN": (
+            "Я не маю доступу до персональних даних третіх осіб — податкових номерів, "
+            "телефонів чи домашніх адрес. Можу допомогти з візами, відкриттям компанії "
+            "або юридичними питаннями в Індонезії. Що вас цікавить?"
+        ),
+    },
+    "realtime_info": {
+        "ITALIAN": (
+            "Non ho accesso a informazioni in tempo reale come meteo, news o risultati sportivi. "
+            "Per queste informazioni ti consiglio di consultare fonti aggiornate. "
+            "Posso invece aiutarti con visa, KITAS, o business in Indonesia?"
+        ),
+        "ENGLISH": (
+            "I don't have access to live figures like market prices or exchange rates — "
+            "I'd be quoting a number I cannot verify. For those, check a live source. "
+            "I can help with visas, KITAS or doing business in Indonesia instead."
+        ),
+        "INDONESIAN": (
+            "Saya tidak punya akses ke angka real-time seperti harga pasar atau kurs — "
+            "saya akan menyebut angka yang tidak bisa saya verifikasi. Untuk itu, silakan "
+            "cek sumber langsung. Saya bisa bantu soal visa, KITAS, atau usaha di Indonesia."
+        ),
+        "RUSSIAN": (
+            "У меня нет доступа к данным в реальном времени — котировкам или курсам валют: "
+            "я назвал бы цифру, которую не могу проверить. Для этого лучше смотреть "
+            "актуальный источник. А с визами, KITAS или бизнесом в Индонезии — помогу."
+        ),
+        "UKRAINIAN": (
+            "Я не маю доступу до даних у реальному часі — котирувань чи курсів валют: "
+            "я назвав би цифру, яку не можу перевірити. Для цього краще дивитися "
+            "актуальне джерело. А з візами, KITAS чи бізнесом в Індонезії — допоможу."
+        ),
+    },
+    "off_topic": {
+        "ITALIAN": (
+            "Questo argomento è fuori dalla mia area di competenza. Sono Zantara, "
+            "l'assistente AI di {company}, specializzato in visa, immigrazione, "
+            "setup aziendale (PT PMA) e questioni legali per stranieri in Indonesia. "
+            "Come posso aiutarti in questi ambiti?"
+        ),
+        "ENGLISH": (
+            "That one is outside what I work on. I'm Zantara, the AI assistant at "
+            "{company}: visas, immigration, company setup (PT PMA) and legal matters "
+            "for foreigners in Indonesia. Anything there I can help with?"
+        ),
+        "INDONESIAN": (
+            "Topik itu di luar bidang saya. Saya Zantara, asisten AI dari {company}: "
+            "visa, imigrasi, pendirian perusahaan (PT PMA), dan urusan hukum untuk "
+            "orang asing di Indonesia. Ada yang bisa saya bantu di situ?"
+        ),
+        "RUSSIAN": (
+            "Эта тема вне моей области. Я Zantara, AI-ассистент {company}: визы, "
+            "иммиграция, регистрация компании (PT PMA) и юридические вопросы для "
+            "иностранцев в Индонезии. Могу чем-то помочь в этих темах?"
+        ),
+        "UKRAINIAN": (
+            "Ця тема поза моєю сферою. Я Zantara, AI-асистент {company}: візи, "
+            "імміграція, реєстрація компанії (PT PMA) та юридичні питання для "
+            "іноземців в Індонезії. Чи можу допомогти в цих темах?"
+        ),
+    },
+    "unknown": {
+        "ITALIAN": (
+            "Non ho informazioni specifiche su questo argomento. "
+            "Posso aiutarti con visa, KITAS, setup PT PMA/Lokal, "
+            "o altre questioni business in Indonesia?"
+        ),
+        "ENGLISH": (
+            "I don't have specific information on that. I can help with visas, KITAS, "
+            "setting up a PT PMA or a local PT, and other business matters in Indonesia."
+        ),
+        "INDONESIAN": (
+            "Saya tidak punya informasi spesifik soal itu. Saya bisa bantu soal visa, "
+            "KITAS, pendirian PT PMA atau PT lokal, dan urusan usaha lain di Indonesia."
+        ),
+        "RUSSIAN": (
+            "По этой теме у меня нет конкретной информации. Могу помочь с визами, KITAS, "
+            "регистрацией PT PMA или локальной PT и другими бизнес-вопросами в Индонезии."
+        ),
+        "UKRAINIAN": (
+            "З цієї теми в мене немає конкретної інформації. Можу допомогти з візами, "
+            "KITAS, реєстрацією PT PMA чи локальної PT та іншими бізнес-питаннями в Індонезії."
+        ),
+    },
 }
+
+
+def get_out_of_domain_response(reason: str, language: str = "ITALIAN") -> str:
+    """Refusal copy for ``reason``, in ``language``.
+
+    Fallback order mirrors ``get_localized_stub``: requested language → ENGLISH →
+    the ``unknown`` refusal. An unmapped language degrading to ENGLISH is
+    deliberate and declared; an unmapped language degrading to ITALIAN — which is
+    what shipping the raw table did — is not.
+    """
+    by_language = _OUT_OF_DOMAIN_BY_LANGUAGE.get(reason) or _OUT_OF_DOMAIN_BY_LANGUAGE["unknown"]
+    text = by_language.get(language) or by_language["ENGLISH"]
+    return text.format(company=settings.COMPANY_NAME)
+
+
+#: Back-compat: the Italian column, formatted, under the name callers already
+#: import. Derived, never re-typed — a second copy of this copy would drift.
+OUT_OF_DOMAIN_RESPONSES = {
+    reason: get_out_of_domain_response(reason, "ITALIAN") for reason in _OUT_OF_DOMAIN_BY_LANGUAGE
+}
+
+
+# Capitalised words that are NOT people. The cost of a missing entry here is a
+# polite refusal on a rare phrasing — the safe direction; the cost of not having
+# the distinction at all was measured on 2026-08-10 as 6 legitimate business
+# questions blocked out of 9.
+_NON_PERSON_CAPITALS = frozenset(
+    {
+        # legal forms and documents
+        "pt",
+        "cv",
+        "pma",
+        "pmdn",
+        "kitas",
+        "kitap",
+        "kbli",
+        "npwp",
+        "nib",
+        "oss",
+        "bpjs",
+        "lkpm",
+        "spt",
+        "voa",
+        "nomor",
+        "no",
+        # places
+        "bali",
+        "indonesia",
+        "denpasar",
+        "jakarta",
+        "badung",
+        "gianyar",
+        "ubud",
+        "canggu",
+        "kerobokan",
+        "seminyak",
+        # institutions and counterparties
+        "societa",
+        "società",
+        "azienda",
+        "impresa",
+        "company",
+        "office",
+        "ufficio",
+        "kantor",
+        "immigration",
+        "immigrazione",
+        "imigrasi",
+        "tribunale",
+        "court",
+        "pengadilan",
+        "notaio",
+        "notary",
+        "notaris",
+        "banca",
+        "bank",
+        "consolato",
+        "consulate",
+        "ambasciata",
+        "embassy",
+        "agenzia",
+        "agency",
+        "ministero",
+        "ministry",
+        "kementerian",
+        "bkpm",
+        "kemenkumham",
+        "zero",
+    }
+)
+
+# An explicit third-party PERSON. `sindaco/presidente/ministro` keep the older
+# rule's intent; the rest are how a real request for someone else's data reads.
+_PERSON_REFERENCE_RE = re.compile(
+    r"\b(sig\.?|signor[ae]?|mr\.?|mrs\.?|ms\.?|"
+    r"(?:il |la )?(?:mio|mia|tuo|tua|suo|sua|nostro|nostra|vostro|vostra)\s+client[ei]|"
+    r"(?:your|my|his|her|their)\s+client|"
+    r"un cliente|qualcuno|someone|somebody|"
+    r"sindaco|presidente|ministro)\b"
+)
+
+_TITLECASE_TOKEN_RE = re.compile(r"\b([A-Z][a-zà-ÿ]{2,})\b")
+
+
+def _names_a_person(query: str, object_start: int) -> bool:
+    """True when the OBJECT of "<attribute> of <object>" is a natural person.
+
+    This is the entity test the old patterns lacked. They matched
+    ``indirizzo (di|del|della) \\w+`` and so refused "l'indirizzo della società
+    registrata" and "the phone number of the immigration office" as third-party
+    personal data, while "il codice fiscale di Mario Rossi" — the only shape the
+    rule exists for — matched for exactly the same reason.
+
+    Two independent signals, either is enough:
+      * an explicit person reference anywhere in the query ("il mio cliente",
+        "mr", "il sindaco");
+      * a Title-cased token IN THE OBJECT that is not a known institution,
+        place, legal form or document.
+
+    ``object_start`` is not a detail: the first pass of this cure scanned the
+    WHOLE query for capitals and blocked 12 of 14 legitimate questions, because
+    the first word of a sentence is capitalised too — a second form-test dressed
+    up as an entity test. The window therefore begins at the object and stops at
+    the end of the clause, so a capitalised word in a following sentence
+    ("…della società? Grazie Zantara") cannot vote either.
+
+    Case is read from the ORIGINAL text, never from ``.lower()``: `PT PMA`,
+    `CV` and `LKPM` are all-caps acronyms and never match `[A-Z][a-zà-ÿ]{2,}`.
+
+    Declared limit: a capitalised institution nobody listed in
+    ``_NON_PERSON_CAPITALS`` still reads as a person. That fails toward the
+    refusal, which is the direction to fail in.
+    """
+    if _PERSON_REFERENCE_RE.search(query.lower()):
+        return True
+    clause = re.split(r"[?.!\n;]", query[object_start:], maxsplit=1)[0]
+    return any(
+        token.lower() not in _NON_PERSON_CAPITALS for token in _TITLECASE_TOKEN_RE.findall(clause)
+    )
 
 
 def is_out_of_domain(query: str) -> tuple[bool, str | None]:
@@ -40,18 +279,31 @@ def is_out_of_domain(query: str) -> tuple[bool, str | None]:
     """
     query_lower = query.lower()
 
-    # Personal data of third parties
+    # Personal data of third parties.
+    #
+    # The shape is necessary but NOT sufficient: these patterns describe
+    # "<attribute> of <object>", and whether that is a privacy question depends
+    # entirely on what the object IS. Superscar #3 — the guard has to name the
+    # entity, not the form. `_names_a_person` is the second half of the test and
+    # the default without it is PASSTHROUGH, so a business question reaches
+    # retrieval instead of a canned Italian refusal.
+    #
+    # The group is the OBJECT — the thing whose data is being asked for. It is
+    # what `_names_a_person` reads; the surrounding shape only says WHERE to look.
     personal_data_patterns = [
-        r"codice fiscale (di|del|della|dello) \w+",
-        r"numero (di )?telefono (di|del|della) \w+",
-        r"indirizzo (di|del|della) \w+",
-        r"email (di|del|della) \w+",
-        r"tax (code|id|number) of \w+",
-        r"phone number of \w+",
+        r"codice fiscale (?:di|del|della|dello) (\w+)",
+        r"numero (?:di )?telefono (?:di|del|della) (\w+)",
+        r"indirizzo (?:di|del|della) (\w+)",
+        r"email (?:di|del|della) (\w+)",
+        r"tax (?:code|id|number) of (\w+)",
+        r"phone number of (\w+)",
     ]
 
     for pattern in personal_data_patterns:
-        if re.search(pattern, query_lower):
+        # Matched on the ORIGINAL string so `match.start(1)` indexes the text
+        # whose capitalisation `_names_a_person` reads.
+        match = re.search(pattern, query, re.IGNORECASE)
+        if match and _names_a_person(query, match.start(1)):
             return True, "personal_data"
 
     # Real-time FINANCIAL information (blocked - cannot verify)

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_query_gates.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_query_gates.py
@@ -114,15 +114,15 @@ def test_check_out_of_domain_gate_uses_cleaner_reason(
     monkeypatch.setattr(module, "is_out_of_domain", lambda query: (True, "medical"))
     monkeypatch.setattr(
         module,
-        "OUT_OF_DOMAIN_RESPONSES",
-        {"medical": "medical blocked", "unknown": "unknown blocked"},
+        "get_out_of_domain_response",
+        lambda reason, language: f"{reason} blocked in {language}",
     )
 
     result = make_gates().check_out_of_domain_gate("diagnose this rash")
 
     assert result.triggered is True
-    assert result.response == "medical blocked"
-    assert result.metadata == {"reason": "medical"}
+    assert result.response == "medical blocked in ENGLISH"
+    assert result.metadata == {"reason": "medical", "language": "ENGLISH"}
 
 
 def test_run_all_gates_returns_first_triggered_gate() -> None:

--- a/apps/backend-rag/backend/tests/services/response/test_out_of_domain_entity_not_shape.py
+++ b/apps/backend-rag/backend/tests/services/response/test_out_of_domain_entity_not_shape.py
@@ -1,0 +1,154 @@
+"""The out-of-domain gate must judge the ENTITY asked about, not the SHAPE of the ask.
+
+WHY THIS FILE EXISTS
+--------------------
+Measured on 2026-08-10, before the cure: **6 of 9 legitimate business questions
+were refused** as "third-party personal data" — the company's registered
+address, the notary's email, the immigration office's phone number, the tax code
+of a PT PMA, the client's own company tax ID, the competent court's address.
+
+The patterns matched ``indirizzo (di|del|della) \\w+`` — i.e. "<attribute> of
+<anything>". "l'indirizzo della società" and "l'indirizzo di Mario Rossi" are
+the same SHAPE, so the guard could not tell a privacy question from a business
+one; superscar #3, the guard that reads the form instead of the entity.
+
+This gate runs BEFORE retrieval (``query_gates.run_all_gates``), so every one of
+those six was a canned refusal instead of an answer — and, on WhatsApp, a canned
+refusal in Italian regardless of what the client wrote in.
+
+The innocence list is FIRST here because it is the list that was failing. The
+guilt list is what the rule exists for and must keep doing.
+
+A note on the cure's own first draft, kept as a test below: it checked the whole
+query for a Title-cased word, which made it worse — 12 of 14 blocked, because
+the first word of a sentence is capitalised too. That was a second form-test
+wearing an entity-test's name. ``test_a_capitalised_first_word_is_not_a_person``
+is the pin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.services.response.cleaner import (
+    OUT_OF_DOMAIN_RESPONSES,
+    get_out_of_domain_response,
+    is_out_of_domain,
+)
+
+#: Real business questions. Every one of these has the shape the old patterns
+#: matched; none of them asks for a natural person's data. The first six are the
+#: ones measured blocked on 2026-08-10.
+LEGITIMATE_BUSINESS_QUESTIONS = [
+    "Qual e' l'indirizzo della societa' registrata?",
+    "Qual e' l'email del notaio che segue la pratica?",
+    "What is the phone number of the immigration office?",
+    "What is the tax code of a PT PMA?",
+    "Tax ID of my company — where do I find it?",
+    "Qual e' l'indirizzo del tribunale competente?",
+    "Come ottengo il codice fiscale della mia azienda?",
+    "What is the phone number of the Bali Zero office?",
+    "Qual e' l'indirizzo della banca per il conto aziendale?",
+    "What is the tax code of a CV in Indonesia?",
+    "Qual e' l'email dell'agenzia che gestisce il NIB?",
+    "Dove trovo il numero di telefono del kantor pajak?",
+    "What is the tax number of the company I want to acquire?",
+]
+
+#: Requests for a natural person's data — what the rule is actually for.
+THIRD_PARTY_PERSONAL_DATA = [
+    "Dammi il codice fiscale di Mario Rossi",
+    "What is the phone number of your client Marco?",
+    "Qual e' l'indirizzo di casa del sindaco di Denpasar?",
+    "Mi dai l'email di Giulia Bianchi?",
+    "Tax code of Mr Johnson please",
+    "Qual e' il numero di telefono del mio cliente?",
+]
+
+
+class TestInnocenceBusinessQuestionsReachRetrieval:
+    """The six measured false refusals, plus the shape's other legitimate uses."""
+
+    @pytest.mark.parametrize("query", LEGITIMATE_BUSINESS_QUESTIONS)
+    def test_business_question_is_not_out_of_domain(self, query: str) -> None:
+        out_of_domain, reason = is_out_of_domain(query)
+        assert out_of_domain is False, (
+            f"{query!r} was refused as {reason!r}. It asks about an institution or "
+            f"the client's own company, not about a person — the gate is reading "
+            f"the shape of the sentence, not who it is about."
+        )
+
+    def test_a_capitalised_first_word_is_not_a_person(self) -> None:
+        """Pins the cure's own first draft, which was worse than the defect.
+
+        Scanning the WHOLE query for a Title-cased token blocked 12 of 14 of the
+        list above: "Qual", "What", "Come", "Dove" are all capitalised. Only the
+        OBJECT of the genitive may vote.
+        """
+        assert is_out_of_domain("Qual e' l'indirizzo della sede legale?") == (False, None)
+        assert is_out_of_domain("What is the tax code of a company?") == (False, None)
+
+    def test_a_capitalised_word_in_a_later_clause_does_not_vote(self) -> None:
+        """The window stops at the end of the clause, not at the end of the string."""
+        assert is_out_of_domain("Qual e' l'indirizzo della societa'? Grazie Zantara") == (
+            False,
+            None,
+        )
+
+    def test_an_all_caps_acronym_is_not_a_person(self) -> None:
+        """`PT`, `CV`, `NPWP` are entities that never match `[A-Z][a-z]+`."""
+        assert is_out_of_domain("What is the tax number of a PT PMA in Bali?") == (False, None)
+
+
+class TestGuiltPersonalDataIsStillRefused:
+    """Widening the gate must not open it."""
+
+    @pytest.mark.parametrize("query", THIRD_PARTY_PERSONAL_DATA)
+    def test_personal_data_request_is_refused(self, query: str) -> None:
+        out_of_domain, reason = is_out_of_domain(query)
+        assert out_of_domain is True, f"{query!r} asks for a person's data and passed"
+        assert reason == "personal_data"
+
+    def test_a_named_person_blocks_even_without_a_person_word(self) -> None:
+        """The name alone is the signal; no "mr"/"cliente" needed."""
+        assert is_out_of_domain("Mi serve l'indirizzo di Giulia Bianchi") == (
+            True,
+            "personal_data",
+        )
+
+    def test_an_unnamed_client_blocks_even_without_a_capital(self) -> None:
+        """And the person-word alone is the signal; no name needed."""
+        assert is_out_of_domain("Qual e' l'email del mio cliente?") == (True, "personal_data")
+
+    def test_realtime_financial_questions_are_untouched_by_the_widening(self) -> None:
+        assert is_out_of_domain("What is the bitcoin price today?") == (True, "realtime_info")
+        assert is_out_of_domain("Qual e' il forex rate USD IDR?") == (True, "realtime_info")
+
+
+class TestTheRefusalSpeaksTheClientsLanguage:
+    """Until 2026-08-10 all four refusals were Italian, on a pre-retrieval gate."""
+
+    @pytest.mark.parametrize("reason", sorted(OUT_OF_DOMAIN_RESPONSES))
+    @pytest.mark.parametrize("language", ["ENGLISH", "INDONESIAN", "RUSSIAN", "UKRAINIAN"])
+    def test_a_non_italian_client_is_not_answered_in_italian(
+        self, reason: str, language: str
+    ) -> None:
+        assert get_out_of_domain_response(reason, language) != OUT_OF_DOMAIN_RESPONSES[reason], (
+            f"the {language} refusal for {reason!r} is byte-identical to the Italian one"
+        )
+
+    def test_the_legacy_export_is_the_italian_column_and_is_formatted(self) -> None:
+        """Back-compat, and no `{company}` placeholder may reach a client."""
+        for reason, text in OUT_OF_DOMAIN_RESPONSES.items():
+            assert text == get_out_of_domain_response(reason, "ITALIAN")
+            assert "{company}" not in text
+
+    def test_an_untranslated_language_degrades_to_english_not_italian(self) -> None:
+        assert get_out_of_domain_response("personal_data", "CHINESE") == (
+            get_out_of_domain_response("personal_data", "ENGLISH")
+        )
+
+    def test_an_unknown_reason_degrades_to_the_unknown_refusal(self) -> None:
+        assert get_out_of_domain_response("medical", "ENGLISH") == (
+            get_out_of_domain_response("unknown", "ENGLISH")
+        )

--- a/apps/backend-rag/backend/tests/services/response/test_out_of_domain_language_coverage.py
+++ b/apps/backend-rag/backend/tests/services/response/test_out_of_domain_language_coverage.py
@@ -1,0 +1,111 @@
+"""The out-of-domain refusals must cover every language the detector can emit.
+
+WHY A SECOND COVERAGE FILE
+--------------------------
+``_reasoning_stubs.STUB_MESSAGES`` is the refusal-copy SSOT and
+``test_reasoning_stubs_language_coverage.py`` guards it. ``cleaner`` cannot
+import that module — ``query_gates`` imports ``cleaner``, so reaching
+``backend.services.rag.agentic._reasoning_stubs`` would execute that package's
+``__init__``, pull the orchestrator, and land back in a half-initialised
+``cleaner``. The COPY therefore lives in two places.
+
+The LANGUAGE SET does not. This file imports ``PROTOCOL_LANGUAGES`` from the
+SSOT and derives the detector's output vocabulary from its AST, exactly as the
+stub test does — so adding a language to ``detect_query_language`` turns BOTH
+tables red, never one. A hand-written list here would be the second copy of the
+truth that the stub test explicitly refuses to keep.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from backend.services.rag.agentic import query_helpers
+from backend.services.rag.agentic._reasoning_stubs import PROTOCOL_LANGUAGES
+from backend.services.response.cleaner import (
+    _OUT_OF_DOMAIN_BY_LANGUAGE,
+    get_out_of_domain_response,
+)
+
+#: Languages the detector emits that these refusals knowingly serve in English.
+#: Kept identical in spirit to the stub table's declaration: a new detector
+#: language must be translated or declared here on purpose.
+DECLARED_ENGLISH_FALLBACK: frozenset[str] = frozenset(
+    {"CHINESE", "ARABIC", "FRENCH", "SPANISH", "GERMAN"}
+)
+
+
+def _languages_the_detector_can_emit() -> set[str]:
+    """Every string literal ``detect_query_language`` can return, from its AST."""
+    source = Path(query_helpers.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "detect_query_language":
+            emitted = {
+                stmt.value.value
+                for stmt in ast.walk(node)
+                if isinstance(stmt, ast.Return)
+                and isinstance(stmt.value, ast.Constant)
+                and isinstance(stmt.value.value, str)
+            }
+            assert emitted, "parsed detect_query_language but found no returned literals"
+            return emitted
+    raise AssertionError("detect_query_language not found in query_helpers.py")
+
+
+class TestGuiltEveryProtocolLanguageIsReallyTranslated:
+    @pytest.mark.parametrize("reason", sorted(_OUT_OF_DOMAIN_BY_LANGUAGE))
+    @pytest.mark.parametrize("language", PROTOCOL_LANGUAGES)
+    def test_reason_has_an_entry_for_every_protocol_language(
+        self, reason: str, language: str
+    ) -> None:
+        assert language in _OUT_OF_DOMAIN_BY_LANGUAGE[reason], (
+            f"out-of-domain refusal {reason!r} has no {language} entry — clients "
+            f"writing {language} receive English and nothing fails"
+        )
+
+    @pytest.mark.parametrize("reason", sorted(_OUT_OF_DOMAIN_BY_LANGUAGE))
+    @pytest.mark.parametrize("language", [lang for lang in PROTOCOL_LANGUAGES if lang != "ENGLISH"])
+    def test_translation_is_not_the_english_text(self, reason: str, language: str) -> None:
+        assert get_out_of_domain_response(reason, language) != get_out_of_domain_response(
+            reason, "ENGLISH"
+        ), f"refusal {reason!r} for {language} is byte-identical to the English text"
+
+    @pytest.mark.parametrize("reason", sorted(_OUT_OF_DOMAIN_BY_LANGUAGE))
+    @pytest.mark.parametrize("language", PROTOCOL_LANGUAGES)
+    def test_no_refusal_is_blank_or_carries_an_unfilled_placeholder(
+        self, reason: str, language: str
+    ) -> None:
+        text = get_out_of_domain_response(reason, language)
+        assert text.strip()
+        assert "{" not in text, f"{reason}/{language} still carries a format placeholder"
+
+
+class TestGuiltTheDetectorCannotOutgrowTheTable:
+    def test_every_emitted_language_is_translated_or_declared(self) -> None:
+        emitted = _languages_the_detector_can_emit() - {"UNKNOWN"}
+        orphans = emitted - (set(PROTOCOL_LANGUAGES) | DECLARED_ENGLISH_FALLBACK)
+        assert not orphans, (
+            f"detect_query_language can return {sorted(orphans)}, which the "
+            f"out-of-domain table does not translate and does not declare."
+        )
+
+    def test_the_declared_fallback_set_is_not_stale(self) -> None:
+        stale = DECLARED_ENGLISH_FALLBACK - _languages_the_detector_can_emit()
+        assert not stale, f"DECLARED_ENGLISH_FALLBACK lists {sorted(stale)}, never emitted"
+
+
+class TestInnocenceTheResolverContract:
+    def test_unknown_language_gets_english(self) -> None:
+        assert get_out_of_domain_response("off_topic", "KLINGON") == get_out_of_domain_response(
+            "off_topic", "ENGLISH"
+        )
+
+    def test_default_language_is_italian_for_callers_that_pass_none(self) -> None:
+        """Back-compat with the pre-2026-08-10 signature, which had no language."""
+        assert get_out_of_domain_response("unknown") == get_out_of_domain_response(
+            "unknown", "ITALIAN"
+        )


### PR DESCRIPTION
Third pre-retrieval gate probed in this loop, same disease as the other two — superscar #3, a guard reading the FORM of a sentence instead of the ENTITY it is about.

## Measured before the change

Nine legitimate business questions run against the live patterns; **six refused** with a canned "I have no access to third parties' personal data":

- `Qual e' l'indirizzo della societa' registrata?`
- `Qual e' l'email del notaio che segue la pratica?`
- `What is the phone number of the immigration office?`
- `What is the tax code of a PT PMA?`
- `Tax ID of my company — where do I find it?`
- `Qual e' l'indirizzo del tribunale competente?`

**0 of 5** genuine privacy questions were missed. The gate was not loose; it was blind.

## The defect

The patterns match `<attribute> di/of <anything>`. `"indirizzo della societa'"` and `"indirizzo di Mario Rossi"` are the same SHAPE, so the guard could not tell a privacy question from a business one. This gate runs **before retrieval** (`query_gates.run_all_gates`), so each of the six was a refusal instead of an answer.

## The cure

The shape now only says WHERE to look; `_names_a_person` decides whether the OBJECT is a natural person — an explicit person reference (`il mio cliente`, `mr`, `il sindaco`) or a Title-cased token in the object that is not a known institution, place, legal form or document. Default is passthrough, so an unlisted institution reaches retrieval rather than a canned refusal.

`object_start` is load-bearing, and the first draft proves it: it scanned the whole query for capitals and blocked **12 of 14**, because the first word of a sentence is capitalised too — a second form-test wearing an entity-test's name. That draft is pinned by `test_a_capitalised_first_word_is_not_a_person`.

## Second defect on the same function

All four `OUT_OF_DOMAIN_RESPONSES` were **Italian-only**, on a gate that fires before a single word has been retrieved. An English or Indonesian client asking a blocked question read Italian. All four now carry the five `PROTOCOL_LANGUAGES` and degrade to ENGLISH — never to Italian — and the gate passes `detect_query_language(query)`.

The copy is duplicated out of `_reasoning_stubs.STUB_MESSAGES` by necessity: `query_gates` imports `cleaner`, so reaching `backend.services.rag.agentic._reasoning_stubs` would execute that package's `__init__`, pull the orchestrator, and land back in a half-initialised `cleaner`. **The language SET is not duplicated** — `test_out_of_domain_language_coverage` imports `PROTOCOL_LANGUAGES` from that same SSOT and derives the detector's vocabulary from its AST, exactly as the stub table's own test does, so adding a language to `detect_query_language` reddens both tables or neither.

## Verification

- After: **0/14** legitimate questions blocked, **0/6** personal-data requests missed.
- Mutation-verified three ways: entity test disabled (15 red), whole-query capital scan restored (15 red), localization reverted (32 red).
- `test_query_gates.py::test_check_out_of_domain_gate_uses_cleaner_reason` updated to patch the new function; what it asserts is unchanged.

## Note on a pre-existing red

Running `backend/tests/unit/services/rag/agentic/...` *before* `backend/tests/services/response/` makes three unrelated `test_standard_templates.py` tests fail. **Measured identical on `origin/main`** with the same command set — not this diff. Cause is the `sys.modules` hijack in `backend/tests/unit/services/rag/agentic/conftest.py` already logged in PENDING-ARMS; CI is green because a full-suite run collects `services/` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)