### PR TITLE
fix(prepush): FIFO ticket so a long waiter is not lapped by a newcomer

### DIFF
--- a/scripts/prepush_suite_lock.sh
+++ b/scripts/prepush_suite_lock.sh
@@ -50,6 +50,14 @@
 #   NUZ_PREPUSH_SUITE_LOCK=0             kill switch — bypass locking
 #                                         entirely, run <command> directly
 #                                         (documented escape hatch).
+#   NUZ_PREPUSH_SUITE_FIFO=0             disable ONLY the fairness layer
+#                                         (2026-08-11): waiters go back to
+#                                         racing for the lock on every poll,
+#                                         which is correct but starvable. The
+#                                         lock itself stays on. Separate from
+#                                         the switch above on purpose — losing
+#                                         fairness must never require losing
+#                                         serialization.
 #   NUZ_PREPUSH_SUITE_LOCK_TIMEOUT=<s>   max wait in seconds before failing
 #                                         closed (default 4500 = 75min).
 #                                         Test-only override in practice.
@@ -114,10 +122,106 @@ LOCK_TIMEOUT_RC=75
 START_TS=$(date +%s)
 LAST_HEARTBEAT=$START_TS
 
+# ---------------------------------------------------------------------------
+# FIFO fairness layer (2026-08-11). MEASURED motivation, one push:
+# a waiter sat 75 minutes and timed out with the suite never starting, while
+# a wrapper born 35 MINUTES LATER took the lock ahead of it — twice in a row,
+# same branch. `mkdir` is atomic but says nothing about ORDER: every poll is
+# an independent race, so a long waiter has no advantage over an arrival that
+# happens to knock at the instant of release. The bounded wait then fires on
+# the politest process while the machine is perfectly healthy.
+#
+# Each wrapper drops a ticket named `<epoch>.<pid>` and only races for the
+# lock once no OLDER live ticket remains. That is approximate FIFO — arrival
+# order at one-second granularity, ties broken by pid — which is all the
+# property needs; it does not have to be a total order, it has to stop a
+# newcomer from lapping a 75-minute waiter.
+#
+# EVERY uncertainty fails OPEN to the pre-FIFO behaviour, because the failure
+# this layer could introduce (a stuck queue stalling every push on the
+# machine) is far worse than the one it fixes (one push waiting too long):
+#   - queue dir not creatable / ticket not writable -> no ticket -> plain race
+#   - ticket owner dead (`kill -0`)                 -> reaped, does not block
+#   - ticket older than the whole TIMEOUT           -> reaped: it cannot
+#     legitimately still be waiting, so it is residue, not a queue position
+#   - malformed ticket name                         -> reaped, never parsed
+#   - NUZ_PREPUSH_SUITE_FIFO=0                      -> layer off entirely
+# The lock itself is unchanged: acquisition is still the same atomic `mkdir`,
+# and the stale-holder reclamation below still runs on every poll.
+# ---------------------------------------------------------------------------
+QUEUE_DIR="${LOCKFILE}.q"
+MY_TICKET=""
+if [ "${NUZ_PREPUSH_SUITE_FIFO:-1}" != "0" ] && mkdir -p "$QUEUE_DIR" 2>/dev/null; then
+    MY_TICKET="$QUEUE_DIR/$START_TS.$$"
+    : > "$MY_TICKET" 2>/dev/null || MY_TICKET=""
+fi
+
+# Is any OTHER live, unexpired ticket older than mine? Reaps what it rejects,
+# so a dead/expired/malformed ticket is removed by the first waiter to see it
+# rather than accumulating.
+older_ticket_waiting() {
+    [ -n "$MY_TICKET" ] || return 1   # no ticket -> never yield (pre-FIFO path)
+    _mine="${MY_TICKET##*/}"
+    _mine_ts="${_mine%.*}"
+    _mine_pid="${_mine##*.}"
+    _now=$(date +%s)
+    for _t in "$QUEUE_DIR"/*; do
+        [ -e "$_t" ] || continue      # unmatched glob
+        _n="${_t##*/}"
+        [ "$_n" = "$_mine" ] && continue
+        _ts="${_n%.*}"
+        _pid="${_n##*.}"
+        case "$_ts$_pid" in
+            ''|*[!0-9]*) rm -f "$_t" 2>/dev/null; continue ;;
+        esac
+        if [ $((_now - _ts)) -gt "$TIMEOUT" ]; then
+            rm -f "$_t" 2>/dev/null
+            continue
+        fi
+        if ! kill -0 "$_pid" 2>/dev/null; then
+            rm -f "$_t" 2>/dev/null
+            continue
+        fi
+        if [ "$_ts" -lt "$_mine_ts" ]; then
+            return 0
+        fi
+        if [ "$_ts" -eq "$_mine_ts" ] && [ "$_pid" -lt "$_mine_pid" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# The trap is installed BEFORE the wait loop so a ticket never outlives its
+# waiter (an orphan ticket is exactly the stall this layer must not cause).
+# `I_HOLD_LOCK` is what makes that safe: without it, a WAITER killed or timed
+# out mid-queue would run `rm -rf "$LOCKFILE"` and delete the LIVE HOLDER's
+# lock — the pre-FIFO code could install the trap late precisely because it
+# only ever ran as the holder. Pinned by the "waiter timing out does not
+# delete the holder's lock" case in the corpus.
+I_HOLD_LOCK=0
+CHILD_PID=""
+cleanup() {
+    if [ -n "$CHILD_PID" ]; then
+        # A signal that targets only THIS wrapper's PID (not the whole
+        # foreground process group) must not leave the wrapped suite running
+        # as an orphan after the lock is already released underneath it.
+        kill -TERM "$CHILD_PID" 2>/dev/null
+    fi
+    if [ "$I_HOLD_LOCK" = "1" ]; then
+        rm -rf "$LOCKFILE" 2>/dev/null
+    fi
+    if [ -n "$MY_TICKET" ]; then
+        rm -f "$MY_TICKET" 2>/dev/null
+    fi
+}
+trap cleanup EXIT INT TERM
+
 while :; do
-    if mkdir "$LOCKFILE" 2>/dev/null; then
+    if ! older_ticket_waiting && mkdir "$LOCKFILE" 2>/dev/null; then
         chmod 700 "$LOCKFILE" 2>/dev/null
         echo $$ > "$LOCKFILE/pid" 2>/dev/null
+        I_HOLD_LOCK=1
         break
     fi
 
@@ -160,20 +264,17 @@ while :; do
     sleep "$POLL_INTERVAL"
 done
 
-# CHILD_PID starts unset: if this wrapper is killed between acquiring the
-# lock and backgrounding the command below, cleanup must only drop the lock,
-# not try to signal a child that was never started.
-CHILD_PID=""
-cleanup() {
-    if [ -n "$CHILD_PID" ]; then
-        # A signal that targets only THIS wrapper's PID (not the whole
-        # foreground process group) must not leave the wrapped suite running
-        # as an orphan after the lock is already released underneath it.
-        kill -TERM "$CHILD_PID" 2>/dev/null
-    fi
-    rm -rf "$LOCKFILE" 2>/dev/null
-}
-trap cleanup EXIT INT TERM
+# The lock is held from here. `cleanup`/`trap` are installed above, before the
+# wait loop (see the FIFO block): CHILD_PID still starts unset, so a wrapper
+# killed between acquiring the lock and backgrounding the command below drops
+# the lock and its ticket without signalling a child that never started.
+# The ticket is dropped now rather than at exit: this wrapper is no longer
+# queueing, and leaving it in place would make every later waiter yield to a
+# position that has already been served.
+if [ -n "$MY_TICKET" ]; then
+    rm -f "$MY_TICKET" 2>/dev/null
+    MY_TICKET=""
+fi
 
 "$@" &
 CHILD_PID=$!

--- a/scripts/tests/test_prepush_suite_lock.sh
+++ b/scripts/tests/test_prepush_suite_lock.sh
@@ -300,6 +300,193 @@ else
     note_fail "tripwire — .husky/pre-push does not classify rc=75; saturation still reads as 'tests FAILED'"
 fi
 
+
+# ===========================================================================
+# FIFO fairness layer (2026-08-11). Measured trigger: one waiter sat 75
+# minutes, timed out with the suite never starting, and a wrapper born 35
+# MINUTES LATER took the lock ahead of it — twice on the same branch. mkdir is
+# atomic but says nothing about order.
+#
+# The cases below split the same way as the rest of this file: the fairness
+# property itself (guilt), then every fail-open path, because the failure this
+# layer could introduce — a stuck queue stalling every push on the machine —
+# is worse than the one it fixes.
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Case F1 (guilt, THE fairness property): the lock is FREE, but an older LIVE
+# ticket is queued. A younger wrapper must YIELD — under the pre-FIFO code it
+# would take the free lock instantly, which is exactly the lapping that cost a
+# real push 75 minutes.
+#
+# The older ticket's owner is a REAL live process (a `sleep` we spawn and
+# later kill), not a plausible-looking number: `kill -0` is what the layer
+# actually asks, so the test must give it a real answer.
+# ---------------------------------------------------------------------------
+LOCKF1="$WORKDIR/fifo-yield.lock"
+QF1="$LOCKF1.q"
+mkdir -p "$QF1"
+sleep 30 &
+OLD_OWNER=$!
+OLD_TS=$(( $(date +%s) - 60 ))
+: > "$QF1/$OLD_TS.$OLD_OWNER"
+
+"$SCRIPT" "$LOCKF1" sh -c 'echo jumped' > "$WORKDIR/f1.out" 2>&1 &
+YOUNGER=$!
+sleep 4
+if kill -0 "$YOUNGER" 2>/dev/null && ! grep -q jumped "$WORKDIR/f1.out" 2>/dev/null; then
+    note_pass "fifo guilt — younger waiter yielded to an older live ticket even with the lock FREE"
+else
+    note_fail "fifo guilt — younger waiter took a free lock ahead of an older live ticket (out: $(cat "$WORKDIR/f1.out" 2>/dev/null))"
+fi
+
+# ...and once the older ticket's owner dies, the younger one must proceed —
+# the yield is a queue position, not a wedge.
+kill "$OLD_OWNER" 2>/dev/null
+wait "$OLD_OWNER" 2>/dev/null
+sleep 5
+if grep -q jumped "$WORKDIR/f1.out" 2>/dev/null; then
+    note_pass "fifo guilt — younger waiter proceeded once the older ticket's owner died"
+else
+    note_fail "fifo guilt — younger waiter still blocked after the older ticket's owner died (WEDGE)"
+fi
+wait "$YOUNGER" 2>/dev/null
+
+# ---------------------------------------------------------------------------
+# Case F2 (innocence): with the layer ON and no contender, a single acquirer
+# must still run immediately. A fairness layer that adds latency to the
+# uncontended path would be paid on every push on every machine.
+# ---------------------------------------------------------------------------
+LOCKF2="$WORKDIR/fifo-solo.lock"
+T0=$(date +%s)
+OUTF2="$("$SCRIPT" "$LOCKF2" sh -c 'echo solo')"
+RCF2=$?
+ELAPSEDF2=$(( $(date +%s) - T0 ))
+if [ "$OUTF2" = "solo" ] && [ "$RCF2" -eq 0 ] && [ "$ELAPSEDF2" -le 3 ]; then
+    note_pass "fifo innocence — uncontended acquirer still immediate (${ELAPSEDF2}s)"
+else
+    note_fail "fifo innocence — uncontended acquirer delayed/broken (${ELAPSEDF2}s, rc=$RCF2, out='$OUTF2')"
+fi
+if [ -d "$LOCKF2.q" ] && [ -n "$(ls -A "$LOCKF2.q" 2>/dev/null)" ]; then
+    note_fail "fifo innocence — ticket left behind after a normal exit: $(ls -A "$LOCKF2.q")"
+else
+    note_pass "fifo innocence — no ticket left behind after a normal exit"
+fi
+
+# ---------------------------------------------------------------------------
+# Case F3 (fail-open, dead owner): a ticket whose owner is dead must be reaped,
+# not obeyed. Same guaranteed-dead-PID discipline as Case 3.
+# ---------------------------------------------------------------------------
+LOCKF3="$WORKDIR/fifo-deadticket.lock"
+QF3="$LOCKF3.q"
+mkdir -p "$QF3"
+sh -c 'exit 0' &
+DEAD_T=$!
+wait "$DEAD_T" 2>/dev/null
+: > "$QF3/$(( $(date +%s) - 60 )).$DEAD_T"
+T0=$(date +%s)
+OUTF3="$("$SCRIPT" "$LOCKF3" sh -c 'echo past-dead' 2>&1)"
+ELAPSEDF3=$(( $(date +%s) - T0 ))
+if printf '%s' "$OUTF3" | grep -q 'past-dead' && [ "$ELAPSEDF3" -le 5 ]; then
+    note_pass "fifo fail-open — dead-owner ticket reaped, waiter proceeded (${ELAPSEDF3}s)"
+else
+    note_fail "fifo fail-open — dead-owner ticket blocked the waiter (${ELAPSEDF3}s, out='$OUTF3')"
+fi
+
+# ---------------------------------------------------------------------------
+# Case F4 (fail-open, expired): a ticket older than the whole timeout cannot
+# legitimately still be waiting — it is residue. It must not block even though
+# its owner IS alive.
+# ---------------------------------------------------------------------------
+LOCKF4="$WORKDIR/fifo-expired.lock"
+QF4="$LOCKF4.q"
+mkdir -p "$QF4"
+sleep 30 &
+LIVE_OLD=$!
+: > "$QF4/$(( $(date +%s) - 99999 )).$LIVE_OLD"
+T0=$(date +%s)
+OUTF4="$("$SCRIPT" "$LOCKF4" sh -c 'echo past-expired' 2>&1)"
+ELAPSEDF4=$(( $(date +%s) - T0 ))
+kill "$LIVE_OLD" 2>/dev/null
+wait "$LIVE_OLD" 2>/dev/null
+if printf '%s' "$OUTF4" | grep -q 'past-expired' && [ "$ELAPSEDF4" -le 5 ]; then
+    note_pass "fifo fail-open — expired ticket (live owner) reaped, waiter proceeded (${ELAPSEDF4}s)"
+else
+    note_fail "fifo fail-open — expired ticket blocked the waiter (${ELAPSEDF4}s, out='$OUTF4')"
+fi
+
+# ---------------------------------------------------------------------------
+# Case F5 (fail-open, malformed): a ticket name that does not parse must be
+# reaped, never interpreted. Arithmetic on a non-numeric field would abort the
+# wrapper under some shells — a queue that can be poisoned by one bad filename
+# is worse than no queue.
+# ---------------------------------------------------------------------------
+LOCKF5="$WORKDIR/fifo-malformed.lock"
+QF5="$LOCKF5.q"
+mkdir -p "$QF5"
+: > "$QF5/not-a-ticket"
+: > "$QF5/abc.def"
+T0=$(date +%s)
+OUTF5="$("$SCRIPT" "$LOCKF5" sh -c 'echo past-malformed' 2>&1)"
+ELAPSEDF5=$(( $(date +%s) - T0 ))
+if printf '%s' "$OUTF5" | grep -q 'past-malformed' && [ "$ELAPSEDF5" -le 5 ]; then
+    note_pass "fifo fail-open — malformed tickets reaped, waiter proceeded (${ELAPSEDF5}s)"
+else
+    note_fail "fifo fail-open — malformed ticket blocked the waiter (${ELAPSEDF5}s, out='$OUTF5')"
+fi
+
+# ---------------------------------------------------------------------------
+# Case F6 (kill switch): NUZ_PREPUSH_SUITE_FIFO=0 turns the fairness layer off
+# WITHOUT turning the lock off — losing fairness must never require losing
+# serialization. With the layer off, the older live ticket of F1 is ignored.
+# ---------------------------------------------------------------------------
+LOCKF6="$WORKDIR/fifo-killswitch.lock"
+QF6="$LOCKF6.q"
+mkdir -p "$QF6"
+sleep 30 &
+BLOCKER=$!
+: > "$QF6/$(( $(date +%s) - 60 )).$BLOCKER"
+T0=$(date +%s)
+OUTF6="$(NUZ_PREPUSH_SUITE_FIFO=0 "$SCRIPT" "$LOCKF6" sh -c 'echo fifo-off' 2>&1)"
+ELAPSEDF6=$(( $(date +%s) - T0 ))
+kill "$BLOCKER" 2>/dev/null
+wait "$BLOCKER" 2>/dev/null
+if printf '%s' "$OUTF6" | grep -q 'fifo-off' && [ "$ELAPSEDF6" -le 5 ]; then
+    note_pass "fifo kill switch — NUZ_PREPUSH_SUITE_FIFO=0 ignores the queue (${ELAPSEDF6}s)"
+else
+    note_fail "fifo kill switch — layer still active with NUZ_PREPUSH_SUITE_FIFO=0 (${ELAPSEDF6}s, out='$OUTF6')"
+fi
+
+# ---------------------------------------------------------------------------
+# Case F7 (SAFETY — the bug this layer could have introduced): the trap now
+# runs in WAITERS too, because a ticket must never outlive its waiter. A
+# waiter that gives up must therefore NOT delete the live HOLDER's lock. Drop
+# the `I_HOLD_LOCK` guard from cleanup() and this case goes red while every
+# other case stays green.
+#
+# Driven through a real timeout (1s) against a real live holder.
+# ---------------------------------------------------------------------------
+LOCKF7="$WORKDIR/fifo-holdersafety.lock"
+mkdir -p "$LOCKF7"
+sleep 30 &
+HOLDER7=$!
+echo "$HOLDER7" > "$LOCKF7/pid"
+NUZ_PREPUSH_SUITE_LOCK_TIMEOUT=1 NUZ_PREPUSH_SUITE_LOCK_POLL=1 \
+    "$SCRIPT" "$LOCKF7" sh -c 'echo should-not-run' > "$WORKDIR/f7.out" 2>&1
+RCF7=$?
+if [ "$RCF7" -eq 75 ] && [ -d "$LOCKF7" ] && [ "$(cat "$LOCKF7/pid" 2>/dev/null)" = "$HOLDER7" ]; then
+    note_pass "fifo safety — a timing-out WAITER left the live holder's lock intact (rc=$RCF7)"
+else
+    note_fail "fifo safety — waiter destroyed or altered the holder's lock (rc=$RCF7, lock exists: $([ -d "$LOCKF7" ] && echo yes || echo NO), pid file: '$(cat "$LOCKF7/pid" 2>/dev/null)')"
+fi
+if [ -d "$LOCKF7.q" ] && [ -n "$(ls -A "$LOCKF7.q" 2>/dev/null)" ]; then
+    note_fail "fifo safety — timing-out waiter left its ticket behind: $(ls -A "$LOCKF7.q")"
+else
+    note_pass "fifo safety — timing-out waiter removed its own ticket"
+fi
+kill "$HOLDER7" 2>/dev/null
+wait "$HOLDER7" 2>/dev/null
+
 echo "---"
 echo "$pass passed, $fail failed"
 


### PR DESCRIPTION
## Measured, not theorised

`mkdir` is atomic but carries **no order**. Every poll of the pre-push suite lock is an
independent race, so a waiter that has been queueing for over an hour has exactly the same
chance as one that happens to knock at the instant of release. The 75-minute bounded wait then
fires on the *politest* process while the machine is perfectly healthy — a timeout that reports
starvation as if it were a stuck holder.

Observed on this machine, twice on the same branch, before this change: a wrapper exhausted the
full cap and exited 75 with the suite never started, while a wrapper born 35 minutes later took
the lock ahead of it.

**And this PR's own push demonstrated it again.** The delivery vehicle for the cure committed
the disease: the `ops-prepush-lock-fifo` push waited **2 minutes**, while the sibling
`ops-allowlist-v7-research-txt` push — already 50 minutes into its wait at that moment — went on
to wait **72 minutes**, three minutes short of the cap.

## What changes

Each wrapper drops a `<epoch>.<pid>` ticket in `<lockfile>.q` and only races for the lock once no
**older live** ticket remains. Approximate FIFO at one-second granularity, ties broken by pid. It
does not need to be a total order; it needs to stop a newcomer from lapping a waiter.

The lock itself is untouched: same atomic `mkdir`, same stale-holder reclamation on every poll.

## Every uncertainty fails OPEN

A stuck queue would stall *every* push on the machine — far worse than the problem being fixed
(one push waiting too long). So all of these degrade to the pre-FIFO race:

| condition | behaviour |
|---|---|
| queue dir not creatable / ticket not writable | no ticket -> plain race |
| ticket owner dead (`kill -0`) | reaped, does not block |
| ticket older than the whole `TIMEOUT` | reaped — it cannot legitimately still be waiting |
| malformed ticket name | reaped, never parsed |
| `NUZ_PREPUSH_SUITE_FIFO=0` | layer off entirely |

`NUZ_PREPUSH_SUITE_FIFO` is deliberately **separate** from `NUZ_PREPUSH_SUITE_LOCK`: losing
fairness must never require losing serialization.

## The trap move, and why it needed a new guard

`cleanup`/`trap` now install **before** the wait loop, so a ticket never outlives its waiter (an
orphan ticket is exactly the stall this layer must not cause). That move is only safe because of
the new `I_HOLD_LOCK` flag: without it, a waiter killed or timed out mid-queue would run
`rm -rf "$LOCKFILE"` and delete the **live holder's** lock. The pre-FIFO code could install the
trap late precisely because it only ever ran as the holder.

## Verification

Corpus `scripts/tests/test_prepush_suite_lock.sh`: **22 passed, 0 failed** (rc measured without a
pipe — `PIPESTATUS` is empty under zsh). 10 new cases: fairness guilt x2, innocence x2, three
fail-open paths, kill switch, two safety cases.

Mutation-verified, one red each with the right message:

| mutation | result |
|---|---|
| fairness yield removed | `younger waiter took a free lock ahead of an older live ticket` (21/1) |
| `I_HOLD_LOCK` guard removed | `waiter destroyed or altered the holder's lock` (21/1) |
| dead-owner reap removed | `younger waiter still blocked after the older ticket's owner died (WEDGE)` |

Pre-push on this branch ran the **FULL** suite by design (`scripts/prepush_suite_lock.sh` is not
allowlisted — a lock must never authorise skipping the suite on its own diff).

## Declared limitation — fairness is only as good as adoption (MEASURED)

Each worktree runs its **own tracked copy** of `scripts/prepush_suite_lock.sh`, so this only takes
effect in a worktree once it has rebased past this commit. Counted right now on Air-M5:

- **16** worktrees carry the wrapper; **1** is FIFO-aware, **15** are on the old one
- all **15** have committed within the last 7 days, i.e. every one of them actually contends

What that does and does not mean, stated precisely — an earlier draft of this section overstated
it and is corrected here:

- With a **single** FIFO-aware wrapper (today's state) the layer is a **no-op**:
  `older_ticket_waiting` yields only to *another* live older ticket, and old wrappers drop no
  ticket, so the queue holds only this wrapper's own entry and it races exactly as before. There
  is **no self-penalty** for being the polite one.
- The ordering property starts paying only once **two or more contending worktrees** carry it,
  and even then it orders *those* correctly while old-wrapper waiters can still lap all of them.

So merging this does not deliver fleet-wide fairness — it installs the mechanism. Tracked as a
PENDING-ARMS row rather than declared done at merge (W81: built is not armed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
