### PR TITLE
fix(mouth): the derived meta description was MDX component source

### DIFF
--- a/apps/mouth/src/lib/blog/articles.ts
+++ b/apps/mouth/src/lib/blog/articles.ts
@@ -142,16 +142,45 @@ function cleanExcerpt(text: string | null): string {
  * Skips all heading lines (## ...) and their immediate content blocks,
  * picks the first paragraph longer than 60 characters.
  */
-function extractBodyExcerpt(body: string): string {
+export function extractBodyExcerpt(body: string): string {
   if (!body) return "";
 
   // Split into lines and process
   const lines = body.split("\n");
   let inHeadingBlock = false;
+  // Depth of the JSX component we are inside, if any. A component's OPENING
+  // line is not the whole component — see the skip rule below.
+  let jsxDepth = 0;
   const paragraphLines: string[] = [];
 
   for (const line of lines) {
     const trimmed = line.trim();
+
+    // A JSX block spans MANY lines, and only its first one starts with `<`:
+    //
+    //     <InfoCard
+    //       title="Quick Summary"
+    //       items={[{ label: "Should I Worry?", value: "Yes" }]}
+    //     />
+    //
+    // Skipping on `^<[A-Z]` alone therefore dropped `<InfoCard` and accepted
+    // everything after it as prose. Measured live 2026-08-11: 52 articles whose
+    // meta description — the sentence Google prints under the link — read
+    // `title="Quick Summary" items={[ { label: "Should I Worry?", value: "Yes" }…`.
+    // So the block is tracked to its close, not just recognised at its start.
+    if (jsxDepth > 0) {
+      jsxDepth += (trimmed.match(/\{/g) || []).length;
+      jsxDepth -= (trimmed.match(/\}/g) || []).length;
+      if (/\/>\s*$|^<\/[A-Za-z]/.test(trimmed) && jsxDepth <= 1) jsxDepth = 0;
+      continue;
+    }
+    if (/^<[A-Z]/.test(trimmed)) {
+      // Self-closing on its own line is over immediately; otherwise stay inside.
+      const opens = (trimmed.match(/\{/g) || []).length;
+      const closes = (trimmed.match(/\}/g) || []).length;
+      jsxDepth = /\/>\s*$/.test(trimmed) ? 0 : 1 + opens - closes;
+      continue;
+    }
 
     // New heading encountered — reset block accumulator and skip
     if (/^#{1,6}\s/.test(trimmed)) {

--- a/apps/mouth/src/lib/blog/body-excerpt.test.ts
+++ b/apps/mouth/src/lib/blog/body-excerpt.test.ts
@@ -1,0 +1,133 @@
+// =============================================================================
+// BODY-DERIVED EXCERPT — when there is no description, what gets invented must
+// still be prose.
+//
+// WHY THIS EXISTS. When an article carries neither `seoDescription` nor
+// `excerpt`, `extractBodyExcerpt` derives one from the body, and the result
+// becomes `<meta name="description">` — the sentence Google prints under the
+// link. It skipped a JSX component by testing whether a line STARTS with `<`:
+//
+//     <InfoCard                       <- skipped
+//       title="Quick Summary"         <- kept, as "prose"
+//       items={[{ label: "Should I Worry?", value: "Yes" }]}
+//     />                              <- kept
+//
+// A component spans many lines and only the first one starts with `<`, so
+// everything after it was accepted as the opening paragraph. Measured live
+// 2026-08-11: 52 articles served
+// `title="Quick Summary" items={[ { label: "Should I Worry?", value: "Yes" }…`
+// as their meta description.
+//
+// HOW IT WAS FOUND, which is the part worth remembering: repairing a DIFFERENT
+// defect removed 36 corrupt `seoDescription` values, and the stated expectation
+// was "those pages will have no meta description and Google will synthesise one
+// from the body". That was wrong — they fell through to this function instead.
+// The prediction about a consequence was not the same thing as observing it,
+// and only the live check told them apart.
+//
+// TWO LEVELS, on purpose: unit cases pin the shapes, and a corpus sweep proves
+// the real articles are clean — a hand-written fixture cannot vouch for 3,353
+// files, and a corpus sweep alone would not say WHICH shape broke.
+// =============================================================================
+
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { describe, expect, it } from "vitest";
+import { extractBodyExcerpt } from "./articles";
+
+const ARTICLES_PATH = path.join(process.cwd(), "src/content/articles");
+
+/** Anything that says "this is source code, not a sentence". */
+const LOOKS_LIKE_SOURCE =
+  /=\{|items=|label:\s*"|value:\s*"|\/>|\}\]|^<[A-Za-z]/;
+
+const PROSE =
+  "Indonesia's immigration framework changed materially in 2026, and the " +
+  "practical consequences for foreign residents are not what the headlines say.";
+
+describe("extractBodyExcerpt", () => {
+  it("skips a multi-line JSX component and returns the paragraph after it", () => {
+    const body = [
+      "<InfoCard",
+      '  title="Quick Summary"',
+      "  items={[",
+      '    { label: "Should I Worry?", value: "Yes" },',
+      '    { label: "Risk Level", value: "High" },',
+      "  ]}",
+      "/>",
+      "",
+      PROSE,
+      "",
+    ].join("\n");
+    const out = extractBodyExcerpt(body);
+    expect(out).toBe(PROSE);
+    expect(out).not.toMatch(LOOKS_LIKE_SOURCE);
+  });
+
+  it("skips a self-closing component written on one line", () => {
+    const body = ['<Callout kind="warning" />', "", PROSE, ""].join("\n");
+    expect(extractBodyExcerpt(body)).toBe(PROSE);
+  });
+
+  it("skips a component with children and a closing tag", () => {
+    const body = [
+      "<Callout>",
+      "  Something inside the component, which is not the article's opening.",
+      "</Callout>",
+      "",
+      PROSE,
+      "",
+    ].join("\n");
+    expect(extractBodyExcerpt(body)).toBe(PROSE);
+  });
+
+  it("still skips headings, and still finds the first real paragraph", () => {
+    const body = ["## TL;DR", "", PROSE, ""].join("\n");
+    expect(extractBodyExcerpt(body)).toBe(PROSE);
+  });
+
+  it("returns empty rather than something wrong when there is no prose", () => {
+    expect(extractBodyExcerpt('<InfoCard\n  title="x"\n/>\n')).toBe("");
+    expect(extractBodyExcerpt("")).toBe("");
+  });
+
+  it("no published article derives a description that is source code", () => {
+    // Only articles that actually reach this function are judged: the page uses
+    // `seoDescription || excerpt` and falls through only when both are absent.
+    const offenders: string[] = [];
+    let checked = 0;
+    for (const folder of fs.readdirSync(ARTICLES_PATH)) {
+      const dir = path.join(ARTICLES_PATH, folder);
+      if (!fs.statSync(dir).isDirectory()) continue;
+      for (const file of fs.readdirSync(dir)) {
+        if (!file.endsWith(".mdx")) continue;
+        let parsed;
+        try {
+          parsed = matter(fs.readFileSync(path.join(dir, file), "utf-8"));
+        } catch {
+          continue;
+        }
+        const sd = parsed.data?.seoDescription;
+        const ex = parsed.data?.excerpt;
+        const hasReal = (v: unknown) => typeof v === "string" && v.trim();
+        if (hasReal(sd) || hasReal(ex)) continue;
+        checked++;
+        const derived = extractBodyExcerpt(parsed.content);
+        if (derived && LOOKS_LIKE_SOURCE.test(derived)) {
+          offenders.push(
+            `${folder}/${file} — ${JSON.stringify(derived.slice(0, 80))}`,
+          );
+        }
+      }
+    }
+    expect(
+      checked,
+      "no article falls through to the body — sweep saw nothing",
+    ).toBeGreaterThan(0);
+    expect(
+      offenders,
+      `these articles would publish source code as their meta description:\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What Google was given to print

When an article carries neither `seoDescription` nor `excerpt`, `extractBodyExcerpt` derives one from the body, and that becomes `<meta name="description">`. It skipped JSX by testing whether a line **starts** with `<`:

```mdx
<InfoCard                                             ← skipped
  title="Quick Summary"                               ← kept, as "prose"
  items={[{ label: "Should I Worry?", value: "Yes" }]}  ← kept
/>                                                    ← kept
```

A component spans many lines and only the first one starts with `<`. So **52 articles** derived a description reading:

```
title="Quick Summary" items={[ { label: "Should I Worry?", value: "Yes" }…
```

The fix tracks the block to its close — brace depth, plus `/>` or a closing tag — instead of recognising only its opening line.

## How this was found

**#4068 removed 36 corrupt `seoDescription` values and stated the consequence as:** *"those pages end up with no meta description and Google synthesises the snippet from the article body."*

That was wrong. They fell through to this function instead, and the PROVE-LIVE run after the promote showed two of them serving `title="Quick Summary" items={[…` where the description belonged.

**The probe had passed.** It searched for `## Facts` and `aiGenerated` — the defect being fixed — and those were gone, so it printed `PROVE-LIVE PASSED` while displaying the new damage in its own output:

```
[ok]   EN — was: aiGenerated: true aiConfidenceScore: 0.85
       title=&quot;Quick Summary&quot; items={[ { label: &quot;Should I Worry?&quot;, value: &quot;Yes&quot; }...
```

A probe only refutes what it was told to look for; the rest has to be read. Predicting a consequence is not the same as observing one, and only the live check told them apart.

## Blast radius, measured twice

The first number was wrong. Counting articles with **no `excerpt`** gave **155** — but the page uses `seoDescription || excerpt`, so most of those never reach this function at all. Counting the ones where **both are absent** gives the real figure:

| | before | after |
|---|---|---|
| articles whose description falls through to the body | 53 | 53 |
| …of which derive source code | **52** | **0** |
| …of which derive real prose | 1 | **53** |

The recovered text is the article's genuine opening paragraph, in its own language — Indonesian for `.id`, Italian for `.it`.

## Guilt-tested, after an inconclusive first attempt

The first attempt reverted `articles.ts` wholesale — which also removed the new `export`, so every test failed on a broken import and proved **nothing** about the defect. Reverting **only** the block-tracking fails exactly three:

- `skips a multi-line JSX component and returns the paragraph after it`
- `skips a component with children and a closing tag`
- `no published article derives a description that is source code`

while the three shapes the old code already handled (self-closing one-liner, headings, empty body) stay green. That is the difference between a guard that detects this bug and a guard that detects a typo in an import.

## The test has two levels, deliberately

Unit cases pin the shapes; a corpus sweep proves the 3,353 real articles are clean. A hand-written fixture cannot vouch for the corpus, and a corpus sweep alone would not say *which* shape broke. The sweep also asserts it actually examined something (`checked > 0`), so a future refactor that makes zero articles reach this function fails loudly instead of reporting all-clear.

## Verification

- `vitest run src/content src/lib/blog …` → **12 files, 87 tests, all green**
- `tsc --noEmit` clean, lint and prettier clean

PROVE-LIVE after merge + promote: no `<meta name="description">` may contain JSX attribute syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
