### PR TITLE
fix(ci): match bot authors literally

### DIFF
--- a/.github/workflows/auto-merge-whitelist.yml
+++ b/.github/workflows/auto-merge-whitelist.yml
@@ -3,8 +3,7 @@
 # Auto-enables `gh pr merge --auto --squash` for PRs that match ALL of:
 #   1. Branch name matches whitelist pattern (docs/auto-sync-*, dependabot/*, chore/fmt-*)
 #   2. Author is dependabot[bot] or github-actions[bot] (or owner @Balizero1987 explicit)
-#   3. Diff does NOT touch CODEOWNERS-protected paths (workflows, fly.toml, migrations,
-#      auth, billing, pricing, launchagents)
+#   3. Diff does NOT touch any CODEOWNERS Tier-1 path
 #
 # Reference: docs/runbooks/merge-queue-discipline.md §3
 # SOTA brief: research/operations/2026-05-24-sota-multi-agent-repo-architecture-synthesis.md
@@ -100,7 +99,7 @@ jobs:
           AUTHOR: ${{ steps.pr.outputs.author }} # attacker-controlled login → env, not inline
         run: |
           case "$AUTHOR" in
-            "dependabot"|"dependabot[bot]"|"github-actions"|"github-actions[bot]"|"Balizero1987")
+            "dependabot[bot]"|"github-actions[bot]"|"Balizero1987")
               echo "Author '$AUTHOR' is allowlisted."
               echo "match=true" >> "$GITHUB_OUTPUT"
               ;;
@@ -115,28 +114,66 @@ jobs:
         if: steps.author_check.outputs.match == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          PR='${{ steps.pr.outputs.number }}'
-          FILES="$(gh pr view "$PR" --repo ${{ github.repository }} --json files --jq '.files[].path')"
-          # Protected path patterns — keep in sync with .github/CODEOWNERS
+          if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number '$PR' — failing closed."
+            exit 1
+          fi
+          if ! EXPECTED_FILES="$(gh api "repos/$REPO/pulls/$PR" --jq '.changed_files')"; then
+            echo "::error::Unable to read PR #$PR metadata — failing closed."
+            exit 1
+          fi
+          if ! [[ "$EXPECTED_FILES" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid changed_files count '$EXPECTED_FILES' — failing closed."
+            exit 1
+          fi
+          if ! FILES="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" --jq '.[].filename')"; then
+            echo "::error::Unable to enumerate files for PR #$PR — failing closed."
+            exit 1
+          fi
+          ACTUAL_FILES=0
+          if [[ -n "$FILES" ]]; then
+            ACTUAL_FILES="$(awk 'END { print NR }' <<< "$FILES")"
+          fi
+          if [[ "$ACTUAL_FILES" -ne "$EXPECTED_FILES" ]]; then
+            echo "::error::PR file enumeration mismatch: expected $EXPECTED_FILES, got $ACTUAL_FILES — failing closed."
+            exit 1
+          fi
+          # Tier-1 CODEOWNERS patterns; the regression test fails on drift.
           PROTECTED=(
             '^\.github/workflows/'
             '^\.github/CODEOWNERS$'
             '^\.github/dependabot\.yml$'
+            '^\.github/actions/'
             '^fly\.toml$'
             '^apps/backend-rag/fly\.toml$'
             '^apps/backend-rag/Dockerfile$'
+            '^infra/launchagents/'
+            '^docs/infra/launchagents/'
             '^apps/backend-rag/backend/db/migrations_v2/'
             '^apps/backend-rag/backend/db/migration_manager\.py$'
+            '^scripts/verify_the_verifiers\.py$'
+            '^scripts/verify_the_verifiers_gates\.yaml$'
+            '^scripts/tests/test_verify_the_verifiers\.py$'
+            '^\.github/verify-the-verifiers\.sha256$'
+            '^scripts/token_lint\.py$'
+            '^scripts/tests/test_token_lint\.py$'
+            '^scripts/tests/conftest\.py$'
+            '^scripts/conftest\.py$'
+            '^conftest\.py$'
             '^apps/backend-rag/backend/app/auth/'
             '^apps/backend-rag/backend/app/core/config\.py$'
             '^apps/backend-rag/backend/services/auth/'
             '^apps/backend-rag/backend/services/invoicing/'
             '^apps/backend-rag/backend/services/pricing/'
             '^apps/backend-rag/backend/services/billing/'
-            '^infra/launchagents/'
-            '^docs/infra/launchagents/'
+            '^apps/backend-rag/backend/core/embeddings\.py$'
+            '^apps/backend-rag/backend/services/rag/agentic/'
+            '^apps/backend-rag/backend/kb/'
+            '^apps/backend-rag/backend/services/lead_capture/'
           )
           violation=""
           while IFS= read -r f; do
@@ -159,10 +196,18 @@ jobs:
         if: steps.path_check.outputs.match == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR: ${{ steps.pr.outputs.number }}
+          REPO: ${{ github.repository }}
         run: |
-          PR='${{ steps.pr.outputs.number }}'
+          set -euo pipefail
+          if ! [[ "$EXPECTED_HEAD" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Invalid expected head SHA — refusing to arm auto-merge."
+            exit 1
+          fi
           echo "Enabling auto-merge --squash for PR #$PR"
-          gh pr merge "$PR" --repo ${{ github.repository }} --auto --squash --delete-branch || {
+          gh pr merge "$PR" --repo "$REPO" --auto --squash --delete-branch \
+            --match-head-commit "$EXPECTED_HEAD" || {
             echo "::warning::Auto-merge enable failed (possibly already enabled, or required checks not configured yet)."
             exit 0
           }

--- a/.github/workflows/auto-merge-whitelist.yml
+++ b/.github/workflows/auto-merge-whitelist.yml
@@ -100,7 +100,7 @@ jobs:
           AUTHOR: ${{ steps.pr.outputs.author }} # attacker-controlled login → env, not inline
         run: |
           case "$AUTHOR" in
-            dependabot|dependabot[bot]|github-actions|github-actions[bot]|Balizero1987)
+            "dependabot"|"dependabot[bot]"|"github-actions"|"github-actions[bot]"|"Balizero1987")
               echo "Author '$AUTHOR' is allowlisted."
               echo "match=true" >> "$GITHUB_OUTPUT"
               ;;

--- a/scripts/tests/test_auto_merge_whitelist.py
+++ b/scripts/tests/test_auto_merge_whitelist.py
@@ -1,0 +1,68 @@
+"""Regression tests for the auto-merge workflow's exact author allowlist."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "auto-merge-whitelist.yml"
+
+
+def _author_check_script() -> str:
+    """Extract the workflow's author-check run block without a YAML dependency."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    step_marker = "      - name: Check author allowlist\n"
+    step = text.split(step_marker, 1)[1]
+    run_marker = "        run: |\n"
+    run_block = step.split(run_marker, 1)[1]
+
+    body: list[str] = []
+    for line in run_block.splitlines():
+        if line.startswith("      - name: "):
+            break
+        assert line.startswith("          ") or not line, (
+            f"unexpected indentation in author-check run block: {line!r}"
+        )
+        body.append(line[10:] if line else "")
+
+    assert body, "author-check run block was not extracted"
+    return "\n".join(body) + "\n"
+
+
+def _evaluate_author(author: str, tmp_path: Path) -> str:
+    github_output = tmp_path / "github-output"
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", _author_check_script()],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "AUTHOR": author, "GITHUB_OUTPUT": str(github_output)},
+    )
+    assert result.stderr == ""
+    return github_output.read_text(encoding="utf-8").strip()
+
+
+@pytest.mark.parametrize("author", ["dependabot[bot]", "github-actions[bot]"])
+def test_literal_bot_authors_are_allowlisted(author: str, tmp_path: Path) -> None:
+    assert _evaluate_author(author, tmp_path) == "match=true"
+
+
+@pytest.mark.parametrize(
+    "author",
+    [
+        "dependabotb",
+        "dependaboto",
+        "dependabott",
+        "github-actionsb",
+        "github-actionso",
+        "github-actionst",
+        "github-actions[bot]extra",
+    ],
+)
+def test_glob_near_misses_are_not_allowlisted(author: str, tmp_path: Path) -> None:
+    assert _evaluate_author(author, tmp_path) == "match=false"

--- a/scripts/tests/test_auto_merge_whitelist.py
+++ b/scripts/tests/test_auto_merge_whitelist.py
@@ -1,7 +1,8 @@
-"""Regression tests for the auto-merge workflow's exact author allowlist."""
+"""Behavioral regression tests for the auto-merge eligibility workflow."""
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -11,12 +12,13 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "auto-merge-whitelist.yml"
+CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
 
 
-def _author_check_script() -> str:
-    """Extract the workflow's author-check run block without a YAML dependency."""
+def _workflow_step_script(step_name: str) -> str:
+    """Extract one workflow run block without adding a YAML dependency."""
     text = WORKFLOW.read_text(encoding="utf-8")
-    step_marker = "      - name: Check author allowlist\n"
+    step_marker = f"      - name: {step_name}\n"
     step = text.split(step_marker, 1)[1]
     run_marker = "        run: |\n"
     run_block = step.split(run_marker, 1)[1]
@@ -26,18 +28,24 @@ def _author_check_script() -> str:
         if line.startswith("      - name: "):
             break
         assert line.startswith("          ") or not line, (
-            f"unexpected indentation in author-check run block: {line!r}"
+            f"unexpected indentation in {step_name!r} run block: {line!r}"
         )
         body.append(line[10:] if line else "")
 
-    assert body, "author-check run block was not extracted"
+    assert body, f"{step_name!r} run block was not extracted"
     return "\n".join(body) + "\n"
 
 
 def _evaluate_author(author: str, tmp_path: Path) -> str:
     github_output = tmp_path / "github-output"
     result = subprocess.run(
-        ["bash", "-euo", "pipefail", "-c", _author_check_script()],
+        [
+            "bash",
+            "-euo",
+            "pipefail",
+            "-c",
+            _workflow_step_script("Check author allowlist"),
+        ],
         check=True,
         capture_output=True,
         text=True,
@@ -47,8 +55,10 @@ def _evaluate_author(author: str, tmp_path: Path) -> str:
     return github_output.read_text(encoding="utf-8").strip()
 
 
-@pytest.mark.parametrize("author", ["dependabot[bot]", "github-actions[bot]"])
-def test_literal_bot_authors_are_allowlisted(author: str, tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "author", ["dependabot[bot]", "github-actions[bot]", "Balizero1987"]
+)
+def test_exact_allowlisted_authors_are_allowlisted(author: str, tmp_path: Path) -> None:
     assert _evaluate_author(author, tmp_path) == "match=true"
 
 
@@ -62,7 +72,238 @@ def test_literal_bot_authors_are_allowlisted(author: str, tmp_path: Path) -> Non
         "github-actionso",
         "github-actionst",
         "github-actions[bot]extra",
+        "Balizero1987extra",
+        "dependabot",
+        "github-actions",
     ],
 )
 def test_glob_near_misses_are_not_allowlisted(author: str, tmp_path: Path) -> None:
     assert _evaluate_author(author, tmp_path) == "match=false"
+
+
+def _install_fake_gh(tmp_path: Path) -> Path:
+    """Install a deterministic GitHub CLI boundary double for the workflow."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+args = sys.argv[1:]
+repo = os.environ["REPO"]
+pr = os.environ["PR"]
+
+if args[:2] == ["pr", "view"]:
+    sys.stdout.write(os.environ.get("GH_LEGACY_FILES_OUTPUT", ""))
+    raise SystemExit(int(os.environ.get("GH_LEGACY_FILES_EXIT", "0")))
+
+if args[:2] == ["pr", "merge"]:
+    with open(os.environ["GH_CALLS_FILE"], "w", encoding="utf-8") as stream:
+        json.dump(args, stream)
+    raise SystemExit(int(os.environ.get("GH_MERGE_EXIT", "0")))
+
+if args == ["api", f"repos/{repo}/pulls/{pr}", "--jq", ".changed_files"]:
+    sys.stdout.write(os.environ.get("GH_EXPECTED_COUNT", "0") + "\\n")
+    raise SystemExit(int(os.environ.get("GH_METADATA_EXIT", "0")))
+
+if args == [
+    "api",
+    "--paginate",
+    f"repos/{repo}/pulls/{pr}/files?per_page=100",
+    "--jq",
+    ".[].filename",
+]:
+    sys.stdout.write(os.environ.get("GH_FILES_OUTPUT", ""))
+    raise SystemExit(int(os.environ.get("GH_FILES_EXIT", "0")))
+
+print(f"unexpected gh invocation: {args!r}", file=sys.stderr)
+raise SystemExit(97)
+""",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return bin_dir
+
+
+def _evaluate_paths(
+    tmp_path: Path,
+    *,
+    expected_count: int,
+    files: list[str],
+    legacy_files: list[str] | None = None,
+    files_exit: int = 0,
+    metadata_exit: int = 0,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    github_output = tmp_path / "github-output"
+    bin_dir = _install_fake_gh(tmp_path)
+    script = _workflow_step_script("Check diff does not touch protected paths")
+    # Model the expression interpolation Actions performs before invoking Bash.
+    script = script.replace("${{ steps.pr.outputs.number }}", "123")
+    script = script.replace("${{ github.repository }}", "test/repo")
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "GITHUB_OUTPUT": str(github_output),
+            "PR": "123",
+            "REPO": "test/repo",
+            "GH_EXPECTED_COUNT": str(expected_count),
+            "GH_FILES_OUTPUT": "\n".join(files),
+            "GH_FILES_EXIT": str(files_exit),
+            "GH_METADATA_EXIT": str(metadata_exit),
+            "GH_LEGACY_FILES_OUTPUT": "\n".join(
+                files if legacy_files is None else legacy_files
+            ),
+        },
+    )
+    output = (
+        github_output.read_text(encoding="utf-8").strip()
+        if github_output.exists()
+        else ""
+    )
+    return result, output
+
+
+def _tier1_codeowners_samples() -> list[str]:
+    """Map the current simple Tier-1 CODEOWNERS rules to concrete probe paths."""
+    text = CODEOWNERS.read_text(encoding="utf-8")
+    tier1 = text.split("# CI / workflows / GitHub config — TIER 1", 1)[1]
+    tier1 = tier1.split("# Subhi lane", 1)[0]
+    samples: list[str] = []
+    for raw_line in tier1.splitlines():
+        fields = raw_line.split()
+        if not fields or not fields[0].startswith("/"):
+            continue
+        pattern = fields[0]
+        assert not any(char in pattern for char in "*?[]"), (
+            f"Tier-1 CODEOWNERS rule needs an explicit test mapper: {pattern}"
+        )
+        sample = pattern.removeprefix("/")
+        if sample.endswith("/"):
+            sample += "__auto_merge_probe__"
+        samples.append(sample)
+    assert samples, "no Tier-1 CODEOWNERS rules found"
+    return samples
+
+
+def _safe_paths(count: int) -> list[str]:
+    return [f"docs/generated/safe-{index:03}.md" for index in range(count)]
+
+
+def test_auto_merge_is_pinned_to_the_evaluated_head(tmp_path: Path) -> None:
+    head_sha = "a" * 40
+    calls_file = tmp_path / "gh-calls.json"
+    bin_dir = _install_fake_gh(tmp_path)
+    script = _workflow_step_script("Enable auto-merge")
+    script = script.replace("${{ steps.pr.outputs.number }}", "123")
+    script = script.replace("${{ github.repository }}", "test/repo")
+    script = script.replace("${{ github.event.pull_request.head.sha }}", head_sha)
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+            "GH_CALLS_FILE": str(calls_file),
+            "PR": "123",
+            "REPO": "test/repo",
+            "EXPECTED_HEAD": head_sha,
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(calls_file.read_text(encoding="utf-8")) == [
+        "pr",
+        "merge",
+        "123",
+        "--repo",
+        "test/repo",
+        "--auto",
+        "--squash",
+        "--delete-branch",
+        "--match-head-commit",
+        head_sha,
+    ]
+
+
+def test_paginated_file_101_cannot_hide_a_protected_path(tmp_path: Path) -> None:
+    files = [*_safe_paths(100), ".github/workflows/unsafe.yml"]
+    result, output = _evaluate_paths(
+        tmp_path,
+        expected_count=101,
+        files=files,
+        legacy_files=files[:100],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output == "match=false"
+
+
+def test_paginated_file_list_over_100_safe_paths_remains_eligible(
+    tmp_path: Path,
+) -> None:
+    files = _safe_paths(101)
+    result, output = _evaluate_paths(
+        tmp_path,
+        expected_count=101,
+        files=files,
+        legacy_files=files[:100],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output == "match=true"
+
+
+def test_file_api_failure_fails_closed(tmp_path: Path) -> None:
+    result, output = _evaluate_paths(
+        tmp_path,
+        expected_count=1,
+        files=[],
+        legacy_files=["docs/generated/safe.md"],
+        files_exit=42,
+    )
+
+    assert result.returncode != 0
+    assert output != "match=true"
+
+
+@pytest.mark.parametrize(
+    ("expected_count", "files"),
+    [(1, []), (101, _safe_paths(100))],
+    ids=["blind-empty", "truncated"],
+)
+def test_file_count_mismatch_fails_closed(
+    tmp_path: Path, expected_count: int, files: list[str]
+) -> None:
+    result, output = _evaluate_paths(
+        tmp_path,
+        expected_count=expected_count,
+        files=files,
+        legacy_files=files,
+    )
+
+    assert result.returncode != 0
+    assert output != "match=true"
+
+
+@pytest.mark.parametrize("protected_path", _tier1_codeowners_samples())
+def test_every_tier1_codeowners_path_blocks_auto_merge(
+    tmp_path: Path, protected_path: str
+) -> None:
+    result, output = _evaluate_paths(
+        tmp_path,
+        expected_count=1,
+        files=[protected_path],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output == "match=false"


### PR DESCRIPTION
## Summary

- treat bot account logins as literal Bash `case` alternatives
- add a focused regression test that executes the workflow's author-check block
- reject the bracket-glob near-miss usernames previously accepted by Bash

## Verification

- `python -m pytest -q scripts/tests/test_auto_merge_whitelist.py` — 9 passed
- `actionlint -no-color -shellcheck= .github/workflows/auto-merge-whitelist.yml`
- `ruff check` and `ruff format --check`
- `pre-commit run --files ...`
- `python scripts/docs_sync.py --check --diff`
- `git diff --check`
