### PR TITLE
fix(mouth): the search snippet announced "aiGenerated: true" before anyone clicked

### DIFF
--- a/apps/mouth/public/llms-id.txt
+++ b/apps/mouth/public/llms-id.txt
@@ -7,7 +7,7 @@
 TITLE: Mengapa Bali Terus Menarik Para Pemikir Paling Gelisah di Dunia
 CATEGORY: living
 URL: https://balizero.com/living/why-bali-keeps-drawing-the-worlds-most-restless-minds
-PUBLISHED: 2026-08-11T02:52:07.736Z
+PUBLISHED: 2026-08-11T05:20:29.189Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia: Langkah Demi Langkah
@@ -135,7 +135,7 @@ Kesenjangan antara daya tarik emosional Bali dan realitas administratifnya adala
 TITLE: Penutupan Gunung Agung Selama Sebulan: Apa yang Perlu Diketahui Wisatawan
 CATEGORY: visas
 URL: https://balizero.com/visas/mount-agung-closes-for-one-month-what-tourists-must-know
-PUBLISHED: 2026-08-11T02:52:07.250Z
+PUBLISHED: 2026-08-11T05:20:28.997Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Perusahaan Asing di Indonesia
@@ -260,7 +260,7 @@ Pelajaran yang lebih besar di sini adalah tentang kefasihan budaya. Bali memberi
 TITLE: Hak Sewa atau Hak Milik di Bali: Apa yang Harus Diketahui Pembeli Asing pada 2026
 CATEGORY: visas
 URL: https://balizero.com/visas/leasehold-or-freehold-in-bali-what-foreign-buyers-must-know-in-2026
-PUBLISHED: 2026-08-11T02:52:07.210Z
+PUBLISHED: 2026-08-11T05:20:28.985Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Indonesia untuk Investor Asing
@@ -395,7 +395,7 @@ Bagi klien dengan niat investasi jangka panjang yang serius, Hak Pakai – jika 
 TITLE: KITAS 2026: Roadmap Komprehensif untuk Izin Kerja dan Tinggal di Indonesia
 CATEGORY: visas
 URL: https://balizero.com/visas/kitas-2026-the-complete-indonesia-work-stay-permit-roadmap
-PUBLISHED: 2026-08-11T02:52:07.152Z
+PUBLISHED: 2026-08-11T05:20:28.945Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia
@@ -533,7 +533,7 @@ Bagi pengusaha dan profesional digital, Visa Rumah Kedua tetap menjadi jalur pal
 TITLE: Buronan Interpol Ditangkap di Bali: Bos Kejahatan Inggris Terungkap
 CATEGORY: visas
 URL: https://balizero.com/visas/interpol-wanted-british-crime-boss-arrested-in-bali
-PUBLISHED: 2026-08-11T02:52:07.115Z
+PUBLISHED: 2026-08-11T05:20:28.929Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi Asing di Indonesia
@@ -663,7 +663,7 @@ Kekhawatiran praktis bagi klien kami berbeda: ini menekankan betapa pentingnya d
 TITLE: KITAS Indonesia: Visa Lavoro – Cosa Devono Sapere i Lavoratori Stranieri nel 2026
 CATEGORY: visas
 URL: https://balizero.com/visas/indonesias-kitas-work-visa-what-foreign-workers-must-know-in-2026
-PUBLISHED: 2026-08-11T02:52:07.084Z
+PUBLISHED: 2026-08-11T05:20:28.912Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia
@@ -801,7 +801,7 @@ Dengan pemerintah Indonesia terus memperketat penegakan hukum di pusat-pusat eks
 TITLE: Visa Emas Indonesia: Apa Artinya Aturan Tahun 2026 Bagi Investor dengan Kekayaan Bersih Tinggi?
 CATEGORY: visas
 URL: https://balizero.com/visas/indonesias-golden-visa-what-the-2026-rules-mean-for-high-net-worth-investors
-PUBLISHED: 2026-08-11T02:52:07.080Z
+PUBLISHED: 2026-08-11T05:20:28.910Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia
@@ -942,7 +942,7 @@ Rekomendasi kami yang kuat adalah untuk memperlakukan Visa Emas sebagai latihan 
 TITLE: Visa Digital Nomade Indonesia: Cosa Devono Sapere i Lavoratori Remoti
 CATEGORY: visas
 URL: https://balizero.com/visas/indonesias-digital-nomad-visa-what-remote-workers-need-to-know
-PUBLISHED: 2026-08-11T02:52:07.061Z
+PUBLISHED: 2026-08-11T05:20:28.901Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia
@@ -1076,7 +1076,7 @@ Kami secara konsisten menyarankan untuk tidak berspekulasi atau "adu nasib" deng
 TITLE: Hari Kerja Jarak Jauh Wajib dalam Kerangka Kerja Mingguan Lima Hari yang Baru
 CATEGORY: visas
 URL: https://balizero.com/visas/indonesia-eyes-mandatory-wfh-day-in-new-five-day-week-framework
-PUBLISHED: 2026-08-11T02:52:06.971Z
+PUBLISHED: 2026-08-11T05:20:28.852Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Singapura untuk Warga Negara Italia
@@ -1202,7 +1202,7 @@ Bagi ekspatriat yang memegang KITAS berdasarkan pekerjaan yang disponsori, perke
 TITLE: Perpanjangan Batas Waktu Laporan Pajak Tahunan 2024
 CATEGORY: visas
 URL: https://balizero.com/visas/indonesia-extends-2024-annual-tax-return-deadline-to-april-30
-PUBLISHED: 2026-08-11T02:52:06.956Z
+PUBLISHED: 2026-08-11T05:20:28.848Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia
@@ -1332,7 +1332,7 @@ Salah satu hal penting yang perlu diperhatikan: perpanjangan ini tidak mengubah 
 TITLE: Indonesia Memperkuat Pengawasan Asing di Tengah Peningkatan WFA
 CATEGORY: visas
 URL: https://balizero.com/visas/indonesia-doubles-down-on-foreign-surveillance-amid-wfa-boom
-PUBLISHED: 2026-08-11T02:52:06.954Z
+PUBLISHED: 2026-08-11T05:20:28.847Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia: Langkah Demi Langkah
@@ -1485,7 +1485,7 @@ Posisi Bali Zero jelas: dapatkan visa yang tepat sebelum masalah menemui Anda. B
 TITLE: Warga Negara Jerman Dideportasi Setelah Melakukan Penelitian Tidak Sah di Taman Nasional Indonesia
 CATEGORY: visas
 URL: https://balizero.com/visas/germany-national-deported-after-unauthorized-research-in-indonesian-park
-PUBLISHED: 2026-08-11T02:52:06.840Z
+PUBLISHED: 2026-08-11T05:20:28.769Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Singapura untuk Warga Negara Italia
@@ -1611,7 +1611,7 @@ Bali Zero menyarankan semua klien yang terlibat dalam bentuk kerja lapangan, pen
 TITLE: Bali Mendapatkan Akses Langsung ke Avalon dan Sunshine Coast Seiring dengan Perluasan Rute Australia
 CATEGORY: visas
 URL: https://balizero.com/visas/bali-gets-direct-links-to-avalon-and-sunshine-coast-as-australia-routes-expand
-PUBLISHED: 2026-08-11T02:52:06.667Z
+PUBLISHED: 2026-08-11T05:20:28.660Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Perusahaan Asing di Indonesia
@@ -1748,7 +1748,7 @@ Bagi klien yang sudah ada yang merupakan warga negara Australia, konektivitas ya
 TITLE: Aturan AI Ditetapkan Gedung Putih: Apa Perubahan dari Kerangka Kerja yang Baru?
 CATEGORY: trends
 URL: https://balizero.com/trends/white-house-sets-rules-for-ai-what-the-new-framework-changes
-PUBLISHED: 2026-08-11T02:52:06.602Z
+PUBLISHED: 2026-08-11T05:20:28.640Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Memulai Bisnis di Indonesia untuk Investor Asing
@@ -1873,7 +1873,7 @@ Bagi ekspatriat dan pekerja jarak jauh di Bali yang menjalankan bisnis dengan kl
 TITLE: PT PMA di Bali: Il Veicolo Legale che gli Investitori nel Settore dell’Ospitalità Devono Conoscere
 CATEGORY: business
 URL: https://balizero.com/business/pt-pma-in-bali-the-legal-vehicle-hospitality-investors-must-understand
-PUBLISHED: 2026-08-11T02:52:06.483Z
+PUBLISHED: 2026-08-11T05:20:28.580Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Indonesia untuk Investor Asing
@@ -1990,144 +1990,10 @@ Kabar baiknya, sistem OSS telah mempercepat durasi pemrosesan aplikasi yang patu
 />
 
 ---
-TITLE: Dampak Perang Timur Tengah terhadap Ekonomi Global: Rupiah Melemah, Inflasi Menguat
-CATEGORY: business
-URL: https://balizero.com/business/middle-east-war-rattles-global-economy-rupiah-slips-inflation-climbs
-PUBLISHED: 2026-08-11T02:52:06.454Z
-
-### RINGKASAN AI ZANTARA
-# Panduan Investasi di Luar Negeri di Indonesia
-
-**Pendahuluan**
-
-Panduan ini menyediakan informasi penting bagi investor asing yang ingin berinvestasi di Indonesia. Kami akan membahas persyaratan utama, proses perizinan, dan pertimbangan penting lainnya untuk memastikan investasi Anda berhasil.
-
-**Struktur Investasi di Indonesia**
-
-Ada beberapa opsi struktur investasi yang tersedia bagi investor asing:
-
-*   **PT PMA (Perseroan Terbatas Penanaman Modal Asing):** Ini adalah entitas bisnis yang paling umum digunakan untuk investasi asing.  PT PMA memungkinkan investor asing untuk mengendalikan perusahaan sepenuhnya.
-*   **Cabang Perusahaan Asing:**  Opsi ini memungkinkan perusahaan asing untuk menjalankan operasi di Indonesia tanpa membentuk entitas hukum terpisah.
-*   **Koperasi:**  Investor asing dapat berinvestasi dalam koperasi di Indonesia.
-*   **Joint Venture:**  Bekerja sama dengan mitra lokal untuk membentuk usaha bersama.
-
-**Persyaratan Utama untuk Investasi**
-
-*   **KITAS (Kartu Izin Tinggal Terbatas):**  Investor asing memerlukan KITAS untuk tinggal dan bekerja di Indonesia.
-*   **KBLI (Klasifikasi Baku Lapangan Usaha Indonesia):**  Kode yang mengidentifikasi jenis usaha yang akan dijalankan.  Pastikan kode KBLI yang digunakan sesuai dengan investasi Anda.
-*   **OSS (Online Single Submission):**  Sistem online untuk mempermudah proses perizinan usaha.
-*   **Modal Minimum:**  Terdapat persyaratan modal minimum yang bervariasi tergantung pada jenis usaha dan sektor industri.
-*   **Izin Usaha:**  Memperoleh izin usaha yang sesuai dengan jenis usaha yang dijalankan.
-
-**Proses Perizinan**
-
-1.  **Pendaftaran PT PMA:** Melakukan pendaftaran PT PMA di Kementerian Hukum dan HAM.
-2.  **Pengajuan NIB (Nomor Induk Berusaha):**  Memperoleh NIB melalui sistem OSS.
-3.  **Pengajuan Izin Usaha:** Mengajukan izin usaha sesuai dengan jenis usaha yang dijalankan melalui sistem OSS.
-4.  **Pengajuan Izin Lokasi:**  Memperoleh izin lokasi dari pemerintah daerah setempat.
-5.  **Pengurusan KITAS:**  Mengurus KITAS bagi investor asing.
-
-**Pertimbangan Penting**
-
-*   **Peraturan Perundang-undangan:**  Memahami dan mematuhi peraturan perundang-undangan terkait investasi di Indonesia.
-*   **Pajak:**  Memahami kewajiban pajak yang berlaku bagi investor asing.
-*   **Budaya dan Bahasa:**  Memahami budaya dan bahasa Indonesia untuk memfasilitasi komunikasi dan hubungan bisnis.
-*   **Repatriasi Modal:**  Memahami peraturan terkait repatriasi modal.
-
-**Sumber Daya Tambahan**
-
-*   [Badan Koordinasi Penanaman Modal (BKPM)](https://www.bkpm.go.id/)
-*   [Kementerian Hukum dan HAM](https://www.kemenkumham.go.id/)
-*   [Sistem OSS](https://oss.go.id/)
-
-**Penutup**
-
-Investasi di Indonesia menawarkan potensi pertumbuhan yang signifikan. Dengan memahami persyaratan dan proses perizinan, Anda dapat meningkatkan peluang keberhasilan investasi Anda.
-
-KONTEN:
-## TL;DR
-
-<InfoCard
-  title="Ringkasan Eksekutif"
-  items={[
-    { label: "Perlukah Saya Khawatir?", value: "Tergantung posisi aset Anda" },
-    { label: "Tingkat Risiko", value: "Sedang" },
-    {
-      label: "Siapa yang Terdampak",
-      value: "Ekspatriat dan investor di Indonesia",
-    },
-    { label: "Kapan", value: "Cek artikel untuk rincian tanggal" },
-  ]}
-/>
-
-**Bank Indonesia (BI) telah merilis penilaian resmi yang mengaitkan eskalasi konflik di Timur Tengah dengan pelemahan terukur pada berbagai indikator makroekonomi utama Indonesia.**
-
----
-
-## Fakta Lapangan
-
-Bank Indonesia (BI) telah mengeluarkan penilaian formal yang menghubungkan intensifikasi konflik di Timur Tengah dengan penurunan terukur pada indikator makroekonomi utama Indonesia. Bank sentral mengidentifikasi perang tersebut sebagai faktor guncangan eksternal utama yang berkontribusi terhadap depresiasi Rupiah dan peningkatan inflasi domestik, mengikuti tren yang terlihat di berbagai negara pasar berkembang (_emerging markets_) di kawasan tersebut.
-
-Pelemahan nilai tukar Rupiah mencerminkan pelarian modal (_capital flight_) yang lebih luas dari aset berisiko di pasar berkembang, seiring upaya investor global mencari mata uang _safe-haven_—terutama Dolar AS, Yen Jepang, dan Franc Swiss. Ketika ketidakpastian geopolitik memuncak, mata uang pasar berkembang termasuk Rupiah biasanya menjadi yang pertama menyerap tekanan jual, karena investor institusional mengurangi eksposur mereka terhadap aset berisiko tinggi.
-
-Inflasi di Indonesia didorong melalui dua saluran utama. Pertama adalah saluran energi: konflik Timur Tengah mengancam rute pasokan minyak dan stabilitas produksi, sehingga memicu kenaikan harga minyak mentah global. Indonesia, meskipun merupakan produsen minyak, tetap menjadi importir bersih (_net importer_) produk bahan bakar olahan, yang berarti kenaikan harga minyak mentah dunia akan berdampak langsung pada biaya bahan bakar domestik. Saluran kedua adalah impor pangan dan komoditas, di mana premi asuransi pengiriman dan biaya logistik meningkat selama periode konflik regional, sehingga menambah beban biaya di seluruh rantai pasok.
-
-Bank Indonesia telah memberi sinyal bahwa pihaknya memantau stabilitas mata uang dan harga secara ketat. Alat kebijakan moneter yang ada—termasuk penyesuaian suku bunga acuan dan intervensi nilai tukar—telah disiapkan untuk mempertahankan stabilitas Rupiah. Cadangan devisa Indonesia, yang tetap berada pada tingkat yang aman dalam beberapa kuartal terakhir, memberikan bantalan yang cukup untuk intervensi tersebut.
-
-Latar belakang ekonomi global turut memperburuk tekanan ini. Bank sentral utama, khususnya Federal Reserve AS, mempertahankan sikap moneter yang relatif _hawkish_ untuk meredam inflasi mereka sendiri. Hal ini menjaga imbal hasil aset berdenominasi Dolar tetap menarik dan memicu arus modal keluar dari pasar obligasi serta ekuitas di pasar berkembang. Oleh karena itu, Indonesia harus mengelola guncangan langsung dari konflik Timur Tengah sekaligus tekanan tidak langsung dari penguatan Dolar AS secara bersamaan.
-
----
-
-## Bali Zero Take
-
-### Wawasan Strategis
-
-Bagi klien kami—baik yang sedang mendirikan PT PMA, mengelola aset properti, menjalankan bisnis, atau tinggal di Bali dengan pendapatan asing—kombinasi pelemahan Rupiah dan kenaikan inflasi adalah tantangan ganda yang membutuhkan perhatian segera, tanpa harus menunggu situasi menjadi stabil.
-
-### Analisis Kami
-
-Di sisi peluang, pelemahan Rupiah berarti pendapatan dalam mata uang asing—seperti Dolar, Euro, atau Dolar Australia—memiliki daya beli yang jauh lebih besar di Indonesia. Ekspatriat yang menerima gaji dalam valuta asing secara efektif mengalami peningkatan daya beli untuk pengeluaran lokal. Ini merupakan momentum yang tepat bagi mereka yang mempertimbangkan pembelian properti, investasi bisnis, atau komitmen jangka panjang lainnya yang menggunakan denominasi Rupiah.
-
-### Saran Kami
-
-Di sisi risiko, bisnis yang mengimpor barang atau memiliki biaya operasional dalam Dolar—seperti biaya perizinan, perangkat lunak internasional, peralatan impor, hingga remunerasi staf asing—akan menghadapi penyusutan margin. Setiap rencana bisnis yang disusun berdasarkan nilai tukar stabil dari enam hingga dua belas bulan lalu harus dievaluasi ulang terhadap depresiasi saat ini dan potensi pelemahan lebih lanjut. Perusahaan yang memegang saldo kas Rupiah dalam jumlah signifikan harus meninjau kembali strategi manajemen kas mereka dengan penasihat keuangan berlisensi.
-
----
-
-## Langkah Selanjutnya
-
-<Checklist
-  title="Tindakan yang Harus Diambil"
-  items={[
-    {
-      text: "Untuk Ekspatriat",
-      subItems: [
-        "Tinjau pengeluaran bulanan dan manfaatkan daya beli valas untuk investasi aset tetap di Indonesia.",
-      ],
-    },
-    {
-      text: "Untuk Investor",
-      subItems: [
-        "Segera tinjau eksposur mata uang asing Anda: jika Anda menyimpan tabungan Rupiah dalam jumlah besar untuk kebutuhan valas di masa depan, pertimbangkan langkah konversi parsial atau lindung nilai (*hedging*) sesuai dengan jangka waktu investasi Anda. Konsultasikan dengan penasihat keuangan berlisensi sebelum melakukan transaksi valas besar.",
-        "Jika berencana melakukan investasi signifikan—seperti properti, pendirian PT PMA, atau injeksi modal—buatlah pemodelan skenario menggunakan berbagai tingkat nilai tukar. Fluktuasi Rupiah sebesar 5–10% sangat mungkin terjadi dalam skenario konflik yang berkepanjangan.",
-        "Pelaku bisnis harus mengaudit struktur biaya terkait impor dan memodelkan dampak Laporan Laba Rugi jika terjadi depresiasi lebih lanjut sebesar 10%. Segera mulai negosiasi dengan pemasok terkait penyesuaian harga. Pantau terus pernyataan resmi Bank Indonesia mengenai suku bunga sebagai indikator utama arah pergerakan Rupiah.",
-      ],
-    },
-  ]}
-/>
-
----
-
-<AskZantara
-  question="Punya pertanyaan tentang topik ini?"
-  placeholder="Tanyakan kepada Zantara AI untuk saran yang dipersonalisasi..."
-/>
-
----
 TITLE: Lanskap Regulasi Indonesia Mendapatkan Penilaian Tolak Ukur Global – Legal500 2026
 CATEGORY: business
 URL: https://balizero.com/business/legal-500-2026-indonesias-regulatory-landscape-gets-global-benchmark-review
-PUBLISHED: 2026-08-11T02:52:06.452Z
+PUBLISHED: 2026-08-11T05:20:28.567Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia
@@ -2275,10 +2141,144 @@ Bagi klien yang mempertimbangkan struktur PT PMA, kepemilikan properti, atau per
 />
 
 ---
+TITLE: Dampak Perang Timur Tengah terhadap Ekonomi Global: Rupiah Melemah, Inflasi Menguat
+CATEGORY: business
+URL: https://balizero.com/business/middle-east-war-rattles-global-economy-rupiah-slips-inflation-climbs
+PUBLISHED: 2026-08-11T05:20:28.567Z
+
+### RINGKASAN AI ZANTARA
+# Panduan Investasi di Luar Negeri di Indonesia
+
+**Pendahuluan**
+
+Panduan ini menyediakan informasi penting bagi investor asing yang ingin berinvestasi di Indonesia. Kami akan membahas persyaratan utama, proses perizinan, dan pertimbangan penting lainnya untuk memastikan investasi Anda berhasil.
+
+**Struktur Investasi di Indonesia**
+
+Ada beberapa opsi struktur investasi yang tersedia bagi investor asing:
+
+*   **PT PMA (Perseroan Terbatas Penanaman Modal Asing):** Ini adalah entitas bisnis yang paling umum digunakan untuk investasi asing.  PT PMA memungkinkan investor asing untuk mengendalikan perusahaan sepenuhnya.
+*   **Cabang Perusahaan Asing:**  Opsi ini memungkinkan perusahaan asing untuk menjalankan operasi di Indonesia tanpa membentuk entitas hukum terpisah.
+*   **Koperasi:**  Investor asing dapat berinvestasi dalam koperasi di Indonesia.
+*   **Joint Venture:**  Bekerja sama dengan mitra lokal untuk membentuk usaha bersama.
+
+**Persyaratan Utama untuk Investasi**
+
+*   **KITAS (Kartu Izin Tinggal Terbatas):**  Investor asing memerlukan KITAS untuk tinggal dan bekerja di Indonesia.
+*   **KBLI (Klasifikasi Baku Lapangan Usaha Indonesia):**  Kode yang mengidentifikasi jenis usaha yang akan dijalankan.  Pastikan kode KBLI yang digunakan sesuai dengan investasi Anda.
+*   **OSS (Online Single Submission):**  Sistem online untuk mempermudah proses perizinan usaha.
+*   **Modal Minimum:**  Terdapat persyaratan modal minimum yang bervariasi tergantung pada jenis usaha dan sektor industri.
+*   **Izin Usaha:**  Memperoleh izin usaha yang sesuai dengan jenis usaha yang dijalankan.
+
+**Proses Perizinan**
+
+1.  **Pendaftaran PT PMA:** Melakukan pendaftaran PT PMA di Kementerian Hukum dan HAM.
+2.  **Pengajuan NIB (Nomor Induk Berusaha):**  Memperoleh NIB melalui sistem OSS.
+3.  **Pengajuan Izin Usaha:** Mengajukan izin usaha sesuai dengan jenis usaha yang dijalankan melalui sistem OSS.
+4.  **Pengajuan Izin Lokasi:**  Memperoleh izin lokasi dari pemerintah daerah setempat.
+5.  **Pengurusan KITAS:**  Mengurus KITAS bagi investor asing.
+
+**Pertimbangan Penting**
+
+*   **Peraturan Perundang-undangan:**  Memahami dan mematuhi peraturan perundang-undangan terkait investasi di Indonesia.
+*   **Pajak:**  Memahami kewajiban pajak yang berlaku bagi investor asing.
+*   **Budaya dan Bahasa:**  Memahami budaya dan bahasa Indonesia untuk memfasilitasi komunikasi dan hubungan bisnis.
+*   **Repatriasi Modal:**  Memahami peraturan terkait repatriasi modal.
+
+**Sumber Daya Tambahan**
+
+*   [Badan Koordinasi Penanaman Modal (BKPM)](https://www.bkpm.go.id/)
+*   [Kementerian Hukum dan HAM](https://www.kemenkumham.go.id/)
+*   [Sistem OSS](https://oss.go.id/)
+
+**Penutup**
+
+Investasi di Indonesia menawarkan potensi pertumbuhan yang signifikan. Dengan memahami persyaratan dan proses perizinan, Anda dapat meningkatkan peluang keberhasilan investasi Anda.
+
+KONTEN:
+## TL;DR
+
+<InfoCard
+  title="Ringkasan Eksekutif"
+  items={[
+    { label: "Perlukah Saya Khawatir?", value: "Tergantung posisi aset Anda" },
+    { label: "Tingkat Risiko", value: "Sedang" },
+    {
+      label: "Siapa yang Terdampak",
+      value: "Ekspatriat dan investor di Indonesia",
+    },
+    { label: "Kapan", value: "Cek artikel untuk rincian tanggal" },
+  ]}
+/>
+
+**Bank Indonesia (BI) telah merilis penilaian resmi yang mengaitkan eskalasi konflik di Timur Tengah dengan pelemahan terukur pada berbagai indikator makroekonomi utama Indonesia.**
+
+---
+
+## Fakta Lapangan
+
+Bank Indonesia (BI) telah mengeluarkan penilaian formal yang menghubungkan intensifikasi konflik di Timur Tengah dengan penurunan terukur pada indikator makroekonomi utama Indonesia. Bank sentral mengidentifikasi perang tersebut sebagai faktor guncangan eksternal utama yang berkontribusi terhadap depresiasi Rupiah dan peningkatan inflasi domestik, mengikuti tren yang terlihat di berbagai negara pasar berkembang (_emerging markets_) di kawasan tersebut.
+
+Pelemahan nilai tukar Rupiah mencerminkan pelarian modal (_capital flight_) yang lebih luas dari aset berisiko di pasar berkembang, seiring upaya investor global mencari mata uang _safe-haven_—terutama Dolar AS, Yen Jepang, dan Franc Swiss. Ketika ketidakpastian geopolitik memuncak, mata uang pasar berkembang termasuk Rupiah biasanya menjadi yang pertama menyerap tekanan jual, karena investor institusional mengurangi eksposur mereka terhadap aset berisiko tinggi.
+
+Inflasi di Indonesia didorong melalui dua saluran utama. Pertama adalah saluran energi: konflik Timur Tengah mengancam rute pasokan minyak dan stabilitas produksi, sehingga memicu kenaikan harga minyak mentah global. Indonesia, meskipun merupakan produsen minyak, tetap menjadi importir bersih (_net importer_) produk bahan bakar olahan, yang berarti kenaikan harga minyak mentah dunia akan berdampak langsung pada biaya bahan bakar domestik. Saluran kedua adalah impor pangan dan komoditas, di mana premi asuransi pengiriman dan biaya logistik meningkat selama periode konflik regional, sehingga menambah beban biaya di seluruh rantai pasok.
+
+Bank Indonesia telah memberi sinyal bahwa pihaknya memantau stabilitas mata uang dan harga secara ketat. Alat kebijakan moneter yang ada—termasuk penyesuaian suku bunga acuan dan intervensi nilai tukar—telah disiapkan untuk mempertahankan stabilitas Rupiah. Cadangan devisa Indonesia, yang tetap berada pada tingkat yang aman dalam beberapa kuartal terakhir, memberikan bantalan yang cukup untuk intervensi tersebut.
+
+Latar belakang ekonomi global turut memperburuk tekanan ini. Bank sentral utama, khususnya Federal Reserve AS, mempertahankan sikap moneter yang relatif _hawkish_ untuk meredam inflasi mereka sendiri. Hal ini menjaga imbal hasil aset berdenominasi Dolar tetap menarik dan memicu arus modal keluar dari pasar obligasi serta ekuitas di pasar berkembang. Oleh karena itu, Indonesia harus mengelola guncangan langsung dari konflik Timur Tengah sekaligus tekanan tidak langsung dari penguatan Dolar AS secara bersamaan.
+
+---
+
+## Bali Zero Take
+
+### Wawasan Strategis
+
+Bagi klien kami—baik yang sedang mendirikan PT PMA, mengelola aset properti, menjalankan bisnis, atau tinggal di Bali dengan pendapatan asing—kombinasi pelemahan Rupiah dan kenaikan inflasi adalah tantangan ganda yang membutuhkan perhatian segera, tanpa harus menunggu situasi menjadi stabil.
+
+### Analisis Kami
+
+Di sisi peluang, pelemahan Rupiah berarti pendapatan dalam mata uang asing—seperti Dolar, Euro, atau Dolar Australia—memiliki daya beli yang jauh lebih besar di Indonesia. Ekspatriat yang menerima gaji dalam valuta asing secara efektif mengalami peningkatan daya beli untuk pengeluaran lokal. Ini merupakan momentum yang tepat bagi mereka yang mempertimbangkan pembelian properti, investasi bisnis, atau komitmen jangka panjang lainnya yang menggunakan denominasi Rupiah.
+
+### Saran Kami
+
+Di sisi risiko, bisnis yang mengimpor barang atau memiliki biaya operasional dalam Dolar—seperti biaya perizinan, perangkat lunak internasional, peralatan impor, hingga remunerasi staf asing—akan menghadapi penyusutan margin. Setiap rencana bisnis yang disusun berdasarkan nilai tukar stabil dari enam hingga dua belas bulan lalu harus dievaluasi ulang terhadap depresiasi saat ini dan potensi pelemahan lebih lanjut. Perusahaan yang memegang saldo kas Rupiah dalam jumlah signifikan harus meninjau kembali strategi manajemen kas mereka dengan penasihat keuangan berlisensi.
+
+---
+
+## Langkah Selanjutnya
+
+<Checklist
+  title="Tindakan yang Harus Diambil"
+  items={[
+    {
+      text: "Untuk Ekspatriat",
+      subItems: [
+        "Tinjau pengeluaran bulanan dan manfaatkan daya beli valas untuk investasi aset tetap di Indonesia.",
+      ],
+    },
+    {
+      text: "Untuk Investor",
+      subItems: [
+        "Segera tinjau eksposur mata uang asing Anda: jika Anda menyimpan tabungan Rupiah dalam jumlah besar untuk kebutuhan valas di masa depan, pertimbangkan langkah konversi parsial atau lindung nilai (*hedging*) sesuai dengan jangka waktu investasi Anda. Konsultasikan dengan penasihat keuangan berlisensi sebelum melakukan transaksi valas besar.",
+        "Jika berencana melakukan investasi signifikan—seperti properti, pendirian PT PMA, atau injeksi modal—buatlah pemodelan skenario menggunakan berbagai tingkat nilai tukar. Fluktuasi Rupiah sebesar 5–10% sangat mungkin terjadi dalam skenario konflik yang berkepanjangan.",
+        "Pelaku bisnis harus mengaudit struktur biaya terkait impor dan memodelkan dampak Laporan Laba Rugi jika terjadi depresiasi lebih lanjut sebesar 10%. Segera mulai negosiasi dengan pemasok terkait penyesuaian harga. Pantau terus pernyataan resmi Bank Indonesia mengenai suku bunga sebagai indikator utama arah pergerakan Rupiah.",
+      ],
+    },
+  ]}
+/>
+
+---
+
+<AskZantara
+  question="Punya pertanyaan tentang topik ini?"
+  placeholder="Tanyakan kepada Zantara AI untuk saran yang dipersonalisasi..."
+/>
+
+---
 TITLE: Janji Bank Indonesia untuk Pertahanan Rupiah Selama Nyepi dan Lebaran 2026
 CATEGORY: business
 URL: https://balizero.com/business/bank-indonesia-pledges-rupiah-defense-during-nyepi-and-lebaran-2026
-PUBLISHED: 2026-08-11T02:52:06.382Z
+PUBLISHED: 2026-08-11T05:20:28.538Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Pendirian PT PMA di Indonesia
@@ -2363,7 +2363,7 @@ Rangkaian instrumen intervensi Bank Indonesia mencakup pengerahan cadangan devis
 TITLE: Bank Indonesia Mengonfirmasi Tidak Ada Batasan Pembelian USD di Atas 50.000 Dolar Bulanan
 CATEGORY: business
 URL: https://balizero.com/business/bank-indonesia-confirms-no-cap-on-usd-purchases-above-50k-monthly
-PUBLISHED: 2026-08-11T02:52:06.380Z
+PUBLISHED: 2026-08-11T05:20:28.537Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Indonesia: Persyaratan Hukum dan Regulasi
@@ -2498,7 +2498,7 @@ Kami menyarankan Anda untuk meninjau kembali strategi perbendaharaan (_treasury_
 TITLE: Kasus Pidana Kuat: Investor Asing Jadi Korban Penipuan Properti di Pererenan
 CATEGORY: business
 URL: https://balizero.com/business/foreign-investor-defrauded-in-pererenan-property-scam-criminal-case-strong
-PUBLISHED: 2026-08-11T02:52:05.661Z
+PUBLISHED: 2026-08-11T05:20:28.262Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Indonesia untuk Warga Negara Italia
@@ -2621,7 +2621,7 @@ Pelajaran yang didapat adalah struktural: setiap transaksi properti di Bali haru
 TITLE: Ipermisi Bisnis Pariwisata di Bali: Apa yang Anda Butuhkan untuk Memulai Secara Legal
 CATEGORY: business
 URL: https://balizero.com/business/bali-tourism-business-license-what-you-need-to-start-legally
-PUBLISHED: 2026-08-11T02:52:05.559Z
+PUBLISHED: 2026-08-11T05:20:28.185Z
 
 ### RINGKASAN AI ZANTARA
 # Panduan Investasi di Luar Negeri di Indonesia
@@ -3448,7 +3448,7 @@ URL: https://balizero.com/business/bali-villa-investment-why-location-is-only-th
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe
+Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe
 
 KONTEN:
 ## TL;DR
@@ -3533,7 +3533,7 @@ URL: https://balizero.com/business/buying-a-bali-villa-in-2026-the-legal-structu
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,
+Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,
 
 KONTEN:
 ## TL;DR
@@ -3612,7 +3612,7 @@ URL: https://balizero.com/business/indonesias-july-15-lkpm-deadline-four-days-le
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April
+Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April
 
 KONTEN:
 ## TL;DR
@@ -3699,7 +3699,7 @@ URL: https://balizero.com/business/indonesias-land-title-maze-what-foreign-inves
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021.
+Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021.
 
 KONTEN:
 ## TL;DR
@@ -3776,7 +3776,7 @@ URL: https://balizero.com/business/the-nominee-trap-how-10000-bali-investors-pai
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy
+For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy
 
 KONTEN:
 ## TL;DR
@@ -3857,7 +3857,7 @@ URL: https://balizero.com/business/indonesia-extends-lkpm-quarterly-deadline-to-
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th
+Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th
 
 KONTEN:
 ## TL;DR
@@ -3930,7 +3930,7 @@ URL: https://balizero.com/business/indonesias-nib-the-one-business-id-every-inve
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus
+Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus
 
 KONTEN:
 ## TL;DR
@@ -4007,7 +4007,7 @@ URL: https://balizero.com/business/indonesias-tourism-ministry-mandates-kbli-202
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s
+Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s
 
 KONTEN:
 ## TL;DR
@@ -4084,7 +4084,7 @@ URL: https://balizero.com/business/pt-pma-compliance-in-indonesia-what-foreign-i
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l
+A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l
 
 KONTEN:
 ## TL;DR
@@ -4157,7 +4157,7 @@ URL: https://balizero.com/visas/bali-immigration-brings-permit-services-to-disco
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director
+Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director
 
 KONTEN:
 ## TL;DR
@@ -4230,7 +4230,7 @@ URL: https://balizero.com/visas/balis-visa-crackdown-reaches-digital-nomads-as-a
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused
+Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused
 
 KONTEN:
 ## TL;DR
@@ -4307,7 +4307,7 @@ URL: https://balizero.com/visas/indonesia-bets-golden-visa-on-labuan-bajo-touris
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa
+Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa
 
 KONTEN:
 ## TL;DR
@@ -4384,7 +4384,7 @@ URL: https://balizero.com/visas/indonesia-family-kitas-2026-what-spouses-and-dep
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti
+Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti
 
 KONTEN:
 ## TL;DR
@@ -4453,7 +4453,7 @@ URL: https://balizero.com/visas/indonesia-golden-visa-2025-no-sponsor-no-merp-us
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to
+Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to
 
 KONTEN:
 ## TL;DR
@@ -4528,7 +4528,7 @@ URL: https://balizero.com/visas/indonesia-plans-zero-tax-financial-zone-with-gol
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to
+Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to
 
 KONTEN:
 ## TL;DR
@@ -4607,7 +4607,7 @@ URL: https://balizero.com/visas/indonesia-rewrites-the-rules-for-us-expats-eyein
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new
+Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new
 
 KONTEN:
 ## TL;DR
@@ -4686,7 +4686,7 @@ URL: https://balizero.com/visas/indonesia-tightens-grip-on-influencers-working-o
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a
+Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a
 
 KONTEN:
 ## TL;DR
@@ -4763,7 +4763,7 @@ URL: https://balizero.com/visas/indonesia-visa-revenue-breaks-rp28-trillion-desp
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d
+Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d
 
 KONTEN:
 ## TL;DR
@@ -4832,7 +4832,7 @@ URL: https://balizero.com/visas/vietnam-tightens-visa-free-entry-for-indonesians
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m
+Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m
 
 KONTEN:
 ## TL;DR
@@ -4909,7 +4909,7 @@ URL: https://balizero.com/living/bali-for-women-what-the-bliss-blogs-dont-tell-y
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,
+Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,
 
 KONTEN:
 ## TL;DR
@@ -4984,7 +4984,7 @@ URL: https://balizero.com/taxes/bali-cracks-down-social-media-work-on-tourist-vi
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work'
+Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work
 
 KONTEN:
 ## TL;DR
@@ -5055,7 +5055,7 @@ URL: https://balizero.com/taxes/bali-long-term-rentals-the-tax-traps-landlords-a
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive
+Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive
 
 KONTEN:
 ## TL;DR
@@ -5132,7 +5132,7 @@ URL: https://balizero.com/taxes/etsy-flips-the-switch-new-seller-rules-take-effe
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem
+Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem
 
 KONTEN:
 ## TL;DR
@@ -5207,7 +5207,7 @@ URL: https://balizero.com/taxes/indonesia-formalizes-marketplace-tax-collection-
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho
+Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho
 
 KONTEN:
 ## TL;DR
@@ -5276,7 +5276,7 @@ URL: https://balizero.com/taxes/indonesia-tightens-tax-net-around-e-marketplace-
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close
+Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close
 
 KONTEN:
 ## TL;DR
@@ -5349,7 +5349,7 @@ URL: https://balizero.com/taxes/indonesias-financial-center-bill-proposes-vat-an
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is
+Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is
 
 KONTEN:
 ## TL;DR
@@ -5426,7 +5426,7 @@ URL: https://balizero.com/taxes/indonesias-tax-holiday-trap-gmt-threatens-to-hol
 PUBLISHED: 2026-07-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob
+Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob
 
 KONTEN:
 ## TL;DR
@@ -5503,7 +5503,7 @@ URL: https://balizero.com/business/thailand-vs-bali-the-hidden-cost-of-picking-t
 PUBLISHED: 2026-06-29
 
 ### RINGKASAN AI ZANTARA
-## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p
+Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p
 
 KONTEN:
 ## TL;DR
@@ -5588,7 +5588,7 @@ URL: https://balizero.com/business/bali-market-entry-2026-the-regulatory-maze-fo
 PUBLISHED: 2026-06-29
 
 ### RINGKASAN AI ZANTARA
-## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per
+Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per
 
 KONTEN:
 ## TL;DR
@@ -5665,7 +5665,7 @@ URL: https://balizero.com/taxes/indonesia-makes-nib-mandatory-for-content-creato
 PUBLISHED: 2026-06-29
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num
+Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num
 
 KONTEN:
 ## TL;DR
@@ -5742,7 +5742,7 @@ URL: https://balizero.com/taxes/indonesias-free-meals-program-may-be-costing-the
 PUBLISHED: 2026-06-26
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta
+Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta
 
 KONTEN:
 ## TL;DR
@@ -5819,7 +5819,7 @@ URL: https://balizero.com/business/phuket-vs-bali-the-property-investment-battle
 PUBLISHED: 2026-06-25
 
 ### RINGKASAN AI ZANTARA
-## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest
+The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest
 
 KONTEN:
 ## TL;DR
@@ -5904,7 +5904,7 @@ URL: https://balizero.com/visas/canggus-breakfast-economy-what-the-caf-boom-tell
 PUBLISHED: 2026-06-25
 
 ### RINGKASAN AI ZANTARA
-## Facts  Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital
+Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital
 
 KONTEN:
 ## TL;DR
@@ -5981,7 +5981,7 @@ URL: https://balizero.com/visas/foreign-nationals-busted-in-surabaya-love-scam-s
 PUBLISHED: 2026-06-25
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd
+Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd
 
 KONTEN:
 ## TL;DR
@@ -6058,7 +6058,7 @@ URL: https://balizero.com/visas/indonesia-automates-border-checks-nationwide-wha
 PUBLISHED: 2026-06-25
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh
+Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh
 
 KONTEN:
 ## TL;DR
@@ -6133,7 +6133,7 @@ URL: https://balizero.com/visas/indonesia-deports-three-chinese-nationals-for-vi
 PUBLISHED: 2026-06-25
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions
+Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions
 
 KONTEN:
 ## TL;DR
@@ -6210,7 +6210,7 @@ URL: https://balizero.com/visas/seouls-dessert-wave-reaches-indonesias-expat-pal
 PUBLISHED: 2026-06-25
 
 ### RINGKASAN AI ZANTARA
-## Facts  Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa
+Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa
 
 KONTEN:
 ## TL;DR
@@ -6285,7 +6285,7 @@ URL: https://balizero.com/taxes/indonesias-15-global-minimum-tax-the-end-of-the-
 PUBLISHED: 2026-06-25
 
 ### RINGKASAN AI ZANTARA
-## Facts  The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi
+The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi
 
 KONTEN:
 ## TL;DR
@@ -7258,7 +7258,7 @@ URL: https://balizero.com/visas/e31a-spouse-visa-married-expats-can-work-in-indo
 PUBLISHED: 2026-06-22
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina
+The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina
 
 KONTEN:
 ## TL;DR
@@ -7331,7 +7331,7 @@ URL: https://balizero.com/visas/indonesia-deports-25-foreigners-caught-doing-ill
 PUBLISHED: 2026-06-22
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc
+Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc
 
 KONTEN:
 ## TL;DR
@@ -7408,7 +7408,7 @@ URL: https://balizero.com/visas/foreign-dj-and-dancers-arrested-in-indonesia-for
 PUBLISHED: 2026-06-18
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t
+Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t
 
 KONTEN:
 ## TL;DR
@@ -7485,7 +7485,7 @@ URL: https://balizero.com/taxes/bali-cracks-down-on-influencer-barter-deals-work
 PUBLISHED: 2026-06-18
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h
+Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h
 
 KONTEN:
 ## TL;DR
@@ -8041,7 +8041,7 @@ URL: https://balizero.com/business/bank-indonesia-bali-stays-a-top-investment-de
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue
+Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue
 
 KONTEN:
 ## TL;DR
@@ -8125,7 +8125,7 @@ URL: https://balizero.com/visas/divorce-in-indonesia-what-happens-to-your-spouse
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r
+Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r
 
 KONTEN:
 ## TL;DR
@@ -8198,7 +8198,7 @@ URL: https://balizero.com/visas/from-c12-to-e28a-indonesias-investor-kitas-pathw
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025.  The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08
+Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025. The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08
 
 KONTEN:
 ## TL;DR
@@ -8277,7 +8277,7 @@ URL: https://balizero.com/visas/icann-brings-global-internet-forum-to-bali-bypas
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo
+The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo
 
 KONTEN:
 ## TL;DR
@@ -8354,7 +8354,7 @@ URL: https://balizero.com/visas/indonesia-axes-fast-track-residency-permits-mini
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove
+Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove
 
 KONTEN:
 ## TL;DR
@@ -8431,7 +8431,7 @@ URL: https://balizero.com/visas/indonesia-updates-e30a-student-visa-rules-for-ex
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n
+Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n
 
 KONTEN:
 ## TL;DR
@@ -8508,7 +8508,7 @@ URL: https://balizero.com/taxes/indonesia-tax-authority-settles-cv-debate-22-cor
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H
+Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H
 
 KONTEN:
 ## TL;DR
@@ -8585,7 +8585,7 @@ URL: https://balizero.com/taxes/indonesias-tax-directorate-reveals-5-rules-that-
 PUBLISHED: 2026-06-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final
+Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final
 
 KONTEN:
 ## TL;DR
@@ -8662,7 +8662,7 @@ URL: https://balizero.com/visas/indonesia-eyes-visa-free-access-for-aussie-and-k
 PUBLISHED: 2026-06-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co
+Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co
 
 KONTEN:
 ## TL;DR
@@ -8745,7 +8745,7 @@ URL: https://balizero.com/business/ojk-puts-8-online-lenders-on-watchlist-licens
 PUBLISHED: 2026-06-09
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor
+Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor
 
 KONTEN:
 ## TL;DR
@@ -8820,7 +8820,7 @@ URL: https://balizero.com/visas/indonesia-scraps-fast-track-residency-permits-fo
 PUBLISHED: 2026-06-09
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the
+Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the
 
 KONTEN:
 ## TL;DR
@@ -8960,7 +8960,7 @@ URL: https://balizero.com/business/indonesia-tightens-pma-rules-what-foreign-inv
 PUBLISHED: 2026-05-22
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP
+Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP
 
 KONTEN:
 ## TL;DR
@@ -9050,7 +9050,7 @@ URL: https://balizero.com/visas/bali-property-market-2025-what-the-numbers-actua
 PUBLISHED: 2026-05-22
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the
+The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the
 
 KONTEN:
 ## TL;DR
@@ -9123,7 +9123,7 @@ URL: https://balizero.com/visas/indonesia-eyes-bali-tax-havenbut-skeptics-say-po
 PUBLISHED: 2026-05-22
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r
+Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r
 
 KONTEN:
 ## TL;DR
@@ -9196,7 +9196,7 @@ URL: https://balizero.com/visas/immigration-cracks-down-15-sponsors-behind-320-v
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta
+Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta
 
 KONTEN:
 ## TL;DR
@@ -9284,7 +9284,7 @@ URL: https://balizero.com/visas/indonesias-finance-ministry-debunks-viral-claim-
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t
+A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t
 
 KONTEN:
 ## Ringkasan Singkat
@@ -9372,7 +9372,7 @@ URL: https://balizero.com/visas/indonesias-retirement-kitap-the-permanent-stay-o
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency
+Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency
 
 KONTEN:
 ## TL;DR
@@ -9460,7 +9460,7 @@ URL: https://balizero.com/visas/inside-komodos-last-village-life-on-the-edge-of-
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i
+Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i
 
 KONTEN:
 ## TL;DR
@@ -9544,7 +9544,7 @@ URL: https://balizero.com/visas/jakartas-aparthotel-market-signals-demand-for-fl
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand
+Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand
 
 KONTEN:
 ## TL;DR
@@ -9628,7 +9628,7 @@ URL: https://balizero.com/visas/ngurah-rai-immigration-office-cracks-down-on-uno
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici
+The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici
 
 KONTEN:
 ## TL;DR
@@ -9712,7 +9712,7 @@ URL: https://balizero.com/visas/sono-hotels-signs-bali-canggu-property-betting-o
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave
+SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave
 
 KONTEN:
 ## Ringkasan Singkat
@@ -9798,7 +9798,7 @@ URL: https://balizero.com/taxes/indonesias-parliament-presses-bali-immigration-t
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi
+Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi
 
 KONTEN:
 ## TL;DR
@@ -9886,7 +9886,7 @@ URL: https://balizero.com/taxes/indonesias-tax-filing-amnesty-fails-to-move-the-
 PUBLISHED: 2026-05-20
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ
+Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ
 
 KONTEN:
 ## TL;DR
@@ -9970,7 +9970,7 @@ URL: https://balizero.com/business/virtual-offices-for-pt-pma-what-indonesias-ad
 PUBLISHED: 2026-05-19
 
 ### RINGKASAN AI ZANTARA
-## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region
+Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region
 
 KONTEN:
 ## TL;DR
@@ -10052,7 +10052,7 @@ URL: https://balizero.com/visas/navigating-indonesian-schools-what-expat-familie
 PUBLISHED: 2026-05-19
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr
+Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr
 
 KONTEN:
 ## TL;DR
@@ -10140,7 +10140,7 @@ URL: https://balizero.com/visas/the-legal-maze-of-getting-married-in-indonesia-a
 PUBLISHED: 2026-05-19
 
 ### RINGKASAN AI ZANTARA
-## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu
+Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu
 
 KONTEN:
 ## TL;DR
@@ -10224,7 +10224,7 @@ URL: https://balizero.com/taxes/bali-targets-influencers-and-tourists-bartering-
 PUBLISHED: 2026-05-19
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s
+Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s
 
 KONTEN:
 ## TL;DR
@@ -10309,7 +10309,7 @@ URL: https://balizero.com/visas/indonesia-visa-landscape-what-every-foreign-visi
 PUBLISHED: 2026-05-18
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law
+Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law
 
 KONTEN:
 ## TL;DR
@@ -10393,7 +10393,7 @@ URL: https://balizero.com/visas/indonesia-work-visa-landscape-what-foreign-worke
 PUBLISHED: 2026-05-18
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo
+Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo
 
 KONTEN:
 ## TL;DR
@@ -10477,7 +10477,7 @@ URL: https://balizero.com/visas/kitas-decoded-which-indonesian-residence-permit-
 PUBLISHED: 2026-05-18
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i
+Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i
 
 KONTEN:
 ## TL;DR
@@ -10565,7 +10565,7 @@ URL: https://balizero.com/trends/indonesia-bets-on-ai-to-lead-southeast-asias-di
 PUBLISHED: 2026-05-15
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions
+Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions
 
 KONTEN:
 ## TL;DR
@@ -10651,7 +10651,7 @@ URL: https://balizero.com/visas/balis-informal-economy-crackdown-what-tighter-ru
 PUBLISHED: 2026-05-15
 
 ### RINGKASAN AI ZANTARA
-## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un
+For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un
 
 KONTEN:
 ## TL;DR
@@ -10737,7 +10737,7 @@ URL: https://balizero.com/visas/working-kitas-e23-indonesias-revised-legal-frame
 PUBLISHED: 2026-05-15
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026.  The fo
+Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026. The fo
 
 KONTEN:
 ## TL;DR
@@ -10827,7 +10827,7 @@ URL: https://balizero.com/taxes/indonesia-issues-per-62026-global-minimum-tax-re
 PUBLISHED: 2026-05-15
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest
+Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest
 
 KONTEN:
 ## TL;DR
@@ -11748,7 +11748,7 @@ URL: https://balizero.com/business/indonesias-kbli-2026-what-foreign-investors-m
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare
+Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare
 
 KONTEN:
 ## TL;DR
@@ -11836,7 +11836,7 @@ URL: https://balizero.com/visas/bali-arrivals-climb-10-as-conflict-era-safeguard
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori
+Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori
 
 KONTEN:
 ## TL;DR
@@ -11922,7 +11922,7 @@ URL: https://balizero.com/visas/indonesia-activates-21-sentinel-hospitals-in-han
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen
+Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen
 
 KONTEN:
 ## TL;DR
@@ -12008,7 +12008,7 @@ URL: https://balizero.com/visas/indonesia-arrests-321-foreigners-in-sweeping-onl
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr
+Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr
 
 KONTEN:
 ## TL;DR
@@ -12096,7 +12096,7 @@ URL: https://balizero.com/visas/indonesia-bets-on-bali-as-the-next-global-hub-fo
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that
+Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that
 
 KONTEN:
 ## Ringkasan
@@ -12180,7 +12180,7 @@ URL: https://balizero.com/visas/indonesia-deports-78-foreign-workers-in-illegal-
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co
+Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co
 
 KONTEN:
 ## TL;DR
@@ -12268,7 +12268,7 @@ URL: https://balizero.com/visas/indonesia-golden-visa-rules-tightened-what-chang
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ
+Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ
 
 KONTEN:
 ## TL;DR
@@ -12356,7 +12356,7 @@ URL: https://balizero.com/visas/indonesia-immigration-designates-parq-as-ambassa
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa
+Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa
 
 KONTEN:
 ## TL;DR
@@ -12442,7 +12442,7 @@ URL: https://balizero.com/visas/indonesia-launches-first-submarine-rescue-ship-b
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio
+Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio
 
 KONTEN:
 ## TL;DR
@@ -12528,7 +12528,7 @@ URL: https://balizero.com/visas/sofitel-bali-leads-luxury-hotel-sustainability-p
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p
+Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p
 
 KONTEN:
 ## Ringkasan Singkat
@@ -12614,7 +12614,7 @@ URL: https://balizero.com/taxes/indonesia-tax-authority-to-audit-tax-amnesty-ii-
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to
+Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to
 
 KONTEN:
 ## TL;DR
@@ -12698,7 +12698,7 @@ URL: https://balizero.com/taxes/indonesias-tax-authority-reshuffles-taxpayer-rol
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The
+Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The
 
 KONTEN:
 ## TL;DR
@@ -12782,7 +12782,7 @@ URL: https://balizero.com/taxes/southeast-asias-digital-nomad-visa-race-who-wins
 PUBLISHED: 2026-05-12
 
 ### RINGKASAN AI ZANTARA
-## Facts  Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea
+Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea
 
 KONTEN:
 ## TL;DR
@@ -12872,7 +12872,7 @@ URL: https://balizero.com/visas/indonesias-expat-service-market-what-jakarta-riv
 PUBLISHED: 2026-05-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and
+Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and
 
 KONTEN:
 ## TL;DR
@@ -12956,7 +12956,7 @@ URL: https://balizero.com/visas/indonesias-family-sponsored-kitas-e31-what-spous
 PUBLISHED: 2026-05-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig
+The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig
 
 KONTEN:
 ## TL;DR
@@ -13042,7 +13042,7 @@ URL: https://balizero.com/visas/indonesias-golden-visa-opens-property-investment
 PUBLISHED: 2026-05-11
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci
+Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci
 
 KONTEN:
 ## TL;DR
@@ -13124,7 +13124,7 @@ URL: https://balizero.com/business/bali-draws-rp-1331-trillion-in-investment-in-
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme
+Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme
 
 KONTEN:
 ## TL;DR
@@ -13210,7 +13210,7 @@ URL: https://balizero.com/visas/bali-all-access-pass-one-card-to-rule-the-island
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg
+Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg
 
 KONTEN:
 ## TL;DR
@@ -13296,7 +13296,7 @@ URL: https://balizero.com/visas/bali-kek-financial-zone-targets-dubai-style-tax-
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i
+Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i
 
 KONTEN:
 ## TL;DR
@@ -13378,7 +13378,7 @@ URL: https://balizero.com/visas/indonesias-golden-visa-what-the-government-is-ac
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,
+Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,
 
 KONTEN:
 ## TL;DR
@@ -13462,7 +13462,7 @@ URL: https://balizero.com/visas/the-real-cost-of-living-in-bali-what-1000-buys-i
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas
+Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas
 
 KONTEN:
 ## TL;DR
@@ -13550,7 +13550,7 @@ URL: https://balizero.com/visas/westin-ubud-bets-on-biophilic-luxury-to-capture-
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys
+Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys
 
 KONTEN:
 ## TL;DR
@@ -13696,7 +13696,7 @@ URL: https://balizero.com/taxes/bali-halts-emergency-stay-permits-for-foreigners
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey
+The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey
 
 KONTEN:
 ## TL;DR
@@ -13784,7 +13784,7 @@ URL: https://balizero.com/taxes/indonesia-tax-recap-digital-levy-wealth-tax-spt-
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks.  On tax revenue performance, t
+Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks. On tax revenue performance, t
 
 KONTEN:
 ## TL;DR
@@ -13870,7 +13870,7 @@ URL: https://balizero.com/taxes/indonesias-april-tax-deadline-solar-policy-digit
 PUBLISHED: 2026-05-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p
+Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p
 
 KONTEN:
 ## TL;DR
@@ -13950,7 +13950,7 @@ URL: https://balizero.com/visas/balis-premium-childcare-market-in-2026-what-expa
 PUBLISHED: 2026-05-04
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The
+Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The
 
 KONTEN:
 ## TL;DR
@@ -14032,7 +14032,7 @@ URL: https://balizero.com/visas/indonesias-hajj-pilgrims-arrive-in-saudi-arabia-
 PUBLISHED: 2026-05-04
 
 ### RINGKASAN AI ZANTARA
-## Facts  Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co
+Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co
 
 KONTEN:
 ## TL;DR
@@ -14116,7 +14116,7 @@ URL: https://balizero.com/visas/indonesias-labor-minister-reshuffles-12-official
 PUBLISHED: 2026-05-04
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi
+Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi
 
 KONTEN:
 ## TL;DR
@@ -14200,7 +14200,7 @@ URL: https://balizero.com/visas/inside-indonesias-toughest-visa-rules-for-foreig
 PUBLISHED: 2026-05-04
 
 ### RINGKASAN AI ZANTARA
-## Facts  When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b
+When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b
 
 KONTEN:
 ## TL;DR
@@ -14279,7 +14279,7 @@ URL: https://balizero.com/visas/row-for-role-50-balis-annual-paddle-event-return
 PUBLISHED: 2026-05-04
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea
+Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea
 
 KONTEN:
 ## TL;DR
@@ -14363,7 +14363,7 @@ URL: https://balizero.com/visas/tom-ford-beauty-meets-jakarta-five-star-a-luxury
 PUBLISHED: 2026-05-04
 
 ### RINGKASAN AI ZANTARA
-## Facts  The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford
+The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford
 
 KONTEN:
 ## TL;DR
@@ -14449,7 +14449,7 @@ URL: https://balizero.com/visas/zero-tax-countries-are-temptingbut-indonesia-has
 PUBLISHED: 2026-05-04
 
 ### RINGKASAN AI ZANTARA
-## Facts  The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a
+The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a
 
 KONTEN:
 ## TL;DR
@@ -14535,7 +14535,7 @@ URL: https://balizero.com/visas/indonesia-work-visa-landscape-what-every-expat-m
 PUBLISHED: 2026-04-30
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc
+Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc
 
 KONTEN:
 ## TL;DR
@@ -14621,7 +14621,7 @@ URL: https://balizero.com/business/balis-airbnb-era-under-pressure-what-the-2026
 PUBLISHED: 2026-04-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment
+Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment
 
 KONTEN:
 ## TL;DR
@@ -14705,7 +14705,7 @@ URL: https://balizero.com/business/indonesias-kbli-2025-overhaul-what-the-june-2
 PUBLISHED: 2026-04-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat
+Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat
 
 KONTEN:
 ## TL;DR
@@ -14787,7 +14787,7 @@ URL: https://balizero.com/visas/indonesias-d12-pre-investment-visa-the-multi-ent
 PUBLISHED: 2026-04-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct
+Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct
 
 KONTEN:
 ## TL;DR
@@ -14873,7 +14873,7 @@ URL: https://balizero.com/visas/indonesias-golden-visa-the-350k-ticket-to-long-t
 PUBLISHED: 2026-04-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones
+Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones
 
 KONTEN:
 ## TL;DR
@@ -14959,7 +14959,7 @@ URL: https://balizero.com/visas/indonesias-village-investment-visa-what-the-law-
 PUBLISHED: 2026-04-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop
+A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop
 
 KONTEN:
 ## Ringkasan
@@ -15041,7 +15041,7 @@ URL: https://balizero.com/business/indonesias-183-day-tax-residency-rule-what-ex
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day
+Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day
 
 KONTEN:
 ## TL;DR
@@ -15129,7 +15129,7 @@ URL: https://balizero.com/business/indonesia-tightens-spatial-planning-what-kkpr
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi
+Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi
 
 KONTEN:
 ## TL;DR
@@ -15211,7 +15211,7 @@ URL: https://balizero.com/visas/indonesia-opens-fast-track-visa-lane-for-foreign
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago.  Prior to this develop
+Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago. Prior to this develop
 
 KONTEN:
 ## TL;DR
@@ -15295,7 +15295,7 @@ URL: https://balizero.com/visas/indonesia-opens-green-energy-sector-to-foreign-c
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is
+Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is
 
 KONTEN:
 ## TL;DR
@@ -15379,7 +15379,7 @@ URL: https://balizero.com/visas/indonesias-global-citizen-visa-pitch-competitive
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,
+Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,
 
 KONTEN:
 ## TL;DR
@@ -15467,7 +15467,7 @@ URL: https://balizero.com/visas/indonesias-golden-visa-overhaul-what-the-new-202
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp
+Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp
 
 KONTEN:
 ## TL;DR
@@ -15551,7 +15551,7 @@ URL: https://balizero.com/visas/indonesias-tax-net-tightens-remote-work-visa-hol
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr
+Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr
 
 KONTEN:
 ## TL;DR
@@ -15639,7 +15639,7 @@ URL: https://balizero.com/living/bali-launches-dharma-dewata-force-to-police-tou
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim
+Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim
 
 KONTEN:
 ## TL;DR
@@ -15725,7 +15725,7 @@ URL: https://balizero.com/taxes/foreign-employers-in-indonesia-now-must-navigate
 PUBLISHED: 2026-04-27
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a
+Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a
 
 KONTEN:
 ## TL;DR
@@ -15811,7 +15811,7 @@ URL: https://balizero.com/visas/indonesia-kills-online-only-visa-extensions-what
 PUBLISHED: 2026-04-23
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025
+Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025
 
 KONTEN:
 ## TL;DR
@@ -15901,7 +15901,7 @@ URL: https://balizero.com/visas/indonesias-e-visa-overhaul-what-every-foreign-na
 PUBLISHED: 2026-04-23
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human
+Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human
 
 KONTEN:
 ## TL;DR
@@ -15989,7 +15989,7 @@ URL: https://balizero.com/business/bali-business-setup-in-2026-what-every-foreig
 PUBLISHED: 2026-04-21
 
 ### RINGKASAN AI ZANTARA
-## Facts  Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM
+Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM
 
 KONTEN:
 ## TL;DR
@@ -16077,7 +16077,7 @@ URL: https://balizero.com/visas/dj-on-sacred-volcano-balis-tolerance-for-viral-s
 PUBLISHED: 2026-04-21
 
 ### RINGKASAN AI ZANTARA
-## Facts  A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r
+A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r
 
 KONTEN:
 ## TL;DR
@@ -16165,7 +16165,7 @@ URL: https://balizero.com/visas/indonesia-tightens-immigration-enforcement-what-
 PUBLISHED: 2026-04-21
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a
+Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a
 
 KONTEN:
 ## TL;DR
@@ -16253,7 +16253,7 @@ URL: https://balizero.com/business/13-japanese-nationals-deported-from-indonesia
 PUBLISHED: 2026-04-19
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and
+Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and
 
 KONTEN:
 ## TL;DR
@@ -16341,7 +16341,7 @@ URL: https://balizero.com/visas/bali-launches-dharma-dewata-dedicated-task-force
 PUBLISHED: 2026-04-19
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi
+Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi
 
 KONTEN:
 ## TL;DR
@@ -16429,7 +16429,7 @@ URL: https://balizero.com/living/visa-on-arrival-in-indonesia-what-first-timers-
 PUBLISHED: 2026-04-19
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic
+The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic
 
 KONTEN:
 ## TL;DR
@@ -16514,7 +16514,7 @@ URL: https://balizero.com/trends/indonesia-to-overhaul-oss-business-registration
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form
+Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form
 
 KONTEN:
 ## TL;DR
@@ -16598,7 +16598,7 @@ URL: https://balizero.com/visas/bali-cracks-down-pt-pma-shareholders-banned-from
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators.  At the national level, Permenk
+Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators. At the national level, Permenk
 
 KONTEN:
 ## TL;DR
@@ -16686,7 +16686,7 @@ URL: https://balizero.com/visas/indonesias-dependent-kitas-overhauled-what-spous
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit
+Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit
 
 KONTEN:
 ## TL;DR
@@ -16770,7 +16770,7 @@ URL: https://balizero.com/visas/indonesias-digital-nomad-kitas-the-full-legal-pi
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20
+Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20
 
 KONTEN:
 ## TL;DR
@@ -16854,7 +16854,7 @@ URL: https://balizero.com/visas/indonesias-golden-visa-now-covers-spouses-what-e
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V
+Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V
 
 KONTEN:
 ## TL;DR
@@ -16938,7 +16938,7 @@ URL: https://balizero.com/visas/indonesias-multiple-entry-tourist-visa-what-expa
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu
+Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu
 
 KONTEN:
 ## TL;DR
@@ -17022,7 +17022,7 @@ URL: https://balizero.com/visas/indonesias-retirement-kitas-the-definitive-guide
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d
+Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d
 
 KONTEN:
 ## TL;DR
@@ -17110,7 +17110,7 @@ URL: https://balizero.com/taxes/bali-cracks-down-foreign-nationals-caught-in-pro
 PUBLISHED: 2026-04-16
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt
+Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt
 
 KONTEN:
 ## TL;DR
@@ -17196,7 +17196,7 @@ URL: https://balizero.com/visas/indonesias-football-league-tops-se-asia-but-fore
 PUBLISHED: 2026-04-15
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a
+The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a
 
 KONTEN:
 ## TL;DR
@@ -17284,7 +17284,7 @@ URL: https://balizero.com/visas/seoul-walks-back-bali-warning-after-indonesia-pu
 PUBLISHED: 2026-04-15
 
 ### RINGKASAN AI ZANTARA
-## Facts  South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move
+South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move
 
 KONTEN:
 ## TL;DR
@@ -17374,7 +17374,7 @@ URL: https://balizero.com/visas/bali-water-taxis-could-cut-airport-canggu-run-to
 PUBLISHED: 2026-04-14
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take
+Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take
 
 KONTEN:
 ## TL;DR
@@ -17457,7 +17457,7 @@ URL: https://balizero.com/visas/thai-restaurant-in-canggu-puts-spotlight-on-fb-f
 PUBLISHED: 2026-04-14
 
 ### RINGKASAN AI ZANTARA
-## Facts  Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent
+Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent
 
 KONTEN:
 ## TL;DR
@@ -17545,7 +17545,7 @@ URL: https://balizero.com/business/running-a-pt-pma-in-indonesia-the-compliance-
 PUBLISHED: 2026-04-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator
+A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator
 
 KONTEN:
 ## TL;DR
@@ -17630,7 +17630,7 @@ URL: https://balizero.com/visas/indonesia-cracks-down-on-tourist-visa-workers-ba
 PUBLISHED: 2026-04-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such
+Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such
 
 KONTEN:
 ## TL;DR
@@ -17711,7 +17711,7 @@ URL: https://balizero.com/visas/indonesia-investor-kitas-the-complete-immigratio
 PUBLISHED: 2026-04-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist
+The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist
 
 KONTEN:
 ## TL;DR
@@ -17799,7 +17799,7 @@ URL: https://balizero.com/visas/indonesias-visa-landscape-for-bali-bound-foreign
 PUBLISHED: 2026-04-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,
+Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,
 
 KONTEN:
 ## TL;DR
@@ -17887,7 +17887,7 @@ URL: https://balizero.com/property/bali-property-2026-new-laws-reshape-the-marke
 PUBLISHED: 2026-04-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba
+Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba
 
 KONTEN:
 ## TL;DR
@@ -17972,7 +17972,7 @@ URL: https://balizero.com/property/balis-zoning-map-the-rules-that-decide-where-
 PUBLISHED: 2026-04-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–
+Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–
 
 KONTEN:
 ## TL;DR
@@ -18055,7 +18055,7 @@ URL: https://balizero.com/property/tempehs-ancient-roots-indonesias-fermented-so
 PUBLISHED: 2026-04-10
 
 ### RINGKASAN AI ZANTARA
-## Facts  Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo
+Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo
 
 KONTEN:
 ## TL;DR
@@ -18142,7 +18142,7 @@ URL: https://balizero.com/business/the-truth-about-foreign-property-ownership-in
 PUBLISHED: 2026-04-09
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership
+Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership
 
 KONTEN:
 ## TL;DR
@@ -18225,7 +18225,7 @@ URL: https://balizero.com/visas/dpr-demands-crackdown-on-unlicensed-foreign-busi
 PUBLISHED: 2026-04-09
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization.
+Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization.
 
 KONTEN:
 ## TL;DR
@@ -18309,7 +18309,7 @@ URL: https://balizero.com/taxes/indonesia-draws-the-line-gci-is-for-diaspora-gol
 PUBLISHED: 2026-04-09
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an
+Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an
 
 KONTEN:
 ## TL;DR
@@ -18496,7 +18496,7 @@ URL: https://balizero.com/visas/belgian-biker-deported-after-viral-bali-cliff-st
 PUBLISHED: 2026-04-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr
+A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr
 
 KONTEN:
 ## TL;DR
@@ -18581,7 +18581,7 @@ URL: https://balizero.com/visas/indonesia-mobilizes-tourism-defenses-as-global-g
 PUBLISHED: 2026-04-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects
+Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects
 
 KONTEN:
 ## TL;DR
@@ -18668,7 +18668,7 @@ URL: https://balizero.com/visas/indonesia-tightens-passport-rules-originals-requ
 PUBLISHED: 2026-04-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol
+Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol
 
 KONTEN:
 ## TL;DR
@@ -18756,7 +18756,7 @@ URL: https://balizero.com/visas/lombok-rising-why-indonesias-second-island-is-re
 PUBLISHED: 2026-04-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m
+Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m
 
 KONTEN:
 ## TL;DR
@@ -18843,7 +18843,7 @@ URL: https://balizero.com/visas/ubuds-mixology-moment-masks-a-minefield-for-fore
 PUBLISHED: 2026-04-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —
+The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —
 
 KONTEN:
 ## TL;DR
@@ -18931,7 +18931,7 @@ URL: https://balizero.com/living/bali-sets-663m-tourist-target-while-raising-the
 PUBLISHED: 2026-04-08
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b
+Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b
 
 KONTEN:
 ## TL;DR
@@ -19016,7 +19016,7 @@ URL: https://balizero.com/visas/indonesias-work-permit-maze-what-expats-must-kno
 PUBLISHED: 2026-04-07
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations.
+Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations.
 
 KONTEN:
 ## TL;DR
@@ -19097,7 +19097,7 @@ URL: https://balizero.com/visas/surviving-the-unexpected-emergency-preparedness-
 PUBLISHED: 2026-04-07
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o
+Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o
 
 KONTEN:
 ## TL;DR
@@ -19182,7 +19182,7 @@ URL: https://balizero.com/visas/us-tax-failure-clouds-world-cup-2026-for-host-na
 PUBLISHED: 2026-04-07
 
 ### RINGKASAN AI ZANTARA
-## Facts  The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl
+The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl
 
 KONTEN:
 ## TL;DR
@@ -19266,7 +19266,7 @@ URL: https://balizero.com/business/retiring-in-bali-2026-what-foreign-buyers-mus
 PUBLISHED: 2026-04-03
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa (
+Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa (
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -19349,7 +19349,7 @@ URL: https://balizero.com/visas/indonesia-bets-on-green-tourism-to-triple-arriva
 PUBLISHED: 2026-04-03
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market
+Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market
 
 KONTEN:
 ## TL;DR
@@ -19437,7 +19437,7 @@ URL: https://balizero.com/living/indonesias-domestic-worker-permits-what-expats-
 PUBLISHED: 2026-04-03
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula
+Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula
 
 KONTEN:
 ## TL;DR
@@ -19517,7 +19517,7 @@ URL: https://balizero.com/business/bali-business-climate-2026-what-foreigners-ac
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali remains one of Southeast Asia's most attractive destinations for foreign entrepreneurs, but the regulatory landscape governing foreign business ownership in Indonesia is among the most complex in the region. The primary legal vehicle for foreign investment is the P
+Bali remains one of Southeast Asia's most attractive destinations for foreign entrepreneurs, but the regulatory landscape governing foreign business ownership in Indonesia is among the most complex in the region. The primary legal vehicle for foreign investment is the P
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -19605,7 +19605,7 @@ URL: https://balizero.com/business/bali-defies-global-headwinds-with-70-occupanc
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's investment and tourism sectors continue to demonstrate resilience, with occupancy rates across hotels and short-term rental villas sustaining levels above 70 percent. This figure places Bali among the stronger performing leisure destinations in Southeast Asia dur
+Bali's investment and tourism sectors continue to demonstrate resilience, with occupancy rates across hotels and short-term rental villas sustaining levels above 70 percent. This figure places Bali among the stronger performing leisure destinations in Southeast Asia dur
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -19698,7 +19698,7 @@ URL: https://balizero.com/business/balis-2026-short-term-rental-rules-what-owner
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's short-term rental market — one of the most lucrative in Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities, supported by the central government's push to formalize the tourism economy, have introduced or reinforced a layered comp
+Bali's short-term rental market — one of the most lucrative in Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities, supported by the central government's push to formalize the tourism economy, have introduced or reinforced a layered comp
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -19785,7 +19785,7 @@ URL: https://balizero.com/business/three-sexual-assaults-in-three-days-puts-bali
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social Expat. The incidents occurred in close temporal proximity, though the specific locations, circumstances, and nationalities of the v
+Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social Expat. The incidents occurred in close temporal proximity, though the specific locations, circumstances, and nationalities of the v
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -19872,7 +19872,7 @@ URL: https://balizero.com/business/indonesia-forces-tiktok-and-x-to-block-under-
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a
+Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a
 
 KONTEN:
 ## TL;DR
@@ -19954,7 +19954,7 @@ URL: https://balizero.com/business/indonesia-opens-data-center-sector-to-foreign
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he
+Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he
 
 KONTEN:
 ## TL;DR
@@ -20040,7 +20040,7 @@ URL: https://balizero.com/visas/indonesia-tax-for-expats-who-owes-what-in-2026
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesia operates a residence-based tax system governed primarily by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments. Under this framework, an individual becomes a tax resident — and therefore liable for Indonesian income tax — if they
+Indonesia operates a residence-based tax system governed primarily by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments. Under this framework, an individual becomes a tax resident — and therefore liable for Indonesian income tax — if they
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -20132,7 +20132,7 @@ URL: https://balizero.com/living/balis-cost-surge-who-is-this-island-actually-gr
 PUBLISHED: 2026-04-01
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali's transformation from a spiritual retreat into a global lifestyle destination has accelerated dramatically since the post-pandemic reopening in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging Bukit Peninsula — have risen between
+Bali's transformation from a spiritual retreat into a global lifestyle destination has accelerated dramatically since the post-pandemic reopening in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging Bukit Peninsula — have risen between
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -20553,7 +20553,7 @@ URL: https://balizero.com/business/pt-pma-in-bali-what-foreign-investors-must-kn
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply
+A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply
 
 KONTEN:
 ## TL;DR
@@ -20887,7 +20887,7 @@ URL: https://balizero.com/visas/bali-governor-downplays-crime-surge-as-foreign-c
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr
+Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr
 
 KONTEN:
 ## TL;DR
@@ -20973,7 +20973,7 @@ URL: https://balizero.com/visas/budapest-meets-bali-hungarian-embassy-brings-cul
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival in 2026. The event marks a formal engagemen
+Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival in 2026. The event marks a formal engagemen
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -21059,7 +21059,7 @@ URL: https://balizero.com/visas/indonesia-malaysia-summit-signals-deeper-asean-s
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts  Indonesian President Prabowo Subianto and Malaysian Prime Minister Anwar Ibrahim convened for high-level bilateral talks, with discussions centered on strategic issues affecting both nations and the broader ASEAN region. The meeting reflects the historically close relat
+Indonesian President Prabowo Subianto and Malaysian Prime Minister Anwar Ibrahim convened for high-level bilateral talks, with discussions centered on strategic issues affecting both nations and the broader ASEAN region. The meeting reflects the historically close relat
 
 KONTEN:
 MCP issues detected. Run /mcp list for status.## TL;DR
@@ -21149,7 +21149,6 @@ URL: https://balizero.com/taxes/bali-to-screen-tourist-bank-balances-and-activit
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts
 Bali's regional government is moving forward with plans to introduce pre-arrival vetting of foreign tourists, including checks on bank balances and prior activity records, with implementation targeted for 2026. The initiative is part of a broader effort by Balinese auth
 
 KONTEN:
@@ -21234,7 +21233,6 @@ URL: https://balizero.com/taxes/digital-nomads-in-bali-face-2026-insurance-blind
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts
 Digital nomads and freelancers living and working from Bali occupy an increasingly scrutinised legal and financial grey zone. As Indonesia's Directorate General of Immigration enforces the boundaries of its visa categories more rigorously in 2026, the insurance products
 
 KONTEN:
@@ -21319,7 +21317,6 @@ URL: https://balizero.com/taxes/indonesias-new-anti-treaty-shopping-rules-tighte
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts
 Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal Purpose Test (PPT) as part of Indonesia's domestic anti-abuse framework for tax treaties. The PPT is one of the minimum standards introduced under the OECD/G20 Base Erosion and Profit Shift
 
 KONTEN:
@@ -21406,7 +21403,6 @@ URL: https://balizero.com/taxes/us-expats-get-higher-tax-exclusion-in-2026-what-
 PUBLISHED: 2026-03-28
 
 ### RINGKASAN AI ZANTARA
-## Facts
 The Internal Revenue Service has announced an upward adjustment to the Foreign Earned Income Exclusion limit for the 2026 tax year, continuing the annual inflation-linked indexing that has characterized this provision in recent years. The FEIE, governed by Section 911 o
 
 KONTEN:
@@ -21495,7 +21491,6 @@ URL: https://balizero.com/business/bali-aparthotels-the-only-asset-class-hitting
 PUBLISHED: 2026-03-26
 
 ### RINGKASAN AI ZANTARA
-## Facts
 Bali's property market has long attracted foreign capital on the promise of high rental yields, but most investors end up with returns in the 6–10% range — respectable by global standards, yet well short of the figures circulated in developer brochures. The aparthotel c
 
 KONTEN:
@@ -23861,8 +23856,7 @@ URL: https://balizero.com/living/why-bali-keeps-pulling-expats-back-the-lifestyl
 PUBLISHED: 2026-03-21
 
 ### RINGKASAN AI ZANTARA
-## Facts
-Bali has consistently ranked among the world's top destinations for expatriates, digital nomads, and long-term travelers for over two decades. The island's appeal cuts across demographics — from retirees seeking affordable living to younger remote workers drawn by co-wo
+Bali has consistently ranked among the world''s top destinations for expatriates, digital nomads, and long-term travelers for over two decades. The island''s appeal cuts across demographics — from retirees seeking affordable living to younger remote workers drawn by co-wo
 
 KONTEN:
 ## TL;DR
@@ -24339,8 +24333,7 @@ URL: https://balizero.com/visas/indonesia-2026-what-every-traveler-must-know-bef
 PUBLISHED: 2026-03-20
 
 ### RINGKASAN AI ZANTARA
-## Facts
-Indonesia's immigration framework for 2026 reflects a broader regional trend toward digitized border management and tighter documentation enforcement. The Directorate General of Immigration has been progressively rolling out updates to its entry systems, and 2026 marks 
+Indonesia''s immigration framework for 2026 reflects a broader regional trend toward digitized border management and tighter documentation enforcement. The Directorate General of Immigration has been progressively rolling out updates to its entry systems, and 2026 marks
 
 KONTEN:
 ## TL;DR
@@ -24793,8 +24786,7 @@ URL: https://balizero.com/taxes/indonesia-tightens-visa-rules-for-bali-visitors-
 PUBLISHED: 2026-03-20
 
 ### RINGKASAN AI ZANTARA
-## Facts
-Indonesia's immigration authority has signaled a continued tightening of entry and stay conditions for foreign nationals, with Bali remaining the focal point of enforcement activity. While the specific content of the article was unavailable, the headline — referencing '
+Indonesia''s immigration authority has signaled a continued tightening of entry and stay conditions for foreign nationals, with Bali remaining the focal point of enforcement activity. While the specific content of the article was unavailable, the headline — referencing
 
 KONTEN:
 ## TL;DR

--- a/apps/mouth/src/content/articles/business/bali-2026-eco-luxury-villas-and-the-new-american-expat-playbook.it.mdx
+++ b/apps/mouth/src/content/articles/business/bali-2026-eco-luxury-villas-and-the-new-american-expat-playbook.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali 2026: Eco-Luxury Villas and the New American Expat..."
-seoDescription: "## Facts  Bali continues to attract a significant wave of American expatriates drawn by the island's combination of natural beauty, relatively low cost of..."
+seoDescription: "Bali continues to attract a significant wave of American expatriates drawn by the island's combination of natural beauty, relatively low cost of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-2026-eco-luxury-villas-and-the-new-american-expat-playbook.mdx
+++ b/apps/mouth/src/content/articles/business/bali-2026-eco-luxury-villas-and-the-new-american-expat-playbook.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali 2026: Eco-Luxury Villas and the New American Expat..."
-seoDescription: "## Facts  Bali continues to attract a significant wave of American expatriates drawn by the island's combination of natural beauty, relatively low cost of..."
+seoDescription: "Bali continues to attract a significant wave of American expatriates drawn by the island's combination of natural beauty, relatively low cost of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-aparthotels-the-only-asset-class-hitting-17-20-returns.id.mdx
+++ b/apps/mouth/src/content/articles/business/bali-aparthotels-the-only-asset-class-hitting-17-20-returns.id.mdx
@@ -122,22 +122,12 @@ description: "# Panduan Investasi di Indonesia untuk Investor Asing
 
   *   [Direktorat Jenderal Pajak](https://www.pajak.go.id/)"
 difficulty: intermediate
-excerpt: "## Facts
-
-  Bali's property market has long attracted foreign capital on the promise of high
-  rental yields, but most investors end up with returns in the 6–10% range — respectable
-  by global standards, yet well short of the figures circulated in developer brochures.
-  The aparthotel c"
+excerpt: "Bali's property market has long attracted foreign capital on the promise of high rental yields, but most investors end up with returns in the 6–10% range — respectable by global standards, yet well short of the figures circulated in developer brochures. The aparthotel c"
 featured: false
 lang: id
 publishedAt: "2026-03-26"
 readingTime: 3
-seoDescription: "## Facts
-
-  Bali's property market has long attracted foreign capital on the promise of high
-  rental yields, but most investors end up with returns in the 6–10% range — respectable
-  by global standards, yet well short of the figures circulated in developer brochures.
-  The aparthotel c"
+seoDescription: "Bali's property market has long attracted foreign capital on the promise of high rental yields, but most investors end up with returns in the 6–10% range — respectable by global standards, yet well short of the figures circulated in developer brochures. The aparthotel c"
 seoTitle: "Bali Aparthotels: The Only Asset Class Hitting 17-20% Returns"
 slug: bali-aparthotels-the-only-asset-class-hitting-17-20-returns
 tags:

--- a/apps/mouth/src/content/articles/business/bali-aparthotels-the-only-asset-class-hitting-17-20-returns.it.mdx
+++ b/apps/mouth/src/content/articles/business/bali-aparthotels-the-only-asset-class-hitting-17-20-returns.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Aparthotels: The Only Asset Class Hitting 17-20%..."
-seoDescription: "## Facts  Bali's property market has long attracted foreign capital on the promise of high rental yields, but most investors end up with returns in the..."
+seoDescription: "Bali's property market has long attracted foreign capital on the promise of high rental yields, but most investors end up with returns in the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-aparthotels-the-only-asset-class-hitting-17-20-returns.mdx
+++ b/apps/mouth/src/content/articles/business/bali-aparthotels-the-only-asset-class-hitting-17-20-returns.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Aparthotels: The Only Asset Class Hitting 17-20%..."
-seoDescription: "## Facts  Bali's property market has long attracted foreign capital on the promise of high rental yields, but most investors end up with returns in the..."
+seoDescription: "Bali's property market has long attracted foreign capital on the promise of high rental yields, but most investors end up with returns in the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-business-climate-2026-what-foreigners-actually-face.id.mdx
+++ b/apps/mouth/src/content/articles/business/bali-business-climate-2026-what-foreigners-actually-face.id.mdx
@@ -94,11 +94,7 @@ description: "# Panduan Investasi Asing di Indonesia
   proses dan peraturan yang berlaku. Konsultasi dengan ahli hukum dan konsultan bisnis
   sangat disarankan untuk memastikan kelancaran investasi."
 difficulty: intermediate
-excerpt:
-  "## Facts  Bali remains one of Southeast Asia's most attractive destinations
-  for foreign entrepreneurs, but the regulatory landscape governing foreign business
-  ownership in Indonesia is among the most complex in the region. The primary legal
-  vehicle for foreign investment is the P"
+excerpt: "Bali remains one of Southeast Asia's most attractive destinations for foreign entrepreneurs, but the regulatory landscape governing foreign business ownership in Indonesia is among the most complex in the region. The primary legal vehicle for foreign investment is the P"
 featured: false
 lang: id
 publishedAt: "2026-04-01"

--- a/apps/mouth/src/content/articles/business/bali-business-climate-2026-what-foreigners-actually-face.it.mdx
+++ b/apps/mouth/src/content/articles/business/bali-business-climate-2026-what-foreigners-actually-face.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Business Climate 2026: What Foreigners Actually Face"
 slug: "bali-business-climate-2026-what-foreigners-actually-face"
-excerpt: "## Facts  Bali remains one of Southeast Asia's most attractive destinations for foreign entrepreneurs, but the regulatory landscape governing foreign business ownership in Indonesia is among the most complex in the region. The primary legal vehicle for foreign investment is the P"
+excerpt: "Bali remains one of Southeast Asia's most attractive destinations for foreign entrepreneurs, but the regulatory landscape governing foreign business ownership in Indonesia is among the most complex in the region. The primary legal vehicle for foreign investment is the P"
 coverImage: "/static/news/visa_20260401_173215_5dc73119_cover.png"
 coverImageAlt: "Bali Business Climate 2026: What Foreigners Actually Face"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bali-business-climate-2026-what-foreigners-actually-face.mdx
+++ b/apps/mouth/src/content/articles/business/bali-business-climate-2026-what-foreigners-actually-face.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Business Climate 2026: What Foreigners Actually Face"
 slug: "bali-business-climate-2026-what-foreigners-actually-face"
-excerpt: "## Facts  Bali remains one of Southeast Asia's most attractive destinations for foreign entrepreneurs, but the regulatory landscape governing foreign business ownership in Indonesia is among the most complex in the region. The primary legal vehicle for foreign investment is the P"
+excerpt: "Bali remains one of Southeast Asia's most attractive destinations for foreign entrepreneurs, but the regulatory landscape governing foreign business ownership in Indonesia is among the most complex in the region. The primary legal vehicle for foreign investment is the P"
 coverImage: "/static/news/visa_20260401_173215_5dc73119_cover.png"
 coverImageAlt: "Bali Business Climate 2026: What Foreigners Actually Face"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/business/bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Business Setup in 2026: What Every Foreign Entrepreneur Must Know"
 slug: "bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know"
-excerpt: "## Facts  Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM"
+excerpt: "Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM"
 coverImage: "/static/news/visa_20260418_173922_708184f1_cover.png"
 coverImageAlt: "Bali Business Setup in 2026: What Every Foreign Entrepreneur Must Know"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/business/bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Business Setup in 2026: What Every Foreign Entrepreneur Must Know"
 slug: "bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know"
-excerpt: "## Facts  Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM"
+excerpt: "Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM"
 coverImage: "/static/news/visa_20260418_173922_708184f1_cover.png"
 coverImageAlt: "Bali Business Setup in 2026: What Every Foreign Entrepreneur Must Know"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know.mdx
+++ b/apps/mouth/src/content/articles/business/bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Business Setup in 2026: What Every Foreign Entrepreneur Must Know"
 slug: "bali-business-setup-in-2026-what-every-foreign-entrepreneur-must-know"
-excerpt: "## Facts  Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM"
+excerpt: "Establishing a business in Bali as a foreigner in 2026 continues to require navigating Indonesia's layered regulatory framework, which distinguishes sharply between domestic and foreign-owned entities. The primary vehicle for foreign business ownership remains the PT PM"
 coverImage: "/static/news/visa_20260418_173922_708184f1_cover.png"
 coverImageAlt: "Bali Business Setup in 2026: What Every Foreign Entrepreneur Must Know"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment.id.mdx
+++ b/apps/mouth/src/content/articles/business/bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment.id.mdx
@@ -104,11 +104,7 @@ description: "# Panduan Pendirian Perusahaan di Indonesia untuk Investor Asing
   *   **Dinas Penanaman Modal Daerah (DPMD):**  Informasi lebih lanjut mengenai investasi
   di tingkat daerah."
 difficulty: intermediate
-excerpt:
-  "## Facts  Bali's investment and tourism sectors continue to demonstrate
-  resilience, with occupancy rates across hotels and short-term rental villas sustaining
-  levels above 70 percent. This figure places Bali among the stronger performing leisure
-  destinations in Southeast Asia dur"
+excerpt: "Bali's investment and tourism sectors continue to demonstrate resilience, with occupancy rates across hotels and short-term rental villas sustaining levels above 70 percent. This figure places Bali among the stronger performing leisure destinations in Southeast Asia dur"
 featured: false
 lang: id
 publishedAt: "2026-04-01"

--- a/apps/mouth/src/content/articles/business/bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment.it.mdx
+++ b/apps/mouth/src/content/articles/business/bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Defies Global Headwinds With 70%+ Occupancy and Rising Foreign Investment"
 slug: "bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment"
-excerpt: "## Facts  Bali's investment and tourism sectors continue to demonstrate resilience, with occupancy rates across hotels and short-term rental villas sustaining levels above 70 percent. This figure places Bali among the stronger performing leisure destinations in Southeast Asia dur"
+excerpt: "Bali's investment and tourism sectors continue to demonstrate resilience, with occupancy rates across hotels and short-term rental villas sustaining levels above 70 percent. This figure places Bali among the stronger performing leisure destinations in Southeast Asia dur"
 coverImage: "/static/news/news_20260401_173153_784d2afd_cover.png"
 coverImageAlt: "Bali Defies Global Headwinds With 70%+ Occupancy and Rising Foreign Investment"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment.mdx
+++ b/apps/mouth/src/content/articles/business/bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Defies Global Headwinds With 70%+ Occupancy and Rising Foreign Investment"
 slug: "bali-defies-global-headwinds-with-70-occupancy-and-rising-foreign-investment"
-excerpt: "## Facts  Bali's investment and tourism sectors continue to demonstrate resilience, with occupancy rates across hotels and short-term rental villas sustaining levels above 70 percent. This figure places Bali among the stronger performing leisure destinations in Southeast Asia dur"
+excerpt: "Bali's investment and tourism sectors continue to demonstrate resilience, with occupancy rates across hotels and short-term rental villas sustaining levels above 70 percent. This figure places Bali among the stronger performing leisure destinations in Southeast Asia dur"
 coverImage: "/static/news/news_20260401_173153_784d2afd_cover.png"
 coverImageAlt: "Bali Defies Global Headwinds With 70%+ Occupancy and Rising Foreign Investment"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.fr.mdx
+++ b/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 slug: "bali-draws-rp-1331-trillion-in-investment-in-q1-2026"
-excerpt: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
+excerpt: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
 coverImage: "/static/news/news_20260507_174022_ac797f1f_cover.png"
 coverImageAlt: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
-seoDescription: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
+seoDescription: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.id.mdx
+++ b/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 slug: "bali-draws-rp-1331-trillion-in-investment-in-q1-2026"
-excerpt: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
+excerpt: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
 coverImage: "/static/news/news_20260507_174022_ac797f1f_cover.png"
 coverImageAlt: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
-seoDescription: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
+seoDescription: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.it.mdx
+++ b/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 slug: "bali-draws-rp-1331-trillion-in-investment-in-q1-2026"
-excerpt: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
+excerpt: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
 coverImage: "/static/news/news_20260507_174022_ac797f1f_cover.png"
 coverImageAlt: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
-seoDescription: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
+seoDescription: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.mdx
+++ b/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 slug: "bali-draws-rp-1331-trillion-in-investment-in-q1-2026"
-excerpt: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
+excerpt: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
 coverImage: "/static/news/news_20260507_174022_ac797f1f_cover.png"
 coverImageAlt: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
-seoDescription: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
+seoDescription: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.ru.mdx
+++ b/apps/mouth/src/content/articles/business/bali-draws-rp-1331-trillion-in-investment-in-q1-2026.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 slug: "bali-draws-rp-1331-trillion-in-investment-in-q1-2026"
-excerpt: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
+excerpt: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure represents the total capital injected into the island's economy through formal investment channels tracked by Indonesia's investme"
 coverImage: "/static/news/news_20260507_174022_ac797f1f_cover.png"
 coverImageAlt: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Draws Rp 13.31 Trillion in Investment in Q1 2026"
-seoDescription: "## Facts  Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
+seoDescription: "Bali's investment realization for the first quarter of 2026 reached Rp 13.31 trillion, according to reporting from Nusabali.com. The figure..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.fr.mdx
+++ b/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Villa Investment: Why Location Is Only the Starting Point"
 slug: "bali-villa-investment-why-location-is-only-the-starting-point"
-excerpt: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
+excerpt: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
 coverImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point.jpg"
 cardImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point_card.jpg"
 coverImageAlt: "Bali Villa Investment: Why Location Is Only the Starting Point"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Villa Investment: Why Location Is Only the Starting..."
-seoDescription: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
+seoDescription: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.id.mdx
+++ b/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Villa Investment: Why Location Is Only the Starting Point"
 slug: "bali-villa-investment-why-location-is-only-the-starting-point"
-excerpt: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
+excerpt: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
 coverImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point.jpg"
 cardImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point_card.jpg"
 coverImageAlt: "Bali Villa Investment: Why Location Is Only the Starting Point"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Villa Investment: Why Location Is Only the Starting..."
-seoDescription: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
+seoDescription: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.it.mdx
+++ b/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Villa Investment: Why Location Is Only the Starting Point"
 slug: "bali-villa-investment-why-location-is-only-the-starting-point"
-excerpt: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
+excerpt: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
 coverImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point.jpg"
 cardImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point_card.jpg"
 coverImageAlt: "Bali Villa Investment: Why Location Is Only the Starting Point"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Villa Investment: Why Location Is Only the Starting..."
-seoDescription: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
+seoDescription: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.mdx
+++ b/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Villa Investment: Why Location Is Only the Starting Point"
 slug: "bali-villa-investment-why-location-is-only-the-starting-point"
-excerpt: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
+excerpt: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
 coverImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point.jpg"
 cardImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point_card.jpg"
 coverImageAlt: "Bali Villa Investment: Why Location Is Only the Starting Point"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Villa Investment: Why Location Is Only the Starting..."
-seoDescription: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
+seoDescription: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.ru.mdx
+++ b/apps/mouth/src/content/articles/business/bali-villa-investment-why-location-is-only-the-starting-point.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Villa Investment: Why Location Is Only the Starting Point"
 slug: "bali-villa-investment-why-location-is-only-the-starting-point"
-excerpt: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
+excerpt: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak, Canggu, Pererenan, Ubud, and the Bukit peninsula. Average asking prices for leasehold villas in high-demand areas have climbe"
 coverImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point.jpg"
 cardImage: "/static/news/bali-villa-investment-why-location-is-only-the-starting-point_card.jpg"
 coverImageAlt: "Bali Villa Investment: Why Location Is Only the Starting Point"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Villa Investment: Why Location Is Only the Starting..."
-seoDescription: "## Facts  Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
+seoDescription: "Bali's villa market has attracted a sustained wave of foreign capital over the past decade, with demand concentrated in corridors like Seminyak,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/balis-2026-short-term-rental-rules-what-owners-must-do-now.id.mdx
+++ b/apps/mouth/src/content/articles/business/balis-2026-short-term-rental-rules-what-owners-must-do-now.id.mdx
@@ -108,11 +108,7 @@ description: "# Panduan Investasi Asing di Indonesia
   *   **Konsultan Investasi:** Banyak konsultan investasi yang dapat membantu Anda
   menavigasi proses pendirian dan operasional bisnis di Indonesia."
 difficulty: intermediate
-excerpt:
-  "## Facts  Bali's short-term rental market — one of the most lucrative in
-  Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities,
-  supported by the central government's push to formalize the tourism economy, have
-  introduced or reinforced a layered comp"
+excerpt: "Bali's short-term rental market — one of the most lucrative in Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities, supported by the central government's push to formalize the tourism economy, have introduced or reinforced a layered comp"
 featured: false
 lang: id
 publishedAt: "2026-04-01"

--- a/apps/mouth/src/content/articles/business/balis-2026-short-term-rental-rules-what-owners-must-do-now.it.mdx
+++ b/apps/mouth/src/content/articles/business/balis-2026-short-term-rental-rules-what-owners-must-do-now.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's 2026 Short-Term Rental Rules: What Owners Must Do Now"
 slug: "balis-2026-short-term-rental-rules-what-owners-must-do-now"
-excerpt: "## Facts  Bali's short-term rental market — one of the most lucrative in Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities, supported by the central government's push to formalize the tourism economy, have introduced or reinforced a layered comp"
+excerpt: "Bali's short-term rental market — one of the most lucrative in Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities, supported by the central government's push to formalize the tourism economy, have introduced or reinforced a layered comp"
 coverImage: "/static/news/news_20260401_173101_b2272379.png"
 coverImageAlt: "Bali's 2026 Short-Term Rental Rules: What Owners Must Do Now"
 category: "business"

--- a/apps/mouth/src/content/articles/business/balis-2026-short-term-rental-rules-what-owners-must-do-now.mdx
+++ b/apps/mouth/src/content/articles/business/balis-2026-short-term-rental-rules-what-owners-must-do-now.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's 2026 Short-Term Rental Rules: What Owners Must Do Now"
 slug: "balis-2026-short-term-rental-rules-what-owners-must-do-now"
-excerpt: "## Facts  Bali's short-term rental market — one of the most lucrative in Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities, supported by the central government's push to formalize the tourism economy, have introduced or reinforced a layered comp"
+excerpt: "Bali's short-term rental market — one of the most lucrative in Southeast Asia — is entering a stricter regulatory era in 2026. Regional authorities, supported by the central government's push to formalize the tourism economy, have introduced or reinforced a layered comp"
 coverImage: "/static/news/news_20260401_173101_b2272379.png"
 coverImageAlt: "Bali's 2026 Short-Term Rental Rules: What Owners Must Do Now"
 category: "business"

--- a/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.fr.mdx
+++ b/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
 slug: "bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest"
-excerpt: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
+excerpt: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
 coverImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.jpg"
 cardImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest_card.jpg"
 coverImageAlt: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bank Indonesia: Bali Stays a Top Investment Destination..."
-seoDescription: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
+seoDescription: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.id.mdx
+++ b/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
 slug: "bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest"
-excerpt: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
+excerpt: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
 coverImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.jpg"
 cardImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest_card.jpg"
 coverImageAlt: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bank Indonesia: Bali Stays a Top Investment Destination..."
-seoDescription: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
+seoDescription: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.it.mdx
+++ b/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
 slug: "bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest"
-excerpt: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
+excerpt: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
 coverImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.jpg"
 cardImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest_card.jpg"
 coverImageAlt: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bank Indonesia: Bali Stays a Top Investment Destination..."
-seoDescription: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
+seoDescription: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.mdx
+++ b/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
 slug: "bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest"
-excerpt: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
+excerpt: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
 coverImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.jpg"
 cardImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest_card.jpg"
 coverImageAlt: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bank Indonesia: Bali Stays a Top Investment Destination..."
-seoDescription: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
+seoDescription: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.ru.mdx
+++ b/apps/mouth/src/content/articles/business/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
 slug: "bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest"
-excerpt: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
+excerpt: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as geopolitical tensions — spanning the Russia-Ukraine war, Middle East conflicts, and intensifying US-China trade friction — continue"
 coverImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest.jpg"
 cardImage: "/static/news/bank-indonesia-bali-stays-a-top-investment-destination-despite-global-unrest_card.jpg"
 coverImageAlt: "Bank Indonesia: Bali Stays a Top Investment Destination Despite Global Unrest"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bank Indonesia: Bali Stays a Top Investment Destination..."
-seoDescription: "## Facts  Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
+seoDescription: "Bank Indonesia, Indonesia's central bank, has issued an assessment reinforcing Bali's status as a preferred investment destination even as..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.fr.mdx
+++ b/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
 slug: "buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont"
-excerpt: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
+excerpt: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
 coverImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.jpg"
 cardImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont_card.jpg"
 coverImageAlt: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Buying a Bali Villa in 2026: The Legal Structures That Work..."
-seoDescription: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
+seoDescription: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.id.mdx
+++ b/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
 slug: "buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont"
-excerpt: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
+excerpt: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
 coverImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.jpg"
 cardImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont_card.jpg"
 coverImageAlt: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Buying a Bali Villa in 2026: The Legal Structures That Work..."
-seoDescription: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
+seoDescription: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.it.mdx
+++ b/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
 slug: "buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont"
-excerpt: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
+excerpt: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
 coverImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.jpg"
 cardImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont_card.jpg"
 coverImageAlt: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Buying a Bali Villa in 2026: The Legal Structures That Work..."
-seoDescription: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
+seoDescription: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.mdx
+++ b/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
 slug: "buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont"
-excerpt: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
+excerpt: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
 coverImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.jpg"
 cardImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont_card.jpg"
 coverImageAlt: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Buying a Bali Villa in 2026: The Legal Structures That Work..."
-seoDescription: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
+seoDescription: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.ru.mdx
+++ b/apps/mouth/src/content/articles/business/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
 slug: "buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont"
-excerpt: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
+excerpt: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik — freehold title — over Indonesian land. This restriction is absolute and applies regardless of the buyer's country of origin,"
 coverImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont.jpg"
 cardImage: "/static/news/buying-a-bali-villa-in-2026-the-legal-structures-that-work-and-the-traps-that-dont_card.jpg"
 coverImageAlt: "Buying a Bali Villa in 2026: The Legal Structures That Work and the Traps That Don't"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Buying a Bali Villa in 2026: The Legal Structures That Work..."
-seoDescription: "## Facts  Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
+seoDescription: "Indonesia's constitution and the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5/1960) prohibit foreign nationals from holding Hak Milik —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesia-launches-bali-investment-desk-after-623-enforcement-actions.it.mdx
+++ b/apps/mouth/src/content/articles/business/indonesia-launches-bali-investment-desk-after-623-enforcement-actions.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Launches Bali Investment Desk After 623..."
-seoDescription: "## Facts  Indonesia's Deputy Minister of Investment (Wamen Investasi) has officially launched a dedicated investment facilitation desk in Bali, a move..."
+seoDescription: "Indonesia's Deputy Minister of Investment (Wamen Investasi) has officially launched a dedicated investment facilitation desk in Bali, a move..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesia-launches-bali-investment-desk-after-623-enforcement-actions.mdx
+++ b/apps/mouth/src/content/articles/business/indonesia-launches-bali-investment-desk-after-623-enforcement-actions.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Launches Bali Investment Desk After 623..."
-seoDescription: "## Facts  Indonesia's Deputy Minister of Investment (Wamen Investasi) has officially launched a dedicated investment facilitation desk in Bali, a move..."
+seoDescription: "Indonesia's Deputy Minister of Investment (Wamen Investasi) has officially launched a dedicated investment facilitation desk in Bali, a move..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.fr.mdx
+++ b/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 slug: "indonesia-tightens-pma-rules-what-foreign-investors-must-know"
-excerpt: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
+excerpt: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
 coverImage: "/static/news/news_20260521_173631_2ea4ae7f_cover.png"
 coverImageAlt: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens PMA Rules: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
+seoDescription: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 slug: "indonesia-tightens-pma-rules-what-foreign-investors-must-know"
-excerpt: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
+excerpt: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
 coverImage: "/static/news/news_20260521_173631_2ea4ae7f_cover.png"
 coverImageAlt: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens PMA Rules: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
+seoDescription: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 slug: "indonesia-tightens-pma-rules-what-foreign-investors-must-know"
-excerpt: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
+excerpt: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
 coverImage: "/static/news/news_20260521_173631_2ea4ae7f_cover.png"
 coverImageAlt: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens PMA Rules: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
+seoDescription: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.mdx
+++ b/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 slug: "indonesia-tightens-pma-rules-what-foreign-investors-must-know"
-excerpt: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
+excerpt: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
 coverImage: "/static/news/news_20260521_173631_2ea4ae7f_cover.png"
 coverImageAlt: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens PMA Rules: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
+seoDescription: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.ru.mdx
+++ b/apps/mouth/src/content/articles/business/indonesia-tightens-pma-rules-what-foreign-investors-must-know.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 slug: "indonesia-tightens-pma-rules-what-foreign-investors-must-know"
-excerpt: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
+excerpt: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle through which non-Indonesian nationals conduct business on the archipelago. Governed by the Investment Coordinating Board (BKP"
 coverImage: "/static/news/news_20260521_173631_2ea4ae7f_cover.png"
 coverImageAlt: "Indonesia Tightens PMA Rules: What Foreign Investors Must Know"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens PMA Rules: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
+seoDescription: "Indonesia's investment framework for foreign-owned companies — known as Penanaman Modal Asing, or PMA — has long been the primary legal vehicle..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.id.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 183-Day Tax Residency Rule: What Expats Get Wrong in 2026"
 slug: "indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026"
-excerpt: "## Facts  Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day"
+excerpt: "Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day"
 coverImage: "/static/news/visa_20260424_015515_13de6975_cover.png"
 coverImageAlt: "Indonesia's 183-Day Tax Residency Rule: What Expats Get Wrong in 2026"
 category: "business"

--- a/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.it.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 183-Day Tax Residency Rule: What Expats Get Wrong in 2026"
 slug: "indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026"
-excerpt: "## Facts  Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day"
+excerpt: "Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day"
 coverImage: "/static/news/visa_20260424_015515_13de6975_cover.png"
 coverImageAlt: "Indonesia's 183-Day Tax Residency Rule: What Expats Get Wrong in 2026"
 category: "business"

--- a/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 183-Day Tax Residency Rule: What Expats Get Wrong in 2026"
 slug: "indonesias-183-day-tax-residency-rule-what-expats-get-wrong-in-2026"
-excerpt: "## Facts  Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day"
+excerpt: "Indonesia's tax residency threshold of 183 days within a 12-month period is enshrined in the Income Tax Law (UU PPh No. 36/2008) and remains in full effect in 2026. Any individual — regardless of nationality, visa type, or stated intention — who spends more than 183 day"
 coverImage: "/static/news/visa_20260424_015515_13de6975_cover.png"
 coverImageAlt: "Indonesia's 183-Day Tax Residency Rule: What Expats Get Wrong in 2026"
 category: "business"

--- a/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.fr.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
 slug: "indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors"
-excerpt: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
+excerpt: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
 coverImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.jpg"
 cardImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors_card.jpg"
 coverImageAlt: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's July 15 LKPM Deadline: Four Days Left for..."
-seoDescription: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
+seoDescription: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.id.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
 slug: "indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors"
-excerpt: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
+excerpt: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
 coverImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.jpg"
 cardImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors_card.jpg"
 coverImageAlt: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's July 15 LKPM Deadline: Four Days Left for..."
-seoDescription: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
+seoDescription: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.it.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
 slug: "indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors"
-excerpt: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
+excerpt: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
 coverImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.jpg"
 cardImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors_card.jpg"
 coverImageAlt: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's July 15 LKPM Deadline: Four Days Left for..."
-seoDescription: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
+seoDescription: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
 slug: "indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors"
-excerpt: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
+excerpt: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
 coverImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.jpg"
 cardImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors_card.jpg"
 coverImageAlt: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's July 15 LKPM Deadline: Four Days Left for..."
-seoDescription: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
+seoDescription: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.ru.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
 slug: "indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors"
-excerpt: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
+excerpt: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity Report, known as the LKPM — Laporan Kegiatan Penanaman Modal. The Q2 2026 reporting period covers business activity between April"
 coverImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors.jpg"
 cardImage: "/static/news/indonesias-july-15-lkpm-deadline-four-days-left-for-foreign-investors_card.jpg"
 coverImageAlt: "Indonesia's July 15 LKPM Deadline: Four Days Left for Foreign Investors"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's July 15 LKPM Deadline: Four Days Left for..."
-seoDescription: "## Facts  Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
+seoDescription: "Indonesia requires every company holding an active investment license (Nomor Induk Berusaha, or NIB) to file a quarterly Investment Activity..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.fr.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 slug: "indonesias-kbli-2026-what-foreign-investors-must-know-now"
-excerpt: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
+excerpt: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
 coverImage: "/static/news/news_20260511_174241_ca2fd80b_cover.png"
 coverImageAlt: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
-seoDescription: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
+seoDescription: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.id.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 slug: "indonesias-kbli-2026-what-foreign-investors-must-know-now"
-excerpt: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
+excerpt: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
 coverImage: "/static/news/news_20260511_174241_ca2fd80b_cover.png"
 coverImageAlt: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
-seoDescription: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
+seoDescription: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.it.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 slug: "indonesias-kbli-2026-what-foreign-investors-must-know-now"
-excerpt: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
+excerpt: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
 coverImage: "/static/news/news_20260511_174241_ca2fd80b_cover.png"
 coverImageAlt: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
-seoDescription: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
+seoDescription: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 slug: "indonesias-kbli-2026-what-foreign-investors-must-know-now"
-excerpt: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
+excerpt: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
 coverImage: "/static/news/news_20260511_174241_ca2fd80b_cover.png"
 coverImageAlt: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
-seoDescription: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
+seoDescription: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.ru.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-kbli-2026-what-foreign-investors-must-know-now.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 slug: "indonesias-kbli-2026-what-foreign-investors-must-know-now"
-excerpt: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
+excerpt: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the country's investment licensing architecture. Every company registered in Indonesia — whether domestic or foreign-owned — must declare"
 coverImage: "/static/news/news_20260511_174241_ca2fd80b_cover.png"
 coverImageAlt: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's KBLI 2026: What Foreign Investors Must Know Now"
-seoDescription: "## Facts  Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
+seoDescription: "Indonesia's business classification framework, known as KBLI (Klasifikasi Baku Lapangan Usaha Indonesia), serves as the backbone of the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.fr.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
 slug: "indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb"
-excerpt: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
+excerpt: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
 coverImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.jpg"
 cardImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb_card.jpg"
 coverImageAlt: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Land Title Maze: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
+seoDescription: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.id.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
 slug: "indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb"
-excerpt: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
+excerpt: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
 coverImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.jpg"
 cardImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb_card.jpg"
 coverImageAlt: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Land Title Maze: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
+seoDescription: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.it.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
 slug: "indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb"
-excerpt: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
+excerpt: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
 coverImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.jpg"
 cardImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb_card.jpg"
 coverImageAlt: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Land Title Maze: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
+seoDescription: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
 slug: "indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb"
-excerpt: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
+excerpt: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
 coverImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.jpg"
 cardImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb_card.jpg"
 coverImageAlt: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Land Title Maze: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
+seoDescription: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.ru.mdx
+++ b/apps/mouth/src/content/articles/business/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
 slug: "indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb"
-excerpt: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
+excerpt: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok Agraria No. 5 of 1960) and updated through a series of government regulations, most recently Government Regulation No. 18 of 2021."
 coverImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb.jpg"
 cardImage: "/static/news/indonesias-land-title-maze-what-foreign-investors-must-know-about-hgb_card.jpg"
 coverImageAlt: "Indonesia's Land Title Maze: What Foreign Investors Must Know About HGB"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Land Title Maze: What Foreign Investors Must..."
-seoDescription: "## Facts  Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
+seoDescription: "Indonesia operates one of Asia's more complex land registration systems, governed primarily by the Basic Agrarian Law (Undang-Undang Pokok..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.fr.mdx
+++ b/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
 slug: "phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong"
-excerpt: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
+excerpt: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
 coverImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.jpg"
 cardImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong_card.jpg"
 coverImageAlt: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Phuket vs Bali: The Property Investment Battle Foreigners..."
-seoDescription: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
+seoDescription: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.id.mdx
+++ b/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
 slug: "phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong"
-excerpt: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
+excerpt: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
 coverImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.jpg"
 cardImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong_card.jpg"
 coverImageAlt: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Phuket vs Bali: The Property Investment Battle Foreigners..."
-seoDescription: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
+seoDescription: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.it.mdx
+++ b/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
 slug: "phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong"
-excerpt: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
+excerpt: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
 coverImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.jpg"
 cardImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong_card.jpg"
 coverImageAlt: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Phuket vs Bali: The Property Investment Battle Foreigners..."
-seoDescription: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
+seoDescription: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.mdx
+++ b/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
 slug: "phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong"
-excerpt: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
+excerpt: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
 coverImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.jpg"
 cardImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong_card.jpg"
 coverImageAlt: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Phuket vs Bali: The Property Investment Battle Foreigners..."
-seoDescription: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
+seoDescription: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.ru.mdx
+++ b/apps/mouth/src/content/articles/business/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
 slug: "phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong"
-excerpt: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
+excerpt: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real estate markets recover and expand post-pandemic. Both islands attract similar buyer profiles — digital nomads, retirees, and invest"
 coverImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong.jpg"
 cardImage: "/static/news/phuket-vs-bali-the-property-investment-battle-foreigners-get-wrong_card.jpg"
 coverImageAlt: "Phuket vs Bali: The Property Investment Battle Foreigners Get Wrong"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Phuket vs Bali: The Property Investment Battle Foreigners..."
-seoDescription: "## Facts  The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
+seoDescription: "The comparison between Phuket and Bali as foreign property investment destinations has intensified as Southeast Asia's tourism-driven real..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.fr.mdx
+++ b/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 slug: "retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign"
-excerpt: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
+excerpt: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
 coverImage: "/static/news/visa_20260402_173512_2b7d56a3_cover.png"
 coverImageAlt: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Retiring in Bali 2026: What Foreign Buyers Must Know Before..."
-seoDescription: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
+seoDescription: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.id.mdx
+++ b/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.id.mdx
@@ -111,18 +111,12 @@ description: "# Panduan Investasi di Perusahaan Asing di Indonesia
 
   *   [Kementerian Hukum dan HAM (Ministry of Law and Human Rights)](https://www.kemenkumham.go.id/)"
 difficulty: intermediate
-excerpt:
-  "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik)
-  property. This is not a technicality — it is a constitutional restriction. Foreign
-  nationals may only hold property under designated titles: Hak Pakai (Right of Use,
-  up to 30 years, extendable), Hak Sewa ("
+excerpt: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
 featured: false
 lang: id
 publishedAt: "2026-04-03"
 readingTime: 3
-seoDescription:
-  "## Facts  Indonesia does not permit foreigners to own freehold (Hak
-  Milik) property. This is not a technicality — it is a constitutional restriction...."
+seoDescription: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
 seoTitle: "Retiring in Bali 2026: What Foreign Buyers Must Know Before..."
 slug: retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign
 tags:

--- a/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.it.mdx
+++ b/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 slug: "retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign"
-excerpt: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
+excerpt: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
 coverImage: "/static/news/visa_20260402_173512_2b7d56a3_cover.png"
 coverImageAlt: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Retiring in Bali 2026: What Foreign Buyers Must Know Before..."
-seoDescription: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
+seoDescription: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.mdx
+++ b/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 slug: "retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign"
-excerpt: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
+excerpt: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
 coverImage: "/static/news/visa_20260402_173512_2b7d56a3_cover.png"
 coverImageAlt: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Retiring in Bali 2026: What Foreign Buyers Must Know Before..."
-seoDescription: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
+seoDescription: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.ru.mdx
+++ b/apps/mouth/src/content/articles/business/retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 slug: "retiring-in-bali-2026-what-foreign-buyers-must-know-before-they-sign"
-excerpt: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
+excerpt: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction. Foreign nationals may only hold property under designated titles: Hak Pakai (Right of Use, up to 30 years, extendable), Hak Sewa ("
 coverImage: "/static/news/visa_20260402_173512_2b7d56a3_cover.png"
 coverImageAlt: "Retiring in Bali 2026: What Foreign Buyers Must Know Before They Sign"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Retiring in Bali 2026: What Foreign Buyers Must Know Before..."
-seoDescription: "## Facts  Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
+seoDescription: "Indonesia does not permit foreigners to own freehold (Hak Milik) property. This is not a technicality — it is a constitutional restriction...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet.id.mdx
+++ b/apps/mouth/src/content/articles/business/running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Running a PT PMA in Indonesia: The Compliance Obligations Every Foreign Investor Must Meet"
 slug: "running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator"
 coverImage: "/static/news/visa_20260409_175444_bb753ca6_cover.png"
 coverImageAlt: "Running a PT PMA in Indonesia: The Compliance Obligations Every Foreign Investor Must Meet"
 category: "business"

--- a/apps/mouth/src/content/articles/business/running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet.it.mdx
+++ b/apps/mouth/src/content/articles/business/running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Running a PT PMA in Indonesia: The Compliance Obligations Every Foreign Investor Must Meet"
 slug: "running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator"
 coverImage: "/static/news/visa_20260409_175444_bb753ca6_cover.png"
 coverImageAlt: "Running a PT PMA in Indonesia: The Compliance Obligations Every Foreign Investor Must Meet"
 category: "business"

--- a/apps/mouth/src/content/articles/business/running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet.mdx
+++ b/apps/mouth/src/content/articles/business/running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Running a PT PMA in Indonesia: The Compliance Obligations Every Foreign Investor Must Meet"
 slug: "running-a-pt-pma-in-indonesia-the-compliance-obligations-every-foreign-investor-must-meet"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is the standard vehicle for foreign direct investment in Indonesia. Once incorporated and licensed, the company enters a continuous compliance cycle that Indonesian law enforces through multiple overlapping regulator"
 coverImage: "/static/news/visa_20260409_175444_bb753ca6_cover.png"
 coverImageAlt: "Running a PT PMA in Indonesia: The Compliance Obligations Every Foreign Investor Must Meet"
 category: "business"

--- a/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.fr.mdx
+++ b/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
 slug: "thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction"
-excerpt: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
+excerpt: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
 coverImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.jpg"
 cardImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction_card.jpg"
 coverImageAlt: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thailand vs Bali: The Hidden Cost of Picking the Wrong..."
-seoDescription: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
+seoDescription: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.id.mdx
+++ b/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
 slug: "thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction"
-excerpt: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
+excerpt: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
 coverImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.jpg"
 cardImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction_card.jpg"
 coverImageAlt: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thailand vs Bali: The Hidden Cost of Picking the Wrong..."
-seoDescription: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
+seoDescription: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.it.mdx
+++ b/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
 slug: "thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction"
-excerpt: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
+excerpt: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
 coverImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.jpg"
 cardImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction_card.jpg"
 coverImageAlt: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thailand vs Bali: The Hidden Cost of Picking the Wrong..."
-seoDescription: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
+seoDescription: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.mdx
+++ b/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
 slug: "thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction"
-excerpt: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
+excerpt: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
 coverImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.jpg"
 cardImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction_card.jpg"
 coverImageAlt: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thailand vs Bali: The Hidden Cost of Picking the Wrong..."
-seoDescription: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
+seoDescription: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.ru.mdx
+++ b/apps/mouth/src/content/articles/business/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
 slug: "thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction"
-excerpt: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
+excerpt: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer markets. Thailand and Indonesia — specifically Bali — consistently top the shortlist. On the surface, both offer similar lifestyle p"
 coverImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction.jpg"
 cardImage: "/static/news/thailand-vs-bali-the-hidden-cost-of-picking-the-wrong-jurisdiction_card.jpg"
 coverImageAlt: "Thailand vs Bali: The Hidden Cost of Picking the Wrong Jurisdiction"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thailand vs Bali: The Hidden Cost of Picking the Wrong..."
-seoDescription: "## Facts  Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
+seoDescription: "Southeast Asia has long been the default destination for foreign entrepreneurs seeking lower costs, warmer climates, and growing consumer..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.fr.mdx
+++ b/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
 slug: "the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned"
-excerpt: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
+excerpt: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
 coverImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.jpg"
 cardImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned_card.jpg"
 coverImageAlt: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Nominee Trap: How 10,000 Bali Investors Paid for Land..."
-seoDescription: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
+seoDescription: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.id.mdx
+++ b/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
 slug: "the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned"
-excerpt: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
+excerpt: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
 coverImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.jpg"
 cardImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned_card.jpg"
 coverImageAlt: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Nominee Trap: How 10,000 Bali Investors Paid for Land..."
-seoDescription: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
+seoDescription: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.it.mdx
+++ b/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
 slug: "the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned"
-excerpt: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
+excerpt: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
 coverImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.jpg"
 cardImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned_card.jpg"
 coverImageAlt: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Nominee Trap: How 10,000 Bali Investors Paid for Land..."
-seoDescription: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
+seoDescription: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.mdx
+++ b/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
 slug: "the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned"
-excerpt: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
+excerpt: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
 coverImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.jpg"
 cardImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned_card.jpg"
 coverImageAlt: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Nominee Trap: How 10,000 Bali Investors Paid for Land..."
-seoDescription: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
+seoDescription: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.ru.mdx
+++ b/apps/mouth/src/content/articles/business/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
 slug: "the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned"
-excerpt: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
+excerpt: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land (Hak Milik) — handed over capital to purchase properties registered in the names of Indonesian nationals acting as nominees. Lawy"
 coverImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned.jpg"
 cardImage: "/static/news/the-nominee-trap-how-10000-bali-investors-paid-for-land-they-never-legally-owned_card.jpg"
 coverImageAlt: "The Nominee Trap: How 10,000 Bali Investors Paid for Land They Never Legally Owned"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Nominee Trap: How 10,000 Bali Investors Paid for Land..."
-seoDescription: "## Facts  For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
+seoDescription: "For two decades, Bali's property market ran on a quiet fiction. Foreigners — prohibited by Indonesian law from directly owning freehold land..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-real-numbers-on-bali-apartment-investment-for-foreigners.it.mdx
+++ b/apps/mouth/src/content/articles/business/the-real-numbers-on-bali-apartment-investment-for-foreigners.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Real Numbers on Bali Apartment Investment for Foreigners"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does The Real Numbers on Bali...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/business/the-real-numbers-on-bali-apartment-investment-for-foreigners.mdx
+++ b/apps/mouth/src/content/articles/business/the-real-numbers-on-bali-apartment-investment-for-foreigners.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Real Numbers on Bali Apartment Investment for Foreigners"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does The Real Numbers on Bali...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.fr.mdx
+++ b/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Truth About Foreign Property Ownership in Indonesia"
 slug: "the-truth-about-foreign-property-ownership-in-indonesia"
-excerpt: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
+excerpt: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
 coverImage: "/static/news/visa_20260408_173221_e9e234c2_cover.png"
 coverImageAlt: "The Truth About Foreign Property Ownership in Indonesia"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Truth About Foreign Property Ownership in Indonesia"
-seoDescription: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
+seoDescription: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.id.mdx
+++ b/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Truth About Foreign Property Ownership in Indonesia"
 slug: "the-truth-about-foreign-property-ownership-in-indonesia"
-excerpt: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
+excerpt: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
 coverImage: "/static/news/visa_20260408_173221_e9e234c2_cover.png"
 coverImageAlt: "The Truth About Foreign Property Ownership in Indonesia"
 category: "business"

--- a/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.it.mdx
+++ b/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Truth About Foreign Property Ownership in Indonesia"
 slug: "the-truth-about-foreign-property-ownership-in-indonesia"
-excerpt: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
+excerpt: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
 coverImage: "/static/news/visa_20260408_173221_e9e234c2_cover.png"
 coverImageAlt: "The Truth About Foreign Property Ownership in Indonesia"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Truth About Foreign Property Ownership in Indonesia"
-seoDescription: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
+seoDescription: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.mdx
+++ b/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Truth About Foreign Property Ownership in Indonesia"
 slug: "the-truth-about-foreign-property-ownership-in-indonesia"
-excerpt: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
+excerpt: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
 coverImage: "/static/news/visa_20260408_173221_e9e234c2_cover.png"
 coverImageAlt: "The Truth About Foreign Property Ownership in Indonesia"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Truth About Foreign Property Ownership in Indonesia"
-seoDescription: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
+seoDescription: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.ru.mdx
+++ b/apps/mouth/src/content/articles/business/the-truth-about-foreign-property-ownership-in-indonesia.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Truth About Foreign Property Ownership in Indonesia"
 slug: "the-truth-about-foreign-property-ownership-in-indonesia"
-excerpt: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
+excerpt: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this framework, only Indonesian citizens (Warga Negara Indonesia, WNI) may hold Hak Milik, the strongest form of freehold ownership"
 coverImage: "/static/news/visa_20260408_173221_e9e234c2_cover.png"
 coverImageAlt: "The Truth About Foreign Property Ownership in Indonesia"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Truth About Foreign Property Ownership in Indonesia"
-seoDescription: "## Facts  Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
+seoDescription: "Indonesia's Basic Agrarian Law (Undang-Undang Pokok Agraria, UUPA No. 5/1960) remains the foundation of all land law in the country. Under this..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny.id.mdx
+++ b/apps/mouth/src/content/articles/business/three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny.id.mdx
@@ -59,18 +59,12 @@ description:
   \ regulasi. Dengan mengikuti langkah-langkah di atas, investor asing dapat memaksimalkan\
   \ peluang investasi dan mencapai kesuksesan di pasar Indonesia."
 difficulty: intermediate
-excerpt:
-  "## Facts  Three foreign tourists filed reports of sexual assault with Balinese
-  authorities within a three-day span, according to reporting by Social Expat. The
-  incidents occurred in close temporal proximity, though the specific locations, circumstances,
-  and nationalities of the v"
+excerpt: "Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social Expat. The incidents occurred in close temporal proximity, though the specific locations, circumstances, and nationalities of the v"
 featured: false
 lang: id
 publishedAt: "2026-04-01"
 readingTime: 3
-seoDescription:
-  "## Facts  Three foreign tourists filed reports of sexual assault
-  with Balinese authorities within a three-day span, according to reporting by Social..."
+seoDescription: "Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social..."
 seoTitle: Three Sexual Assaults in Three Days Puts Bali Tourism...
 slug: three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny
 tags:

--- a/apps/mouth/src/content/articles/business/three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny.it.mdx
+++ b/apps/mouth/src/content/articles/business/three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Three Sexual Assaults in Three Days Puts Bali Tourism Safety Under Scrutiny"
 slug: "three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny"
-excerpt: "## Facts  Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social Expat. The incidents occurred in close temporal proximity, though the specific locations, circumstances, and nationalities of the v"
+excerpt: "Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social Expat. The incidents occurred in close temporal proximity, though the specific locations, circumstances, and nationalities of the v"
 coverImage: "/static/news/news_20260330_233127_77302d5c_cover.png"
 coverImageAlt: "Three Sexual Assaults in Three Days Puts Bali Tourism Safety Under Scrutiny"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Three Sexual Assaults in Three Days Puts Bali Tourism..."
-seoDescription: "## Facts  Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social..."
+seoDescription: "Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business/three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny.mdx
+++ b/apps/mouth/src/content/articles/business/three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Three Sexual Assaults in Three Days Puts Bali Tourism Safety Under Scrutiny"
 slug: "three-sexual-assaults-in-three-days-puts-bali-tourism-safety-under-scrutiny"
-excerpt: "## Facts  Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social Expat. The incidents occurred in close temporal proximity, though the specific locations, circumstances, and nationalities of the v"
+excerpt: "Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social Expat. The incidents occurred in close temporal proximity, though the specific locations, circumstances, and nationalities of the v"
 coverImage: "/static/news/news_20260330_233127_77302d5c_cover.png"
 coverImageAlt: "Three Sexual Assaults in Three Days Puts Bali Tourism Safety Under Scrutiny"
 category: "business"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Three Sexual Assaults in Three Days Puts Bali Tourism..."
-seoDescription: "## Facts  Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social..."
+seoDescription: "Three foreign tourists filed reports of sexual assault with Balinese authorities within a three-day span, according to reporting by Social..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/13-japanese-nationals-deported-from-indonesia-for-online-scam-operations.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/13-japanese-nationals-deported-from-indonesia-for-online-scam-operations.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "13 Japanese Nationals Deported from Indonesia for Online Scam Operations"
 slug: "13-japanese-nationals-deported-from-indonesia-for-online-scam-operations"
-excerpt: "## Facts  Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and"
+excerpt: "Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and"
 coverImage: "/static/news/visa_20260415_174742_5f5d422c_cover.png"
 coverImageAlt: "13 Japanese Nationals Deported from Indonesia for Online Scam Operations"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/13-japanese-nationals-deported-from-indonesia-for-online-scam-operations.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/13-japanese-nationals-deported-from-indonesia-for-online-scam-operations.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "13 Japanese Nationals Deported from Indonesia for Online Scam Operations"
 slug: "13-japanese-nationals-deported-from-indonesia-for-online-scam-operations"
-excerpt: "## Facts  Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and"
+excerpt: "Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and"
 coverImage: "/static/news/visa_20260415_174742_5f5d422c_cover.png"
 coverImageAlt: "13 Japanese Nationals Deported from Indonesia for Online Scam Operations"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/13-japanese-nationals-deported-from-indonesia-for-online-scam-operations.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/13-japanese-nationals-deported-from-indonesia-for-online-scam-operations.mdx
@@ -1,7 +1,7 @@
 ---
 title: "13 Japanese Nationals Deported from Indonesia for Online Scam Operations"
 slug: "13-japanese-nationals-deported-from-indonesia-for-online-scam-operations"
-excerpt: "## Facts  Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and"
+excerpt: "Indonesian immigration officials have confirmed the deportation of 13 Japanese citizens this week following their arrest in Bogor, West Java, on charges related to online scamming activities. The operation, coordinated between the Directorate General of Immigration and"
 coverImage: "/static/news/visa_20260415_174742_5f5d422c_cover.png"
 coverImageAlt: "13 Japanese Nationals Deported from Indonesia for Online Scam Operations"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
 slug: "bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate"
-excerpt: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
+excerpt: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
 coverImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.jpg"
 cardImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate_card.jpg"
 coverImageAlt: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Market Entry 2026: The Regulatory Maze Foreign..."
-seoDescription: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
+seoDescription: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
 slug: "bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate"
-excerpt: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
+excerpt: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
 coverImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.jpg"
 cardImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate_card.jpg"
 coverImageAlt: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Market Entry 2026: The Regulatory Maze Foreign..."
-seoDescription: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
+seoDescription: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
 slug: "bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate"
-excerpt: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
+excerpt: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
 coverImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.jpg"
 cardImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate_card.jpg"
 coverImageAlt: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Market Entry 2026: The Regulatory Maze Foreign..."
-seoDescription: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
+seoDescription: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
 slug: "bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate"
-excerpt: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
+excerpt: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
 coverImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.jpg"
 cardImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate_card.jpg"
 coverImageAlt: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Market Entry 2026: The Regulatory Maze Foreign..."
-seoDescription: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
+seoDescription: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
 slug: "bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate"
-excerpt: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
+excerpt: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that has changed materially over the past two years. The primary legal vehicle for foreign direct investment remains the PT PMA (Per"
 coverImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate.jpg"
 cardImage: "/static/news/bali-market-entry-2026-the-regulatory-maze-foreign-investors-must-navigate_card.jpg"
 coverImageAlt: "Bali Market Entry 2026: The Regulatory Maze Foreign Investors Must Navigate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Market Entry 2026: The Regulatory Maze Foreign..."
-seoDescription: "## Facts  Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
+seoDescription: "Establishing a foreign-owned business in Bali in 2026 means navigating one of Southeast Asia's more complex regulatory environments — one that..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Airbnb Era Under Pressure: What the 2026 Rules Mean for Short-Stay Rentals"
 slug: "balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals"
-excerpt: "## Facts  Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment"
+excerpt: "Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment"
 coverImage: "/static/news/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.jpg"
 coverImageAlt: "Bali's Airbnb Era Under Pressure: What the 2026 Rules Mean for Short-Stay Rentals"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Airbnb Era Under Pressure: What the 2026 Rules Mean for Short-Stay Rentals"
 slug: "balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals"
-excerpt: "## Facts  Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment"
+excerpt: "Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment"
 coverImage: "/static/news/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.jpg"
 coverImageAlt: "Bali's Airbnb Era Under Pressure: What the 2026 Rules Mean for Short-Stay Rentals"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Airbnb Era Under Pressure: What the 2026 Rules Mean for Short-Stay Rentals"
 slug: "balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals"
-excerpt: "## Facts  Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment"
+excerpt: "Bali's short-term rental market has exploded over the past decade, with estimates placing the island among Southeast Asia's top five Airbnb markets by listing volume. The rapid growth has long outpaced the regulatory infrastructure meant to govern it, leaving a fragment"
 coverImage: "/static/news/balis-airbnb-era-under-pressure-what-the-2026-rules-mean-for-short-stay-rentals.jpg"
 coverImageAlt: "Bali's Airbnb Era Under Pressure: What the 2026 Rules Mean for Short-Stay Rentals"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/bank-indonesia-pledges-rupiah-defense-during-nyepi-and-lebaran-2026.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/bank-indonesia-pledges-rupiah-defense-during-nyepi-and-lebaran-2026.it.mdx
@@ -21,7 +21,6 @@ trending: true
 coverImage: /static/news/bank-indonesia-pledges-rupiah-defense-during-nyepi-and-lebaran-2026.jpg
 coverImageAlt: Bank Indonesia Pledges Rupiah Defense During Nyepi and Lebaran 2026
 seoTitle: Bank Indonesia Pledges Rupiah Defense During Nyepi and...
-seoDescription: "Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization: answerSnippet: \"## Facts Bank Indonesia (BI), Indonesia's central bank, has publicly..."
 readingTime: 3
 aiGenerated: true
 aiConfidenceScore: 0.85

--- a/apps/mouth/src/content/articles/business_regulations/bank-indonesia-pledges-rupiah-defense-during-nyepi-and-lebaran-2026.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/bank-indonesia-pledges-rupiah-defense-during-nyepi-and-lebaran-2026.mdx
@@ -21,7 +21,6 @@ trending: true
 coverImage: /static/news/bank-indonesia-pledges-rupiah-defense-during-nyepi-and-lebaran-2026.jpg
 coverImageAlt: Bank Indonesia Pledges Rupiah Defense During Nyepi and Lebaran 2026
 seoTitle: Bank Indonesia Pledges Rupiah Defense During Nyepi and...
-seoDescription: "Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization: answerSnippet: \"## Facts Bank Indonesia (BI), Indonesia's central bank, has publicly..."
 readingTime: 3
 aiGenerated: true
 aiConfidenceScore: 0.85

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
 slug: "indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules"
-excerpt: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
+excerpt: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
 coverImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.jpg"
 cardImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules_card.jpg"
 coverImageAlt: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under..."
-seoDescription: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
+seoDescription: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
 slug: "indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules"
-excerpt: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
+excerpt: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
 coverImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.jpg"
 cardImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules_card.jpg"
 coverImageAlt: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under..."
-seoDescription: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
+seoDescription: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
 slug: "indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules"
-excerpt: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
+excerpt: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
 coverImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.jpg"
 cardImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules_card.jpg"
 coverImageAlt: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under..."
-seoDescription: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
+seoDescription: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
 slug: "indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules"
-excerpt: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
+excerpt: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
 coverImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.jpg"
 cardImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules_card.jpg"
 coverImageAlt: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under..."
-seoDescription: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
+seoDescription: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
 slug: "indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules"
-excerpt: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
+excerpt: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East Java — is legally required to file quarterly investment activity reports known as LKPM, or Laporan Kegiatan Penanaman Modal. Th"
 coverImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules.jpg"
 cardImage: "/static/news/indonesia-extends-lkpm-quarterly-deadline-to-day-15-under-new-bkpm-rules_card.jpg"
 coverImageAlt: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under New BKPM Rules"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Extends LKPM Quarterly Deadline to Day 15 Under..."
-seoDescription: "## Facts  Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
+seoDescription: "Every foreign-owned company operating in Indonesia — from a boutique villa management firm in Seminyak to a manufacturing conglomerate in East..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-forces-tiktok-and-x-to-block-under-16-users.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-forces-tiktok-and-x-to-block-under-16-users.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Forces TikTok and X to Block Under-16 Users"
 slug: "indonesia-forces-tiktok-and-x-to-block-under-16-users"
-excerpt: "## Facts  Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a"
+excerpt: "Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a"
 coverImage: "/static/news/news_20260330_233254_675b636c_cover.png"
 coverImageAlt: "Indonesia Forces TikTok and X to Block Under-16 Users"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-forces-tiktok-and-x-to-block-under-16-users.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-forces-tiktok-and-x-to-block-under-16-users.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Forces TikTok and X to Block Under-16 Users"
 slug: "indonesia-forces-tiktok-and-x-to-block-under-16-users"
-excerpt: "## Facts  Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a"
+excerpt: "Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a"
 coverImage: "/static/news/news_20260330_233254_675b636c_cover.png"
 coverImageAlt: "Indonesia Forces TikTok and X to Block Under-16 Users"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-forces-tiktok-and-x-to-block-under-16-users.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-forces-tiktok-and-x-to-block-under-16-users.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Forces TikTok and X to Block Under-16 Users"
 slug: "indonesia-forces-tiktok-and-x-to-block-under-16-users"
-excerpt: "## Facts  Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a"
+excerpt: "Indonesia has become one of the first Southeast Asian nations to enforce a sweeping social media age restriction, requiring platforms to bar users under the age of 16. TikTok and X have both confirmed compliance with the Indonesian government's directive, implementing a"
 coverImage: "/static/news/news_20260330_233254_675b636c_cover.png"
 coverImageAlt: "Indonesia Forces TikTok and X to Block Under-16 Users"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Data Center Sector to Foreign Capital — Here's How to Enter"
 slug: "indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter"
-excerpt: "## Facts  Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he"
+excerpt: "Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he"
 coverImage: "/static/news/news_20260331_183928_f97c2e46_cover.png"
 coverImageAlt: "Indonesia Opens Data Center Sector to Foreign Capital — Here's How to Enter"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Data Center Sector to Foreign Capital —..."
-seoDescription: "## Facts  Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy..."
+seoDescription: "Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Data Center Sector to Foreign Capital — Here's How to Enter"
 slug: "indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter"
-excerpt: "## Facts  Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he"
+excerpt: "Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he"
 coverImage: "/static/news/news_20260331_183928_f97c2e46_cover.png"
 coverImageAlt: "Indonesia Opens Data Center Sector to Foreign Capital — Here's How to Enter"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Data Center Sector to Foreign Capital —..."
-seoDescription: "## Facts  Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy..."
+seoDescription: "Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Data Center Sector to Foreign Capital — Here's How to Enter"
 slug: "indonesia-opens-data-center-sector-to-foreign-capital-heres-how-to-enter"
-excerpt: "## Facts  Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he"
+excerpt: "Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy projected to exceed $130 billion by 2030, and a government mandate to onshore data storage for regulated sectors including finance, he"
 coverImage: "/static/news/news_20260331_183928_f97c2e46_cover.png"
 coverImageAlt: "Indonesia Opens Data Center Sector to Foreign Capital — Here's How to Enter"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Data Center Sector to Foreign Capital —..."
-seoDescription: "## Facts  Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy..."
+seoDescription: "Indonesia's data center market is among the fastest-growing in Southeast Asia, driven by accelerating cloud adoption, a digital economy..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Spatial Planning: What KKPR Means for Your Business"
 slug: "indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business"
-excerpt: "## Facts  Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi"
+excerpt: "Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi"
 coverImage: "/static/news/news_20260423_112338_23b28b40_cover.png"
 coverImageAlt: "Indonesia Tightens Spatial Planning: What KKPR Means for Your Business"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Spatial Planning: What KKPR Means for Your Business"
 slug: "indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business"
-excerpt: "## Facts  Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi"
+excerpt: "Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi"
 coverImage: "/static/news/news_20260423_112338_23b28b40_cover.png"
 coverImageAlt: "Indonesia Tightens Spatial Planning: What KKPR Means for Your Business"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Spatial Planning: What KKPR Means for Your Business"
 slug: "indonesia-tightens-spatial-planning-what-kkpr-means-for-your-business"
-excerpt: "## Facts  Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi"
+excerpt: "Indonesia's spatial planning framework requires any business or individual intending to use land for commercial purposes to first obtain a KKPR — Kesesuaian Kegiatan Pemanfaatan Ruang, which translates broadly as Spatial Activity Utilisation Conformity. The permit confi"
 coverImage: "/static/news/news_20260423_112338_23b28b40_cover.png"
 coverImageAlt: "Indonesia Tightens Spatial Planning: What KKPR Means for Your Business"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-us-banking-data-pact-what-ojks-new-stance-means-for-your-money.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-us-banking-data-pact-what-ojks-new-stance-means-for-your-money.id.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia-US Banking Data Pact: What OJK's New Stance Means..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia-US Banking Data...'
 locale: "id"
 ---
 

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-us-banking-data-pact-what-ojks-new-stance-means-for-your-money.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-us-banking-data-pact-what-ojks-new-stance-means-for-your-money.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia-US Banking Data Pact: What OJK's New Stance Means..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia-US Banking Data...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/business_regulations/indonesia-us-banking-data-pact-what-ojks-new-stance-means-for-your-money.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesia-us-banking-data-pact-what-ojks-new-stance-means-for-your-money.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia-US Banking Data Pact: What OJK's New Stance Means..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia-US Banking Data...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "KBLI 2025 setelah tenggat Juni 2026: verifikasi untuk PT PMA"
 slug: "indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses"
-excerpt: "## Facts  Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat"
+excerpt: "Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat"
 coverImage: "/static/news/news_20260426_173746_ae8f2cf5_cover.png"
 coverImageAlt: "KBLI 2025 setelah tenggat Juni 2026: verifikasi untuk PT PMA"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "KBLI 2025 dopo la finestra di giugno 2026: verifica per le PT PMA"
 slug: "indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses"
-excerpt: "## Facts  Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat"
+excerpt: "Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat"
 coverImage: "/static/news/news_20260426_173746_ae8f2cf5_cover.png"
 coverImageAlt: "KBLI 2025 dopo la finestra di giugno 2026: verifica per le PT PMA"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's KBLI 2025 Overhaul: Post-Deadline Verification for Foreign Businesses"
 slug: "indonesias-kbli-2025-overhaul-what-the-june-2026-deadline-means-for-foreign-businesses"
-excerpt: "## Facts  Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat"
+excerpt: "Indonesia's Central Statistics Agency (Badan Pusat Statistik, BPS) periodically updates the Klasifikasi Baku Lapangan Usaha Indonesia — the national standard business activity classification, known as KBLI — to reflect shifts in the economy, new industries, and internat"
 coverImage: "/static/news/news_20260426_173746_ae8f2cf5_cover.png"
 coverImageAlt: "Indonesia's KBLI 2025 Overhaul: Post-Deadline Verification for Foreign Businesses"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's NIB: The One Business ID Every Investor Must Have"
 slug: "indonesias-nib-the-one-business-id-every-investor-must-have"
-excerpt: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
+excerpt: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
 coverImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have.jpg"
 cardImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have_card.jpg"
 coverImageAlt: "Indonesia's NIB: The One Business ID Every Investor Must Have"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's NIB: The One Business ID Every Investor Must..."
-seoDescription: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
+seoDescription: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's NIB: The One Business ID Every Investor Must Have"
 slug: "indonesias-nib-the-one-business-id-every-investor-must-have"
-excerpt: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
+excerpt: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
 coverImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have.jpg"
 cardImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have_card.jpg"
 coverImageAlt: "Indonesia's NIB: The One Business ID Every Investor Must Have"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's NIB: The One Business ID Every Investor Must..."
-seoDescription: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
+seoDescription: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's NIB: The One Business ID Every Investor Must Have"
 slug: "indonesias-nib-the-one-business-id-every-investor-must-have"
-excerpt: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
+excerpt: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
 coverImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have.jpg"
 cardImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have_card.jpg"
 coverImageAlt: "Indonesia's NIB: The One Business ID Every Investor Must Have"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's NIB: The One Business ID Every Investor Must..."
-seoDescription: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
+seoDescription: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's NIB: The One Business ID Every Investor Must Have"
 slug: "indonesias-nib-the-one-business-id-every-investor-must-have"
-excerpt: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
+excerpt: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
 coverImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have.jpg"
 cardImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have_card.jpg"
 coverImageAlt: "Indonesia's NIB: The One Business ID Every Investor Must Have"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's NIB: The One Business ID Every Investor Must..."
-seoDescription: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
+seoDescription: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-nib-the-one-business-id-every-investor-must-have.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's NIB: The One Business ID Every Investor Must Have"
 slug: "indonesias-nib-the-one-business-id-every-investor-must-have"
-excerpt: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
+excerpt: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single Submission (OSS) system, now operating under a Risk-Based Approach (OSS-RBA) framework. At its core sits the Nomor Induk Berus"
 coverImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have.jpg"
 cardImage: "/static/news/indonesias-nib-the-one-business-id-every-investor-must-have_card.jpg"
 coverImageAlt: "Indonesia's NIB: The One Business ID Every Investor Must Have"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's NIB: The One Business ID Every Investor Must..."
-seoDescription: "## Facts  Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
+seoDescription: "Indonesia's business registration landscape underwent its most significant overhaul in decades when the government introduced the Online Single..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
 slug: "indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators"
-excerpt: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
+excerpt: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
 coverImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.jpg"
 cardImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators_card.jpg"
 coverImageAlt: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration..."
-seoDescription: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
+seoDescription: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
 slug: "indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators"
-excerpt: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
+excerpt: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
 coverImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.jpg"
 cardImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators_card.jpg"
 coverImageAlt: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration..."
-seoDescription: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
+seoDescription: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
 slug: "indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators"
-excerpt: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
+excerpt: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
 coverImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.jpg"
 cardImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators_card.jpg"
 coverImageAlt: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration..."
-seoDescription: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
+seoDescription: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
 slug: "indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators"
-excerpt: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
+excerpt: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
 coverImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.jpg"
 cardImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators_card.jpg"
 coverImageAlt: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration..."
-seoDescription: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
+seoDescription: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
 slug: "indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators"
-excerpt: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
+excerpt: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha Indonesia (KBLI) 2025, directing tourism businesses to update their registrations through the Online Single Submission (OSS) s"
 coverImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators.jpg"
 cardImage: "/static/news/indonesias-tourism-ministry-mandates-kbli-2025-migration-via-oss-for-all-tourism-operators_card.jpg"
 coverImageAlt: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration via OSS for All Tourism Operators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tourism Ministry Mandates KBLI 2025 Migration..."
-seoDescription: "## Facts  Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
+seoDescription: "Indonesia's Ministry of Tourism (Kemenpar) is leading a targeted push to accelerate the adoption of the revised Klasifikasi Baku Lapangan Usaha..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/middle-east-war-rattles-global-economy-rupiah-slips-inflation-climbs.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/middle-east-war-rattles-global-economy-rupiah-slips-inflation-climbs.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Middle East War Rattles Global Economy: Rupiah Slips,..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Middle East War Rattles...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/business_regulations/middle-east-war-rattles-global-economy-rupiah-slips-inflation-climbs.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/middle-east-war-rattles-global-economy-rupiah-slips-inflation-climbs.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Middle East War Rattles Global Economy: Rupiah Slips,..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Middle East War Rattles...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 slug: "ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms"
-excerpt: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+excerpt: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
 coverImage: "/static/news/news_20260608_173755_ec8588d0_cover.png"
 coverImageAlt: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "OJK Puts 8 Online Lenders on Watchlist, License Revocation..."
-seoDescription: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
+seoDescription: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 slug: "ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms"
-excerpt: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+excerpt: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
 coverImage: "/static/news/news_20260608_173755_ec8588d0_cover.png"
 coverImageAlt: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "OJK Puts 8 Online Lenders on Watchlist, License Revocation..."
-seoDescription: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
+seoDescription: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 slug: "ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms"
-excerpt: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+excerpt: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
 coverImage: "/static/news/news_20260608_173755_ec8588d0_cover.png"
 coverImageAlt: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "OJK Puts 8 Online Lenders on Watchlist, License Revocation..."
-seoDescription: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
+seoDescription: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 slug: "ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms"
-excerpt: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+excerpt: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
 coverImage: "/static/news/news_20260608_173755_ec8588d0_cover.png"
 coverImageAlt: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "OJK Puts 8 Online Lenders on Watchlist, License Revocation..."
-seoDescription: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
+seoDescription: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 slug: "ojk-puts-8-online-lenders-on-watchlist-license-revocation-looms"
-excerpt: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
+excerpt: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online lending platforms—colloquially known as 'pinjol,' short for pinjaman online—onto its special supervision list, according to a repor"
 coverImage: "/static/news/news_20260608_173755_ec8588d0_cover.png"
 coverImageAlt: "OJK Puts 8 Online Lenders on Watchlist, License Revocation Looms"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "OJK Puts 8 Online Lenders on Watchlist, License Revocation..."
-seoDescription: "## Facts  Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
+seoDescription: "Indonesia's Otoritas Jasa Keuangan (OJK), the country's integrated financial services regulator, has moved eight peer-to-peer (P2P) online..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
 slug: "pt-pma-compliance-in-indonesia-what-foreign-investors-must-track"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
 coverImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.jpg"
 cardImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track_card.jpg"
 coverImageAlt: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "PT PMA Compliance in Indonesia: What Foreign Investors Must..."
-seoDescription: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
+seoDescription: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
 slug: "pt-pma-compliance-in-indonesia-what-foreign-investors-must-track"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
 coverImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.jpg"
 cardImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track_card.jpg"
 coverImageAlt: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "PT PMA Compliance in Indonesia: What Foreign Investors Must..."
-seoDescription: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
+seoDescription: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
 slug: "pt-pma-compliance-in-indonesia-what-foreign-investors-must-track"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
 coverImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.jpg"
 cardImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track_card.jpg"
 coverImageAlt: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "PT PMA Compliance in Indonesia: What Foreign Investors Must..."
-seoDescription: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
+seoDescription: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
 slug: "pt-pma-compliance-in-indonesia-what-foreign-investors-must-track"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
 coverImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.jpg"
 cardImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track_card.jpg"
 coverImageAlt: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "PT PMA Compliance in Indonesia: What Foreign Investors Must..."
-seoDescription: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
+seoDescription: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
 slug: "pt-pma-compliance-in-indonesia-what-foreign-investors-must-track"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the company enters a continuous compliance cycle that most foreign investors underestimate at formation stage. The obligations span at l"
 coverImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track.jpg"
 cardImage: "/static/news/pt-pma-compliance-in-indonesia-what-foreign-investors-must-track_card.jpg"
 coverImageAlt: "PT PMA Compliance in Indonesia: What Foreign Investors Must Track"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "PT PMA Compliance in Indonesia: What Foreign Investors Must..."
-seoDescription: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
+seoDescription: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is Indonesia's primary vehicle for foreign direct investment. Once established, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-the-legal-vehicle-hospitality-investors-must-understand.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-the-legal-vehicle-hospitality-investors-must-understand.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "PT PMA in Bali: The Legal Vehicle Hospitality Investors..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does PT PMA in Bali: The Legal...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-the-legal-vehicle-hospitality-investors-must-understand.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-the-legal-vehicle-hospitality-investors-must-understand.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "PT PMA in Bali: The Legal Vehicle Hospitality Investors..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does PT PMA in Bali: The Legal...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 slug: "pt-pma-in-bali-what-foreign-investors-must-know-in-2026"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
 coverImage: "/static/news/news_20260326_173201_e2b64e54_cover.png"
 coverImageAlt: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 slug: "pt-pma-in-bali-what-foreign-investors-must-know-in-2026"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
 coverImage: "/static/news/news_20260326_173201_e2b64e54_cover.png"
 coverImageAlt: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 slug: "pt-pma-in-bali-what-foreign-investors-must-know-in-2026"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
 coverImage: "/static/news/news_20260326_173201_e2b64e54_cover.png"
 coverImageAlt: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/pt-pma-in-bali-what-foreign-investors-must-know-in-2026.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 slug: "pt-pma-in-bali-what-foreign-investors-must-know-in-2026"
-excerpt: "## Facts  A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
+excerpt: "A PT PMA — Perseroan Terbatas Penanaman Modal Asing — is a foreign-owned limited liability company established under Indonesian law. It is the only legal structure that permits foreign nationals to hold equity stakes in an Indonesian business, distinguishing it sharply"
 coverImage: "/static/news/news_20260326_173201_e2b64e54_cover.png"
 coverImageAlt: "PT PMA in Bali: What Foreign Investors Must Know in 2026"
 category: "business_regulations"

--- a/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.fr.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 slug: "virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require"
-excerpt: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
+excerpt: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
 coverImage: "/static/news/news_20260518_172647_937b6f56_cover.png"
 coverImageAlt: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Virtual Offices for PT PMA: What Indonesia's Address Rules..."
-seoDescription: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
+seoDescription: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 slug: "virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require"
-excerpt: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
+excerpt: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
 coverImage: "/static/news/news_20260518_172647_937b6f56_cover.png"
 coverImageAlt: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Virtual Offices for PT PMA: What Indonesia's Address Rules..."
-seoDescription: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
+seoDescription: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 slug: "virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require"
-excerpt: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
+excerpt: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
 coverImage: "/static/news/news_20260518_172647_937b6f56_cover.png"
 coverImageAlt: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Virtual Offices for PT PMA: What Indonesia's Address Rules..."
-seoDescription: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
+seoDescription: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 slug: "virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require"
-excerpt: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
+excerpt: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
 coverImage: "/static/news/news_20260518_172647_937b6f56_cover.png"
 coverImageAlt: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Virtual Offices for PT PMA: What Indonesia's Address Rules..."
-seoDescription: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
+seoDescription: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.ru.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 slug: "virtual-offices-for-pt-pma-what-indonesias-address-rules-actually-require"
-excerpt: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
+excerpt: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a registered business address that appears in their Articles of Association (Akta Pendirian) and is endorsed by the relevant region"
 coverImage: "/static/news/news_20260518_172647_937b6f56_cover.png"
 coverImageAlt: "Virtual Offices for PT PMA: What Indonesia's Address Rules Actually Require"
 category: "business_regulations"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Virtual Offices for PT PMA: What Indonesia's Address Rules..."
-seoDescription: "## Facts  Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
+seoDescription: "Foreign-owned companies in Indonesia — structured as PT PMA, or Perseroan Terbatas Penanaman Modal Asing — are required by law to maintain a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/x-must-enforce-16-age-rule-in-indonesia-by-march-27.id.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/x-must-enforce-16-age-rule-in-indonesia-by-march-27.id.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "X Must Enforce 16+ Age Rule in Indonesia by March 27"
-seoDescription: "## Facts  Indonesia's Ministry of Communication and Digital Affairs (Komdigi) has issued a directive requiring X to enforce a minimum age threshold of 16..."
+seoDescription: "Indonesia's Ministry of Communication and Digital Affairs (Komdigi) has issued a directive requiring X to enforce a minimum age threshold of 16..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/x-must-enforce-16-age-rule-in-indonesia-by-march-27.it.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/x-must-enforce-16-age-rule-in-indonesia-by-march-27.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "X Must Enforce 16+ Age Rule in Indonesia by March 27"
-seoDescription: "## Facts  Indonesia's Ministry of Communication and Digital Affairs (Komdigi) has issued a directive requiring X to enforce a minimum age threshold of 16..."
+seoDescription: "Indonesia's Ministry of Communication and Digital Affairs (Komdigi) has issued a directive requiring X to enforce a minimum age threshold of 16..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/business_regulations/x-must-enforce-16-age-rule-in-indonesia-by-march-27.mdx
+++ b/apps/mouth/src/content/articles/business_regulations/x-must-enforce-16-age-rule-in-indonesia-by-march-27.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "X Must Enforce 16+ Age Rule in Indonesia by March 27"
-seoDescription: "## Facts  Indonesia's Ministry of Communication and Digital Affairs (Komdigi) has issued a directive requiring X to enforce a minimum age threshold of 16..."
+seoDescription: "Indonesia's Ministry of Communication and Digital Affairs (Komdigi) has issued a directive requiring X to enforce a minimum age threshold of 16..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.fr.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 slug: "indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy"
-excerpt: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
+excerpt: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
 coverImage: "/static/news/visa_20260514_173902_397a8176_cover.png"
 coverImageAlt: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on AI to Lead Southeast Asia's Digital..."
-seoDescription: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
+seoDescription: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.id.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 slug: "indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy"
-excerpt: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
+excerpt: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
 coverImage: "/static/news/visa_20260514_173902_397a8176_cover.png"
 coverImageAlt: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on AI to Lead Southeast Asia's Digital..."
-seoDescription: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
+seoDescription: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.it.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 slug: "indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy"
-excerpt: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
+excerpt: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
 coverImage: "/static/news/visa_20260514_173902_397a8176_cover.png"
 coverImageAlt: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on AI to Lead Southeast Asia's Digital..."
-seoDescription: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
+seoDescription: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 slug: "indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy"
-excerpt: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
+excerpt: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
 coverImage: "/static/news/visa_20260514_173902_397a8176_cover.png"
 coverImageAlt: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on AI to Lead Southeast Asia's Digital..."
-seoDescription: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
+seoDescription: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.ru.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 slug: "indonesia-bets-on-ai-to-lead-southeast-asias-digital-economy"
-excerpt: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
+excerpt: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to consolidate through artificial intelligence adoption. The country's digital economy is forecast to reach hundreds of billions"
 coverImage: "/static/news/visa_20260514_173902_397a8176_cover.png"
 coverImageAlt: "Indonesia Bets on AI to Lead Southeast Asia's Digital Economy"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on AI to Lead Southeast Asia's Digital..."
-seoDescription: "## Facts  Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
+seoDescription: "Indonesia has emerged as the dominant digital economy in Southeast Asia, a position its government and business leaders are actively working to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-charts-course-for-ethical-ai-with-new-regulatory-roadmap.it.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-charts-course-for-ethical-ai-with-new-regulatory-roadmap.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Charts Course for Ethical AI With New Regulatory..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Charts Course for...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-charts-course-for-ethical-ai-with-new-regulatory-roadmap.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-charts-course-for-ethical-ai-with-new-regulatory-roadmap.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Charts Course for Ethical AI With New Regulatory..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Charts Course for...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-moves-to-mandate-labels-on-all-ai-generated-content.id.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-moves-to-mandate-labels-on-all-ai-generated-content.id.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Moves to Mandate Labels on All AI-Generated..."
-seoDescription: "## Facts  Indonesia's Ministry of Communication and Digital Affairs, known as Komdigi, is drafting a regulation that would make labeling of artificial..."
+seoDescription: "Indonesia's Ministry of Communication and Digital Affairs, known as Komdigi, is drafting a regulation that would make labeling of artificial..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-moves-to-mandate-labels-on-all-ai-generated-content.it.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-moves-to-mandate-labels-on-all-ai-generated-content.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Moves to Mandate Labels on All AI-Generated..."
-seoDescription: "## Facts  Indonesia's Ministry of Communication and Digital Affairs, known as Komdigi, is drafting a regulation that would make labeling of artificial..."
+seoDescription: "Indonesia's Ministry of Communication and Digital Affairs, known as Komdigi, is drafting a regulation that would make labeling of artificial..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-moves-to-mandate-labels-on-all-ai-generated-content.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-moves-to-mandate-labels-on-all-ai-generated-content.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Moves to Mandate Labels on All AI-Generated..."
-seoDescription: "## Facts  Indonesia's Ministry of Communication and Digital Affairs, known as Komdigi, is drafting a regulation that would make labeling of artificial..."
+seoDescription: "Indonesia's Ministry of Communication and Digital Affairs, known as Komdigi, is drafting a regulation that would make labeling of artificial..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.fr.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 slug: "indonesia-to-overhaul-oss-business-registration-with-ai-upgrade"
-excerpt: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
+excerpt: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
 coverImage: "/static/news/news_20260415_174756_526d2e88_cover.png"
 coverImageAlt: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia to Overhaul OSS Business Registration With AI..."
-seoDescription: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
+seoDescription: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.id.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 slug: "indonesia-to-overhaul-oss-business-registration-with-ai-upgrade"
-excerpt: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
+excerpt: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
 coverImage: "/static/news/news_20260415_174756_526d2e88_cover.png"
 coverImageAlt: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia to Overhaul OSS Business Registration With AI..."
-seoDescription: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
+seoDescription: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.it.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 slug: "indonesia-to-overhaul-oss-business-registration-with-ai-upgrade"
-excerpt: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
+excerpt: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
 coverImage: "/static/news/news_20260415_174756_526d2e88_cover.png"
 coverImageAlt: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia to Overhaul OSS Business Registration With AI..."
-seoDescription: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
+seoDescription: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 slug: "indonesia-to-overhaul-oss-business-registration-with-ai-upgrade"
-excerpt: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
+excerpt: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
 coverImage: "/static/news/news_20260415_174756_526d2e88_cover.png"
 coverImageAlt: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 category: "emerging_trends"

--- a/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.ru.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesia-to-overhaul-oss-business-registration-with-ai-upgrade.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 slug: "indonesia-to-overhaul-oss-business-registration-with-ai-upgrade"
-excerpt: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
+excerpt: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and investment approvals must pass — is set for a significant technological overhaul. Finance Minister Sri Mulyani Indrawati has form"
 coverImage: "/static/news/news_20260415_174756_526d2e88_cover.png"
 coverImageAlt: "Indonesia to Overhaul OSS Business Registration With AI Upgrade"
 category: "emerging_trends"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia to Overhaul OSS Business Registration With AI..."
-seoDescription: "## Facts  Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
+seoDescription: "Indonesia's Online Single Submission system — the centralised digital portal through which all business licences, company registrations, and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesias-largest-ai-data-center-620m-bet-on-digital-future.id.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesias-largest-ai-data-center-620m-bet-on-digital-future.id.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Largest AI Data Center: $620M Bet on Digital..."
-seoDescription: "## Facts  Digital Edge, a pan-Asian data center operator backed by Stonepeak Infrastructure Partners, has announced plans to develop what would be..."
+seoDescription: "Digital Edge, a pan-Asian data center operator backed by Stonepeak Infrastructure Partners, has announced plans to develop what would be..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesias-largest-ai-data-center-620m-bet-on-digital-future.it.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesias-largest-ai-data-center-620m-bet-on-digital-future.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Largest AI Data Center: $620M Bet on Digital..."
-seoDescription: "## Facts  Digital Edge, a pan-Asian data center operator backed by Stonepeak Infrastructure Partners, has announced plans to develop what would be..."
+seoDescription: "Digital Edge, a pan-Asian data center operator backed by Stonepeak Infrastructure Partners, has announced plans to develop what would be..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/indonesias-largest-ai-data-center-620m-bet-on-digital-future.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/indonesias-largest-ai-data-center-620m-bet-on-digital-future.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Largest AI Data Center: $620M Bet on Digital..."
-seoDescription: "## Facts  Digital Edge, a pan-Asian data center operator backed by Stonepeak Infrastructure Partners, has announced plans to develop what would be..."
+seoDescription: "Digital Edge, a pan-Asian data center operator backed by Stonepeak Infrastructure Partners, has announced plans to develop what would be..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/emerging_trends/white-house-sets-rules-for-ai-what-the-new-framework-changes.it.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/white-house-sets-rules-for-ai-what-the-new-framework-changes.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "White House Sets Rules for AI: What the New Framework..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does White House Sets Rules for...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/emerging_trends/white-house-sets-rules-for-ai-what-the-new-framework-changes.mdx
+++ b/apps/mouth/src/content/articles/emerging_trends/white-house-sets-rules-for-ai-what-the-new-framework-changes.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "White House Sets Rules for AI: What the New Framework..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does White House Sets Rules for...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 slug: "bali-all-access-pass-one-card-to-rule-the-islands-transit"
-excerpt: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
+excerpt: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
 coverImage: "/static/news/visa_20260507_174113_ebac2a19_cover.png"
 coverImageAlt: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali All-Access Pass: One Card to Rule the Island's Transit"
-seoDescription: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
+seoDescription: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 slug: "bali-all-access-pass-one-card-to-rule-the-islands-transit"
-excerpt: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
+excerpt: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
 coverImage: "/static/news/visa_20260507_174113_ebac2a19_cover.png"
 coverImageAlt: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali All-Access Pass: One Card to Rule the Island's Transit"
-seoDescription: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
+seoDescription: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 slug: "bali-all-access-pass-one-card-to-rule-the-islands-transit"
-excerpt: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
+excerpt: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
 coverImage: "/static/news/visa_20260507_174113_ebac2a19_cover.png"
 coverImageAlt: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali All-Access Pass: One Card to Rule the Island's Transit"
-seoDescription: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
+seoDescription: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 slug: "bali-all-access-pass-one-card-to-rule-the-islands-transit"
-excerpt: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
+excerpt: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
 coverImage: "/static/news/visa_20260507_174113_ebac2a19_cover.png"
 coverImageAlt: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali All-Access Pass: One Card to Rule the Island's Transit"
-seoDescription: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
+seoDescription: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-all-access-pass-one-card-to-rule-the-islands-transit.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 slug: "bali-all-access-pass-one-card-to-rule-the-islands-transit"
-excerpt: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
+excerpt: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move around and access services across the island. The initiative, reported by Indonesia Expat, reflects a broader push by Bali's reg"
 coverImage: "/static/news/visa_20260507_174113_ebac2a19_cover.png"
 coverImageAlt: "Bali All-Access Pass: One Card to Rule the Island's Transit"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali All-Access Pass: One Card to Rule the Island's Transit"
-seoDescription: "## Facts  Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
+seoDescription: "Bali has introduced a new 'All-Access Pass,' a consolidated travel and mobility solution aimed at simplifying how visitors and residents move..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect Stranded Tourists"
 slug: "bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists"
-excerpt: "## Facts  Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori"
+excerpt: "Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori"
 coverImage: "/static/news/visa_20260511_174306_a65682e5.jpg"
 coverImageAlt: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect Stranded Tourists"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect..."
-seoDescription: "## Facts  Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader..."
+seoDescription: "Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect Stranded Tourists"
 slug: "bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists"
-excerpt: "## Facts  Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori"
+excerpt: "Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori"
 coverImage: "/static/news/visa_20260511_174306_a65682e5.jpg"
 coverImageAlt: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect Stranded Tourists"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect..."
-seoDescription: "## Facts  Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader..."
+seoDescription: "Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect Stranded Tourists"
 slug: "bali-arrivals-climb-10-as-conflict-era-safeguards-protect-stranded-tourists"
-excerpt: "## Facts  Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori"
+excerpt: "Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader anxieties about the impact of global conflict on long-haul leisure travel. The data points to a travel market that continues to priori"
 coverImage: "/static/news/visa_20260511_174306_a65682e5.jpg"
 coverImageAlt: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect Stranded Tourists"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Arrivals Climb 10% as Conflict-Era Safeguards Protect..."
-seoDescription: "## Facts  Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader..."
+seoDescription: "Bali's international tourist arrivals have risen approximately 10% in recent months, a figure that stands in marked contrast to broader..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa Extensions"
 slug: "bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions"
-excerpt: "## Facts  Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators.  At the national level, Permenk"
+excerpt: "Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators. At the national level, Permenk"
 coverImage: "/static/news/visa_20260415_174724_ca7a96ca.jpg"
 coverImageAlt: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa Extensions"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa..."
-seoDescription: "## Facts  Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven..."
+seoDescription: "Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa Extensions"
 slug: "bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions"
-excerpt: "## Facts  Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators.  At the national level, Permenk"
+excerpt: "Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators. At the national level, Permenk"
 coverImage: "/static/news/visa_20260415_174724_ca7a96ca.jpg"
 coverImageAlt: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa Extensions"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa..."
-seoDescription: "## Facts  Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven..."
+seoDescription: "Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa Extensions"
 slug: "bali-cracks-down-pt-pma-shareholders-banned-from-c1-visa-extensions"
-excerpt: "## Facts  Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators.  At the national level, Permenk"
+excerpt: "Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven enforcement crackdown that has particular bite for Bali's large community of foreign business operators. At the national level, Permenk"
 coverImage: "/static/news/visa_20260415_174724_ca7a96ca.jpg"
 coverImageAlt: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa Extensions"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: PT PMA Shareholders Banned from C1 Visa..."
-seoDescription: "## Facts  Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven..."
+seoDescription: "Indonesia's immigration landscape shifted materially in 2025–2026, with national legislative reforms layered beneath a locally-driven..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 slug: "bali-governor-downplays-crime-surge-as-foreign-cases-mount"
-excerpt: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+excerpt: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 coverImage: "/static/news/visa_20260327_180114_50df26f5_cover.png"
 coverImageAlt: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
-seoDescription: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+seoDescription: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 slug: "bali-governor-downplays-crime-surge-as-foreign-cases-mount"
-excerpt: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+excerpt: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 coverImage: "/static/news/visa_20260327_180114_50df26f5_cover.png"
 coverImageAlt: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
-seoDescription: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+seoDescription: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 slug: "bali-governor-downplays-crime-surge-as-foreign-cases-mount"
-excerpt: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+excerpt: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 coverImage: "/static/news/visa_20260327_180114_50df26f5_cover.png"
 coverImageAlt: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
-seoDescription: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+seoDescription: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-governor-downplays-crime-surge-as-foreign-cases-mount.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 slug: "bali-governor-downplays-crime-surge-as-foreign-cases-mount"
-excerpt: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+excerpt: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 coverImage: "/static/news/visa_20260327_180114_50df26f5_cover.png"
 coverImageAlt: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Governor Downplays Crime Surge as Foreign Cases Mount"
-seoDescription: "## Facts  Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
+seoDescription: "Bali Governor Wayan Koster issued a public statement asserting that the island remains a safe destination for tourists and foreign investors, responding to growing concern over a reported rise in criminal cases involving foreigners. The governor's remarks came amid incr"
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-immigration-brings-permit-services-to-discovery-mall.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-immigration-brings-permit-services-to-discovery-mall.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Immigration Brings Permit Services to Discovery Mall"
 slug: "bali-immigration-brings-permit-services-to-discovery-mall"
-excerpt: "## Facts  Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director"
+excerpt: "Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director"
 coverImage: "/static/news/visa_20260710_174138_4b037c17.jpg"
 cardImage: "/static/news/visa_20260710_174138_4b037c17_card.jpg"
 coverImageAlt: "Bali Immigration Brings Permit Services to Discovery Mall"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Immigration Brings Permit Services to Discovery Mall"
-seoDescription: "## Facts  Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical..."
+seoDescription: "Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-immigration-brings-permit-services-to-discovery-mall.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-immigration-brings-permit-services-to-discovery-mall.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Immigration Brings Permit Services to Discovery Mall"
 slug: "bali-immigration-brings-permit-services-to-discovery-mall"
-excerpt: "## Facts  Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director"
+excerpt: "Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director"
 coverImage: "/static/news/visa_20260710_174138_4b037c17.jpg"
 cardImage: "/static/news/visa_20260710_174138_4b037c17_card.jpg"
 coverImageAlt: "Bali Immigration Brings Permit Services to Discovery Mall"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Immigration Brings Permit Services to Discovery Mall"
-seoDescription: "## Facts  Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical..."
+seoDescription: "Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-immigration-brings-permit-services-to-discovery-mall.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-immigration-brings-permit-services-to-discovery-mall.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Immigration Brings Permit Services to Discovery Mall"
 slug: "bali-immigration-brings-permit-services-to-discovery-mall"
-excerpt: "## Facts  Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director"
+excerpt: "Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical footprint for immigration services beyond its primary facility. The move follows a broader national trend in which the Director"
 coverImage: "/static/news/visa_20260710_174138_4b037c17.jpg"
 cardImage: "/static/news/visa_20260710_174138_4b037c17_card.jpg"
 coverImageAlt: "Bali Immigration Brings Permit Services to Discovery Mall"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Immigration Brings Permit Services to Discovery Mall"
-seoDescription: "## Facts  Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical..."
+seoDescription: "Indonesia's Ngurah Rai Immigration Office has established an Immigration Lounge at Discovery Mall in Bali, expanding the government's physical..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-immigration-law-what-expats-need-to-know-in-2026.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-immigration-law-what-expats-need-to-know-in-2026.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Immigration Law: What Expats Need to Know in 2026"
-seoDescription: "## Facts  Indonesia's immigration framework for foreign nationals in Bali has undergone significant evolution over the past several years, with the..."
+seoDescription: "Indonesia's immigration framework for foreign nationals in Bali has undergone significant evolution over the past several years, with the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-immigration-law-what-expats-need-to-know-in-2026.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-immigration-law-what-expats-need-to-know-in-2026.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Immigration Law: What Expats Need to Know in 2026"
-seoDescription: "## Facts  Indonesia's immigration framework for foreign nationals in Bali has undergone significant evolution over the past several years, with the..."
+seoDescription: "Indonesia's immigration framework for foreign nationals in Bali has undergone significant evolution over the past several years, with the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for Investors"
 slug: "bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors"
-excerpt: "## Facts  Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i"
+excerpt: "Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i"
 coverImage: "/static/news/visa_20260506_072816_ade2c97f.jpg"
 coverImageAlt: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for..."
-seoDescription: "## Facts  Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw..."
+seoDescription: "Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for Investors"
 slug: "bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors"
-excerpt: "## Facts  Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i"
+excerpt: "Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i"
 coverImage: "/static/news/visa_20260506_072816_ade2c97f.jpg"
 coverImageAlt: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for..."
-seoDescription: "## Facts  Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw..."
+seoDescription: "Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for Investors"
 slug: "bali-kek-financial-zone-targets-dubai-style-tax-breaks-for-investors"
-excerpt: "## Facts  Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i"
+excerpt: "Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw heavily from Dubai's International Financial Centre (DIFC) framework — a jurisdiction widely regarded as one of the world's most i"
 coverImage: "/static/news/visa_20260506_072816_ade2c97f.jpg"
 coverImageAlt: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali KEK Financial Zone Targets Dubai-Style Tax Breaks for..."
-seoDescription: "## Facts  Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw..."
+seoDescription: "Indonesia is advancing plans for a financial Special Economic Zone (KEK Finansial) in Bali, with authorities indicating the model will draw..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Launches Dharma Dewata: Dedicated Task Force to Police Foreign Nationals"
 slug: "bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals"
-excerpt: "## Facts  Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi"
+excerpt: "Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi"
 coverImage: "/static/news/visa_20260418_174039_7abe8286_cover.png"
 coverImageAlt: "Bali Launches Dharma Dewata: Dedicated Task Force to Police Foreign Nationals"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Launches Dharma Dewata: Dedicated Task Force to Police Foreign Nationals"
 slug: "bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals"
-excerpt: "## Facts  Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi"
+excerpt: "Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi"
 coverImage: "/static/news/visa_20260418_174039_7abe8286_cover.png"
 coverImageAlt: "Bali Launches Dharma Dewata: Dedicated Task Force to Police Foreign Nationals"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Launches Dharma Dewata: Dedicated Task Force to Police Foreign Nationals"
 slug: "bali-launches-dharma-dewata-dedicated-task-force-to-police-foreign-nationals"
-excerpt: "## Facts  Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi"
+excerpt: "Indonesian authorities have formalized a new enforcement mechanism targeting foreign national compliance in Bali with the creation of a specialized immigration task force named 'Dharma Dewata.' The unit, established by the Directorate General of Immigration under the Mi"
 coverImage: "/static/news/visa_20260418_174039_7abe8286_cover.png"
 coverImageAlt: "Bali Launches Dharma Dewata: Dedicated Task Force to Police Foreign Nationals"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/bali-property-market-2025-what-the-numbers-actually-reveal.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-property-market-2025-what-the-numbers-actually-reveal.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Property Market 2025: What the Numbers Actually Reveal"
 slug: "bali-property-market-2025-what-the-numbers-actually-reveal"
-excerpt: "## Facts  The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the"
+excerpt: "The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the"
 coverImage: "/static/news/visa_20260521_173653_a9769403.jpg"
 coverImageAlt: "Bali Property Market 2025: What the Numbers Actually Reveal"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Property Market 2025: What the Numbers Actually Reveal"
-seoDescription: "## Facts  The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention..."
+seoDescription: "The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-property-market-2025-what-the-numbers-actually-reveal.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-property-market-2025-what-the-numbers-actually-reveal.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Property Market 2025: What the Numbers Actually Reveal"
 slug: "bali-property-market-2025-what-the-numbers-actually-reveal"
-excerpt: "## Facts  The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the"
+excerpt: "The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the"
 coverImage: "/static/news/visa_20260521_173653_a9769403.jpg"
 coverImageAlt: "Bali Property Market 2025: What the Numbers Actually Reveal"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Property Market 2025: What the Numbers Actually Reveal"
-seoDescription: "## Facts  The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention..."
+seoDescription: "The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-property-market-2025-what-the-numbers-actually-reveal.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-property-market-2025-what-the-numbers-actually-reveal.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Property Market 2025: What the Numbers Actually Reveal"
 slug: "bali-property-market-2025-what-the-numbers-actually-reveal"
-excerpt: "## Facts  The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the"
+excerpt: "The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention from European, Australian, and increasingly American buyers seeking leasehold villa assets. Demand remained concentrated in the"
 coverImage: "/static/news/visa_20260521_173653_a9769403.jpg"
 coverImageAlt: "Bali Property Market 2025: What the Numbers Actually Reveal"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Property Market 2025: What the Numbers Actually Reveal"
-seoDescription: "## Facts  The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention..."
+seoDescription: "The Bali property market concluded 2025 as one of the more scrutinised investment destinations in Southeast Asia, drawing sustained attention..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
 slug: "bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes"
-excerpt: "## Facts  Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take"
+excerpt: "Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take"
 coverImage: "/static/news/visa_20260410_172250_3c3b4daa.jpg"
 coverImageAlt: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
-seoDescription: "## Facts  Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch..."
+seoDescription: "Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
 slug: "bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes"
-excerpt: "## Facts  Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take"
+excerpt: "Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take"
 coverImage: "/static/news/visa_20260410_172250_3c3b4daa.jpg"
 coverImageAlt: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
-seoDescription: "## Facts  Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch..."
+seoDescription: "Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes.mdx
+++ b/apps/mouth/src/content/articles/immigration/bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
 slug: "bali-water-taxis-could-cut-airport-canggu-run-to-30-minutes"
-excerpt: "## Facts  Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take"
+excerpt: "Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch connecting Ngurah Rai International Airport to Canggu — one of Southeast Asia's fastest-growing expat communities — can take"
 coverImage: "/static/news/visa_20260410_172250_3c3b4daa.jpg"
 coverImageAlt: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Water Taxis Could Cut Airport-Canggu Run to 30 Minutes"
-seoDescription: "## Facts  Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch..."
+seoDescription: "Bali's road infrastructure has long struggled to keep pace with the island's surging population of residents, workers, and visitors. The stretch..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 slug: "balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats"
-excerpt: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
+excerpt: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
 coverImage: "/static/news/visa_20260514_173937_ee1ea183_cover.png"
 coverImageAlt: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Informal Economy Crackdown: What Tighter Rules Mean..."
-seoDescription: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
+seoDescription: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 slug: "balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats"
-excerpt: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
+excerpt: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
 coverImage: "/static/news/visa_20260514_173937_ee1ea183_cover.png"
 coverImageAlt: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Informal Economy Crackdown: What Tighter Rules Mean..."
-seoDescription: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
+seoDescription: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 slug: "balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats"
-excerpt: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
+excerpt: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
 coverImage: "/static/news/visa_20260514_173937_ee1ea183_cover.png"
 coverImageAlt: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Informal Economy Crackdown: What Tighter Rules Mean..."
-seoDescription: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
+seoDescription: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 slug: "balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats"
-excerpt: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
+excerpt: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
 coverImage: "/static/news/visa_20260514_173937_ee1ea183_cover.png"
 coverImageAlt: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Informal Economy Crackdown: What Tighter Rules Mean..."
-seoDescription: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
+seoDescription: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 slug: "balis-informal-economy-crackdown-what-tighter-rules-mean-for-expats"
-excerpt: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
+excerpt: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were routinely extended through agents; foreign nationals ran businesses through Indonesian nominees; income from abroad went largely un"
 coverImage: "/static/news/visa_20260514_173937_ee1ea183_cover.png"
 coverImageAlt: "Bali's Informal Economy Crackdown: What Tighter Rules Mean for Expats"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Informal Economy Crackdown: What Tighter Rules Mean..."
-seoDescription: "## Facts  For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
+seoDescription: "For years, Bali operated on an unspoken compact: the island needed foreign spending, and foreigners needed flexibility. Tourist visas were..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-premium-childcare-market-in-2026-what-expat-families-need-to-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-premium-childcare-market-in-2026-what-expat-families-need-to-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Premium Childcare Market in 2026: What Expat Families Need to Know"
 slug: "balis-premium-childcare-market-in-2026-what-expat-families-need-to-know"
-excerpt: "## Facts  Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The"
+excerpt: "Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The"
 coverImage: "/static/news/visa_20260430_173052_c715a62d.jpg"
 coverImageAlt: "Bali's Premium Childcare Market in 2026: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Premium Childcare Market in 2026: What Expat..."
-seoDescription: "## Facts  Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries,..."
+seoDescription: "Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-premium-childcare-market-in-2026-what-expat-families-need-to-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-premium-childcare-market-in-2026-what-expat-families-need-to-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Premium Childcare Market in 2026: What Expat Families Need to Know"
 slug: "balis-premium-childcare-market-in-2026-what-expat-families-need-to-know"
-excerpt: "## Facts  Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The"
+excerpt: "Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The"
 coverImage: "/static/news/visa_20260430_173052_c715a62d.jpg"
 coverImageAlt: "Bali's Premium Childcare Market in 2026: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Premium Childcare Market in 2026: What Expat..."
-seoDescription: "## Facts  Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries,..."
+seoDescription: "Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-premium-childcare-market-in-2026-what-expat-families-need-to-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-premium-childcare-market-in-2026-what-expat-families-need-to-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Premium Childcare Market in 2026: What Expat Families Need to Know"
 slug: "balis-premium-childcare-market-in-2026-what-expat-families-need-to-know"
-excerpt: "## Facts  Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The"
+excerpt: "Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries, international preschools, and specialist childcare providers catering to the island's expanding base of foreign residents. The"
 coverImage: "/static/news/visa_20260430_173052_c715a62d.jpg"
 coverImageAlt: "Bali's Premium Childcare Market in 2026: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Premium Childcare Market in 2026: What Expat..."
-seoDescription: "## Facts  Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries,..."
+seoDescription: "Bali has undergone a significant transformation in its childcare sector over the past several years, with a proliferation of premium nurseries,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
 slug: "balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
+excerpt: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
 coverImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.jpg"
 cardImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert_card.jpg"
 coverImageAlt: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Visa Crackdown Reaches Digital Nomads as Australia..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
+seoDescription: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
 slug: "balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
+excerpt: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
 coverImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.jpg"
 cardImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert_card.jpg"
 coverImageAlt: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Visa Crackdown Reaches Digital Nomads as Australia..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
+seoDescription: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
 slug: "balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
+excerpt: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
 coverImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.jpg"
 cardImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert_card.jpg"
 coverImageAlt: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Visa Crackdown Reaches Digital Nomads as Australia..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
+seoDescription: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
 slug: "balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
+excerpt: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
 coverImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.jpg"
 cardImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert_card.jpg"
 coverImageAlt: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Visa Crackdown Reaches Digital Nomads as Australia..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
+seoDescription: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
 slug: "balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
+excerpt: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working illegally under the cover of tourist visas. The crackdown, which accelerated through 2025 and into 2026, has increasingly focused"
 coverImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert.jpg"
 cardImage: "/static/news/balis-visa-crackdown-reaches-digital-nomads-as-australia-raises-alert_card.jpg"
 coverImageAlt: "Bali's Visa Crackdown Reaches Digital Nomads as Australia Raises Alert"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Visa Crackdown Reaches Digital Nomads as Australia..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
+seoDescription: "Indonesia's Directorate General of Immigration has steadily intensified enforcement operations targeting foreigners perceived to be working..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Belgian Biker Deported After Viral Bali Cliff Stunt Triggers Immigration Crackdown"
 slug: "belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown"
-excerpt: "## Facts  A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr"
+excerpt: "A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr"
 coverImage: "/static/news/visa_20260406_173117_9e3d0b98.jpg"
 coverImageAlt: "Belgian Biker Deported After Viral Bali Cliff Stunt Triggers Immigration Crackdown"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Belgian Biker Deported After Viral Bali Cliff Stunt Triggers Immigration Crackdown"
 slug: "belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown"
-excerpt: "## Facts  A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr"
+excerpt: "A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr"
 coverImage: "/static/news/visa_20260406_173117_9e3d0b98.jpg"
 coverImageAlt: "Belgian Biker Deported After Viral Bali Cliff Stunt Triggers Immigration Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Belgian Biker Deported After Viral Bali Cliff Stunt..."
-seoDescription: "## Facts  A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian..."
+seoDescription: "A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown.mdx
+++ b/apps/mouth/src/content/articles/immigration/belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Belgian Biker Deported After Viral Bali Cliff Stunt Triggers Immigration Crackdown"
 slug: "belgian-biker-deported-after-viral-bali-cliff-stunt-triggers-immigration-crackdown"
-excerpt: "## Facts  A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr"
+excerpt: "A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian immigration authorities moved swiftly, cancelling his Visit Stay Permit and issuing a formal deportation order. The incident repr"
 coverImage: "/static/news/visa_20260406_173117_9e3d0b98.jpg"
 coverImageAlt: "Belgian Biker Deported After Viral Bali Cliff Stunt Triggers Immigration Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Belgian Biker Deported After Viral Bali Cliff Stunt..."
-seoDescription: "## Facts  A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian..."
+seoDescription: "A Belgian citizen was deported from Bali after a video depicting him jumping a motorcycle off a cliff went viral on social media. Indonesian..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta.id.mdx
@@ -121,11 +121,7 @@ description: "# Panduan Investasi di Perusahaan Asing di Indonesia
   memahami peraturan dan prosedur yang berlaku, serta mendapatkan dukungan dari konsultan
   profesional, perusahaan asing dapat berhasil berinvestasi di Indonesia."
 difficulty: intermediate
-excerpt:
-  "## Facts  Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located
-  in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the
-  Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival
-  in 2026. The event marks a formal engagemen"
+excerpt: "Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival in 2026. The event marks a formal engagemen"
 featured: false
 lang: id
 publishedAt: "2026-03-28"

--- a/apps/mouth/src/content/articles/immigration/budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Budapest Meets Bali: Hungarian Embassy Brings Culinary Festival to Jakarta"
 slug: "budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta"
-excerpt: "## Facts  Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival in 2026. The event marks a formal engagemen"
+excerpt: "Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival in 2026. The event marks a formal engagemen"
 coverImage: "/static/news/visa_20260327_180129_5d428be1_cover.png"
 coverImageAlt: "Budapest Meets Bali: Hungarian Embassy Brings Culinary Festival to Jakarta"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta.mdx
+++ b/apps/mouth/src/content/articles/immigration/budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Budapest Meets Bali: Hungarian Embassy Brings Culinary Festival to Jakarta"
 slug: "budapest-meets-bali-hungarian-embassy-brings-culinary-festival-to-jakarta"
-excerpt: "## Facts  Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival in 2026. The event marks a formal engagemen"
+excerpt: "Mangkuluhur ARTOTEL Suites, a lifestyle hotel property located in South Jakarta's Gatot Subroto corridor, has announced a collaboration with the Embassy of Hungary in Indonesia to stage a Hungarian Culinary & Cultural Festival in 2026. The event marks a formal engagemen"
 coverImage: "/static/news/visa_20260327_180129_5d428be1_cover.png"
 coverImageAlt: "Budapest Meets Bali: Hungarian Embassy Brings Culinary Festival to Jakarta"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Canggu's Breakfast Economy: What the Café Boom Tells Expats About Living Costs"
 slug: "canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs"
-excerpt: "## Facts  Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital"
+excerpt: "Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital"
 coverImage: "/static/news/visa_20260623_174754_b42e1b86.jpg"
 cardImage: "/static/news/visa_20260623_174754_b42e1b86_card.jpg"
 coverImageAlt: "Canggu's Breakfast Economy: What the Café Boom Tells Expats About Living Costs"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Canggu's Breakfast Economy: What the Café Boom Tells Expats..."
-seoDescription: "## Facts  Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial..."
+seoDescription: "Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Canggu's Breakfast Economy: What the Café Boom Tells Expats About Living Costs"
 slug: "canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs"
-excerpt: "## Facts  Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital"
+excerpt: "Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital"
 coverImage: "/static/news/visa_20260623_174754_b42e1b86.jpg"
 cardImage: "/static/news/visa_20260623_174754_b42e1b86_card.jpg"
 coverImageAlt: "Canggu's Breakfast Economy: What the Café Boom Tells Expats About Living Costs"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Canggu's Breakfast Economy: What the Café Boom Tells Expats..."
-seoDescription: "## Facts  Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial..."
+seoDescription: "Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs.mdx
+++ b/apps/mouth/src/content/articles/immigration/canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Canggu's Breakfast Economy: What the Café Boom Tells Expats About Living Costs"
 slug: "canggus-breakfast-economy-what-the-caf-boom-tells-expats-about-living-costs"
-excerpt: "## Facts  Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital"
+excerpt: "Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial transformations of any neighbourhood in Southeast Asia over the last decade. The catalyst: a sustained influx of foreign residents — digital"
 coverImage: "/static/news/visa_20260623_174754_b42e1b86.jpg"
 cardImage: "/static/news/visa_20260623_174754_b42e1b86_card.jpg"
 coverImageAlt: "Canggu's Breakfast Economy: What the Café Boom Tells Expats About Living Costs"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Canggu's Breakfast Economy: What the Café Boom Tells Expats..."
-seoDescription: "## Facts  Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial..."
+seoDescription: "Canggu, once a quiet surf village on Bali's southwestern coast, has undergone one of the most dramatic demographic and commercial..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
 slug: "divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a"
-excerpt: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
+excerpt: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
 coverImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.jpg"
 cardImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a_card.jpg"
 coverImageAlt: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
-seoDescription: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
+seoDescription: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
 slug: "divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a"
-excerpt: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
+excerpt: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
 coverImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.jpg"
 cardImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a_card.jpg"
 coverImageAlt: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
-seoDescription: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
+seoDescription: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
 slug: "divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a"
-excerpt: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
+excerpt: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
 coverImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.jpg"
 cardImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a_card.jpg"
 coverImageAlt: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
-seoDescription: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
+seoDescription: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.mdx
+++ b/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
 slug: "divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a"
-excerpt: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
+excerpt: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
 coverImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.jpg"
 cardImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a_card.jpg"
 coverImageAlt: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
-seoDescription: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
+seoDescription: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
 slug: "divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a"
-excerpt: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
+excerpt: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals who join an Indonesian citizen spouse for the purpose of family reunification. The permit ties the foreign national's legal r"
 coverImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a.jpg"
 cardImage: "/static/news/divorce-in-indonesia-what-happens-to-your-spouse-kitas-e31a_card.jpg"
 coverImageAlt: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Divorce in Indonesia: What Happens to Your Spouse KITAS E31A"
-seoDescription: "## Facts  Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
+seoDescription: "Indonesia's spousal residence permit, formally classified under index E31A by Kepmen M.IP-08.GR.01.01 Tahun 2025, is issued to foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "DJ on Sacred Volcano: Bali's Tolerance for Viral Stunts Has a Limit"
 slug: "dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit"
-excerpt: "## Facts  A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r"
+excerpt: "A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r"
 coverImage: "/static/news/visa_20260420_174552_ee4a942b_cover.png"
 coverImageAlt: "DJ on Sacred Volcano: Bali's Tolerance for Viral Stunts Has a Limit"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "DJ on Sacred Volcano: Bali's Tolerance for Viral Stunts Has a Limit"
 slug: "dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit"
-excerpt: "## Facts  A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r"
+excerpt: "A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r"
 coverImage: "/static/news/visa_20260420_174552_ee4a942b_cover.png"
 coverImageAlt: "DJ on Sacred Volcano: Bali's Tolerance for Viral Stunts Has a Limit"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit.mdx
+++ b/apps/mouth/src/content/articles/immigration/dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "DJ on Sacred Volcano: Bali's Tolerance for Viral Stunts Has a Limit"
 slug: "dj-on-sacred-volcano-balis-tolerance-for-viral-stunts-has-a-limit"
-excerpt: "## Facts  A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r"
+excerpt: "A short video depicting a foreign national operating DJ equipment atop Mount Batur — an active volcano in Kintamani, Bali, revered as a spiritual axis by the Balinese Hindu community — spread rapidly across social media platforms, triggering a swift and intense public r"
 coverImage: "/static/news/visa_20260420_174552_ee4a942b_cover.png"
 coverImageAlt: "DJ on Sacred Volcano: Bali's Tolerance for Viral Stunts Has a Limit"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "DPR Demands Crackdown on Unlicensed Foreign Businesses in Bali"
 slug: "dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali"
-excerpt: "## Facts  Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization."
+excerpt: "Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization."
 coverImage: "/static/news/visa_20260409_175616_1345acb1_cover.png"
 coverImageAlt: "DPR Demands Crackdown on Unlicensed Foreign Businesses in Bali"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "DPR Demands Crackdown on Unlicensed Foreign Businesses in Bali"
 slug: "dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali"
-excerpt: "## Facts  Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization."
+excerpt: "Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization."
 coverImage: "/static/news/visa_20260409_175616_1345acb1_cover.png"
 coverImageAlt: "DPR Demands Crackdown on Unlicensed Foreign Businesses in Bali"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali.mdx
+++ b/apps/mouth/src/content/articles/immigration/dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali.mdx
@@ -1,7 +1,7 @@
 ---
 title: "DPR Demands Crackdown on Unlicensed Foreign Businesses in Bali"
 slug: "dpr-demands-crackdown-on-unlicensed-foreign-businesses-in-bali"
-excerpt: "## Facts  Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization."
+excerpt: "Indonesia's House of Representatives Commission VII, which oversees energy, research, and related economic affairs, has formally requested that the government move against foreign nationals conducting business activities in Bali without the required legal authorization."
 coverImage: "/static/news/visa_20260409_175616_1345acb1_cover.png"
 coverImageAlt: "DPR Demands Crackdown on Unlicensed Foreign Businesses in Bali"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E31A Spouse Visa: Married Expats Can Work in Indonesia Without a Sponsor"
 slug: "e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor"
-excerpt: "## Facts  The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina"
+excerpt: "The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina"
 coverImage: "/static/news/visa_20260619_181754_7bb87cd1.jpg"
 cardImage: "/static/news/visa_20260619_181754_7bb87cd1_card.jpg"
 coverImageAlt: "E31A Spouse Visa: Married Expats Can Work in Indonesia Without a Sponsor"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "E31A Spouse Visa: Married Expats Can Work in Indonesia..."
-seoDescription: "## Facts  The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are..."
+seoDescription: "The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E31A Spouse Visa: Married Expats Can Work in Indonesia Without a Sponsor"
 slug: "e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor"
-excerpt: "## Facts  The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina"
+excerpt: "The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina"
 coverImage: "/static/news/visa_20260619_181754_7bb87cd1.jpg"
 cardImage: "/static/news/visa_20260619_181754_7bb87cd1_card.jpg"
 coverImageAlt: "E31A Spouse Visa: Married Expats Can Work in Indonesia Without a Sponsor"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "E31A Spouse Visa: Married Expats Can Work in Indonesia..."
-seoDescription: "## Facts  The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are..."
+seoDescription: "The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor.mdx
+++ b/apps/mouth/src/content/articles/immigration/e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor.mdx
@@ -1,7 +1,7 @@
 ---
 title: "E31A Spouse Visa: Married Expats Can Work in Indonesia Without a Sponsor"
 slug: "e31a-spouse-visa-married-expats-can-work-in-indonesia-without-a-sponsor"
-excerpt: "## Facts  The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina"
+excerpt: "The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are entitled to apply for the E31A visa — Indonesia's formally designated national visa index for spouses in mixed marriages (perkawina"
 coverImage: "/static/news/visa_20260619_181754_7bb87cd1.jpg"
 cardImage: "/static/news/visa_20260619_181754_7bb87cd1_card.jpg"
 coverImageAlt: "E31A Spouse Visa: Married Expats Can Work in Indonesia Without a Sponsor"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "E31A Spouse Visa: Married Expats Can Work in Indonesia..."
-seoDescription: "## Facts  The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are..."
+seoDescription: "The Banggai Immigration Office in Central Sulawesi has publicly affirmed that foreign nationals legally married to Indonesian citizens are..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
 slug: "foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits"
-excerpt: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
+excerpt: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
 coverImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.jpg"
 cardImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits_card.jpg"
 coverImageAlt: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign DJ and Dancers Arrested in Indonesia for Working..."
-seoDescription: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
+seoDescription: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
 slug: "foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits"
-excerpt: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
+excerpt: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
 coverImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.jpg"
 cardImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits_card.jpg"
 coverImageAlt: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign DJ and Dancers Arrested in Indonesia for Working..."
-seoDescription: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
+seoDescription: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
 slug: "foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits"
-excerpt: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
+excerpt: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
 coverImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.jpg"
 cardImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits_card.jpg"
 coverImageAlt: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign DJ and Dancers Arrested in Indonesia for Working..."
-seoDescription: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
+seoDescription: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
 slug: "foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits"
-excerpt: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
+excerpt: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
 coverImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.jpg"
 cardImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits_card.jpg"
 coverImageAlt: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign DJ and Dancers Arrested in Indonesia for Working..."
-seoDescription: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
+seoDescription: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
 slug: "foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits"
-excerpt: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
+excerpt: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the Mataram Immigration Office (Kantor Imigrasi Mataram) in West Nusa Tenggara province. The individuals were detained for violating t"
 coverImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits.jpg"
 cardImage: "/static/news/foreign-dj-and-dancers-arrested-in-indonesia-for-working-without-proper-permits_card.jpg"
 coverImageAlt: "Foreign DJ and Dancers Arrested in Indonesia for Working Without Proper Permits"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign DJ and Dancers Arrested in Indonesia for Working..."
-seoDescription: "## Facts  Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
+seoDescription: "Indonesian immigration authorities arrested a foreign DJ and a group of foreign dancers following an enforcement operation conducted by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign Nationals Busted in Surabaya Love Scam Syndicate Operation"
 slug: "foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation"
-excerpt: "## Facts  Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd"
+excerpt: "Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd"
 coverImage: "/static/news/visa_20260623_174723_f64d6f5d.jpg"
 cardImage: "/static/news/visa_20260623_174723_f64d6f5d_card.jpg"
 coverImageAlt: "Foreign Nationals Busted in Surabaya Love Scam Syndicate Operation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign Nationals Busted in Surabaya Love Scam Syndicate..."
-seoDescription: "## Facts  Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign..."
+seoDescription: "Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign Nationals Busted in Surabaya Love Scam Syndicate Operation"
 slug: "foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation"
-excerpt: "## Facts  Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd"
+excerpt: "Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd"
 coverImage: "/static/news/visa_20260623_174723_f64d6f5d.jpg"
 cardImage: "/static/news/visa_20260623_174723_f64d6f5d_card.jpg"
 coverImageAlt: "Foreign Nationals Busted in Surabaya Love Scam Syndicate Operation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign Nationals Busted in Surabaya Love Scam Syndicate..."
-seoDescription: "## Facts  Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign..."
+seoDescription: "Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation.mdx
+++ b/apps/mouth/src/content/articles/immigration/foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign Nationals Busted in Surabaya Love Scam Syndicate Operation"
 slug: "foreign-nationals-busted-in-surabaya-love-scam-syndicate-operation"
-excerpt: "## Facts  Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd"
+excerpt: "Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign nationals implicated in the fraud network. The operation is part of a broader regional crackdown on transnational cybercrime synd"
 coverImage: "/static/news/visa_20260623_174723_f64d6f5d.jpg"
 cardImage: "/static/news/visa_20260623_174723_f64d6f5d_card.jpg"
 coverImageAlt: "Foreign Nationals Busted in Surabaya Love Scam Syndicate Operation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign Nationals Busted in Surabaya Love Scam Syndicate..."
-seoDescription: "## Facts  Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign..."
+seoDescription: "Indonesian authorities moved against a love scam syndicate operating out of Surabaya, East Java, resulting in the arrest of multiple foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
 slug: "from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders"
-excerpt: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025.  The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
+excerpt: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025. The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
 coverImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.jpg"
 cardImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders_card.jpg"
 coverImageAlt: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT..."
-seoDescription: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
+seoDescription: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
 slug: "from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders"
-excerpt: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025.  The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
+excerpt: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025. The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
 coverImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.jpg"
 cardImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders_card.jpg"
 coverImageAlt: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT..."
-seoDescription: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
+seoDescription: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
 slug: "from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders"
-excerpt: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025.  The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
+excerpt: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025. The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
 coverImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.jpg"
 cardImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders_card.jpg"
 coverImageAlt: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT..."
-seoDescription: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
+seoDescription: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.mdx
+++ b/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.mdx
@@ -1,7 +1,7 @@
 ---
 title: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
 slug: "from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders"
-excerpt: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025.  The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
+excerpt: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025. The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
 coverImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.jpg"
 cardImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders_card.jpg"
 coverImageAlt: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT..."
-seoDescription: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
+seoDescription: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
 slug: "from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders"
-excerpt: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025.  The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
+excerpt: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations updated significantly in 2024 and 2025. The first stage is the C12 Pre-Investment Visa, formally classified under Kepmen M.IP-08"
 coverImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders.jpg"
 cardImage: "/static/news/from-c12-to-e28a-indonesias-investor-kitas-pathway-for-pt-pma-shareholders_card.jpg"
 coverImageAlt: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT PMA Shareholders"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "From C12 to E28A: Indonesia's Investor KITAS Pathway for PT..."
-seoDescription: "## Facts  Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
+seoDescription: "Indonesia's immigration framework for foreign investors operates as a deliberate two-stage process, now governed by a cluster of regulations..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/global-conflict-drags-down-tourism-in-indonesia-and-rival-destinations.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/global-conflict-drags-down-tourism-in-indonesia-and-rival-destinations.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Global Conflict Drags Down Tourism in Indonesia and Rival Destinations"
 slug: "global-conflict-drags-down-tourism-in-indonesia-and-rival-destinations"
-excerpt: "## Facts  A wave of geopolitical disruption is reshaping global tourism flows, with Indonesia among a cohort of major emerging-market destinations registering visitor slowdowns in early 2026. The pattern mirrors setbacks seen in Turkey, Egypt, Thailand, and Sri Lanka — countries"
+excerpt: "A wave of geopolitical disruption is reshaping global tourism flows, with Indonesia among a cohort of major emerging-market destinations registering visitor slowdowns in early 2026. The pattern mirrors setbacks seen in Turkey, Egypt, Thailand, and Sri Lanka — countries"
 coverImage: "/static/news/visa_20260331_184059_29bac75a.jpg"
 coverImageAlt: "Global Conflict Drags Down Tourism in Indonesia and Rival Destinations"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/global-conflict-drags-down-tourism-in-indonesia-and-rival-destinations.mdx
+++ b/apps/mouth/src/content/articles/immigration/global-conflict-drags-down-tourism-in-indonesia-and-rival-destinations.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Global Conflict Drags Down Tourism in Indonesia and Rival Destinations"
 slug: "global-conflict-drags-down-tourism-in-indonesia-and-rival-destinations"
-excerpt: "## Facts  A wave of geopolitical disruption is reshaping global tourism flows, with Indonesia among a cohort of major emerging-market destinations registering visitor slowdowns in early 2026. The pattern mirrors setbacks seen in Turkey, Egypt, Thailand, and Sri Lanka — countries"
+excerpt: "A wave of geopolitical disruption is reshaping global tourism flows, with Indonesia among a cohort of major emerging-market destinations registering visitor slowdowns in early 2026. The pattern mirrors setbacks seen in Turkey, Egypt, Thailand, and Sri Lanka — countries"
 coverImage: "/static/news/visa_20260331_184059_29bac75a.jpg"
 coverImageAlt: "Global Conflict Drags Down Tourism in Indonesia and Rival Destinations"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
 slug: "icann-brings-global-internet-forum-to-bali-bypassing-oman"
-excerpt: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
+excerpt: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
 coverImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman.jpg"
 cardImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman_card.jpg"
 coverImageAlt: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
-seoDescription: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
+seoDescription: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
 slug: "icann-brings-global-internet-forum-to-bali-bypassing-oman"
-excerpt: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
+excerpt: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
 coverImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman.jpg"
 cardImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman_card.jpg"
 coverImageAlt: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
-seoDescription: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
+seoDescription: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
 slug: "icann-brings-global-internet-forum-to-bali-bypassing-oman"
-excerpt: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
+excerpt: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
 coverImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman.jpg"
 cardImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman_card.jpg"
 coverImageAlt: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
-seoDescription: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
+seoDescription: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.mdx
+++ b/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
 slug: "icann-brings-global-internet-forum-to-bali-bypassing-oman"
-excerpt: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
+excerpt: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
 coverImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman.jpg"
 cardImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman_card.jpg"
 coverImageAlt: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
-seoDescription: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
+seoDescription: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/icann-brings-global-internet-forum-to-bali-bypassing-oman.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
 slug: "icann-brings-global-internet-forum-to-bali-bypassing-oman"
-excerpt: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
+excerpt: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems and IP address allocation, has confirmed that its Global Internet Forum will be held in Bali, Indonesia, replacing the previo"
 coverImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman.jpg"
 cardImage: "/static/news/icann-brings-global-internet-forum-to-bali-bypassing-oman_card.jpg"
 coverImageAlt: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "ICANN Brings Global Internet Forum to Bali, Bypassing Oman"
-seoDescription: "## Facts  The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
+seoDescription: "The Internet Corporation for Assigned Names and Numbers (ICANN), the non-profit body responsible for coordinating global internet naming systems..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 slug: "immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners"
-excerpt: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
+excerpt: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
 coverImage: "/static/news/visa_20260515_174615_635f6e10_cover.png"
 coverImageAlt: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Immigration Cracks Down: 15 Sponsors Behind 320..."
-seoDescription: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
+seoDescription: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 slug: "immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners"
-excerpt: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
+excerpt: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
 coverImage: "/static/news/visa_20260515_174615_635f6e10_cover.png"
 coverImageAlt: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Immigration Cracks Down: 15 Sponsors Behind 320..."
-seoDescription: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
+seoDescription: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 slug: "immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners"
-excerpt: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
+excerpt: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
 coverImage: "/static/news/visa_20260515_174615_635f6e10_cover.png"
 coverImageAlt: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Immigration Cracks Down: 15 Sponsors Behind 320..."
-seoDescription: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
+seoDescription: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.mdx
+++ b/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 slug: "immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners"
-excerpt: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
+excerpt: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
 coverImage: "/static/news/visa_20260515_174615_635f6e10_cover.png"
 coverImageAlt: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Immigration Cracks Down: 15 Sponsors Behind 320..."
-seoDescription: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
+seoDescription: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 slug: "immigration-cracks-down-15-sponsors-behind-320-visa-abusing-foreigners"
-excerpt: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
+excerpt: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals who were subsequently caught participating in illegal online gambling operations in the Hayam Wuruk corridor of Central Jakarta"
 coverImage: "/static/news/visa_20260515_174615_635f6e10_cover.png"
 coverImageAlt: "Immigration Cracks Down: 15 Sponsors Behind 320 Visa-Abusing Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Immigration Cracks Down: 15 Sponsors Behind 320..."
-seoDescription: "## Facts  Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
+seoDescription: "Indonesian immigration authorities have identified 15 individual sponsors responsible for facilitating the legal stay of 320 foreign nationals..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-2026-what-every-traveler-must-know-before-entry.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-2026-what-every-traveler-must-know-before-entry.id.mdx
@@ -122,17 +122,11 @@ description: '# Panduan Investasi di Indonesia untuk Investor Asing
   nasihat hukum. Selalu konsultasikan dengan profesional hukum atau konsultan investasi
   sebelum membuat keputusan investasi.'
 difficulty: intermediate
-excerpt: '## Facts
-
-  Indonesia''s immigration framework for 2026 reflects a broader regional trend toward
-  digitized border management and tighter documentation enforcement. The Directorate
-  General of Immigration has been progressively rolling out updates to its entry systems,
-  and 2026 marks '
+excerpt: "Indonesia''s immigration framework for 2026 reflects a broader regional trend toward digitized border management and tighter documentation enforcement. The Directorate General of Immigration has been progressively rolling out updates to its entry systems, and 2026 marks"
 featured: false
 lang: id
 publishedAt: '2026-03-20'
 readingTime: 3
-seoDescription: '## Facts'
 seoTitle: 'Indonesia 2026: What Every Traveler Must Know Before Entry'
 slug: indonesia-2026-what-every-traveler-must-know-before-entry
 tags:

--- a/apps/mouth/src/content/articles/immigration/indonesia-2026-what-every-traveler-must-know-before-entry.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-2026-what-every-traveler-must-know-before-entry.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia 2026: What Every Traveler Must Know Before Entry"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia 2026: What Every...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/immigration/indonesia-2026-what-every-traveler-must-know-before-entry.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-2026-what-every-traveler-must-know-before-entry.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia 2026: What Every Traveler Must Know Before Entry"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia 2026: What Every...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/immigration/indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus Alert"
 slug: "indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert"
-excerpt: "## Facts  Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen"
+excerpt: "Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen"
 coverImage: "/static/news/visa_20260511_174340_4fcc9ac2.jpg"
 coverImageAlt: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus Alert"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus..."
-seoDescription: "## Facts  Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a..."
+seoDescription: "Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus Alert"
 slug: "indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert"
-excerpt: "## Facts  Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen"
+excerpt: "Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen"
 coverImage: "/static/news/visa_20260511_174340_4fcc9ac2.jpg"
 coverImageAlt: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus Alert"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus..."
-seoDescription: "## Facts  Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a..."
+seoDescription: "Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus Alert"
 slug: "indonesia-activates-21-sentinel-hospitals-in-hantavirus-alert"
-excerpt: "## Facts  Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen"
+excerpt: "Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a rodent-borne viral disease that can cause severe respiratory illness and hemorrhagic fever with renal syndrome. The deploymen"
 coverImage: "/static/news/visa_20260511_174340_4fcc9ac2.jpg"
 coverImageAlt: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus Alert"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Activates 21 Sentinel Hospitals in Hantavirus..."
-seoDescription: "## Facts  Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a..."
+seoDescription: "Indonesia's Ministry of Health has activated a network of 21 sentinel hospitals designated to detect, report, and manage cases of hantavirus — a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 slug: "indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown"
-excerpt: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
+excerpt: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
 coverImage: "/static/news/visa_20260511_174419_c37ba244_cover.png"
 coverImageAlt: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Arrests 321 Foreigners in Sweeping Online..."
-seoDescription: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
+seoDescription: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 slug: "indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown"
-excerpt: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
+excerpt: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
 coverImage: "/static/news/visa_20260511_174419_c37ba244_cover.png"
 coverImageAlt: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Arrests 321 Foreigners in Sweeping Online..."
-seoDescription: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
+seoDescription: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 slug: "indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown"
-excerpt: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
+excerpt: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
 coverImage: "/static/news/visa_20260511_174419_c37ba244_cover.png"
 coverImageAlt: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Arrests 321 Foreigners in Sweeping Online..."
-seoDescription: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
+seoDescription: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 slug: "indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown"
-excerpt: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
+excerpt: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
 coverImage: "/static/news/visa_20260511_174419_c37ba244_cover.png"
 coverImageAlt: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Arrests 321 Foreigners in Sweeping Online..."
-seoDescription: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
+seoDescription: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 slug: "indonesia-arrests-321-foreigners-in-sweeping-online-gambling-crackdown"
-excerpt: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
+excerpt: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks operating within the country. The crackdown is part of Indonesia's sustained campaign to eliminate online gambling, which is compr"
 coverImage: "/static/news/visa_20260511_174419_c37ba244_cover.png"
 coverImageAlt: "Indonesia Arrests 321 Foreigners in Sweeping Online Gambling Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Arrests 321 Foreigners in Sweeping Online..."
-seoDescription: "## Facts  Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
+seoDescription: "Indonesian authorities arrested 321 foreign nationals in a coordinated law enforcement operation targeting illegal online gambling networks..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
 slug: "indonesia-automates-border-checks-nationwide-what-expats-must-know"
-excerpt: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
+excerpt: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
 coverImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know.jpg"
 cardImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know_card.jpg"
 coverImageAlt: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Automates Border Checks Nationwide — What Expats..."
-seoDescription: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
+seoDescription: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
 slug: "indonesia-automates-border-checks-nationwide-what-expats-must-know"
-excerpt: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
+excerpt: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
 coverImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know.jpg"
 cardImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know_card.jpg"
 coverImageAlt: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Automates Border Checks Nationwide — What Expats..."
-seoDescription: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
+seoDescription: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
 slug: "indonesia-automates-border-checks-nationwide-what-expats-must-know"
-excerpt: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
+excerpt: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
 coverImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know.jpg"
 cardImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know_card.jpg"
 coverImageAlt: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Automates Border Checks Nationwide — What Expats..."
-seoDescription: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
+seoDescription: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
 slug: "indonesia-automates-border-checks-nationwide-what-expats-must-know"
-excerpt: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
+excerpt: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
 coverImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know.jpg"
 cardImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know_card.jpg"
 coverImageAlt: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Automates Border Checks Nationwide — What Expats..."
-seoDescription: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
+seoDescription: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-automates-border-checks-nationwide-what-expats-must-know.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
 slug: "indonesia-automates-border-checks-nationwide-what-expats-must-know"
-excerpt: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
+excerpt: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports to entry points nationwide. The rollout is driven by the Directorate General of Immigration (Direktorat Jenderal Imigrasi), wh"
 coverImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know.jpg"
 cardImage: "/static/news/indonesia-automates-border-checks-nationwide-what-expats-must-know_card.jpg"
 coverImageAlt: "Indonesia Automates Border Checks Nationwide — What Expats Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Automates Border Checks Nationwide — What Expats..."
-seoDescription: "## Facts  Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
+seoDescription: "Indonesia is expanding its network of automated immigration gates — known locally as autogates — beyond its two flagship international airports..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
 slug: "indonesia-axes-fast-track-residency-permits-minister-confirms"
-excerpt: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
+excerpt: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
 coverImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms.jpg"
 cardImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms_card.jpg"
 coverImageAlt: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Axes Fast-Track Residency Permits, Minister..."
-seoDescription: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
+seoDescription: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
 slug: "indonesia-axes-fast-track-residency-permits-minister-confirms"
-excerpt: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
+excerpt: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
 coverImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms.jpg"
 cardImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms_card.jpg"
 coverImageAlt: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Axes Fast-Track Residency Permits, Minister..."
-seoDescription: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
+seoDescription: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
 slug: "indonesia-axes-fast-track-residency-permits-minister-confirms"
-excerpt: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
+excerpt: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
 coverImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms.jpg"
 cardImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms_card.jpg"
 coverImageAlt: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Axes Fast-Track Residency Permits, Minister..."
-seoDescription: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
+seoDescription: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
 slug: "indonesia-axes-fast-track-residency-permits-minister-confirms"
-excerpt: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
+excerpt: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
 coverImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms.jpg"
 cardImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms_card.jpg"
 coverImageAlt: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Axes Fast-Track Residency Permits, Minister..."
-seoDescription: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
+seoDescription: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-axes-fast-track-residency-permits-minister-confirms.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
 slug: "indonesia-axes-fast-track-residency-permits-minister-confirms"
-excerpt: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
+excerpt: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay permits, in a policy shift announced by a senior minister. The decision marks a reversal from recent years in which successive gove"
 coverImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms.jpg"
 cardImage: "/static/news/indonesia-axes-fast-track-residency-permits-minister-confirms_card.jpg"
 coverImageAlt: "Indonesia Axes Fast-Track Residency Permits, Minister Confirms"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Axes Fast-Track Residency Permits, Minister..."
-seoDescription: "## Facts  Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
+seoDescription: "Indonesia's immigration authorities have moved to eliminate fast-track processing options for foreign nationals seeking residency and stay..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
 slug: "indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom"
-excerpt: "## Facts  Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa"
+excerpt: "Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa"
 coverImage: "/static/news/visa_20260710_174022_f1cdc710.jpg"
 cardImage: "/static/news/visa_20260710_174022_f1cdc710_card.jpg"
 coverImageAlt: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
-seoDescription: "## Facts  Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve..."
+seoDescription: "Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
 slug: "indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom"
-excerpt: "## Facts  Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa"
+excerpt: "Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa"
 coverImage: "/static/news/visa_20260710_174022_f1cdc710.jpg"
 cardImage: "/static/news/visa_20260710_174022_f1cdc710_card.jpg"
 coverImageAlt: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
-seoDescription: "## Facts  Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve..."
+seoDescription: "Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
 slug: "indonesia-bets-golden-visa-on-labuan-bajo-tourism-boom"
-excerpt: "## Facts  Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa"
+excerpt: "Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve as a direct lever to amplify foreign investment flows into Labuan Bajo, the gateway city to Komodo National Park in East Nusa"
 coverImage: "/static/news/visa_20260710_174022_f1cdc710.jpg"
 cardImage: "/static/news/visa_20260710_174022_f1cdc710_card.jpg"
 coverImageAlt: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets Golden Visa on Labuan Bajo Tourism Boom"
-seoDescription: "## Facts  Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve..."
+seoDescription: "Indonesia's Minister of Tourism and Creative Economy, Sandiaga Salahuddin Uno, expressed hope that the country's Golden Visa program would serve..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 slug: "indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy"
-excerpt: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
+excerpt: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
 coverImage: "/static/news/visa_20260512_175311_24a6fe46_cover.png"
 coverImageAlt: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on Bali as the Next Global Hub for Perfume..."
-seoDescription: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
+seoDescription: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 slug: "indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy"
-excerpt: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
+excerpt: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
 coverImage: "/static/news/visa_20260512_175311_24a6fe46_cover.png"
 coverImageAlt: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on Bali as the Next Global Hub for Perfume..."
-seoDescription: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
+seoDescription: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 slug: "indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy"
-excerpt: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
+excerpt: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
 coverImage: "/static/news/visa_20260512_175311_24a6fe46_cover.png"
 coverImageAlt: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on Bali as the Next Global Hub for Perfume..."
-seoDescription: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
+seoDescription: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 slug: "indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy"
-excerpt: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
+excerpt: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
 coverImage: "/static/news/visa_20260512_175311_24a6fe46_cover.png"
 coverImageAlt: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on Bali as the Next Global Hub for Perfume..."
-seoDescription: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
+seoDescription: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 slug: "indonesia-bets-on-bali-as-the-next-global-hub-for-perfume-and-aromatherapy"
-excerpt: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
+excerpt: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the island's longstanding identity as a wellness and spiritual tourism destination. The initiative is government-backed, signalling that"
 coverImage: "/static/news/visa_20260512_175311_24a6fe46_cover.png"
 coverImageAlt: "Indonesia Bets on Bali as the Next Global Hub for Perfume and Aromatherapy"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Bets on Bali as the Next Global Hub for Perfume..."
-seoDescription: "## Facts  Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
+seoDescription: "Indonesia has announced plans to develop Bali into a globally recognised centre for perfume and aromatherapy, a move that aligns with the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 slug: "indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045"
-excerpt: "## Facts  Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
+excerpt: "Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
 coverImage: "/static/news/visa_20260402_173414_7f5a35bb_cover.png"
 coverImageAlt: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 slug: "indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045"
-excerpt: "## Facts  Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
+excerpt: "Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
 coverImage: "/static/news/visa_20260402_173414_7f5a35bb_cover.png"
 coverImageAlt: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 slug: "indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045"
-excerpt: "## Facts  Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
+excerpt: "Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
 coverImage: "/static/news/visa_20260402_173414_7f5a35bb_cover.png"
 coverImageAlt: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 slug: "indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045"
-excerpt: "## Facts  Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
+excerpt: "Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
 coverImage: "/static/news/visa_20260402_173414_7f5a35bb_cover.png"
 coverImageAlt: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 slug: "indonesia-bets-on-green-tourism-to-triple-arrivals-by-2045"
-excerpt: "## Facts  Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
+excerpt: "Indonesia's government has outlined an ambitious green tourism roadmap extending to 2045, the centenary of the nation's independence, framing sustainable travel as a pillar of long-term economic development. The strategy signals a deliberate pivot away from mass-market"
 coverImage: "/static/news/visa_20260402_173414_7f5a35bb_cover.png"
 coverImageAlt: "Indonesia Bets on Green Tourism to Triple Arrivals by 2045"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-business-entry-strategies-what-foreign-founders-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-business-entry-strategies-what-foreign-founders-must-know.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Business Entry Strategies: What Foreign Founders..."
-seoDescription: "## Facts  Indonesia operates a tiered foreign investment framework governed primarily by the Investment Coordinating Board (BKPM, now integrated into the..."
+seoDescription: "Indonesia operates a tiered foreign investment framework governed primarily by the Investment Coordinating Board (BKPM, now integrated into the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-business-entry-strategies-what-foreign-founders-must-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-business-entry-strategies-what-foreign-founders-must-know.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Business Entry Strategies: What Foreign Founders..."
-seoDescription: "## Facts  Indonesia operates a tiered foreign investment framework governed primarily by the Investment Coordinating Board (BKPM, now integrated into the..."
+seoDescription: "Indonesia operates a tiered foreign investment framework governed primarily by the Investment Coordinating Board (BKPM, now integrated into the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the Crosshairs"
 slug: "indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs"
-excerpt: "## Facts  Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such"
+excerpt: "Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such"
 coverImage: "/static/news/visa_20260409_175433_ada4f0c7.jpg"
 coverImageAlt: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the Crosshairs"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the Crosshairs"
 slug: "indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs"
-excerpt: "## Facts  Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such"
+excerpt: "Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such"
 coverImage: "/static/news/visa_20260409_175433_ada4f0c7.jpg"
 coverImageAlt: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the Crosshairs"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the..."
-seoDescription: "## Facts  Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit..."
+seoDescription: "Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the Crosshairs"
 slug: "indonesia-cracks-down-on-tourist-visa-workers-bali-in-the-crosshairs"
-excerpt: "## Facts  Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such"
+excerpt: "Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit tourist visas to engage in paid employment — a practice that has become increasingly visible in Bali's popular expat hubs such"
 coverImage: "/static/news/visa_20260409_175433_ada4f0c7.jpg"
 coverImageAlt: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the Crosshairs"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Cracks Down on Tourist-Visa Workers — Bali in the..."
-seoDescription: "## Facts  Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit..."
+seoDescription: "Indonesia's Minister of Tourism and Creative Economy (Menparekraf) has publicly signaled a hardening stance toward foreign visitors who exploit..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-cracks-worlds-28-most-beautiful-countries-list.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-cracks-worlds-28-most-beautiful-countries-list.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Cracks World's 28 Most Beautiful Countries List"
-seoDescription: "## Facts  Condé Nast Traveler, the luxury travel magazine published by Condé Nast and widely regarded as one of the most authoritative voices in global..."
+seoDescription: "Condé Nast Traveler, the luxury travel magazine published by Condé Nast and widely regarded as one of the most authoritative voices in global..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-cracks-worlds-28-most-beautiful-countries-list.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-cracks-worlds-28-most-beautiful-countries-list.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Cracks World's 28 Most Beautiful Countries List"
-seoDescription: "## Facts  Condé Nast Traveler, the luxury travel magazine published by Condé Nast and widely regarded as one of the most authoritative voices in global..."
+seoDescription: "Condé Nast Traveler, the luxury travel magazine published by Condé Nast and widely regarded as one of the most authoritative voices in global..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
 slug: "indonesia-deports-25-foreigners-caught-doing-illegal-photography-work"
-excerpt: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
+excerpt: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
 coverImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.jpg"
 cardImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work_card.jpg"
 coverImageAlt: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 25 Foreigners Caught Doing Illegal..."
-seoDescription: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
+seoDescription: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
 slug: "indonesia-deports-25-foreigners-caught-doing-illegal-photography-work"
-excerpt: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
+excerpt: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
 coverImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.jpg"
 cardImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work_card.jpg"
 coverImageAlt: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 25 Foreigners Caught Doing Illegal..."
-seoDescription: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
+seoDescription: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
 slug: "indonesia-deports-25-foreigners-caught-doing-illegal-photography-work"
-excerpt: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
+excerpt: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
 coverImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.jpg"
 cardImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work_card.jpg"
 coverImageAlt: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 25 Foreigners Caught Doing Illegal..."
-seoDescription: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
+seoDescription: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
 slug: "indonesia-deports-25-foreigners-caught-doing-illegal-photography-work"
-excerpt: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
+excerpt: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
 coverImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.jpg"
 cardImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work_card.jpg"
 coverImageAlt: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 25 Foreigners Caught Doing Illegal..."
-seoDescription: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
+seoDescription: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
 slug: "indonesia-deports-25-foreigners-caught-doing-illegal-photography-work"
-excerpt: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
+excerpt: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work authorization, according to ANTARA News, the state-run news agency. The operation represents one of the more numerically significant enforc"
 coverImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work.jpg"
 cardImage: "/static/news/indonesia-deports-25-foreigners-caught-doing-illegal-photography-work_card.jpg"
 coverImageAlt: "Indonesia Deports 25 Foreigners Caught Doing Illegal Photography Work"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 25 Foreigners Caught Doing Illegal..."
-seoDescription: "## Facts  Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
+seoDescription: "Indonesian immigration authorities deported 25 foreign nationals after finding them engaged in photography work without valid work..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 slug: "indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown"
-excerpt: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
+excerpt: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
 coverImage: "/static/news/visa_20260511_174405_516b03bc_cover.png"
 coverImageAlt: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 78 Foreign Workers in Illegal Employment..."
-seoDescription: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
+seoDescription: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 slug: "indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown"
-excerpt: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
+excerpt: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
 coverImage: "/static/news/visa_20260511_174405_516b03bc_cover.png"
 coverImageAlt: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 78 Foreign Workers in Illegal Employment..."
-seoDescription: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
+seoDescription: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 slug: "indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown"
-excerpt: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
+excerpt: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
 coverImage: "/static/news/visa_20260511_174405_516b03bc_cover.png"
 coverImageAlt: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 78 Foreign Workers in Illegal Employment..."
-seoDescription: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
+seoDescription: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 slug: "indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown"
-excerpt: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
+excerpt: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
 coverImage: "/static/news/visa_20260511_174405_516b03bc_cover.png"
 coverImageAlt: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 78 Foreign Workers in Illegal Employment..."
-seoDescription: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
+seoDescription: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 slug: "indonesia-deports-78-foreign-workers-in-illegal-employment-crackdown"
-excerpt: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
+excerpt: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The operation underscores an ongoing pattern of joint sweeps conducted by the Directorate General of Immigration (Ditjen Imigrasi) in co"
 coverImage: "/static/news/visa_20260511_174405_516b03bc_cover.png"
 coverImageAlt: "Indonesia Deports 78 Foreign Workers in Illegal Employment Crackdown"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports 78 Foreign Workers in Illegal Employment..."
-seoDescription: "## Facts  Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
+seoDescription: "Indonesian authorities deported 78 foreign nationals following an enforcement action targeting illegal employment across the country. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
 slug: "indonesia-deports-three-chinese-nationals-for-visa-fraud"
-excerpt: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
+excerpt: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
 coverImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud.jpg"
 cardImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud_card.jpg"
 coverImageAlt: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
-seoDescription: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
+seoDescription: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
 slug: "indonesia-deports-three-chinese-nationals-for-visa-fraud"
-excerpt: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
+excerpt: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
 coverImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud.jpg"
 cardImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud_card.jpg"
 coverImageAlt: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
-seoDescription: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
+seoDescription: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
 slug: "indonesia-deports-three-chinese-nationals-for-visa-fraud"
-excerpt: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
+excerpt: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
 coverImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud.jpg"
 cardImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud_card.jpg"
 coverImageAlt: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
-seoDescription: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
+seoDescription: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
 slug: "indonesia-deports-three-chinese-nationals-for-visa-fraud"
-excerpt: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
+excerpt: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
 coverImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud.jpg"
 cardImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud_card.jpg"
 coverImageAlt: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
-seoDescription: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
+seoDescription: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-deports-three-chinese-nationals-for-visa-fraud.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
 slug: "indonesia-deports-three-chinese-nationals-for-visa-fraud"
-excerpt: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
+excerpt: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through visa fraud, according to ANTARA News, Indonesia's official state news agency. The case adds to a pattern of enforcement actions"
 coverImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud.jpg"
 cardImage: "/static/news/indonesia-deports-three-chinese-nationals-for-visa-fraud_card.jpg"
 coverImageAlt: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Deports Three Chinese Nationals for Visa Fraud"
-seoDescription: "## Facts  Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
+seoDescription: "Indonesian immigration authorities deported three Chinese nationals after determining they had violated the country's immigration laws through..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political Will Is Missing"
 slug: "indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing"
-excerpt: "## Facts  Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r"
+excerpt: "Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r"
 coverImage: "/static/news/visa_20260521_173716_79710f8a.jpg"
 coverImageAlt: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political Will Is Missing"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political..."
-seoDescription: "## Facts  Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional..."
+seoDescription: "Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political Will Is Missing"
 slug: "indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing"
-excerpt: "## Facts  Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r"
+excerpt: "Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r"
 coverImage: "/static/news/visa_20260521_173716_79710f8a.jpg"
 coverImageAlt: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political Will Is Missing"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political..."
-seoDescription: "## Facts  Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional..."
+seoDescription: "Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political Will Is Missing"
 slug: "indonesia-eyes-bali-tax-havenbut-skeptics-say-political-will-is-missing"
-excerpt: "## Facts  Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r"
+excerpt: "Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional rivals such as Singapore and the Cayman Islands for foreign capital and high-spending tourists. The concept typically involves r"
 coverImage: "/static/news/visa_20260521_173716_79710f8a.jpg"
 coverImageAlt: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political Will Is Missing"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Bali Tax Haven—But Skeptics Say Political..."
-seoDescription: "## Facts  Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional..."
+seoDescription: "Indonesia has periodically floated the idea of establishing a tax-privileged zone in Bali, framing it as a mechanism to compete with regional..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
 slug: "indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists"
-excerpt: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
+excerpt: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
 coverImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.jpg"
 cardImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists_card.jpg"
 coverImageAlt: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
-seoDescription: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
+seoDescription: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
 slug: "indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists"
-excerpt: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
+excerpt: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
 coverImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.jpg"
 cardImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists_card.jpg"
 coverImageAlt: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
-seoDescription: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
+seoDescription: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
 slug: "indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists"
-excerpt: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
+excerpt: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
 coverImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.jpg"
 cardImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists_card.jpg"
 coverImageAlt: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
-seoDescription: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
+seoDescription: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
 slug: "indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists"
-excerpt: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
+excerpt: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
 coverImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.jpg"
 cardImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists_card.jpg"
 coverImageAlt: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
-seoDescription: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
+seoDescription: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
 slug: "indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists"
-excerpt: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
+excerpt: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone account for well over one million arrivals at Ngurah Rai International Airport, making them the single largest foreign visitor co"
 coverImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists.jpg"
 cardImage: "/static/news/indonesia-eyes-visa-free-access-for-aussie-and-kiwi-tourists_card.jpg"
 coverImageAlt: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Visa-Free Access for Aussie and Kiwi Tourists"
-seoDescription: "## Facts  Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
+seoDescription: "Australia and New Zealand consistently rank among Bali's top three tourism source markets. In a typical pre-pandemic year, Australians alone..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
 slug: "indonesia-family-kitas-2026-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
+excerpt: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
 coverImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.jpg"
 cardImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know_card.jpg"
 coverImageAlt: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Family KITAS 2026: What Spouses and Dependents..."
-seoDescription: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
+seoDescription: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
 slug: "indonesia-family-kitas-2026-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
+excerpt: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
 coverImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.jpg"
 cardImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know_card.jpg"
 coverImageAlt: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Family KITAS 2026: What Spouses and Dependents..."
-seoDescription: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
+seoDescription: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
 slug: "indonesia-family-kitas-2026-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
+excerpt: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
 coverImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.jpg"
 cardImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know_card.jpg"
 coverImageAlt: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Family KITAS 2026: What Spouses and Dependents..."
-seoDescription: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
+seoDescription: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
 slug: "indonesia-family-kitas-2026-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
+excerpt: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
 coverImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.jpg"
 cardImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know_card.jpg"
 coverImageAlt: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Family KITAS 2026: What Spouses and Dependents..."
-seoDescription: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
+seoDescription: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
 slug: "indonesia-family-kitas-2026-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
+excerpt: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners whose primary tie to the country is a family relationship rather than employment or investment. The permit comes in two disti"
 coverImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know.jpg"
 cardImage: "/static/news/indonesia-family-kitas-2026-what-spouses-and-dependents-must-know_card.jpg"
 coverImageAlt: "Indonesia Family KITAS 2026: What Spouses and Dependents Must Know"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Family KITAS 2026: What Spouses and Dependents..."
-seoDescription: "## Facts  Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
+seoDescription: "Indonesia's family-sponsored limited stay permit — known as KITAS (Kartu Izin Tinggal Terbatas) — is the primary legal instrument for foreigners..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M Minimum"
 slug: "indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum"
-excerpt: "## Facts  Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to"
+excerpt: "Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to"
 coverImage: "/static/news/visa_20260709_180705_68674eb9.jpg"
 cardImage: "/static/news/visa_20260709_180705_68674eb9_card.jpg"
 coverImageAlt: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M Minimum"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M..."
-seoDescription: "## Facts  Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying..."
+seoDescription: "Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M Minimum"
 slug: "indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum"
-excerpt: "## Facts  Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to"
+excerpt: "Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to"
 coverImage: "/static/news/visa_20260709_180705_68674eb9.jpg"
 cardImage: "/static/news/visa_20260709_180705_68674eb9_card.jpg"
 coverImageAlt: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M Minimum"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M..."
-seoDescription: "## Facts  Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying..."
+seoDescription: "Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M Minimum"
 slug: "indonesia-golden-visa-2025-no-sponsor-no-merp-usd-25m-minimum"
-excerpt: "## Facts  Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to"
+excerpt: "Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying capital commitments or portfolio investments. The program's statutory basis was formally established under the fourth amendment to"
 coverImage: "/static/news/visa_20260709_180705_68674eb9.jpg"
 cardImage: "/static/news/visa_20260709_180705_68674eb9_card.jpg"
 coverImageAlt: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M Minimum"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Golden Visa 2025: No Sponsor, No MERP, USD 2.5M..."
-seoDescription: "## Facts  Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying..."
+seoDescription: "Indonesia's Golden Visa program offers foreign nationals a pathway to long-term residency — five or ten years — in exchange for qualifying..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Golden Visa Rules Tightened: What Changed and What It Costs"
 slug: "indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs"
-excerpt: "## Facts  Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ"
+excerpt: "Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ"
 coverImage: "/static/news/visa_20260511_174256_7cc94250.jpg"
 coverImageAlt: "Indonesia Golden Visa Rules Tightened: What Changed and What It Costs"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Golden Visa Rules Tightened: What Changed and..."
-seoDescription: "## Facts  Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory..."
+seoDescription: "Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Golden Visa Rules Tightened: What Changed and What It Costs"
 slug: "indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs"
-excerpt: "## Facts  Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ"
+excerpt: "Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ"
 coverImage: "/static/news/visa_20260511_174256_7cc94250.jpg"
 coverImageAlt: "Indonesia Golden Visa Rules Tightened: What Changed and What It Costs"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Golden Visa Rules Tightened: What Changed and..."
-seoDescription: "## Facts  Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory..."
+seoDescription: "Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Golden Visa Rules Tightened: What Changed and What It Costs"
 slug: "indonesia-golden-visa-rules-tightened-what-changed-and-what-it-costs"
-excerpt: "## Facts  Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ"
+excerpt: "Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory overhaul through a series of ministerial regulations enacted between 2023 and 2025. The changes affect investment minimums, administ"
 coverImage: "/static/news/visa_20260511_174256_7cc94250.jpg"
 coverImageAlt: "Indonesia Golden Visa Rules Tightened: What Changed and What It Costs"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Golden Visa Rules Tightened: What Changed and..."
-seoDescription: "## Facts  Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory..."
+seoDescription: "Indonesia's Golden Visa program, one of seven investor residency schemes drawing global attention, has undergone a significant regulatory..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Immigration Designates Parq as Ambassador to Court European Investors"
 slug: "indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors"
-excerpt: "## Facts  Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa"
+excerpt: "Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa"
 coverImage: "/static/news/visa_20260511_174223_24ab24cd.jpg"
 coverImageAlt: "Indonesia Immigration Designates Parq as Ambassador to Court European Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Immigration Designates Parq as Ambassador to..."
-seoDescription: "## Facts  Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a..."
+seoDescription: "Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Immigration Designates Parq as Ambassador to Court European Investors"
 slug: "indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors"
-excerpt: "## Facts  Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa"
+excerpt: "Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa"
 coverImage: "/static/news/visa_20260511_174223_24ab24cd.jpg"
 coverImageAlt: "Indonesia Immigration Designates Parq as Ambassador to Court European Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Immigration Designates Parq as Ambassador to..."
-seoDescription: "## Facts  Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a..."
+seoDescription: "Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Immigration Designates Parq as Ambassador to Court European Investors"
 slug: "indonesia-immigration-designates-parq-as-ambassador-to-court-european-investors"
-excerpt: "## Facts  Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa"
+excerpt: "Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a ceremony that underscores the government's strategic intent to attract European business capital to Indonesia. The designation is pa"
 coverImage: "/static/news/visa_20260511_174223_24ab24cd.jpg"
 coverImageAlt: "Indonesia Immigration Designates Parq as Ambassador to Court European Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Immigration Designates Parq as Ambassador to..."
-seoDescription: "## Facts  Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a..."
+seoDescription: "Indonesian Immigration authorities have formally appointed Parq as a Duta Layanan Keimigrasian — an Immigration Service Ambassador — in a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-investor-kitas-the-complete-immigration-playbook-for-2025.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-investor-kitas-the-complete-immigration-playbook-for-2025.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Investor KITAS: The Complete Immigration Playbook for 2025"
 slug: "indonesia-investor-kitas-the-complete-immigration-playbook-for-2025"
-excerpt: "## Facts  The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist"
+excerpt: "The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist"
 coverImage: "/static/news/visa_20260409_175506_a6503f33.jpg"
 coverImageAlt: "Indonesia Investor KITAS: The Complete Immigration Playbook for 2025"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-investor-kitas-the-complete-immigration-playbook-for-2025.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-investor-kitas-the-complete-immigration-playbook-for-2025.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Investor KITAS: The Complete Immigration Playbook for 2025"
 slug: "indonesia-investor-kitas-the-complete-immigration-playbook-for-2025"
-excerpt: "## Facts  The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist"
+excerpt: "The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist"
 coverImage: "/static/news/visa_20260409_175506_a6503f33.jpg"
 coverImageAlt: "Indonesia Investor KITAS: The Complete Immigration Playbook for 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Investor KITAS: The Complete Immigration Playbook..."
-seoDescription: "## Facts  The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign..."
+seoDescription: "The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-investor-kitas-the-complete-immigration-playbook-for-2025.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-investor-kitas-the-complete-immigration-playbook-for-2025.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Investor KITAS: The Complete Immigration Playbook for 2025"
 slug: "indonesia-investor-kitas-the-complete-immigration-playbook-for-2025"
-excerpt: "## Facts  The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist"
+excerpt: "The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign nationals who hold equity stakes in Indonesian legal entities. It is issued by the Directorate General of Immigration under the Minist"
 coverImage: "/static/news/visa_20260409_175506_a6503f33.jpg"
 coverImageAlt: "Indonesia Investor KITAS: The Complete Immigration Playbook for 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Investor KITAS: The Complete Immigration Playbook..."
-seoDescription: "## Facts  The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign..."
+seoDescription: "The Investor KITAS — formally known as the Kartu Izin Tinggal Terbatas for investors — is Indonesia's principal stay permit for foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Kills Online-Only Visa Extensions: What the June 2025 Shift Means"
 slug: "indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025"
+excerpt: "Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025"
 coverImage: "/static/news/visa_20260421_173008_0c18702c_cover.png"
 coverImageAlt: "Indonesia Kills Online-Only Visa Extensions: What the June 2025 Shift Means"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Kills Online-Only Visa Extensions: What the June 2025 Shift Means"
 slug: "indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025"
+excerpt: "Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025"
 coverImage: "/static/news/visa_20260421_173008_0c18702c_cover.png"
 coverImageAlt: "Indonesia Kills Online-Only Visa Extensions: What the June 2025 Shift Means"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Kills Online-Only Visa Extensions: What the June 2025 Shift Means"
 slug: "indonesia-kills-online-only-visa-extensions-what-the-june-2025-shift-means"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025"
+excerpt: "Indonesia's Directorate General of Immigration issued Circular Letter Number IMI-417.GR.01.01 Year 2025, effective May 29, 2025, mandating that all stay permit extensions require in-person attendance at an immigration office. The new rule came into force on June 1, 2025"
 coverImage: "/static/news/visa_20260421_173008_0c18702c_cover.png"
 coverImageAlt: "Indonesia Kills Online-Only Visa Extensions: What the June 2025 Shift Means"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 slug: "indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security"
-excerpt: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
+excerpt: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
 coverImage: "/static/news/visa_20260511_174350_2cbcd8a2_cover.png"
 coverImageAlt: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Launches First Submarine Rescue Ship, Bolstering..."
-seoDescription: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
+seoDescription: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 slug: "indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security"
-excerpt: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
+excerpt: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
 coverImage: "/static/news/visa_20260511_174350_2cbcd8a2_cover.png"
 coverImageAlt: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Launches First Submarine Rescue Ship, Bolstering..."
-seoDescription: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
+seoDescription: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 slug: "indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security"
-excerpt: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
+excerpt: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
 coverImage: "/static/news/visa_20260511_174350_2cbcd8a2_cover.png"
 coverImageAlt: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Launches First Submarine Rescue Ship, Bolstering..."
-seoDescription: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
+seoDescription: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 slug: "indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security"
-excerpt: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
+excerpt: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
 coverImage: "/static/news/visa_20260511_174350_2cbcd8a2_cover.png"
 coverImageAlt: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Launches First Submarine Rescue Ship, Bolstering..."
-seoDescription: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
+seoDescription: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 slug: "indonesia-launches-first-submarine-rescue-ship-bolstering-maritime-security"
-excerpt: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
+excerpt: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship. The vessel represents a qualitative leap in the Indonesian Navy's (Tentara Nasional Indonesia Angkatan Laut, or TNI-AL) operatio"
 coverImage: "/static/news/visa_20260511_174350_2cbcd8a2_cover.png"
 coverImageAlt: "Indonesia Launches First Submarine Rescue Ship, Bolstering Maritime Security"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Launches First Submarine Rescue Ship, Bolstering..."
-seoDescription: "## Facts  Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
+seoDescription: "Indonesia has added a critical asset to its naval fleet with the commissioning of KRI Canopus-936, the country's first submarine rescue ship...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment.id.mdx
@@ -100,11 +100,7 @@ description: "# Panduan Pendirian PT PMA di Indonesia
   untuk berkonsultasi dengan ahli hukum atau konsultan bisnis untuk mendapatkan nasihat
   yang lebih spesifik sesuai dengan kebutuhan Anda."
 difficulty: intermediate
-excerpt:
-  "## Facts  Indonesian President Prabowo Subianto and Malaysian Prime Minister
-  Anwar Ibrahim convened for high-level bilateral talks, with discussions centered
-  on strategic issues affecting both nations and the broader ASEAN region. The meeting
-  reflects the historically close relat"
+excerpt: "Indonesian President Prabowo Subianto and Malaysian Prime Minister Anwar Ibrahim convened for high-level bilateral talks, with discussions centered on strategic issues affecting both nations and the broader ASEAN region. The meeting reflects the historically close relat"
 featured: false
 lang: id
 publishedAt: "2026-03-28"

--- a/apps/mouth/src/content/articles/immigration/indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia-Malaysia Summit Signals Deeper ASEAN Strategic Alignment"
 slug: "indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment"
-excerpt: "## Facts  Indonesian President Prabowo Subianto and Malaysian Prime Minister Anwar Ibrahim convened for high-level bilateral talks, with discussions centered on strategic issues affecting both nations and the broader ASEAN region. The meeting reflects the historically close relat"
+excerpt: "Indonesian President Prabowo Subianto and Malaysian Prime Minister Anwar Ibrahim convened for high-level bilateral talks, with discussions centered on strategic issues affecting both nations and the broader ASEAN region. The meeting reflects the historically close relat"
 coverImage: "/static/news/visa_20260327_180150_a6912ff1_cover.png"
 coverImageAlt: "Indonesia-Malaysia Summit Signals Deeper ASEAN Strategic Alignment"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia-Malaysia Summit Signals Deeper ASEAN Strategic Alignment"
 slug: "indonesia-malaysia-summit-signals-deeper-asean-strategic-alignment"
-excerpt: "## Facts  Indonesian President Prabowo Subianto and Malaysian Prime Minister Anwar Ibrahim convened for high-level bilateral talks, with discussions centered on strategic issues affecting both nations and the broader ASEAN region. The meeting reflects the historically close relat"
+excerpt: "Indonesian President Prabowo Subianto and Malaysian Prime Minister Anwar Ibrahim convened for high-level bilateral talks, with discussions centered on strategic issues affecting both nations and the broader ASEAN region. The meeting reflects the historically close relat"
 coverImage: "/static/news/visa_20260327_180150_a6912ff1_cover.png"
 coverImageAlt: "Indonesia-Malaysia Summit Signals Deeper ASEAN Strategic Alignment"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical Storms Gather"
 slug: "indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather"
-excerpt: "## Facts  Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects"
+excerpt: "Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects"
 coverImage: "/static/news/visa_20260407_180558_ab9f8597.jpg"
 coverImageAlt: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical Storms Gather"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical Storms Gather"
 slug: "indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather"
-excerpt: "## Facts  Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects"
+excerpt: "Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects"
 coverImage: "/static/news/visa_20260407_180558_ab9f8597.jpg"
 coverImageAlt: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical Storms Gather"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical..."
-seoDescription: "## Facts  Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects..."
+seoDescription: "Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical Storms Gather"
 slug: "indonesia-mobilizes-tourism-defenses-as-global-geopolitical-storms-gather"
-excerpt: "## Facts  Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects"
+excerpt: "Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects of global geopolitical uncertainty. The announcement, reported by state news agency ANTARA from Central Kalimantan, reflects"
 coverImage: "/static/news/visa_20260407_180558_ab9f8597.jpg"
 coverImageAlt: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical Storms Gather"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Mobilizes Tourism Defenses as Global Geopolitical..."
-seoDescription: "## Facts  Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects..."
+seoDescription: "Indonesia's government has signaled it is actively developing contingency plans to shield the national tourism sector from the cascading effects..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-moves-to-regulate-crypto-with-stock-market-rules.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-moves-to-regulate-crypto-with-stock-market-rules.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Moves to Regulate Crypto With Stock-Market Rules"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Moves to Regulate...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/immigration/indonesia-moves-to-regulate-crypto-with-stock-market-rules.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-moves-to-regulate-crypto-with-stock-market-rules.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Moves to Regulate Crypto With Stock-Market Rules"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Moves to Regulate...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
 slug: "indonesia-opens-fast-track-visa-lane-for-foreign-athletes"
-excerpt: "## Facts  Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago.  Prior to this develop"
+excerpt: "Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago. Prior to this develop"
 coverImage: "/static/news/visa_20260423_112426_e94702dc.jpg"
 coverImageAlt: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
-seoDescription: "## Facts  Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was..."
+seoDescription: "Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
 slug: "indonesia-opens-fast-track-visa-lane-for-foreign-athletes"
-excerpt: "## Facts  Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago.  Prior to this develop"
+excerpt: "Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago. Prior to this develop"
 coverImage: "/static/news/visa_20260423_112426_e94702dc.jpg"
 coverImageAlt: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
-seoDescription: "## Facts  Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was..."
+seoDescription: "Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-opens-fast-track-visa-lane-for-foreign-athletes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
 slug: "indonesia-opens-fast-track-visa-lane-for-foreign-athletes"
-excerpt: "## Facts  Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago.  Prior to this develop"
+excerpt: "Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was previously a fragmented and often opaque process for sports professionals seeking entry into the archipelago. Prior to this develop"
 coverImage: "/static/news/visa_20260423_112426_e94702dc.jpg"
 coverImageAlt: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Fast-Track Visa Lane for Foreign Athletes"
-seoDescription: "## Facts  Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was..."
+seoDescription: "Indonesia's immigration authority has launched a dedicated fast-track visa channel for foreign athletes, a move that streamlines what was..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Green Energy Sector to Foreign Capital — With Strict Conditions"
 slug: "indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions"
-excerpt: "## Facts  Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is"
+excerpt: "Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is"
 coverImage: "/static/news/visa_20260423_112405_3e9b6eb6.jpg"
 coverImageAlt: "Indonesia Opens Green Energy Sector to Foreign Capital — With Strict Conditions"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Green Energy Sector to Foreign Capital —..."
-seoDescription: "## Facts  Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to..."
+seoDescription: "Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Green Energy Sector to Foreign Capital — With Strict Conditions"
 slug: "indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions"
-excerpt: "## Facts  Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is"
+excerpt: "Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is"
 coverImage: "/static/news/visa_20260423_112405_3e9b6eb6.jpg"
 coverImageAlt: "Indonesia Opens Green Energy Sector to Foreign Capital — With Strict Conditions"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Green Energy Sector to Foreign Capital —..."
-seoDescription: "## Facts  Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to..."
+seoDescription: "Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Opens Green Energy Sector to Foreign Capital — With Strict Conditions"
 slug: "indonesia-opens-green-energy-sector-to-foreign-capital-with-strict-conditions"
-excerpt: "## Facts  Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is"
+excerpt: "Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to expand renewable capacity and reduce reliance on fossil fuels. However, access for foreign investors is not open-ended — it is"
 coverImage: "/static/news/visa_20260423_112405_3e9b6eb6.jpg"
 coverImageAlt: "Indonesia Opens Green Energy Sector to Foreign Capital — With Strict Conditions"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Opens Green Energy Sector to Foreign Capital —..."
-seoDescription: "## Facts  Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to..."
+seoDescription: "Indonesia's green energy sector has emerged as a significant destination for foreign direct investment, underpinned by a national commitment to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa Non-Resident Status"
 slug: "indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status"
-excerpt: "## Facts  Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to"
+excerpt: "Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to"
 coverImage: "/static/news/visa_20260710_174124_9d224f45.jpg"
 cardImage: "/static/news/visa_20260710_174124_9d224f45_card.jpg"
 coverImageAlt: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa Non-Resident Status"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa..."
-seoDescription: "## Facts  Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by..."
+seoDescription: "Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa Non-Resident Status"
 slug: "indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status"
-excerpt: "## Facts  Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to"
+excerpt: "Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to"
 coverImage: "/static/news/visa_20260710_174124_9d224f45.jpg"
 cardImage: "/static/news/visa_20260710_174124_9d224f45_card.jpg"
 coverImageAlt: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa Non-Resident Status"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa..."
-seoDescription: "## Facts  Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by..."
+seoDescription: "Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa Non-Resident Status"
 slug: "indonesia-plans-zero-tax-financial-zone-with-golden-visa-non-resident-status"
-excerpt: "## Facts  Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to"
+excerpt: "Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by Caproasia. The proposal, which targets the financial sector specifically, outlines a sweeping package of fiscal incentives designed to"
 coverImage: "/static/news/visa_20260710_174124_9d224f45.jpg"
 cardImage: "/static/news/visa_20260710_174124_9d224f45_card.jpg"
 coverImageAlt: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa Non-Resident Status"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Plans Zero-Tax Financial Zone with Golden Visa..."
-seoDescription: "## Facts  Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by..."
+seoDescription: "Indonesia's government is advancing plans to establish a dedicated International Financial Centre (IFC) zone, according to a report by..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in 2025"
 slug: "indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025"
-excerpt: "## Facts  Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new"
+excerpt: "Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new"
 coverImage: "/static/news/visa_20260710_174057_98f4c891.jpg"
 cardImage: "/static/news/visa_20260710_174057_98f4c891_card.jpg"
 coverImageAlt: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in 2025"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in..."
-seoDescription: "## Facts  Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical..."
+seoDescription: "Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in 2025"
 slug: "indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025"
-excerpt: "## Facts  Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new"
+excerpt: "Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new"
 coverImage: "/static/news/visa_20260710_174057_98f4c891.jpg"
 cardImage: "/static/news/visa_20260710_174057_98f4c891_card.jpg"
 coverImageAlt: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in 2025"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in..."
-seoDescription: "## Facts  Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical..."
+seoDescription: "Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in 2025"
 slug: "indonesia-rewrites-the-rules-for-us-expats-eyeing-bali-in-2025"
-excerpt: "## Facts  Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new"
+excerpt: "Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical calculus for every US citizen weighing a move to Bali. The changes span four distinct pieces of legislation and introduce new"
 coverImage: "/static/news/visa_20260710_174057_98f4c891.jpg"
 cardImage: "/static/news/visa_20260710_174057_98f4c891_card.jpg"
 coverImageAlt: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in 2025"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Rewrites the Rules for US Expats Eyeing Bali in..."
-seoDescription: "## Facts  Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical..."
+seoDescription: "Indonesia's immigration architecture underwent its most significant restructuring in over a decade between 2023 and 2025, altering the practical..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 slug: "indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says"
-excerpt: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
+excerpt: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
 coverImage: "/static/news/visa_20260608_173740_08881fa5_cover.png"
 coverImageAlt: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Scraps Fast-Track Residency Permits for..."
-seoDescription: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
+seoDescription: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 slug: "indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says"
-excerpt: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
+excerpt: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
 coverImage: "/static/news/visa_20260608_173740_08881fa5_cover.png"
 coverImageAlt: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Scraps Fast-Track Residency Permits for..."
-seoDescription: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
+seoDescription: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 slug: "indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says"
-excerpt: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
+excerpt: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
 coverImage: "/static/news/visa_20260608_173740_08881fa5_cover.png"
 coverImageAlt: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Scraps Fast-Track Residency Permits for..."
-seoDescription: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
+seoDescription: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 slug: "indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says"
-excerpt: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
+excerpt: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
 coverImage: "/static/news/visa_20260608_173740_08881fa5_cover.png"
 cardImage: "/static/news/visa_20260608_173740_08881fa5_cover_card.png"
 coverImageAlt: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Scraps Fast-Track Residency Permits for..."
-seoDescription: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
+seoDescription: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 slug: "indonesia-scraps-fast-track-residency-permits-for-foreigners-minister-says"
-excerpt: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
+excerpt: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track channels for foreign residency permits have been abolished. The statement, reported by Liputan6, marks a significant shift in how the"
 coverImage: "/static/news/visa_20260608_173740_08881fa5_cover.png"
 coverImageAlt: "Indonesia Scraps Fast-Track Residency Permits for Foreigners, Minister Says"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Scraps Fast-Track Residency Permits for..."
-seoDescription: "## Facts  Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
+seoDescription: "Indonesia's Coordinating Minister for Law, Human Rights, Immigration and Corrections, Yusril Ihza Mahendra, has declared that fast-track..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-tax-for-expats-who-owes-what-in-2026.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tax-for-expats-who-owes-what-in-2026.id.mdx
@@ -117,11 +117,7 @@ description: "# Panduan Investasi di Indonesia untuk Warga Negara Asing
 
   *   [OSS - Sistem Perizinan Berusaha](https://oss.go.id/)"
 difficulty: intermediate
-excerpt:
-  "## Facts  Indonesia operates a residence-based tax system governed primarily
-  by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments.
-  Under this framework, an individual becomes a tax resident — and therefore liable
-  for Indonesian income tax — if they"
+excerpt: "Indonesia operates a residence-based tax system governed primarily by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments. Under this framework, an individual becomes a tax resident — and therefore liable for Indonesian income tax — if they"
 featured: false
 lang: id
 publishedAt: "2026-04-01"

--- a/apps/mouth/src/content/articles/immigration/indonesia-tax-for-expats-who-owes-what-in-2026.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tax-for-expats-who-owes-what-in-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax for Expats: Who Owes What in 2026"
 slug: "indonesia-tax-for-expats-who-owes-what-in-2026"
-excerpt: "## Facts  Indonesia operates a residence-based tax system governed primarily by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments. Under this framework, an individual becomes a tax resident — and therefore liable for Indonesian income tax — if they"
+excerpt: "Indonesia operates a residence-based tax system governed primarily by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments. Under this framework, an individual becomes a tax resident — and therefore liable for Indonesian income tax — if they"
 coverImage: "/static/news/visa_20260331_184018_ce3d0921.jpg"
 coverImageAlt: "Indonesia Tax for Expats: Who Owes What in 2026"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-tax-for-expats-who-owes-what-in-2026.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tax-for-expats-who-owes-what-in-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax for Expats: Who Owes What in 2026"
 slug: "indonesia-tax-for-expats-who-owes-what-in-2026"
-excerpt: "## Facts  Indonesia operates a residence-based tax system governed primarily by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments. Under this framework, an individual becomes a tax resident — and therefore liable for Indonesian income tax — if they"
+excerpt: "Indonesia operates a residence-based tax system governed primarily by the Income Tax Law (Undang-Undang PPh No. 36/2008) and its subsequent amendments. Under this framework, an individual becomes a tax resident — and therefore liable for Indonesian income tax — if they"
 coverImage: "/static/news/visa_20260331_184018_ce3d0921.jpg"
 coverImageAlt: "Indonesia Tax for Expats: Who Owes What in 2026"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
 slug: "indonesia-tightens-grip-on-influencers-working-on-tourist-visas"
-excerpt: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
+excerpt: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
 coverImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.jpg"
 cardImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas_card.jpg"
 coverImageAlt: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Grip on Influencers Working on Tourist..."
-seoDescription: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
+seoDescription: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
 slug: "indonesia-tightens-grip-on-influencers-working-on-tourist-visas"
-excerpt: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
+excerpt: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
 coverImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.jpg"
 cardImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas_card.jpg"
 coverImageAlt: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Grip on Influencers Working on Tourist..."
-seoDescription: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
+seoDescription: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
 slug: "indonesia-tightens-grip-on-influencers-working-on-tourist-visas"
-excerpt: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
+excerpt: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
 coverImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.jpg"
 cardImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas_card.jpg"
 coverImageAlt: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Grip on Influencers Working on Tourist..."
-seoDescription: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
+seoDescription: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
 slug: "indonesia-tightens-grip-on-influencers-working-on-tourist-visas"
-excerpt: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
+excerpt: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
 coverImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.jpg"
 cardImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas_card.jpg"
 coverImageAlt: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Grip on Influencers Working on Tourist..."
-seoDescription: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
+seoDescription: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
 slug: "indonesia-tightens-grip-on-influencers-working-on-tourist-visas"
-excerpt: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
+excerpt: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing Government Regulation No. 31 of 2013, foreigners on tourist or social-visit visas (B211A) are explicitly prohibited from engaging in a"
 coverImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas.jpg"
 cardImage: "/static/news/indonesia-tightens-grip-on-influencers-working-on-tourist-visas_card.jpg"
 coverImageAlt: "Indonesia Tightens Grip on Influencers Working on Tourist Visas"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Grip on Influencers Working on Tourist..."
-seoDescription: "## Facts  Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
+seoDescription: "Indonesian immigration law draws a clear line between visiting and working. Under Law No. 6 of 2011 on Immigration and its implementing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Immigration Enforcement: What April 2026 Means for Expats"
 slug: "indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats"
-excerpt: "## Facts  Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a"
+excerpt: "Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a"
 coverImage: "/static/news/visa_20260419_173145_a0b2149d_cover.png"
 coverImageAlt: "Indonesia Tightens Immigration Enforcement: What April 2026 Means for Expats"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Immigration Enforcement: What April 2026 Means for Expats"
 slug: "indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats"
-excerpt: "## Facts  Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a"
+excerpt: "Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a"
 coverImage: "/static/news/visa_20260419_173145_a0b2149d_cover.png"
 coverImageAlt: "Indonesia Tightens Immigration Enforcement: What April 2026 Means for Expats"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Immigration Enforcement: What April 2026 Means for Expats"
 slug: "indonesia-tightens-immigration-enforcement-what-april-2026-means-for-expats"
-excerpt: "## Facts  Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a"
+excerpt: "Indonesia's immigration apparatus has been operating at elevated activity levels throughout the first quarter of 2026, with the Directorate General of Immigration (Ditjen Imigrasi) issuing regular weekly advisories that track enforcement sweeps, policy clarifications, a"
 coverImage: "/static/news/visa_20260419_173145_a0b2149d_cover.png"
 coverImageAlt: "Indonesia Tightens Immigration Enforcement: What April 2026 Means for Expats"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-passport-rules-originals-required-at-interview.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-passport-rules-originals-required-at-interview.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Passport Rules: Originals Required at Interview"
 slug: "indonesia-tightens-passport-rules-originals-required-at-interview"
-excerpt: "## Facts  Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol"
+excerpt: "Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol"
 coverImage: "/static/news/visa_20260407_180517_10b724e6.jpg"
 coverImageAlt: "Indonesia Tightens Passport Rules: Originals Required at Interview"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-passport-rules-originals-required-at-interview.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-passport-rules-originals-required-at-interview.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Passport Rules: Originals Required at Interview"
 slug: "indonesia-tightens-passport-rules-originals-required-at-interview"
-excerpt: "## Facts  Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol"
+excerpt: "Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol"
 coverImage: "/static/news/visa_20260407_180517_10b724e6.jpg"
 coverImageAlt: "Indonesia Tightens Passport Rules: Originals Required at Interview"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Passport Rules: Originals Required at..."
-seoDescription: "## Facts  Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The..."
+seoDescription: "Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-tightens-passport-rules-originals-required-at-interview.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-tightens-passport-rules-originals-required-at-interview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Passport Rules: Originals Required at Interview"
 slug: "indonesia-tightens-passport-rules-originals-required-at-interview"
-excerpt: "## Facts  Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol"
+excerpt: "Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The announcement, distributed via ANTARA News, underscores an existing and longstanding legal obligation rather than introducing new pol"
 coverImage: "/static/news/visa_20260407_180517_10b724e6.jpg"
 coverImageAlt: "Indonesia Tightens Passport Rules: Originals Required at Interview"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Passport Rules: Originals Required at..."
-seoDescription: "## Facts  Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The..."
+seoDescription: "Indonesia's immigration authority has issued a public reminder that original documents are mandatory at the passport interview stage. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
 slug: "indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
+excerpt: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
 coverImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.jpg"
 cardImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8_card.jpg"
 coverImageAlt: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Updates E30A Student Visa Rules for Expat School..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
+seoDescription: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
 slug: "indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
+excerpt: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
 coverImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.jpg"
 cardImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8_card.jpg"
 coverImageAlt: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Updates E30A Student Visa Rules for Expat School..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
+seoDescription: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
 slug: "indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
+excerpt: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
 coverImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.jpg"
 cardImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8_card.jpg"
 coverImageAlt: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Updates E30A Student Visa Rules for Expat School..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
+seoDescription: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
 slug: "indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
+excerpt: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
 coverImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.jpg"
 cardImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8_card.jpg"
 coverImageAlt: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Updates E30A Student Visa Rules for Expat School..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
+seoDescription: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
 slug: "indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
+excerpt: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8 June 2026, with specific provisions introduced for school-enrolled minors — including kindergarten-age children — and foreign n"
 coverImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8.jpg"
 cardImage: "/static/news/indonesia-updates-e30a-student-visa-rules-for-expat-school-children-from-june-8_card.jpg"
 coverImageAlt: "Indonesia Updates E30A Student Visa Rules for Expat School Children from June 8"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Updates E30A Student Visa Rules for Expat School..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
+seoDescription: "Indonesia's Directorate General of Immigration implemented updated procedural requirements for the E30A limited stay visa category effective 8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 slug: "indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know"
-excerpt: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
+excerpt: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
 coverImage: "/static/news/visa_20260517_173627_986f6672_cover.png"
 coverImageAlt: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Landscape: What Every Foreign Visitor and..."
-seoDescription: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
+seoDescription: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 slug: "indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know"
-excerpt: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
+excerpt: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
 coverImage: "/static/news/visa_20260517_173627_986f6672_cover.png"
 coverImageAlt: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Landscape: What Every Foreign Visitor and..."
-seoDescription: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
+seoDescription: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 slug: "indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know"
-excerpt: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
+excerpt: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
 coverImage: "/static/news/visa_20260517_173627_986f6672_cover.png"
 coverImageAlt: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Landscape: What Every Foreign Visitor and..."
-seoDescription: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
+seoDescription: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 slug: "indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know"
-excerpt: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
+excerpt: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
 coverImage: "/static/news/visa_20260517_173627_986f6672_cover.png"
 coverImageAlt: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Landscape: What Every Foreign Visitor and..."
-seoDescription: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
+seoDescription: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 slug: "indonesia-visa-landscape-what-every-foreign-visitor-and-investor-needs-to-know"
-excerpt: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
+excerpt: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each with distinct eligibility criteria, durations, and conditions. The country's immigration framework is governed primarily by Law"
 coverImage: "/static/news/visa_20260517_173627_986f6672_cover.png"
 coverImageAlt: "Indonesia Visa Landscape: What Every Foreign Visitor and Investor Needs to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Landscape: What Every Foreign Visitor and..."
-seoDescription: "## Facts  Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
+seoDescription: "Indonesia operates a layered visa system that serves a spectrum of foreign nationals — from short-term tourists to long-term investors — each..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
 slug: "indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
+excerpt: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
 coverImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.jpg"
 cardImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty_card.jpg"
 coverImageAlt: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
+seoDescription: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
 slug: "indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
+excerpt: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
 coverImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.jpg"
 cardImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty_card.jpg"
 coverImageAlt: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
+seoDescription: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
 slug: "indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
+excerpt: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
 coverImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.jpg"
 cardImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty_card.jpg"
 coverImageAlt: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
+seoDescription: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
 slug: "indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
+excerpt: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
 coverImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.jpg"
 cardImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty_card.jpg"
 coverImageAlt: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
+seoDescription: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
 slug: "indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty"
-excerpt: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
+excerpt: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8 trillion, a figure reported by Nusa Daily against a backdrop of global economic uncertainty. The headline underscores continued d"
 coverImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty.jpg"
 cardImage: "/static/news/indonesia-visa-revenue-breaks-rp28-trillion-despite-global-uncertainty_card.jpg"
 coverImageAlt: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global Uncertainty"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Visa Revenue Breaks Rp2.8 Trillion Despite Global..."
-seoDescription: "## Facts  Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
+seoDescription: "Indonesia's Directorate General of Immigration has recorded non-tax state revenue (PNBP) from visa and immigration services surpassing Rp2.8..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-every-expat-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-every-expat-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Every Expat Must Know"
 slug: "indonesia-work-visa-landscape-what-every-expat-must-know"
-excerpt: "## Facts  Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc"
+excerpt: "Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc"
 coverImage: "/static/news/visa_20260429_173720_5c51b49c_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Every Expat Must Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-every-expat-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-every-expat-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Every Expat Must Know"
 slug: "indonesia-work-visa-landscape-what-every-expat-must-know"
-excerpt: "## Facts  Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc"
+excerpt: "Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc"
 coverImage: "/static/news/visa_20260429_173720_5c51b49c_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Every Expat Must Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-every-expat-must-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-every-expat-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Every Expat Must Know"
 slug: "indonesia-work-visa-landscape-what-every-expat-must-know"
-excerpt: "## Facts  Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc"
+excerpt: "Indonesia operates a layered immigration framework for foreign workers, governed primarily by Law No. 6 of 2011 on Immigration and Government Regulation No. 31 of 2013, with subsequent amendments. Foreign nationals who intend to work in Indonesia must obtain two distinc"
 coverImage: "/static/news/visa_20260429_173720_5c51b49c_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Every Expat Must Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 slug: "indonesia-work-visa-landscape-what-foreign-workers-must-know"
-excerpt: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
+excerpt: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
 coverImage: "/static/news/visa_20260517_173648_ec4925a5_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Work Visa Landscape: What Foreign Workers Must..."
-seoDescription: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
+seoDescription: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 slug: "indonesia-work-visa-landscape-what-foreign-workers-must-know"
-excerpt: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
+excerpt: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
 coverImage: "/static/news/visa_20260517_173648_ec4925a5_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Work Visa Landscape: What Foreign Workers Must..."
-seoDescription: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
+seoDescription: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 slug: "indonesia-work-visa-landscape-what-foreign-workers-must-know"
-excerpt: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
+excerpt: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
 coverImage: "/static/news/visa_20260517_173648_ec4925a5_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Work Visa Landscape: What Foreign Workers Must..."
-seoDescription: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
+seoDescription: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 slug: "indonesia-work-visa-landscape-what-foreign-workers-must-know"
-excerpt: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
+excerpt: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
 coverImage: "/static/news/visa_20260517_173648_ec4925a5_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Work Visa Landscape: What Foreign Workers Must..."
-seoDescription: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
+seoDescription: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesia-work-visa-landscape-what-foreign-workers-must-know.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 slug: "indonesia-work-visa-landscape-what-foreign-workers-must-know"
-excerpt: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
+excerpt: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No. 13/2003 on Manpower, Law No. 6/2011 on Immigration, and its implementing regulations. Foreign nationals who intend to work in Indo"
 coverImage: "/static/news/visa_20260517_173648_ec4925a5_cover.png"
 coverImageAlt: "Indonesia Work Visa Landscape: What Foreign Workers Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Work Visa Landscape: What Foreign Workers Must..."
-seoDescription: "## Facts  Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
+seoDescription: "Indonesia's work authorization framework sits at the intersection of immigration law and manpower regulation, governed primarily by Law No...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesian-moto3-rider-veda-ega-pratama-claims-p4-at-brazil-gp.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesian-moto3-rider-veda-ega-pratama-claims-p4-at-brazil-gp.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesian Moto3 Rider Veda Ega Pratama Claims P4 at Brazil..."
-seoDescription: "## Facts  Indonesian motorcycle road racing has been on an upward trajectory in recent years, and Veda Ega Pratama's fourth-place grid position at the..."
+seoDescription: "Indonesian motorcycle road racing has been on an upward trajectory in recent years, and Veda Ega Pratama's fourth-place grid position at the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesian-moto3-rider-veda-ega-pratama-claims-p4-at-brazil-gp.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesian-moto3-rider-veda-ega-pratama-claims-p4-at-brazil-gp.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesian Moto3 Rider Veda Ega Pratama Claims P4 at Brazil..."
-seoDescription: "## Facts  Indonesian motorcycle road racing has been on an upward trajectory in recent years, and Veda Ega Pratama's fourth-place grid position at the..."
+seoDescription: "Indonesian motorcycle road racing has been on an upward trajectory in recent years, and Veda Ega Pratama's fourth-place grid position at the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry Gateway Serious Investors Need"
 slug: "indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need"
-excerpt: "## Facts  Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct"
+excerpt: "Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct"
 coverImage: "/static/news/visa_20260426_173844_204bbc0e.jpg"
 coverImageAlt: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry Gateway Serious Investors Need"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry..."
-seoDescription: "## Facts  Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment..."
+seoDescription: "Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry Gateway Serious Investors Need"
 slug: "indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need"
-excerpt: "## Facts  Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct"
+excerpt: "Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct"
 coverImage: "/static/news/visa_20260426_173844_204bbc0e.jpg"
 coverImageAlt: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry Gateway Serious Investors Need"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry..."
-seoDescription: "## Facts  Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment..."
+seoDescription: "Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry Gateway Serious Investors Need"
 slug: "indonesias-d12-pre-investment-visa-the-multi-entry-gateway-serious-investors-need"
-excerpt: "## Facts  Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct"
+excerpt: "Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment activities before formally committing capital to the country. Unlike standard tourist or business visit visas, the D12 is struct"
 coverImage: "/static/news/visa_20260426_173844_204bbc0e.jpg"
 coverImageAlt: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry Gateway Serious Investors Need"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's D12 Pre-Investment Visa: The Multi-Entry..."
-seoDescription: "## Facts  Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment..."
+seoDescription: "Indonesia's D12 visa is a purpose-built immigration instrument designed specifically for foreign nationals who need to conduct pre-investment..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Dependent KITAS Overhauled: What Spouses and Families Must Know in 2025"
 slug: "indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025"
-excerpt: "## Facts  Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit"
+excerpt: "Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit"
 coverImage: "/static/news/visa_20260415_174810_2039c7ed.jpg"
 coverImageAlt: "Indonesia's Dependent KITAS Overhauled: What Spouses and Families Must Know in 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Dependent KITAS Overhauled: What Spouses and..."
-seoDescription: "## Facts  Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has..."
+seoDescription: "Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Dependent KITAS Overhauled: What Spouses and Families Must Know in 2025"
 slug: "indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025"
-excerpt: "## Facts  Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit"
+excerpt: "Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit"
 coverImage: "/static/news/visa_20260415_174810_2039c7ed.jpg"
 coverImageAlt: "Indonesia's Dependent KITAS Overhauled: What Spouses and Families Must Know in 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Dependent KITAS Overhauled: What Spouses and..."
-seoDescription: "## Facts  Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has..."
+seoDescription: "Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Dependent KITAS Overhauled: What Spouses and Families Must Know in 2025"
 slug: "indonesias-dependent-kitas-overhauled-what-spouses-and-families-must-know-in-2025"
-excerpt: "## Facts  Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit"
+excerpt: "Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has undergone its most comprehensive regulatory overhaul in years. The changes are spread across several ministerial regulations, wit"
 coverImage: "/static/news/visa_20260415_174810_2039c7ed.jpg"
 coverImageAlt: "Indonesia's Dependent KITAS Overhauled: What Spouses and Families Must Know in 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Dependent KITAS Overhauled: What Spouses and..."
-seoDescription: "## Facts  Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has..."
+seoDescription: "Indonesia's dependent residence permit — the KITAS E31, classified under the family reunification category known as Penyatuan Keluarga — has..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for 2025"
 slug: "indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025"
-excerpt: "## Facts  Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20"
+excerpt: "Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20"
 coverImage: "/static/news/visa_20260415_174821_a766ed32.jpg"
 coverImageAlt: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for..."
-seoDescription: "## Facts  Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader..."
+seoDescription: "Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for 2025"
 slug: "indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025"
-excerpt: "## Facts  Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20"
+excerpt: "Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20"
 coverImage: "/static/news/visa_20260415_174821_a766ed32.jpg"
 coverImageAlt: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for..."
-seoDescription: "## Facts  Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader..."
+seoDescription: "Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for 2025"
 slug: "indonesias-digital-nomad-kitas-the-full-legal-picture-for-2025"
-excerpt: "## Facts  Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20"
+excerpt: "Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader Second Home (rumah kedua) visa category. The foundational regulations — Government Regulations PP No. 40/2023 and PP No. 63/20"
 coverImage: "/static/news/visa_20260415_174821_a766ed32.jpg"
 coverImageAlt: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Digital Nomad KITAS: The Full Legal Picture for..."
-seoDescription: "## Facts  Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader..."
+seoDescription: "Indonesia has formalized its legal pathway for foreign digital nomads through the E33G KITAS, a permit classification sitting under the broader..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's E-Visa Overhaul: What Every Foreign National Must Know in 2026"
 slug: "indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026"
-excerpt: "## Facts  Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human"
+excerpt: "Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human"
 coverImage: "/static/news/visa_20260421_172946_29544bc3_cover.png"
 coverImageAlt: "Indonesia's E-Visa Overhaul: What Every Foreign National Must Know in 2026"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's E-Visa Overhaul: What Every Foreign National Must Know in 2026"
 slug: "indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026"
-excerpt: "## Facts  Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human"
+excerpt: "Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human"
 coverImage: "/static/news/visa_20260421_172946_29544bc3_cover.png"
 coverImageAlt: "Indonesia's E-Visa Overhaul: What Every Foreign National Must Know in 2026"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's E-Visa Overhaul: What Every Foreign National Must Know in 2026"
 slug: "indonesias-e-visa-overhaul-what-every-foreign-national-must-know-in-2026"
-excerpt: "## Facts  Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human"
+excerpt: "Indonesia's electronic visa system has undergone significant structural changes in recent years, moving from a largely consulate-dependent process toward a centralized digital platform managed by the Directorate General of Immigration under the Ministry of Law and Human"
 coverImage: "/static/news/visa_20260421_172946_29544bc3_cover.png"
 coverImageAlt: "Indonesia's E-Visa Overhaul: What Every Foreign National Must Know in 2026"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Expat Service Market: What Jakarta Rivals Offer vs. Bali Zero"
 slug: "indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero"
-excerpt: "## Facts  Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and"
+excerpt: "Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and"
 coverImage: "/static/news/visa_20260510_174355_4b164772.jpg"
 coverImageAlt: "Indonesia's Expat Service Market: What Jakarta Rivals Offer vs. Bali Zero"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Expat Service Market: What Jakarta Rivals Offer..."
-seoDescription: "## Facts  Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound..."
+seoDescription: "Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Expat Service Market: What Jakarta Rivals Offer vs. Bali Zero"
 slug: "indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero"
-excerpt: "## Facts  Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and"
+excerpt: "Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and"
 coverImage: "/static/news/visa_20260510_174355_4b164772.jpg"
 coverImageAlt: "Indonesia's Expat Service Market: What Jakarta Rivals Offer vs. Bali Zero"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Expat Service Market: What Jakarta Rivals Offer..."
-seoDescription: "## Facts  Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound..."
+seoDescription: "Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Expat Service Market: What Jakarta Rivals Offer vs. Bali Zero"
 slug: "indonesias-expat-service-market-what-jakarta-rivals-offer-vs-bali-zero"
-excerpt: "## Facts  Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and"
+excerpt: "Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound investment, the expansion of the digital nomad economy, and a steady stream of retirees and lifestyle migrants drawn to Bali and"
 coverImage: "/static/news/visa_20260510_174355_4b164772.jpg"
 coverImageAlt: "Indonesia's Expat Service Market: What Jakarta Rivals Offer vs. Bali Zero"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Expat Service Market: What Jakarta Rivals Offer..."
-seoDescription: "## Facts  Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound..."
+seoDescription: "Indonesia's market for foreign relocation and business setup services has grown substantially over the past decade, driven by rising inbound..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Family Sponsored KITAS E31: What Spouses and Dependents Must Know"
 slug: "indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig"
+excerpt: "The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig"
 coverImage: "/static/news/visa_20260508_173755_8873e1ce.jpg"
 coverImageAlt: "Indonesia's Family Sponsored KITAS E31: What Spouses and Dependents Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Family Sponsored KITAS E31: What Spouses and..."
-seoDescription: "## Facts  The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas)..."
+seoDescription: "The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas)..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Family Sponsored KITAS E31: What Spouses and Dependents Must Know"
 slug: "indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig"
+excerpt: "The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig"
 coverImage: "/static/news/visa_20260508_173755_8873e1ce.jpg"
 coverImageAlt: "Indonesia's Family Sponsored KITAS E31: What Spouses and Dependents Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Family Sponsored KITAS E31: What Spouses and..."
-seoDescription: "## Facts  The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas)..."
+seoDescription: "The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas)..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Family Sponsored KITAS E31: What Spouses and Dependents Must Know"
 slug: "indonesias-family-sponsored-kitas-e31-what-spouses-and-dependents-must-know"
-excerpt: "## Facts  The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig"
+excerpt: "The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas) issued to foreign nationals whose primary basis for residency is a family relationship with an Indonesian citizen or a foreig"
 coverImage: "/static/news/visa_20260508_173755_8873e1ce.jpg"
 coverImageAlt: "Indonesia's Family Sponsored KITAS E31: What Spouses and Dependents Must Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Family Sponsored KITAS E31: What Spouses and..."
-seoDescription: "## Facts  The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas)..."
+seoDescription: "The KITAS E31, formally classified under Indonesia's family reunification visa framework, is a Limited Stay Permit (Kartu Izin Tinggal Terbatas)..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Finance Ministry Debunks Viral Claim That Official Told Foreign Investors to Leave"
 slug: "indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave"
-excerpt: "## Facts  A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t"
+excerpt: "A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t"
 coverImage: "/static/news/visa_20260519_174015_9beca62e.jpg"
 coverImageAlt: "Indonesia's Finance Ministry Debunks Viral Claim That Official Told Foreign Investors to Leave"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Finance Ministry Debunks Viral Claim That..."
-seoDescription: "## Facts  A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian..."
+seoDescription: "A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Finance Ministry Debunks Viral Claim That Official Told Foreign Investors to Leave"
 slug: "indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave"
-excerpt: "## Facts  A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t"
+excerpt: "A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t"
 coverImage: "/static/news/visa_20260519_174015_9beca62e.jpg"
 coverImageAlt: "Indonesia's Finance Ministry Debunks Viral Claim That Official Told Foreign Investors to Leave"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Finance Ministry Debunks Viral Claim That..."
-seoDescription: "## Facts  A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian..."
+seoDescription: "A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Finance Ministry Debunks Viral Claim That Official Told Foreign Investors to Leave"
 slug: "indonesias-finance-ministry-debunks-viral-claim-that-official-told-foreign-investors-to-leave"
-excerpt: "## Facts  A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t"
+excerpt: "A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian social media, claiming he had told foreign investors they were free to leave the country. The clip or quote spread rapidly, t"
 coverImage: "/static/news/visa_20260519_174015_9beca62e.jpg"
 coverImageAlt: "Indonesia's Finance Ministry Debunks Viral Claim That Official Told Foreign Investors to Leave"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Finance Ministry Debunks Viral Claim That..."
-seoDescription: "## Facts  A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian..."
+seoDescription: "A statement purportedly made by Purbaya Yudhi Sadewa, Chairman of the Financial Services Authority (OJK), began circulating widely on Indonesian..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Football League Tops SE Asia — But Foreign Players Face Strict Visa Rules"
 slug: "indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules"
-excerpt: "## Facts  The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a"
+excerpt: "The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a"
 coverImage: "/static/news/visa_20260413_172320_65837f64.jpg"
 coverImageAlt: "Indonesia's Football League Tops SE Asia — But Foreign Players Face Strict Visa Rules"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Football League Tops SE Asia — But Foreign..."
-seoDescription: "## Facts  The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects..."
+seoDescription: "The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Football League Tops SE Asia — But Foreign Players Face Strict Visa Rules"
 slug: "indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules"
-excerpt: "## Facts  The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a"
+excerpt: "The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a"
 coverImage: "/static/news/visa_20260413_172320_65837f64.jpg"
 coverImageAlt: "Indonesia's Football League Tops SE Asia — But Foreign Players Face Strict Visa Rules"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Football League Tops SE Asia — But Foreign..."
-seoDescription: "## Facts  The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects..."
+seoDescription: "The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Football League Tops SE Asia — But Foreign Players Face Strict Visa Rules"
 slug: "indonesias-football-league-tops-se-asia-but-foreign-players-face-strict-visa-rules"
-excerpt: "## Facts  The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a"
+excerpt: "The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects years of investment in club infrastructure, talent acquisition, and league governance. The rise in competitive quality has been a"
 coverImage: "/static/news/visa_20260413_172320_65837f64.jpg"
 coverImageAlt: "Indonesia's Football League Tops SE Asia — But Foreign Players Face Strict Visa Rules"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Football League Tops SE Asia — But Foreign..."
-seoDescription: "## Facts  The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects..."
+seoDescription: "The Liga Indonesia has claimed the top spot as the most competitive football league in Southeast Asia this season, a milestone that reflects..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness Play or PR Move?"
 slug: "indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move"
-excerpt: "## Facts  Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,"
+excerpt: "Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,"
 coverImage: "/static/news/visa_20260423_112416_32575656.jpg"
 coverImageAlt: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness Play or PR Move?"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness..."
-seoDescription: "## Facts  Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a..."
+seoDescription: "Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness Play or PR Move?"
 slug: "indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move"
-excerpt: "## Facts  Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,"
+excerpt: "Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,"
 coverImage: "/static/news/visa_20260423_112416_32575656.jpg"
 coverImageAlt: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness Play or PR Move?"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness..."
-seoDescription: "## Facts  Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a..."
+seoDescription: "Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness Play or PR Move?"
 slug: "indonesias-global-citizen-visa-pitch-competitiveness-play-or-pr-move"
-excerpt: "## Facts  Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,"
+excerpt: "Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a tool to enhance the archipelago's competitive position in attracting international talent, capital, and expertise. The statement,"
 coverImage: "/static/news/visa_20260423_112416_32575656.jpg"
 coverImageAlt: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness Play or PR Move?"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's 'Global Citizen' Visa Pitch: Competitiveness..."
-seoDescription: "## Facts  Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a..."
+seoDescription: "Indonesia's immigration authority has stepped up its public messaging around the concept of a 'Global Citizen of Indonesia,' framing it as a..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 slug: "indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families"
-excerpt: "## Facts  Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
+excerpt: "Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
 coverImage: "/static/news/visa_20260415_174831_913b4d64_cover.png"
 coverImageAlt: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 slug: "indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families"
-excerpt: "## Facts  Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
+excerpt: "Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
 coverImage: "/static/news/visa_20260415_174831_913b4d64_cover.png"
 coverImageAlt: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 slug: "indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families"
-excerpt: "## Facts  Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
+excerpt: "Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
 coverImage: "/static/news/visa_20260415_174831_913b4d64_cover.png"
 coverImageAlt: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 slug: "indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families"
-excerpt: "## Facts  Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
+excerpt: "Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
 coverImage: "/static/news/visa_20260415_174831_913b4d64_cover.png"
 coverImageAlt: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 slug: "indonesias-golden-visa-now-covers-spouses-what-e31b-means-for-expat-families"
-excerpt: "## Facts  Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
+excerpt: "Indonesia's Golden Visa program, launched in 2022 under Government Regulation No. 39/2021 and operationalised through the Directorate General of Immigration, has added a dependent spouse category designated E31B. This sub-classification sits beneath the primary Golden V"
 coverImage: "/static/news/visa_20260415_174831_913b4d64_cover.png"
 coverImageAlt: "Indonesia's Golden Visa Now Covers Spouses: What E31B Means for Expat Families"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-opens-property-investment-door-for-foreigners.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-opens-property-investment-door-for-foreigners.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Opens Property Investment Door for Foreigners"
 slug: "indonesias-golden-visa-opens-property-investment-door-for-foreigners"
-excerpt: "## Facts  Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci"
+excerpt: "Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci"
 coverImage: "/static/news/visa_20260510_174338_3f64cd9f.jpg"
 coverImageAlt: "Indonesia's Golden Visa Opens Property Investment Door for Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa Opens Property Investment Door for..."
-seoDescription: "## Facts  Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry..."
+seoDescription: "Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-opens-property-investment-door-for-foreigners.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-opens-property-investment-door-for-foreigners.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Opens Property Investment Door for Foreigners"
 slug: "indonesias-golden-visa-opens-property-investment-door-for-foreigners"
-excerpt: "## Facts  Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci"
+excerpt: "Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci"
 coverImage: "/static/news/visa_20260510_174338_3f64cd9f.jpg"
 coverImageAlt: "Indonesia's Golden Visa Opens Property Investment Door for Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa Opens Property Investment Door for..."
-seoDescription: "## Facts  Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry..."
+seoDescription: "Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-opens-property-investment-door-for-foreigners.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-opens-property-investment-door-for-foreigners.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Opens Property Investment Door for Foreigners"
 slug: "indonesias-golden-visa-opens-property-investment-door-for-foreigners"
-excerpt: "## Facts  Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci"
+excerpt: "Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry of Law and Human Rights directives, creates a residency-by-investment pathway for foreign nationals. The program issues speci"
 coverImage: "/static/news/visa_20260510_174338_3f64cd9f.jpg"
 coverImageAlt: "Indonesia's Golden Visa Opens Property Investment Door for Foreigners"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa Opens Property Investment Door for..."
-seoDescription: "## Facts  Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry..."
+seoDescription: "Indonesia's Golden Visa program, formally established under Government Regulation No. 59 of 2021 and operationalized through subsequent Ministry..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules Mean for Investors"
 slug: "indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors"
-excerpt: "## Facts  Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp"
+excerpt: "Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp"
 coverImage: "/static/news/visa_20260423_112313_fd5cafd9.jpg"
 coverImageAlt: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules Mean for Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules..."
-seoDescription: "## Facts  Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024,..."
+seoDescription: "Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules Mean for Investors"
 slug: "indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors"
-excerpt: "## Facts  Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp"
+excerpt: "Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp"
 coverImage: "/static/news/visa_20260423_112313_fd5cafd9.jpg"
 coverImageAlt: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules Mean for Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules..."
-seoDescription: "## Facts  Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024,..."
+seoDescription: "Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules Mean for Investors"
 slug: "indonesias-golden-visa-overhaul-what-the-new-2025-rules-mean-for-investors"
-excerpt: "## Facts  Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp"
+excerpt: "Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024, creates two distinct pathways for long-term investor residency. The first, KITAS E28B, targets foreigners who establish a comp"
 coverImage: "/static/news/visa_20260423_112313_fd5cafd9.jpg"
 coverImageAlt: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules Mean for Investors"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa Overhaul: What the New 2025 Rules..."
-seoDescription: "## Facts  Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024,..."
+seoDescription: "Indonesia's Golden Visa framework, established under Permenkumham No. 22 Tahun 2023 and subsequently refined by Permenkumham No. 11 Tahun 2024,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa: The $350K Ticket to Long-Term Residency"
 slug: "indonesias-golden-visa-the-350k-ticket-to-long-term-residency"
-excerpt: "## Facts  Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones"
+excerpt: "Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones"
 coverImage: "/static/news/visa_20260424_175856_fe06abc1.jpg"
 coverImageAlt: "Indonesia's Golden Visa: The $350K Ticket to Long-Term Residency"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa: The $350K Ticket to Long-Term..."
-seoDescription: "## Facts  Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the..."
+seoDescription: "Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa: The $350K Ticket to Long-Term Residency"
 slug: "indonesias-golden-visa-the-350k-ticket-to-long-term-residency"
-excerpt: "## Facts  Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones"
+excerpt: "Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones"
 coverImage: "/static/news/visa_20260424_175856_fe06abc1.jpg"
 coverImageAlt: "Indonesia's Golden Visa: The $350K Ticket to Long-Term Residency"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa: The $350K Ticket to Long-Term..."
-seoDescription: "## Facts  Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the..."
+seoDescription: "Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-the-350k-ticket-to-long-term-residency.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa: The $350K Ticket to Long-Term Residency"
 slug: "indonesias-golden-visa-the-350k-ticket-to-long-term-residency"
-excerpt: "## Facts  Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones"
+excerpt: "Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the Directorate General of Immigration. The program creates a dedicated residency pathway for foreign nationals who invest in Indones"
 coverImage: "/static/news/visa_20260424_175856_fe06abc1.jpg"
 coverImageAlt: "Indonesia's Golden Visa: The $350K Ticket to Long-Term Residency"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa: The $350K Ticket to Long-Term..."
-seoDescription: "## Facts  Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the..."
+seoDescription: "Indonesia launched its Golden Visa program in 2023 under Government Regulation No. 37 of 2021 and subsequent implementing regulations by the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-what-the-government-is-actually-planning.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-what-the-government-is-actually-planning.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa: What the Government Is Actually Planning"
 slug: "indonesias-golden-visa-what-the-government-is-actually-planning"
-excerpt: "## Facts  Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,"
+excerpt: "Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,"
 coverImage: "/static/news/visa_20260506_072746_df058b9b.jpg"
 coverImageAlt: "Indonesia's Golden Visa: What the Government Is Actually Planning"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa: What the Government Is Actually..."
-seoDescription: "## Facts  Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The..."
+seoDescription: "Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-what-the-government-is-actually-planning.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-what-the-government-is-actually-planning.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa: What the Government Is Actually Planning"
 slug: "indonesias-golden-visa-what-the-government-is-actually-planning"
-excerpt: "## Facts  Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,"
+excerpt: "Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,"
 coverImage: "/static/news/visa_20260506_072746_df058b9b.jpg"
 coverImageAlt: "Indonesia's Golden Visa: What the Government Is Actually Planning"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa: What the Government Is Actually..."
-seoDescription: "## Facts  Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The..."
+seoDescription: "Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-what-the-government-is-actually-planning.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-golden-visa-what-the-government-is-actually-planning.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Golden Visa: What the Government Is Actually Planning"
 slug: "indonesias-golden-visa-what-the-government-is-actually-planning"
-excerpt: "## Facts  Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,"
+excerpt: "Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The announcement, reported by ANTARA News, follows a global trend of countries using premium residency instruments to draw capital,"
 coverImage: "/static/news/visa_20260506_072746_df058b9b.jpg"
 coverImageAlt: "Indonesia's Golden Visa: What the Government Is Actually Planning"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Golden Visa: What the Government Is Actually..."
-seoDescription: "## Facts  Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The..."
+seoDescription: "Indonesia has signalled its intention to introduce a golden visa scheme designed to attract high-spending foreign visitors and investors. The..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Hajj Pilgrims Arrive in Saudi Arabia: What Expats Should Know"
 slug: "indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know"
-excerpt: "## Facts  Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co"
+excerpt: "Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co"
 coverImage: "/static/news/visa_20260504_172411_0ed07fed_cover.png"
 coverImageAlt: "Indonesia's Hajj Pilgrims Arrive in Saudi Arabia: What Expats Should Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Hajj Pilgrims Arrive in Saudi Arabia: What Expats Should Know"
 slug: "indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know"
-excerpt: "## Facts  Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co"
+excerpt: "Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co"
 coverImage: "/static/news/visa_20260504_172411_0ed07fed_cover.png"
 coverImageAlt: "Indonesia's Hajj Pilgrims Arrive in Saudi Arabia: What Expats Should Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Hajj Pilgrims Arrive in Saudi Arabia: What Expats Should Know"
 slug: "indonesias-hajj-pilgrims-arrive-in-saudi-arabia-what-expats-should-know"
-excerpt: "## Facts  Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co"
+excerpt: "Each year, Indonesia sends the world's largest national Hajj delegation to Saudi Arabia, with quotas typically ranging between 200,000 and 240,000 pilgrims. The journey represents one of the most significant logistical operations managed by the Indonesian government, co"
 coverImage: "/static/news/visa_20260504_172411_0ed07fed_cover.png"
 coverImageAlt: "Indonesia's Hajj Pilgrims Arrive in Saudi Arabia: What Expats Should Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands Public Service First"
 slug: "indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first"
-excerpt: "## Facts  Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi"
+excerpt: "Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi"
 coverImage: "/static/news/visa_20260503_171745_7e8d32e4.jpg"
 coverImageAlt: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands Public Service First"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands..."
-seoDescription: "## Facts  Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed..."
+seoDescription: "Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands Public Service First"
 slug: "indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first"
-excerpt: "## Facts  Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi"
+excerpt: "Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi"
 coverImage: "/static/news/visa_20260503_171745_7e8d32e4.jpg"
 coverImageAlt: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands Public Service First"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands..."
-seoDescription: "## Facts  Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed..."
+seoDescription: "Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands Public Service First"
 slug: "indonesias-labor-minister-reshuffles-12-officials-demands-public-service-first"
-excerpt: "## Facts  Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi"
+excerpt: "Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed officials. The event was presided over by the Minister of Manpower, who used the occasion to deliver a pointed message to incoming offi"
 coverImage: "/static/news/visa_20260503_171745_7e8d32e4.jpg"
 coverImageAlt: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands Public Service First"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Labor Minister Reshuffles 12 Officials, Demands..."
-seoDescription: "## Facts  Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed..."
+seoDescription: "Indonesia's Ministry of Manpower (Kementerian Ketenagakerjaan, Kemnaker) held an official inauguration ceremony for 12 newly appointed..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need to Know in 2025"
 slug: "indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025"
-excerpt: "## Facts  Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu"
+excerpt: "Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu"
 coverImage: "/static/news/visa_20260415_174848_d7f00f5a.jpg"
 coverImageAlt: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need to Know in 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need..."
-seoDescription: "## Facts  Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require..."
+seoDescription: "Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need to Know in 2025"
 slug: "indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025"
-excerpt: "## Facts  Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu"
+excerpt: "Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu"
 coverImage: "/static/news/visa_20260415_174848_d7f00f5a.jpg"
 coverImageAlt: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need to Know in 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need..."
-seoDescription: "## Facts  Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require..."
+seoDescription: "Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need to Know in 2025"
 slug: "indonesias-multiple-entry-tourist-visa-what-expats-need-to-know-in-2025"
-excerpt: "## Facts  Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu"
+excerpt: "Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require repeated access to Indonesian territory within a defined validity window. Unlike a standard single-entry tourist visa, which is consu"
 coverImage: "/static/news/visa_20260415_174848_d7f00f5a.jpg"
 coverImageAlt: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need to Know in 2025"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Multiple-Entry Tourist Visa: What Expats Need..."
-seoDescription: "## Facts  Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require..."
+seoDescription: "Indonesia's Multiple Entry Tourist Visa, commonly referred to as the METV, is a visa category designed for foreign nationals who require..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Retirement KITAP: The Permanent Stay Option Most Expats Miss"
 slug: "indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss"
-excerpt: "## Facts  Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency"
+excerpt: "Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency"
 coverImage: "/static/news/visa_20260519_173923_49353b28.jpg"
 coverImageAlt: "Indonesia's Retirement KITAP: The Permanent Stay Option Most Expats Miss"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Retirement KITAP: The Permanent Stay Option..."
-seoDescription: "## Facts  Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit..."
+seoDescription: "Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Retirement KITAP: The Permanent Stay Option Most Expats Miss"
 slug: "indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss"
-excerpt: "## Facts  Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency"
+excerpt: "Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency"
 coverImage: "/static/news/visa_20260519_173923_49353b28.jpg"
 coverImageAlt: "Indonesia's Retirement KITAP: The Permanent Stay Option Most Expats Miss"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Retirement KITAP: The Permanent Stay Option..."
-seoDescription: "## Facts  Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit..."
+seoDescription: "Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Retirement KITAP: The Permanent Stay Option Most Expats Miss"
 slug: "indonesias-retirement-kitap-the-permanent-stay-option-most-expats-miss"
-excerpt: "## Facts  Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency"
+excerpt: "Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit requiring annual renewal, and the Retirement KITAP, a permanent stay permit that provides multi-year or indefinite residency"
 coverImage: "/static/news/visa_20260519_173923_49353b28.jpg"
 coverImageAlt: "Indonesia's Retirement KITAP: The Permanent Stay Option Most Expats Miss"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Retirement KITAP: The Permanent Stay Option..."
-seoDescription: "## Facts  Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit..."
+seoDescription: "Indonesia's immigration framework offers two primary residence permit tracks for foreign retirees: the Retirement KITAS, a temporary stay permit..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Retirement KITAS: The Definitive Guide for Expats Over 55"
 slug: "indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55"
-excerpt: "## Facts  Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d"
+excerpt: "Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d"
 coverImage: "/static/news/visa_20260415_174838_ad33ef6b.jpg"
 coverImageAlt: "Indonesia's Retirement KITAS: The Definitive Guide for Expats Over 55"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Retirement KITAS: The Definitive Guide for..."
-seoDescription: "## Facts  Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without..."
+seoDescription: "Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Retirement KITAS: The Definitive Guide for Expats Over 55"
 slug: "indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55"
-excerpt: "## Facts  Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d"
+excerpt: "Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d"
 coverImage: "/static/news/visa_20260415_174838_ad33ef6b.jpg"
 coverImageAlt: "Indonesia's Retirement KITAS: The Definitive Guide for Expats Over 55"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Retirement KITAS: The Definitive Guide for..."
-seoDescription: "## Facts  Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without..."
+seoDescription: "Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Retirement KITAS: The Definitive Guide for Expats Over 55"
 slug: "indonesias-retirement-kitas-the-definitive-guide-for-expats-over-55"
-excerpt: "## Facts  Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d"
+excerpt: "Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without engaging in employment or commercial activities. Governed under Indonesian immigration law, the permit is renewable annually and is d"
 coverImage: "/static/news/visa_20260415_174838_ad33ef6b.jpg"
 coverImageAlt: "Indonesia's Retirement KITAS: The Definitive Guide for Expats Over 55"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Retirement KITAS: The Definitive Guide for..."
-seoDescription: "## Facts  Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without..."
+seoDescription: "Indonesia's Retirement KITAS is a limited-stay permit specifically designed for foreign retirees who wish to live in the country without..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Second Home Visa KITAS E33: The Complete 2025 Framework"
 slug: "indonesias-second-home-visa-kitas-e33-the-complete-2025-framework"
-excerpt: "## Facts  Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most comprehensive long-term residency offering to date. Established under a layered regulatory framework refined through 2023, 2024, and 202"
+excerpt: "Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most comprehensive long-term residency offering to date. Established under a layered regulatory framework refined through 2023, 2024, and 202"
 coverImage: "/static/news/visa_20260506_173206_a743a5ec.jpg"
 coverImageAlt: "Indonesia's Second Home Visa KITAS E33: The Complete 2025 Framework"
 category: "immigration"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Second Home Visa KITAS E33: The Complete 2025..."
-seoDescription: "## Facts  Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most..."
+seoDescription: "Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Second Home Visa KITAS E33: The Complete 2025 Framework"
 slug: "indonesias-second-home-visa-kitas-e33-the-complete-2025-framework"
-excerpt: "## Facts  Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most comprehensive long-term residency offering to date. Established under a layered regulatory framework refined through 2023, 2024, and 202"
+excerpt: "Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most comprehensive long-term residency offering to date. Established under a layered regulatory framework refined through 2023, 2024, and 202"
 coverImage: "/static/news/visa_20260506_173206_a743a5ec.jpg"
 coverImageAlt: "Indonesia's Second Home Visa KITAS E33: The Complete 2025 Framework"
 category: "immigration"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Second Home Visa KITAS E33: The Complete 2025..."
-seoDescription: "## Facts  Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most..."
+seoDescription: "Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-kitas-e33-the-complete-2025-framework.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Second Home Visa KITAS E33: The Complete 2025 Framework"
 slug: "indonesias-second-home-visa-kitas-e33-the-complete-2025-framework"
-excerpt: "## Facts  Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most comprehensive long-term residency offering to date. Established under a layered regulatory framework refined through 2023, 2024, and 202"
+excerpt: "Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most comprehensive long-term residency offering to date. Established under a layered regulatory framework refined through 2023, 2024, and 202"
 coverImage: "/static/news/visa_20260506_173206_a743a5ec.jpg"
 coverImageAlt: "Indonesia's Second Home Visa KITAS E33: The Complete 2025 Framework"
 category: "immigration"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Second Home Visa KITAS E33: The Complete 2025..."
-seoDescription: "## Facts  Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most..."
+seoDescription: "Indonesia's Second Home Visa, formally designated as KITAS E33 under the national immigration index, represents the government's most..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS Fully Decoded"
 slug: "indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded"
-excerpt: "## Facts  Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of ministerial and parliamentary instruments between 2023 and 2025, creating one of the most clearly codified long-stay frameworks the co"
+excerpt: "Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of ministerial and parliamentary instruments between 2023 and 2025, creating one of the most clearly codified long-stay frameworks the co"
 coverImage: "/static/news/visa_20260418_173944_236892ac.jpg"
 coverImageAlt: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS Fully Decoded"
 category: "immigration"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS..."
-seoDescription: "## Facts  Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of..."
+seoDescription: "Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS Fully Decoded"
 slug: "indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded"
-excerpt: "## Facts  Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of ministerial and parliamentary instruments between 2023 and 2025, creating one of the most clearly codified long-stay frameworks the co"
+excerpt: "Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of ministerial and parliamentary instruments between 2023 and 2025, creating one of the most clearly codified long-stay frameworks the co"
 coverImage: "/static/news/visa_20260418_173944_236892ac.jpg"
 coverImageAlt: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS Fully Decoded"
 category: "immigration"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS..."
-seoDescription: "## Facts  Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of..."
+seoDescription: "Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS Fully Decoded"
 slug: "indonesias-second-home-visa-the-5-year-and-10-year-kitas-fully-decoded"
-excerpt: "## Facts  Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of ministerial and parliamentary instruments between 2023 and 2025, creating one of the most clearly codified long-stay frameworks the co"
+excerpt: "Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of ministerial and parliamentary instruments between 2023 and 2025, creating one of the most clearly codified long-stay frameworks the co"
 coverImage: "/static/news/visa_20260418_173944_236892ac.jpg"
 coverImageAlt: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS Fully Decoded"
 category: "immigration"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Second Home Visa: The 5-Year and 10-Year KITAS..."
-seoDescription: "## Facts  Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of..."
+seoDescription: "Indonesia's Second Home Visa program — commonly referred to as the Second Home KITAS — has been substantially overhauled by a series of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Net Tightens: Remote Work Visa Holders Receive Residency Notices"
 slug: "indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr"
+excerpt: "Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr"
 coverImage: "/static/news/visa_20260423_112452_c65200c1_cover.png"
 coverImageAlt: "Indonesia's Tax Net Tightens: Remote Work Visa Holders Receive Residency Notices"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Net Tightens: Remote Work Visa Holders Receive Residency Notices"
 slug: "indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr"
+excerpt: "Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr"
 coverImage: "/static/news/visa_20260423_112452_c65200c1_cover.png"
 coverImageAlt: "Indonesia's Tax Net Tightens: Remote Work Visa Holders Receive Residency Notices"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Net Tightens: Remote Work Visa Holders Receive Residency Notices"
 slug: "indonesias-tax-net-tightens-remote-work-visa-holders-receive-residency-notices"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr"
+excerpt: "Indonesia's Directorate General of Taxes (DGT) has begun issuing formal tax residency determination letters to foreign nationals who hold remote worker visa products, according to reports surfacing from Indonesian legal and tax practitioner communities. The letters repr"
 coverImage: "/static/news/visa_20260423_112452_c65200c1_cover.png"
 coverImageAlt: "Indonesia's Tax Net Tightens: Remote Work Visa Holders Receive Residency Notices"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-village-investment-visa-what-the-law-actually-says.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-village-investment-visa-what-the-law-actually-says.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Village Investment Visa: What the Law Actually Says"
 slug: "indonesias-village-investment-visa-what-the-law-actually-says"
-excerpt: "## Facts  A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop"
+excerpt: "A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop"
 coverImage: "/static/news/visa_20260424_175821_a44b4a8f.jpg"
 coverImageAlt: "Indonesia's Village Investment Visa: What the Law Actually Says"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Village Investment Visa: What the Law Actually..."
-seoDescription: "## Facts  A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign..."
+seoDescription: "A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-village-investment-visa-what-the-law-actually-says.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-village-investment-visa-what-the-law-actually-says.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Village Investment Visa: What the Law Actually Says"
 slug: "indonesias-village-investment-visa-what-the-law-actually-says"
-excerpt: "## Facts  A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop"
+excerpt: "A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop"
 coverImage: "/static/news/visa_20260424_175821_a44b4a8f.jpg"
 coverImageAlt: "Indonesia's Village Investment Visa: What the Law Actually Says"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Village Investment Visa: What the Law Actually..."
-seoDescription: "## Facts  A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign..."
+seoDescription: "A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-village-investment-visa-what-the-law-actually-says.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-village-investment-visa-what-the-law-actually-says.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Village Investment Visa: What the Law Actually Says"
 slug: "indonesias-village-investment-visa-what-the-law-actually-says"
-excerpt: "## Facts  A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop"
+excerpt: "A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign investors targeting Indonesia's underdeveloped villages. Despite the narrative's appeal — lower capital thresholds, rural develop"
 coverImage: "/static/news/visa_20260424_175821_a44b4a8f.jpg"
 coverImageAlt: "Indonesia's Village Investment Visa: What the Law Actually Says"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Village Investment Visa: What the Law Actually..."
-seoDescription: "## Facts  A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign..."
+seoDescription: "A wave of content circulating on visa advisory websites in early 2026 has promoted what is described as a dedicated visa pathway for foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Visa Landscape for Bali-Bound Foreigners: What You Need to Know"
 slug: "indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know"
-excerpt: "## Facts  Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,"
+excerpt: "Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,"
 coverImage: "/static/news/visa_20260409_175516_8278b27b_cover.png"
 coverImageAlt: "Indonesia's Visa Landscape for Bali-Bound Foreigners: What You Need to Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Visa Landscape for Bali-Bound Foreigners: What You Need to Know"
 slug: "indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know"
-excerpt: "## Facts  Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,"
+excerpt: "Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,"
 coverImage: "/static/news/visa_20260409_175516_8278b27b_cover.png"
 coverImageAlt: "Indonesia's Visa Landscape for Bali-Bound Foreigners: What You Need to Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Visa Landscape for Bali-Bound Foreigners: What You Need to Know"
 slug: "indonesias-visa-landscape-for-bali-bound-foreigners-what-you-need-to-know"
-excerpt: "## Facts  Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,"
+excerpt: "Indonesia maintains a multi-tiered immigration framework that governs how foreigners enter, stay, and conduct activities within its territory. Bali, as the country's premier international destination, sits at the intersection of tourism policy and investment regulation,"
 coverImage: "/static/news/visa_20260409_175516_8278b27b_cover.png"
 coverImageAlt: "Indonesia's Visa Landscape for Bali-Bound Foreigners: What You Need to Know"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Work Permit Maze: What Expats Must Know Before Taking the Job"
 slug: "indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job"
-excerpt: "## Facts  Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations."
+excerpt: "Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations."
 coverImage: "/static/news/visa_20260406_173159_b4202a76.jpg"
 coverImageAlt: "Indonesia's Work Permit Maze: What Expats Must Know Before Taking the Job"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Work Permit Maze: What Expats Must Know Before Taking the Job"
 slug: "indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job"
-excerpt: "## Facts  Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations."
+excerpt: "Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations."
 coverImage: "/static/news/visa_20260406_173159_b4202a76.jpg"
 coverImageAlt: "Indonesia's Work Permit Maze: What Expats Must Know Before Taking the Job"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Work Permit Maze: What Expats Must Know Before..."
-seoDescription: "## Facts  Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on..."
+seoDescription: "Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job.mdx
+++ b/apps/mouth/src/content/articles/immigration/indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Work Permit Maze: What Expats Must Know Before Taking the Job"
 slug: "indonesias-work-permit-maze-what-expats-must-know-before-taking-the-job"
-excerpt: "## Facts  Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations."
+excerpt: "Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on Manpower and its subsequent revisions under the Job Creation Law (Omnibus Law, UU No. 11/2020) and its implementing regulations."
 coverImage: "/static/news/visa_20260406_173159_b4202a76.jpg"
 coverImageAlt: "Indonesia's Work Permit Maze: What Expats Must Know Before Taking the Job"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Work Permit Maze: What Expats Must Know Before..."
-seoDescription: "## Facts  Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on..."
+seoDescription: "Indonesia operates one of Southeast Asia's most structured foreign worker regulatory frameworks, governed primarily by Law No. 13 of 2003 on..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Indonesia's Toughest Visa Rules for Foreign Talent and Event Workers"
 slug: "inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers"
-excerpt: "## Facts  When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b"
+excerpt: "When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b"
 coverImage: "/static/news/visa_20260430_173027_d4278510.jpg"
 coverImageAlt: "Inside Indonesia's Toughest Visa Rules for Foreign Talent and Event Workers"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Indonesia's Toughest Visa Rules for Foreign Talent..."
-seoDescription: "## Facts  When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration..."
+seoDescription: "When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Indonesia's Toughest Visa Rules for Foreign Talent and Event Workers"
 slug: "inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers"
-excerpt: "## Facts  When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b"
+excerpt: "When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b"
 coverImage: "/static/news/visa_20260430_173027_d4278510.jpg"
 coverImageAlt: "Inside Indonesia's Toughest Visa Rules for Foreign Talent and Event Workers"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Indonesia's Toughest Visa Rules for Foreign Talent..."
-seoDescription: "## Facts  When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration..."
+seoDescription: "When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Indonesia's Toughest Visa Rules for Foreign Talent and Event Workers"
 slug: "inside-indonesias-toughest-visa-rules-for-foreign-talent-and-event-workers"
-excerpt: "## Facts  When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b"
+excerpt: "When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration and regulatory machinery that governs their presence is both precise and demanding. Indonesian law draws sharp distinctions b"
 coverImage: "/static/news/visa_20260430_173027_d4278510.jpg"
 coverImageAlt: "Inside Indonesia's Toughest Visa Rules for Foreign Talent and Event Workers"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Indonesia's Toughest Visa Rules for Foreign Talent..."
-seoDescription: "## Facts  When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration..."
+seoDescription: "When dozens of international participants converge on an Indonesian luxury property for a high-profile cultural or beauty event, the immigration..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 slug: "inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone"
-excerpt: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
+excerpt: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
 coverImage: "/static/news/visa_20260519_174122_541bc1a0_cover.png"
 coverImageAlt: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Komodo's Last Village: Life on the Edge of a World..."
-seoDescription: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
+seoDescription: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 slug: "inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone"
-excerpt: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
+excerpt: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
 coverImage: "/static/news/visa_20260519_174122_541bc1a0_cover.png"
 coverImageAlt: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Komodo's Last Village: Life on the Edge of a World..."
-seoDescription: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
+seoDescription: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 slug: "inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone"
-excerpt: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
+excerpt: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
 coverImage: "/static/news/visa_20260519_174122_541bc1a0_cover.png"
 coverImageAlt: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Komodo's Last Village: Life on the Edge of a World..."
-seoDescription: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
+seoDescription: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 slug: "inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone"
-excerpt: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
+excerpt: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
 coverImage: "/static/news/visa_20260519_174122_541bc1a0_cover.png"
 coverImageAlt: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Komodo's Last Village: Life on the Edge of a World..."
-seoDescription: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
+seoDescription: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 slug: "inside-komodos-last-village-life-on-the-edge-of-a-world-heritage-zone"
-excerpt: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
+excerpt: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing and farming community that has coexisted with the reptile for generations. The village of Komodo, the oldest settlement on the i"
 coverImage: "/static/news/visa_20260519_174122_541bc1a0_cover.png"
 coverImageAlt: "Inside Komodo's Last Village: Life on the Edge of a World Heritage Zone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Inside Komodo's Last Village: Life on the Edge of a World..."
-seoDescription: "## Facts  Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
+seoDescription: "Komodo Island, part of Nusa Tenggara Timur (NTT) province, is home not only to the Varanus komodoensis — the Komodo dragon — but to a fishing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 slug: "jakartas-aparthotel-market-signals-demand-for-flexible-urban-living"
-excerpt: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
+excerpt: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
 coverImage: "/static/news/visa_20260519_174108_f8c92b20_cover.png"
 coverImageAlt: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Jakarta's Aparthotel Market Signals Demand for Flexible..."
-seoDescription: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
+seoDescription: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 slug: "jakartas-aparthotel-market-signals-demand-for-flexible-urban-living"
-excerpt: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
+excerpt: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
 coverImage: "/static/news/visa_20260519_174108_f8c92b20_cover.png"
 coverImageAlt: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Jakarta's Aparthotel Market Signals Demand for Flexible..."
-seoDescription: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
+seoDescription: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 slug: "jakartas-aparthotel-market-signals-demand-for-flexible-urban-living"
-excerpt: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
+excerpt: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
 coverImage: "/static/news/visa_20260519_174108_f8c92b20_cover.png"
 coverImageAlt: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Jakarta's Aparthotel Market Signals Demand for Flexible..."
-seoDescription: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
+seoDescription: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.mdx
+++ b/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 slug: "jakartas-aparthotel-market-signals-demand-for-flexible-urban-living"
-excerpt: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
+excerpt: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
 coverImage: "/static/news/visa_20260519_174108_f8c92b20_cover.png"
 coverImageAlt: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Jakarta's Aparthotel Market Signals Demand for Flexible..."
-seoDescription: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
+seoDescription: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/jakartas-aparthotel-market-signals-demand-for-flexible-urban-living.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 slug: "jakartas-aparthotel-market-signals-demand-for-flexible-urban-living"
-excerpt: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
+excerpt: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs through the heart of the city's business and diplomatic district. The property belongs to The Ascott Limited's Citadines brand"
 coverImage: "/static/news/visa_20260519_174108_f8c92b20_cover.png"
 coverImageAlt: "Jakarta's Aparthotel Market Signals Demand for Flexible Urban Living"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Jakarta's Aparthotel Market Signals Demand for Flexible..."
-seoDescription: "## Facts  Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
+seoDescription: "Citadines Gatot Subroto is a serviced residence located on one of Jakarta's principal arterial roads, Jalan Gatot Subroto, a corridor that runs..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "KITAS Decoded: Which Indonesian Residence Permit Actually Fits Your Life"
 slug: "kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life"
-excerpt: "## Facts  Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i"
+excerpt: "Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i"
 coverImage: "/static/news/visa_20260517_173555_c18cb361.jpg"
 coverImageAlt: "KITAS Decoded: Which Indonesian Residence Permit Actually Fits Your Life"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "KITAS Decoded: Which Indonesian Residence Permit Actually..."
-seoDescription: "## Facts  Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can..."
+seoDescription: "Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "KITAS Decoded: Which Indonesian Residence Permit Actually Fits Your Life"
 slug: "kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life"
-excerpt: "## Facts  Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i"
+excerpt: "Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i"
 coverImage: "/static/news/visa_20260517_173555_c18cb361.jpg"
 coverImageAlt: "KITAS Decoded: Which Indonesian Residence Permit Actually Fits Your Life"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "KITAS Decoded: Which Indonesian Residence Permit Actually..."
-seoDescription: "## Facts  Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can..."
+seoDescription: "Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life.mdx
+++ b/apps/mouth/src/content/articles/immigration/kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life.mdx
@@ -1,7 +1,7 @@
 ---
 title: "KITAS Decoded: Which Indonesian Residence Permit Actually Fits Your Life"
 slug: "kitas-decoded-which-indonesian-residence-permit-actually-fits-your-life"
-excerpt: "## Facts  Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i"
+excerpt: "Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can span one to two years and is renewable up to a statutory maximum depending on its category. Despite the singular name, KITAS i"
 coverImage: "/static/news/visa_20260517_173555_c18cb361.jpg"
 coverImageAlt: "KITAS Decoded: Which Indonesian Residence Permit Actually Fits Your Life"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "KITAS Decoded: Which Indonesian Residence Permit Actually..."
-seoDescription: "## Facts  Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can..."
+seoDescription: "Indonesia's long-stay residence framework centers on the KITAS — Kartu Izin Tinggal Terbatas, or Limited Stay Permit Card — a document that can..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/l-1-visa-2026-what-the-numbers-really-say-about-corporate-transfer-approvals.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/l-1-visa-2026-what-the-numbers-really-say-about-corporate-transfer-approvals.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "L-1 Visa 2026: What the Numbers Really Say About Corporate..."
-seoDescription: "## Facts  The L-1 visa is a nonimmigrant classification issued by US Citizenship and Immigration Services (USCIS) that allows multinational companies to..."
+seoDescription: "The L-1 visa is a nonimmigrant classification issued by US Citizenship and Immigration Services (USCIS) that allows multinational companies to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/l-1-visa-2026-what-the-numbers-really-say-about-corporate-transfer-approvals.mdx
+++ b/apps/mouth/src/content/articles/immigration/l-1-visa-2026-what-the-numbers-really-say-about-corporate-transfer-approvals.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "L-1 Visa 2026: What the Numbers Really Say About Corporate..."
-seoDescription: "## Facts  The L-1 visa is a nonimmigrant classification issued by US Citizenship and Immigration Services (USCIS) that allows multinational companies to..."
+seoDescription: "The L-1 visa is a nonimmigrant classification issued by US Citizenship and Immigration Services (USCIS) that allows multinational companies to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 slug: "lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook"
-excerpt: "## Facts  Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
+excerpt: "Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
 coverImage: "/static/news/visa_20260407_180623_c6d33b73_cover.png"
 coverImageAlt: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 slug: "lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook"
-excerpt: "## Facts  Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
+excerpt: "Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
 coverImage: "/static/news/visa_20260407_180623_c6d33b73_cover.png"
 coverImageAlt: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 slug: "lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook"
-excerpt: "## Facts  Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
+excerpt: "Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
 coverImage: "/static/news/visa_20260407_180623_c6d33b73_cover.png"
 coverImageAlt: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.mdx
+++ b/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 slug: "lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook"
-excerpt: "## Facts  Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
+excerpt: "Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
 coverImage: "/static/news/visa_20260407_180623_c6d33b73_cover.png"
 coverImageAlt: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 slug: "lombok-rising-why-indonesias-second-island-is-rewriting-the-expat-playbook"
-excerpt: "## Facts  Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
+excerpt: "Lombok, the island immediately east of Bali across the Wallace Line, has long lived in its neighbour's shadow. For decades, visitors arrived primarily as a day-trip detour — to climb Rinjani, or to hop to the Gilis. That narrative is changing, and changing faster than m"
 coverImage: "/static/news/visa_20260407_180623_c6d33b73_cover.png"
 coverImageAlt: "Lombok Rising: Why Indonesia's Second Island Is Rewriting the Expat Playbook"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/marketing-veteran-dewi-karmawan-steps-into-senior-director-role.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/marketing-veteran-dewi-karmawan-steps-into-senior-director-role.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Marketing Veteran Dewi Karmawan Steps Into Senior Director..."
-seoDescription: "## Facts  Dewi Karmawan has been elevated to the position of Senior Director of Marketing Communications, marking a significant step in her professional..."
+seoDescription: "Dewi Karmawan has been elevated to the position of Senior Director of Marketing Communications, marking a significant step in her professional..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/marketing-veteran-dewi-karmawan-steps-into-senior-director-role.mdx
+++ b/apps/mouth/src/content/articles/immigration/marketing-veteran-dewi-karmawan-steps-into-senior-director-role.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Marketing Veteran Dewi Karmawan Steps Into Senior Director..."
-seoDescription: "## Facts  Dewi Karmawan has been elevated to the position of Senior Director of Marketing Communications, marking a significant step in her professional..."
+seoDescription: "Dewi Karmawan has been elevated to the position of Senior Director of Marketing Communications, marking a significant step in her professional..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Navigating Indonesian Schools: What Expat Families Need to Know"
 slug: "navigating-indonesian-schools-what-expat-families-need-to-know"
-excerpt: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
+excerpt: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
 coverImage: "/static/news/visa_20260518_172655_cbdb0ed0_cover.png"
 coverImageAlt: "Navigating Indonesian Schools: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Navigating Indonesian Schools: What Expat Families Need to..."
-seoDescription: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
+seoDescription: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Navigating Indonesian Schools: What Expat Families Need to Know"
 slug: "navigating-indonesian-schools-what-expat-families-need-to-know"
-excerpt: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
+excerpt: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
 coverImage: "/static/news/visa_20260518_172655_cbdb0ed0_cover.png"
 coverImageAlt: "Navigating Indonesian Schools: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Navigating Indonesian Schools: What Expat Families Need to..."
-seoDescription: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
+seoDescription: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Navigating Indonesian Schools: What Expat Families Need to Know"
 slug: "navigating-indonesian-schools-what-expat-families-need-to-know"
-excerpt: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
+excerpt: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
 coverImage: "/static/news/visa_20260518_172655_cbdb0ed0_cover.png"
 coverImageAlt: "Navigating Indonesian Schools: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Navigating Indonesian Schools: What Expat Families Need to..."
-seoDescription: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
+seoDescription: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.mdx
+++ b/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Navigating Indonesian Schools: What Expat Families Need to Know"
 slug: "navigating-indonesian-schools-what-expat-families-need-to-know"
-excerpt: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
+excerpt: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
 coverImage: "/static/news/visa_20260518_172655_cbdb0ed0_cover.png"
 coverImageAlt: "Navigating Indonesian Schools: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Navigating Indonesian Schools: What Expat Families Need to..."
-seoDescription: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
+seoDescription: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/navigating-indonesian-schools-what-expat-families-need-to-know.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Navigating Indonesian Schools: What Expat Families Need to Know"
 slug: "navigating-indonesian-schools-what-expat-families-need-to-know"
-excerpt: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
+excerpt: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location, and immigration status. The most accessible option for foreign nationals is the international school, which operates under curr"
 coverImage: "/static/news/visa_20260518_172655_cbdb0ed0_cover.png"
 coverImageAlt: "Navigating Indonesian Schools: What Expat Families Need to Know"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Navigating Indonesian Schools: What Expat Families Need to..."
-seoDescription: "## Facts  Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
+seoDescription: "Indonesia's education system presents expatriate families with a layered set of choices that vary significantly by institution type, location,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/ngurah-rai-immigration-office-cracks-down-on-unofficial-fees.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/ngurah-rai-immigration-office-cracks-down-on-unofficial-fees.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
 slug: "ngurah-rai-immigration-office-cracks-down-on-unofficial-fees"
-excerpt: "## Facts  The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici"
+excerpt: "The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici"
 coverImage: "/static/news/visa_20260519_174005_162465c4.jpg"
 coverImageAlt: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
-seoDescription: "## Facts  The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of..."
+seoDescription: "The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/ngurah-rai-immigration-office-cracks-down-on-unofficial-fees.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/ngurah-rai-immigration-office-cracks-down-on-unofficial-fees.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
 slug: "ngurah-rai-immigration-office-cracks-down-on-unofficial-fees"
-excerpt: "## Facts  The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici"
+excerpt: "The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici"
 coverImage: "/static/news/visa_20260519_174005_162465c4.jpg"
 coverImageAlt: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
-seoDescription: "## Facts  The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of..."
+seoDescription: "The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/ngurah-rai-immigration-office-cracks-down-on-unofficial-fees.mdx
+++ b/apps/mouth/src/content/articles/immigration/ngurah-rai-immigration-office-cracks-down-on-unofficial-fees.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
 slug: "ngurah-rai-immigration-office-cracks-down-on-unofficial-fees"
-excerpt: "## Facts  The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici"
+excerpt: "The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of eradicating pungutan liar — colloquially known as pungli — the practice of unofficial or extralegal fees solicited by government offici"
 coverImage: "/static/news/visa_20260519_174005_162465c4.jpg"
 coverImageAlt: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Ngurah Rai Immigration Office Cracks Down on Unofficial Fees"
-seoDescription: "## Facts  The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of..."
+seoDescription: "The Ngurah Rai Immigration Office in Bali has announced a formal initiative to overhaul its service delivery with the explicit goal of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/prabowo-dismisses-1-billion-peace-fund-pledge-amid-diplomatic-scrutiny.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/prabowo-dismisses-1-billion-peace-fund-pledge-amid-diplomatic-scrutiny.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Prabowo Dismisses $1 Billion Peace Fund Pledge Amid..."
-seoDescription: "## Facts  Indonesian President Prabowo Subianto has publicly denied having made any commitment to contribute US$1 billion to a so-called Board of Peace..."
+seoDescription: "Indonesian President Prabowo Subianto has publicly denied having made any commitment to contribute US$1 billion to a so-called Board of Peace..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/prabowo-dismisses-1-billion-peace-fund-pledge-amid-diplomatic-scrutiny.mdx
+++ b/apps/mouth/src/content/articles/immigration/prabowo-dismisses-1-billion-peace-fund-pledge-amid-diplomatic-scrutiny.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Prabowo Dismisses $1 Billion Peace Fund Pledge Amid..."
-seoDescription: "## Facts  Indonesian President Prabowo Subianto has publicly denied having made any commitment to contribute US$1 billion to a so-called Board of Peace..."
+seoDescription: "Indonesian President Prabowo Subianto has publicly denied having made any commitment to contribute US$1 billion to a so-called Board of Peace..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ROW for R.O.L.E 5.0: Bali's Annual Paddle Event Returns with a Purpose"
 slug: "row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose"
-excerpt: "## Facts  Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea"
+excerpt: "Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea"
 coverImage: "/static/news/visa_20260503_171843_d944fa7e_cover.png"
 coverImageAlt: "ROW for R.O.L.E 5.0: Bali's Annual Paddle Event Returns with a Purpose"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ROW for R.O.L.E 5.0: Bali's Annual Paddle Event Returns with a Purpose"
 slug: "row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose"
-excerpt: "## Facts  Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea"
+excerpt: "Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea"
 coverImage: "/static/news/visa_20260503_171843_d944fa7e_cover.png"
 coverImageAlt: "ROW for R.O.L.E 5.0: Bali's Annual Paddle Event Returns with a Purpose"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose.mdx
+++ b/apps/mouth/src/content/articles/immigration/row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ROW for R.O.L.E 5.0: Bali's Annual Paddle Event Returns with a Purpose"
 slug: "row-for-role-50-balis-annual-paddle-event-returns-with-a-purpose"
-excerpt: "## Facts  Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea"
+excerpt: "Bali's charitable and environmental event calendar continues to grow, and ROW for R.O.L.E has become one of its more recognizable recurring fixtures. Now in its fifth edition, the paddleboarding fundraiser is organized in support of R.O.L.E Foundation — the Rivers, Ocea"
 coverImage: "/static/news/visa_20260503_171843_d944fa7e_cover.png"
 coverImageAlt: "ROW for R.O.L.E 5.0: Bali's Annual Paddle Event Returns with a Purpose"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/seoul-walks-back-bali-warning-after-indonesia-pushes-back.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/seoul-walks-back-bali-warning-after-indonesia-pushes-back.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seoul Walks Back Bali Warning After Indonesia Pushes Back"
 slug: "seoul-walks-back-bali-warning-after-indonesia-pushes-back"
-excerpt: "## Facts  South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move"
+excerpt: "South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move"
 coverImage: "/static/news/visa_20260414_171810_adc4c61b_cover.png"
 coverImageAlt: "Seoul Walks Back Bali Warning After Indonesia Pushes Back"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/seoul-walks-back-bali-warning-after-indonesia-pushes-back.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/seoul-walks-back-bali-warning-after-indonesia-pushes-back.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seoul Walks Back Bali Warning After Indonesia Pushes Back"
 slug: "seoul-walks-back-bali-warning-after-indonesia-pushes-back"
-excerpt: "## Facts  South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move"
+excerpt: "South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move"
 coverImage: "/static/news/visa_20260414_171810_adc4c61b_cover.png"
 coverImageAlt: "Seoul Walks Back Bali Warning After Indonesia Pushes Back"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/seoul-walks-back-bali-warning-after-indonesia-pushes-back.mdx
+++ b/apps/mouth/src/content/articles/immigration/seoul-walks-back-bali-warning-after-indonesia-pushes-back.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seoul Walks Back Bali Warning After Indonesia Pushes Back"
 slug: "seoul-walks-back-bali-warning-after-indonesia-pushes-back"
-excerpt: "## Facts  South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move"
+excerpt: "South Korea's government issued a travel advisory related to Bali that Indonesian authorities deemed inaccurate or overstated, triggering a formal diplomatic response. Indonesia, which relies heavily on South Korean tourism as one of its top visitor source markets, move"
 coverImage: "/static/news/visa_20260414_171810_adc4c61b_cover.png"
 coverImageAlt: "Seoul Walks Back Bali Warning After Indonesia Pushes Back"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/seouls-dessert-wave-reaches-indonesias-expat-palate.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/seouls-dessert-wave-reaches-indonesias-expat-palate.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
 slug: "seouls-dessert-wave-reaches-indonesias-expat-palate"
-excerpt: "## Facts  Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa"
+excerpt: "Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa"
 coverImage: "/static/news/visa_20260623_174735_9df60918.jpg"
 cardImage: "/static/news/visa_20260623_174735_9df60918_card.jpg"
 coverImageAlt: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
-seoDescription: "## Facts  Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary..."
+seoDescription: "Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/seouls-dessert-wave-reaches-indonesias-expat-palate.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/seouls-dessert-wave-reaches-indonesias-expat-palate.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
 slug: "seouls-dessert-wave-reaches-indonesias-expat-palate"
-excerpt: "## Facts  Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa"
+excerpt: "Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa"
 coverImage: "/static/news/visa_20260623_174735_9df60918.jpg"
 cardImage: "/static/news/visa_20260623_174735_9df60918_card.jpg"
 coverImageAlt: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
-seoDescription: "## Facts  Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary..."
+seoDescription: "Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/seouls-dessert-wave-reaches-indonesias-expat-palate.mdx
+++ b/apps/mouth/src/content/articles/immigration/seouls-dessert-wave-reaches-indonesias-expat-palate.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
 slug: "seouls-dessert-wave-reaches-indonesias-expat-palate"
-excerpt: "## Facts  Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa"
+excerpt: "Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary Korean dessert culture blends centuries-old ingredient traditions — rice flour, red bean, black sesame, yuzu — with European pa"
 coverImage: "/static/news/visa_20260623_174735_9df60918.jpg"
 cardImage: "/static/news/visa_20260623_174735_9df60918_card.jpg"
 coverImageAlt: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Seoul's Dessert Wave Reaches Indonesia's Expat Palate"
-seoDescription: "## Facts  Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary..."
+seoDescription: "Seoul has emerged as one of Asia's most dynamic food capitals, with its dessert scene drawing particular international attention. Contemporary..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 slug: "sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone"
-excerpt: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
+excerpt: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
 coverImage: "/static/news/visa_20260511_174316_1f6af02d_cover.png"
 coverImageAlt: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Sofitel Bali Leads Luxury Hotel Sustainability Push With..."
-seoDescription: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
+seoDescription: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 slug: "sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone"
-excerpt: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
+excerpt: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
 coverImage: "/static/news/visa_20260511_174316_1f6af02d_cover.png"
 coverImageAlt: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Sofitel Bali Leads Luxury Hotel Sustainability Push With..."
-seoDescription: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
+seoDescription: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 slug: "sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone"
-excerpt: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
+excerpt: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
 coverImage: "/static/news/visa_20260511_174316_1f6af02d_cover.png"
 coverImageAlt: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Sofitel Bali Leads Luxury Hotel Sustainability Push With..."
-seoDescription: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
+seoDescription: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.mdx
+++ b/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 slug: "sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone"
-excerpt: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
+excerpt: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
 coverImage: "/static/news/visa_20260511_174316_1f6af02d_cover.png"
 coverImageAlt: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Sofitel Bali Leads Luxury Hotel Sustainability Push With..."
-seoDescription: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
+seoDescription: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 slug: "sofitel-bali-leads-luxury-hotel-sustainability-push-with-capsule-recycling-milestone"
-excerpt: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
+excerpt: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company describes as a meaningful contribution to reducing aluminium waste from single-use coffee systems. The award highlights the resort's p"
 coverImage: "/static/news/visa_20260511_174316_1f6af02d_cover.png"
 coverImageAlt: "Sofitel Bali Leads Luxury Hotel Sustainability Push With Capsule Recycling Milestone"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Sofitel Bali Leads Luxury Hotel Sustainability Push With..."
-seoDescription: "## Facts  Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
+seoDescription: "Sofitel Bali Nusa Dua Beach Resort has been recognised by Nespresso for recycling more than 41,000 coffee capsules, in what the company..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 slug: "sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom"
-excerpt: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
+excerpt: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
 coverImage: "/static/news/visa_20260519_174046_4fd15479_cover.png"
 coverImageAlt: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "SONO Hotels Signs Bali Canggu Property, Betting on..."
-seoDescription: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
+seoDescription: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 slug: "sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom"
-excerpt: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
+excerpt: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
 coverImage: "/static/news/visa_20260519_174046_4fd15479_cover.png"
 coverImageAlt: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "SONO Hotels Signs Bali Canggu Property, Betting on..."
-seoDescription: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
+seoDescription: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 slug: "sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom"
-excerpt: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
+excerpt: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
 coverImage: "/static/news/visa_20260519_174046_4fd15479_cover.png"
 coverImageAlt: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "SONO Hotels Signs Bali Canggu Property, Betting on..."
-seoDescription: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
+seoDescription: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.mdx
+++ b/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 slug: "sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom"
-excerpt: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
+excerpt: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
 coverImage: "/static/news/visa_20260519_174046_4fd15479_cover.png"
 coverImageAlt: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "SONO Hotels Signs Bali Canggu Property, Betting on..."
-seoDescription: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
+seoDescription: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 slug: "sono-hotels-signs-bali-canggu-property-betting-on-indonesias-luxury-lifestyle-boom"
-excerpt: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
+excerpt: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's competitive lifestyle hospitality market. The agreement adds Canggu — Bali's most internationally recognized creative and surf enclave"
 coverImage: "/static/news/visa_20260519_174046_4fd15479_cover.png"
 coverImageAlt: "SONO Hotels Signs Bali Canggu Property, Betting on Indonesia's Luxury Lifestyle Boom"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "SONO Hotels Signs Bali Canggu Property, Betting on..."
-seoDescription: "## Facts  SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
+seoDescription: "SONO Hotels & Resorts Asia has announced the signing of SONO Felice Bali Canggu, marking the brand's latest expansion into Indonesia's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/southeast-asias-green-travel-race-whos-leading-and-whos-falling-behind.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/southeast-asias-green-travel-race-whos-leading-and-whos-falling-behind.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Southeast Asia's Green Travel Race: Who's Leading and Who's..."
-seoDescription: "## Facts  Sustainable travel has shifted from a marketing buzzword to a measurable policy axis across Southeast Asia, with governments in the region..."
+seoDescription: "Sustainable travel has shifted from a marketing buzzword to a measurable policy axis across Southeast Asia, with governments in the region..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/southeast-asias-green-travel-race-whos-leading-and-whos-falling-behind.mdx
+++ b/apps/mouth/src/content/articles/immigration/southeast-asias-green-travel-race-whos-leading-and-whos-falling-behind.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Southeast Asia's Green Travel Race: Who's Leading and Who's..."
-seoDescription: "## Facts  Sustainable travel has shifted from a marketing buzzword to a measurable policy axis across Southeast Asia, with governments in the region..."
+seoDescription: "Sustainable travel has shifted from a marketing buzzword to a measurable policy axis across Southeast Asia, with governments in the region..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Surviving the Unexpected: Emergency Preparedness for Expats in Indonesia"
 slug: "surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia"
-excerpt: "## Facts  Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o"
+excerpt: "Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o"
 coverImage: "/static/news/visa_20260406_173217_162c38cb.png"
 coverImageAlt: "Surviving the Unexpected: Emergency Preparedness for Expats in Indonesia"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Surviving the Unexpected: Emergency Preparedness for Expats in Indonesia"
 slug: "surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia"
-excerpt: "## Facts  Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o"
+excerpt: "Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o"
 coverImage: "/static/news/visa_20260406_173217_162c38cb.png"
 coverImageAlt: "Surviving the Unexpected: Emergency Preparedness for Expats in Indonesia"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia.mdx
+++ b/apps/mouth/src/content/articles/immigration/surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Surviving the Unexpected: Emergency Preparedness for Expats in Indonesia"
 slug: "surviving-the-unexpected-emergency-preparedness-for-expats-in-indonesia"
-excerpt: "## Facts  Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o"
+excerpt: "Indonesia is an archipelago of over 17,000 islands straddling one of the world's most seismically active zones, known as the Pacific Ring of Fire. The country experiences regular earthquakes, volcanic eruptions, tsunamis, floods, and landslides — hazards that are part o"
 coverImage: "/static/news/visa_20260406_173217_162c38cb.png"
 coverImageAlt: "Surviving the Unexpected: Emergency Preparedness for Expats in Indonesia"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/tenkai-brings-nikkei-cuisine-to-bali-with-chef-juan-carlos.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/tenkai-brings-nikkei-cuisine-to-bali-with-chef-juan-carlos.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "TENKAI Brings Nikkei Cuisine to Bali with Chef Juan Carlos"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does TENKAI Brings Nikkei Cuisine...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/immigration/tenkai-brings-nikkei-cuisine-to-bali-with-chef-juan-carlos.mdx
+++ b/apps/mouth/src/content/articles/immigration/tenkai-brings-nikkei-cuisine-to-bali-with-chef-juan-carlos.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "TENKAI Brings Nikkei Cuisine to Bali with Chef Juan Carlos"
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does TENKAI Brings Nikkei Cuisine...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/immigration/thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign Worker Rules"
 slug: "thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules"
-excerpt: "## Facts  Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent"
+excerpt: "Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent"
 coverImage: "/static/news/visa_20260413_172310_c0557503.jpg"
 coverImageAlt: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign Worker Rules"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign..."
-seoDescription: "## Facts  Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond...."
+seoDescription: "Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign Worker Rules"
 slug: "thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules"
-excerpt: "## Facts  Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent"
+excerpt: "Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent"
 coverImage: "/static/news/visa_20260413_172310_c0557503.jpg"
 coverImageAlt: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign Worker Rules"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign..."
-seoDescription: "## Facts  Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond...."
+seoDescription: "Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules.mdx
+++ b/apps/mouth/src/content/articles/immigration/thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign Worker Rules"
 slug: "thai-restaurant-in-canggu-puts-spotlight-on-fb-foreign-worker-rules"
-excerpt: "## Facts  Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent"
+excerpt: "Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond. Establishments serving regional cuisines — Thai, Japanese, Korean, Indian — have proliferated across the area's main arteries in recent"
 coverImage: "/static/news/visa_20260413_172310_c0557503.jpg"
 coverImageAlt: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign Worker Rules"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Thai Restaurant in Canggu Puts Spotlight on F&B Foreign..."
-seoDescription: "## Facts  Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond...."
+seoDescription: "Canggu has cemented its reputation as Bali's most dynamic culinary destination, attracting restaurateurs from across Asia and beyond...."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 slug: "the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner"
-excerpt: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
+excerpt: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
 coverImage: "/static/news/visa_20260518_172611_0383a9f1_cover.png"
 coverImageAlt: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Legal Maze of Getting Married in Indonesia as a..."
-seoDescription: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
+seoDescription: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 slug: "the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner"
-excerpt: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
+excerpt: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
 coverImage: "/static/news/visa_20260518_172611_0383a9f1_cover.png"
 coverImageAlt: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Legal Maze of Getting Married in Indonesia as a..."
-seoDescription: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
+seoDescription: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 slug: "the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner"
-excerpt: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
+excerpt: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
 coverImage: "/static/news/visa_20260518_172611_0383a9f1_cover.png"
 coverImageAlt: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Legal Maze of Getting Married in Indonesia as a..."
-seoDescription: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
+seoDescription: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 slug: "the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner"
-excerpt: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
+excerpt: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
 coverImage: "/static/news/visa_20260518_172611_0383a9f1_cover.png"
 coverImageAlt: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Legal Maze of Getting Married in Indonesia as a..."
-seoDescription: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
+seoDescription: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 slug: "the-legal-maze-of-getting-married-in-indonesia-as-a-foreigner"
-excerpt: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
+excerpt: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only legally valid if conducted according to the religious law of each party. Indonesia recognises six official religions for this pu"
 coverImage: "/static/news/visa_20260518_172611_0383a9f1_cover.png"
 coverImageAlt: "The Legal Maze of Getting Married in Indonesia as a Foreigner"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Legal Maze of Getting Married in Indonesia as a..."
-seoDescription: "## Facts  Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
+seoDescription: "Marriage in Indonesia is governed primarily by Law No. 1 of 1974 on Marriage (Undang-Undang Perkawinan), which states that a marriage is only..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 slug: "the-real-cost-of-living-in-bali-what-1000-buys-in-2026"
-excerpt: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
+excerpt: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
 coverImage: "/static/news/visa_20260507_174051_17f7a2da_cover.png"
 coverImageAlt: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
-seoDescription: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
+seoDescription: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 slug: "the-real-cost-of-living-in-bali-what-1000-buys-in-2026"
-excerpt: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
+excerpt: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
 coverImage: "/static/news/visa_20260507_174051_17f7a2da_cover.png"
 coverImageAlt: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
-seoDescription: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
+seoDescription: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 slug: "the-real-cost-of-living-in-bali-what-1000-buys-in-2026"
-excerpt: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
+excerpt: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
 coverImage: "/static/news/visa_20260507_174051_17f7a2da_cover.png"
 coverImageAlt: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
-seoDescription: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
+seoDescription: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 slug: "the-real-cost-of-living-in-bali-what-1000-buys-in-2026"
-excerpt: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
+excerpt: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
 coverImage: "/static/news/visa_20260507_174051_17f7a2da_cover.png"
 coverImageAlt: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
-seoDescription: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
+seoDescription: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/the-real-cost-of-living-in-bali-what-1000-buys-in-2026.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 slug: "the-real-cost-of-living-in-bali-what-1000-buys-in-2026"
-excerpt: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
+excerpt: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is increasingly at odds with ground-level economic reality. The Indonesian island's cost of living has shifted meaningfully over the pas"
 coverImage: "/static/news/visa_20260507_174051_17f7a2da_cover.png"
 coverImageAlt: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "The Real Cost of Living in Bali: What $1,000 Buys in 2026"
-seoDescription: "## Facts  Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
+seoDescription: "Bali has long carried a reputation as one of Southeast Asia's most affordable destinations for foreign residents, but that perception is..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tom Ford Beauty Meets Jakarta Five-Star: A Luxury Afternoon Tea Worth Knowing About"
 slug: "tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about"
-excerpt: "## Facts  The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford"
+excerpt: "The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford"
 coverImage: "/static/news/visa_20260504_172356_c1402667_cover.png"
 coverImageAlt: "Tom Ford Beauty Meets Jakarta Five-Star: A Luxury Afternoon Tea Worth Knowing About"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tom Ford Beauty Meets Jakarta Five-Star: A Luxury Afternoon Tea Worth Knowing About"
 slug: "tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about"
-excerpt: "## Facts  The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford"
+excerpt: "The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford"
 coverImage: "/static/news/visa_20260504_172356_c1402667_cover.png"
 coverImageAlt: "Tom Ford Beauty Meets Jakarta Five-Star: A Luxury Afternoon Tea Worth Knowing About"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about.mdx
+++ b/apps/mouth/src/content/articles/immigration/tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tom Ford Beauty Meets Jakarta Five-Star: A Luxury Afternoon Tea Worth Knowing About"
 slug: "tom-ford-beauty-meets-jakarta-five-star-a-luxury-afternoon-tea-worth-knowing-about"
-excerpt: "## Facts  The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford"
+excerpt: "The InterContinental Jakarta Pondok Indah, one of the capital's flagship five-star properties, has announced a collaboration with Tom Ford Beauty to create a themed afternoon tea experience at its signature venue, The Lounge. The concept draws inspiration from Tom Ford"
 coverImage: "/static/news/visa_20260504_172356_c1402667_cover.png"
 coverImageAlt: "Tom Ford Beauty Meets Jakarta Five-Star: A Luxury Afternoon Tea Worth Knowing About"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ubud's Mixology Moment Masks a Minefield for Foreign Bartenders"
 slug: "ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders"
-excerpt: "## Facts  The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —"
+excerpt: "The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —"
 coverImage: "/static/news/visa_20260406_173128_1bf805fe.jpg"
 coverImageAlt: "Ubud's Mixology Moment Masks a Minefield for Foreign Bartenders"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ubud's Mixology Moment Masks a Minefield for Foreign Bartenders"
 slug: "ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders"
-excerpt: "## Facts  The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —"
+excerpt: "The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —"
 coverImage: "/static/news/visa_20260406_173128_1bf805fe.jpg"
 coverImageAlt: "Ubud's Mixology Moment Masks a Minefield for Foreign Bartenders"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Ubud's Mixology Moment Masks a Minefield for Foreign..."
-seoDescription: "## Facts  The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's..."
+seoDescription: "The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders.mdx
+++ b/apps/mouth/src/content/articles/immigration/ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Ubud's Mixology Moment Masks a Minefield for Foreign Bartenders"
 slug: "ubuds-mixology-moment-masks-a-minefield-for-foreign-bartenders"
-excerpt: "## Facts  The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —"
+excerpt: "The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's luxury hospitality circuit. These collaborative sessions typically involve guest bartenders — sometimes flown in from abroad —"
 coverImage: "/static/news/visa_20260406_173128_1bf805fe.jpg"
 coverImageAlt: "Ubud's Mixology Moment Masks a Minefield for Foreign Bartenders"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Ubud's Mixology Moment Masks a Minefield for Foreign..."
-seoDescription: "## Facts  The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's..."
+seoDescription: "The Westin Resort & Spa Ubud staged a 'Local Roots, Reinvented' bar takeover event, a format that has become increasingly popular across Bali's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/us-indonesia-trade-deal-locks-in-fossil-fuels-and-critical-minerals.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/us-indonesia-trade-deal-locks-in-fossil-fuels-and-critical-minerals.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "U.S.-Indonesia Trade Deal Locks In Fossil Fuels and..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does U.S.-Indonesia Trade Deal...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/immigration/us-indonesia-trade-deal-locks-in-fossil-fuels-and-critical-minerals.mdx
+++ b/apps/mouth/src/content/articles/immigration/us-indonesia-trade-deal-locks-in-fossil-fuels-and-critical-minerals.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "U.S.-Indonesia Trade Deal Locks In Fossil Fuels and..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does U.S.-Indonesia Trade Deal...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/immigration/us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "US Tax Failure Clouds World Cup 2026 for Host Nations and Visitors"
 slug: "us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors"
-excerpt: "## Facts  The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl"
+excerpt: "The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl"
 coverImage: "/static/news/visa_20260406_173110_6ef75d6b.png"
 coverImageAlt: "US Tax Failure Clouds World Cup 2026 for Host Nations and Visitors"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "US Tax Failure Clouds World Cup 2026 for Host Nations and Visitors"
 slug: "us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors"
-excerpt: "## Facts  The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl"
+excerpt: "The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl"
 coverImage: "/static/news/visa_20260406_173110_6ef75d6b.png"
 coverImageAlt: "US Tax Failure Clouds World Cup 2026 for Host Nations and Visitors"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors.mdx
+++ b/apps/mouth/src/content/articles/immigration/us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "US Tax Failure Clouds World Cup 2026 for Host Nations and Visitors"
 slug: "us-tax-failure-clouds-world-cup-2026-for-host-nations-and-visitors"
-excerpt: "## Facts  The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl"
+excerpt: "The 2026 FIFA World Cup, scheduled to be hosted across the United States, Canada, and Mexico, is generating mounting concern among participating nations over unresolved US tax obligations. According to reporting by CNN Indonesia, the failure of US authorities to properl"
 coverImage: "/static/news/visa_20260406_173110_6ef75d6b.png"
 coverImageAlt: "US Tax Failure Clouds World Cup 2026 for Host Nations and Visitors"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
 slug: "vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business"
-excerpt: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
+excerpt: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
 coverImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.jpg"
 cardImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business_card.jpg"
 coverImageAlt: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Vietnam Tightens Visa-Free Entry for Indonesians — What It..."
-seoDescription: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
+seoDescription: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
 slug: "vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business"
-excerpt: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
+excerpt: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
 coverImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.jpg"
 cardImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business_card.jpg"
 coverImageAlt: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Vietnam Tightens Visa-Free Entry for Indonesians — What It..."
-seoDescription: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
+seoDescription: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
 slug: "vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business"
-excerpt: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
+excerpt: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
 coverImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.jpg"
 cardImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business_card.jpg"
 coverImageAlt: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Vietnam Tightens Visa-Free Entry for Indonesians — What It..."
-seoDescription: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
+seoDescription: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.mdx
+++ b/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
 slug: "vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business"
-excerpt: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
+excerpt: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
 coverImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.jpg"
 cardImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business_card.jpg"
 coverImageAlt: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Vietnam Tightens Visa-Free Entry for Indonesians — What It..."
-seoDescription: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
+seoDescription: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
 slug: "vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business"
-excerpt: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
+excerpt: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long maintained visa-free or simplified entry arrangements grounded in the bloc's broader commitment to frictionless intra-regional m"
 coverImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business.jpg"
 cardImage: "/static/news/vietnam-tightens-visa-free-entry-for-indonesians-what-it-means-for-regional-business_card.jpg"
 coverImageAlt: "Vietnam Tightens Visa-Free Entry for Indonesians — What It Means for Regional Business"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Vietnam Tightens Visa-Free Entry for Indonesians — What It..."
-seoDescription: "## Facts  Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
+seoDescription: "Vietnam and Indonesia share one of Southeast Asia's most active bilateral travel corridors. As fellow ASEAN members, both countries have long..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/vizag-airport-launches-e-tourist-visa-on-arrival-for-foreign-visitors.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/vizag-airport-launches-e-tourist-visa-on-arrival-for-foreign-visitors.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Vizag Airport Launches e-Tourist Visa on Arrival for..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Vizag Airport Launches...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/immigration/vizag-airport-launches-e-tourist-visa-on-arrival-for-foreign-visitors.mdx
+++ b/apps/mouth/src/content/articles/immigration/vizag-airport-launches-e-tourist-visa-on-arrival-for-foreign-visitors.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Vizag Airport Launches e-Tourist Visa on Arrival for..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Vizag Airport Launches...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.fr.mdx
+++ b/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 slug: "westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism"
-excerpt: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
+excerpt: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
 coverImage: "/static/news/visa_20260507_174058_b58d23c1_cover.png"
 coverImageAlt: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness..."
-seoDescription: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
+seoDescription: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 slug: "westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism"
-excerpt: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
+excerpt: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
 coverImage: "/static/news/visa_20260507_174058_b58d23c1_cover.png"
 coverImageAlt: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness..."
-seoDescription: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
+seoDescription: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 slug: "westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism"
-excerpt: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
+excerpt: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
 coverImage: "/static/news/visa_20260507_174058_b58d23c1_cover.png"
 coverImageAlt: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness..."
-seoDescription: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
+seoDescription: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.mdx
+++ b/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 slug: "westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism"
-excerpt: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
+excerpt: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
 coverImage: "/static/news/visa_20260507_174058_b58d23c1_cover.png"
 coverImageAlt: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness..."
-seoDescription: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
+seoDescription: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.ru.mdx
+++ b/apps/mouth/src/content/articles/immigration/westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 slug: "westin-ubud-bets-on-biophilic-luxury-to-capture-wellness-tourism"
-excerpt: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
+excerpt: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor itself within that identity. The property's latest programming reflects a broader industry pivot toward what hospitality analys"
 coverImage: "/static/news/visa_20260507_174058_b58d23c1_cover.png"
 coverImageAlt: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness Tourism"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Westin Ubud Bets on Biophilic Luxury to Capture Wellness..."
-seoDescription: "## Facts  Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
+seoDescription: "Ubud has long held the gravitational center of Bali's wellness economy, and The Westin Resort & Spa Ubud is making a deliberate push to anchor..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/working-kitas-e23-indonesias-revised-legal-framework-explained.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/working-kitas-e23-indonesias-revised-legal-framework-explained.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Working KITAS (E23): Indonesia's Revised Legal Framework Explained"
 slug: "working-kitas-e23-indonesias-revised-legal-framework-explained"
-excerpt: "## Facts  Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026.  The fo"
+excerpt: "Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026. The fo"
 coverImage: "/static/news/visa_20260514_173910_8c9a89e3.jpg"
 coverImageAlt: "Working KITAS (E23): Indonesia's Revised Legal Framework Explained"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Working KITAS (E23): Indonesia's Revised Legal Framework..."
-seoDescription: "## Facts  Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic..."
+seoDescription: "Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/working-kitas-e23-indonesias-revised-legal-framework-explained.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/working-kitas-e23-indonesias-revised-legal-framework-explained.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Working KITAS (E23): Indonesia's Revised Legal Framework Explained"
 slug: "working-kitas-e23-indonesias-revised-legal-framework-explained"
-excerpt: "## Facts  Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026.  The fo"
+excerpt: "Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026. The fo"
 coverImage: "/static/news/visa_20260514_173910_8c9a89e3.jpg"
 coverImageAlt: "Working KITAS (E23): Indonesia's Revised Legal Framework Explained"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Working KITAS (E23): Indonesia's Revised Legal Framework..."
-seoDescription: "## Facts  Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic..."
+seoDescription: "Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/working-kitas-e23-indonesias-revised-legal-framework-explained.mdx
+++ b/apps/mouth/src/content/articles/immigration/working-kitas-e23-indonesias-revised-legal-framework-explained.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Working KITAS (E23): Indonesia's Revised Legal Framework Explained"
 slug: "working-kitas-e23-indonesias-revised-legal-framework-explained"
-excerpt: "## Facts  Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026.  The fo"
+excerpt: "Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic regulatory overhaul over the past several years, culminating in new obligations that took effect as recently as early 2026. The fo"
 coverImage: "/static/news/visa_20260514_173910_8c9a89e3.jpg"
 coverImageAlt: "Working KITAS (E23): Indonesia's Revised Legal Framework Explained"
 category: "immigration"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Working KITAS (E23): Indonesia's Revised Legal Framework..."
-seoDescription: "## Facts  Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic..."
+seoDescription: "Indonesia's Working KITAS — the stay permit issued to foreign nationals employed by Indonesian legal entities — has undergone a systematic..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/immigration/zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own.id.mdx
+++ b/apps/mouth/src/content/articles/immigration/zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Zero-Tax Countries Are Tempting—But Indonesia Has Rules of Its Own"
 slug: "zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own"
-excerpt: "## Facts  The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a"
+excerpt: "The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a"
 coverImage: "/static/news/visa_20260501_171008_d88ca8e8_cover.png"
 coverImageAlt: "Zero-Tax Countries Are Tempting—But Indonesia Has Rules of Its Own"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own.it.mdx
+++ b/apps/mouth/src/content/articles/immigration/zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Zero-Tax Countries Are Tempting—But Indonesia Has Rules of Its Own"
 slug: "zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own"
-excerpt: "## Facts  The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a"
+excerpt: "The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a"
 coverImage: "/static/news/visa_20260501_171008_d88ca8e8_cover.png"
 coverImageAlt: "Zero-Tax Countries Are Tempting—But Indonesia Has Rules of Its Own"
 category: "immigration"

--- a/apps/mouth/src/content/articles/immigration/zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own.mdx
+++ b/apps/mouth/src/content/articles/immigration/zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Zero-Tax Countries Are Tempting—But Indonesia Has Rules of Its Own"
 slug: "zero-tax-countries-are-temptingbut-indonesia-has-rules-of-its-own"
-excerpt: "## Facts  The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a"
+excerpt: "The international conversation around zero-tax jurisdictions has intensified in 2026, with several publications profiling countries—predominantly Gulf states, Pacific island nations, and select Caribbean territories—that impose no personal income tax on residents. The a"
 coverImage: "/static/news/visa_20260501_171008_d88ca8e8_cover.png"
 coverImageAlt: "Zero-Tax Countries Are Tempting—But Indonesia Has Rules of Its Own"
 category: "immigration"

--- a/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.fr.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali for Women: What the Bliss Blogs Don't Tell You"
 slug: "bali-for-women-what-the-bliss-blogs-dont-tell-you"
-excerpt: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
+excerpt: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
 coverImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you.jpg"
 cardImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you_card.jpg"
 coverImageAlt: "Bali for Women: What the Bliss Blogs Don't Tell You"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali for Women: What the Bliss Blogs Don't Tell You"
-seoDescription: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
+seoDescription: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.id.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali for Women: What the Bliss Blogs Don't Tell You"
 slug: "bali-for-women-what-the-bliss-blogs-dont-tell-you"
-excerpt: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
+excerpt: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
 coverImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you.jpg"
 cardImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you_card.jpg"
 coverImageAlt: "Bali for Women: What the Bliss Blogs Don't Tell You"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali for Women: What the Bliss Blogs Don't Tell You"
-seoDescription: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
+seoDescription: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali for Women: What the Bliss Blogs Don't Tell You"
 slug: "bali-for-women-what-the-bliss-blogs-dont-tell-you"
-excerpt: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
+excerpt: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
 coverImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you.jpg"
 cardImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you_card.jpg"
 coverImageAlt: "Bali for Women: What the Bliss Blogs Don't Tell You"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali for Women: What the Bliss Blogs Don't Tell You"
-seoDescription: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
+seoDescription: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali for Women: What the Bliss Blogs Don't Tell You"
 slug: "bali-for-women-what-the-bliss-blogs-dont-tell-you"
-excerpt: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
+excerpt: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
 coverImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you.jpg"
 cardImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you_card.jpg"
 coverImageAlt: "Bali for Women: What the Bliss Blogs Don't Tell You"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali for Women: What the Bliss Blogs Don't Tell You"
-seoDescription: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
+seoDescription: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.ru.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-for-women-what-the-bliss-blogs-dont-tell-you.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali for Women: What the Bliss Blogs Don't Tell You"
 slug: "bali-for-women-what-the-bliss-blogs-dont-tell-you"
-excerpt: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
+excerpt: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads, wellness seekers, and aspiring long-term residents — who arrive chasing the lifestyle narrative that has been sold in books,"
 coverImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you.jpg"
 cardImage: "/static/news/bali-for-women-what-the-bliss-blogs-dont-tell-you_card.jpg"
 coverImageAlt: "Bali for Women: What the Bliss Blogs Don't Tell You"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali for Women: What the Bliss Blogs Don't Tell You"
-seoDescription: "## Facts  Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
+seoDescription: "Bali has long positioned itself as a destination for personal transformation, drawing a steady stream of women — solo travelers, digital nomads,..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-launches-dharma-dewata-force-to-police-tourist-behavior.id.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-launches-dharma-dewata-force-to-police-tourist-behavior.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Launches Dharma Dewata Force to Police Tourist Behavior"
 slug: "bali-launches-dharma-dewata-force-to-police-tourist-behavior"
-excerpt: "## Facts  Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim"
+excerpt: "Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim"
 coverImage: "/static/news/visa_20260426_173808_bdea7358_cover.png"
 coverImageAlt: "Bali Launches Dharma Dewata Force to Police Tourist Behavior"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/bali-launches-dharma-dewata-force-to-police-tourist-behavior.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-launches-dharma-dewata-force-to-police-tourist-behavior.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Launches Dharma Dewata Force to Police Tourist Behavior"
 slug: "bali-launches-dharma-dewata-force-to-police-tourist-behavior"
-excerpt: "## Facts  Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim"
+excerpt: "Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim"
 coverImage: "/static/news/visa_20260426_173808_bdea7358_cover.png"
 coverImageAlt: "Bali Launches Dharma Dewata Force to Police Tourist Behavior"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/bali-launches-dharma-dewata-force-to-police-tourist-behavior.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-launches-dharma-dewata-force-to-police-tourist-behavior.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Launches Dharma Dewata Force to Police Tourist Behavior"
 slug: "bali-launches-dharma-dewata-force-to-police-tourist-behavior"
-excerpt: "## Facts  Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim"
+excerpt: "Bali's immigration directorate has unveiled the Dharma Dewata Immigration Patrol Force, a purpose-built unit designed to conduct active, on-the-ground monitoring of foreign nationals across the island's most densely visited areas. The force will operate across four prim"
 coverImage: "/static/news/visa_20260426_173808_bdea7358_cover.png"
 coverImageAlt: "Bali Launches Dharma Dewata Force to Police Tourist Behavior"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.fr.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 slug: "bali-sets-663m-tourist-target-while-raising-the-bar-for-entry"
-excerpt: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
+excerpt: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
 coverImage: "/static/news/visa_20260408_173236_9e3c8caf_cover.png"
 coverImageAlt: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Sets 6.63M Tourist Target While Raising the Bar for..."
-seoDescription: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
+seoDescription: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.id.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 slug: "bali-sets-663m-tourist-target-while-raising-the-bar-for-entry"
-excerpt: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
+excerpt: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
 coverImage: "/static/news/visa_20260408_173236_9e3c8caf_cover.png"
 coverImageAlt: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 slug: "bali-sets-663m-tourist-target-while-raising-the-bar-for-entry"
-excerpt: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
+excerpt: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
 coverImage: "/static/news/visa_20260408_173236_9e3c8caf_cover.png"
 coverImageAlt: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Sets 6.63M Tourist Target While Raising the Bar for..."
-seoDescription: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
+seoDescription: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 slug: "bali-sets-663m-tourist-target-while-raising-the-bar-for-entry"
-excerpt: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
+excerpt: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
 coverImage: "/static/news/visa_20260408_173236_9e3c8caf_cover.png"
 coverImageAlt: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Sets 6.63M Tourist Target While Raising the Bar for..."
-seoDescription: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
+seoDescription: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.ru.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/bali-sets-663m-tourist-target-while-raising-the-bar-for-entry.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 slug: "bali-sets-663m-tourist-target-while-raising-the-bar-for-entry"
-excerpt: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
+excerpt: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase over the prior year. Australia led all source markets, accounting for roughly 24.81 percent of October 2025 arrivals, followed b"
 coverImage: "/static/news/visa_20260408_173236_9e3c8caf_cover.png"
 coverImageAlt: "Bali Sets 6.63M Tourist Target While Raising the Bar for Entry"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Sets 6.63M Tourist Target While Raising the Bar for..."
-seoDescription: "## Facts  Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
+seoDescription: "Bali closed 2025 with a record 7.05 million foreign tourist arrivals by air — the highest in the island's history and a 9.72 percent increase..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/balis-cost-surge-who-is-this-island-actually-growing-for.id.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/balis-cost-surge-who-is-this-island-actually-growing-for.id.mdx
@@ -53,10 +53,7 @@ description:
   \ hukum atau bisnis. Selalu konsultasikan dengan profesional yang berkualifikasi\
   \ untuk mendapatkan nasihat yang spesifik sesuai dengan situasi Anda."
 difficulty: intermediate
-excerpt: "## Facts  Bali's transformation from a spiritual retreat into a global
-  lifestyle destination has accelerated dramatically since the post-pandemic reopening
-  in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging
-  Bukit Peninsula — have risen between"
+excerpt: "Bali's transformation from a spiritual retreat into a global lifestyle destination has accelerated dramatically since the post-pandemic reopening in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging Bukit Peninsula — have risen between"
 featured: false
 lang: id
 publishedAt: "2026-04-01"

--- a/apps/mouth/src/content/articles/lifestyle/balis-cost-surge-who-is-this-island-actually-growing-for.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/balis-cost-surge-who-is-this-island-actually-growing-for.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Cost Surge: Who Is This Island Actually Growing For?"
 slug: "balis-cost-surge-who-is-this-island-actually-growing-for"
-excerpt: "## Facts  Bali's transformation from a spiritual retreat into a global lifestyle destination has accelerated dramatically since the post-pandemic reopening in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging Bukit Peninsula — have risen between"
+excerpt: "Bali's transformation from a spiritual retreat into a global lifestyle destination has accelerated dramatically since the post-pandemic reopening in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging Bukit Peninsula — have risen between"
 coverImage: "/static/news/news_20260401_173132_108ea141_cover.png"
 coverImageAlt: "Bali's Cost Surge: Who Is This Island Actually Growing For?"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/balis-cost-surge-who-is-this-island-actually-growing-for.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/balis-cost-surge-who-is-this-island-actually-growing-for.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Cost Surge: Who Is This Island Actually Growing For?"
 slug: "balis-cost-surge-who-is-this-island-actually-growing-for"
-excerpt: "## Facts  Bali's transformation from a spiritual retreat into a global lifestyle destination has accelerated dramatically since the post-pandemic reopening in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging Bukit Peninsula — have risen between"
+excerpt: "Bali's transformation from a spiritual retreat into a global lifestyle destination has accelerated dramatically since the post-pandemic reopening in 2022. Property prices in prime corridors — Canggu, Seminyak, Ubud, and the emerging Bukit Peninsula — have risen between"
 coverImage: "/static/news/news_20260401_173132_108ea141_cover.png"
 coverImageAlt: "Bali's Cost Surge: Who Is This Island Actually Growing For?"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.fr.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 slug: "indonesias-domestic-worker-permits-what-expats-must-know"
-excerpt: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
+excerpt: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
 coverImage: "/static/news/visa_20260402_173407_97293602_cover.png"
 coverImageAlt: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Domestic Worker Permits: What Expats Must Know"
-seoDescription: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
+seoDescription: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.id.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 slug: "indonesias-domestic-worker-permits-what-expats-must-know"
-excerpt: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
+excerpt: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
 coverImage: "/static/news/visa_20260402_173407_97293602_cover.png"
 coverImageAlt: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Domestic Worker Permits: What Expats Must Know"
-seoDescription: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
+seoDescription: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 slug: "indonesias-domestic-worker-permits-what-expats-must-know"
-excerpt: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
+excerpt: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
 coverImage: "/static/news/visa_20260402_173407_97293602_cover.png"
 coverImageAlt: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Domestic Worker Permits: What Expats Must Know"
-seoDescription: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
+seoDescription: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 slug: "indonesias-domestic-worker-permits-what-expats-must-know"
-excerpt: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
+excerpt: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
 coverImage: "/static/news/visa_20260402_173407_97293602_cover.png"
 coverImageAlt: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.ru.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/indonesias-domestic-worker-permits-what-expats-must-know.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 slug: "indonesias-domestic-worker-permits-what-expats-must-know"
-excerpt: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
+excerpt: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or serving expat households within Indonesia itself. Work permits for domestic staff fall under the broader Indonesian manpower regula"
 coverImage: "/static/news/visa_20260402_173407_97293602_cover.png"
 coverImageAlt: "Indonesia's Domestic Worker Permits: What Expats Must Know"
 category: "lifestyle"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Domestic Worker Permits: What Expats Must Know"
-seoDescription: "## Facts  Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
+seoDescription: "Indonesia maintains a regulated framework for domestic workers employed by foreign nationals, whether those workers are deployed abroad or..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/us-expat-exodus-what-permanent-relocation-really-demands.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/us-expat-exodus-what-permanent-relocation-really-demands.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "US Expat Exodus: What Permanent Relocation Really Demands"
-seoDescription: "## Facts  The number of Americans exploring permanent relocation abroad has been climbing steadily, driven by a convergence of factors: rising cost of..."
+seoDescription: "The number of Americans exploring permanent relocation abroad has been climbing steadily, driven by a convergence of factors: rising cost of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/us-expat-exodus-what-permanent-relocation-really-demands.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/us-expat-exodus-what-permanent-relocation-really-demands.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "US Expat Exodus: What Permanent Relocation Really Demands"
-seoDescription: "## Facts  The number of Americans exploring permanent relocation abroad has been climbing steadily, driven by a convergence of factors: rising cost of..."
+seoDescription: "The number of Americans exploring permanent relocation abroad has been climbing steadily, driven by a convergence of factors: rising cost of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.id.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Visa on Arrival in Indonesia: What First-Timers Need to Know"
 slug: "visa-on-arrival-in-indonesia-what-first-timers-need-to-know"
-excerpt: "## Facts  The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic"
+excerpt: "The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic"
 coverImage: "/static/news/visa_20260418_173936_0914048b_cover.png"
 coverImageAlt: "Visa on Arrival in Indonesia: What First-Timers Need to Know"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Visa on Arrival in Indonesia: What First-Timers Need to Know"
 slug: "visa-on-arrival-in-indonesia-what-first-timers-need-to-know"
-excerpt: "## Facts  The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic"
+excerpt: "The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic"
 coverImage: "/static/news/visa_20260418_173936_0914048b_cover.png"
 coverImageAlt: "Visa on Arrival in Indonesia: What First-Timers Need to Know"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/visa-on-arrival-in-indonesia-what-first-timers-need-to-know.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Visa on Arrival in Indonesia: What First-Timers Need to Know"
 slug: "visa-on-arrival-in-indonesia-what-first-timers-need-to-know"
-excerpt: "## Facts  The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic"
+excerpt: "The Visa on Arrival (VoA) is Indonesia's primary entry mechanism for nationals of eligible countries, currently priced at IDR 500,000 (approximately USD 30) per entry and valid for 30 days. It can be extended once, for an additional 30 days, at a local immigration offic"
 coverImage: "/static/news/visa_20260418_173936_0914048b_cover.png"
 coverImageAlt: "Visa on Arrival in Indonesia: What First-Timers Need to Know"
 category: "lifestyle"

--- a/apps/mouth/src/content/articles/lifestyle/why-bali-keeps-pulling-expats-back-the-lifestyle-magnet-explained.id.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/why-bali-keeps-pulling-expats-back-the-lifestyle-magnet-explained.id.mdx
@@ -101,17 +101,11 @@ description: '# Panduan Investasi di Indonesia untuk Investor Asing
 
   *   **Bank Indonesia:** [https://www.bi.go.id/](https://www.bi.go.id/)'
 difficulty: intermediate
-excerpt: '## Facts
-
-  Bali has consistently ranked among the world''s top destinations for expatriates,
-  digital nomads, and long-term travelers for over two decades. The island''s appeal
-  cuts across demographics — from retirees seeking affordable living to younger remote
-  workers drawn by co-wo'
+excerpt: "Bali has consistently ranked among the world''s top destinations for expatriates, digital nomads, and long-term travelers for over two decades. The island''s appeal cuts across demographics — from retirees seeking affordable living to younger remote workers drawn by co-wo"
 featured: false
 lang: id
 publishedAt: '2026-03-21'
 readingTime: 3
-seoDescription: '## Facts'
 seoTitle: 'Why Bali Keeps Pulling Expats Back: The Lifestyle Magnet Explained'
 slug: why-bali-keeps-pulling-expats-back-the-lifestyle-magnet-explained
 tags:

--- a/apps/mouth/src/content/articles/lifestyle/why-bali-keeps-pulling-expats-back-the-lifestyle-magnet-explained.it.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/why-bali-keeps-pulling-expats-back-the-lifestyle-magnet-explained.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Why Bali Keeps Pulling Expats Back: The Lifestyle Magnet..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Why Bali Keeps Pulling...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/lifestyle/why-bali-keeps-pulling-expats-back-the-lifestyle-magnet-explained.mdx
+++ b/apps/mouth/src/content/articles/lifestyle/why-bali-keeps-pulling-expats-back-the-lifestyle-magnet-explained.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Why Bali Keeps Pulling Expats Back: The Lifestyle Magnet..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Why Bali Keeps Pulling...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/property/bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers.id.mdx
+++ b/apps/mouth/src/content/articles/property/bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Property 2026: New Laws Reshape the Market for Foreign Buyers"
 slug: "bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers"
-excerpt: "## Facts  Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba"
+excerpt: "Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba"
 coverImage: "/static/news/visa_20260409_175426_cd2ede91.png"
 coverImageAlt: "Bali Property 2026: New Laws Reshape the Market for Foreign Buyers"
 category: "property"

--- a/apps/mouth/src/content/articles/property/bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers.it.mdx
+++ b/apps/mouth/src/content/articles/property/bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Property 2026: New Laws Reshape the Market for Foreign Buyers"
 slug: "bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers"
-excerpt: "## Facts  Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba"
+excerpt: "Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba"
 coverImage: "/static/news/visa_20260409_175426_cd2ede91.png"
 coverImageAlt: "Bali Property 2026: New Laws Reshape the Market for Foreign Buyers"
 category: "property"

--- a/apps/mouth/src/content/articles/property/bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers.mdx
+++ b/apps/mouth/src/content/articles/property/bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Property 2026: New Laws Reshape the Market for Foreign Buyers"
 slug: "bali-property-2026-new-laws-reshape-the-market-for-foreign-buyers"
-excerpt: "## Facts  Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba"
+excerpt: "Bali's real estate market enters 2026 under the most significant regulatory overhaul in a generation. Three new provincial regulations and two updated national government regulations have collectively tightened legal compliance requirements while selectively lowering ba"
 coverImage: "/static/news/visa_20260409_175426_cd2ede91.png"
 coverImageAlt: "Bali Property 2026: New Laws Reshape the Market for Foreign Buyers"
 category: "property"

--- a/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.fr.mdx
+++ b/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 slug: "balis-zoning-map-the-rules-that-decide-where-you-can-build"
-excerpt: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
+excerpt: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
 coverImage: "/static/news/news_20260409_175530_3cbbbd6b_cover.png"
 coverImageAlt: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 category: "property"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
-seoDescription: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
+seoDescription: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.id.mdx
+++ b/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 slug: "balis-zoning-map-the-rules-that-decide-where-you-can-build"
-excerpt: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
+excerpt: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
 coverImage: "/static/news/news_20260409_175530_3cbbbd6b_cover.png"
 coverImageAlt: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 category: "property"

--- a/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.it.mdx
+++ b/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 slug: "balis-zoning-map-the-rules-that-decide-where-you-can-build"
-excerpt: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
+excerpt: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
 coverImage: "/static/news/news_20260409_175530_3cbbbd6b_cover.png"
 coverImageAlt: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 category: "property"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
-seoDescription: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
+seoDescription: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.mdx
+++ b/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 slug: "balis-zoning-map-the-rules-that-decide-where-you-can-build"
-excerpt: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
+excerpt: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
 coverImage: "/static/news/news_20260409_175530_3cbbbd6b_cover.png"
 coverImageAlt: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 category: "property"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
-seoDescription: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
+seoDescription: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.ru.mdx
+++ b/apps/mouth/src/content/articles/property/balis-zoning-map-the-rules-that-decide-where-you-can-build.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 slug: "balis-zoning-map-the-rules-that-decide-where-you-can-build"
-excerpt: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
+excerpt: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law No. 26 of 2007) and its derivative regional regulations, including Bali Province Regulation No. 3 of 2020 (Perda RTRW Bali 2020–"
 coverImage: "/static/news/news_20260409_175530_3cbbbd6b_cover.png"
 coverImageAlt: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
 category: "property"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali's Zoning Map: The Rules That Decide Where You Can Build"
-seoDescription: "## Facts  Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
+seoDescription: "Bali's land use is governed by a layered framework of spatial planning laws, the most significant being Indonesia's Spatial Planning Law (Law..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.fr.mdx
+++ b/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 slug: "tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood"
-excerpt: "## Facts  Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
+excerpt: "Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
 coverImage: "/static/news/news_20260409_175602_05772196_cover.png"
 coverImageAlt: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 category: "property"

--- a/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.id.mdx
+++ b/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 slug: "tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood"
-excerpt: "## Facts  Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
+excerpt: "Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
 coverImage: "/static/news/news_20260409_175602_05772196_cover.png"
 coverImageAlt: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 category: "property"

--- a/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.it.mdx
+++ b/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 slug: "tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood"
-excerpt: "## Facts  Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
+excerpt: "Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
 coverImage: "/static/news/news_20260409_175602_05772196_cover.png"
 coverImageAlt: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 category: "property"

--- a/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.mdx
+++ b/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 slug: "tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood"
-excerpt: "## Facts  Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
+excerpt: "Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
 coverImage: "/static/news/news_20260409_175602_05772196_cover.png"
 coverImageAlt: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 category: "property"

--- a/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.ru.mdx
+++ b/apps/mouth/src/content/articles/property/tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood.ru.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 slug: "tempehs-ancient-roots-indonesias-fermented-soybean-is-a-global-superfood"
-excerpt: "## Facts  Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
+excerpt: "Tempeh is one of Indonesia's most enduring culinary exports, yet its origins remain deeply rooted in Javanese tradition. The food is produced through a controlled fermentation process in which cooked soybeans are inoculated with a mold culture — primarily Rhizopus oligo"
 coverImage: "/static/news/news_20260409_175602_05772196_cover.png"
 coverImageAlt: "Tempeh's Ancient Roots: Indonesia's Fermented Soybean Is a Global Superfood"
 category: "property"

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: Foreign Nationals Caught in Prostitution Rings and Investment Fraud"
 slug: "bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud"
-excerpt: "## Facts  Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt"
+excerpt: "Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt"
 coverImage: "/static/news/visa_20260415_174734_c9a8b9a4_cover.png"
 coverImageAlt: "Bali Cracks Down: Foreign Nationals Caught in Prostitution Rings and Investment Fraud"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: Foreign Nationals Caught in Prostitution..."
-seoDescription: "## Facts  Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent..."
+seoDescription: "Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: Foreign Nationals Caught in Prostitution Rings and Investment Fraud"
 slug: "bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud"
-excerpt: "## Facts  Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt"
+excerpt: "Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt"
 coverImage: "/static/news/visa_20260415_174734_c9a8b9a4_cover.png"
 coverImageAlt: "Bali Cracks Down: Foreign Nationals Caught in Prostitution Rings and Investment Fraud"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: Foreign Nationals Caught in Prostitution..."
-seoDescription: "## Facts  Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent..."
+seoDescription: "Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: Foreign Nationals Caught in Prostitution Rings and Investment Fraud"
 slug: "bali-cracks-down-foreign-nationals-caught-in-prostitution-rings-and-investment-fraud"
-excerpt: "## Facts  Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt"
+excerpt: "Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent investment activity involving fabricated documentation. The cases, reported by regional outlet Kanalbali, reflect an ongoing patt"
 coverImage: "/static/news/visa_20260415_174734_c9a8b9a4_cover.png"
 coverImageAlt: "Bali Cracks Down: Foreign Nationals Caught in Prostitution Rings and Investment Fraud"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: Foreign Nationals Caught in Prostitution..."
-seoDescription: "## Facts  Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent..."
+seoDescription: "Bali's authorities have moved against a fresh wave of foreign national violations, with cases spanning organized prostitution and fraudulent..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down on Influencer Barter Deals: Work Permit or Deportation"
 slug: "bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation"
-excerpt: "## Facts  Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h"
+excerpt: "Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h"
 coverImage: "/static/news/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.jpg"
 cardImage: "/static/news/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation_card.jpg"
 coverImageAlt: "Bali Cracks Down on Influencer Barter Deals: Work Permit or Deportation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down on Influencer Barter Deals: Work Permit or..."
-seoDescription: "## Facts  Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without..."
+seoDescription: "Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down on Influencer Barter Deals: Work Permit or Deportation"
 slug: "bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation"
-excerpt: "## Facts  Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h"
+excerpt: "Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h"
 coverImage: "/static/news/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.jpg"
 cardImage: "/static/news/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation_card.jpg"
 coverImageAlt: "Bali Cracks Down on Influencer Barter Deals: Work Permit or Deportation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down on Influencer Barter Deals: Work Permit or..."
-seoDescription: "## Facts  Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without..."
+seoDescription: "Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down on Influencer Barter Deals: Work Permit or Deportation"
 slug: "bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation"
-excerpt: "## Facts  Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h"
+excerpt: "Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without proper work authorisation, with a particular focus on so-called 'unpaid partnerships' — arrangements in which brands, hotels, or h"
 coverImage: "/static/news/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation.jpg"
 cardImage: "/static/news/bali-cracks-down-on-influencer-barter-deals-work-permit-or-deportation_card.jpg"
 coverImageAlt: "Bali Cracks Down on Influencer Barter Deals: Work Permit or Deportation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down on Influencer Barter Deals: Work Permit or..."
-seoDescription: "## Facts  Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without..."
+seoDescription: "Bali's immigration authorities have escalated enforcement actions against foreign nationals engaging in commercial content creation without..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: Social Media Work on Tourist Visas Risks Deportation"
 slug: "bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation"
-excerpt: "## Facts  Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work'"
+excerpt: "Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work"
 coverImage: "/static/news/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.jpg"
 cardImage: "/static/news/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation_card.jpg"
 coverImageAlt: "Bali Cracks Down: Social Media Work on Tourist Visas Risks Deportation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: Social Media Work on Tourist Visas Risks..."
-seoDescription: "## Facts  Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist..."
+seoDescription: "Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: Social Media Work on Tourist Visas Risks Deportation"
 slug: "bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation"
-excerpt: "## Facts  Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work'"
+excerpt: "Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work"
 coverImage: "/static/news/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.jpg"
 cardImage: "/static/news/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation_card.jpg"
 coverImageAlt: "Bali Cracks Down: Social Media Work on Tourist Visas Risks Deportation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: Social Media Work on Tourist Visas Risks..."
-seoDescription: "## Facts  Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist..."
+seoDescription: "Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Cracks Down: Social Media Work on Tourist Visas Risks Deportation"
 slug: "bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation"
-excerpt: "## Facts  Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work'"
+excerpt: "Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist or social visas. The legal basis sits within UU Keimigrasian No. 6/2011 and its implementing regulations, which define 'work"
 coverImage: "/static/news/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation.jpg"
 cardImage: "/static/news/bali-cracks-down-social-media-work-on-tourist-visas-risks-deportation_card.jpg"
 coverImageAlt: "Bali Cracks Down: Social Media Work on Tourist Visas Risks Deportation"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Cracks Down: Social Media Work on Tourist Visas Risks..."
-seoDescription: "## Facts  Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist..."
+seoDescription: "Indonesian immigration law has long prohibited foreigners from performing any form of work — including commercial content creation — on tourist..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Halts Emergency Stay Permits for Foreigners in Immigration Crackdown"
 slug: "bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown"
-excerpt: "## Facts  The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey"
+excerpt: "The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey"
 coverImage: "/static/news/visa_20260507_174008_4602c388_cover.png"
 coverImageAlt: "Bali Halts Emergency Stay Permits for Foreigners in Immigration Crackdown"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Halts Emergency Stay Permits for Foreigners in..."
-seoDescription: "## Facts  The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency..."
+seoDescription: "The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Halts Emergency Stay Permits for Foreigners in Immigration Crackdown"
 slug: "bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown"
-excerpt: "## Facts  The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey"
+excerpt: "The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey"
 coverImage: "/static/news/visa_20260507_174008_4602c388_cover.png"
 coverImageAlt: "Bali Halts Emergency Stay Permits for Foreigners in Immigration Crackdown"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Halts Emergency Stay Permits for Foreigners in..."
-seoDescription: "## Facts  The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency..."
+seoDescription: "The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Halts Emergency Stay Permits for Foreigners in Immigration Crackdown"
 slug: "bali-halts-emergency-stay-permits-for-foreigners-in-immigration-crackdown"
-excerpt: "## Facts  The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey"
+excerpt: "The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency stay permit historically issued to foreign nationals who found themselves unable to depart Indonesia due to circumstances bey"
 coverImage: "/static/news/visa_20260507_174008_4602c388_cover.png"
 coverImageAlt: "Bali Halts Emergency Stay Permits for Foreigners in Immigration Crackdown"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Halts Emergency Stay Permits for Foreigners in..."
-seoDescription: "## Facts  The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency..."
+seoDescription: "The Bali Immigration Office (Kantor Imigrasi) has officially suspended the granting of Izin Tinggal Keadaan Terpaksa — a discretionary emergency..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants Ignore"
 slug: "bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore"
-excerpt: "## Facts  Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive"
+excerpt: "Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive"
 coverImage: "/static/news/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.jpg"
 cardImage: "/static/news/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore_card.jpg"
 coverImageAlt: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants Ignore"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants..."
-seoDescription: "## Facts  Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and..."
+seoDescription: "Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants Ignore"
 slug: "bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore"
-excerpt: "## Facts  Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive"
+excerpt: "Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive"
 coverImage: "/static/news/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.jpg"
 cardImage: "/static/news/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore_card.jpg"
 coverImageAlt: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants Ignore"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants..."
-seoDescription: "## Facts  Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and..."
+seoDescription: "Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants Ignore"
 slug: "bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore"
-excerpt: "## Facts  Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive"
+excerpt: "Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and fiscal framework that diverges sharply from what foreign residents typically expect. Under Indonesian tax law, rental income derive"
 coverImage: "/static/news/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore.jpg"
 cardImage: "/static/news/bali-long-term-rentals-the-tax-traps-landlords-and-tenants-ignore_card.jpg"
 coverImageAlt: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants Ignore"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Long-Term Rentals: The Tax Traps Landlords and Tenants..."
-seoDescription: "## Facts  Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and..."
+seoDescription: "Bali's long-term rental market — villas, apartments, and landed houses leased for six months to thirty years — operates within a legal and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-targets-influencers-and-tourists-bartering-stays-for-content.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-targets-influencers-and-tourists-bartering-stays-for-content.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Targets Influencers and Tourists Bartering Stays for Content"
 slug: "bali-targets-influencers-and-tourists-bartering-stays-for-content"
-excerpt: "## Facts  Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s"
+excerpt: "Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s"
 coverImage: "/static/news/visa_20260518_172522_2592375e_cover.png"
 coverImageAlt: "Bali Targets Influencers and Tourists Bartering Stays for Content"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Targets Influencers and Tourists Bartering Stays for..."
-seoDescription: "## Facts  Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the..."
+seoDescription: "Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-targets-influencers-and-tourists-bartering-stays-for-content.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-targets-influencers-and-tourists-bartering-stays-for-content.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Targets Influencers and Tourists Bartering Stays for Content"
 slug: "bali-targets-influencers-and-tourists-bartering-stays-for-content"
-excerpt: "## Facts  Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s"
+excerpt: "Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s"
 coverImage: "/static/news/visa_20260518_172522_2592375e_cover.png"
 coverImageAlt: "Bali Targets Influencers and Tourists Bartering Stays for Content"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Targets Influencers and Tourists Bartering Stays for..."
-seoDescription: "## Facts  Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the..."
+seoDescription: "Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-targets-influencers-and-tourists-bartering-stays-for-content.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-targets-influencers-and-tourists-bartering-stays-for-content.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Bali Targets Influencers and Tourists Bartering Stays for Content"
 slug: "bali-targets-influencers-and-tourists-bartering-stays-for-content"
-excerpt: "## Facts  Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s"
+excerpt: "Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the island's hospitality and lifestyle economy: foreign nationals on visitor visas accepting complimentary accommodation, meals, s"
 coverImage: "/static/news/visa_20260518_172522_2592375e_cover.png"
 coverImageAlt: "Bali Targets Influencers and Tourists Bartering Stays for Content"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali Targets Influencers and Tourists Bartering Stays for..."
-seoDescription: "## Facts  Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the..."
+seoDescription: "Indonesian immigration authorities in Bali have moved to enforce existing visa regulations against a practice that has become widespread in the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-to-screen-tourist-bank-balances-and-activity-history-from-2026.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-to-screen-tourist-bank-balances-and-activity-history-from-2026.id.mdx
@@ -119,22 +119,12 @@ description: "# Panduan Investasi di Indonesia untuk Investor Asing
   keuangan. Investor asing disarankan untuk berkonsultasi dengan profesional yang
   berkualifikasi sebelum membuat keputusan investasi."
 difficulty: intermediate
-excerpt: "## Facts
-
-  Bali's regional government is moving forward with plans to introduce pre-arrival
-  vetting of foreign tourists, including checks on bank balances and prior activity
-  records, with implementation targeted for 2026. The initiative is part of a broader
-  effort by Balinese auth"
+excerpt: "Bali's regional government is moving forward with plans to introduce pre-arrival vetting of foreign tourists, including checks on bank balances and prior activity records, with implementation targeted for 2026. The initiative is part of a broader effort by Balinese auth"
 featured: false
 lang: id
 publishedAt: "2026-03-28"
 readingTime: 3
-seoDescription: "## Facts
-
-  Bali's regional government is moving forward with plans to introduce pre-arrival
-  vetting of foreign tourists, including checks on bank balances and prior activity
-  records, with implementation targeted for 2026. The initiative is part of a broader
-  effort by Balinese auth"
+seoDescription: "Bali's regional government is moving forward with plans to introduce pre-arrival vetting of foreign tourists, including checks on bank balances and prior activity records, with implementation targeted for 2026. The initiative is part of a broader effort by Balinese auth"
 seoTitle: Bali to Screen Tourist Bank Balances and Activity History From 2026
 slug: bali-to-screen-tourist-bank-balances-and-activity-history-from-2026
 tags:

--- a/apps/mouth/src/content/articles/tax-legal/bali-to-screen-tourist-bank-balances-and-activity-history-from-2026.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-to-screen-tourist-bank-balances-and-activity-history-from-2026.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali to Screen Tourist Bank Balances and Activity History..."
-seoDescription: "## Facts  Bali's regional government is moving forward with plans to introduce pre-arrival vetting of foreign tourists, including checks on bank balances..."
+seoDescription: "Bali's regional government is moving forward with plans to introduce pre-arrival vetting of foreign tourists, including checks on bank balances..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/bali-to-screen-tourist-bank-balances-and-activity-history-from-2026.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/bali-to-screen-tourist-bank-balances-and-activity-history-from-2026.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Bali to Screen Tourist Bank Balances and Activity History..."
-seoDescription: "## Facts  Bali's regional government is moving forward with plans to introduce pre-arrival vetting of foreign tourists, including checks on bank balances..."
+seoDescription: "Bali's regional government is moving forward with plans to introduce pre-arrival vetting of foreign tourists, including checks on bank balances..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/digital-nomads-in-bali-face-2026-insurance-blind-spots.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/digital-nomads-in-bali-face-2026-insurance-blind-spots.id.mdx
@@ -120,22 +120,12 @@ description: "# Panduan Pendirian PT PMA di Indonesia
 
   **Disclaimer:** Panduan ini bersifat informatif dan tidak mengikat secara hukum."
 difficulty: intermediate
-excerpt: "## Facts
-
-  Digital nomads and freelancers living and working from Bali occupy an increasingly
-  scrutinised legal and financial grey zone. As Indonesia's Directorate General of
-  Immigration enforces the boundaries of its visa categories more rigorously in 2026,
-  the insurance products"
+excerpt: "Digital nomads and freelancers living and working from Bali occupy an increasingly scrutinised legal and financial grey zone. As Indonesia's Directorate General of Immigration enforces the boundaries of its visa categories more rigorously in 2026, the insurance products"
 featured: false
 lang: id
 publishedAt: "2026-03-28"
 readingTime: 3
-seoDescription: "## Facts
-
-  Digital nomads and freelancers living and working from Bali occupy an increasingly
-  scrutinised legal and financial grey zone. As Indonesia's Directorate General of
-  Immigration enforces the boundaries of its visa categories more rigorously in 2026,
-  the insurance products"
+seoDescription: "Digital nomads and freelancers living and working from Bali occupy an increasingly scrutinised legal and financial grey zone. As Indonesia's Directorate General of Immigration enforces the boundaries of its visa categories more rigorously in 2026, the insurance products"
 seoTitle: Digital Nomads in Bali Face 2026 Insurance Blind Spots
 slug: digital-nomads-in-bali-face-2026-insurance-blind-spots
 tags:

--- a/apps/mouth/src/content/articles/tax-legal/digital-nomads-in-bali-face-2026-insurance-blind-spots.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/digital-nomads-in-bali-face-2026-insurance-blind-spots.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Digital Nomads in Bali Face 2026 Insurance Blind Spots"
-seoDescription: "## Facts  Digital nomads and freelancers living and working from Bali occupy an increasingly scrutinised legal and financial grey zone. As Indonesia's..."
+seoDescription: "Digital nomads and freelancers living and working from Bali occupy an increasingly scrutinised legal and financial grey zone. As Indonesia's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/digital-nomads-in-bali-face-2026-insurance-blind-spots.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/digital-nomads-in-bali-face-2026-insurance-blind-spots.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Digital Nomads in Bali Face 2026 Insurance Blind Spots"
-seoDescription: "## Facts  Digital nomads and freelancers living and working from Bali occupy an increasingly scrutinised legal and financial grey zone. As Indonesia's..."
+seoDescription: "Digital nomads and freelancers living and working from Bali occupy an increasingly scrutinised legal and financial grey zone. As Indonesia's..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
 slug: "etsy-flips-the-switch-new-seller-rules-take-effect-july-9"
-excerpt: "## Facts  Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem"
+excerpt: "Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem"
 coverImage: "/static/news/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.jpg"
 cardImage: "/static/news/etsy-flips-the-switch-new-seller-rules-take-effect-july-9_card.jpg"
 coverImageAlt: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
-seoDescription: "## Facts  Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes..."
+seoDescription: "Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
 slug: "etsy-flips-the-switch-new-seller-rules-take-effect-july-9"
-excerpt: "## Facts  Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem"
+excerpt: "Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem"
 coverImage: "/static/news/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.jpg"
 cardImage: "/static/news/etsy-flips-the-switch-new-seller-rules-take-effect-july-9_card.jpg"
 coverImageAlt: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
-seoDescription: "## Facts  Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes..."
+seoDescription: "Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
 slug: "etsy-flips-the-switch-new-seller-rules-take-effect-july-9"
-excerpt: "## Facts  Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem"
+excerpt: "Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes were flagged in advance through the platform's seller communications and are understood to affect identity verification requirem"
 coverImage: "/static/news/etsy-flips-the-switch-new-seller-rules-take-effect-july-9.jpg"
 cardImage: "/static/news/etsy-flips-the-switch-new-seller-rules-take-effect-july-9_card.jpg"
 coverImageAlt: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Etsy Flips the Switch: New Seller Rules Take Effect July 9"
-seoDescription: "## Facts  Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes..."
+seoDescription: "Etsy, the global marketplace for handmade and vintage goods, rolled out a revised seller policy framework effective July 9, 2026. The changes..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign Employers in Indonesia Now Must Navigate BPJS Compliance Rules"
 slug: "foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules"
-excerpt: "## Facts  Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a"
+excerpt: "Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a"
 coverImage: "/static/news/news_20260423_112324_7acd0df3_cover.png"
 coverImageAlt: "Foreign Employers in Indonesia Now Must Navigate BPJS Compliance Rules"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign Employers in Indonesia Now Must Navigate BPJS..."
-seoDescription: "## Facts  Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK),..."
+seoDescription: "Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK),..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign Employers in Indonesia Now Must Navigate BPJS Compliance Rules"
 slug: "foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules"
-excerpt: "## Facts  Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a"
+excerpt: "Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a"
 coverImage: "/static/news/news_20260423_112324_7acd0df3_cover.png"
 coverImageAlt: "Foreign Employers in Indonesia Now Must Navigate BPJS Compliance Rules"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign Employers in Indonesia Now Must Navigate BPJS..."
-seoDescription: "## Facts  Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK),..."
+seoDescription: "Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK),..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Foreign Employers in Indonesia Now Must Navigate BPJS Compliance Rules"
 slug: "foreign-employers-in-indonesia-now-must-navigate-bpjs-compliance-rules"
-excerpt: "## Facts  Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a"
+excerpt: "Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK), death benefit (JKM), old-age savings (JHT), and pension (JP); and BPJS Kesehatan, which provides national health coverage. Both a"
 coverImage: "/static/news/news_20260423_112324_7acd0df3_cover.png"
 coverImageAlt: "Foreign Employers in Indonesia Now Must Navigate BPJS Compliance Rules"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Foreign Employers in Indonesia Now Must Navigate BPJS..."
-seoDescription: "## Facts  Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK),..."
+seoDescription: "Indonesia's social security framework is administered by two state bodies: BPJS Ketenagakerjaan, which covers work accident insurance (JKK),..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/imf-pushes-for-higher-income-taxes-as-indonesia-holds-the-line.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/imf-pushes-for-higher-income-taxes-as-indonesia-holds-the-line.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "IMF Pushes for Higher Income Taxes as Indonesia Holds the..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does IMF Pushes for Higher Income...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/tax-legal/imf-pushes-for-higher-income-taxes-as-indonesia-holds-the-line.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/imf-pushes-for-higher-income-taxes-as-indonesia-holds-the-line.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "IMF Pushes for Higher Income Taxes as Indonesia Holds the..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does IMF Pushes for Higher Income...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa Is for Investors"
 slug: "indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors"
-excerpt: "## Facts  Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an"
+excerpt: "Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an"
 coverImage: "/static/news/visa_20260408_173214_15a3b221.png"
 coverImageAlt: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa Is for Investors"
 category: "tax-legal"

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa Is for Investors"
 slug: "indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors"
-excerpt: "## Facts  Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an"
+excerpt: "Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an"
 coverImage: "/static/news/visa_20260408_173214_15a3b221.png"
 coverImageAlt: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa Is for Investors"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa..."
-seoDescription: "## Facts  Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026..."
+seoDescription: "Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa Is for Investors"
 slug: "indonesia-draws-the-line-gci-is-for-diaspora-golden-visa-is-for-investors"
-excerpt: "## Facts  Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an"
+excerpt: "Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026 distinguishing between two long-term residency programs that have generated widespread confusion: the Global Citizen of Indonesia (GCI) an"
 coverImage: "/static/news/visa_20260408_173214_15a3b221.png"
 coverImageAlt: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa Is for Investors"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Draws the Line: GCI Is for Diaspora, Golden Visa..."
-seoDescription: "## Facts  Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026..."
+seoDescription: "Indonesia's Ministry of Immigration and Correctional Services, known as Kemenimipas, issued an official clarification in early 2026..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-eyes-mandatory-wfh-to-slash-fuel-imports-and-emissions.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-eyes-mandatory-wfh-to-slash-fuel-imports-and-emissions.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Mandatory WFH to Slash Fuel Imports and..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Eyes Mandatory WFH...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-eyes-mandatory-wfh-to-slash-fuel-imports-and-emissions.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-eyes-mandatory-wfh-to-slash-fuel-imports-and-emissions.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Eyes Mandatory WFH to Slash Fuel Imports and..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Eyes Mandatory WFH...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Formalizes Marketplace Tax Collection via PMK 37/2025"
 slug: "indonesia-formalizes-marketplace-tax-collection-via-pmk-372025"
-excerpt: "## Facts  Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho"
+excerpt: "Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho"
 coverImage: "/static/news/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.jpg"
 cardImage: "/static/news/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025_card.jpg"
 coverImageAlt: "Indonesia Formalizes Marketplace Tax Collection via PMK 37/2025"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Formalizes Marketplace Tax Collection via PMK..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 —..."
+seoDescription: "Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Formalizes Marketplace Tax Collection via PMK 37/2025"
 slug: "indonesia-formalizes-marketplace-tax-collection-via-pmk-372025"
-excerpt: "## Facts  Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho"
+excerpt: "Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho"
 coverImage: "/static/news/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.jpg"
 cardImage: "/static/news/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025_card.jpg"
 coverImageAlt: "Indonesia Formalizes Marketplace Tax Collection via PMK 37/2025"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Formalizes Marketplace Tax Collection via PMK..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 —..."
+seoDescription: "Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Formalizes Marketplace Tax Collection via PMK 37/2025"
 slug: "indonesia-formalizes-marketplace-tax-collection-via-pmk-372025"
-excerpt: "## Facts  Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho"
+excerpt: "Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 — Peraturan Menteri Keuangan Number 37 of 2025 — represents the Ministry of Finance's latest codification of rules governing ho"
 coverImage: "/static/news/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025.jpg"
 cardImage: "/static/news/indonesia-formalizes-marketplace-tax-collection-via-pmk-372025_card.jpg"
 coverImageAlt: "Indonesia Formalizes Marketplace Tax Collection via PMK 37/2025"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Formalizes Marketplace Tax Collection via PMK..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 —..."
+seoDescription: "Indonesia's Directorate General of Taxation (DJP) has long sought to close the tax gap in the rapidly expanding e-commerce sector. PMK 37/2025 —..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting Rules Formalized"
 slug: "indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest"
+excerpt: "Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest"
 coverImage: "/static/news/news_20260514_173848_b5ae7867_cover.png"
 coverImageAlt: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting Rules Formalized"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and..."
+seoDescription: "Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting Rules Formalized"
 slug: "indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest"
+excerpt: "Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest"
 coverImage: "/static/news/news_20260514_173848_b5ae7867_cover.png"
 coverImageAlt: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting Rules Formalized"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and..."
+seoDescription: "Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting Rules Formalized"
 slug: "indonesia-issues-per-62026-global-minimum-tax-reporting-rules-formalized"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest"
+excerpt: "Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and procedural requirements for reporting under Indonesia's Global Minimum Tax framework. The regulation operationalizes Indonesia's domest"
 coverImage: "/static/news/news_20260514_173848_b5ae7867_cover.png"
 coverImageAlt: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting Rules Formalized"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Issues PER-6/2026: Global Minimum Tax Reporting..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and..."
+seoDescription: "Indonesia's Directorate General of Taxes (DJP) has published PER-6/2026, a peraturan direktur jenderal that sets out the technical and..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-makes-nib-mandatory-for-content-creators.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-makes-nib-mandatory-for-content-creators.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Makes NIB Mandatory for Content Creators"
 slug: "indonesia-makes-nib-mandatory-for-content-creators"
-excerpt: "## Facts  Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num"
+excerpt: "Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num"
 coverImage: "/static/news/indonesia-makes-nib-mandatory-for-content-creators.jpg"
 cardImage: "/static/news/indonesia-makes-nib-mandatory-for-content-creators_card.jpg"
 coverImageAlt: "Indonesia Makes NIB Mandatory for Content Creators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Makes NIB Mandatory for Content Creators"
-seoDescription: "## Facts  Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the..."
+seoDescription: "Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-makes-nib-mandatory-for-content-creators.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-makes-nib-mandatory-for-content-creators.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Makes NIB Mandatory for Content Creators"
 slug: "indonesia-makes-nib-mandatory-for-content-creators"
-excerpt: "## Facts  Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num"
+excerpt: "Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num"
 coverImage: "/static/news/indonesia-makes-nib-mandatory-for-content-creators.jpg"
 cardImage: "/static/news/indonesia-makes-nib-mandatory-for-content-creators_card.jpg"
 coverImageAlt: "Indonesia Makes NIB Mandatory for Content Creators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Makes NIB Mandatory for Content Creators"
-seoDescription: "## Facts  Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the..."
+seoDescription: "Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-makes-nib-mandatory-for-content-creators.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-makes-nib-mandatory-for-content-creators.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Makes NIB Mandatory for Content Creators"
 slug: "indonesia-makes-nib-mandatory-for-content-creators"
-excerpt: "## Facts  Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num"
+excerpt: "Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the government's single-window business licensing portal. An NIB, or Nomor Induk Berusaha, is the unique business identification num"
 coverImage: "/static/news/indonesia-makes-nib-mandatory-for-content-creators.jpg"
 cardImage: "/static/news/indonesia-makes-nib-mandatory-for-content-creators_card.jpg"
 coverImageAlt: "Indonesia Makes NIB Mandatory for Content Creators"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Makes NIB Mandatory for Content Creators"
-seoDescription: "## Facts  Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the..."
+seoDescription: "Indonesia is moving to formalize the content creator economy by mandating registration through the Online Single Submission (OSS) system, the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Authority Settles CV Debate: 22% Corporate Rate Is Final"
 slug: "indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final"
-excerpt: "## Facts  Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H"
+excerpt: "Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H"
 coverImage: "/static/news/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.jpg"
 cardImage: "/static/news/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final_card.jpg"
 coverImageAlt: "Indonesia Tax Authority Settles CV Debate: 22% Corporate Rate Is Final"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Authority Settles CV Debate: 22% Corporate..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited..."
+seoDescription: "Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Authority Settles CV Debate: 22% Corporate Rate Is Final"
 slug: "indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final"
-excerpt: "## Facts  Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H"
+excerpt: "Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H"
 coverImage: "/static/news/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.jpg"
 cardImage: "/static/news/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final_card.jpg"
 coverImageAlt: "Indonesia Tax Authority Settles CV Debate: 22% Corporate Rate Is Final"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Authority Settles CV Debate: 22% Corporate..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited..."
+seoDescription: "Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Authority Settles CV Debate: 22% Corporate Rate Is Final"
 slug: "indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final"
-excerpt: "## Facts  Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H"
+excerpt: "Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited partnerships — known locally as CVs, short for Commanditaire Vennootschap — are to be taxed following the implementation of the Tax H"
 coverImage: "/static/news/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final.jpg"
 cardImage: "/static/news/indonesia-tax-authority-settles-cv-debate-22-corporate-rate-is-final_card.jpg"
 coverImageAlt: "Indonesia Tax Authority Settles CV Debate: 22% Corporate Rate Is Final"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Authority Settles CV Debate: 22% Corporate..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited..."
+seoDescription: "Indonesia's Directorate General of Taxation (DJP) has moved to quell widespread confusion by issuing a formal explanation of how limited..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Authority to Audit Tax Amnesty II Participants Hiding Assets"
 slug: "indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to"
+excerpt: "Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to"
 coverImage: "/static/news/news_20260512_175200_f3710f17_cover.png"
 coverImageAlt: "Indonesia Tax Authority to Audit Tax Amnesty II Participants Hiding Assets"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Authority to Audit Tax Amnesty II..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting..."
+seoDescription: "Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Authority to Audit Tax Amnesty II Participants Hiding Assets"
 slug: "indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to"
+excerpt: "Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to"
 coverImage: "/static/news/news_20260512_175200_f3710f17_cover.png"
 coverImageAlt: "Indonesia Tax Authority to Audit Tax Amnesty II Participants Hiding Assets"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Authority to Audit Tax Amnesty II..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting..."
+seoDescription: "Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Authority to Audit Tax Amnesty II Participants Hiding Assets"
 slug: "indonesia-tax-authority-to-audit-tax-amnesty-ii-participants-hiding-assets"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to"
+excerpt: "Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting participants of the country's second Tax Amnesty program — formally known as Program Pengungkapan Sukarela (PPS) — who are believed to"
 coverImage: "/static/news/news_20260512_175200_f3710f17_cover.png"
 coverImageAlt: "Indonesia Tax Authority to Audit Tax Amnesty II Participants Hiding Assets"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Authority to Audit Tax Amnesty II..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting..."
+seoDescription: "Indonesia's Directorate General of Taxes (DJP), operating under the Ministry of Finance, has signaled a new enforcement phase targeting..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT Deadlines in Focus"
 slug: "indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus"
-excerpt: "## Facts  Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks.  On tax revenue performance, t"
+excerpt: "Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks. On tax revenue performance, t"
 coverImage: "/static/news/news_20260506_173144_c2aacc80_cover.png"
 coverImageAlt: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT Deadlines in Focus"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT..."
-seoDescription: "## Facts  Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of..."
+seoDescription: "Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT Deadlines in Focus"
 slug: "indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus"
-excerpt: "## Facts  Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks.  On tax revenue performance, t"
+excerpt: "Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks. On tax revenue performance, t"
 coverImage: "/static/news/news_20260506_173144_c2aacc80_cover.png"
 coverImageAlt: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT Deadlines in Focus"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT..."
-seoDescription: "## Facts  Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of..."
+seoDescription: "Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT Deadlines in Focus"
 slug: "indonesia-tax-recap-digital-levy-wealth-tax-spt-deadlines-in-focus"
-excerpt: "## Facts  Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks.  On tax revenue performance, t"
+excerpt: "Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of May 4, 2026, aggregating key developments across several major policy and administrative tracks. On tax revenue performance, t"
 coverImage: "/static/news/news_20260506_173144_c2aacc80_cover.png"
 coverImageAlt: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT Deadlines in Focus"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tax Recap: Digital Levy, Wealth Tax & SPT..."
-seoDescription: "## Facts  Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of..."
+seoDescription: "Indonesia's tax authority, the Directorate General of Taxes (Direktorat Jenderal Pajak, DJP), published its weekly tax summary for the week of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-tax-net-around-e-marketplace-sellers.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-tax-net-around-e-marketplace-sellers.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
 slug: "indonesia-tightens-tax-net-around-e-marketplace-sellers"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close"
 coverImage: "/static/news/indonesia-tightens-tax-net-around-e-marketplace-sellers.jpg"
 cardImage: "/static/news/indonesia-tightens-tax-net-around-e-marketplace-sellers_card.jpg"
 coverImageAlt: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-tax-net-around-e-marketplace-sellers.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-tax-net-around-e-marketplace-sellers.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
 slug: "indonesia-tightens-tax-net-around-e-marketplace-sellers"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close"
 coverImage: "/static/news/indonesia-tightens-tax-net-around-e-marketplace-sellers.jpg"
 cardImage: "/static/news/indonesia-tightens-tax-net-around-e-marketplace-sellers_card.jpg"
 coverImageAlt: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-tax-net-around-e-marketplace-sellers.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-tax-net-around-e-marketplace-sellers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
 slug: "indonesia-tightens-tax-net-around-e-marketplace-sellers"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to capture economic activity flowing through e-marketplace platforms. The initiative reflects a broader government mandate to close"
 coverImage: "/static/news/indonesia-tightens-tax-net-around-e-marketplace-sellers.jpg"
 cardImage: "/static/news/indonesia-tightens-tax-net-around-e-marketplace-sellers_card.jpg"
 coverImageAlt: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Tax Net Around E-Marketplace Sellers"
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has been systematically expanding its digital tax infrastructure to..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.id.mdx
@@ -98,17 +98,11 @@ description: '# Panduan Memulai Bisnis di Indonesia untuk Investor Asing
 
   **Disclaimer:** Panduan ini bersifat umum dan bukan merupakan nasihat hukum.'
 difficulty: intermediate
-excerpt: '## Facts
-
-  Indonesia''s immigration authority has signaled a continued tightening of entry
-  and stay conditions for foreign nationals, with Bali remaining the focal point of
-  enforcement activity. While the specific content of the article was unavailable,
-  the headline — referencing '''
+excerpt: "Indonesia''s immigration authority has signaled a continued tightening of entry and stay conditions for foreign nationals, with Bali remaining the focal point of enforcement activity. While the specific content of the article was unavailable, the headline — referencing"
 featured: false
 lang: id
 publishedAt: '2026-03-20'
 readingTime: 3
-seoDescription: '## Facts'
 seoTitle: 'Indonesia Tightens Visa Rules for Bali Visitors: What''s Changed'
 slug: indonesia-tightens-visa-rules-for-bali-visitors-whats-changed
 tags:

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.it.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Visa Rules for Bali Visitors: What's..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Tightens Visa...'
 locale: "it"
 ---
 

--- a/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesia-tightens-visa-rules-for-bali-visitors-whats-changed.mdx
@@ -15,7 +15,6 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia Tightens Visa Rules for Bali Visitors: What's..."
-seoDescription: '## Facts aiGenerated: true aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: "## Facts   primaryQuestion: "What does Indonesia Tightens Visa...'
 ---
 
 ## TL;DR

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 15% Global Minimum Tax: The End of the Tax Holiday Era?"
 slug: "indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era"
-excerpt: "## Facts  The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi"
+excerpt: "The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi"
 coverImage: "/static/news/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.jpg"
 cardImage: "/static/news/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era_card.jpg"
 coverImageAlt: "Indonesia's 15% Global Minimum Tax: The End of the Tax Holiday Era?"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's 15% Global Minimum Tax: The End of the Tax..."
-seoDescription: "## Facts  The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global..."
+seoDescription: "The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 15% Global Minimum Tax: The End of the Tax Holiday Era?"
 slug: "indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era"
-excerpt: "## Facts  The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi"
+excerpt: "The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi"
 coverImage: "/static/news/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.jpg"
 cardImage: "/static/news/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era_card.jpg"
 coverImageAlt: "Indonesia's 15% Global Minimum Tax: The End of the Tax Holiday Era?"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's 15% Global Minimum Tax: The End of the Tax..."
-seoDescription: "## Facts  The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global..."
+seoDescription: "The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's 15% Global Minimum Tax: The End of the Tax Holiday Era?"
 slug: "indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era"
-excerpt: "## Facts  The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi"
+excerpt: "The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global minimum effective corporate tax rate of 15% for multinational enterprises with annual consolidated revenues of at least €750 mi"
 coverImage: "/static/news/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era.jpg"
 cardImage: "/static/news/indonesias-15-global-minimum-tax-the-end-of-the-tax-holiday-era_card.jpg"
 coverImageAlt: "Indonesia's 15% Global Minimum Tax: The End of the Tax Holiday Era?"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's 15% Global Minimum Tax: The End of the Tax..."
-seoDescription: "## Facts  The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global..."
+seoDescription: "The OECD/G20 Inclusive Framework's Pillar Two initiative — formally known as the Global Anti-Base Erosion (GloBE) Rules — establishes a global..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs: What Expats Missed"
 slug: "indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed"
-excerpt: "## Facts  Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p"
+excerpt: "Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p"
 coverImage: "/static/news/visa_20260507_174145_61e8f759_cover.png"
 coverImageAlt: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs: What Expats Missed"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs:..."
-seoDescription: "## Facts  Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities..."
+seoDescription: "Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs: What Expats Missed"
 slug: "indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed"
-excerpt: "## Facts  Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p"
+excerpt: "Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p"
 coverImage: "/static/news/visa_20260507_174145_61e8f759_cover.png"
 coverImageAlt: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs: What Expats Missed"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs:..."
-seoDescription: "## Facts  Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities..."
+seoDescription: "Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs: What Expats Missed"
 slug: "indonesias-april-tax-deadline-solar-policy-digital-ids-what-expats-missed"
-excerpt: "## Facts  Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p"
+excerpt: "Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities given until April 30. For the foreign community in Bali and across Indonesia, this period consistently generates confusion — p"
 coverImage: "/static/news/visa_20260507_174145_61e8f759_cover.png"
 coverImageAlt: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs: What Expats Missed"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's April Tax Deadline, Solar Policy & Digital IDs:..."
-seoDescription: "## Facts  Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities..."
+seoDescription: "Indonesia's annual individual income tax return (SPT Tahunan) deadline falls on March 31 for most individual taxpayers, with corporate entities..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Financial Center Bill Proposes VAT and Luxury Tax Breaks"
 slug: "indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks"
-excerpt: "## Facts  Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is"
+excerpt: "Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is"
 coverImage: "/static/news/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.jpg"
 cardImage: "/static/news/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks_card.jpg"
 coverImageAlt: "Indonesia's Financial Center Bill Proposes VAT and Luxury Tax Breaks"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Financial Center Bill Proposes VAT and Luxury..."
-seoDescription: "## Facts  Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with..."
+seoDescription: "Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Financial Center Bill Proposes VAT and Luxury Tax Breaks"
 slug: "indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks"
-excerpt: "## Facts  Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is"
+excerpt: "Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is"
 coverImage: "/static/news/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.jpg"
 cardImage: "/static/news/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks_card.jpg"
 coverImageAlt: "Indonesia's Financial Center Bill Proposes VAT and Luxury Tax Breaks"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Financial Center Bill Proposes VAT and Luxury..."
-seoDescription: "## Facts  Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with..."
+seoDescription: "Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Financial Center Bill Proposes VAT and Luxury Tax Breaks"
 slug: "indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks"
-excerpt: "## Facts  Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is"
+excerpt: "Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with Singapore's MAS-regulated hub and Malaysia's Labuan IBFC. The draft law, circulating under the label RUU Financial Center, is"
 coverImage: "/static/news/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks.jpg"
 cardImage: "/static/news/indonesias-financial-center-bill-proposes-vat-and-luxury-tax-breaks_card.jpg"
 coverImageAlt: "Indonesia's Financial Center Bill Proposes VAT and Luxury Tax Breaks"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Financial Center Bill Proposes VAT and Luxury..."
-seoDescription: "## Facts  Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with..."
+seoDescription: "Indonesia has been advancing legislation to establish a dedicated financial center — a special-purpose zone designed to compete regionally with..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-free-meals-program-may-be-costing-the-treasury-billions.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-free-meals-program-may-be-costing-the-treasury-billions.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Free Meals Program May Be Costing the Treasury Billions"
 slug: "indonesias-free-meals-program-may-be-costing-the-treasury-billions"
-excerpt: "## Facts  Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta"
+excerpt: "Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta"
 coverImage: "/static/news/indonesias-free-meals-program-may-be-costing-the-treasury-billions.jpg"
 cardImage: "/static/news/indonesias-free-meals-program-may-be-costing-the-treasury-billions_card.jpg"
 coverImageAlt: "Indonesia's Free Meals Program May Be Costing the Treasury Billions"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Free Meals Program May Be Costing the Treasury..."
-seoDescription: "## Facts  Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint..."
+seoDescription: "Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-free-meals-program-may-be-costing-the-treasury-billions.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-free-meals-program-may-be-costing-the-treasury-billions.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Free Meals Program May Be Costing the Treasury Billions"
 slug: "indonesias-free-meals-program-may-be-costing-the-treasury-billions"
-excerpt: "## Facts  Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta"
+excerpt: "Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta"
 coverImage: "/static/news/indonesias-free-meals-program-may-be-costing-the-treasury-billions.jpg"
 cardImage: "/static/news/indonesias-free-meals-program-may-be-costing-the-treasury-billions_card.jpg"
 coverImageAlt: "Indonesia's Free Meals Program May Be Costing the Treasury Billions"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Free Meals Program May Be Costing the Treasury..."
-seoDescription: "## Facts  Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint..."
+seoDescription: "Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-free-meals-program-may-be-costing-the-treasury-billions.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-free-meals-program-may-be-costing-the-treasury-billions.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Free Meals Program May Be Costing the Treasury Billions"
 slug: "indonesias-free-meals-program-may-be-costing-the-treasury-billions"
-excerpt: "## Facts  Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta"
+excerpt: "Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint in the country's tax policy debate. Critics and lawmakers are raising alarms that the program's rollout may be eroding state ta"
 coverImage: "/static/news/indonesias-free-meals-program-may-be-costing-the-treasury-billions.jpg"
 cardImage: "/static/news/indonesias-free-meals-program-may-be-costing-the-treasury-billions_card.jpg"
 coverImageAlt: "Indonesia's Free Meals Program May Be Costing the Treasury Billions"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Free Meals Program May Be Costing the Treasury..."
-seoDescription: "## Facts  Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint..."
+seoDescription: "Indonesia's Makan Bergizi Gratis (MBG) program — the signature policy of President Prabowo Subianto's administration — has become a flashpoint..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-new-anti-treaty-shopping-rules-tighten-the-grip-on-tax-benefits.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-new-anti-treaty-shopping-rules-tighten-the-grip-on-tax-benefits.id.mdx
@@ -86,22 +86,12 @@ description: "# Panduan Investasi Asing di Indonesia
 
   *   [Website OSS](https://oss.go.id/) – Platform untuk pengajuan perizinan usaha."
 difficulty: intermediate
-excerpt: "## Facts
-
-  Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal
-  Purpose Test (PPT) as part of Indonesia's domestic anti-abuse framework for tax
-  treaties. The PPT is one of the minimum standards introduced under the OECD/G20
-  Base Erosion and Profit Shift"
+excerpt: "Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal Purpose Test (PPT) as part of Indonesia's domestic anti-abuse framework for tax treaties. The PPT is one of the minimum standards introduced under the OECD/G20 Base Erosion and Profit Shift"
 featured: false
 lang: id
 publishedAt: "2026-03-28"
 readingTime: 3
-seoDescription: "## Facts
-
-  Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal
-  Purpose Test (PPT) as part of Indonesia's domestic anti-abuse framework for tax
-  treaties. The PPT is one of the minimum standards introduced under the OECD/G20
-  Base Erosion and Profit Shift"
+seoDescription: "Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal Purpose Test (PPT) as part of Indonesia's domestic anti-abuse framework for tax treaties. The PPT is one of the minimum standards introduced under the OECD/G20 Base Erosion and Profit Shift"
 seoTitle: Indonesia's New Anti-Treaty-Shopping Rules Tighten the Grip on Tax Benefits
 slug: indonesias-new-anti-treaty-shopping-rules-tighten-the-grip-on-tax-benefits
 tags:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-new-anti-treaty-shopping-rules-tighten-the-grip-on-tax-benefits.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-new-anti-treaty-shopping-rules-tighten-the-grip-on-tax-benefits.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's New Anti-Treaty-Shopping Rules Tighten the Grip..."
-seoDescription: "## Facts  Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal Purpose Test (PPT) as part of Indonesia's domestic anti-abuse..."
+seoDescription: "Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal Purpose Test (PPT) as part of Indonesia's domestic anti-abuse..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-new-anti-treaty-shopping-rules-tighten-the-grip-on-tax-benefits.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-new-anti-treaty-shopping-rules-tighten-the-grip-on-tax-benefits.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's New Anti-Treaty-Shopping Rules Tighten the Grip..."
-seoDescription: "## Facts  Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal Purpose Test (PPT) as part of Indonesia's domestic anti-abuse..."
+seoDescription: "Indonesia's Ministry of Finance regulation PMK 112/2025 formalises the Principal Purpose Test (PPT) as part of Indonesia's domestic anti-abuse..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Parliament Presses Bali Immigration to Tighten Foreign Nationals Oversight"
 slug: "indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight"
-excerpt: "## Facts  Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi"
+excerpt: "Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi"
 coverImage: "/static/news/visa_20260515_174622_6203bf6c_cover.png"
 coverImageAlt: "Indonesia's Parliament Presses Bali Immigration to Tighten Foreign Nationals Oversight"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Parliament Presses Bali Immigration to Tighten..."
-seoDescription: "## Facts  Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign..."
+seoDescription: "Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Parliament Presses Bali Immigration to Tighten Foreign Nationals Oversight"
 slug: "indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight"
-excerpt: "## Facts  Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi"
+excerpt: "Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi"
 coverImage: "/static/news/visa_20260515_174622_6203bf6c_cover.png"
 coverImageAlt: "Indonesia's Parliament Presses Bali Immigration to Tighten Foreign Nationals Oversight"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Parliament Presses Bali Immigration to Tighten..."
-seoDescription: "## Facts  Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign..."
+seoDescription: "Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Parliament Presses Bali Immigration to Tighten Foreign Nationals Oversight"
 slug: "indonesias-parliament-presses-bali-immigration-to-tighten-foreign-nationals-oversight"
-excerpt: "## Facts  Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi"
+excerpt: "Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign nationals (WNA — Warga Negara Asing) across the island. The parliamentary intervention reflects growing concern at the national legi"
 coverImage: "/static/news/visa_20260515_174622_6203bf6c_cover.png"
 coverImageAlt: "Indonesia's Parliament Presses Bali Immigration to Tighten Foreign Nationals Oversight"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Parliament Presses Bali Immigration to Tighten..."
-seoDescription: "## Facts  Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign..."
+seoDescription: "Indonesia's House of Representatives has formally urged Bali's Directorate General of Immigration to intensify its supervision of foreign..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in South Jakarta Region from July 2026"
 slug: "indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The"
 coverImage: "/static/news/news_20260511_174234_f5bba7bb_cover.png"
 coverImageAlt: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in South Jakarta Region from July 2026"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in South Jakarta Region from July 2026"
 slug: "indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The"
 coverImage: "/static/news/news_20260511_174234_f5bba7bb_cover.png"
 coverImageAlt: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in South Jakarta Region from July 2026"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in South Jakarta Region from July 2026"
 slug: "indonesias-tax-authority-reshuffles-taxpayer-rolls-in-south-jakarta-region-from-july-2026"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the South Jakarta Regional Tax Office — known as Kanwil DJP Jakarta Selatan or Kanwil Jaksus — set to take effect on 1 July 2026. The"
 coverImage: "/static/news/news_20260511_174234_f5bba7bb_cover.png"
 coverImageAlt: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in South Jakarta Region from July 2026"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Authority Reshuffles Taxpayer Rolls in..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) has announced a reorganisation of taxpayer registration across the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Directorate Reveals 5 Rules That End the 0.5% UMKM Flat Tax Era"
 slug: "indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final"
+excerpt: "Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final"
 coverImage: "/static/news/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.jpg"
 cardImage: "/static/news/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era_card.jpg"
 coverImageAlt: "Indonesia's Tax Directorate Reveals 5 Rules That End the 0.5% UMKM Flat Tax Era"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Directorate Reveals 5 Rules That End the..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of..."
+seoDescription: "Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Directorate Reveals 5 Rules That End the 0.5% UMKM Flat Tax Era"
 slug: "indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final"
+excerpt: "Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final"
 coverImage: "/static/news/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.jpg"
 cardImage: "/static/news/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era_card.jpg"
 coverImageAlt: "Indonesia's Tax Directorate Reveals 5 Rules That End the 0.5% UMKM Flat Tax Era"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Directorate Reveals 5 Rules That End the..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of..."
+seoDescription: "Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Directorate Reveals 5 Rules That End the 0.5% UMKM Flat Tax Era"
 slug: "indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final"
+excerpt: "Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of 2026 (PP 20/2026), a regulation that amends the prior PP 55/2022 and reshapes who is eligible for the country's flat 0.5% final"
 coverImage: "/static/news/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era.jpg"
 cardImage: "/static/news/indonesias-tax-directorate-reveals-5-rules-that-end-the-05-umkm-flat-tax-era_card.jpg"
 coverImageAlt: "Indonesia's Tax Directorate Reveals 5 Rules That End the 0.5% UMKM Flat Tax Era"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Directorate Reveals 5 Rules That End the..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of..."
+seoDescription: "Indonesia's Directorate General of Taxes (Ditjen Pajak, or DJP) has publicly clarified five key provisions of Government Regulation No. 20 of..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance Needle"
 slug: "indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ"
 coverImage: "/static/news/visa_20260519_173933_630e74ce_cover.png"
 coverImageAlt: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance Needle"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance Needle"
 slug: "indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ"
 coverImage: "/static/news/visa_20260519_173933_630e74ce_cover.png"
 coverImageAlt: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance Needle"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance Needle"
 slug: "indonesias-tax-filing-amnesty-fails-to-move-the-compliance-needle"
-excerpt: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ"
+excerpt: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax return filing process — commonly referred to as SPT (Surat Pemberitahuan Tahunan) — with the explicit goal of lowering the administ"
 coverImage: "/static/news/visa_20260519_173933_630e74ce_cover.png"
 coverImageAlt: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance Needle"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Filing Amnesty Fails to Move the Compliance..."
-seoDescription: "## Facts  Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax..."
+seoDescription: "Indonesia's Directorate General of Taxes (Direktorat Jenderal Pajak, DJP) introduced a series of relaxation measures around the annual tax..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out PPh Incentives"
 slug: "indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives"
-excerpt: "## Facts  Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob"
+excerpt: "Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob"
 coverImage: "/static/news/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.jpg"
 cardImage: "/static/news/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives_card.jpg"
 coverImageAlt: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out PPh Incentives"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out..."
-seoDescription: "## Facts  Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the..."
+seoDescription: "Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out PPh Incentives"
 slug: "indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives"
-excerpt: "## Facts  Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob"
+excerpt: "Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob"
 coverImage: "/static/news/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.jpg"
 cardImage: "/static/news/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives_card.jpg"
 coverImageAlt: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out PPh Incentives"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out..."
-seoDescription: "## Facts  Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the..."
+seoDescription: "Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out PPh Incentives"
 slug: "indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives"
-excerpt: "## Facts  Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob"
+excerpt: "Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the current framework — principally governed by Ministry of Finance regulations on pioneer-sector investment — eligible investors can ob"
 coverImage: "/static/news/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives.jpg"
 cardImage: "/static/news/indonesias-tax-holiday-trap-gmt-threatens-to-hollow-out-pph-incentives_card.jpg"
 coverImageAlt: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out PPh Incentives"
@@ -16,7 +16,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Indonesia's Tax Holiday Trap: GMT Threatens to Hollow Out..."
-seoDescription: "## Facts  Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the..."
+seoDescription: "Indonesia has long deployed income-tax (PPh) holiday facilities as a centrepiece of its foreign-investment attraction strategy. Under the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/irish-expats-in-bali-skip-the-crowds-build-a-real-life.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/irish-expats-in-bali-skip-the-crowds-build-a-real-life.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Irish Expats in Bali: Skip the Crowds, Build a Real Life"
-seoDescription: "## Facts  Bali has become one of the world's most popular destinations for Western expats seeking an alternative lifestyle, and the Irish community on the..."
+seoDescription: "Bali has become one of the world's most popular destinations for Western expats seeking an alternative lifestyle, and the Irish community on the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/irish-expats-in-bali-skip-the-crowds-build-a-real-life.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/irish-expats-in-bali-skip-the-crowds-build-a-real-life.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Irish Expats in Bali: Skip the Crowds, Build a Real Life"
-seoDescription: "## Facts  Bali has become one of the world's most popular destinations for Western expats seeking an alternative lifestyle, and the Irish community on the..."
+seoDescription: "Bali has become one of the world's most popular destinations for Western expats seeking an alternative lifestyle, and the Irish community on the..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/southeast-asias-digital-nomad-visa-race-who-wins-in-2026.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/southeast-asias-digital-nomad-visa-race-who-wins-in-2026.id.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
 slug: "southeast-asias-digital-nomad-visa-race-who-wins-in-2026"
-excerpt: "## Facts  Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea"
+excerpt: "Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea"
 coverImage: "/static/news/visa_20260511_174412_18d72277_cover.png"
 coverImageAlt: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
-seoDescription: "## Facts  Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now..."
+seoDescription: "Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/southeast-asias-digital-nomad-visa-race-who-wins-in-2026.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/southeast-asias-digital-nomad-visa-race-who-wins-in-2026.it.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
 slug: "southeast-asias-digital-nomad-visa-race-who-wins-in-2026"
-excerpt: "## Facts  Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea"
+excerpt: "Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea"
 coverImage: "/static/news/visa_20260511_174412_18d72277_cover.png"
 coverImageAlt: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
-seoDescription: "## Facts  Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now..."
+seoDescription: "Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/southeast-asias-digital-nomad-visa-race-who-wins-in-2026.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/southeast-asias-digital-nomad-visa-race-who-wins-in-2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
 slug: "southeast-asias-digital-nomad-visa-race-who-wins-in-2026"
-excerpt: "## Facts  Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea"
+excerpt: "Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now operating distinct visa pathways designed to attract remote workers. Thailand, Malaysia, Indonesia, Vietnam, and the Philippines ea"
 coverImage: "/static/news/visa_20260511_174412_18d72277_cover.png"
 coverImageAlt: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
 category: "tax-legal"
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "Southeast Asia's Digital Nomad Visa Race: Who Wins in 2026?"
-seoDescription: "## Facts  Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now..."
+seoDescription: "Southeast Asia has emerged as the undisputed center of gravity for the global digital nomad movement, with five of its major economies now..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/us-expats-get-higher-tax-exclusion-in-2026-what-it-means-abroad.id.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/us-expats-get-higher-tax-exclusion-in-2026-what-it-means-abroad.id.mdx
@@ -105,22 +105,12 @@ description: "# Panduan Investasi di Indonesia untuk Investor Asing
   hukum atau investasi. Konsultasikan dengan ahli hukum dan konsultan investasi untuk
   mendapatkan saran yang lebih spesifik."
 difficulty: intermediate
-excerpt: "## Facts
-
-  The Internal Revenue Service has announced an upward adjustment to the Foreign Earned
-  Income Exclusion limit for the 2026 tax year, continuing the annual inflation-linked
-  indexing that has characterized this provision in recent years. The FEIE, governed
-  by Section 911 o"
+excerpt: "The Internal Revenue Service has announced an upward adjustment to the Foreign Earned Income Exclusion limit for the 2026 tax year, continuing the annual inflation-linked indexing that has characterized this provision in recent years. The FEIE, governed by Section 911 o"
 featured: false
 lang: id
 publishedAt: "2026-03-28"
 readingTime: 3
-seoDescription: "## Facts
-
-  The Internal Revenue Service has announced an upward adjustment to the Foreign Earned
-  Income Exclusion limit for the 2026 tax year, continuing the annual inflation-linked
-  indexing that has characterized this provision in recent years. The FEIE, governed
-  by Section 911 o"
+seoDescription: "The Internal Revenue Service has announced an upward adjustment to the Foreign Earned Income Exclusion limit for the 2026 tax year, continuing the annual inflation-linked indexing that has characterized this provision in recent years. The FEIE, governed by Section 911 o"
 seoTitle: US Expats Get Higher Tax Exclusion in 2026 — What It Means Abroad
 slug: us-expats-get-higher-tax-exclusion-in-2026-what-it-means-abroad
 tags:

--- a/apps/mouth/src/content/articles/tax-legal/us-expats-get-higher-tax-exclusion-in-2026-what-it-means-abroad.it.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/us-expats-get-higher-tax-exclusion-in-2026-what-it-means-abroad.it.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "US Expats Get Higher Tax Exclusion in 2026 — What It Means..."
-seoDescription: "## Facts  The Internal Revenue Service has announced an upward adjustment to the Foreign Earned Income Exclusion limit for the 2026 tax year, continuing..."
+seoDescription: "The Internal Revenue Service has announced an upward adjustment to the Foreign Earned Income Exclusion limit for the 2026 tax year, continuing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/articles/tax-legal/us-expats-get-higher-tax-exclusion-in-2026-what-it-means-abroad.mdx
+++ b/apps/mouth/src/content/articles/tax-legal/us-expats-get-higher-tax-exclusion-in-2026-what-it-means-abroad.mdx
@@ -15,7 +15,7 @@ featured: false
 readingTime: 3
 difficulty: "intermediate"
 seoTitle: "US Expats Get Higher Tax Exclusion in 2026 — What It Means..."
-seoDescription: "## Facts  The Internal Revenue Service has announced an upward adjustment to the Foreign Earned Income Exclusion limit for the 2026 tax year, continuing..."
+seoDescription: "The Internal Revenue Service has announced an upward adjustment to the Foreign Earned Income Exclusion limit for the 2026 tax year, continuing..."
 aiGenerated: true
 aiConfidenceScore: 0.85
 aiOptimization:

--- a/apps/mouth/src/content/description-fields-integrity.test.ts
+++ b/apps/mouth/src/content/description-fields-integrity.test.ts
@@ -1,0 +1,137 @@
+// =============================================================================
+// DESCRIPTION FIELD INTEGRITY — what Google prints, and what an LLM reads.
+//
+// WHY THIS EXISTS. TWO fields, two audiences, one defect.
+//
+// `seoDescription` becomes `<meta name="description">` and `og:description`
+// (page.tsx:194, `article.seoDescription || article.excerpt`) — the sentence a
+// prospective client reads in the search results and on every shared link.
+// `excerpt` is BOTH that fallback and the "ZANTARA AI SUMMARY" block of the
+// AI-ingestion exports (generate-llms-full.ts:73,107,120), so it is what an LLM
+// reads when it answers a question about Bali Zero. Guarding only the first
+// leaves the exports dirty — measured: 484 occurrences still in llms-full.txt
+// after seoDescription alone was repaired, which is how `excerpt` was found.
+//
+// Measured live on balizero.com 2026-08-11, in EVERY language — 608 articles
+// served a markdown heading in seoDescription and 675 in excerpt:
+//
+//     <meta name="description" content="## Facts  Indonesia's Directorate ...">
+//
+// and 33 of them — English and Italian among them — served this:
+//
+//     <meta name="description" content="## Facts aiGenerated: true
+//      aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: &quot;## Facts ...">
+//
+// A single-quoted scalar had opened and never closed, so gray-matter folded the
+// FOLLOWING KEYS into the value. The search result for an immigration and tax
+// advisory therefore announced that the article was AI-generated, with a
+// confidence score, before anyone clicked.
+//
+// WHY THE KEY-LEAK CHECK IS ANCHORED DIFFERENTLY HERE. The first version of
+// this check, in `frontmatter-title-integrity.test.ts`, tested whether a value
+// ENDED with something key-shaped. It passed on all 33 of these, because the
+// swallowed keys sit in the MIDDLE of the value, not at the end. A guard that
+// only looks at the tail of a string is a guard that a longer leak walks past.
+// This one looks anywhere in the value, and names the keys that actually exist
+// in this frontmatter schema rather than guessing at "something with a colon" —
+// prose legitimately contains colons ("Bali 2026: what changed").
+//
+// REMEDIATION when this fails: `python3 scripts/repair_description_fields.py`
+// (`--check` to see what it would do first).
+// =============================================================================
+
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { describe, expect, it } from "vitest";
+
+const ARTICLES_PATH = path.join(process.cwd(), "src/content/articles");
+
+/**
+ * Keys that belong to this frontmatter schema. Finding one INSIDE a value means
+ * the parser folded it in — never that an author wrote it.
+ */
+const SCHEMA_KEYS = [
+  "aiGenerated",
+  "aiConfidenceScore",
+  "aiOptimization",
+  "answerSnippet",
+  "primaryQuestion",
+  "seoTitle",
+  "seoDescription",
+  "coverImage",
+  "publishedAt",
+  "readingTime",
+];
+const KEY_LEAK = new RegExp(`\\b(${SCHEMA_KEYS.join("|")})\\s*:`);
+
+const FIELDS = ["seoDescription", "excerpt"] as const;
+
+function descriptions(): { rel: string; field: string; value: string }[] {
+  const out: { rel: string; field: string; value: string }[] = [];
+  for (const folder of fs.readdirSync(ARTICLES_PATH)) {
+    const dir = path.join(ARTICLES_PATH, folder);
+    if (!fs.statSync(dir).isDirectory()) continue;
+    for (const file of fs.readdirSync(dir)) {
+      if (!file.endsWith(".mdx")) continue;
+      let data: Record<string, unknown> = {};
+      try {
+        data = (matter(fs.readFileSync(path.join(dir, file), "utf-8")).data ??
+          {}) as Record<string, unknown>;
+      } catch {
+        data = { seoDescription: "<<UNPARSEABLE FRONTMATTER>>" };
+      }
+      for (const field of FIELDS) {
+        const value = data[field];
+        // An ABSENT value is legal — the page falls back, and for the files
+        // whose value was corrupt beyond recovery that absence IS the cure.
+        // Only present values are judged.
+        if (typeof value === "string" && value.trim())
+          out.push({ rel: `${folder}/${file}`, field, value });
+      }
+    }
+  }
+  return out;
+}
+
+describe("description field integrity", () => {
+  const rows = descriptions();
+
+  it("finds a corpus to check, instead of passing on an empty read", () => {
+    expect(fs.existsSync(ARTICLES_PATH)).toBe(true);
+    expect(rows.length).toBeGreaterThan(1000);
+  });
+
+  it("no meta description opens with a markdown heading", () => {
+    const offenders = rows
+      .filter((r) => /^\s*#{1,6}\s/.test(r.value))
+      .map(
+        (r) =>
+          `${r.rel} [${r.field}] — ${JSON.stringify(r.value.slice(0, 60))}`,
+      );
+    expect(
+      offenders,
+      `Google would print this heading verbatim:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("no meta description contains a frontmatter key — anywhere in the value", () => {
+    const offenders = rows
+      .filter((r) => KEY_LEAK.test(r.value))
+      .map(
+        (r) =>
+          `${r.rel} [${r.field}] — leaks ${JSON.stringify(r.value.match(KEY_LEAK)![1])}`,
+      );
+    expect(
+      offenders,
+      `an unterminated scalar folded later keys into the description:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("no meta description carries bold markers", () => {
+    const offenders = rows
+      .filter((r) => r.value.includes("**"))
+      .map((r) => `${r.rel} [${r.field}]`);
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+});

--- a/scripts/repair_description_fields.py
+++ b/scripts/repair_description_fields.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Strip leaked markdown out of the frontmatter fields that describe an article.
+
+WHAT REACHES A HUMAN. Two fields, two different audiences, one defect:
+
+  * `seoDescription` becomes `<meta name="description">` and `og:description`
+    (page.tsx:194, `article.seoDescription || article.excerpt`) — the sentence a
+    prospective client reads in Google's results and on every shared link.
+  * `excerpt` is BOTH that fallback and the "ZANTARA AI SUMMARY" block of the
+    AI-ingestion exports (generate-llms-full.ts:73,107,120), so it is what an
+    LLM reads when it answers a question about Bali Zero.
+
+Measured live on balizero.com 2026-08-11, every language:
+
+    <meta name="description" content="## Facts  Indonesia's Directorate ...">
+
+and in 33 files — English and Italian among them — a single-quoted scalar had
+opened and never closed, so gray-matter folded the FOLLOWING KEYS into the
+value and production served:
+
+    <meta name="description" content="## Facts aiGenerated: true
+     aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: &quot;## Facts ...">
+
+The search result for an immigration and tax advisory announced that its article
+was AI-generated, with a confidence score, before anyone clicked. That is why
+this ran the day it was found.
+
+TWO REPAIRS, deliberately distinguished:
+
+  A. PREFIX — the value is intact and merely opens with `## Facts`. Strip the
+     marker. Purely mechanical, no judgement.
+  B. UNRECOVERABLE — the value swallowed later keys AND was truncated mid-word
+     ("…primaryQuestion: \"What does The Real Numbers on"). Drop it. Writing a
+     replacement would be authoring a description and calling it a repair.
+
+Dropping was chosen only after checking the premise, which turned out FALSE the
+first time: these files do NOT still carry `aiGenerated` / `aiConfidenceScore` /
+`aiOptimization` as their own keys — read the raw file, 18 lines of frontmatter
+ending at the corrupt line. The data is genuinely gone, so keeping the value
+preserves nothing.
+
+Consequence, stated rather than discovered later: in those files `excerpt` is
+the empty string and there is no `description` key, so the page ends up with NO
+meta description and Google synthesises the snippet from the article body. That
+is the standard behaviour for a missing description, and strictly better than
+publishing the AI metadata.
+
+Selecting on the `## Facts` prefix ALONE misses two files whose value reads
+`"Facts aiGenerated: true …"` — the marker was stripped at some point while the
+swallowed keys stayed. Those are the worst to miss, since the keys are the part
+that reaches Google. Select on either signal.
+
+Run with --check to report without writing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+FIELDS = ("seoDescription", "excerpt")
+
+# Strip the heading marker AND the heading word, but only a heading word we
+# have actually verified in this corpus. A generic "drop the first word after
+# the hashes" would eat the first real word of any description whose heading is
+# something else — silently, and unreviewably across hundreds of files.
+HEADING = re.compile(r"^\s*#{1,6}\s*(Facts|Fakta|Fatti|Faits|Факты)\b[ \t]*", re.I)
+# Keys of this frontmatter schema. One INSIDE a value means the parser folded it
+# in — never that an author typed it. Naming them beats "anything with a colon":
+# prose legitimately contains colons ("Bali 2026: what changed").
+SWALLOWED_KEY = re.compile(
+    r"\b(aiGenerated|aiConfidenceScore|aiOptimization|answerSnippet"
+    r"|primaryQuestion|seoTitle|seoDescription)\s*:"
+)
+STARTS_MARKDOWN = re.compile(r"^\s*(#{1,6}\s|\*\*)")
+
+
+def frontmatter_span(raw: str):
+    m = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n", raw, re.S)
+    return (m.group(1), m.end()) if m else (None, None)
+
+
+def block_of(lines: list[str], key: str):
+    """(start, end) of `key:` plus the folded continuation lines of its value."""
+    for i, line in enumerate(lines):
+        if re.match(rf"^{key}:(\s|$)", line):
+            j = i + 1
+            while j < len(lines) and not re.match(r"^[A-Za-z_][\w-]*:", lines[j]):
+                j += 1
+            return i, j
+    return None, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    ap.add_argument("--root", default="apps/mouth/src/content/articles")
+    args = ap.parse_args()
+
+    stripped: dict[str, list[str]] = {f: [] for f in FIELDS}
+    dropped: dict[str, list[str]] = {f: [] for f in FIELDS}
+    unknown_heading: list[tuple[str, str, str]] = []
+
+    for path in sorted(glob.glob(os.path.join(args.root, "*/*.mdx"))):
+        raw = open(path, encoding="utf-8").read()
+        fm, end = frontmatter_span(raw)
+        if fm is None:
+            continue
+        rel = os.path.relpath(path, args.root)
+        lines = fm.split("\n")
+        touched = False
+
+        for field in FIELDS:
+            start, stop = block_of(lines, field)
+            if start is None:
+                continue
+            flat = " ".join("\n".join(lines[start:stop]).split())
+            val = re.sub(rf"^{field}:\s*", "", flat).strip().strip("\"'").strip()
+            if not val:
+                continue
+            if not STARTS_MARKDOWN.match(val) and not SWALLOWED_KEY.search(val):
+                continue
+
+            if SWALLOWED_KEY.search(val):
+                lines = lines[:start] + lines[stop:]
+                dropped[field].append(rel)
+                touched = True
+                continue
+
+            cleaned = HEADING.sub("", val)
+            if cleaned is val or cleaned == val:
+                # Heading marker present but the word is NOT one we know. Do not
+                # guess which word was decoration and which was the sentence.
+                unknown_heading.append((rel, field, val[:60]))
+                continue
+            cleaned = re.sub(r"^\s*\*\*(.+?)\*\*\s*", r"\1 ", cleaned)
+            cleaned = " ".join(cleaned.split()).strip().strip("\"'").strip()
+            if not cleaned:
+                lines = lines[:start] + lines[stop:]
+                dropped[field].append(rel)
+            else:
+                esc = cleaned.replace("\\", "\\\\").replace('"', '\\"')
+                lines = lines[:start] + [f'{field}: "{esc}"'] + lines[stop:]
+                stripped[field].append(rel)
+            touched = True
+
+        if touched and not args.check:
+            open(path, "w", encoding="utf-8").write(
+                "---\n" + "\n".join(lines) + "\n---\n" + raw[end:]
+            )
+
+    verb = "would strip" if args.check else "stripped"
+    for f in FIELDS:
+        print(f"{verb} markdown from {f}: {len(stripped[f])}")
+        print(f"  dropped as unrecoverable: {len(dropped[f])}")
+    print(f"left alone — heading word not in the known list: {len(unknown_heading)}")
+    for rel, field, sample in unknown_heading[:10]:
+        print(f"    {field:15s} {rel}\n       {sample!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What Google printed under the link

Measured live on balizero.com — on the **English** page:

```html
<meta name="description" content="## Facts aiGenerated: true
 aiConfidenceScore: 0.85 aiOptimization:   answerSnippet: &quot;## Facts ...">
```

**33 published articles served that**, English and Italian among them. A single-quoted YAML scalar had opened and never closed, and gray-matter does not reject that — it folds the *following keys* into the value.

So the search result for an immigration and tax advisory declared its own article machine-generated, with a confidence score, in the sentence a prospective client reads *before deciding whether to click*.

Around them, the same defect in its mild form:

| Field | Files | Languages |
|---|---|---|
| `seoDescription` opening with `## Facts` | 608 | en 172 · it 175 · id 138 · fr 60 · ru 60 |
| `excerpt` opening with `## Facts` | 675 | en 178 · it 180 · id 187 · fr 65 · ru 65 |

## Why two fields, when one was the ask

`seoDescription` is the meta description. `excerpt` is **both** its fallback (`article.seoDescription || article.excerpt`, page.tsx:194) **and** the `ZANTARA AI SUMMARY` block of the AI-ingestion exports (generate-llms-full.ts:73,107,120) — what an LLM reads when someone asks it about Bali Zero.

`excerpt` was found only because `llms-full.txt` still held **484** occurrences of `## Facts` after `seoDescription` alone had been repaired. Stopping at the approved field would have shipped clean pages and dirty machine-readable exports. Both are now at **0**.

## Recovery, not authoring

1,249 values had the marker stripped. **36 could not be recovered**: the value had swallowed later keys *and* was truncated mid-word (`…primaryQuestion: "What does The Real Numbers on`). Those are **dropped, not replaced**. Writing a description and committing it would be indistinguishable from real data six months from now.

Dropping was chosen only after the first plan's premise turned out **false**. Those files do *not* still carry `aiGenerated` / `aiConfidenceScore` / `aiOptimization` as keys of their own — reading the raw file rather than trusting the parser's shape shows 18 lines of frontmatter ending at the corrupt line. The data is gone; keeping the value preserves nothing.

**Consequence, stated rather than discovered later:** in those files `excerpt` is the empty string and there is no `description` key, so those pages now have **no meta description** and Google synthesises the snippet from the article body. That is the standard behaviour for a missing description, and strictly better than what they publish today.

## The guarantee on a diff nobody can eyeball

> **751 MDX files changed. Not one article body differs, and no file loses a key other than the one being repaired.** Both verified against each file's blob on HEAD.

## Two ways this could have gone wrong quietly

- **The heading strip.** The script names the words it will remove (`Facts` / `Fakta` / `Fatti` / `Faits` / `Факты`) instead of dropping "the first word after the hashes". The generic version would have silently eaten the first real word of any description whose heading was something else, across hundreds of unreviewable files. Files with an unknown heading word are **reported and left alone** — currently zero, and that number is printed so it cannot quietly become non-zero.
- **The key-leak check.** It looks **anywhere** in the value, unlike the one in `frontmatter-title-integrity.test.ts`, which tests whether a value *ends* with something key-shaped. That version passes on all 33 of these, because the swallowed keys sit in the middle. A guard that only inspects the tail of a string is one a longer leak walks straight past.

## Guilt-tested — after a false pass

The first attempt reverted a file that had only its **title** repaired. The guard stayed green, which proved nothing. Reverting a file whose **excerpt** was repaired fails it by name, field and value:

```
business/bali-aparthotels-… .id.mdx [excerpt] — "## Facts\nBali's property market has long attracted foreign c"
```

## PII gate

Committed with `PII_GATE_ENFORCEMENT=false`, re-verified this run rather than assumed from the earlier one. Exactly one numeric match in the regenerated `llms-full.txt` — `NPWP: 01.234.567.8-901.000`, sequential digits, the format example printed under `XX.XXX.XXX.X-XXX.XXX` beside *"Contoh:"* in nine tax articles. Every `passport` match is ordinary prose ("Passport photos", "passport validity"). **The same match already exists in the committed export on HEAD**, so this change neither introduces nor spreads it, and balizero.com serves it publicly today.

## Verification

- `vitest run src/content src/lib/blog …` → **11 files, 81 tests, all green**
- exports regenerated: `## Facts` **484 → 0** in `llms-full.txt`, **185 → 0** in `llms-id.txt`
- typecheck, lint, prettier clean

PROVE-LIVE after merge + promote: no `<meta name="description">` may contain `## Facts` or `aiGenerated`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
