### PR TITLE
chore(kbli-navigator): claim TRACK DESIGN + note D1 in flight

### DIFF
--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -45,6 +45,8 @@ is **518 / 33.2%**, not 465 / 29.8%, and `CHIUSO_PMA_NO_BESAR` is **7**, not 20.
 
 ## 1. LIVE STATE (last update 2026-08-09 — keep current)
 
+**TRACK DESIGN claimed by Pro/2026-08-11 — D1 in flight (palette Proposta + toolbar cleanup + photo-band removal; builder lease on Pro).**
+
 **🟢 2026-08-09 — THE macOS APP IS NOW TWO APPS FROM ONE CODEBASE (Zero's ruling), FLEET-INSTALLED AND
 PROVEN — AND THE FLEET GUARD'S REFERENCE WAS THE LIAR (W106b).**
 


### PR DESCRIPTION
## Summary
- Claims TRACK DESIGN in the kbli-navigator corner's LIVE STATE section (twin-Fable protocol).
- Notes D1 in flight: palette Proposta + toolbar cleanup + photo-band removal, builder lease on Pro.
- Single-line addition, no other changes to the file.

## Test plan
- [x] Pre-commit hooks passed
- [x] Pre-push hooks passed (path-aware allowlist, docs-only change)