### PR TITLE
docs(prepush): the v9 docstring contradicted itself on docs/ and research/

### DIFF
--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -37,10 +37,11 @@ inputs, CONVERGED findings):
   is suffix-scoped through `ALLOWLIST_PREFIX_SUFFIX_PAIRS` — a path must be
   a descendant of the directory prefix AND end in an explicitly-listed
   extension. Exact files use `ALLOWLIST_EXACT_PATHS` and cannot match
-  descendants. docs/research/.claude-content-dirs are scoped to `.md` ONLY
-  (verified: 100% of files under .claude/{skills,rules,commands,agents}
-  are already .md: 12/12, 7/7, 5/5, 15/15; docs/research are dominated by
-  .md with the aforementioned executable outliers now correctly excluded).
+  descendants. The .claude content dirs are scoped to `.md` ONLY (verified:
+  100% of files under .claude/{skills,rules,commands,agents} are already
+  .md: 12/12, 7/7, 5/5, 15/15); docs/** and research/** admit `.md` AND
+  `.txt` since v9 — see the "v9 EXTENSION" section below for the measurement
+  — with the aforementioned executable outliers still correctly excluded.
   `infra/launchagents/**` keeps `.plist`/`.sh` as a DECLARED, deliberate
   choice (these launchd wrapper scripts never touch the pytest backend
   suite) — not an accident of a bare-prefix glob, the same suffix-scoped
@@ -406,9 +407,14 @@ ALLOWLIST_EXACT_PATHS: frozenset[str] = frozenset(
 # exactly the gap round-1 red-team caught):
 #
 #   docs/**               940 .md but ALSO 8 .py + 7 .sh among the
-#                         outliers today -> scoped to `.md` ONLY.
+#                         outliers today -> scoped to `.md` + `.txt` (v9,
+#                         2026-08-11; 25 tracked .txt, none executable,
+#                         none read by backend/ or tests/). The .py/.sh
+#                         outliers stay excluded — that is the whole point
+#                         of suffix-scoping, and .txt does not weaken it.
 #   research/**           602 .md but ALSO 14 .py among the outliers
-#                         today -> scoped to `.md` ONLY.
+#                         today -> scoped to `.md` + `.txt` (v9, same
+#                         measurement: 11 tracked .txt, same exclusions).
 #   .claude/skills/**     12/12 files are .md -> scoped to `.md`.
 #   .claude/rules/**       7/7 files are .md -> scoped to `.md`.
 #   .claude/commands/**    5/5 files are .md -> scoped to `.md`.


### PR DESCRIPTION
## The defect

#4055 added `.txt` to `docs/**` and `research/**` and documented it in a new **"v9 EXTENSION"**
section — and left three older assertions in the same file saying the opposite:

| line | text |
|---|---|
| 40 | `docs/research/.claude-content-dirs are scoped to `.md` ONLY` |
| 409 | `docs/**    ... -> scoped to `.md` ONLY.` |
| 411 | `research/** ... -> scoped to `.md` ONLY.` |

So the file that decides **which diffs may skip the backend suite** carried a false statement about
its own rule. A reader who greps `scoped to .md ONLY` finds it, concludes `.txt` is excluded, and
may "restore" a restriction that was removed on purpose — or mis-triage a skip decision.

This is mine: I wrote the v9 section and did not reconcile the prose it contradicts.

## Censused, not spot-fixed

Five occurrences of the phrase exist in the file. The two covering `.agents/skills/**` and
`scripts` are **still true** and are left untouched — curing one instance of five and calling the
class closed is exactly the W107 failure. Only the three that cover `docs/` or `research/` change.

## What does NOT change

- **Behaviour.** Verified after the edit: `research/x.txt` + `docs/y.txt` still resolve to
  `skip-backend` via `research/** (.md/.txt)` / `docs/** (.md/.txt)`; `research/x.py` still forces
  `full`. The `.py`/`.sh` outliers stay excluded — that is what suffix-scoping is for, and `.txt`
  does not weaken it.
- **`ALLOWLIST_VERSION`, deliberately NOT bumped.** The version exists so a skip-banner line
  (`allowlist vN`) is attributable to the specific *rules* that approved it. No rule changed here;
  bumping for prose would signal a rules change that did not happen.

`scripts/tests/test_prepush_classify.py`: **150 passed**.

Pre-push ran the **FULL** suite by design — `scripts/prepush_classify.py` is in
`NEVER_INNOCENT_EXACT_PATHS`, because a classifier must never authorise skipping the suite on its
own diff, not even for a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)