### PR TITLE
feat(curated-qa): count the served points no corpus row explains

### DIFF
--- a/.agents/skills/bot/SKILL.md
+++ b/.agents/skills/bot/SKILL.md
@@ -22,6 +22,35 @@ WhatsApp Business (Meta Cloud API) number **+62 821-3465-159** = Zantara. Two au
 
 ## 1. LIVE STATE (last update 2026-08-11 — keep current)
 
+- **📚 HALF THE CURATED GROUNDING STORE IS SERVED, UNREVIEWABLE, AND CANNOT BE WITHDRAWN
+  (2026-08-11).** The `curated_qa` Qdrant collection holds **808 points**. Exactly **396** map to a
+  row in `apps/backend-rag/data/curated_qa/*.jsonl` (verified by recomputing
+  `_stable_point_id(question, domain)` for every row — all 396 present, none missing). The other
+  **412 map to nothing on disk**: all `domain=visa`, all `source_date` in 2026-07, **61 of them in
+  the verbatim class `JELAS`**. They carry none of the Phase-0 payload fields (`batch_id`,
+  `active`, `invalidated_at`, `verbatim_eligible`, `client_specific`), and no manifest references
+  them — `curated_qa_drift_report.py` reports `21 files, in_sync=21, zero source_missing`, so the
+  disk↔manifest view is clean and blind to all of this.
+  - **They ARE served.** `orchestrator_core._inject_curated_qa_grounding` filters with
+    `metadata.get("active", True) is False` — missing `active` means active, deliberately ("a
+    pre-Phase-0 point written before this rail existed — treated as active, not silently
+    dropped"). Every one of the 412 lacks the field.
+  - **They cannot be withdrawn.** `curated_qa_regen_trigger.quarantine_row` takes a corpus ROW and
+    derives its target via `_stable_point_id`. A point with no row on disk can never be selected,
+    so a regulatory delta can invalidate the 396 tracked answers and leave anything untracked
+    serving the superseded fact indefinitely.
+  - **Sampled, not assumed**: the 9 orphans that assert a land-tenure duration read substantively
+    CORRECT (E33/Second Home, SHM-Sarusun, USD 1M threshold). This is a governance gap, not a
+    proven wrong answer — do NOT sell it as the cause of the beta's Hak Pakai 65 / HGB 70 error.
+  - **REFUTED, so nobody re-derives it**: the elegant hypothesis that the 412 are id-derivation
+    twins of the current rows (the `domain:` prefix was folded into the digest later — the
+    FATAL-1 note in `_stable_point_id`) is FALSE. Recomputing all 396 rows under three older
+    derivations matched **zero** live points. They are different questions, not old copies.
+  - **`faq_committed` is `false` on all 21 manifests**, so the exact-match FAQ sink — the one that
+    bypasses the abstain gate — carries none of this corpus. The abstain-bypass exposure is
+    currently theoretical; the grounding exposure is live.
+  - Countable from now on: `scripts/curated_qa_serving_audit.py` (pure reporter, never writes).
+
 - **🕳️ THE WEBHOOK ROUTER'S FALLBACK BRANCH WAS DEAD FOR ~5 MONTHS, AND NOTHING NOTICED BECAUSE
   NOTHING EVER RAN IT (2026-08-11, PR #4081).** `whatsapp_chat.process_whatsapp_message` answers
   from OpenClaw when it responds and from the RAG orchestrator when it does not. The second path

--- a/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_serving_audit.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_curated_qa_serving_audit.py
@@ -1,0 +1,276 @@
+"""Guilt + innocence for the curated_qa serving audit.
+
+The fake sits at the **HTTP boundary** — it answers `/points/scroll` with the
+envelope shape measured against the live Qdrant on 2026-08-11
+(`{"result": {"points": [...], "next_page_offset": ...}}`), not at the client
+boundary. A fake placed at the service boundary would speak whatever
+vocabulary the caller imagined, and two copies of one assumption confirming
+each other is not evidence.
+
+Every corpus here is built under `tmp_path`; nothing reads the real corpus or
+the real collection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.curated_qa_harvest import _stable_point_id
+from scripts.curated_qa_serving_audit import (
+    EXIT_CANNOT_VERIFY,
+    EXIT_OK,
+    EXIT_ORPHANS,
+    EXIT_ROWS_NOT_SERVED,
+    audit,
+    scroll_all,
+)
+from scripts.curated_qa_serving_audit import (
+    _load_disk_rows as load_disk_rows,
+)
+
+
+class _Resp:
+    def __init__(self, body: dict[str, Any]) -> None:
+        self._body = body
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _FakeQdrant:
+    """Answers scroll like the live API: one page per call, cursor in the body."""
+
+    def __init__(self, pages: list[list[dict]]) -> None:
+        self.pages = pages
+        self.calls: list[dict] = []
+
+    async def post(self, url: str, body: dict) -> _Resp:
+        self.calls.append(body)
+        idx = 0 if "offset" not in body else int(body["offset"])
+        page = self.pages[idx] if idx < len(self.pages) else []
+        nxt = idx + 1 if idx + 1 < len(self.pages) else None
+        return _Resp({"result": {"points": page, "next_page_offset": nxt}})
+
+
+class _BrokenQdrant:
+    async def post(self, url: str, body: dict) -> _Resp:
+        raise ConnectionError("qdrant unreachable")
+
+
+def _row(question: str, domain: str = "visa", cls: str = "BERSYARAT") -> dict:
+    return {
+        "question": question,
+        "answer": f"vetted answer for {question}",
+        "domain": domain,
+        "lang": "en",
+        "source_ref": "FIXTURE#1",
+        "source_date": "2026-07-19",
+        "confidence_class": cls,
+        "law_refs": [],
+        "source_priority": 10,
+        "verbatim_eligible": cls == "JELAS",
+        "client_specific": False,
+    }
+
+
+def _corpus(tmp_path: Path, rows: list[dict], name: str = "visa-fixture.jsonl") -> Path:
+    d = tmp_path / "curated_qa"
+    d.mkdir(exist_ok=True)
+    (d / name).write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in rows) + "\n", encoding="utf-8"
+    )
+    return d
+
+
+def _point(row: dict, **payload_overrides: Any) -> dict:
+    """A served point built the way the harvester builds one."""
+    payload = {
+        "domain": row["domain"],
+        "confidence_class": row["confidence_class"],
+        "answer": row["answer"],
+        "text": row["question"],
+        "source_date": row["source_date"],
+    }
+    payload.update(payload_overrides)
+    return {"id": _stable_point_id(row["question"], row["domain"]), "payload": payload}
+
+
+def _orphan_point(question: str, domain: str = "visa", **payload: Any) -> dict:
+    """A point whose (domain, question) is NOT on disk — the 412-shape.
+
+    Deliberately carries no `active`, no `batch_id`: that is exactly what the
+    pre-Phase-0 points look like, and `active` missing is what makes them
+    reach grounding.
+    """
+    base = {"domain": domain, "confidence_class": "BERSYARAT", "answer": "…", "text": question}
+    base.update(payload)
+    return {"id": _stable_point_id(question, domain), "payload": base}
+
+
+class TestGuiltTheOrphansAreSeen:
+    def test_a_point_with_no_corpus_row_is_reported_as_orphan(self, tmp_path: Path) -> None:
+        rows = [_row("q1")]
+        d = _corpus(tmp_path, rows)
+        ids, problems = load_disk_rows(d)
+        assert problems == []
+
+        a = audit([_point(rows[0]), _orphan_point("a question nobody kept on disk")], ids)
+
+        assert a.orphans == 1
+        assert a.matched == 1
+        assert a.served_points == 2
+
+    def test_an_orphan_without_active_counts_as_reaching_grounding(self, tmp_path: Path) -> None:
+        """Missing `active` means served — this mirrors the read path's own
+        default, which is what makes the 412 a live condition rather than
+        archaeology. An audit that assumed the safer reading would report a
+        problem smaller than the one production has."""
+        ids, _ = load_disk_rows(_corpus(tmp_path, [_row("q1")]))
+
+        a = audit([_orphan_point("untracked")], ids)
+
+        assert a.orphans == 1
+        assert a.orphans_reachable == 1
+
+    def test_a_corpus_row_that_no_point_answers_is_reported(self, tmp_path: Path) -> None:
+        rows = [_row("q1"), _row("q2")]
+        ids, _ = load_disk_rows(_corpus(tmp_path, rows))
+
+        a = audit([_point(rows[0])], ids)
+
+        assert len(a.rows_not_served) == 1
+        assert "q2" in a.rows_not_served[0]
+
+    @pytest.mark.asyncio
+    async def test_an_orphan_on_the_second_page_is_not_missed(self, tmp_path: Path) -> None:
+        """One scroll call returns ONE page. Reading it as the collection
+        under-reports every orphan past the first page — the failure this
+        tool exists to prevent, committed by the tool itself."""
+        rows = [_row("q1")]
+        ids, _ = load_disk_rows(_corpus(tmp_path, rows))
+        fake = _FakeQdrant([[_point(rows[0])], [_orphan_point("only on page two")]])
+
+        points, problems = await scroll_all(fake.post, "curated_qa", page_size=1)
+
+        assert problems == []
+        assert len(points) == 2, "the cursor must be followed to exhaustion"
+        assert audit(points, ids).orphans == 1
+
+    @pytest.mark.asyncio
+    async def test_a_scroll_that_never_terminates_is_a_problem_not_a_result(self) -> None:
+        never_ending = _FakeQdrant([[{"id": "x", "payload": {}}]] * 5)
+        points, problems = await scroll_all(never_ending.post, "curated_qa", max_pages=2)
+
+        assert problems, "a truncated read must be declared, never returned as the answer"
+        assert len(points) == 2
+
+
+class TestGuiltItRefusesToReadCleanWhenItSawNothing:
+    @pytest.mark.asyncio
+    async def test_an_unreachable_collection_is_cannot_verify(self) -> None:
+        points, problems = await scroll_all(_BrokenQdrant().post, "curated_qa")
+
+        assert points == []
+        assert problems and "scroll failed" in problems[0]
+
+    def test_a_missing_corpus_dir_is_a_problem(self, tmp_path: Path) -> None:
+        ids, problems = load_disk_rows(tmp_path / "nope")
+        assert ids == {}
+        assert problems
+
+    def test_a_corpus_dir_without_jsonl_is_a_problem(self, tmp_path: Path) -> None:
+        (tmp_path / "curated_qa").mkdir()
+        ids, problems = load_disk_rows(tmp_path / "curated_qa")
+        assert ids == {}
+        assert problems, "no rows means nothing to attribute points to — never 'clean'"
+
+
+class TestInnocence:
+    def test_a_collection_that_matches_disk_exactly_is_clean(self, tmp_path: Path) -> None:
+        rows = [_row("q1"), _row("q2", cls="JELAS")]
+        ids, _ = load_disk_rows(_corpus(tmp_path, rows))
+
+        a = audit([_point(r) for r in rows], ids)
+
+        assert a.orphans == 0
+        assert a.rows_not_served == []
+        assert a.matched == 2
+
+    def test_a_matched_point_flagged_inactive_is_not_an_orphan(self, tmp_path: Path) -> None:
+        """Quarantine sets `active=False` and deliberately KEEPS the point as
+        an audit trail. Calling that an orphan would turn every correctly
+        withdrawn answer into a finding."""
+        rows = [_row("q1")]
+        ids, _ = load_disk_rows(_corpus(tmp_path, rows))
+
+        a = audit([_point(rows[0], active=False)], ids)
+
+        assert a.orphans == 0
+        assert a.matched == 1
+
+    def test_an_orphan_already_flagged_inactive_does_not_count_as_reaching_grounding(
+        self, tmp_path: Path
+    ) -> None:
+        ids, _ = load_disk_rows(_corpus(tmp_path, [_row("q1")]))
+
+        a = audit([_orphan_point("withdrawn", active=False)], ids)
+
+        assert a.orphans == 1
+        assert a.orphans_reachable == 0, "explicitly inactive is exactly what the read path drops"
+
+    def test_the_same_question_in_two_domains_is_two_distinct_rows(self, tmp_path: Path) -> None:
+        """The id folds `domain` in (harvester FATAL-1). If this audit ever
+        stopped honouring that, the second domain's point would read as an
+        orphan of the first."""
+        rows = [_row("same wording", domain="visa"), _row("same wording", domain="tax")]
+        ids, _ = load_disk_rows(_corpus(tmp_path, rows))
+
+        assert len(ids) == 2
+        assert audit([_point(r) for r in rows], ids).orphans == 0
+
+
+def test_the_audit_uses_the_harvesters_own_id_rule_not_a_copy() -> None:
+    """Two implementations of one id rule diverge the day one of them
+    changes, and this one would then report the entire corpus as orphaned."""
+    import scripts.curated_qa_harvest as harvest
+    import scripts.curated_qa_serving_audit as sut
+
+    assert sut._stable_point_id is harvest._stable_point_id
+
+
+@pytest.mark.parametrize(
+    ("orphans", "rows_not_served", "strict", "expect_bits"),
+    [
+        (0, 0, False, EXIT_OK),
+        (0, 1, False, EXIT_ROWS_NOT_SERVED),
+        (1, 0, False, EXIT_OK),
+        (1, 0, True, EXIT_ORPHANS),
+    ],
+)
+def test_exit_bits_follow_the_documented_severity(
+    orphans: int, rows_not_served: int, strict: bool, expect_bits: int, tmp_path: Path
+) -> None:
+    """A row the bot cannot ground on is always non-zero; a bare orphan is
+    advisory unless asked. `--strict` must not be the only way to learn that
+    coverage is missing."""
+    rows = [_row(f"q{i}") for i in range(1 + rows_not_served)]
+    ids, _ = load_disk_rows(_corpus(tmp_path, rows))
+    points = [_point(rows[0])]
+    points += [_orphan_point(f"orphan{i}") for i in range(orphans)]
+
+    a = audit(points, ids)
+    code = EXIT_OK
+    if a.rows_not_served:
+        code |= EXIT_ROWS_NOT_SERVED
+    if strict and a.orphans:
+        code |= EXIT_ORPHANS
+
+    assert code == expect_bits
+    assert not (code & EXIT_CANNOT_VERIFY)

--- a/apps/backend-rag/scripts/curated_qa_serving_audit.py
+++ b/apps/backend-rag/scripts/curated_qa_serving_audit.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Report curated_qa points production SERVES that no corpus row explains.
+
+WHY THIS EXISTS
+---------------
+`curated_qa_drift_report.py` compares the corpus on disk against its
+manifests. That is the whole picture only if the collection contains exactly
+what the manifests describe. It does not.
+
+Measured against prod on 2026-08-11: the `curated_qa` collection holds **808
+points**; **396** map to a row in `data/curated_qa/*.jsonl`; the remaining
+**412 map to nothing on disk** — all `domain=visa`, all `source_date` in
+2026-07, 61 of them in the verbatim class `JELAS`. They carry none of the
+Phase-0 payload fields (`batch_id`, `active`, `invalidated_at`,
+`verbatim_eligible`, `client_specific`), so they predate that schema, and no
+manifest references them (`curated_qa_drift_report` reports zero
+`source_missing`).
+
+Two facts make that a governance gap rather than harmless archaeology, and
+both are quoted from the code, not inferred:
+
+1. **They are served.** `orchestrator_core._inject_curated_qa_grounding`
+   filters with `metadata.get("active", True) is False` — a MISSING `active`
+   field means active, deliberately ("a pre-Phase-0 point written before this
+   rail existed — treated as active, not silently dropped"). Every one of the
+   412 lacks the field.
+2. **They cannot be withdrawn.** `curated_qa_regen_trigger.quarantine_row`
+   takes a corpus ROW and derives the point id from it
+   (`_stable_point_id(question, domain)`). A point with no row on disk can
+   never be selected, so a regulatory delta can invalidate the 396 tracked
+   answers and leave anything untracked serving the superseded fact forever.
+
+So the corpus README's claim that the on-disk files are "the audit trail
+behind the safety invariant" holds for 396 of 808 points. This script is what
+makes the other half countable.
+
+NOT a hypothesis this script tested and confirmed: an earlier guess that the
+412 were id-derivation twins of the current rows (the `domain:` prefix was
+added to the digest later, as `_stable_point_id`'s FATAL-1 note records) was
+REFUTED — recomputing every disk row under three older derivations matched
+zero live points. They are different questions, not old copies of these ones.
+
+Pure reporter — it never writes, never deletes, never flags a point.
+Withdrawing or re-homing an orphan is a judgment call about vetted client
+content, not something a scan should do on its own.
+
+    python scripts/curated_qa_serving_audit.py            # human summary
+    python scripts/curated_qa_serving_audit.py --json     # machine-readable
+
+Exit codes (bitwise, fail-visible):
+    0  every served point maps to a corpus row, and every row is served
+    1  orphans: points served with no reviewable source  (--strict, else advisory)
+    2  corpus rows that production does NOT serve — always non-zero: the
+       corpus claims grounding coverage the bot does not actually have
+    4  CANNOT VERIFY — no corpus, or the collection could not be read in full.
+       Never reported as clean: zero points traversed is not evidence of
+       health, and a scroll that stops at page one under-reports by design.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import collections
+import json
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# The id rule is IMPORTED, never re-implemented: an audit that derives point
+# ids its own way stops agreeing with the harvester the day the harvester
+# changes, and would then report the whole corpus as orphaned.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scripts.curated_qa_harvest import (
+    _CURATED_QA_COLLECTION_NAME,
+    _stable_point_id,
+)
+
+EXIT_OK = 0
+EXIT_ORPHANS = 1
+EXIT_ROWS_NOT_SERVED = 2
+EXIT_CANNOT_VERIFY = 4
+
+VERBATIM_CLASS = "JELAS"
+
+# Mirrors orchestrator_core._inject_curated_qa_grounding: a point is excluded
+# from grounding ONLY by an explicit `active is False`. Missing = served.
+_SERVED_UNLESS_EXPLICITLY_INACTIVE = True
+
+
+@dataclass
+class Audit:
+    served_points: int = 0
+    matched: int = 0
+    orphans: int = 0
+    orphans_reachable: int = 0  # orphan AND served (not explicitly inactive)
+    rows_on_disk: int = 0
+    rows_not_served: list[str] = field(default_factory=list)
+    orphan_domains: dict[str, int] = field(default_factory=dict)
+    orphan_classes: dict[str, int] = field(default_factory=dict)
+    problems: list[str] = field(default_factory=list)
+
+
+def _point_is_served(payload: dict[str, Any]) -> bool:
+    """A point reaches grounding unless it is EXPLICITLY flagged inactive.
+
+    Written to match the read path rather than to be strict: the whole point
+    of this audit is what production actually serves, so it has to inherit
+    the read path's default, not a safer-looking one of its own.
+    """
+    return payload.get("active", _SERVED_UNLESS_EXPLICITLY_INACTIVE) is not False
+
+
+def _load_disk_rows(corpus_dir: Path) -> tuple[dict[str, str], list[str]]:
+    """Return ({point_id: "<domain>/<question head>"}, problems)."""
+    problems: list[str] = []
+    if not corpus_dir.is_dir():
+        return {}, [f"corpus dir not found: {corpus_dir}"]
+
+    ids: dict[str, str] = {}
+    files = sorted(corpus_dir.glob("*.jsonl"))
+    if not files:
+        return {}, [f"no *.jsonl under {corpus_dir} — nothing to attribute points to"]
+
+    for path in files:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                problems.append(f"{path.name}: unparseable line (corpus is not valid JSONL)")
+                continue
+            question = rec.get("question")
+            domain = rec.get("domain")
+            if not question or not domain:
+                problems.append(f"{path.name}: row without question/domain — cannot be attributed")
+                continue
+            ids[_stable_point_id(question, domain)] = f"{domain}/{str(question)[:60]}"
+    return ids, problems
+
+
+async def scroll_all(
+    post: Callable[[str, dict], Awaitable[Any]],
+    collection: str,
+    *,
+    page_size: int = 256,
+    max_pages: int = 10_000,
+) -> tuple[list[dict], list[str]]:
+    """Read EVERY point's payload, following `next_page_offset`.
+
+    A single scroll call returns one page. Reading that page as if it were
+    the collection is how a partial list gets consumed as a complete one, and
+    here it would silently under-report orphans — so exhausting the cursor is
+    the contract, and hitting `max_pages` is a PROBLEM (exit 4), never a
+    quietly truncated answer.
+    """
+    points: list[dict] = []
+    problems: list[str] = []
+    offset: Any = None
+    for _ in range(max_pages):
+        body: dict[str, Any] = {
+            "limit": page_size,
+            "with_payload": True,
+            "with_vectors": False,
+        }
+        if offset is not None:
+            body["offset"] = offset
+        try:
+            resp = await post(f"/collections/{collection}/points/scroll", body)
+            resp.raise_for_status()
+            result = resp.json().get("result") or {}
+        except Exception as exc:
+            problems.append(f"scroll failed after {len(points)} point(s): {type(exc).__name__}")
+            return points, problems
+        page = result.get("points") or []
+        points.extend(page)
+        offset = result.get("next_page_offset")
+        if offset is None or not page:
+            return points, problems
+    problems.append(f"scroll did not terminate within {max_pages} pages — result is partial")
+    return points, problems
+
+
+def audit(points: list[dict], disk_ids: dict[str, str]) -> Audit:
+    out = Audit(served_points=len(points), rows_on_disk=len(disk_ids))
+    domains: collections.Counter[str] = collections.Counter()
+    classes: collections.Counter[str] = collections.Counter()
+    seen_ids: set[str] = set()
+
+    for point in points:
+        pid = str(point.get("id"))
+        seen_ids.add(pid)
+        payload = point.get("payload") or {}
+        if pid in disk_ids:
+            out.matched += 1
+            continue
+        out.orphans += 1
+        if _point_is_served(payload):
+            out.orphans_reachable += 1
+        domains[str(payload.get("domain"))] += 1
+        classes[str(payload.get("confidence_class"))] += 1
+
+    out.rows_not_served = sorted(label for pid, label in disk_ids.items() if pid not in seen_ids)
+    out.orphan_domains = dict(domains.most_common())
+    out.orphan_classes = dict(classes.most_common())
+    return out
+
+
+def render(a: Audit) -> str:
+    lines = [
+        f"curated_qa serving audit — {a.served_points} point(s) in the collection, "
+        f"{a.rows_on_disk} row(s) on disk: matched={a.matched} orphan={a.orphans} "
+        f"rows_not_served={len(a.rows_not_served)}"
+    ]
+    if a.orphans:
+        lines += [
+            "",
+            f"  ORPHANS — {a.orphans} served point(s) no corpus row explains, of which",
+            f"  {a.orphans_reachable} reach grounding (not flagged inactive). They cannot be",
+            "  reviewed (no file), and quarantine_row() derives its target from a corpus",
+            "  row, so a regulatory delta can never withdraw them.",
+            f"    by domain: {a.orphan_domains}",
+            f"    by class:  {a.orphan_classes}",
+        ]
+        verbatim = a.orphan_classes.get(VERBATIM_CLASS, 0)
+        if verbatim:
+            lines.append(
+                f"    {verbatim} are {VERBATIM_CLASS} — the class that carries verbatim"
+                " eligibility when harvested."
+            )
+    if a.rows_not_served:
+        lines += [
+            "",
+            f"  NOT SERVED — {len(a.rows_not_served)} vetted row(s) exist on disk but no",
+            "  point answers to them: the corpus claims coverage the bot does not have.",
+        ]
+        lines += [f"    {label}" for label in a.rows_not_served[:20]]
+        if len(a.rows_not_served) > 20:
+            lines.append(f"    … and {len(a.rows_not_served) - 20} more")
+    for problem in a.problems:
+        lines.append(f"  CANNOT VERIFY: {problem}")
+    if not a.orphans and not a.rows_not_served and not a.problems and a.served_points:
+        lines.append("  every served point maps to a corpus row, and every row is served.")
+    return "\n".join(lines)
+
+
+async def run(corpus_dir: Path, collection: str) -> Audit:
+    disk_ids, problems = _load_disk_rows(corpus_dir)
+    if problems and not disk_ids:
+        a = Audit()
+        a.problems = problems
+        return a
+
+    from backend.core.qdrant_db import QdrantClient
+
+    client = QdrantClient(collection_name=collection)
+    try:
+        http = await client._get_client()
+
+        async def post(url: str, body: dict) -> Any:
+            return await http.post(url, json=body)
+
+        points, scroll_problems = await scroll_all(post, collection)
+    finally:
+        await client.close()
+
+    a = audit(points, disk_ids)
+    a.problems = problems + scroll_problems
+    if not points:
+        a.problems.append(f"zero points read from '{collection}' — not evidence of health")
+    return a
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument(
+        "--corpus-dir",
+        default=str(Path(__file__).resolve().parents[1] / "data" / "curated_qa"),
+        help="directory holding the *.jsonl corpus (ops-populated; empty in a worktree)",
+    )
+    ap.add_argument("--collection", default=_CURATED_QA_COLLECTION_NAME)
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--strict", action="store_true", help="exit non-zero on orphans too")
+    args = ap.parse_args(argv)
+
+    a = asyncio.run(run(Path(args.corpus_dir), args.collection))
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "served_points": a.served_points,
+                    "rows_on_disk": a.rows_on_disk,
+                    "matched": a.matched,
+                    "orphans": a.orphans,
+                    "orphans_reachable": a.orphans_reachable,
+                    "rows_not_served": a.rows_not_served,
+                    "orphan_domains": a.orphan_domains,
+                    "orphan_classes": a.orphan_classes,
+                    "problems": a.problems,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(render(a))
+
+    code = EXIT_OK
+    if a.problems:
+        code |= EXIT_CANNOT_VERIFY
+    if a.rows_not_served:
+        code |= EXIT_ROWS_NOT_SERVED
+    if args.strict and a.orphans:
+        code |= EXIT_ORPHANS
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 695 services · 1345 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 695 services · 1347 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What

A pure reporter for the half of the curated grounding store that nothing on disk explains.

`curated_qa_drift_report.py` (#4083) compares the corpus against its manifests. That is the whole picture only if the collection contains what the manifests describe. **It does not.**

## Measured against prod (2026-08-11)

`curated_qa` holds **808 points**. **396** map to a row in `data/curated_qa/*.jsonl` — verified by recomputing `_stable_point_id(question, domain)` for every row: all 396 present, **none missing**. The other **412 map to nothing on disk**: all `domain=visa`, all `source_date` in 2026-07, **61 in the verbatim class `JELAS`**. They carry none of the Phase-0 payload fields (`batch_id`, `active`, `invalidated_at`, `verbatim_eligible`, `client_specific`) and no manifest references them — so the disk↔manifest view reads `21 files, in_sync=21, source_missing=0` while half the store sits outside it.

Two facts make that a governance gap rather than harmless archaeology. Both are quoted from the code, not inferred:

1. **They are served.** `orchestrator_core._inject_curated_qa_grounding` filters with `metadata.get("active", True) is False` — a *missing* `active` means active, deliberately (*"a pre-Phase-0 point written before this rail existed — treated as active, not silently dropped"*). Every one of the 412 lacks the field.
2. **They cannot be withdrawn.** `curated_qa_regen_trigger.quarantine_row` takes a corpus **row** and derives the point id from it. A point with no row can never be selected — so a regulatory delta can invalidate the 396 tracked answers and leave anything untracked serving the superseded fact indefinitely.

**Sampled, not assumed:** the 9 orphans that assert a land-tenure duration read substantively **correct** (E33/Second Home, SHM-Sarusun, USD 1M threshold). This is a governance gap, **not** a proven wrong answer — it is deliberately not sold as the cause of the team beta's Hak Pakai 65 / HGB 70 error.

**Refuted, and recorded so nobody re-derives it:** the elegant hypothesis that the 412 are id-derivation twins of the current rows (the `domain:` prefix was folded into the digest later — the FATAL-1 note in `_stable_point_id`) is **false**. Recomputing all 396 rows under three older derivations matched **zero** live points. Different questions, not old copies.

Related, measured on the way: `faq_committed` is `false` on all 21 manifests, so the exact-match FAQ sink — the one that bypasses the abstain gate — carries none of this corpus. That exposure is currently theoretical; the grounding exposure is live.

## Why a separate tool, not a flag on #4083

The drift reporter is pure filesystem and runs in CI. This one needs a live Qdrant. Different dependency, different failure mode — a filesystem-only check should not grow a network dependency to cover a different question.

Pure reporter: never writes, never deletes, never flags a point. Withdrawing or re-homing an orphan is a judgment call about vetted client content, not something a scan should do on its own.

## Verification

17 tests, guilt + innocence. The fake sits at the **HTTP boundary**, answering `/points/scroll` with the envelope shape measured against the live API — a fake at the service boundary would speak whatever vocabulary the caller imagined, and two copies of one assumption confirming each other is not evidence.

Mutation-verified **6/6 killed, both controls survive**:

| mutation | killed by |
|---|---|
| scroll stops after page one | `test_an_orphan_on_the_second_page_is_not_missed` + the truncation test |
| inactive points counted as served | `test_an_orphan_already_flagged_inactive_does_not_count_as_reaching_grounding` |
| unreachable collection reads clean | `test_an_unreachable_collection_is_cannot_verify` |
| unserved corpus rows hidden | `test_a_corpus_row_that_no_point_answers_is_reported` |
| truncated scroll not declared | `test_a_scroll_that_never_terminates_is_a_problem_not_a_result` |
| id rule re-implemented instead of imported | 10 tests, incl. `test_the_audit_uses_the_harvesters_own_id_rule_not_a_copy` |

The first mutation matters most: reading one scroll page as if it were the collection is exactly how this tool would under-report the thing it exists to count.

## Live output

```
curated_qa serving audit — 808 point(s) in the collection, 396 row(s) on disk: matched=396 orphan=412 rows_not_served=0

  ORPHANS — 412 served point(s) no corpus row explains, of which
  412 reach grounding (not flagged inactive). They cannot be
  reviewed (no file), and quarantine_row() derives its target from a corpus
  row, so a regulatory delta can never withdraw them.
    by domain: {'visa': 412}
    by class:  {'BERSYARAT': 225, 'BELUM_DIATUR_PUBLIK': 72, 'JELAS': 61, 'KEBIJAKAN_PENYEDIA': 34, 'DINAMIS': 20}
    61 are JELAS — the class that carries verbatim eligibility when harvested.
```

Also records the finding in the bot corner (`.agents/skills/bot/SKILL.md` §1 LIVE STATE), including the refuted hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)