### PR TITLE
fix(ops): make queue baseline metrics fail-visible

### DIFF
--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -635,6 +635,18 @@ fork-origin runs), the minutes are never dropped — they land in
 `unattributed_group_minutes` / `unattributed_pr_minutes` respectively (scar family #2,
 "esiste ≠ armato" — no silent caps).
 
+For this public repository the timing endpoint's billable OS buckets are present but zero.
+The organ therefore falls back to the same response's `run_duration_ms` and records the
+choice under `timing_sources.run_duration`; this is effective runner consumption, not a
+monetary charge. Private-repo non-zero billable buckets still win. A zero-billable response
+without `run_duration_ms` is recorded explicitly as `billable_zero_without_duration` (the
+normal shape for a skipped run), never inferred to carry hidden duration.
+
+The runs census is independently fail-visible. The organ compares the unique run IDs fetched
+across every `--paginate` page with GitHub's `total_count`. If GitHub stops at its server-side
+cap, the record carries `run_collection.complete=false` plus a numeric shortfall in
+`errors[]`; exactly 1,000 fetched runs can no longer masquerade as the whole day.
+
 **Fail-visible by construction**: every `gh` API denial, timeout, or unparseable response is
 appended to the record's `errors[]` array. A record is always written — even a total-failure
 day — but `errors[]` non-empty makes the probe (and the wrapper that invokes it) exit

--- a/scripts/queue_baseline_probe.py
+++ b/scripts/queue_baseline_probe.py
@@ -45,6 +45,14 @@ DECLARED ATTRIBUTION RULE (spec §4, Codex CONFIRMED-DEFECT F6 — verbatim requ
   are not part of per-PR attribution by construction; their minutes land in
   `other_event_minutes` and still count toward `slot_utilization.runner_minutes_today`.
 
+  TIMING SOURCE: private-repo billing buckets expose non-zero `billable.*.total_ms`; this
+  repository is public, so those buckets are present but zero. In that case the same timing
+  endpoint exposes `run_duration_ms`, which is used as the effective runner duration and
+  recorded under `timing_sources.run_duration`. A run with zero billable milliseconds and no
+  duration (for example a skipped run that never started a job) contributes zero under
+  `timing_sources.billable_zero_without_duration`. This fallback measures runner consumption,
+  not a monetary charge; the source counts in every record keep that distinction explicit.
+
 DECLARED EJECTION HEURISTIC (spec §4 Wave 1 bullet: "heuristic from failed merge_group run
 conclusions/log heads — declare the heuristic in the docstring"):
   A merge_group run whose conclusion is one of {"failure", "cancelled", "timed_out"} counts as
@@ -97,6 +105,11 @@ a day with real zero activity (empty `errors`, zero counts) is a different, legi
 positive record; this script never conflates the two. `main()` returns 0 only when `errors`
 is empty; any non-empty `errors` list makes the process exit 1 so the wrapper's rc-based
 alerting (W101 discipline) sees the failure.
+
+The workflow-runs endpoint is also census-checked: every paginated response's `total_count` is
+compared with the number of unique run IDs actually fetched. GitHub currently caps this query
+at 1,000 results even when `total_count` is larger; any such shortfall is written to `errors[]`
+and `run_collection.complete=false`, never presented as a complete quiet day.
 """
 
 from __future__ import annotations
@@ -111,13 +124,15 @@ import sys
 import traceback
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 logger = logging.getLogger("queue_baseline_probe")
 
 DEFAULT_REPO = "Bali-Zero/Teman2"
 DEFAULT_OUT_DIR = Path.home() / ".nuzantara-mq" / "baseline"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+
+TimingSource = Literal["billable", "run_duration", "billable_zero_without_duration"]
 
 # round-3 system-wide doc, 2026-08-09/10 measurement window (see module docstring). A snapshot
 # constant, not re-measured live by this script.
@@ -309,8 +324,16 @@ def _parse_concatenated_json(text: str) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def list_workflow_runs(repo: str, day: date) -> tuple[list[dict[str, Any]], list[str]]:
-    """All workflow runs created on `day` (UTC), every page combined."""
+def list_workflow_runs(
+    repo: str,
+    day: date,
+) -> tuple[list[dict[str, Any]], int | None, list[str]]:
+    """Workflow runs created on `day` (UTC), with an explicit census check.
+
+    Returns `(unique_runs, reported_total, errors)`. GitHub can stop pagination at a
+    server-side cap while still reporting a larger `total_count`; that is a partial record,
+    not success, and is therefore returned as an error.
+    """
     created_query = f"{day.isoformat()}..{day.isoformat()}"
     cmd = [
         "gh", "api", f"repos/{repo}/actions/runs",
@@ -323,52 +346,94 @@ def list_workflow_runs(repo: str, day: date) -> tuple[list[dict[str, Any]], list
     try:
         proc = _run_gh(cmd, timeout=GH_TIMEOUT_LIST_RUNS)
     except subprocess.TimeoutExpired as exc:
-        return [], [f"list_workflow_runs timeout: {exc}"]
+        return [], None, [f"list_workflow_runs timeout: {exc}"]
     except OSError as exc:
-        return [], [f"list_workflow_runs OSError: {exc}"]
+        return [], None, [f"list_workflow_runs OSError: {exc}"]
     if proc.returncode != 0:
-        return [], [
+        return [], None, [
             f"list_workflow_runs failed rc={proc.returncode} "
             f"stderr={proc.stderr.strip()[:400]}"
         ]
     try:
         pages = _parse_concatenated_json(proc.stdout)
     except json.JSONDecodeError as exc:
-        return [], [f"list_workflow_runs bad JSON: {exc}"]
-    runs: list[dict[str, Any]] = []
+        return [], None, [f"list_workflow_runs bad JSON: {exc}"]
+
+    reported_totals = {
+        int(page["total_count"])
+        for page in pages
+        if isinstance(page.get("total_count"), int)
+    }
+    reported_total = max(reported_totals) if reported_totals else None
+    # The Actions endpoint reports the real total on the first page but can emit zero on
+    # later `--paginate` pages. Treat zero as a pagination sentinel when a positive total
+    # exists; conflicting positive totals remain fail-visible.
+    positive_reported_totals = {total for total in reported_totals if total > 0}
+    if len(positive_reported_totals) > 1:
+        errors.append(
+            "list_workflow_runs inconsistent positive total_count values across pages: "
+            f"{sorted(positive_reported_totals)}"
+        )
+    if reported_total is None:
+        errors.append("list_workflow_runs response missing integer total_count")
+
+    runs_by_id: dict[int, dict[str, Any]] = {}
+    runs_without_id: list[dict[str, Any]] = []
     for page in pages:
-        runs.extend(page.get("workflow_runs") or [])
-    return runs, errors
+        for run in page.get("workflow_runs") or []:
+            run_id = run.get("id") if isinstance(run, dict) else None
+            if isinstance(run_id, int):
+                runs_by_id[run_id] = run
+            elif isinstance(run, dict):
+                runs_without_id.append(run)
+    runs = [*runs_by_id.values(), *runs_without_id]
+    if reported_total is not None and len(runs) < reported_total:
+        errors.append(
+            "list_workflow_runs pagination shortfall: "
+            f"fetched={len(runs)} reported_total={reported_total}; record is partial"
+        )
+    return runs, reported_total, errors
 
 
-def fetch_run_timing_minutes(repo: str, run_id: int) -> tuple[float | None, str | None]:
-    """GET .../actions/runs/{run_id}/timing -> total billable minutes across all OS buckets.
+def fetch_run_timing_minutes(
+    repo: str,
+    run_id: int,
+) -> tuple[float | None, TimingSource | None, str | None]:
+    """GET .../timing -> minutes, declared timing source, and error.
 
-    Returns (minutes, error). `minutes` is None on failure — the caller must record the
-    error and route the run's contribution to `errors`, never silently treat None as 0.
+    Non-zero billable buckets win. Public repositories report those buckets as zero, so
+    `run_duration_ms` is the declared fallback. If both are zero/absent, the run contributes
+    an explicit zero-duration source (the normal shape for a skipped run).
     """
     cmd = ["gh", "api", f"repos/{repo}/actions/runs/{run_id}/timing"]
     try:
         proc = _run_gh(cmd, timeout=GH_TIMEOUT_SHORT)
     except subprocess.TimeoutExpired as exc:
-        return None, f"timing fetch timeout run={run_id}: {exc}"
+        return None, None, f"timing fetch timeout run={run_id}: {exc}"
     except OSError as exc:
-        return None, f"timing fetch OSError run={run_id}: {exc}"
+        return None, None, f"timing fetch OSError run={run_id}: {exc}"
     if proc.returncode != 0:
-        return None, (
+        return None, None, (
             f"timing fetch failed run={run_id} rc={proc.returncode} "
             f"stderr={proc.stderr.strip()[:300]}"
         )
     try:
         payload = json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
-        return None, f"timing fetch bad JSON run={run_id}: {exc}"
+        return None, None, f"timing fetch bad JSON run={run_id}: {exc}"
     billable = payload.get("billable") or {}
     total_ms = 0
     for _os_name, os_data in billable.items():
         if isinstance(os_data, dict):
             total_ms += int(os_data.get("total_ms") or 0)
-    return total_ms / 60000.0, None
+    if total_ms > 0:
+        return total_ms / 60000.0, "billable", None
+
+    run_duration_ms = payload.get("run_duration_ms")
+    if isinstance(run_duration_ms, (int, float)) and run_duration_ms >= 0:
+        return float(run_duration_ms) / 60000.0, "run_duration", None
+
+    return 0.0, "billable_zero_without_duration", None
 
 
 def fetch_run_jobs(repo: str, run_id: int) -> tuple[list[dict[str, Any]], str | None]:
@@ -509,6 +574,16 @@ def _empty_record(repo: str, day: date) -> dict[str, Any]:
         "unattributed_pr_minutes": 0.0,
         "other_event_minutes": 0.0,
         "total_runner_minutes": 0.0,
+        "timing_sources": {
+            "billable": {"runs": 0, "minutes": 0.0},
+            "run_duration": {"runs": 0, "minutes": 0.0},
+            "billable_zero_without_duration": {"runs": 0, "minutes": 0.0},
+        },
+        "run_collection": {
+            "reported_total": None,
+            "fetched": 0,
+            "complete": False,
+        },
         "queue_transit_minutes": {},
         "queue_transit_p50_minutes": None,
         "queue_transit_p95_minutes": None,
@@ -543,8 +618,13 @@ def build_record(repo: str, day: date) -> dict[str, Any]:
     record = _empty_record(repo, day)
     errors: list[str] = record["errors"]
 
-    runs, run_list_errors = list_workflow_runs(repo, day)
+    runs, reported_total, run_list_errors = list_workflow_runs(repo, day)
     errors.extend(run_list_errors)
+    record["run_collection"] = {
+        "reported_total": reported_total,
+        "fetched": len(runs),
+        "complete": reported_total == len(runs),
+    }
 
     billed_per_pr: dict[str, float] = {}
     unattributed_group: list[float] = []
@@ -576,13 +656,16 @@ def build_record(repo: str, day: date) -> dict[str, Any]:
         if run_id is None:
             errors.append(f"run missing id, skipped: {run.get('name', '?')!r}")
             continue
-        minutes, timing_error = fetch_run_timing_minutes(repo, run_id)
+        minutes, timing_source, timing_error = fetch_run_timing_minutes(repo, run_id)
         if timing_error:
             errors.append(timing_error)
             continue
-        if minutes is None:
-            errors.append(f"timing fetch returned no minutes for run={run_id}, skipped")
+        if minutes is None or timing_source is None:
+            errors.append(f"timing fetch returned incomplete data for run={run_id}, skipped")
             continue
+        source_record = record["timing_sources"][timing_source]
+        source_record["runs"] += 1
+        source_record["minutes"] += minutes
         allocate_run_minutes(run, minutes, billed_per_pr, unattributed_group, unattributed_pr, other_event)
 
     total_runner_minutes = (

--- a/scripts/tests/test_queue_baseline_probe.py
+++ b/scripts/tests/test_queue_baseline_probe.py
@@ -81,6 +81,8 @@ def _make_fake_gh(
     repo: str,
     runs: list[dict],
     timing_ms_by_id: dict[int, int],
+    run_duration_ms_by_id: dict[int, int] | None = None,
+    reported_run_total: int | None = None,
     merged_prs: list[dict] | None = None,
     jobs_by_id: dict[int, list[dict]] | None = None,
     pr_view_by_number: dict[int, dict] | None = None,
@@ -90,6 +92,8 @@ def _make_fake_gh(
     module issues, matched by exact argv content (the real shapes the module builds).
     """
     merged_prs = merged_prs if merged_prs is not None else []
+    run_duration_ms_by_id = run_duration_ms_by_id or {}
+    reported_run_total = len(runs) if reported_run_total is None else reported_run_total
     jobs_by_id = jobs_by_id or {}
     pr_view_by_number = pr_view_by_number or {}
     automerge_by_pr = automerge_by_pr or {}
@@ -97,12 +101,19 @@ def _make_fake_gh(
     def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003 — mirrors subprocess.run's own loose signature
         assert cmd[0] == "gh", f"unexpected non-gh subprocess call: {cmd}"
         if cmd[1] == "api" and len(cmd) > 2 and cmd[2] == f"repos/{repo}/actions/runs":
-            return _proc(cmd, 0, json.dumps({"workflow_runs": runs}))
+            return _proc(
+                cmd,
+                0,
+                json.dumps({"total_count": reported_run_total, "workflow_runs": runs}),
+            )
         if cmd[1] == "api" and len(cmd) > 2 and cmd[2].endswith("/timing"):
             run_id = int(cmd[2].split("/")[-2])
             if run_id not in timing_ms_by_id:
                 return _proc(cmd, 1, "", f"404 run {run_id} not found")
-            return _proc(cmd, 0, json.dumps({"billable": {"UBUNTU": {"total_ms": timing_ms_by_id[run_id]}}}))
+            payload = {"billable": {"UBUNTU": {"total_ms": timing_ms_by_id[run_id]}}}
+            if run_id in run_duration_ms_by_id:
+                payload["run_duration_ms"] = run_duration_ms_by_id[run_id]
+            return _proc(cmd, 0, json.dumps(payload))
         if cmd[1] == "api" and len(cmd) > 2 and cmd[2].endswith("/jobs"):
             run_id = int(cmd[2].split("/")[-2])
             return _proc(cmd, 0, json.dumps({"jobs": jobs_by_id.get(run_id, [])}))
@@ -138,6 +149,83 @@ def _make_fake_gh(
 def _fail_everything(cmd, **kwargs):  # noqa: ANN001, ANN003
     assert cmd[0] == "gh"
     return _proc(cmd, 1, "", "HTTP 403: API rate limit exceeded for installation")
+
+
+def test_list_workflow_runs_reports_server_side_pagination_shortfall(monkeypatch):
+    runs = [_mk_run(1, "push"), _mk_run(2, "pull_request")]
+    fake = _make_fake_gh(
+        qbp.DEFAULT_REPO,
+        runs,
+        timing_ms_by_id={},
+        reported_run_total=17_648,
+    )
+    monkeypatch.setattr(qbp.subprocess, "run", fake)
+
+    fetched, reported_total, errors = qbp.list_workflow_runs(
+        qbp.DEFAULT_REPO,
+        date(2026, 8, 9),
+    )
+
+    assert [run["id"] for run in fetched] == [1, 2]
+    assert reported_total == 17_648
+    assert errors == [
+        "list_workflow_runs pagination shortfall: "
+        "fetched=2 reported_total=17648; record is partial"
+    ]
+
+
+def test_list_workflow_runs_combines_all_pages_and_deduplicates_ids(monkeypatch):
+    pages = [
+        {"total_count": 3, "workflow_runs": [_mk_run(1, "push"), _mk_run(2, "push")]},
+        # The live endpoint can emit zero after reporting the real total on page one.
+        {"total_count": 0, "workflow_runs": [_mk_run(2, "push"), _mk_run(3, "push")]},
+    ]
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        return _proc(cmd, 0, "".join(json.dumps(page) for page in pages))
+
+    monkeypatch.setattr(qbp.subprocess, "run", fake_run)
+
+    fetched, reported_total, errors = qbp.list_workflow_runs(
+        qbp.DEFAULT_REPO,
+        date(2026, 8, 9),
+    )
+
+    assert [run["id"] for run in fetched] == [1, 2, 3]
+    assert reported_total == 3
+    assert errors == []
+
+
+def test_public_repo_timing_falls_back_to_run_duration_ms(monkeypatch):
+    fake = _make_fake_gh(
+        qbp.DEFAULT_REPO,
+        runs=[],
+        timing_ms_by_id={7001: 0},
+        run_duration_ms_by_id={7001: 90_000},
+    )
+    monkeypatch.setattr(qbp.subprocess, "run", fake)
+
+    minutes, source, error = qbp.fetch_run_timing_minutes(qbp.DEFAULT_REPO, 7001)
+
+    assert minutes == pytest.approx(1.5)
+    assert source == "run_duration"
+    assert error is None
+
+
+def test_nonzero_billable_timing_wins_over_run_duration(monkeypatch):
+    fake = _make_fake_gh(
+        qbp.DEFAULT_REPO,
+        runs=[],
+        timing_ms_by_id={7002: 120_000},
+        run_duration_ms_by_id={7002: 600_000},
+    )
+    monkeypatch.setattr(qbp.subprocess, "run", fake)
+
+    minutes, source, error = qbp.fetch_run_timing_minutes(qbp.DEFAULT_REPO, 7002)
+
+    assert minutes == pytest.approx(2.0)
+    assert source == "billable"
+    assert error is None
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +271,12 @@ def test_attribution_even_split_and_unattributed_group_minutes(monkeypatch):
     assert record["unattributed_group_minutes"] == pytest.approx(15.0)
     assert record["unattributed_pr_minutes"] == pytest.approx(0.0)
     assert record["total_runner_minutes"] == pytest.approx(40.0 + 20.0 + 30.0 + 15.0)
+    assert record["timing_sources"]["billable"] == {"runs": 4, "minutes": 105.0}
+    assert record["run_collection"] == {
+        "reported_total": 4,
+        "fetched": 4,
+        "complete": True,
+    }
     assert record["counts"]["runs_seen"] == 4
     assert record["counts"]["pull_request_runs"] == 2
     assert record["counts"]["merge_group_runs"] == 2
@@ -254,6 +348,26 @@ def test_non_pr_non_merge_group_run_counts_toward_slot_utilization_only(monkeypa
     assert record["slot_utilization"]["runner_minutes_today"] == pytest.approx(5.0)
 
 
+def test_public_repo_duration_fallback_populates_runner_minutes(monkeypatch):
+    day = date(2026, 8, 9)
+    runs = [_mk_run(3002, "schedule")]
+    fake = _make_fake_gh(
+        qbp.DEFAULT_REPO,
+        runs,
+        timing_ms_by_id={3002: 0},
+        run_duration_ms_by_id={3002: 5 * 60_000},
+        merged_prs=[],
+    )
+    monkeypatch.setattr(qbp.subprocess, "run", fake)
+
+    record = qbp.build_record(qbp.DEFAULT_REPO, day)
+
+    assert record["errors"] == []
+    assert record["other_event_minutes"] == pytest.approx(5.0)
+    assert record["total_runner_minutes"] == pytest.approx(5.0)
+    assert record["timing_sources"]["run_duration"] == {"runs": 1, "minutes": 5.0}
+
+
 # ---------------------------------------------------------------------------
 # 2. Empty-day record still carries the schema with zeros and empty errors.
 # ---------------------------------------------------------------------------
@@ -273,6 +387,16 @@ def test_empty_day_record_carries_full_schema_with_zeros(monkeypatch):
     assert record["unattributed_pr_minutes"] == 0.0
     assert record["other_event_minutes"] == 0.0
     assert record["total_runner_minutes"] == 0.0
+    assert record["timing_sources"] == {
+        "billable": {"runs": 0, "minutes": 0.0},
+        "run_duration": {"runs": 0, "minutes": 0.0},
+        "billable_zero_without_duration": {"runs": 0, "minutes": 0.0},
+    }
+    assert record["run_collection"] == {
+        "reported_total": 0,
+        "fetched": 0,
+        "complete": True,
+    }
     assert record["queue_transit_minutes"] == {}
     assert record["queue_transit_p50_minutes"] is None
     assert record["queue_transit_p95_minutes"] is None


### PR DESCRIPTION
## What changed

- detects server-side workflow-run pagination shortfalls by comparing unique fetched IDs with `total_count`
- records `run_collection.reported_total`, `fetched`, and `complete` in schema v2
- uses `run_duration_ms` when public-repository billable buckets are present but zero
- records timing provenance under `timing_sources`
- documents both metric semantics in the merge-queue runbook

## Root causes cured

The first live baseline record reported exactly 1,000 runs even though GitHub reported 17,648 for the day, but the cap was silent. The same public-repository timing payload exposed zero billable OS buckets while carrying a non-zero `run_duration_ms`, so runner consumption was incorrectly flattened to `0.0`.

## Impact

Partial censuses now fail visibly through `errors[]` and `run_collection.complete=false`. Public-repository runner consumption is populated from the declared duration fallback while private-repository non-zero billable data still wins. This is measurement-only; queue behavior and branch protection are unchanged.

## Validation

- focused probe tests: 24 passed
- `ruff check scripts/queue_baseline_probe.py scripts/tests/test_queue_baseline_probe.py`
- `git diff --check`
- pre-commit hooks passed
- repository pre-push gate passed, including the serialized full backend suite
- bounded live check: `fetched=1000`, `reported_total=17648`, explicit pagination-shortfall error
- bounded live timing check: 79,000 ms became 1.3167 minutes from source `run_duration`

## Handoff

This PR is intentionally draft and unarmed. An independent Claude session must review and rerun the relevant tests before using the normal bare `mq arm` path. The seven-record Wave 1 acceptance window cannot be closed from the old silent-partial record.