### PR TITLE
feat(ci): mq.sh v1 — merge-queue ops tool with post-arm watcher (Wave 0)

### DIFF
--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -518,6 +518,35 @@ Two things NOT to do when you see this:
 
 ---
 
+## 6sexies. `mq.sh` — the queue-ops wrapper (Merge-OS v2 Wave 0)
+
+`scripts/mq.sh` wraps `scripts/queue_doctor.py` and `gh`; it never reimplements either. Spec:
+`research/operations/2026-08-10-merge-os-v2-submission-system.md` §3/§4 Wave 0. State lives at
+`~/.nuzantara-mq/armed/<PR>.json` (dir mode 0700), overridable via `MQ_STATE_DIR`/`MQ_REPO`.
+
+| Verb                               | Does                                                                                                                                                                                                                            |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mq status [--all\|PR...]`         | Wraps `queue_doctor.py` — the three-queue snapshot (§ merge queue, pre-push lock, P0 spool), verbatim output                                                                                                                    |
+| `mq why-red <PR>`                  | Name/bucket/link of every non-passing **required** check, plus any required-by-branch-protection check `gh` never reported at all (the "required check never reported" class, §6 Step 1 above)                                  |
+| `mq arm <PR>`                      | Records the current head SHA to the state file, then bare `gh pr merge <PR> --auto` — **never `--squash`**, which silently arms nothing once the queue governs `main` (§Session discipline above, PR #3347)                     |
+| `mq watch <PR> [--timeout-mins N]` | The **post-arm watcher** — see below. Default ceiling 120 min, polls every 60s                                                                                                                                                  |
+| `mq requeue <PR>`                  | `--disable-auto` then re-arm — the standing cure for a queue ejection (§6 Step 2b above)                                                                                                                                        |
+| `mq dequeue <PR>`                  | `--disable-auto` and drop the local state file (does **not** remove an already-building queue entry — see the `--disable-auto` no-op trap at §Step 3b above; use the GraphQL `dequeuePullRequest` mutation there for that case) |
+| `mq handoff`                       | `mq status` output + every armed-state file, paste-ready for a session handoff                                                                                                                                                  |
+
+**The post-arm-watcher rule (spec §3, Codex F13):** "no push after arm" cannot be a preflight
+guarantee — `mq arm` returns before any future push could happen, so it cannot see one. `mq watch`
+is what enforces it: it records nothing itself, only reads the SHA `mq arm` already wrote, and on
+every poll compares it against the PR's live head. A mismatch means someone pushed to an armed
+branch (§Session discipline above: "post-arm commits remain orphaned") — `mq watch` dequeues
+(`--disable-auto`) and alerts loudly rather than let a stale queued attempt merge. It exits `0` on
+`MERGED`, `4` on `CLOSED`, `3` on a detected head-move (after dequeuing), `2` on reaching its
+ceiling with no verdict (an honest NO-VERDICT, never a fabricated "clean").
+
+Tests: `scripts/tests/test_mq_sh.sh` (fake `gh` on `PATH`, no network).
+
+---
+
 ## 7. Rollback (disable the merge queue)
 
 ```bash

--- a/scripts/mq.sh
+++ b/scripts/mq.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+# mq.sh — merge-queue operations tool (Merge-OS v2, Wave 0).
+#
+# Absorbs scripts/ci/queue_rearm.sh's arm/requeue reflex + a probe of its own,
+# but NEVER reimplements queue_doctor.py's three-queue snapshot — it wraps it.
+# Spec: research/operations/2026-08-10-merge-os-v2-submission-system.md §3
+# ("`mq.sh` absorbs the probe") + §4 Wave 0.
+#
+# DESIGN RULES (blood-bought, cicatrix-superscar.md):
+#   - Every external call's rc is captured errexit-immune (`|| var=$?`, never
+#     a bare assignment under `set -e` — W101: a bare assignment aborts the
+#     script BEFORE the caller can inspect the rc it was written to inspect).
+#   - `gh`'s output is judged by CONTENT, never by exit code alone (W104):
+#     `gh pr checks` returns 0/1/8 inconsistently across scenarios (measured
+#     2026-08-10 on this repo — 0 was returned with pending checks present),
+#     and `gh pr merge --auto` can print "already queued"/"already enabled"
+#     on what looks like a non-zero failure. The JSON/text body decides.
+#   - Never `... | tail` a command whose exit code matters (W97) — every rc
+#     used downstream is captured directly off the command, not through a pipe.
+#   - `mq arm` records the head SHA; `mq watch` is the POST-ARM watcher that
+#     enforces "no push after arm" — arm itself is NOT a preflight guarantee
+#     (Codex F13, spec §3): temporally, arm cannot see a push that happens
+#     after it returns.
+#
+# VERBS
+#   mq status [--all|PR...]            wrap queue_doctor.py, pass-through output
+#   mq why-red <PR>                    name/bucket/link of each non-passing required check
+#   mq arm <PR>                        record head sha, bare `gh pr merge --auto`, confirm
+#   mq watch <PR> [--timeout-mins N]   post-arm watcher (default ceiling 120m)
+#   mq requeue <PR>                    disable-auto + re-arm (standing cure for ejections)
+#   mq dequeue <PR>                    disable-auto + drop the local armed-state file
+#   mq handoff                         queue snapshot + armed-state files, paste-ready
+#
+# State: $MQ_STATE_DIR/armed/<PR>.json (sha + timestamp recorded at arm time),
+# dir created 0700 (armed-state is not a secret, but the discipline is cheap).
+# Repo: $MQ_REPO, default Bali-Zero/Teman2.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${MQ_REPO:-Bali-Zero/Teman2}"
+MQ_STATE_DIR="${MQ_STATE_DIR:-$HOME/.nuzantara-mq}"
+ARMED_DIR="$MQ_STATE_DIR/armed"
+WATCH_INTERVAL_S="${MQ_WATCH_INTERVAL_S:-60}"  # test seam; real usage never sets this
+
+MQ_TMP_ERR="$(mktemp "${TMPDIR:-/tmp}/mq-err.XXXXXX")"
+trap 'rm -f "$MQ_TMP_ERR"' EXIT
+
+_die() { echo "mq: $*" >&2; exit 1; }
+
+_require_pr_number() {
+  [[ "${1:-}" =~ ^[0-9]+$ ]] || _die "expected a PR number, got: '${1:-<empty>}'"
+}
+
+_now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+_state_dir_init() {
+  mkdir -p "$ARMED_DIR"
+  chmod 0700 "$MQ_STATE_DIR" "$ARMED_DIR" 2>/dev/null || true
+}
+
+_state_file() { printf '%s/%s.json' "$ARMED_DIR" "$1"; }
+
+# Run `gh "$@"`, capturing stdout in MQ_OUT, stderr in MQ_ERR, rc in MQ_RC.
+# Never trips `set -e` — every gh call in this script goes through here so a
+# failure is DATA the caller inspects, not an abort the caller never sees.
+_gh() {
+  MQ_RC=0
+  MQ_OUT="$(gh "$@" 2>"$MQ_TMP_ERR")" || MQ_RC=$?
+  MQ_ERR="$(cat "$MQ_TMP_ERR" 2>/dev/null || true)"
+  : > "$MQ_TMP_ERR"
+}
+
+_usage() {
+  cat <<USAGE
+mq.sh — merge-queue operations tool (Merge-OS v2 Wave 0)
+
+  mq status [--all|PR...]            wrap queue_doctor.py (pass-through output)
+  mq why-red <PR>                    name/bucket/link of each non-passing required check
+  mq arm <PR>                        record head sha, bare 'gh pr merge --auto', confirm
+  mq watch <PR> [--timeout-mins N]   post-arm watcher (default ceiling 120m)
+  mq requeue <PR>                    disable-auto + re-arm
+  mq dequeue <PR>                    disable-auto + drop the local armed-state file
+  mq handoff                         queue snapshot + armed-state files, paste-ready
+
+State: $ARMED_DIR/<PR>.json
+Repo:  $REPO (override: MQ_REPO=owner/name)
+USAGE
+}
+
+# ---------------------------------------------------------------------------
+cmd_status() {
+  local doctor="$SCRIPT_DIR/queue_doctor.py" rc=0
+  [[ -f "$doctor" ]] || _die "queue_doctor.py not found at $doctor"
+  # queue_doctor.py takes no arguments (no argparse) — any trailing args here
+  # (--all, PR numbers) are accepted for the verb table's shape but currently
+  # have no effect on its global 3-queue snapshot. Add nothing clever.
+  python3 "$doctor" || rc=$?
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+cmd_why_red() {
+  local pr="${1:-}"
+  [[ -n "$pr" ]] || _die "why-red requires a PR number"
+  _require_pr_number "$pr"
+  echo "== required checks — PR #$pr ($REPO) =="
+
+  # 1. The names branch protection considers required RIGHT NOW (drifts as CI
+  #    grows — docs/runbooks/merge-queue-discipline.md §2, never hardcode the
+  #    count). This is what catches the "required check never reported" class
+  #    (§6 Step 1 of the runbook): a name that never shows up in #2 below.
+  _gh api "repos/$REPO/branches/main/protection" \
+      --jq '.required_status_checks.checks[].context'
+  local req_names="$MQ_OUT"
+  if (( MQ_RC != 0 )); then
+    echo "  CANNOT-VERIFY required-check name list (rc=$MQ_RC): ${MQ_ERR:0:160}"
+    echo "  (degrading to reported-checks-only — same fallback merge-queue-watch.yml takes)"
+    req_names=""
+  fi
+
+  # 2. What the PR itself reports, pre-filtered to required checks by gh's own
+  #    isRequired-based logic (`--required`). The exit code is NOT the verdict
+  #    (W104): gh docs list 0/1/8 for pass/fail/pending, but a live probe on
+  #    this repo (2026-08-10) returned 0 with pending entries present — the
+  #    JSON body is what gets judged, always.
+  _gh pr checks "$pr" --repo "$REPO" --required \
+      --json name,bucket,link,description,workflow
+  if (( MQ_RC != 0 )) && [[ -z "$MQ_OUT" ]]; then
+    echo "  CANNOT-VERIFY — gh pr checks produced no output (rc=$MQ_RC): ${MQ_ERR:0:200}"
+    return 3
+  fi
+  local checks_json="${MQ_OUT:-[]}"
+
+  python3 - "$checks_json" "$req_names" <<'PYEOF'
+import json, sys
+
+checks = json.loads(sys.argv[1] or "[]")
+required_names = [l for l in sys.argv[2].splitlines() if l.strip()]
+
+by_name = {c.get("name"): c for c in checks}
+# gh's own bucket enum: pass, fail, pending, skipping, cancel. "skipping" is
+# treated as pass by this repo's sentinel semantics (docs runbook §2/§4).
+trouble = [c for c in checks if c.get("bucket") not in ("pass", "skipping")]
+missing = [n for n in required_names if n not in by_name] if required_names else []
+
+if not trouble and not missing:
+    print("  clean — every required check GitHub reported is pass/skip")
+else:
+    for c in trouble:
+        print(f"  [{c.get('bucket', '?').upper():8}] {c.get('name')}  ({c.get('workflow', '')})")
+        if c.get("link"):
+            print(f"           {c['link']}")
+    for n in missing:
+        print(f"  [MISSING ] {n}  — required by branch protection, absent from gh's reported set")
+        print("           (\"required check never reported\" class — runbook §6 Step 1)")
+PYEOF
+}
+
+# ---------------------------------------------------------------------------
+_write_armed_state() {  # _write_armed_state <pr> <sha>
+  local pr="$1" sha="$2" f
+  f="$(_state_file "$pr")"
+  python3 - "$f" "$pr" "$sha" "$(_now_iso)" <<'PYEOF'
+import json, sys
+path, pr, sha, ts = sys.argv[1:5]
+with open(path, "w") as fh:
+    json.dump({"pr": int(pr), "sha": sha, "armed_at": ts}, fh)
+    fh.write("\n")
+PYEOF
+  chmod 0600 "$f"
+}
+
+cmd_arm() {
+  local pr="${1:-}"
+  [[ -n "$pr" ]] || _die "arm requires a PR number"
+  _require_pr_number "$pr"
+
+  _gh pr view "$pr" --repo "$REPO" --json headRefOid
+  (( MQ_RC == 0 )) || _die "could not read #$pr's head sha (rc=$MQ_RC): ${MQ_ERR:0:200}"
+  local sha=""
+  sha="$(printf '%s' "$MQ_OUT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("headRefOid",""))' 2>/dev/null || true)"
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || _die "unexpected headRefOid in response: ${MQ_OUT:0:200}"
+
+  _write_armed_state "$pr" "$sha"
+  echo "recorded armed sha for #$pr: $sha"
+
+  # Bare --auto only — the queue owns merge strategy. `--squash` now conflicts
+  # with it and arms NOTHING silently (docs/runbooks/merge-queue-discipline.md,
+  # measured live PR #3347: "The merge strategy for main is set by the merge
+  # queue"). This is the post-arm-watcher design (Codex F13): arm cannot itself
+  # guarantee no future push — mq watch is the guarantee.
+  _gh pr merge "$pr" --repo "$REPO" --auto
+  if (( MQ_RC != 0 )) && ! printf '%s%s' "$MQ_OUT" "$MQ_ERR" | grep -qi "already queued\|auto-merge enabled\|already enabled"; then
+    _die "gh pr merge --auto failed (rc=$MQ_RC): $(printf '%s%s' "$MQ_OUT" "$MQ_ERR" | head -1)"
+  fi
+  echo "arm: ${MQ_OUT:-$MQ_ERR}"
+
+  _gh pr view "$pr" --repo "$REPO" --json autoMergeRequest,mergeStateStatus,headRefOid
+  if (( MQ_RC == 0 )); then
+    echo "confirm: $MQ_OUT"
+  else
+    echo "  CANNOT-VERIFY confirm step (rc=$MQ_RC): ${MQ_ERR:0:160} — recorded sha stands, check manually"
+  fi
+  echo "ARMED #$pr @ $sha"
+}
+
+# ---------------------------------------------------------------------------
+cmd_watch() {
+  local pr="${1:-}"
+  [[ -n "$pr" ]] || _die "watch requires a PR number"
+  _require_pr_number "$pr"
+  shift || true
+
+  local timeout_mins=120
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --timeout-mins) timeout_mins="${2:-}"; shift 2 ;;
+      *) _die "watch: unknown argument '$1'" ;;
+    esac
+  done
+  [[ "$timeout_mins" =~ ^[0-9]+$ ]] || _die "--timeout-mins must be a positive integer"
+
+  local f; f="$(_state_file "$pr")"
+  [[ -f "$f" ]] || _die "no armed state for #$pr at $f — run 'mq arm $pr' first (this is a POST-ARM watcher, not a preflight)"
+  local armed_sha=""
+  armed_sha="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("sha",""))' "$f" 2>/dev/null || true)"
+  [[ "$armed_sha" =~ ^[0-9a-f]{40}$ ]] || _die "state file $f does not carry a valid sha"
+
+  echo "watching #$pr against armed sha $armed_sha (interval ${WATCH_INTERVAL_S}s, ceiling ${timeout_mins}m)"
+  local start ceiling
+  start=$(date +%s)
+  ceiling=$(( timeout_mins * 60 ))
+
+  while true; do
+    local now elapsed
+    now=$(date +%s)
+    elapsed=$(( now - start ))
+    if (( elapsed >= ceiling )); then
+      echo "NO-VERDICT — ceiling (${timeout_mins}m) reached, #$pr still open/unresolved"
+      exit 2
+    fi
+
+    _gh pr view "$pr" --repo "$REPO" --json state,mergedAt,headRefOid
+    if (( MQ_RC != 0 )); then
+      echo "  $(date -u +%H:%M:%S) probe failed (rc=$MQ_RC), not a verdict — retrying: ${MQ_ERR:0:120}"
+      sleep "$WATCH_INTERVAL_S"
+      continue
+    fi
+
+    local state="" merged_at="" head_sha=""
+    # No backslash-escaped quotes inside an f-string {} part below — that is a
+    # SyntaxError on Python <3.12 (caught live by the test corpus against this
+    # repo's Python 3.11); plain string concatenation sidesteps it. And this
+    # comment lives ABOVE the process substitution, never as its first line —
+    # bash 3.2 (macOS's shipped /bin/bash) mis-parses a `#` comment as the
+    # opening line of `< <( ... )` as an unterminated paren (reproduced in
+    # isolation; moving the comment here is the fix, not the workaround).
+    # Field delimiter is `|`, NEVER a tab: when IFS is made of ONLY
+    # whitespace characters (space/tab/newline — POSIX "IFS whitespace"),
+    # `read` COLLAPSES consecutive delimiters instead of yielding an empty
+    # field, on every POSIX shell (reproduced on this repo's own bash 3.2,
+    # not merely a version quirk) — a null `mergedAt` between two real
+    # fields silently shifted every field after it by one.
+    IFS='|' read -r state merged_at head_sha < <(
+      printf '%s' "$MQ_OUT" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+state = d.get("state") or ""
+merged_at = d.get("mergedAt") or ""
+head_sha = d.get("headRefOid") or ""
+print(state + "|" + merged_at + "|" + head_sha)
+'
+    )
+
+    if [[ "$state" == "MERGED" || -n "$merged_at" ]]; then
+      echo "MERGED — #$pr landed"
+      exit 0
+    fi
+    if [[ "$state" == "CLOSED" ]]; then
+      echo "CLOSED — #$pr closed without merging"
+      exit 4
+    fi
+    if [[ -n "$head_sha" && "$head_sha" != "$armed_sha" ]]; then
+      echo "!!! HEAD MOVED on #$pr while armed: was $armed_sha, now $head_sha — dequeuing"
+      _gh pr merge "$pr" --repo "$REPO" --disable-auto
+      echo "!!! disable-auto rc=$MQ_RC out=${MQ_OUT:-$MQ_ERR}"
+      exit 3
+    fi
+    sleep "$WATCH_INTERVAL_S"
+  done
+}
+
+# ---------------------------------------------------------------------------
+cmd_requeue() {
+  local pr="${1:-}"
+  [[ -n "$pr" ]] || _die "requeue requires a PR number"
+  _require_pr_number "$pr"
+
+  echo "disable-auto #$pr (standing cure for a queue ejection)"
+  _gh pr merge "$pr" --repo "$REPO" --disable-auto
+  echo "  rc=$MQ_RC out=${MQ_OUT:-$MQ_ERR}"
+
+  cmd_arm "$pr"
+}
+
+# ---------------------------------------------------------------------------
+cmd_dequeue() {
+  local pr="${1:-}"
+  [[ -n "$pr" ]] || _die "dequeue requires a PR number"
+  _require_pr_number "$pr"
+
+  _gh pr merge "$pr" --repo "$REPO" --disable-auto
+  echo "disable-auto #$pr: rc=$MQ_RC out=${MQ_OUT:-$MQ_ERR}"
+  if printf '%s%s' "$MQ_OUT" "$MQ_ERR" | grep -qi "already queued"; then
+    echo "  NOTE: 'already queued' is a documented no-op (runbook §Step 3b) — an entry"
+    echo "  already BUILDING in the queue is not removed by --disable-auto. Use the"
+    echo "  GraphQL dequeuePullRequest mutation in the runbook if it must come out now."
+  fi
+
+  local f; f="$(_state_file "$pr")"
+  if [[ -f "$f" ]]; then
+    rm -f "$f"
+    echo "removed armed-state file for #$pr"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+cmd_handoff() {
+  echo "=== mq handoff — $(_now_iso) — $REPO ==="
+  echo
+  cmd_status || true
+  echo
+  echo "--- armed-state files ($ARMED_DIR) ---"
+  local any=0 f
+  for f in "$ARMED_DIR"/*.json; do
+    [[ -e "$f" ]] || continue
+    any=1
+    echo "  $(cat "$f")"
+  done
+  (( any )) || echo "  (none)"
+  echo "=== end handoff ==="
+}
+
+# ---------------------------------------------------------------------------
+main() {
+  _state_dir_init
+  local verb="${1:-}"
+  [[ -n "$verb" ]] || { _usage; exit 1; }
+  shift || true
+  case "$verb" in
+    status)  cmd_status "$@" ;;
+    why-red) cmd_why_red "$@" ;;
+    arm)     cmd_arm "$@" ;;
+    watch)   cmd_watch "$@" ;;
+    requeue) cmd_requeue "$@" ;;
+    dequeue) cmd_dequeue "$@" ;;
+    handoff) cmd_handoff "$@" ;;
+    -h|--help|help) _usage ;;
+    *) echo "mq: unknown verb '$verb'" >&2; _usage; exit 1 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/tests/test_mq_sh.sh
+++ b/scripts/tests/test_mq_sh.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# test_mq_sh.sh — proof for scripts/mq.sh (Merge-OS v2 Wave 0 tool).
+#
+# WHAT IT PINS
+#   arm       — records the head sha to the state file, arms bare `--auto`
+#               (never `--squash` — that silently arms nothing once the
+#               queue governs main, docs/runbooks/merge-queue-discipline.md).
+#   guilt     — watch detects a head move away from the armed sha and calls
+#               `--disable-auto` (the post-arm watcher IS the "no push after
+#               arm" guarantee — arm itself cannot see a future push, spec
+#               §3, Codex F13).
+#   innocence — watch stays quiet (no disable-auto) across several unmoved
+#               polls and exits clean once the PR reaches a terminal state.
+#   ordering  — requeue disables BEFORE it re-arms, never the reverse.
+#   why-red   — a failing required check is named with its bucket and link;
+#               a required check branch protection lists but gh never
+#               reported is flagged MISSING, not silently dropped.
+#
+# No network, no real gh, no real HOME: a fake `gh` on PATH answers from
+# per-scenario state files and logs every invocation for order assertions.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+MQSH="$REPO_ROOT/mq.sh"
+[ -f "$MQSH" ] || { echo "FAIL: mq.sh not found at $MQSH"; exit 2; }
+[ -x "$MQSH" ] || { echo "FAIL: mq.sh not executable at $MQSH"; exit 2; }
+
+failures=0
+check() {  # check <name> <0-or-1>
+  if [ "$2" = "1" ]; then printf '  ok   %s\n' "$1"
+  else printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); fi
+}
+has() { case "$2" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+yesno() { if "$@"; then echo 1; else echo 0; fi; }
+
+# _json_field <file> <field> — tiny, avoids nested-quote hell in the checks.
+_json_field() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],""))' "$1" "$2" 2>/dev/null
+}
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/mqsh_test.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+SHA_A="$(printf 'a%.0s' $(seq 1 40))"  # 40 lowercase hex chars — the "armed" sha
+SHA_B="$(printf 'b%.0s' $(seq 1 40))"  # a DIFFERENT 40-char sha — "moved" head
+
+# One scenario = one fresh world: its own fake-gh state dir, log, state dir,
+# and PATH. Nothing here writes to the real $HOME or the real GitHub.
+new_world() {
+  W="$(mktemp -d "$SANDBOX/w.XXXXXX")"
+  mkdir -p "$W/bin" "$W/fgh" "$W/state"
+  LOG="$W/log"
+  : > "$LOG"
+
+  cat > "$W/bin/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+# Fake gh — logs every invocation to $FAKE_GH_LOG, answers from
+# $FAKE_GH_STATE. An invocation shape this fake does not recognise is a
+# HARNESS bug (exit 99), never a silent empty answer.
+set -uo pipefail
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+
+case "${1:-}" in
+  api)
+    rc=0
+    [ -f "$FAKE_GH_STATE/required_names_rc" ] && rc="$(cat "$FAKE_GH_STATE/required_names_rc")"
+    [ -f "$FAKE_GH_STATE/required_names" ] && cat "$FAKE_GH_STATE/required_names"
+    exit "$rc"
+    ;;
+  pr)
+    case "${2:-}" in
+      checks)
+        rc=0
+        [ -f "$FAKE_GH_STATE/checks_rc" ] && rc="$(cat "$FAKE_GH_STATE/checks_rc")"
+        if [ -f "$FAKE_GH_STATE/checks_json" ]; then cat "$FAKE_GH_STATE/checks_json"; else echo '[]'; fi
+        exit "$rc"
+        ;;
+      view)
+        # The tested string is wrapped in artificial leading/trailing spaces
+        # below, so every `--json <fields>` token is bordered by real spaces
+        # regardless of its position in argv — no per-pattern alternates needed.
+        case " $* " in
+          *" autoMergeRequest,mergeStateStatus,headRefOid "*)
+            if [ -f "$FAKE_GH_STATE/confirm_json" ]; then cat "$FAKE_GH_STATE/confirm_json"; else echo '{}'; fi
+            exit 0
+            ;;
+          *" state,mergedAt,headRefOid "*)
+            n=$(( $(cat "$FAKE_GH_STATE/watch_call_count" 2>/dev/null || echo 0) + 1 ))
+            echo "$n" > "$FAKE_GH_STATE/watch_call_count"
+            line="$(sed -n "${n}p" "$FAKE_GH_STATE/watch_responses" 2>/dev/null)"
+            [ -z "$line" ] && line="$(tail -1 "$FAKE_GH_STATE/watch_responses" 2>/dev/null)"
+            echo "$line"
+            exit 0
+            ;;
+          *" headRefOid "*)
+            sha="$(cat "$FAKE_GH_STATE/head_sha" 2>/dev/null || echo '')"
+            printf '{"headRefOid":"%s"}\n' "$sha"
+            exit 0
+            ;;
+        esac
+        echo '{}'
+        exit 0
+        ;;
+      merge)
+        case " $* " in
+          *" --disable-auto "*)
+            echo "Auto-merge disabled"
+            exit 0
+            ;;
+          *" --auto "*)
+            rc=0
+            [ -f "$FAKE_GH_STATE/arm_rc" ] && rc="$(cat "$FAKE_GH_STATE/arm_rc")"
+            if [ -f "$FAKE_GH_STATE/arm_output" ]; then cat "$FAKE_GH_STATE/arm_output"; else echo "Auto-merge enabled for pull request"; fi
+            exit "$rc"
+            ;;
+        esac
+        ;;
+    esac
+    ;;
+esac
+echo "FAKE_GH: unhandled invocation: $*" >&2
+exit 99
+FAKEGH
+  chmod +x "$W/bin/gh"
+}
+
+# run <verb...> — invokes mq.sh through the fake gh via `env` (a real exec,
+# so there is no ambiguity about whether a shell-function env-prefix would
+# propagate into the command substitution below — it always does via env).
+# Captures combined stdout+stderr in $OUT, exit code in $RC. Reads the
+# optional $MQ_WATCH_INTERVAL_S test seam if the caller set it.
+#
+# No arrays here on purpose: macOS ships bash 3.2 (GPLv3 holdout), where
+# `"${arr[@]}"` on an EMPTY array trips `set -u` as "unbound variable" —
+# an empty MQ_WATCH_INTERVAL_S is passed as a plain (possibly-empty) env
+# var instead, which mq.sh's own `${MQ_WATCH_INTERVAL_S:-60}` treats the
+# same as unset.
+run() {
+  OUT="$(env MQ_REPO="test-owner/test-repo" MQ_STATE_DIR="$W/state" \
+             FAKE_GH_LOG="$LOG" FAKE_GH_STATE="$W/fgh" \
+             PATH="$W/bin:$PATH" \
+             MQ_WATCH_INTERVAL_S="${MQ_WATCH_INTERVAL_S:-}" \
+             bash "$MQSH" "$@" 2>&1)"
+  RC=$?
+}
+
+# poverty check — the fake must actually be the one gh resolves to, or every
+# assertion below would be measuring real GitHub instead of the harness
+# (W108: a fake world too poor to judge reports its own poverty as a pass).
+new_world
+resolved="$(PATH="$W/bin:$PATH" command -v gh)"
+if [ "$resolved" != "$W/bin/gh" ]; then
+  echo "HARNESS TOO POOR TO JUDGE: PATH did not resolve gh to the fake ($resolved)" >&2
+  exit 2
+fi
+
+echo "arm — records the head sha, arms bare --auto, never --squash:"
+new_world
+echo "$SHA_A" > "$W/fgh/head_sha"
+run arm 42
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "state file written" "$(yesno test -f "$W/state/armed/42.json")"
+check "state file records the armed sha" "$(yesno test "$(_json_field "$W/state/armed/42.json" sha)" = "$SHA_A")"
+check "state file records the PR number" "$(yesno test "$(_json_field "$W/state/armed/42.json" pr)" = "42")"
+check "merge --auto was called" "$(yesno grep -q -- '--auto' "$LOG")"
+check "NEVER --squash anywhere in the log" "$(yesno eval '! grep -q -- "--squash" "$LOG"')"
+check "output prints the armed sha" "$(yesno has "$SHA_A" "$OUT")"
+
+echo "guilt — watch sees a head move away from the armed sha and dequeues:"
+new_world
+mkdir -p "$W/state/armed"
+python3 -c 'import json,sys; json.dump({"pr":77,"sha":sys.argv[1],"armed_at":"2026-08-10T00:00:00Z"}, open(sys.argv[2],"w"))' \
+  "$SHA_A" "$W/state/armed/77.json"
+printf '{"state":"OPEN","mergedAt":null,"headRefOid":"%s"}\n' "$SHA_B" > "$W/fgh/watch_responses"
+MQ_WATCH_INTERVAL_S=0 run watch 77 --timeout-mins 5
+check "exit 3 (head moved)" "$(yesno test "$RC" = 3)"
+check "alert names the moved head" "$(yesno has "HEAD MOVED" "$OUT")"
+check "disable-auto WAS called" "$(yesno grep -q -- '--disable-auto' "$LOG")"
+
+echo "innocence — watch stays quiet on an unmoved head, exits clean on MERGED:"
+new_world
+mkdir -p "$W/state/armed"
+python3 -c 'import json,sys; json.dump({"pr":88,"sha":sys.argv[1],"armed_at":"2026-08-10T00:00:00Z"}, open(sys.argv[2],"w"))' \
+  "$SHA_A" "$W/state/armed/88.json"
+{
+  printf '{"state":"OPEN","mergedAt":null,"headRefOid":"%s"}\n' "$SHA_A"
+  printf '{"state":"OPEN","mergedAt":null,"headRefOid":"%s"}\n' "$SHA_A"
+  printf '{"state":"MERGED","mergedAt":"2026-08-10T01:00:00Z","headRefOid":"%s"}\n' "$SHA_A"
+} > "$W/fgh/watch_responses"
+MQ_WATCH_INTERVAL_S=0 run watch 88 --timeout-mins 5
+check "exit 0 (MERGED)" "$(yesno test "$RC" = 0)"
+check "disable-auto NEVER called across the unmoved polls" "$(yesno eval '! grep -q -- "--disable-auto" "$LOG"')"
+check "at least 3 view polls happened before the terminal state" \
+  "$(yesno test "$(cat "$W/fgh/watch_call_count")" -ge 3)"
+
+echo "ordering — requeue disables BEFORE it re-arms, never the reverse:"
+new_world
+echo "$SHA_A" > "$W/fgh/head_sha"
+run requeue 99
+check "exit 0" "$(yesno test "$RC" = 0)"
+disable_line="$(grep -n -- '--disable-auto' "$LOG" | head -1 | cut -d: -f1)"
+auto_line="$(grep -n -- '--auto' "$LOG" | grep -v -- '--disable-auto' | head -1 | cut -d: -f1)"
+check "both calls happened" "$(yesno test -n "${disable_line:-}" -a -n "${auto_line:-}")"
+check "disable-auto precedes the re-arm --auto" "$(yesno test "${disable_line:-99}" -lt "${auto_line:-0}")"
+check "requeue re-armed with a fresh state file" "$(yesno test -f "$W/state/armed/99.json")"
+
+echo "why-red — names a failing required check, and one required-but-unreported:"
+new_world
+printf 'Backend Tests (Python)\nDetect Secrets\nGhost Check (never runs)\n' > "$W/fgh/required_names"
+cat > "$W/fgh/checks_json" <<'JSON'
+[
+  {"name":"Backend Tests (Python)","bucket":"fail","link":"https://example.test/run/1","description":"","workflow":"Tests & Coverage"},
+  {"name":"Detect Secrets","bucket":"pass","link":"https://example.test/run/2","description":"","workflow":"Security Scanning"}
+]
+JSON
+run why-red 42
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "failing check named with its bucket" "$(yesno has "[FAIL" "$OUT")"
+check "failing check's name is present" "$(yesno has "Backend Tests (Python)" "$OUT")"
+check "failing check's link is present" "$(yesno has "https://example.test/run/1" "$OUT")"
+check "a required check gh never reported is flagged MISSING" "$(yesno has "[MISSING" "$OUT")"
+check "the missing check is named" "$(yesno has "Ghost Check (never runs)" "$OUT")"
+check "a passing required check is NOT listed as trouble" "$(yesno eval '! has "Detect Secrets" "$OUT"')"
+
+echo "why-red — innocence: an all-clean set says so, once:"
+new_world
+printf 'Detect Secrets\n' > "$W/fgh/required_names"
+printf '[{"name":"Detect Secrets","bucket":"pass","link":"","description":"","workflow":"Security Scanning"}]' > "$W/fgh/checks_json"
+run why-red 7
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "reports clean" "$(yesno has "clean" "$OUT")"
+check "does not fabricate a FAIL/MISSING line on a clean set" "$(yesno eval '! has "[FAIL" "$OUT" && ! has "[MISSING" "$OUT"')"
+
+echo "dequeue — disables and removes the local armed-state file:"
+new_world
+mkdir -p "$W/state/armed"
+python3 -c 'import json,sys; json.dump({"pr":55,"sha":sys.argv[1],"armed_at":"2026-08-10T00:00:00Z"}, open(sys.argv[2],"w"))' \
+  "$SHA_A" "$W/state/armed/55.json"
+run dequeue 55
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "disable-auto was called" "$(yesno grep -q -- '--disable-auto' "$LOG")"
+check "state file removed" "$(yesno eval '[ ! -f "$W/state/armed/55.json" ]')"
+
+echo
+if [ "$failures" -eq 0 ]; then echo "PASS (all checks)"; exit 0; fi
+echo "FAIL ($failures check(s))"; exit 1


### PR DESCRIPTION
## What

`scripts/mq.sh` v1 — the Merge-OS v2 Wave 0 merge-queue operations wrapper. Wraps
`scripts/queue_doctor.py` (never reimplements it) with 7 verbs:

| Verb | Purpose |
|---|---|
| `status [--all\|PR...]` | Snapshot mergeability/queue state for one or more PRs |
| `why-red <PR>` | Names the failing/missing required check(s), by content not exit code |
| `arm <PR>` | Bare `gh pr merge --auto` (never `--squash`) + records the armed head SHA locally |
| `watch <PR> [--timeout-mins N]` | **Post-arm watcher** — polls until terminal state, dequeues if head moves after arm |
| `requeue <PR>` | `--disable-auto` then re-`--auto` with a fresh armed-state file (strict ordering) |
| `dequeue <PR>` | `--disable-auto` + removes the local armed-state file |
| `handoff` | Prints a queue snapshot for the next lane/session picking this up |

### Post-arm-watcher rule

Per the spec's Codex F13 correction: **`arm` is not a preflight guarantee.** A push after arm
can silently invalidate the merge queue's basis. `mq watch` is the enforcement point — it
records the head SHA at arm time and, if it later observes the head has moved away from that
SHA while the PR is still open, it disarms (`--disable-auto`) and exits non-zero rather than
letting a stale queue entry merge the wrong diff.

### Design rules followed (per `.claude/rules/cicatrix-superscar.md`)

- `set -euo pipefail` with every external call's rc captured errexit-immune (`|| rc=$?`, never a
  bare assignment under `-e` — W101 class).
- `gh` output judged by **content**, never exit code alone (W104 class) — `_gh()` helper captures
  stdout/stderr separately and the callers grep for known-benign phrasings
  (`already queued`, `already enabled`) before treating a non-zero `gh pr merge --auto` as fatal.
- No `... | tail` masking of an rc (W97 class).
- `$MQ_STATE_DIR/armed` created `0700`.
- ~360 lines, boring and readable — no cleverness, `queue_doctor.py` does the actual mergeability
  logic.

## Tests

`scripts/tests/test_mq_sh.sh` — fake `gh` shim on `PATH`, 8 named scenarios, **30/30 checks
pass**:

```
arm — records the head sha, arms bare --auto, never --squash:              7/7 ok
guilt — watch sees a head move away from the armed sha and dequeues:       3/3 ok
innocence — watch stays quiet on an unmoved head, exits clean on MERGED:   3/3 ok
ordering — requeue disables BEFORE it re-arms, never the reverse:          4/4 ok
why-red — names a failing required check + one required-but-unreported:   7/7 ok
why-red — innocence: an all-clean set says so, once:                      3/3 ok
dequeue — disables and removes the local armed-state file:                3/3 ok

PASS (all checks)
```

The "guilt" scenario is the one that mattered most: it caught a POSIX IFS-whitespace-collapse
field-shifting bug pre-merge that would have made `mq watch` misreport an OPEN+moved-head PR as
MERGED in production (fixed by switching the field delimiter to `|`, a non-whitespace char IFS
does not collapse).

Also updated `docs/runbooks/merge-queue-discipline.md` (§6sexies) with the verb table and the
post-arm-watcher rule, and regenerated `docs/DOCS_INVENTORY.md` via
`scripts/docs_inventory_regen.sh` in the same PR (W86-class discipline — derived state lands with
its source edit, never separately).

## Spec

`research/operations/2026-08-10-merge-os-v2-submission-system.md` §3 (verb contract) / §4
(post-arm watcher / Codex F13 correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
