### PR TITLE
fix(rag): the answer formatter deleted 56-61% of a procedural answer and returned a numbered list that reads complete

### DIFF
--- a/apps/backend-rag/backend/services/communication/language_detector.py
+++ b/apps/backend-rag/backend/services/communication/language_detector.py
@@ -17,7 +17,7 @@ import re
 from typing import Any, Literal
 
 
-def detect_language(text: str) -> Literal["it", "en", "id", "uk", "ru"]:
+def detect_language(text: str) -> Literal["it", "en", "id", "uk", "ru", "auto"]:
     """
     Detect language from query text with Italian focus.
 
@@ -25,7 +25,13 @@ def detect_language(text: str) -> Literal["it", "en", "id", "uk", "ru"]:
         text: User query text
 
     Returns:
-        Language code: "it" (Italian), "en" (English), or "id" (Indonesian)
+        One of "it", "en", "id", "uk", "ru", or **"auto"** when no marker
+        matched. "auto" is a real, frequently-returned value — the annotation
+        omitted it and the docstring listed only three of the six, so callers
+        were written against a vocabulary this function does not emit and
+        silently took their own `.get(...)` default instead (measured
+        2026-08-10: `_add_emotional_acknowledgment` defaulted to Italian).
+        `get_language_instruction` below has always had an "auto" entry.
     """
     if not text:
         return "it"

--- a/apps/backend-rag/backend/services/rag/agentic/response_processor.py
+++ b/apps/backend-rag/backend/services/rag/agentic/response_processor.py
@@ -90,10 +90,40 @@ def _format_as_numbered_list(text: str, language: str) -> str:
         "id": ["siapkan", "cari", "ajukan", "isi", "kirim", "tunggu", "ambil"],
     }
 
-    verbs = action_verbs.get(language, action_verbs["en"])
-    actionable_sentences = [
-        s for s in sentences if any(verb in s.lower() for verb in verbs) and len(s) > 20
-    ]
+    # No verb list for this language -> do not reformat. Running the ENGLISH
+    # list over a Russian answer is not a neutral default, it is a guess about
+    # a language we have no vocabulary for.
+    verbs = action_verbs.get(language)
+    if not verbs:
+        return text
+
+    # Word-boundary, not substring (superscar #3): bare `in` makes the
+    # Indonesian "isi" fire inside "revisi", "efisiensi", "administrasi".
+    verb_re = re.compile(r"\b(?:" + "|".join(re.escape(v) for v in verbs) + r")\w*", re.IGNORECASE)
+    # No length floor. The old `len(s) > 20` was a proxy for "is this a real
+    # step", and combined with the conservation guard below it turns a short
+    # but genuine step ("Find the office", 15 chars) into a dropped sentence,
+    # which then declines a list that is entirely steps. The "every sentence
+    # must be actionable" rule is the real filter; a length is not.
+    actionable_sentences = [s for s in sentences if verb_re.search(s)]
+
+    # CONSERVATION GUARD. This function used to return ONLY the sentences it
+    # liked, silently discarding every other sentence of a correct answer.
+    # Measured 2026-08-10 on a 5-sentence procedural answer, in all three
+    # supported languages: 56% / 57% / 61% of the answer deleted, and what
+    # went with it was the Bali Zero service fee and the overstay penalty —
+    # while the client received a tidy numbered list that reads COMPLETE.
+    # Formatting may reorder nothing and drop nothing: if any substantive
+    # sentence is not part of the list, leave the answer alone.
+    substantive = [s for s in sentences if s.strip()]
+    if len(actionable_sentences) != len(substantive):
+        logger.debug(
+            "[post_process] declining to renumber: %d of %d sentences are not steps, "
+            "reformatting would drop the rest",
+            len(substantive) - len(actionable_sentences),
+            len(substantive),
+        )
+        return text
 
     if len(actionable_sentences) >= 2:
         # Format as numbered list
@@ -115,13 +145,24 @@ def _has_emotional_acknowledgment(text: str, language: str) -> bool:
     """
     text_lower = text.lower()[:200]  # Check first 200 chars
 
+    # Same five keys `detect_language()` emits, mirroring _APOLOGY_TEXTS /
+    # _ACK_TEXTS in wa_outbox_worker. The table used to carry three and fall
+    # back to English, so a Russian answer was searched for English keywords,
+    # never matched, and was therefore always judged to be missing its
+    # acknowledgment.
     acknowledgment_keywords = {
         "it": ["capisco", "tranquillo", "aiuto", "soluzione", "possibilità"],
         "en": ["understand", "don't worry", "help", "solution", "possible"],
         "id": ["mengerti", "tenang", "bantuan", "solusi", "kemungkinan"],
+        "ru": ["понимаю", "не волнуйтесь", "помощь", "решение", "возможно"],
+        "uk": ["розумію", "не хвилюйтеся", "допомога", "рішення", "можливо"],
     }
 
-    keywords = acknowledgment_keywords.get(language, acknowledgment_keywords["en"])
+    keywords = acknowledgment_keywords.get(language)
+    if not keywords:
+        # Unknown language: we cannot tell whether the acknowledgment is there,
+        # and claiming it is missing is what makes the caller prepend one.
+        return True
     return any(keyword in text_lower for keyword in keywords)
 
 
@@ -140,9 +181,19 @@ def _add_emotional_acknowledgment(text: str, language: str) -> str:
         "it": "Capisco la frustrazione, ma tranquillo - quasi ogni situazione ha una soluzione. ",
         "en": "I understand the frustration, but don't worry - almost every situation has a solution. ",
         "id": "Saya mengerti frustrasinya, tapi tenang - hampir setiap situasi ada solusinya. ",
+        "ru": "Понимаю ваше беспокойство, но не волнуйтесь - почти для любой ситуации есть решение. ",
+        "uk": "Розумію ваше занепокоєння, але не хвилюйтеся - майже для кожної ситуації є рішення. ",
     }
 
-    acknowledgment = acknowledgments.get(language, acknowledgments["it"])
+    # `detect_language()` also returns "auto" when no marker matched — a value
+    # its own Literal did not admit until this diff. The old default was
+    # ITALIAN, so an unrecognised language got an Italian sentence grafted onto
+    # the front of its answer; measured reachable end-to-end on a Russian
+    # message (lang='ru', emotional=True) before "ru" was added below. There is
+    # no safe language to guess: prepend nothing rather than the wrong tongue.
+    acknowledgment = acknowledgments.get(language)
+    if not acknowledgment:
+        return text
 
     # Don't add if already present
     if acknowledgment.lower()[:20] not in text.lower()[:200]:

--- a/apps/backend-rag/backend/tests/services/rag/agentic/test_response_processor_never_drops_content.py
+++ b/apps/backend-rag/backend/tests/services/rag/agentic/test_response_processor_never_drops_content.py
@@ -1,0 +1,245 @@
+"""Guilt + innocence for the two post-generation mutators that rewrite a
+finished answer: `_format_as_numbered_list` and `_add_emotional_acknowledgment`.
+
+Measured 2026-08-10, on the live WhatsApp path (`create_default_pipeline` ->
+`PostProcessingStage` -> `post_process_response`):
+
+  * the numbered-list formatter returned ONLY the sentences whose text matched
+    an action verb and discarded every other sentence — 56% / 57% / 61% of a
+    five-sentence procedural answer deleted in en / it / id respectively, and
+    what went with it was the Bali Zero service fee and the overstay penalty.
+    The client received a tidy numbered list that reads COMPLETE. That is worse
+    than an empty answer: an empty answer is visibly nothing, this is
+    confidently wrong.
+  * `_add_emotional_acknowledgment` carried three languages while
+    `detect_language()` emits six, and defaulted to ITALIAN — reachable
+    end-to-end on a Russian message (lang='ru', emotional=True).
+
+Both are the same disease as the cleaner: a heuristic allowed to REMOVE or
+REPLACE parts of an answer that already passed retrieval and the abstain gate.
+"""
+
+import typing
+
+import pytest
+
+from backend.services.communication import detect_language
+from backend.services.rag.agentic.response_processor import (
+    _add_emotional_acknowledgment,
+    _format_as_numbered_list,
+    _has_emotional_acknowledgment,
+    post_process_response,
+)
+
+# ---------------------------------------------------------------------------
+# INNOCENCE — formatting may never delete a fact
+# ---------------------------------------------------------------------------
+
+PROCEDURAL_ANSWERS = [
+    pytest.param(
+        "en",
+        "What are the steps to extend my C1 tourist visa?",
+        "To extend a C1 tourist visa you must act before it expires. "
+        "Prepare your passport with at least 6 months validity. "
+        "The Bali Zero service fee is IDR 1,500,000 all inclusive. "
+        "Submit the application at least 7 working days before expiry. "
+        "Overstaying costs IDR 1,000,000 per day.",
+        ["IDR 1,500,000", "IDR 1,000,000 per day", "before it expires"],
+        id="en",
+    ),
+    pytest.param(
+        "it",
+        "Quali sono i passaggi per estendere il visto turistico C1?",
+        "Per estendere il visto C1 devi muoverti prima della scadenza. "
+        "Prepara il passaporto con almeno 6 mesi di validita. "
+        "Il costo del servizio Bali Zero e IDR 1.500.000 tutto incluso. "
+        "Invia la domanda almeno 7 giorni lavorativi prima della scadenza. "
+        "L'overstay costa IDR 1.000.000 al giorno.",
+        ["IDR 1.500.000", "IDR 1.000.000 al giorno", "prima della scadenza"],
+        id="it",
+    ),
+    pytest.param(
+        "id",
+        "Bagaimana langkah-langkah memperpanjang visa turis C1?",
+        "Untuk memperpanjang visa C1 Anda harus bertindak sebelum kadaluarsa. "
+        "Siapkan paspor dengan masa berlaku minimal 6 bulan. "
+        "Biaya layanan Bali Zero adalah IDR 1.500.000 sudah termasuk semua. "
+        "Kirim permohonan minimal 7 hari kerja sebelum kadaluarsa. "
+        "Overstay dikenakan IDR 1.000.000 per hari.",
+        ["IDR 1.500.000", "IDR 1.000.000 per hari", "sebelum kadaluarsa"],
+        id="id",
+    ),
+]
+
+
+@pytest.mark.parametrize(("lang", "query", "answer", "facts"), PROCEDURAL_ANSWERS)
+def test_post_processing_a_procedural_answer_deletes_no_fact(
+    lang: str, query: str, answer: str, facts: list[str]
+) -> None:
+    """End-to-end through the function the pipeline actually calls."""
+    out = post_process_response(answer, query)
+    missing = [f for f in facts if f not in out]
+    assert not missing, f"[{lang}] post-processing deleted {missing} from the answer:\n{out}"
+
+
+@pytest.mark.parametrize(("lang", "query", "answer", "facts"), PROCEDURAL_ANSWERS)
+def test_the_formatter_declines_when_it_would_drop_a_sentence(
+    lang: str, query: str, answer: str, facts: list[str]
+) -> None:
+    """The conservation guard: partial-match input is left ALONE, not filtered.
+
+    Asserted as identity, not as "no fact missing" — the point is that a
+    formatter has no licence to choose which sentences of an answer survive.
+    """
+    assert _format_as_numbered_list(answer, lang) == answer
+
+
+def test_an_unknown_language_is_not_reformatted_with_english_verbs() -> None:
+    russian = (
+        "Подготовьте паспорт со сроком действия не менее 6 месяцев. "
+        "Отправьте заявление за 7 рабочих дней до истечения срока."
+    )
+    assert _format_as_numbered_list(russian, "auto") == russian
+    assert _format_as_numbered_list(russian, "ru") == russian
+
+
+def test_a_language_with_no_verb_table_declines_even_when_english_verbs_match() -> None:
+    """Isolates the BRANCH from the payload — the Russian test above cannot.
+
+    Measured 2026-08-10 by mutation: restoring the old
+    `action_verbs.get(language, action_verbs["en"])` fallback left the Russian
+    case GREEN, because Russian prose matches no English verb and so returns
+    unchanged through a different branch. The assertion held with the branch it
+    names deleted. A surviving mutant is not always a missing test — sometimes
+    it is a test that reaches the right answer down the wrong path.
+
+    So: English-looking sentences, declared as a language we have no vocabulary
+    for. The content is artificial on purpose; the branch under test is not.
+    """
+    text = "Prepare your passport. Submit the form at the immigration office."
+    assert _format_as_numbered_list(text, "fr") == text
+    assert _format_as_numbered_list(text, "auto") == text
+    # Innocence: the same sentences under a language we DO have are numbered.
+    assert _format_as_numbered_list(text, "en").startswith("1. Prepare your passport")
+
+
+def test_indonesian_prose_is_not_renumbered_because_isi_hides_inside_revisi() -> None:
+    """Word boundary, not substring (superscar #3).
+
+    Under the old bare `verb in sentence` rule BOTH sentences matched the
+    action verb "isi" — inside "revisi" — so this administrative prose was
+    renumbered as a two-step procedure.
+    """
+    prose = (
+        "Kami melakukan revisi administrasi untuk efisiensi proses ini. "
+        "Ada revisi lain pada dokumen administrasi tersebut juga."
+    )
+    assert _format_as_numbered_list(prose, "id") == prose
+
+
+# ---------------------------------------------------------------------------
+# GUILT — the formatter must still do its job
+# ---------------------------------------------------------------------------
+
+
+def test_an_all_steps_answer_is_still_numbered() -> None:
+    steps = (
+        "Prepare your passport and two photographs. "
+        "Submit the form at the immigration office. "
+        "Collect the receipt from the counter."
+    )
+    out = _format_as_numbered_list(steps, "en")
+    assert out.startswith("1. Prepare your passport")
+    assert "\n2. Submit the form" in out
+    assert "\n3. Collect the receipt" in out
+
+
+def test_a_single_step_is_not_a_list() -> None:
+    one = "Prepare your passport with at least six months of remaining validity."
+    assert _format_as_numbered_list(one, "en") == one
+
+
+# ---------------------------------------------------------------------------
+# The emotional prefix must never speak a language the client did not use
+# ---------------------------------------------------------------------------
+
+ANSWER = "Your KITAS can be renewed within 30 days of expiry."
+
+EXPECTED_PREFIX_MARKER = {
+    "it": "Capisco",
+    "en": "I understand",
+    "id": "Saya mengerti",
+    "ru": "Понимаю",
+    "uk": "Розумію",
+}
+
+
+@pytest.mark.parametrize(("lang", "marker"), sorted(EXPECTED_PREFIX_MARKER.items()))
+def test_the_acknowledgment_is_written_in_the_clients_language(lang: str, marker: str) -> None:
+    out = _add_emotional_acknowledgment(ANSWER, lang)
+    assert out.startswith(marker), f"[{lang}] got: {out[:60]!r}"
+    assert out.endswith(ANSWER), "the answer itself must survive the prepend"
+
+
+@pytest.mark.parametrize("lang", ["auto", "fr", "es", "de", ""])
+def test_an_unknown_language_gets_no_acknowledgment_rather_than_an_italian_one(
+    lang: str,
+) -> None:
+    """The old default was Italian. There is no safe language to guess."""
+    assert _add_emotional_acknowledgment(ANSWER, lang) == ANSWER
+
+
+def test_an_acknowledgment_is_not_prepended_twice() -> None:
+    once = _add_emotional_acknowledgment(ANSWER, "it")
+    assert _add_emotional_acknowledgment(once, "it") == once
+
+
+def test_an_unknown_language_answer_is_not_judged_to_be_missing_its_acknowledgment() -> None:
+    """`_has_emotional_acknowledgment` searched ENGLISH keywords in any unknown
+    language, never matched, and so reported "missing" — which is precisely
+    what made the caller graft a foreign sentence on."""
+    assert _has_emotional_acknowledgment("Понимаю ваше беспокойство, всё решаемо.", "auto")
+
+
+def test_a_russian_answer_that_already_acknowledges_is_recognised() -> None:
+    assert _has_emotional_acknowledgment("Понимаю ваше беспокойство, есть решение.", "ru")
+
+
+def test_a_russian_answer_without_acknowledgment_is_recognised_as_missing() -> None:
+    """Innocence for the check above: "unknown language" must not become
+    "always satisfied" for languages we DO have keywords for."""
+    assert not _has_emotional_acknowledgment("Ваш KITAS истекает через 14 дней.", "ru")
+
+
+# ---------------------------------------------------------------------------
+# STRUCTURAL — the two sides must agree by construction, not by coincidence
+# ---------------------------------------------------------------------------
+
+
+def _emitted_languages() -> set[str]:
+    """Every value `detect_language` declares it can return."""
+    hints = typing.get_type_hints(detect_language)
+    return set(typing.get_args(hints["return"]))
+
+
+def test_detect_language_declares_the_auto_sentinel_it_actually_returns() -> None:
+    """It returns "auto" whenever no marker matched — the annotation used to
+    omit it, so every consumer was written against a vocabulary the function
+    does not emit and silently fell through to its own default."""
+    assert detect_language("xyzzy 12345") == "auto"
+    assert "auto" in _emitted_languages()
+
+
+def test_every_emitted_language_is_either_translated_or_explicitly_declined() -> None:
+    """The 3-vs-5 drift that produced the Italian default cannot come back.
+
+    A language the detector emits must EITHER have its own copy OR be declined
+    outright — what it must never do is silently borrow another language's.
+    """
+    for lang in sorted(_emitted_languages()):
+        out = _add_emotional_acknowledgment(ANSWER, lang)
+        if out == ANSWER:
+            continue  # explicitly declined - acceptable
+        marker = EXPECTED_PREFIX_MARKER.get(lang)
+        assert marker, f"{lang!r} is prepended text but has no declared copy of its own"
+        assert out.startswith(marker), f"{lang!r} borrowed another language's copy: {out[:50]!r}"

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_response_processor_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_response_processor_coverage.py
@@ -265,10 +265,20 @@ class TestAddEmotionalAcknowledgment:
         assert result.count("Capisco la frustrazione") == 1
 
     def test_add_emotional_acknowledgment_unknown_language(self):
-        """Test with unknown language defaults to Italian"""
+        """An unknown language gets NO acknowledgment rather than an Italian one.
+
+        EXPECTATION INVERTED 2026-08-10. This test used to assert
+        `result.startswith("Capisco la frustrazione")` for language "fr",
+        with the comment "Defaults to Italian" — it encoded the defect as the
+        contract. `detect_language()` emits six values ("it"/"en"/"id"/"uk"/
+        "ru"/"auto") against a three-entry table, so the Italian default was
+        reachable in production: measured on a Russian message that classified
+        as lang='ru' with emotional content, before "ru" copy existed. Grafting
+        an Italian sentence onto the front of a French or Russian answer is a
+        worse outcome than prepending nothing, so the function now declines.
+        """
         text = "Here is the solution."
-        result = _add_emotional_acknowledgment(text, "fr")
-        assert result.startswith("Capisco la frustrazione")  # Defaults to Italian
+        assert _add_emotional_acknowledgment(text, "fr") == text
 
     def test_add_emotional_acknowledgment_partial_match(self):
         """Test that partial match prevents duplicate"""

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 693 services · 1326 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 693 services · 1329 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
On the live WhatsApp path (`create_default_pipeline` → `PostProcessingStage` →
`post_process_response`), `_format_as_numbered_list` returned **only** the
sentences whose text matched an action verb, and discarded every other sentence.

## Measured

A five-sentence procedural answer, in each supported language:

| lang | deleted | what went with it |
|---|---|---|
| en | 56% | Bali Zero service fee, overstay penalty |
| it | 57% | idem |
| id | 61% | idem |

The client received a tidy numbered list. That is worse than an empty reply: an
empty reply is visibly nothing, this one **reads complete**.

## The cure is a conservation guard, not a better verb list

If any substantive sentence is not part of the list, the answer is left alone.
A formatter has no licence to choose which sentences of an answer survive. Same
disease as the cleaner PR — a heuristic allowed to REMOVE part of an answer that
already passed retrieval *and* the abstain gate.

Three further defects on the same two functions, each measured:

* **Word boundary, not substring** (superscar #3): the bare `verb in sentence`
  rule fired the Indonesian action verb `isi` inside `revisi`, `efisiensi`,
  `administrasi` — administrative prose was renumbered as a procedure.
* **The `len(s) > 20` floor removed.** It was a proxy for "is this a real step"
  and excluded a short but genuine one ("Find the office", 15 chars); combined
  with the guard above, that turns an answer which *is* entirely steps into a
  declined one. The actionable rule is the filter; a length is not.
* **Language table 3 vs 6.** `_add_emotional_acknowledgment` and
  `_has_emotional_acknowledgment` carried three languages while
  `detect_language()` emits six, and the former defaulted to **Italian** —
  reachable end-to-end on a Russian message (`lang='ru'`, emotional). Russian and
  Ukrainian copy added; an unrecognised language now gets **no** prefix rather
  than a foreign one. There is no safe language to guess.

`detect_language`'s annotation also omitted `"auto"`, a real and frequently
returned value, so consumers were written against a vocabulary the function does
not emit and silently took their own `.get(...)` default. The `Literal` now
declares it, and a structural test walks every emitted language and requires each
to be either translated or explicitly declined.

## One test is inverted, not deleted

`test_add_emotional_acknowledgment_unknown_language` asserted
`result.startswith("Capisco la frustrazione")` for language `"fr"`, commented
*"Defaults to Italian"* — it encoded the defect as the contract. Its new
docstring records why it flipped.

## Verification

* **Mutation 8/8 killed** (guard removed · word-boundary reverted · English verbs
  over an unknown language · Italian default restored · unknown-language ack
  judged missing again · length floor restored · ru/uk copy removed · `"auto"`
  dropped from the `Literal`).
* Two harness notes, since both read as results and neither was one:
  * the first unknown-language test **survived** its mutation — Russian prose
    matches no English verb, so it returned unchanged through a *different*
    branch and held with the branch it names deleted. A surviving mutant is not
    always a missing test; sometimes it is a test that reaches the right answer
    down the wrong path. Replaced with one that isolates the branch.
  * the harness reported every kill as "(0 red)" because it passed `-q` on top of
    `pytest.ini`'s own `-q`; `-qq` suppresses the summary line. The number was
    measuring my flags, not the tests.
* **2006 passed** across the four affected areas. The 8 failures there are
  pre-existing, baselined by re-running the identical command with this diff
  stashed: 5 in `test_prompt_builder`/`test_reasoning_utils`, and 3 in
  `test_standard_templates` from cross-directory pollution that leaves a
  `MagicMock` on `settings` (passes alone, fails after
  `backend/tests/services/communication` runs). None owned by this diff; the
  pollution is logged, not smuggled in here.

`docs/AI_ONBOARDING.md` regen rides in the same commit (W86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
