### PR TITLE
fix(hooks): `git clean -f` and `git restore` discarded main-checkout state unguarded

### DIFF
--- a/infra/claude-hooks/test_block_regex.py
+++ b/infra/claude-hooks/test_block_regex.py
@@ -38,6 +38,25 @@ CASES = {
     "git checkout main": True,
     "git stash": True,
     "git reset --hard": True,
+    # W117 class-audit (2026-08-10): `clean` and `restore` were never in this
+    # enumeration, so five shapes of the SAME damage passed in the main checkout
+    # while reset/checkout/stash blocked. Both letter tests read the flag CLUSTER,
+    # not a string ending in the letter — the first draft let `--force` through
+    # and blocked `-ndf`, which git treats as a dry run (form vs entity, #3).
+    "git clean -fd": True,
+    "git clean -fdx": True,
+    "git clean -f": True,
+    "git clean --force": True,
+    "git clean -xdf": True,
+    "git restore apps/": True,
+    "git restore --staged .": True,
+    # ... and the read-only probes stay spared (W85's rule, applied to `clean`):
+    "git clean -n": False,
+    "git clean --dry-run": False,
+    "git clean -fdn": False,
+    "git clean -ndf": False,
+    "git clean -n -d": False,
+    "git clean -x": False,
     # must ALLOW
     'git commit -m "x"': False,
     'git commit -m "add a feature"': False,

--- a/infra/claude-hooks/worktree_isolation.py
+++ b/infra/claude-hooks/worktree_isolation.py
@@ -139,6 +139,26 @@ BLOCKED_SUBCMD_RE = re.compile(
     r"(checkout|switch|stash(?!\s+(?:list|show)\b)|reset|merge|rebase|pull)\b"
     r"|\bgit\s+commit\s+(?:[^\s]+\s+)*(?:-[A-Za-z]*a|--all\b)"  # commit -a / -am / -a -m / --all
     r"|\bgit\s+add\s+(?:-A|-a|--all|\.)"  # add -A / add -a / add --all / add .
+    # W117 class-audit (2026-08-10): the enumeration above never included `clean`
+    # or `restore`, so five shapes of the SAME damage — `git clean -f|-fd|-fdx`,
+    # `git restore <path>`, `git restore --staged .` — passed inside the main
+    # checkout while `reset --hard` / `checkout -- .` / `stash` blocked. Measured
+    # after the remote direction was cured: fixing only the direction that bit me
+    # would just move WHICH verb destroys Pro's runtime state in silence (W107).
+    # `clean` is enumerated by INTENT, not by bare token (W85): a forcing flag is
+    # required, and the read-only probes `-n` / `--dry-run` are spared — note
+    # `git clean -fdn` IS a dry run, so the lookahead must win over the -f test.
+    # Both letter tests read the flag CLUSTER, not a string that ENDS in the
+    # letter. The first draft got this wrong in both directions and measurement
+    # said so: `--force` escaped (an under-match, no single-dash cluster) and
+    # `-ndf` blocked (an over-match: the `n` test demanded `n\b`, which a cluster
+    # spells only when `n` happens to come last). Form vs entity, family #3.
+    # Declared limit: a stray ` -n…` elsewhere in the same segment spares the
+    # command — erring toward NOT blocking on an exotic shape, never the reverse.
+    r"|\bgit\s+(?:-c\s+\S+\s+)*(?:-C\s+\S+\s+)?clean\b"
+    r"(?![^;&|\n]*(?:--dry-run\b|\s-[A-Za-z]*n))"  # -n anywhere in a cluster, or --dry-run
+    r"[^;&|\n]*(?:--force\b|\s-[A-Za-z]*f)"  # --force, or -f anywhere in a cluster
+    r"|\bgit\s+(?:-c\s+\S+\s+)*(?:-C\s+\S+\s+)?restore\b"  # discards the worktree copy
 )
 
 # Extract `git -C <path>` target.


### PR DESCRIPTION
Class-audit of the W117 cure. #3993 covers the **ssh-dispatched** direction; this covers the
**local** one. Curing only the direction that bit me would have moved *which* verb destroys
Pro's runtime state in silence, not removed the risk — W107 verbatim ("I cured one wrapper of
five and called the disease closed").

## Measured before the diff, inside the main checkout

| command | before |
|---|---|
| `git clean -fd` / `-fdx` / `-f` | **PASSED** |
| `git restore <path>` / `--staged .` | **PASSED** |
| `git reset --hard` / `checkout -- .` / `stash` | blocked |

`BLOCKED_SUBCMD_RE` enumerates `checkout|switch|stash|reset|merge|rebase|pull` and never
included the other two: five shapes of the same damage class, blind on the local channel. The
damage is the same one #3993 documents — on 2026-08-10 a discard on that checkout cost 159
entries of the intel publish ledger (its loss RE-PUBLISHES already-published articles) and 24
open escalations, both runtime state no commit holds.

## The cure

`clean` is enumerated by **intent**, not bare token — W85's rule applied to a second verb: a
forcing flag is required, and the read-only probes are spared, including `git clean -fdn`,
which git treats as a **dry run** despite the `-f`. `restore` has no read-only form, so it
matches plainly.

Both letter tests read the flag **cluster**, not a string *ending* in the letter. The first
draft got that wrong in both directions and measurement said so:

- `git clean --force` **escaped** (under-match: no single-dash cluster to end in `f`)
- `git clean -ndf` **blocked** (over-match: the `n` test demanded `n\b`, which a cluster spells
  only when `n` happens to land last)

Form vs entity, family #3 — in my own regex, two commits after writing the scar record about it.

## Verification

- **19/19** outcomes correct through the live hook (7 guilt incl. `--force` and `-xdf`;
  12 innocence incl. `-n`, `--dry-run`, `-fdn`, `-ndf`, `-n -d`, bare `-x`, both verbs inside a
  worktree, the verb quoted in a string, and `grep 'restore'` as search text)
- `test_block_regex` **20 -> 33** cases, **mutation-verified 5/5**: removing either branch, or
  regressing either letter test back to ends-with, turns it red
- no regression: all 11 hook suites green · `guard_fuzz_harness` **445/445** ·
  guard-conformance clean

## Arming

Same delivery as #3993: the live hooks in `~/.claude/hooks/` are **real files**, not symlinks,
so the merge alone leaves this inert on every machine (W81). `install_worktree_hooks.sh` is the
only sanctioned path (it self-verifies with the innocence vaccine and rolls back if red). The
pair is declared in `infra/home-fork/declared-pairs.json`, so a forgotten install shows up as a
red HOME-fork lint rather than passing in silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)