### PR TITLE
feat(r1-gate): add Qwen 3.8 Max to the adversarial-review seat registry

### DIFF
--- a/scripts/check_adversarial_review.py
+++ b/scripts/check_adversarial_review.py
@@ -96,6 +96,9 @@ KNOWN_SEATS = {
     "grok",
     "nlm",
     "notebooklm",
+    # Qwen 3.8 Max (TP1 Token Plan wing seat) — ratified by Zero 2026-08-10.
+    "qwen-3.8-max",
+    "qwen",
 }
 
 FRONTMATTER_KEY_RE = re.compile(r"^adversarial_review\s*:\s*(.*)$", re.IGNORECASE)

--- a/scripts/tests/test_adversarial_review_gate.py
+++ b/scripts/tests/test_adversarial_review_gate.py
@@ -157,6 +157,17 @@ def test_innocence_valid_seat_and_section(tmp_path):
     assert v.ok is True
 
 
+def test_innocence_qwen_seat_accepted(tmp_path):
+    p = _write(
+        tmp_path,
+        "research/operations/x.md",
+        "---\ndate: 2026-08-10\nadversarial_review: qwen-3.8-max\n---\n\n"
+        "# Title\n\n## Adversarial review\n\nnone survived, 2 raised\n",
+    )
+    v = car.evaluate_file(p)
+    assert v.ok is True
+
+
 def test_innocence_human_seat_accepted(tmp_path):
     p = _write(
         tmp_path,


### PR DESCRIPTION
## Summary

Adds Qwen 3.8 Max (`qwen-3.8-max`, plus the bare `qwen` alias) to `KNOWN_SEATS` in `scripts/check_adversarial_review.py`, the R1 adversarial-review gate registry — mirroring how the other cross-family seats (Kimi, GLM, Codex, Gemini, agy, grok, NotebookLM) are already registered.

Qwen 3.8 Max is a live **TP1 (Token Plan) wing seat**, ratified by Zero on 2026-08-10 per the fleet-order spec (`research/operations/2026-08-10-fleet-order-spec.md`, TP1 wing rows) and `modus` SKILL.md §Arsenal. Without this entry, a capture crediting a Qwen 3.8 Max adversarial review would fail the R1 gate as an unknown seat.

## Changes

- `scripts/check_adversarial_review.py`: add `qwen-3.8-max` + `qwen` to `KNOWN_SEATS`, with a one-line comment citing the ratification.
- `scripts/tests/test_adversarial_review_gate.py`: new innocence test `test_innocence_qwen_seat_accepted`, mirroring the existing `kimi-k3` valid-seat pattern — asserts a file with `adversarial_review: qwen-3.8-max` + a proper `## Adversarial review` section PASSES.
- `docs/AI_ONBOARDING.md`: docs-sync regen bump (test count 1331→1333) included in the same PR per scar W86 (a stale quick-numbers block on main turns the `check-docs-sync` gate red for the next innocent PR).

## Verification

`python3 -m pytest scripts/tests/test_adversarial_review_gate.py -q` → 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)