### PR TITLE
fix(mini): give the SOS probe an exit that does not depend on the Pro

### DIFF
--- a/scripts/mini/mini_sos_report.sh
+++ b/scripts/mini/mini_sos_report.sh
@@ -134,7 +134,13 @@ fi
 # --- exfiltrate over the direction that still works.
 REMOTE_NAME="mini-sos-$(date +%Y%m%d-%H%M%S).txt"
 DELIVERED=0
-for TARGET in pro nuzantara@100.107.22.111; do
+# M5 is third and not decorative: on 2026-08-12 04:53 the Pro rebooted and came
+# up at the login window, so its Tailscale — an App Store build that lives in
+# the user's GUI session — never started, and BOTH of the first two targets are
+# Tailscale addresses of that same host. A rescue whose only exit depends on one
+# machine being logged in is not a rescue. M5 already authorises the same key
+# and its sshd listens; the loop stops at whichever answers first.
+for TARGET in pro nuzantara@100.107.22.111 nuzantara@100.110.186.116; do
     if ssh -o BatchMode=yes -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new \
            "$TARGET" "cat > /tmp/$REMOTE_NAME && cp /tmp/$REMOTE_NAME /tmp/mini-sos-latest.txt" \
            < "$OUT" 2>>"$LOG_FILE"; then


### PR DESCRIPTION
Both delivery targets of the Mini rescue probe (#4070) were Tailscale addresses of the **same host**, the Pro.

On 2026-08-12 at 04:53 the Pro rebooted and came up at the login window — `who` empty, 0 users, 53 LaunchAgents loaded instead of the usual ~176. Its Tailscale is an App Store build that lives in the user's GUI session, so it never started: `open -a Tailscale` over ssh fails with `Domain does not support specified action`, and there is no LaunchDaemon to kickstart. The machine was fine and reachable on the LAN the whole time — it was simply off the tailnet until somebody logged in physically.

A rescue whose only exit depends on one machine being logged in is not a rescue. The Mini has been unreachable for ~39 hours; its report would have sat undelivered for as long as the Pro stayed logged out, and nothing would have said so.

M5 is added as a third target: it already authorises the same key the Mini uses on the Pro (`nuzantara@macbook-pro`, no command restriction) and its sshd listens. The loop stops at whichever target answers first, so nothing changes once the Pro is back.

## Verified in a fake Mini

- With the two Pro targets failing **exactly as they do right now**, the report is delivered to `100.110.186.116` and the marker is written only after that success.
- With all three failing, no marker is written and the probe retries on the next pull — the retry-until-delivered property from #4070 is preserved.

## Removal

Goes out with the probe once the Mini is reachable again; the probe's own deadline guard retires it on 2026-08-25 regardless.