### PR TITLE
fix(infra): launchagent_reconcile compares HOME forks against origin/main (W106b)

### DIFF
--- a/scripts/launchagent_reconcile.py
+++ b/scripts/launchagent_reconcile.py
@@ -455,6 +455,31 @@ def _is_under(path: Path, root: Path) -> bool:
         return False
 
 
+def origin_main_blob(root: Path, rel: str) -> Optional[bytes]:
+    """Bytes of `origin/main:<rel>` — the fleet's copy, never this checkout's.
+
+    W106b (2026-07-27→08-08): comparing a HOME payload against the LOCAL
+    checkout mistakes checkout staleness for a real fork. A checkout N
+    commits behind origin/main makes every file origin/main touched in that
+    window look "diverged" from a live copy that already matches the fleet.
+    lint_home_fork.origin_main_sha and proprioception.origin_main_sha carry
+    the identical helper for the identical reason — pinned as twins by
+    test_home_fork_stale_side_attribution.py; if you change the attribution
+    rule here, change those too (superscar #9: three tools, one lesson,
+    don't cure only one — that is how this gap survived until now).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "show", f"origin/main:{rel}"],
+            capture_output=True, timeout=15,
+        )
+        if proc.returncode != 0:
+            return None
+        return proc.stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # The reconcile pass
 # ─────────────────────────────────────────────────────────────────────────
@@ -534,6 +559,7 @@ def reconcile(
 
     broken_target = []
     home_fork_target = []
+    checkout_stale_target = []
     canon_paired = []
     repo_divergent = []
     repo_symlinked = []
@@ -588,12 +614,37 @@ def reconcile(
                 # the disease this whole tool exists to catch (superscar #1).
                 pass
             else:
-                detail = (
-                    f"DIVERGED from canon {canon.relative_to(repo_root)}" if canon is not None
-                    else "no repo canon (basename not found under scripts/, infra/, or apps/*/scripts/)"
-                )
-                home_fork_target.append({"label": label, "file": f.name, "target": t,
-                                         "detail": detail})
+                # Before crying HOME-fork: is the live copy actually current
+                # (matches origin/main) while it's only THIS checkout that's
+                # behind? filecmp above already proved live != local canon —
+                # this asks the fleet's copy, not the checkout's, which side
+                # is stale (W106b).
+                canon_rel = canon.relative_to(repo_root).as_posix() if canon is not None else None
+                checkout_stale = False
+                if canon_rel is not None:
+                    upstream = origin_main_blob(repo_root, canon_rel)
+                    if upstream is not None:
+                        try:
+                            live_bytes = rp.read_bytes()
+                        except OSError:
+                            live_bytes = None
+                        checkout_stale = live_bytes is not None and live_bytes == upstream
+                if checkout_stale:
+                    checkout_stale_target.append({
+                        "label": label, "file": f.name, "target": t, "canon": canon_rel,
+                        "detail": (
+                            f"the LIVE copy already matches origin/main:{canon_rel} — "
+                            "this checkout is behind, not the live copy a fork. Update "
+                            "the checkout; do NOT realign the live copy from it."
+                        ),
+                    })
+                else:
+                    detail = (
+                        f"DIVERGED from canon {canon.relative_to(repo_root)}" if canon is not None
+                        else "no repo canon (basename not found under scripts/, infra/, or apps/*/scripts/)"
+                    )
+                    home_fork_target.append({"label": label, "file": f.name, "target": t,
+                                             "detail": detail})
             break
 
         twin = repo_infra / f.name
@@ -625,6 +676,7 @@ def reconcile(
         "present_not_loaded": present_not_loaded,
         "broken_target": broken_target,
         "home_fork_target": home_fork_target,
+        "checkout_stale_target": checkout_stale_target,
         "canon_paired": canon_paired,
         "repo_divergent": repo_divergent,
         "repo_symlinked": repo_symlinked,
@@ -702,6 +754,11 @@ def render_markdown(report: dict, verdicts) -> str:
     section(
         "HOME-fork target (superscar #1)", report["home_fork_target"],
         lambda h: f"- `{h['label']}` → `{h['target']}` ({h.get('detail', 'under $HOME, outside repo/deploy, not a repo symlink')})",
+    )
+    section(
+        "Checkout-stale target (not a fork — W106b: this checkout is behind origin/main)",
+        report.get("checkout_stale_target", []),
+        lambda h: f"- `{h['label']}` → `{h['target']}` (matches `origin/main:{h['canon']}`)",
     )
     section(
         "Canon-paired HOME target (byte-identical to repo canon — W84-safe placement, not a fork)",
@@ -812,6 +869,7 @@ def main(argv=None) -> int:
             f"{len(report['present_not_loaded'])} not-loaded, "
             f"{len(report['broken_target'])} broken-target, "
             f"{len(report['home_fork_target'])} home-fork, "
+            f"{len(report.get('checkout_stale_target', []))} checkout-stale, "
             f"{len(report.get('canon_paired', []))} canon-paired, "
             f"{len(report['repo_divergent'])} repo-divergent. "
             f"Report: {out}"

--- a/scripts/tests/test_launchagent_reconcile.py
+++ b/scripts/tests/test_launchagent_reconcile.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import plistlib
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -751,3 +752,93 @@ def test_parse_plist_genuinely_corrupt_returns_none(tmp_path):
     p = tmp_path / "corrupt.plist"
     p.write_text("this is not xml and not a plist")
     assert lar.parse_plist(p) is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# origin/main attribution (W106b) — a checkout N commits behind must not
+# read as a HOME-fork when the LIVE copy already matches the fleet's copy.
+# Twin of test_home_fork_stale_side_attribution.py's git fixture, adapted to
+# reconcile()'s API (agents_dir/repo_dir/loaded_labels, not declared pairs).
+# ─────────────────────────────────────────────────────────────────────────
+
+def _git(repo, *args):
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                    capture_output=True, timeout=30)
+
+
+def _git_world(tmp_path):
+    """A fake HOME + a REAL git repo whose origin/main can diverge from the
+    working tree, mirroring a checkout that trails the fleet."""
+    home = tmp_path / "home"
+    agents = home / "Library" / "LaunchAgents"
+    agents.mkdir(parents=True)
+    repo = tmp_path / "repo"
+    (repo / "infra" / "launchagents").mkdir(parents=True)
+    (repo / "scripts").mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+    return {"home": home, "agents": agents, "repo": repo}
+
+
+def _publish_origin_main(repo, rel, content):
+    """Commit `content` at `rel`, then stamp refs/remotes/origin/main at HEAD
+    — the working tree keeps whatever is on disk; only the ref moves."""
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    _git(repo, "add", rel)
+    _git(repo, "commit", "-qm", "publish")
+    head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True, timeout=30,
+    ).stdout.strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", head)
+
+
+def test_checkout_stale_target_not_flagged_as_home_fork(tmp_path):
+    """The bug this PR fixes: origin/main moved the canon forward, the LOCAL
+    checkout has not caught up, but the LIVE copy already matches origin/main.
+    Must land in checkout_stale_target, NEVER home_fork_target — flagging it
+    as a fork and 'realigning' would overwrite a current file with a stale
+    one (the exact W106b damage shape)."""
+    w = _git_world(tmp_path)
+    rel = "scripts/wrapper.sh"
+    _publish_origin_main(w["repo"], rel, "#!/bin/sh\necho origin-version\n")
+    # Now let the LOCAL checkout drift behind: an older commit's content,
+    # simulating a checkout that never pulled origin/main's latest.
+    (w["repo"] / rel).write_text("#!/bin/sh\necho stale-checkout-version\n")
+    live = w["home"] / ".nuzantara-cron" / "wrapper.sh"
+    live.parent.mkdir(parents=True)
+    live.write_text("#!/bin/sh\necho origin-version\n")  # matches origin/main
+    write_plist(
+        w["agents"] / "com.balizero.uptodate.plist",
+        "com.balizero.uptodate",
+        program_args=[str(live)],
+    )
+    r = run_reconcile(w, loaded=None)
+    assert r["home_fork_target"] == []
+    assert [h["label"] for h in r["checkout_stale_target"]] == ["com.balizero.uptodate"]
+    assert r["checkout_stale_target"][0]["canon"] == rel
+
+
+def test_home_fork_still_flagged_when_live_diverges_from_origin_too(tmp_path):
+    """Guilt case: origin/main and the local checkout agree (checkout is
+    current), but the LIVE copy genuinely differs — a real fork, not a
+    checkout-staleness artifact. Must stay in home_fork_target."""
+    w = _git_world(tmp_path)
+    rel = "scripts/wrapper.sh"
+    _publish_origin_main(w["repo"], rel, "#!/bin/sh\necho repo-version\n")
+    (w["repo"] / rel).write_text("#!/bin/sh\necho repo-version\n")  # current
+    live = w["home"] / ".nuzantara-cron" / "wrapper.sh"
+    live.parent.mkdir(parents=True)
+    live.write_text("#!/bin/sh\necho drifted-version\n")
+    write_plist(
+        w["agents"] / "com.balizero.realfork.plist",
+        "com.balizero.realfork",
+        program_args=[str(live)],
+    )
+    r = run_reconcile(w, loaded=None)
+    assert r["checkout_stale_target"] == []
+    assert [h["label"] for h in r["home_fork_target"]] == ["com.balizero.realfork"]
+    assert "DIVERGED from canon" in r["home_fork_target"][0]["detail"]


### PR DESCRIPTION
Reproduced live: com.nuzantara.healer.4h false-flagged HOME-fork DIVERGED by launchagent_reconcile.py while proprioception.py's home_fork_scripts probe (already W106b-fixed) reports RECONCILED for the same pair. Root cause: filecmp against local checkout instead of origin/main. Fix adds origin_main_blob() (twin of lint_home_fork/proprioception helper) + checkout_stale_target category. 43/43 tests pass (2 new: guilt+innocence). Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>