### PR TITLE
fix(ci): Merge-OS v2 Wave 0 trap-disarm — required.d snapshot + docs-sync/migration-lint paths-filter cure + conformance guard

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,51 +1,39 @@
 name: Docs Sync Check
 
+# SENTINEL PATTERN (2026-08-11 — Merge-OS v2 Wave 0 trap-disarm,
+# research/operations/2026-08-10-merge-os-v2-submission-system.md §4 Wave 0,
+# Codex F12). This workflow used to gate on a top-level `paths:` filter on
+# BOTH `pull_request` and `push`, and had no `merge_group` trigger at all.
+# That is a trap, not an optimization: a required check whose WORKFLOW is
+# `paths:`-filtered never even STARTS a run on a PR outside those paths —
+# there is no skipped/neutral run to satisfy the check, so GitHub shows the
+# context "Expected — waiting for status to be reported" forever, and an
+# innocent PR is hard-blocked. Adding `merge_group:` alone would not have
+# fixed this — the PR-side context would still hang; the top-level `paths:`
+# itself has to go (confirmed independently by two cross-family adversarial
+# seats against this exact file, §6.2 of the spec above).
+#
+# Fix, same shape as guard-conformance.yml / immune-enforcement.yml /
+# frontend-typecheck.yml / prettier-changed-files.yml: no top-level `paths:`
+# anywhere in `on:` — the workflow ALWAYS triggers, so it is required-safe
+# by construction. Relevance is decided INSIDE the job (job-level change
+# detection, "Docs-sync-relevant paths in this diff?" below); on a path-miss
+# PR the job ends success (skip = success, the sentinel semantics this repo
+# already uses on 17+ workflows) instead of never running at all.
+#
+# The changed-file set is enumerated from the MERGE-BASE via the existing
+# scripts/ci/hotzone_changed_files.sh, never a two-dot `git diff BASE HEAD`:
+# `pull_request.base.sha` is main's CURRENT tip, so a PR behind main would be
+# blamed for every file main gained since the branch point (scar W102, which
+# hard-blocked innocent PR #3057 the same way). That helper exits 3 when it
+# cannot determine the changed set — this job treats that as FAILURE, never
+# as "nothing changed, skip" (a blind-empty read would be a disarmed gate
+# that still reports green — superscar #2 "esiste ≠ armato").
 on:
-  pull_request:
-    paths:
-      - "apps/backend-rag/backend/app/setup/router_registration.py"
-      - "apps/backend-rag/backend/services/**"
-      - "apps/backend-rag/backend/tests/**"
-      - "apps/backend-rag/backend/channels/**"
-      - "apps/*/README.md"
-      - "package.json"
-      - "scripts/docs_sync.py"
-      - "scripts/tests/test_docs_sync_atlas.py"
-      - "scripts/ci/docs_sync_gate.sh"
-      - "scripts/tests/test_docs_sync_gate_failclosed.sh"
-      - "scripts/automation_catalog.json"
-      - "README.md"
-      - "INDEX.md"
-      - "docs/AI_ONBOARDING.md"
-      - "docs/AUTOMATIONS_REFERENCE.md"
-      - "docs/runbooks/**"
-      - "infra/workflows/**"
-      - "infra/launchagents/**"
-      - ".claude/skills/**"
-      - ".github/workflows/docs-sync.yml"
+  pull_request: # NO top-level paths: — always trigger (job decides relevance)
   push:
     branches: [main]
-    paths:
-      - "apps/backend-rag/backend/app/setup/router_registration.py"
-      - "apps/backend-rag/backend/services/**"
-      - "apps/backend-rag/backend/tests/**"
-      - "apps/backend-rag/backend/channels/**"
-      - "apps/*/README.md"
-      - "package.json"
-      - "scripts/docs_sync.py"
-      - "scripts/tests/test_docs_sync_atlas.py"
-      - "scripts/ci/docs_sync_gate.sh"
-      - "scripts/tests/test_docs_sync_gate_failclosed.sh"
-      - "scripts/automation_catalog.json"
-      - "README.md"
-      - "INDEX.md"
-      - "docs/AI_ONBOARDING.md"
-      - "docs/AUTOMATIONS_REFERENCE.md"
-      - "docs/runbooks/**"
-      - "infra/workflows/**"
-      - "infra/launchagents/**"
-      - ".claude/skills/**"
-      - ".github/workflows/docs-sync.yml"
+  merge_group:
 
 concurrency:
   group: docs-sync-${{ github.ref }}
@@ -68,8 +56,39 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history so the merge-base diff below resolves
+          filter: blob:none
+
+      - name: Docs-sync-relevant paths in this diff?
+        id: relevant
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha || github.event.after || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          if [ ! -f scripts/ci/hotzone_changed_files.sh ]; then
+            echo "::error::enumerator missing — refusing to guess the changed set"
+            exit 1
+          fi
+          CHANGED="$(bash scripts/ci/hotzone_changed_files.sh "$BASE_SHA" "$HEAD_SHA" "$PR_NUMBER")"
+          ENUM_RC=$?
+          if [ "$ENUM_RC" -ne 0 ]; then
+            echo "::error::could not determine the changed set (rc=$ENUM_RC) — failing rather than skipping"
+            exit 1
+          fi
+          RELEVANT=false
+          if printf '%s\n' "$CHANGED" | grep -qE \
+            '^apps/backend-rag/backend/app/setup/router_registration\.py$|^apps/backend-rag/backend/services/|^apps/backend-rag/backend/tests/|^apps/backend-rag/backend/channels/|^apps/[^/]+/README\.md$|^package\.json$|^scripts/docs_sync\.py$|^scripts/tests/test_docs_sync_atlas\.py$|^scripts/ci/docs_sync_gate\.sh$|^scripts/tests/test_docs_sync_gate_failclosed\.sh$|^scripts/automation_catalog\.json$|^README\.md$|^INDEX\.md$|^docs/AI_ONBOARDING\.md$|^docs/AUTOMATIONS_REFERENCE\.md$|^docs/runbooks/|^infra/workflows/|^infra/launchagents/|^\.claude/skills/|^\.github/workflows/docs-sync\.yml$'; then
+            RELEVANT=true
+          fi
+          echo "relevant=$RELEVANT" >> "$GITHUB_OUTPUT"
+          echo "::notice::docs-sync relevant=$RELEVANT ($(printf '%s\n' "$CHANGED" | grep -c .) changed files)"
 
       - uses: actions/setup-python@v7
+        if: steps.relevant.outputs.relevant == 'true'
         with:
           python-version: "3.11"
 
@@ -77,12 +96,19 @@ jobs:
       # the same). Cheap, and it is what makes the fail-closed behaviour below
       # more than an assertion in a comment.
       - name: Gate self-test (guilt + innocence)
+        if: steps.relevant.outputs.relevant == 'true'
         run: bash scripts/tests/test_docs_sync_gate_failclosed.sh
 
       - name: Check docs are in sync
+        if: steps.relevant.outputs.relevant == 'true'
         run: bash scripts/ci/docs_sync_gate.sh check
 
       - name: Run docs_sync unit tests
+        if: steps.relevant.outputs.relevant == 'true'
         run: |
           python -m pip install --quiet pytest
           bash scripts/ci/docs_sync_gate.sh test
+
+      - name: Not docs-sync-relevant
+        if: steps.relevant.outputs.relevant != 'true'
+        run: echo "::notice::no docs-sync-relevant path in this diff; check skipped (sentinel success)"

--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -224,6 +224,14 @@ jobs:
               apps/evaluator/nlm_deep_research/tests/test_run_verdict.py|\
               apps/evaluator/nlm_deep_research/tests/test_calendar_skip_marker_class.py|\
               .claude/skills/modus/PENDING-ARMS.md|\
+              scripts/ci/required_context_map.py|\
+              scripts/ci/snapshot_required_contexts.py|\
+              scripts/ci/check_required_workflow_conformance.py|\
+              scripts/tests/test_required_context_map.py|\
+              scripts/tests/test_check_required_workflow_conformance.py|\
+              infra/required.d/contexts.json|\
+              infra/guard-conformance/registry.json|\
+              infra/guard-conformance/check_guard_conformance.py|\
               .github/workflows/immune-enforcement.yml|\
               .github/workflows/*.yml|\
               .github/workflows/*.yaml)
@@ -325,7 +333,9 @@ jobs:
             scripts/tests/test_immune_enforcement_trigger_symmetry.py \
             scripts/tests/test_drive_watchdog_fly_path.py \
             scripts/tests/test_drive_watchdog_tier_ratchet.py \
-            scripts/test_lint_test_reward_hacking.py ; do
+            scripts/test_lint_test_reward_hacking.py \
+            scripts/tests/test_required_context_map.py \
+            scripts/tests/test_check_required_workflow_conformance.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"
               python -m pytest "$t" -q || fail=1
@@ -730,6 +740,17 @@ jobs:
           # absent status is CANNOT-VERIFY rather than success — a blind check is not a
           # clean check.
           bash scripts/ci/test_telegram_verdict.sh
+
+      - name: Required-workflow conformance (Merge-OS v2 Wave 0, Codex F12)
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # infra/required.d/contexts.json + scripts/ci/check_required_workflow_conformance.py
+          # shipped together, docs-sync.yml/migration-lint.yml cured same PR. The
+          # guilt+innocence corpus above (test_check_required_workflow_conformance.py)
+          # proves the CHECKER can still bite; this step proves the REAL repo tree is
+          # clean today — a censused guard that no workflow actually runs against
+          # live data is theater (W81).
+          python3 scripts/ci/check_required_workflow_conformance.py
 
       - name: declared-pairs.json is valid JSON with sane shape
         if: steps.paths.outputs.relevant == 'true'

--- a/.github/workflows/migration-lint.yml
+++ b/.github/workflows/migration-lint.yml
@@ -15,11 +15,24 @@ name: Migration Lint (Squawk)
 # at PR-check time, ~2 hours earlier than the pre-deploy gate would catch
 # the same class of issues.
 
+# SENTINEL PATTERN (2026-08-11 — Merge-OS v2 Wave 0 trap-disarm,
+# research/operations/2026-08-10-merge-os-v2-submission-system.md §4 Wave 0,
+# Codex F12). This workflow used to gate on a top-level `paths:` filter and
+# had no `merge_group` trigger. That is a trap: a required check whose
+# WORKFLOW is `paths:`-filtered never even STARTS a run on a PR outside
+# those paths — there is no skipped/neutral run to satisfy the check, so
+# GitHub shows the context "Expected — waiting for status to be reported"
+# forever, hard-blocking an innocent PR. Adding `merge_group:` alone would
+# not have fixed this — the PR-side context would still hang; the top-level
+# `paths:` itself has to go. Fix, same shape as guard-conformance.yml /
+# immune-enforcement.yml / frontend-typecheck.yml: no top-level `paths:` —
+# the workflow ALWAYS triggers, so it is required-safe by construction.
+# Relevance (did this diff touch a migration file at all) is decided INSIDE
+# the "Detect added/modified migrations" step below (job-level change
+# detection); on a path-miss PR the job ends success (skip = success).
 on:
-  pull_request:
-    paths:
-      - "apps/backend-rag/backend/db/migrations_v2/**.sql"
-      - ".github/workflows/migration-lint.yml"
+  pull_request: # NO top-level paths: — always trigger (job decides relevance)
+  merge_group:
   workflow_dispatch: {}
 
 concurrency:
@@ -54,12 +67,47 @@ jobs:
 
       - name: Detect added/modified migrations on this PR
         id: changed
+        env:
+          # Immutable event-pair SHAs, never a moving `main` recompute —
+          # merge_group.base_sha/head_sha for the queue, pull_request.*.sha
+          # for a PR. Merge-base anchored via scripts/ci/hotzone_changed_files.sh
+          # (three-dot semantics), never a two-dot diff against a possibly-
+          # stale `pull_request.base.sha` (scar W102, PR #3057).
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Diff against the PR base (origin/main by default for pull_request).
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
-          files=$(git diff --name-only --diff-filter=AM "$base...$head" -- \
-                  'apps/backend-rag/backend/db/migrations_v2/*.sql' || true)
+          set -uo pipefail
+          # workflow_dispatch has no base/head event pair to diff — preserve
+          # the pre-existing graceful "nothing auto-detected" behaviour
+          # rather than failing a manual, no-PR-context run.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "files=" >> "$GITHUB_OUTPUT"
+            echo "::notice::workflow_dispatch has no PR/merge_group SHA pair — nothing auto-detected"
+            exit 0
+          fi
+          if [ ! -f scripts/ci/hotzone_changed_files.sh ]; then
+            echo "::error::enumerator missing — refusing to guess the changed set"
+            exit 1
+          fi
+          CHANGED="$(bash scripts/ci/hotzone_changed_files.sh "$BASE_SHA" "$HEAD_SHA" "$PR_NUMBER")"
+          ENUM_RC=$?
+          if [ "$ENUM_RC" -ne 0 ]; then
+            echo "::error::could not determine the changed set (rc=$ENUM_RC) — failing rather than skipping"
+            exit 1
+          fi
+          # --diff-filter=AM semantics preserved: only migration files that
+          # still EXIST in this tree are candidates (a deleted/renamed-away
+          # file has nothing for squawk to lint — same [ -f ] discipline as
+          # prettier-changed-files.yml). No leading/trailing whitespace on
+          # any line here — the squawk loop below word-splits this list.
+          CANDIDATES="$(printf '%s\n' "$CHANGED" | grep -E '^apps/backend-rag/backend/db/migrations_v2/.*\.sql$' || true)"
+          files=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ -f "$f" ] && files="${files:+$files$'\n'}$f"
+          done <<< "$CANDIDATES"
           echo "Changed migration files:"
           echo "$files"
           # Output for downstream step. If no migrations changed, skip lint.

--- a/infra/guard-conformance/check_guard_conformance.py
+++ b/infra/guard-conformance/check_guard_conformance.py
@@ -357,12 +357,18 @@ def main(argv: list[str] | None = None) -> int:
     violations += check_bridge(
         registry["surfaces"]["wa_mirror_control_api"], wf_text, label="wa-mirror-api"
     )
+    violations += check_bridge(
+        registry["surfaces"]["required_workflow_conformance"],
+        wf_text,
+        label="required-workflow-conformance",
+    )
     violations += check_simple_surfaces(registry, wf_text)
 
     bridge_count = len(registry["surfaces"]["bridge_reply_guards"]["guards"])
     hook_count = len(registry["surfaces"]["command_hooks"]["entries"])
     pregate_count = len(registry["surfaces"]["wr2_editorial_pregate"]["guards"])
     evidence_pack_count = len(registry["surfaces"]["evidence_pack_lint"]["guards"])
+    required_wf_count = len(registry["surfaces"]["required_workflow_conformance"]["guards"])
 
     if as_json:
         print(json.dumps({
@@ -371,6 +377,7 @@ def main(argv: list[str] | None = None) -> int:
             "hook_entries": hook_count,
             "wr2_pregate_checks": pregate_count,
             "evidence_pack_lint_checks": evidence_pack_count,
+            "required_workflow_conformance_checks": required_wf_count,
             "violations": violations,
             "conformant": not violations,
         }, indent=2))
@@ -378,7 +385,8 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"guard-conformance: {bridge_count} bridge guards, {hook_count} hook entries, "
             f"{pregate_count} wr2-pregate checks, {evidence_pack_count} evidence-pack-lint "
-            f"checks, {len(violations)} violation(s)"
+            f"checks, {required_wf_count} required-workflow-conformance checks, "
+            f"{len(violations)} violation(s)"
         )
         for v in violations:
             print(f"  ✗ {v}")

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -480,6 +480,43 @@
           ]
         }
       }
+    },
+    "required_workflow_conformance": {
+      "_doc": "Merge-OS v2 Wave 0 trap-disarm (research/operations/2026-08-10-merge-os-v2-submission-system.md §4 Wave 0, Codex F12). scripts/ci/check_required_workflow_conformance.py reads infra/required.d/contexts.json and fails if a required context's defining workflow lacks a merge_group: trigger or carries a top-level pull_request.paths: filter — the exact defect docs-sync.yml and migration-lint.yml shipped (cured same PR): a required check gated by a top-level paths: filter never even starts a run on an innocent PR, so GitHub shows it 'Expected — waiting' forever. Each check_* function IS a guard in the superscar #3 sense, same shape as evidence_pack_lint.py/wr2_editorial_pregate.py.",
+      "source": "scripts/ci/check_required_workflow_conformance.py",
+      "census": {
+        "method": "ast-def-prefix",
+        "prefix": "check_"
+      },
+      "test_file": "scripts/tests/test_check_required_workflow_conformance.py",
+      "guards": {
+        "check_merge_group_trigger": {
+          "scar": ["Codex-F12"],
+          "guilt": ["test_guilt_missing_merge_group_flagged"],
+          "innocence": ["test_innocence_merge_group_present_passes"]
+        },
+        "check_no_pull_request_paths_filter": {
+          "scar": ["Codex-F12"],
+          "guilt": ["test_guilt_toplevel_pr_paths_filter_flagged"],
+          "innocence": [
+            "test_innocence_pull_request_without_paths_passes",
+            "test_innocence_push_paths_filter_is_out_of_scope"
+          ]
+        },
+        "check_context_workflow_file_exists": {
+          "scar": ["Codex-F12"],
+          "guilt": ["test_guilt_missing_workflow_file_flagged"],
+          "innocence": ["test_innocence_real_workflow_file_passes"]
+        },
+        "check_allowlist_entry_has_reason": {
+          "scar": ["Codex-F12"],
+          "guilt": [
+            "test_guilt_empty_allowlist_reason_flagged",
+            "test_guilt_missing_allowlist_reason_flagged"
+          ],
+          "innocence": ["test_innocence_real_allowlist_reason_passes"]
+        }
+      }
     }
   }
 }

--- a/infra/required.d/contexts.json
+++ b/infra/required.d/contexts.json
@@ -1,0 +1,173 @@
+{
+  "_doc": "Advisory snapshot of main's required-status-check contexts (Merge-OS v2 Wave 0, research/operations/2026-08-10-merge-os-v2-submission-system.md §4). Read by scripts/ci/check_required_workflow_conformance.py. Drift vs live branch protection is expected and cured by REGEN, never hand-edit — see regen_command below.",
+  "generated_at": "2026-08-11",
+  "source": "api",
+  "derived_from_pr": null,
+  "repo": "Bali-Zero/Teman2",
+  "branch": "main",
+  "regen_command": "python3 scripts/ci/snapshot_required_contexts.py --branch main --out infra/required.d/contexts.json",
+  "contexts": [
+    {
+      "name": "Backend Tests (Python)",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/tests.yml",
+      "job_id": "backend-tests"
+    },
+    {
+      "name": "Bandit Python Security",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/security.yml",
+      "job_id": "bandit"
+    },
+    {
+      "name": "Canary self-test + incremental mutation",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/p1s2-mutation-incremental.yml",
+      "job_id": "mutation-gate"
+    },
+    {
+      "name": "CodeQL Analysis (javascript)",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/security.yml",
+      "job_id": "codeql"
+    },
+    {
+      "name": "CodeQL Analysis (python)",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/security.yml",
+      "job_id": "codeql"
+    },
+    {
+      "name": "Detect Secrets",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/security.yml",
+      "job_id": "detect-secrets"
+    },
+    {
+      "name": "E2E Tests (Playwright)",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/tests.yml",
+      "job_id": "e2e-tests"
+    },
+    {
+      "name": "Every guard proves guilt AND innocence",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/guard-conformance.yml",
+      "job_id": "conformance"
+    },
+    {
+      "name": "Every organ is born with its genes",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/organ-conformance.yml",
+      "job_id": "conformance"
+    },
+    {
+      "name": "Frontend Tests (Next.js) (mouth, true)",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/tests.yml",
+      "job_id": "frontend-tests"
+    },
+    {
+      "name": "Harness floor recompute",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/harness-floor.yml",
+      "job_id": "harness-floor"
+    },
+    {
+      "name": "Hot-zone enforcement",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/hot-zone-pr-gate.yml",
+      "job_id": "hot-zone-gate"
+    },
+    {
+      "name": "MCP Server Tests",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/tests.yml",
+      "job_id": "mcp-tests"
+    },
+    {
+      "name": "P3 static validation (enforcing)",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/p3-sandbox-gates.yml",
+      "job_id": "p3-static-validation"
+    },
+    {
+      "name": "P6 parallelize-hypothesis falsifiable gates",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/p6-federation-parallelize.yml",
+      "job_id": "parallelize-gate"
+    },
+    {
+      "name": "Prove hooks bite only the guilty",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/hook-innocence-gate.yml",
+      "job_id": "innocence"
+    },
+    {
+      "name": "R1 gate — adversarial review present",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/adversarial-review-gate.yml",
+      "job_id": "gate"
+    },
+    {
+      "name": "actionlint — workflow schema + expression gate",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/actionlint.yml",
+      "job_id": "lint"
+    },
+    {
+      "name": "antidotes",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/immune-enforcement.yml",
+      "job_id": "antidotes"
+    },
+    {
+      "name": "asyncpg-lint",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/asyncpg-lint.yml",
+      "job_id": "asyncpg-lint"
+    },
+    {
+      "name": "brand-api-gate",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/p8-brand-api.yml",
+      "job_id": "brand-api-gate"
+    },
+    {
+      "name": "cost-breaker-tests",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/p9-cost-breaker.yml",
+      "job_id": "cost-breaker-tests"
+    },
+    {
+      "name": "lesson-harvester-gate",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/p7-lesson-harvester.yml",
+      "job_id": "lesson-harvester-gate"
+    },
+    {
+      "name": "npm lock honors manifest",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/npm-lock-sync.yml",
+      "job_id": "lock-honors-manifest"
+    },
+    {
+      "name": "prepush-guards",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/prepush-guards.yml",
+      "job_id": "prepush-guards"
+    },
+    {
+      "name": "root-guard",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/root-guard.yml",
+      "job_id": "root-guard"
+    },
+    {
+      "name": "verify-the-verifiers",
+      "app_id": 15368,
+      "workflow_file": ".github/workflows/verify-the-verifiers.yml",
+      "job_id": "verify-the-verifiers"
+    }
+  ]
+}

--- a/scripts/ci/check_required_workflow_conformance.py
+++ b/scripts/ci/check_required_workflow_conformance.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""check_required_workflow_conformance.py — continuous (per-PR, not weekly)
+guard that every required-status-check context's DEFINING workflow is safe
+to be required at all.
+
+WHY THIS EXISTS (Merge-OS v2 Wave 0, spec §4 Wave 0 "continuous conformance
+check": research/operations/2026-08-10-merge-os-v2-submission-system.md,
+Qwen F9). The specific trap this closes (Codex F12, independently confirmed
+by a second cross-family seat against this exact repo, spec §6.2): a
+required status check is satisfied only by a run of the workflow that
+REPORTS that context. If that workflow's `on:` block carries a top-level
+`paths:` filter, a PR outside those paths never starts a run at all — there
+is no skipped/neutral status to satisfy the check, so GitHub shows the
+context "Expected — waiting for status to be reported" FOREVER, and the PR
+is hard-blocked with nothing red to fix. `docs-sync.yml` and
+`migration-lint.yml` shipped exactly this defect (cured in this same PR);
+this guard exists so the NEXT workflow that becomes required doesn't ship it
+again, checked on every PR rather than caught after the fact.
+
+WHAT IT CHECKS, against infra/required.d/contexts.json (the advisory
+snapshot from scripts/ci/snapshot_required_contexts.py):
+
+  For every context whose `workflow_file` is set (i.e. it IS produced by a
+  workflow in this repo, as opposed to an external check like a required
+  Copilot review):
+    1. that workflow file exists on disk;
+    2. its `on:` block includes a `merge_group:` trigger — a required
+       context with no `merge_group` trigger cannot be satisfied by a
+       merge-queue run at all, which either stalls the queue (nothing to
+       report) or silently excludes the check from queue enforcement,
+       neither of which is a state a required check should be in;
+    3. its `on.pull_request` sub-block carries NO top-level `paths:` key —
+       the exact Codex F12 trap.
+
+  For every context whose `workflow_file` is null (declared not
+  workflow-produced — the allowlist path), the registered
+  `allowlist_reason` must be a non-empty, non-placeholder string. An empty
+  or missing reason fails: "not workflow-produced" is an assertion about the
+  context, not a default for anything the resolver could not figure out
+  (mirrors superscar #3's rule for exemptions generally — an exemption is a
+  guard running in reverse, and wants its own justification, not a free
+  pass). `scripts/ci/snapshot_required_contexts.py` writes a deliberately
+  generic placeholder reason for anything it could not resolve — the point
+  of requiring a "real" reason is that placeholder text must be replaced by
+  a human/session who checked, not silently accepted.
+
+DECLARED SCOPE LIMIT (residual risk, not hidden — same style as
+scripts/lint_workflow_timeout_floor.py's own declared limit): rule 3 checks
+`on.pull_request.paths` ONLY, never `on.push.paths`. A `push:`-triggered run
+targets `main` directly, after the PR already merged — it never gates
+whether a PR's required context resolves, so a `paths:` filter there is a
+different, legitimate cost optimization (skip re-running on an irrelevant
+push to main), not the Codex F12 trap. Checked empirically against this
+repo's OWN required-context workflows at authoring time (2026-08-11): 12 of
+them carry a `push.paths` filter and would ALL false-positive under a
+scope that didn't draw this line — none of them carry a `pull_request.paths`
+filter. `merge_group:` itself does not support a `paths:` sub-key in GitHub
+Actions at all, so there is nothing to check there.
+
+Usage:
+    python3 scripts/ci/check_required_workflow_conformance.py
+        [--contexts infra/required.d/contexts.json] [--repo-root .]
+
+Exit codes: 0 conformant · 1 one or more violations · 2 cannot verify
+(contexts.json missing/unparseable, or has zero contexts — an empty sweep
+is not a pass, W84 "esiste ≠ armato").
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_CONTEXTS = REPO_ROOT / "infra" / "required.d" / "contexts.json"
+
+_PLACEHOLDER_MARKERS = ("UNRESOLVED", "TODO", "FIXME", "")
+
+
+def load_contexts(path: Path) -> dict[str, Any] | None:
+    """Returns None on any failure to parse — never a partial/empty dict
+    that a caller could mistake for 'zero contexts, all clean' (W84)."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or not isinstance(data.get("contexts"), list):
+        return None
+    return data
+
+
+def load_on_block(workflow_path: Path) -> dict[str, Any] | None:
+    """The workflow's `on:` block, or None if the file is missing/unparseable.
+    PyYAML parses a bare `on:` key as the boolean `True` (YAML 1.1 boolean
+    literal) — `doc.get(True) or doc.get("on")` covers both spellings, the
+    same pattern already used by scripts/verify_main_watch_schedule_scope.py."""
+    try:
+        doc = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(doc, dict):
+        return None
+    on_block = doc.get(True)
+    if on_block is None:
+        on_block = doc.get("on")
+    return on_block if isinstance(on_block, dict) else {}
+
+
+# ------------------------------------------------------------------ checks
+# Every check_* function returns a list of violation strings (empty = pass).
+# AST-censused by infra/guard-conformance/registry.json (ast-def-prefix
+# "check_") — the guilt+innocence discipline this repo requires of every
+# textual guard applies to the guard that watches OTHER guards' triggers too.
+
+
+def check_merge_group_trigger(on_block: dict[str, Any]) -> list[str]:
+    if "merge_group" not in on_block:
+        return [
+            "missing `merge_group:` trigger — this context cannot be satisfied "
+            "by a merge-queue run"
+        ]
+    return []
+
+
+def check_no_pull_request_paths_filter(on_block: dict[str, Any]) -> list[str]:
+    pr_block = on_block.get("pull_request")
+    if isinstance(pr_block, dict) and "paths" in pr_block:
+        return [
+            "top-level `paths:` filter under `on.pull_request` — an innocent PR "
+            "outside those paths never starts a run, so this required context "
+            "hangs 'Expected — waiting' forever (Codex F12)"
+        ]
+    return []
+
+
+def check_context_workflow_file_exists(entry: dict[str, Any], repo_root: Path) -> list[str]:
+    """Assumes the caller only invokes this for entries that declare a
+    workflow_file at all (evaluate() below branches allowlisted entries to
+    check_allowlist_entry_has_reason instead) — a falsy workflow_file here
+    is treated as absent, not specially reported, since that shape belongs
+    to the allowlist check, not this one."""
+    workflow_file = entry.get("workflow_file")
+    if not workflow_file:
+        return []
+    if not (repo_root / workflow_file).exists():
+        return [f"declared workflow_file `{workflow_file}` does not exist on disk"]
+    return []
+
+
+def check_allowlist_entry_has_reason(entry: dict[str, Any]) -> list[str]:
+    reason = entry.get("allowlist_reason")
+    if not isinstance(reason, str) or reason.strip() in _PLACEHOLDER_MARKERS:
+        return [
+            f"context `{entry.get('name')}` is allowlisted as not workflow-produced "
+            f"(workflow_file: null) but carries no real `allowlist_reason` — "
+            f"'not workflow-produced' is an assertion, not a default; write down why"
+        ]
+    return []
+
+
+# ------------------------------------------------------------------ driver
+
+
+def evaluate(contexts_path: Path, repo_root: Path) -> tuple[list[str], int]:
+    """Returns (violations, contexts_checked). violations is empty on a
+    clean run; contexts_checked == 0 is itself a violation-adjacent state
+    the caller must treat as CANNOT-VERIFY, not as a pass."""
+    data = load_contexts(contexts_path)
+    if data is None:
+        return ([f"BLIND: {contexts_path} is missing or not valid JSON"], 0)
+
+    contexts = data["contexts"]
+    if not contexts:
+        return ([f"BLIND: {contexts_path} declares zero contexts"], 0)
+
+    violations: list[str] = []
+    on_block_cache: dict[str, dict[str, Any] | None] = {}
+
+    for entry in contexts:
+        name = entry.get("name", "<unnamed>")
+        workflow_file = entry.get("workflow_file")
+
+        if not workflow_file:
+            violations.extend(check_allowlist_entry_has_reason(entry))
+            continue
+
+        file_violations = check_context_workflow_file_exists(entry, repo_root)
+        if file_violations:
+            violations.extend(f"[{name}] {v}" for v in file_violations)
+            continue
+
+        if workflow_file not in on_block_cache:
+            on_block_cache[workflow_file] = load_on_block(repo_root / workflow_file)
+        on_block = on_block_cache[workflow_file]
+        if on_block is None:
+            violations.append(f"[{name}] workflow {workflow_file} could not be parsed")
+            continue
+
+        for v in check_merge_group_trigger(on_block):
+            violations.append(f"[{name}] {workflow_file}: {v}")
+        for v in check_no_pull_request_paths_filter(on_block):
+            violations.append(f"[{name}] {workflow_file}: {v}")
+
+    return (violations, len(contexts))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contexts", default=str(DEFAULT_CONTEXTS))
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    args = parser.parse_args(argv)
+
+    contexts_path = Path(args.contexts)
+    repo_root = Path(args.repo_root)
+
+    violations, checked = evaluate(contexts_path, repo_root)
+
+    if checked == 0:
+        print(f"required-workflow-conformance: CANNOT VERIFY — {violations[0] if violations else 'no contexts'}")
+        return 2
+
+    print(f"required-workflow-conformance: {checked} required context(s) checked, {len(violations)} violation(s)")
+    for v in violations:
+        print(f"  ✗ {v}")
+    if not violations:
+        print("  ✓ every required context's defining workflow has merge_group + no top-level pull_request paths:")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/required_context_map.py
+++ b/scripts/ci/required_context_map.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""required_context_map.py — resolve a branch-protection required-status-check
+context name back to the `.github/workflows/*.yml` file + job that produces it.
+
+WHY THIS EXISTS (Merge-OS v2 Wave 0, spec §4 — Codex F12 trap-disarm slice):
+a required context is a job's REPORTED name — the job's `name:` field, or the
+job id when `name:` is absent, with `" (v1, v2, ...)"` appended per matrix
+combination (GitHub's own convention: matrix VALUES joined by ", ", in
+declaration order, never the matrix KEYS). Nothing in this repo previously
+wrote that resolution down; it lived only in each engineer's head. This
+module is the single place that computes it, shared by:
+
+  - scripts/ci/snapshot_required_contexts.py (regenerates infra/required.d/
+    contexts.json from the live branch-protection API)
+  - scripts/ci/check_required_workflow_conformance.py (the per-PR guard that
+    reads that snapshot and enforces merge_group + no-top-level-paths on
+    every context's defining workflow)
+
+Matrix support is deliberately narrow, matching how THIS repo actually uses
+`strategy.matrix` (verified against every job in .github/workflows/ at
+authoring time, 2026-08-10):
+  - `matrix: {include: [{...}, {...}]}` — each include entry IS one combo;
+    values taken in the entry's own key order (tests.yml frontend-tests).
+  - `matrix: {key: [v1, v2], ...}` — cartesian product across keys, in the
+    matrix mapping's own key order (security.yml codeql: language:
+    [python, javascript]).
+A job combining both forms, or using `exclude:`, is out of scope — this is a
+snapshot/lint convenience, not a GitHub Actions expression interpreter (same
+declared-limit style as scripts/verify_main_watch_schedule_scope.py).
+
+No network calls. Pure stdlib + PyYAML (already a repo dependency —
+scripts/lint_workflow_timeout_floor.py, scripts/evidence_pack_lint.py, etc.).
+"""
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def load_workflow(path: Path) -> dict[str, Any] | None:
+    """Parse one workflow YAML. Returns None (never raises) on a parse
+    failure or a non-mapping document — a workflow that cannot be understood
+    contributes zero contexts, it never crashes the whole scan (W84: an
+    empty/partial result must never be silently read as 'nothing here')."""
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError:
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def _matrix_combos(matrix: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every combination `strategy.matrix` produces, values only (order
+    preserved per combo). `include` entries are combos verbatim; plain
+    `key: [v1, v2, ...]` mappings cross-product (itertools.product, key
+    order = declaration order — Python dicts preserve insertion order)."""
+    combos: list[dict[str, Any]] = []
+    include = matrix.get("include")
+    if isinstance(include, list):
+        for entry in include:
+            if isinstance(entry, dict):
+                combos.append(dict(entry))
+    plain_keys = [k for k in matrix.keys() if k not in ("include", "exclude")]
+    if plain_keys:
+        value_lists = [matrix[k] if isinstance(matrix[k], list) else [matrix[k]] for k in plain_keys]
+        for values in itertools.product(*value_lists):
+            combos.append(dict(zip(plain_keys, values)))
+    return combos
+
+
+def _gh_stringify(value: Any) -> str:
+    """GitHub renders a matrix value in a status-check context the way its
+    own expression engine stringifies it — lowercase `true`/`false`, not
+    Python's `True`/`False`. Caught empirically: `coverage: true` in
+    tests.yml's frontend-tests matrix produced a context this module could
+    not resolve until this conversion existed (`str(True)` -> "True")."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    return str(value)
+
+
+def _context_names_for_job(job_id: str, job: dict[str, Any]) -> Iterator[str]:
+    base_name = str(job.get("name", job_id))
+    strategy = job.get("strategy")
+    matrix = strategy.get("matrix") if isinstance(strategy, dict) else None
+    if isinstance(matrix, dict) and matrix:
+        for combo in _matrix_combos(matrix):
+            suffix = ", ".join(_gh_stringify(v) for v in combo.values())
+            if suffix:
+                yield f"{base_name} ({suffix})"
+                continue
+        return
+    yield base_name
+
+
+def build_context_index(workflows_dir: Path = WORKFLOWS_DIR) -> dict[str, list[tuple[str, str]]]:
+    """context name -> list of (workflow filename, job id) that produce it.
+    A list (not a single match) so an ambiguous name — two jobs reporting the
+    identical context string — is visible to the caller rather than silently
+    picking one (W65: a resolver that guesses is a resolver that hallucinates)."""
+    index: dict[str, list[tuple[str, str]]] = {}
+    if not workflows_dir.exists():
+        return index
+    for path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
+        doc = load_workflow(path)
+        if not doc:
+            continue
+        jobs = doc.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_id, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            for ctx_name in _context_names_for_job(job_id, job):
+                index.setdefault(ctx_name, []).append((path.name, str(job_id)))
+    return index
+
+
+def resolve(context_name: str, workflows_dir: Path = WORKFLOWS_DIR) -> tuple[str, str] | None:
+    """Single (workflow filename, job id) for a context name, or None if
+    zero or more-than-one job in the repo reports that exact name."""
+    matches = build_context_index(workflows_dir).get(context_name, [])
+    if len(matches) != 1:
+        return None
+    return matches[0]

--- a/scripts/ci/snapshot_required_contexts.py
+++ b/scripts/ci/snapshot_required_contexts.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""snapshot_required_contexts.py — regenerate infra/required.d/contexts.json.
+
+WHY THIS EXISTS (Merge-OS v2 Wave 0, spec §4 "required.d snapshot (advisory)":
+research/operations/2026-08-10-merge-os-v2-submission-system.md). The live
+branch-protection required-status-check list is authoritative but invisible
+to a PR diff — nothing in the repo could previously say, in a reviewable
+text file, "these are the 27 contexts main requires, and this is which
+workflow file produces each one." infra/required.d/contexts.json is that
+snapshot: ADVISORY (a data file other tools read — right now
+scripts/ci/check_required_workflow_conformance.py), never authoritative.
+Drift between this file and the live branch-protection API is EXPECTED
+(someone adds/removes a required check via GitHub Settings, or a workflow
+job is renamed) and is cured by re-running this script, never by hand-
+editing the JSON.
+
+SOURCE OF TRUTH, TWO TIERS:
+  1. `gh api repos/<owner>/<repo>/branches/<branch>/protection/required_status_checks`
+     — the classic branch-protection contexts endpoint. This is what main
+     actually enforces (verified live 2026-08-10: 27 contexts, the
+     `merge-queue-main` ruleset id 19779175 governs queue MECHANICS —
+     grouping/batching — not the required-context list itself, which still
+     lives on branches/main/protection). `source: "api"` when this succeeds.
+  2. Fallback — `gh pr checks <PR>` on a recent MERGED pr — used only if the
+     API call is denied (some tokens can read a repo's workflows but not its
+     branch-protection settings). `source: "derived"` in that case, and the
+     PR number used is recorded, because a derived list is a snapshot of
+     "checks that ran on one PR," not a verified requirement list — the
+     conformance guard and any human reading this file need to know which
+     kind of ground truth they are trusting.
+
+WORKFLOW RESOLUTION: scripts/ci/required_context_map.py (shared with the
+guard) maps each context name back to the `.github/workflows/*.yml` file +
+job id that reports it, by parsing every workflow's `jobs:` (+ matrix
+expansion). A context with zero or more-than-one matching job is recorded
+with `workflow_file: null` and a `resolution` note — this is the allowlist
+path: `scripts/ci/check_required_workflow_conformance.py` requires a
+`reason` for any such entry before it will accept it as "not workflow-
+produced" rather than "the mapper's most likely explanation is a bug."
+
+Usage:
+    python3 scripts/ci/snapshot_required_contexts.py [--branch main] [--out infra/required.d/contexts.json]
+
+No mutation of GitHub state — read-only `gh api`/`gh pr checks` calls only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from required_context_map import resolve  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_OUT = REPO_ROOT / "infra" / "required.d" / "contexts.json"
+
+
+def _gh(args: list[str]) -> str | None:
+    try:
+        out = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout
+
+
+def repo_slug() -> str:
+    out = _gh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+    if not out or not out.strip():
+        print("FATAL: could not resolve repo slug via `gh repo view`", file=sys.stderr)
+        sys.exit(2)
+    return out.strip()
+
+
+def fetch_via_api(repo: str, branch: str) -> list[dict] | None:
+    out = _gh(
+        [
+            "api",
+            f"repos/{repo}/branches/{branch}/protection/required_status_checks",
+        ]
+    )
+    if not out:
+        return None
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    checks = data.get("checks")
+    if not isinstance(checks, list):
+        return None
+    return [{"name": c.get("context"), "app_id": c.get("app_id")} for c in checks if c.get("context")]
+
+
+def fetch_via_derived_pr(repo: str, pr_number: str) -> list[dict] | None:
+    out = _gh(["pr", "checks", pr_number, "--repo", repo, "--json", "name"])
+    if not out:
+        return None
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list):
+        return None
+    return [{"name": row.get("name"), "app_id": None} for row in data if row.get("name")]
+
+
+def build_snapshot(branch: str, derived_pr: str | None) -> dict:
+    repo = repo_slug()
+    source = "api"
+    checks = fetch_via_api(repo, branch)
+    if checks is None:
+        if not derived_pr:
+            print(
+                "FATAL: branch-protection API denied and no --derived-from-pr given — "
+                "refusing to write a blind-empty snapshot (W84)",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        source = "derived"
+        checks = fetch_via_derived_pr(repo, derived_pr)
+        if checks is None:
+            print(f"FATAL: could not derive contexts from PR #{derived_pr} either", file=sys.stderr)
+            sys.exit(2)
+
+    contexts = []
+    for c in sorted(checks, key=lambda x: x["name"]):
+        match = resolve(c["name"])
+        entry = {
+            "name": c["name"],
+            "app_id": c.get("app_id"),
+        }
+        if match:
+            entry["workflow_file"] = f".github/workflows/{match[0]}"
+            entry["job_id"] = match[1]
+        else:
+            entry["workflow_file"] = None
+            entry["allowlist_reason"] = (
+                "UNRESOLVED by scripts/ci/required_context_map.py — either a genuinely "
+                "external check (Vercel, GitHub-native code scanning not backed by a "
+                "workflow file in this repo, a required Copilot review, ...) or the "
+                "mapper needs a fix. Do not leave this placeholder in place without "
+                "checking which one it is."
+            )
+        contexts.append(entry)
+
+    return {
+        "_doc": (
+            "Advisory snapshot of main's required-status-check contexts (Merge-OS v2 "
+            "Wave 0, research/operations/2026-08-10-merge-os-v2-submission-system.md "
+            "§4). Read by scripts/ci/check_required_workflow_conformance.py. Drift vs "
+            "live branch protection is expected and cured by REGEN, never hand-edit — "
+            "see regen_command below."
+        ),
+        "generated_at": "2026-08-11",
+        "source": source,
+        "derived_from_pr": derived_pr if source == "derived" else None,
+        "repo": repo,
+        "branch": branch,
+        "regen_command": (
+            "python3 scripts/ci/snapshot_required_contexts.py "
+            f"--branch {branch} --out infra/required.d/contexts.json"
+        ),
+        "contexts": contexts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--out", default=str(DEFAULT_OUT))
+    parser.add_argument(
+        "--derived-from-pr",
+        default=None,
+        help="Fallback PR number to derive the context list from if the branch-"
+        "protection API call is denied.",
+    )
+    args = parser.parse_args()
+
+    snapshot = build_snapshot(args.branch, args.derived_from_pr)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    unresolved = [c["name"] for c in snapshot["contexts"] if c["workflow_file"] is None]
+    print(f"wrote {out_path} — {len(snapshot['contexts'])} contexts, source={snapshot['source']}")
+    if unresolved:
+        print(f"  {len(unresolved)} UNRESOLVED (need a workflow_file or a real allowlist reason):")
+        for name in unresolved:
+            print(f"    - {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_required_workflow_conformance.py
+++ b/scripts/tests/test_check_required_workflow_conformance.py
@@ -1,0 +1,221 @@
+"""Tests for scripts/ci/check_required_workflow_conformance.py.
+
+Guilt+innocence per cicatrix-superscar.md #3 ("nessuna guardia mergiata
+senza un test di innocenza E di colpevolezza") for every `check_*` function
+the module exports, PLUS a guilt+innocence pair on the real repo tree —
+this is the guard's own guilt proof cited in the Merge-OS v2 Wave 0 PR body
+(research/operations/2026-08-10-merge-os-v2-submission-system.md §4 Wave 0):
+docs-sync.yml / migration-lint.yml FAILED this guard before their cure in
+this same PR, and PASS it after.
+
+Run:  python3 -m pytest scripts/tests/test_check_required_workflow_conformance.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = REPO_ROOT / "scripts" / "ci" / "check_required_workflow_conformance.py"
+_spec = importlib.util.spec_from_file_location("check_required_workflow_conformance", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+
+# --------------------------------------------------------------- check_merge_group_trigger
+
+
+def test_guilt_missing_merge_group_flagged():
+    on_block = {"pull_request": {}, "push": {"branches": ["main"]}}
+    violations = mod.check_merge_group_trigger(on_block)
+    assert violations
+    assert "merge_group" in violations[0]
+
+
+def test_innocence_merge_group_present_passes():
+    on_block = {"pull_request": {}, "merge_group": None}
+    assert mod.check_merge_group_trigger(on_block) == []
+
+
+# --------------------------------------------------------- check_no_pull_request_paths_filter
+
+
+def test_guilt_toplevel_pr_paths_filter_flagged():
+    # The exact shape docs-sync.yml/migration-lint.yml shipped before this PR.
+    on_block = {"pull_request": {"paths": ["scripts/docs_sync.py"]}, "merge_group": None}
+    violations = mod.check_no_pull_request_paths_filter(on_block)
+    assert violations
+    assert "paths" in violations[0]
+
+
+def test_innocence_pull_request_without_paths_passes():
+    on_block = {"pull_request": None, "merge_group": None}
+    assert mod.check_no_pull_request_paths_filter(on_block) == []
+
+
+def test_innocence_push_paths_filter_is_out_of_scope():
+    # Declared scope limit (docstring): on.push.paths is a different,
+    # legitimate optimization, never the Codex F12 trap. 12 real required
+    # workflows in this repo carry exactly this shape.
+    on_block = {
+        "pull_request": {},
+        "merge_group": None,
+        "push": {"branches": ["main"], "paths": ["scripts/**"]},
+    }
+    assert mod.check_no_pull_request_paths_filter(on_block) == []
+
+
+# ----------------------------------------------------- check_context_workflow_file_exists
+
+
+def test_guilt_missing_workflow_file_flagged(tmp_path):
+    entry = {"workflow_file": ".github/workflows/does-not-exist.yml"}
+    violations = mod.check_context_workflow_file_exists(entry, tmp_path)
+    assert violations
+    assert "does not exist" in violations[0]
+
+
+def test_innocence_real_workflow_file_passes():
+    entry = {"workflow_file": ".github/workflows/root-guard.yml"}
+    assert mod.check_context_workflow_file_exists(entry, REPO_ROOT) == []
+
+
+# -------------------------------------------------------- check_allowlist_entry_has_reason
+
+
+def test_guilt_empty_allowlist_reason_flagged():
+    entry = {"name": "Some External Check", "workflow_file": None, "allowlist_reason": ""}
+    violations = mod.check_allowlist_entry_has_reason(entry)
+    assert violations
+    assert "Some External Check" in violations[0]
+
+
+def test_guilt_missing_allowlist_reason_flagged():
+    entry = {"name": "Some External Check", "workflow_file": None}
+    assert mod.check_allowlist_entry_has_reason(entry)
+
+
+def test_innocence_real_allowlist_reason_passes():
+    entry = {
+        "name": "Vercel",
+        "workflow_file": None,
+        "allowlist_reason": "External Vercel deployment check, not produced by any "
+        "workflow file in this repo — verified 2026-08-11.",
+    }
+    assert mod.check_allowlist_entry_has_reason(entry) == []
+
+
+# --------------------------------------------------------------------------- evaluate()
+
+
+def _write_contexts(tmp_path: Path, contexts: list[dict]) -> Path:
+    path = tmp_path / "contexts.json"
+    path.write_text(json.dumps({"contexts": contexts}), encoding="utf-8")
+    return path
+
+
+def test_guilt_evaluate_flags_the_pre_cure_docs_sync_shape(tmp_path):
+    """Reconstructs the EXACT on: shape docs-sync.yml carried before this PR
+    (top-level pull_request.paths, no merge_group) and proves evaluate()
+    catches it — the guard's own guilt proof against a real historical
+    defect, not just a synthetic fixture."""
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "docs-sync.yml").write_text(
+        "on:\n"
+        "  pull_request:\n"
+        "    paths:\n"
+        "      - scripts/docs_sync.py\n"
+        "  push:\n"
+        "    branches: [main]\n"
+        "jobs:\n"
+        "  check-docs-sync:\n"
+        "    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    contexts_path = _write_contexts(
+        tmp_path,
+        [{"name": "check-docs-sync", "workflow_file": ".github/workflows/docs-sync.yml"}],
+    )
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 1
+    assert len(violations) == 2  # missing merge_group AND top-level paths
+    joined = " ".join(violations)
+    assert "merge_group" in joined
+    assert "paths" in joined
+
+
+def test_innocence_evaluate_passes_the_cured_shape(tmp_path):
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "docs-sync.yml").write_text(
+        "on:\n"
+        "  pull_request:\n"
+        "  push:\n"
+        "    branches: [main]\n"
+        "  merge_group:\n"
+        "jobs:\n"
+        "  check-docs-sync:\n"
+        "    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    contexts_path = _write_contexts(
+        tmp_path,
+        [{"name": "check-docs-sync", "workflow_file": ".github/workflows/docs-sync.yml"}],
+    )
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 1
+    assert violations == []
+
+
+def test_innocence_allowlisted_context_with_reason_passes(tmp_path):
+    contexts_path = _write_contexts(
+        tmp_path,
+        [
+            {
+                "name": "Vercel",
+                "workflow_file": None,
+                "allowlist_reason": "External check, verified 2026-08-11.",
+            }
+        ],
+    )
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 1
+    assert violations == []
+
+
+def test_guilt_blind_on_missing_contexts_file(tmp_path):
+    violations, checked = mod.evaluate(tmp_path / "does-not-exist.json", tmp_path)
+    assert checked == 0
+    assert violations and "BLIND" in violations[0]
+
+
+def test_guilt_blind_on_zero_contexts(tmp_path):
+    contexts_path = _write_contexts(tmp_path, [])
+    violations, checked = mod.evaluate(contexts_path, tmp_path)
+    assert checked == 0
+    assert violations and "BLIND" in violations[0]
+
+
+# ------------------------------------------------------------- live repo tree (guilt proof)
+
+
+def test_the_real_repo_tree_is_conformant_today():
+    """The actual proof this PR ships: run the guard against the REAL
+    infra/required.d/contexts.json + the REAL .github/workflows/ tree. Fails
+    if a future required context regresses into the Codex F12 trap without
+    anyone noticing (this test is what makes the guard armed, not just
+    present — W81 "esiste != armato")."""
+    violations, checked = mod.evaluate(mod.DEFAULT_CONTEXTS, REPO_ROOT)
+    assert checked > 0, "contexts.json must declare at least one required context"
+    assert violations == [], f"live repo tree has conformance violations: {violations}"
+
+
+def test_main_cli_exits_zero_on_the_real_repo_tree(capsys):
+    rc = mod.main([])
+    captured = capsys.readouterr()
+    assert rc == 0, captured.out

--- a/scripts/tests/test_required_context_map.py
+++ b/scripts/tests/test_required_context_map.py
@@ -1,0 +1,152 @@
+"""Tests for scripts/ci/required_context_map.py — the context-name -> workflow
+file/job resolver shared by scripts/ci/snapshot_required_contexts.py and
+scripts/ci/check_required_workflow_conformance.py.
+
+Not a superscar #3 "guard" (it doesn't accept/reject anything — it resolves a
+name to a location), so it is not registered in
+infra/guard-conformance/registry.json; this is plain regression coverage,
+pinning the one real bug found while writing it (matrix boolean values
+stringify as Python `True`/`False`, not GitHub's lowercase `true`/`false`) so
+it cannot silently return.
+
+Run:  python3 -m pytest scripts/tests/test_required_context_map.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = REPO_ROOT / "scripts" / "ci" / "required_context_map.py"
+_spec = importlib.util.spec_from_file_location("required_context_map", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+
+def _write(wf_dir: Path, name: str, content: str) -> None:
+    (wf_dir / name).write_text(content, encoding="utf-8")
+
+
+def test_simple_job_no_matrix_resolves_by_name(tmp_path):
+    wf_dir = tmp_path
+    _write(
+        wf_dir,
+        "a.yml",
+        "on:\n  pull_request:\njobs:\n  root-guard:\n    runs-on: ubuntu-latest\n",
+    )
+    # No `name:` -> context name defaults to the job id.
+    assert mod.resolve("root-guard", wf_dir) == ("a.yml", "root-guard")
+
+
+def test_named_job_resolves_by_declared_name(tmp_path):
+    wf_dir = tmp_path
+    _write(
+        wf_dir,
+        "a.yml",
+        "on:\n  pull_request:\njobs:\n  lint:\n    name: Lint\n    runs-on: ubuntu-latest\n",
+    )
+    assert mod.resolve("Lint", wf_dir) == ("a.yml", "lint")
+    assert mod.resolve("lint", wf_dir) is None  # job id alone is not the context once name: is set
+
+
+def test_matrix_include_boolean_value_lowercases_like_github(tmp_path):
+    """Regression pin: the bug this module shipped with while being written —
+    `str(True)` -> "True", but GitHub's own context-name rendering of a
+    matrix boolean value is lowercase "true". Reproduces tests.yml's real
+    frontend-tests job shape (matrix.include with a `coverage: true` field)."""
+    wf_dir = tmp_path
+    _write(
+        wf_dir,
+        "a.yml",
+        "on:\n  pull_request:\n"
+        "jobs:\n"
+        "  frontend-tests:\n"
+        "    name: Frontend Tests (Next.js)\n"
+        "    runs-on: ubuntu-latest\n"
+        "    strategy:\n"
+        "      matrix:\n"
+        "        include:\n"
+        "          - app: mouth\n"
+        "            coverage: true\n"
+        "          - app: admin-dashboard\n"
+        "            coverage: false\n",
+    )
+    assert mod.resolve("Frontend Tests (Next.js) (mouth, true)", wf_dir) == ("a.yml", "frontend-tests")
+    assert mod.resolve("Frontend Tests (Next.js) (admin-dashboard, false)", wf_dir) == ("a.yml", "frontend-tests")
+    # Never the Python-str spelling.
+    assert mod.resolve("Frontend Tests (Next.js) (mouth, True)", wf_dir) is None
+
+
+def test_matrix_cross_product_single_key(tmp_path):
+    """security.yml's real codeql job shape: matrix.language: [python, javascript]
+    (no `include:`) cross-products into 2 distinct contexts."""
+    wf_dir = tmp_path
+    _write(
+        wf_dir,
+        "a.yml",
+        "on:\n  pull_request:\n"
+        "jobs:\n"
+        "  codeql:\n"
+        "    name: CodeQL Analysis\n"
+        "    runs-on: ubuntu-latest\n"
+        "    strategy:\n"
+        "      matrix:\n"
+        "        language: [python, javascript]\n",
+    )
+    assert mod.resolve("CodeQL Analysis (python)", wf_dir) == ("a.yml", "codeql")
+    assert mod.resolve("CodeQL Analysis (javascript)", wf_dir) == ("a.yml", "codeql")
+
+
+def test_ambiguous_name_across_two_jobs_resolves_to_none(tmp_path):
+    """Two jobs reporting the identical context string is a resolver
+    ambiguity, not a coin flip (W65: a resolver that guesses hallucinates)."""
+    wf_dir = tmp_path
+    _write(
+        wf_dir,
+        "a.yml",
+        "on:\n  pull_request:\njobs:\n  x:\n    name: Same Name\n    runs-on: ubuntu-latest\n",
+    )
+    _write(
+        wf_dir,
+        "b.yml",
+        "on:\n  pull_request:\njobs:\n  y:\n    name: Same Name\n    runs-on: ubuntu-latest\n",
+    )
+    assert mod.resolve("Same Name", wf_dir) is None
+
+
+def test_unparseable_workflow_contributes_nothing_not_a_crash(tmp_path):
+    wf_dir = tmp_path
+    _write(wf_dir, "broken.yml", "not: valid: yaml: [unterminated")
+    _write(
+        wf_dir,
+        "a.yml",
+        "on:\n  pull_request:\njobs:\n  x:\n    name: Fine\n    runs-on: ubuntu-latest\n",
+    )
+    assert mod.resolve("Fine", wf_dir) == ("a.yml", "x")
+
+
+def test_the_real_repo_workflows_resolve_every_live_required_context():
+    """Guilt-adjacent live proof: every context this repo's actual branch
+    protection requires (frozen list, 2026-08-11 — see
+    infra/required.d/contexts.json) resolves against the REAL
+    .github/workflows/ tree. A future job rename that silently breaks this
+    resolver is exactly the failure mode snapshot regen would then blind-
+    allowlist without anyone noticing."""
+    live_contexts = [
+        "E2E Tests (Playwright)", "MCP Server Tests", "Detect Secrets",
+        "Backend Tests (Python)", "Bandit Python Security",
+        "CodeQL Analysis (python)", "CodeQL Analysis (javascript)", "root-guard",
+        "Frontend Tests (Next.js) (mouth, true)",
+        "Canary self-test + incremental mutation", "verify-the-verifiers",
+        "Hot-zone enforcement", "asyncpg-lint", "P3 static validation (enforcing)",
+        "lesson-harvester-gate", "brand-api-gate", "cost-breaker-tests",
+        "P6 parallelize-hypothesis falsifiable gates",
+        "Every organ is born with its genes", "R1 gate — adversarial review present",
+        "antidotes", "npm lock honors manifest",
+        "actionlint — workflow schema + expression gate",
+        "Every guard proves guilt AND innocence", "Prove hooks bite only the guilty",
+        "prepush-guards", "Harness floor recompute",
+    ]
+    unresolved = [name for name in live_contexts if mod.resolve(name) is None]
+    assert unresolved == [], f"could not resolve: {unresolved}"


### PR DESCRIPTION
## What

Wave 0 slice of Merge-OS v2 (`research/operations/2026-08-10-merge-os-v2-submission-system.md` §4 Wave 0), scoped to: required.d snapshot, path-filter cure on `docs-sync.yml`/`migration-lint.yml`, and a continuous per-PR conformance guard (Codex F12).

### 1. `infra/required.d/contexts.json` — advisory snapshot (commit `bf2fb78`)
Regenerable snapshot of main's 27 required-status-check contexts, each mapped to the workflow file + job that produces it (`scripts/ci/snapshot_required_contexts.py`, source of truth = `gh api .../branches/main/protection/required_status_checks`). Shared resolver `scripts/ci/required_context_map.py` handles matrix-job context names (both the `include:` and cross-product `matrix:` forms this repo uses). All 27 resolve; zero UNRESOLVED placeholders.

**Discovery worth flagging to the team**: `check-docs-sync` and `Lint` (migration-lint.yml) are **not currently required contexts** on main. The path-filter cure below is preemptive hardening for whenever either is promoted — it isn't fixing something actively blocking a PR today.

### 2. Path-filter cure, done right (commit `523caa3`)
`docs-sync.yml` and `migration-lint.yml` both had a top-level `paths:` filter and no `merge_group:` trigger — the exact Codex F12 trap: a PR outside those paths never starts a run at all, so a required context would hang "Expected — waiting" forever (adding `merge_group:` alone would not fix this).

Fix: removed top-level `paths:`, added `merge_group:`, moved relevance detection **inside the job** via the merge-base-anchored `scripts/ci/hotzone_changed_files.sh` enumerator (never a two-dot diff — scar W102), same shape as `frontend-typecheck.yml`/`prettier-changed-files.yml`/`guard-conformance.yml`. `migration-lint.yml`'s manual `git diff ... || true` (which silently swallowed enumeration failures) was replaced with the fail-loud shared enumerator; `--diff-filter=AM` semantics preserved via an explicit `[ -f ]` existence check. Job names/ids unchanged (verified against the contexts.json snapshot — branch protection matches by name).

### 3. Continuous conformance guard (commit `1fa0404`)
`scripts/ci/check_required_workflow_conformance.py` reads `infra/required.d/contexts.json` and fails if any required context's defining workflow lacks `merge_group:` or carries a top-level `on.pull_request.paths:` filter — so the *next* workflow promoted to required can't ship the same trap. Runs on every PR (not weekly — Qwen F9), wired as a real step in `immune-enforcement.yml`'s `antidotes` job (gated on the existing sentinel path detector), not left to the report-only `scripts-tests-sweep.yml`'s loose ancestor-dir substring match (which would have made `check_guard_conformance.py`'s `is_armed()` pass without the corpus ever running anywhere that blocks a PR).

Declared scope limit (in the module docstring): checks `on.pull_request.paths` only, never `on.push.paths` — a push-triggered run never gates whether a PR's required context resolves. Verified empirically: 12 of the repo's 27 required-context workflows carry a legitimate `push.paths` filter and would all false-positive under a scope that didn't draw this line.

Registered in `infra/guard-conformance/registry.json` (superscar #3 discipline) with guilt+innocence tests for each of its 4 `check_*` functions, wired into `check_guard_conformance.py`'s `main()` via the existing shape-generic `check_bridge()`.

## Guilt → innocence proof (live, captured before opening this PR)

Ran the guard against **origin/main's actual pre-cure file content** (synthetic contexts.json, since neither context is live-required today) vs. this branch's cured content:

```
=== PRE-CURE (origin/main content) — expect violations ===
required-workflow-conformance: 2 required context(s) checked, 4 violation(s)
  ✗ [check-docs-sync] .github/workflows/docs-sync.yml: missing `merge_group:` trigger — this context cannot be satisfied by a merge-queue run
  ✗ [check-docs-sync] .github/workflows/docs-sync.yml: top-level `paths:` filter under `on.pull_request` — an innocent PR outside those paths never starts a run, so this required context hangs 'Expected — waiting' forever (Codex F12)
  ✗ [Lint] .github/workflows/migration-lint.yml: missing `merge_group:` trigger — this context cannot be satisfied by a merge-queue run
  ✗ [Lint] .github/workflows/migration-lint.yml: top-level `paths:` filter under `on.pull_request` — an innocent PR outside those paths never starts a run, so this required context hangs 'Expected — waiting' forever (Codex F12)
rc=1

=== POST-CURE (this worktree) — expect clean ===
required-workflow-conformance: 2 required context(s) checked, 0 violation(s)
  ✓ every required context's defining workflow has merge_group + no top-level pull_request paths:
rc=0
```

Against the real `infra/required.d/contexts.json` + `.github/workflows/` tree: **27 contexts checked, 0 violations.**

## Verification run in this worktree

- `actionlint` (incl. shellcheck) clean on `docs-sync.yml`, `migration-lint.yml`, `immune-enforcement.yml`.
- `python3 -m pytest scripts/tests/test_check_required_workflow_conformance.py scripts/tests/test_required_context_map.py -q` → **24 passed**.
- `python3 infra/guard-conformance/check_guard_conformance.py` → 0 violations (new surface armed, not phantom).
- `python3 scripts/lint_workflow_timeout_floor.py` → clean (121 jobs).
- `bash scripts/tests/test_docs_sync_gate_failclosed.sh` + `python3 scripts/docs_sync.py --check` → unaffected, both pass.
- Full backend pre-push suite: green (ran under the machine-wide lock, ~75min queue wait due to concurrent sibling lanes — not a verdict on this diff, per the wrapper's own guarantee).

## Scope

Per mandate: did not touch `scripts/mq.sh` or any baseline-organ file (other lanes own those). Wave 0 acceptance criteria this slice satisfies: "conformance guard green on a probe PR" (self-satisfied, shown above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)