### PR TITLE
fix(ci): docs-sync gate fails closed when its judge or corpus is deleted

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -11,6 +11,8 @@ on:
       - "package.json"
       - "scripts/docs_sync.py"
       - "scripts/tests/test_docs_sync_atlas.py"
+      - "scripts/ci/docs_sync_gate.sh"
+      - "scripts/tests/test_docs_sync_gate_failclosed.sh"
       - "scripts/automation_catalog.json"
       - "README.md"
       - "INDEX.md"
@@ -32,6 +34,8 @@ on:
       - "package.json"
       - "scripts/docs_sync.py"
       - "scripts/tests/test_docs_sync_atlas.py"
+      - "scripts/ci/docs_sync_gate.sh"
+      - "scripts/tests/test_docs_sync_gate_failclosed.sh"
       - "scripts/automation_catalog.json"
       - "README.md"
       - "INDEX.md"
@@ -69,20 +73,16 @@ jobs:
         with:
           python-version: "3.11"
 
+      # The gate proves itself before it judges anyone (the hot-zone gate does
+      # the same). Cheap, and it is what makes the fail-closed behaviour below
+      # more than an assertion in a comment.
+      - name: Gate self-test (guilt + innocence)
+        run: bash scripts/tests/test_docs_sync_gate_failclosed.sh
+
       - name: Check docs are in sync
-        run: |
-          if [ ! -f scripts/docs_sync.py ]; then
-            echo "scripts/docs_sync.py is absent — skipping docs-sync check."
-            echo "Restore the script or remove this workflow to re-enable the gate."
-            exit 0
-          fi
-          python scripts/docs_sync.py --check
+        run: bash scripts/ci/docs_sync_gate.sh check
 
       - name: Run docs_sync unit tests
         run: |
-          if [ ! -f scripts/tests/test_docs_sync_atlas.py ]; then
-            echo "no docs_sync tests present — skipping."
-            exit 0
-          fi
           python -m pip install --quiet pytest
-          python -m pytest scripts/tests/test_docs_sync_atlas.py -q
+          bash scripts/ci/docs_sync_gate.sh test

--- a/scripts/ci/docs_sync_gate.sh
+++ b/scripts/ci/docs_sync_gate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Fail-closed existence gate for the `check-docs-sync` required check.
+#
+# WHY THIS IS NOT INLINE YAML ANY MORE (2026-08-10, found by the Merge-OS v2
+# refutation round, Codex F4 — see research/operations/2026-08-10-merge-os-v2-submission-system.md §8.2):
+# both branches of the inline version ended in `exit 0` when their target file
+# was missing:
+#
+#     if [ ! -f scripts/docs_sync.py ]; then
+#       echo "scripts/docs_sync.py is absent — skipping docs-sync check."
+#       exit 0
+#     fi
+#
+# `scripts/docs_sync.py` and `scripts/tests/test_docs_sync_atlas.py` are both in
+# this workflow's `paths:` filter, so a PR that DELETES them triggers the gate —
+# and the gate waved it through green. A required check that can be removed by
+# the same diff it exists to stop is not a gate. Absence is now a FAILURE.
+#
+# A legitimate retirement of docs_sync removes this workflow in the SAME PR;
+# `.github/workflows/` is CODEOWNERS-TIER1 and actionlint-gated, so that path
+# stays reviewed by construction. There is no state in which the judge is gone
+# and the verdict should still be green.
+#
+# Logic lives here rather than in a `run:` block because an `exit 0` inside YAML
+# has no guilt test and no innocence test. Corpus:
+# scripts/tests/test_docs_sync_gate_failclosed.sh
+#
+# Usage: docs_sync_gate.sh check|test     (run from the repo root)
+#   check — the docs are in sync (judge: scripts/docs_sync.py)
+#   test  — the judge's own unit tests pass (corpus: scripts/tests/test_docs_sync_atlas.py)
+#
+# PYTHON may override the interpreter (absolute path in CI contexts — W108:
+# an alarm must not share the failure mode of the thing it reports).
+
+set -uo pipefail
+
+MODE="${1:-}"
+PYTHON="${PYTHON:-python}"
+
+require_file() {
+  local target="$1"
+  if [ ! -f "$target" ]; then
+    echo "docs-sync gate FAILED: ${target} is ABSENT." >&2
+    echo "  This check is required, so its judge cannot be deleted while it is armed." >&2
+    echo "  If retiring docs-sync is intentional, remove .github/workflows/docs-sync.yml" >&2
+    echo "  in the SAME pull request. Skipping here would let a diff delete its own gate." >&2
+    return 1
+  fi
+  return 0
+}
+
+case "$MODE" in
+  check)
+    require_file "scripts/docs_sync.py" || exit 1
+    "$PYTHON" scripts/docs_sync.py --check
+    exit $?
+    ;;
+  test)
+    require_file "scripts/tests/test_docs_sync_atlas.py" || exit 1
+    "$PYTHON" -m pytest scripts/tests/test_docs_sync_atlas.py -q
+    exit $?
+    ;;
+  *)
+    echo "usage: $0 check|test" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/tests/test_docs_sync_gate_failclosed.sh
+++ b/scripts/tests/test_docs_sync_gate_failclosed.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Corpus for scripts/ci/docs_sync_gate.sh — guilt AND innocence (superscar #3).
+#
+# GUILT: the judge (or its corpus) is missing => the gate must FAIL. This is the
+# defect that existed until 2026-08-10: the inline YAML answered `exit 0`, so a
+# PR deleting scripts/docs_sync.py passed the required check green.
+#
+# INNOCENCE: with the judge present the gate must not invent a failure, and it
+# must PROPAGATE the judge's own exit code rather than flattening it — a gate
+# that turns 3 into 1, or 3 into 0, is a different lie.
+#
+# Every case runs in a temp cwd (W96/W110: a corpus must not write into the
+# repo, and must leave no residue).
+
+set -uo pipefail
+
+GATE="$(cd "$(dirname "$0")/../.." && pwd)/scripts/ci/docs_sync_gate.sh"
+[ -x "$GATE" ] || { echo "FATAL: gate not executable at $GATE"; exit 1; }
+
+PASS=0
+FAIL=0
+
+run_case() {
+  # run_case <name> <expected_rc> <setup_fn> <mode>
+  local name="$1" expected="$2" setup="$3" mode="$4"
+  local tmp
+  tmp="$(mktemp -d)"
+  ( cd "$tmp" && "$setup" ) || { echo "FATAL: setup failed for $name"; rm -rf "$tmp"; exit 1; }
+  local rc
+  ( cd "$tmp" && PYTHON="$tmp/fakepython" "$GATE" "$mode" >/dev/null 2>&1 )
+  rc=$?
+  if [ "$rc" -eq "$expected" ]; then
+    echo "  PASS  $name (rc=$rc)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $name (expected rc=$expected, got rc=$rc)"
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$tmp"
+}
+
+# --- fixtures -----------------------------------------------------------------
+
+_fakepython() {
+  # $1 = exit code the fake interpreter should return
+  cat > fakepython <<EOF
+#!/bin/sh
+exit $1
+EOF
+  chmod +x fakepython
+}
+
+setup_no_judge() {            # guilt: judge deleted
+  mkdir -p scripts/tests
+  _fakepython 0
+}
+
+setup_no_corpus() {           # guilt: judge's unit tests deleted
+  mkdir -p scripts/tests
+  printf '#\n' > scripts/docs_sync.py
+  _fakepython 0
+}
+
+setup_judge_green() {         # innocence: everything present, docs in sync
+  mkdir -p scripts/tests
+  printf '#\n' > scripts/docs_sync.py
+  printf '#\n' > scripts/tests/test_docs_sync_atlas.py
+  _fakepython 0
+}
+
+setup_judge_red() {           # innocence-of-verdict: judge says stale
+  mkdir -p scripts/tests
+  printf '#\n' > scripts/docs_sync.py
+  printf '#\n' > scripts/tests/test_docs_sync_atlas.py
+  _fakepython 3
+}
+
+setup_bare() {                # usage error
+  _fakepython 0
+}
+
+# --- cases --------------------------------------------------------------------
+
+echo "docs-sync gate — fail-closed corpus"
+
+# GUILT — absence must be a failure, on BOTH targets (symmetry clause, W101-recidiva:
+# a fix that covers only the branch that bit you is half a fix).
+run_case "guilt: judge absent            -> check FAILS" 1 setup_no_judge  check
+run_case "guilt: corpus absent           -> test  FAILS" 1 setup_no_corpus test
+
+# INNOCENCE — present and green must stay green.
+run_case "innocence: all present, green  -> check PASSES" 0 setup_judge_green check
+run_case "innocence: all present, green  -> test  PASSES" 0 setup_judge_green test
+
+# The gate must not flatten the judge's verdict into its own.
+run_case "propagates judge rc=3          -> check returns 3" 3 setup_judge_red check
+run_case "propagates pytest rc=3         -> test  returns 3" 3 setup_judge_red test
+
+# Misuse is neither guilt nor innocence — it is a caller bug and must be loud.
+run_case "usage: no mode                 -> rc 2" 2 setup_bare ""
+
+echo "----"
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## The defect (live on `main` until this PR)

`check-docs-sync` is a **required** check. Both of its escape hatches ended in `exit 0`:

```yaml
if [ ! -f scripts/docs_sync.py ]; then
  echo "scripts/docs_sync.py is absent — skipping docs-sync check."
  exit 0
fi
python scripts/docs_sync.py --check
```

…and the same shape guarded `scripts/tests/test_docs_sync_atlas.py`.

Both of those files are listed in this workflow's own `paths:` filter, so a PR that **deletes them triggers the gate — and the gate passes it green**. A required check that can be removed by the same diff it exists to stop is not a gate (cicatrix family #2, *esiste ≠ armato*).

Found by the cross-family refutation round run on the Merge-OS v2 spec (Codex `gpt-5.6-sol`, finding **F4**), recorded in `research/operations/2026-08-10-merge-os-v2-submission-system.md` §8.2. This PR cures the *live* instance; it arms no wave of that spec.

## The cure

- **`scripts/ci/docs_sync_gate.sh`** (new) — absence of the judge, or of its corpus, is a **failure**. The error names the one legitimate retirement path: remove `.github/workflows/docs-sync.yml` in the *same* PR. `.github/workflows/` is CODEOWNERS-TIER1 and actionlint-gated, so that path stays reviewed by construction. The gate **propagates** the judge's exit code rather than flattening it, and honors `PYTHON` so the interpreter can be pinned absolute (W108: an alarm must not share the failure mode of the thing it reports).
- **`scripts/tests/test_docs_sync_gate_failclosed.sh`** (new) — guilt **and** innocence, 7 cases, each in a `mktemp -d` cwd so the corpus writes nothing into the repo (W96/W110). Guilt covers **both** targets, not only the branch that bit us (symmetry clause, W101-recidiva). Innocence covers present+green on both modes, and rc-propagation (`3` stays `3`) so the fix cannot be a different lie.
- **`.github/workflows/docs-sync.yml`** — calls the script for both modes and **runs the corpus as a step**, so the gate proves itself before it judges anyone (same shape as the hot-zone gate). Both new files are in both `paths:` lists, so a diff touching them re-runs the gate.

## Evidence (local, this branch)

| check | result |
|---|---|
| corpus | `passed=7 failed=0` |
| mutation (`require_file` → `return 0`) | `passed=5 failed=2` — both guilt cases go red, then restored |
| `actionlint .github/workflows/docs-sync.yml` | clean |
| `bash scripts/ci/docs_sync_gate.sh check` (real repo) | `DOCSYNC OK (no changes)` rc=0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)