### PR TITLE
test(security): the ReDoS sweep measures CPU time, not scheduler wait

### DIFF
--- a/apps/backend-rag/backend/tests/unit/core/legal/test_redos_anchor_patterns.py
+++ b/apps/backend-rag/backend/tests/unit/core/legal/test_redos_anchor_patterns.py
@@ -74,9 +74,13 @@ PAYLOADS = {
 
 
 def _elapsed(rx: re.Pattern, text: str) -> float:
-    start = time.perf_counter()
+    # Regex complexity is CPU work. Wall time also counts time when another process has
+    # pre-empted pytest, which turned ordinary linear scans into apparent 3-5x growth on
+    # shared developer machines. Process CPU time preserves genuine backtracking cost
+    # while excluding scheduler wait; the absolute and ratio thresholds stay unchanged.
+    start = time.process_time()
     rx.findall(text)
-    return time.perf_counter() - start
+    return time.process_time() - start
 
 
 # Repetitions for the RATIO verdict only. Timing noise is strictly additive — the
@@ -595,6 +599,7 @@ _LINEAR_CONTROL_MAX_RATIO = 2.5
 # stands down 0 of 60 times under load while sitting far above the 0.7 of the false red.
 _LINEAR_CONTROL_MIN_RATIO = 1.2
 
+
 SWEEP_PREFIXES = (
     "",
     "\n",
@@ -703,6 +708,18 @@ class TestRatioConfirmation:
     this change — the branch that fired falsely was also the branch with no proof it fires
     truly — and it is on the ledger. These tests cover the DECISION.
     """
+
+    def test_elapsed_measures_regex_cpu_not_scheduler_wait(self) -> None:
+        """A pre-empted worker must not turn a linear regex into a security verdict."""
+
+        class SleepingPattern:
+            @staticmethod
+            def findall(text: str) -> list[str]:
+                del text
+                time.sleep(0.03)
+                return []
+
+        assert _elapsed(SleepingPattern(), "payload") < 0.01
 
     def test_elapsed_min_takes_the_minimum_not_the_first_or_the_mean(self, monkeypatch):
         """Load only ever ADDS time, so the minimum is the estimator — first and mean are not.


### PR DESCRIPTION
## What

`_elapsed()` in `test_redos_anchor_patterns.py` now measures **process CPU time** (`time.process_time()`) instead of wall time (`time.perf_counter()`), plus a guard test proving scheduler wait no longer reaches the verdict. Thresholds, the #3908 two-window confirmation, and the linear control are all untouched — only the clock changes.

## Why — the wall-time sweep convicts innocent regexes on loaded machines

Regex complexity is CPU work; wall time also counts pre-emption. On shared developer machines the sweep's base measurements sit at 4–9 ms, the same scale as a scheduler burst, and one night produced this record:

- **M5, 5 pre-push suites killed in one night** on this sweep (the branch being pushed only touched DLQ scripts). Under queue contention: `PASAL_PATTERN` 3.4x and 4.8x vs the 3.0 bound.
- **M5, quiet machine (load 4.5), direct run: SEVEN patterns convicted at once** (`AYAT_MARKER_PREFIX` 3.2x, `AYAT_PATTERN` 3.3x, `BAB_PATTERN` 3.0x, `NOISE_PATTERNS[3]` 3.7x, `NOISE_PATTERNS[4]` 4.9x, `PAGE_NUMBER_LINE` 3.3x, `PASAL_PATTERN` 3.0x). Seven unrelated regexes do not become quadratic together — the measurement is noise-dominated at this scale.
- **Pro, load 27–32 (daemon host): five variants in one shot** (3.1x–4.0x).
- **Counter-proof both ways**: solo-run on the identical tree is green (RC=0), and the same tests are double-green in GitHub Actions (PR-branch run + merge-queue re-run of #3938) on unloaded runners.
- The #3908 two-window cure helped but cannot save this: a multi-second contention burst spans all adjacent min-of-k samples and both windows.

Conclusion (already on the PENDING-ARMS ledger via #3980): single-shot wall-time bounds do not hold on loaded machines; CPU time is the class cure — it preserves genuine backtracking cost (the guilt control still convicts) while excluding CPU-queue wait.

## Verification (independent, generator≠grader)

- Full file green **in this branch's tree on the machine that was convicting 3–7 patterns the same hour** (`PYTEST_RC=0`, captured before any pipe).
- `test_control_the_sweep_rejects_the_pre_fix_quadratic` (guilt) still passes: a real quadratic burns CPU and still convicts under `process_time`.
- New innocence guard `test_elapsed_measures_regex_cpu_not_scheduler_wait`: a pattern that sleeps 30 ms must measure < 10 ms — scheduler wait is provably excluded from the verdict.
- No residual wall-clock timing sites in the file: the only two timing calls are the cured ones (no half-cure).

## Provenance

Commit `0e34a94f16` was authored by another M5 session that ended before its push could land (its first push died queued behind the machine-wide suite lock's 75-minute ceiling). Adopted and shipped **verbatim — zero edits** — by the orchestrator session after the liveness check (no processes in the worktree beyond git's own detached `fsmonitor--daemon`, no activity since commit time) and the independent verification above. Measurement receipts contributed by a third session (fleet-order lane, PR #3938 logs + #3980 ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
