### PR TITLE
docs(kbli-navigator): TRACK DESIGN — D1 + D2 shipped

### DIFF
--- a/.agents/skills/kbli-navigator/SKILL.md
+++ b/.agents/skills/kbli-navigator/SKILL.md
@@ -45,7 +45,7 @@ is **518 / 33.2%**, not 465 / 29.8%, and `CHIUSO_PMA_NO_BESAR` is **7**, not 20.
 
 ## 1. LIVE STATE (last update 2026-08-09 — keep current)
 
-**TRACK DESIGN claimed by Pro/2026-08-11 — D1 in flight (palette Proposta + toolbar cleanup + photo-band removal; builder lease on Pro).**
+**TRACK DESIGN — D1 shipped (5609abb) · D2 shipped (6ce988a) — verdict-on-top supersedes the 2026-06-30 order per Zero 2026-08-11.**
 
 **🟢 2026-08-09 — THE macOS APP IS NOW TWO APPS FROM ONE CODEBASE (Zero's ruling), FLEET-INSTALLED AND
 PROVEN — AND THE FLEET GUARD'S REFERENCE WAS THE LIAR (W106b).**


### PR DESCRIPTION
## Summary
- Corner status update: D1 (5609abb) and D2 (6ce988a) both landed in the KBLI Navigator macOS app repo (M5, local commits, no remote).
- D2: menu-bar keyboard model (Search Codes ⌘K / Copy KBLI Code ⌘C / Toggle Density ⌘⇧D), hover ≠ selection ≠ focus row states, persisted row density (compact/comfortable), and the card reorder (verdict-on-top + new 4-up facts inspector) — supersedes the 2026-06-30 "verdict moved down" ruling per Zero's 2026-08-11 D2 plan approval.
- PR #4027 (the original TRACK DESIGN claim) was already MERGED when this session checked, so this status update lands as its own PR rather than reopening that one.

## Test plan
- [x] Docs-only change (single-line corner update), no code/data touched by this PR.
- [x] `.agents/skills/kbli-navigator/SKILL.md` §1 LIVE STATE line verified to read the new status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)