### PR TITLE
fix(prepush): allowlist .txt beside .md under docs/ and research/ (v9)

### DIFF
--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -132,6 +132,49 @@ gate this module exists to skip:
   the direct `echo ... | python3 scripts/prepush_classify.py` runs logged
   in the task #43 PR body.
 
+v9 EXTENSION (2026-08-11): `.txt` added to the two content trees that
+already admit `.md` — `docs/**` and `research/**` — plus a
+belt-and-suspenders basename net for the requirements family.
+
+  The trigger is a measured incident, not a hypothetical. PR #4002 carried
+  three files: one `research/**/*.md` and two verbatim refutation
+  transcripts under `research/operations/refutations/*.txt`. The two
+  `.txt` alone flipped the verdict to `full`, and that diff then queued
+  behind this machine's suite lock for **75 minutes and timed out with the
+  suite never starting — twice** — before landing on a third attempt 72
+  minutes in. None of the three files can be opened by
+  `pytest backend/tests/`. A transcript is prose; `.txt` is the RIGHT
+  format for it (renaming it `.md` to satisfy this classifier would both
+  game the gate and hand a verbatim record to Prettier — W112), so the
+  classifier is what had to change.
+
+  Innocence measured on disk in the branch worktree, not argued:
+    - 11 tracked `.txt` under `research/`, 25 under `docs/`. NONE is mode
+      100755 — the executable-outlier hazard that forced v2's extension
+      scoping (`research/` has 14 real `.py` files) does not recur for
+      this suffix.
+    - No test under `apps/backend-rag/backend/tests/` opens a `.txt`
+      living in either tree. Every `research/**` path appearing in that
+      suite is a `.md` string in a docstring or fixture; every `.txt`
+      reference is the requirements family at the APP root
+      (`apps/backend-rag/requirements*.txt`, read by
+      `test_lock_honors_requirements.py`), which is outside both prefixes
+      and therefore unreachable by a `docs`/`research` prefix rule.
+
+  WHY THE BASENAME NET SHIPS IN THE SAME CHANGE: the requirements family
+  is the one `.txt` class in this repo a backend test really does read,
+  and W98 is the scar proving it matters (Dependabot regenerated a lock
+  past the manifest's anti-malware `!=` pin and shipped it to prod). No
+  allowlist prefix can reach those files TODAY. The entry is not about
+  today — it is the same self-paranoia NEVER_INNOCENT_EXACT_PATHS applies
+  to `.husky/pre-push`: now that `.txt` is an admitted suffix anywhere, a
+  future prefix broadening must not be able to swallow a dependency
+  manifest. Pinned by
+  test_guilt_requirements_family_under_an_allowlisted_prefix_forces_full,
+  which asserts the HYPOTHETICAL (`docs/requirements.txt`) rather than
+  today's layout — a guilt test that only asserts the current tree stops
+  being a guilt test the moment the tree moves.
+
 CONTRACT
 --------
 Input:  a list of repo-relative file paths, one per line, via:
@@ -275,7 +318,13 @@ VERDICT_SKIP = "skip-backend"
 # valid Git paths such as `apps/wa-mirror/package.json/probe.json` and
 # `.gitignore/probe.gitignore`. Exact files now require string equality;
 # directory rules retain descendant + suffix semantics.
-ALLOWLIST_VERSION = 8
+# v9 (2026-08-11): `.txt` added to the existing `docs`/`research` directory
+# entries — the class that cost PR #4002 two 75-minute lock timeouts for two
+# verbatim refutation transcripts — and, in the same change, the requirements
+# family added to NEVER_INNOCENT_BASENAMES so the newly-admitted suffix cannot
+# later be broadened into a manifest a backend test actually reads (W98).
+# Measurement in the module-docstring "v9 EXTENSION" section above.
+ALLOWLIST_VERSION = 9
 
 # ---------------------------------------------------------------------------
 # NEVER_INNOCENT_EXACT_PATHS — checked FIRST, unconditionally, before any
@@ -310,6 +359,18 @@ NEVER_INNOCENT_BASENAMES: frozenset[str] = frozenset(
         "docker-compose.yml",
         "docker-compose.yaml",
         ".env.example",
+        # v9: the dependency manifests + their locks. `.txt` became an
+        # admitted suffix in v9 (docs/**, research/**); these four are the
+        # one `.txt` class a backend test really reads
+        # (test_lock_honors_requirements.py, the W98 tripwire), so they are
+        # nailed down directory-independently BEFORE any future prefix
+        # broadening can reach them. Redundant today — no allowlist prefix
+        # covers apps/backend-rag/ — and deliberately so: that is what
+        # "belt-and-suspenders" means in this block.
+        "requirements.txt",
+        "requirements.lock.txt",
+        "requirements-prod.txt",
+        "requirements-prod.lock.txt",
     }
 )
 
@@ -661,8 +722,12 @@ ALLOWLIST_EXACT_PATHS: frozenset[str] = frozenset(
 # that must match an exact-file rule or a directory prefix AND suffix to skip.
 # ---------------------------------------------------------------------------
 ALLOWLIST_PREFIX_SUFFIX_PAIRS: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("docs", (".md",)),
-    ("research", (".md",)),
+    # v9: `.txt` alongside `.md`. Measured innocent (11 research / 25 docs
+    # tracked `.txt`, none executable, none opened by backend/tests/) — see
+    # the module docstring's "v9 EXTENSION". The requirements family is
+    # nailed shut in NEVER_INNOCENT_BASENAMES, checked first.
+    ("docs", (".md", ".txt")),
+    ("research", (".md", ".txt")),
     (".claude/skills", (".md",)),
     (".claude/rules", (".md",)),
     (".claude/commands", (".md",)),

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -1687,3 +1687,150 @@ def test_allowlist_version_bumped_to_8_for_the_exact_path_fix() -> None:
     assert "apps/wa-mirror/package-lock.json" in pc.ALLOWLIST_EXACT_PATHS
     assert "apps/organism/organism/organs_registry.yaml" in pc.ALLOWLIST_EXACT_PATHS
     assert ".husky/pre-commit" in pc.NEVER_INNOCENT_EXACT_PATHS
+
+
+# ===========================================================================
+# v9 (2026-08-11) — `.txt` under docs/** and research/**, plus the
+# requirements-family basename net.
+#
+# The trigger was measured, not imagined: PR #4002's three files (one
+# research `.md`, two verbatim refutation transcripts `.txt`) forced `full`
+# and then lost TWO 75-minute lock waits to timeout before landing on a
+# third attempt. Innocence for the suffix was measured on disk — 11 tracked
+# `.txt` under research/, 25 under docs/, none mode-100755, and no test in
+# apps/backend-rag/backend/tests/ opens one.
+#
+# The guilt half is deliberately HYPOTHETICAL where it matters. No allowlist
+# prefix reaches apps/backend-rag/ today, so a guilt test written against
+# today's tree would pass with the basename net deleted. The one below puts
+# a requirements manifest INSIDE an allowlisted prefix — the exact shape a
+# future broadening would create — so it fails if the net is removed.
+# ===========================================================================
+
+
+def test_innocence_research_txt_transcript_skips() -> None:
+    """The literal file that started v9 — a verbatim refuter transcript."""
+    verdict, unknown = pc.classify(
+        ["research/operations/refutations/2026-08-10-mergeos-v2-codex-sol.txt"]
+    )
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_pr_4002_real_diff_skips() -> None:
+    """PR #4002's ACTUAL three-file diff, verbatim.
+
+    Under v8 this returned `full` and paid two 75-minute lock timeouts. The
+    regression this pins is the whole reason v9 exists — assert the real
+    file list, not a hand-made stand-in.
+    """
+    verdict, unknown = pc.classify(
+        [
+            "research/operations/2026-08-10-merge-os-v2-submission-system.md",
+            "research/operations/refutations/2026-08-10-mergeos-v2-agy-gemini.txt",
+            "research/operations/refutations/2026-08-10-mergeos-v2-codex-sol.txt",
+        ]
+    )
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_innocence_docs_txt_skips() -> None:
+    """SYMMETRY (W101-recidiva): docs/** and research/** are one class. A
+    fix that only covers the tree that bit us is half a fix."""
+    verdict, unknown = pc.classify(["docs/notes/scratch.txt"])
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_guilt_requirements_family_under_an_allowlisted_prefix_forces_full() -> None:
+    """THE load-bearing guilt test for v9.
+
+    Delete the requirements entries from NEVER_INNOCENT_BASENAMES and this
+    is the only BEHAVIOURAL test that goes red — measured, not asserted:
+    the mutation kills exactly this test plus
+    test_allowlist_version_bumped_to_9, and that one asserts the constant
+    rather than the behaviour. The paths are hypothetical ON PURPOSE — the
+    real manifests live at apps/backend-rag/, which no prefix reaches
+    today, so asserting the real tree would prove nothing about the net
+    (W98 is the scar that makes the net worth having).
+    """
+    for path in (
+        "docs/requirements.txt",
+        "research/requirements.txt",
+        "docs/requirements.lock.txt",
+        "research/requirements-prod.txt",
+        "docs/requirements-prod.lock.txt",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL, f"{path} must never read as innocent"
+        assert unknown == [path]
+
+
+def test_guilt_real_requirements_manifests_still_force_full() -> None:
+    """The manifests as they actually live today (read by the W98 tripwire
+    test_lock_honors_requirements.py) — unchanged by v9."""
+    for path in (
+        "apps/backend-rag/requirements.txt",
+        "apps/backend-rag/requirements.lock.txt",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL
+        assert unknown == [path]
+
+
+def test_guilt_txt_outside_docs_and_research_forces_full() -> None:
+    """v9 widened exactly two prefixes. `.txt` is not innocent by extension
+    anywhere else — least of all inside the tree whose tests get skipped."""
+    for path in (
+        "apps/backend-rag/backend/data/seed.txt",
+        "scripts/notes.txt",
+        "notes.txt",
+        ".claude/skills/modus/notes.txt",
+    ):
+        verdict, unknown = pc.classify([path])
+        assert verdict == pc.VERDICT_FULL, f"{path} must not be innocent"
+        assert unknown == [path]
+
+
+def test_guilt_research_txt_mixed_with_backend_forces_full() -> None:
+    """Composition: one innocent transcript does not launder a backend file."""
+    verdict, unknown = pc.classify(
+        [
+            "research/operations/refutations/2026-08-10-mergeos-v2-codex-sol.txt",
+            "apps/backend-rag/backend/services/rag/reasoning.py",
+        ]
+    )
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["apps/backend-rag/backend/services/rag/reasoning.py"]
+
+
+def test_guilt_traversal_out_of_research_with_txt_forces_full() -> None:
+    """HARDENING-2 still holds for the newly-admitted suffix."""
+    path = "research/../apps/backend-rag/backend/x.txt"
+    verdict, unknown = pc.classify([path])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [path]
+
+
+def test_allowlist_version_bumped_to_9_for_the_txt_entries() -> None:
+    """The skip-banner logs the version that approved a skip; a rules change
+    without a bump makes the log line unattributable."""
+    assert pc.ALLOWLIST_VERSION >= 9
+    assert ("docs", (".md", ".txt")) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+    assert ("research", (".md", ".txt")) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+    for name in (
+        "requirements.txt",
+        "requirements.lock.txt",
+        "requirements-prod.txt",
+        "requirements-prod.lock.txt",
+    ):
+        assert name in pc.NEVER_INNOCENT_BASENAMES
+
+
+def test_edge_v9_added_no_second_allowlist_mechanism() -> None:
+    """v9 widened existing entries and one basename set. It must not have
+    introduced a third matching path (the v1 bare-prefix mistake)."""
+    for _prefix, suffixes in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS:
+        assert suffixes, "no bare-prefix (suffix-less) entry may exist"
+        assert all(s.startswith(".") for s in suffixes)


### PR DESCRIPTION
## Why

The path-aware pre-push classifier lets a diff skip the ~13-minute backend suite only when
**every** changed file is on the innocent allowlist. `docs/` and `research/` were allowlisted for
`.md` but not for `.txt`, so a verbatim transcript or a captured tool output parked next to the
markdown it documents forced the full suite for no reason.

`.txt` is not an arbitrary widening — it is the **correct** format for verbatim material in this
repo. W112: Prettier rewrites literal tokens inside long prose paragraphs, so a transcript that
must survive byte-for-byte belongs in `.txt`, not `.md`. The allowlist was pushing against a rule
the repo already learned the hard way.

## Measured innocence, not assumed

Tracked `.txt` under the two prefixes: **11 in `research/`, 25 in `docs/`**. None executable, none
imported or opened by anything under `backend/` or `tests/`. Counted in the worktree at v8, not in
the main checkout — which is months behind and had me reading a phantom `v6` on the first pass.

## The dangerous name is nailed shut first

`requirements.txt` and its family are the obvious way this widening could go wrong: a dependency
change is the least innocent diff in the repo. Four names go into `NEVER_INNOCENT_BASENAMES`,
which is checked **before** the prefix/suffix allowlist:

- `requirements.txt`
- `requirements.lock.txt`
- `requirements-prod.txt`
- `requirements-prod.lock.txt`

Guilt case pins it: a hypothetical `docs/requirements.txt` — i.e. the family sitting *under an
allowlisted prefix* — still forces the full suite.

## Verification

`scripts/tests/test_prepush_classify.py`: **150 passed**. 9 new cases, including
`test_innocence_pr_4002_real_diff_skips`, which asserts against the actual three-file list of a
real merged PR rather than a hand-invented one.

`ALLOWLIST_VERSION` bumped 8 -> 9 so the skip banner stays attributable to the rules that produced
it.

Pre-push on this branch ran the **FULL** suite by design: `scripts/prepush_classify.py` is in
`NEVER_INNOCENT_EXACT_PATHS`, because a classifier must never authorise skipping the suite on its
own diff. It waited 72 minutes for the machine's suite lock (cap is 75) — see #4054.

🤖 Generated with [Claude Code](https://claude.com/claude-code)