### PR TITLE
fix(security): close anonymous read of 500 client rows on the dashboard map (P0)

### DIFF
--- a/apps/backend-rag/backend/app/auth/public_endpoints.py
+++ b/apps/backend-rag/backend/app/auth/public_endpoints.py
@@ -57,7 +57,9 @@ class PublicEndpoint:
             if len(prefix_parts) != len(path_parts):
                 return False
             return all(
-                bool(actual) if expected.startswith("{") and expected.endswith("}") else actual == expected
+                bool(actual)
+                if expected.startswith("{") and expected.endswith("}")
+                else actual == expected
                 for expected, actual in zip(prefix_parts, path_parts, strict=True)
             )
         return path.startswith(self.prefix)
@@ -374,11 +376,62 @@ _PREVIEW = (
         Category.PREVIEW,
         "Article preview pages for Telegram approval — no indexing, public preview",
     ),
+    # REMOVED 2026-08-12 (P0, measured live): "/api/dashboard/map/" was a PREFIX
+    # entry, so every route the dashboard router ever mounts inherited public
+    # access — including `GET /api/dashboard/map/clients/geo`, which ran
+    # `SELECT id, full_name, email, phone, status, address FROM clients WHERE
+    # status='active' LIMIT 500` with no principal and no ownership filter. An
+    # anonymous request from the public internet answered HTTP 200 with 500
+    # client rows (500 names, 274 phones, 164 emails, 110 addresses).
+    #
+    # The blanket prefix IS the defect, not just the one route: it also left
+    # `POST /api/dashboard/map/analytics/log-lookup` writable anonymously with a
+    # caller-supplied `user_email`, i.e. forgeable attribution. A router that can
+    # reach the `clients` table must never sit behind a prefix entry — if a
+    # specific route here genuinely needs to be public, add THAT path, never the
+    # prefix, and never one that shares a router with client data.
+    #
+    # The three entries below are NOT new public access: they restore, per-route,
+    # the posture the 2026-07-17 mutating-routes audit had already justified one
+    # by one (`research/operations/2026-07-17-mutating-routes-authz-ledger.md`
+    # lines 233-235, category `preview`). That audit read THIS router and cleared
+    # these three as stateless compute — and never named `GET /clients/geo`,
+    # because its scope was mutating methods only. The client book was invisible
+    # to an audit that read the file it lives in: the scope was the METHOD, not
+    # the DATA. Hence per-route entries — the granularity the audit's own
+    # verdicts were written at, which the prefix silently over-delivered.
     PublicEndpoint(
-        "/api/dashboard/map/",
+        "/api/dashboard/map/validate-property",
         Category.PREVIEW,
-        "Streamlit dashboard — KBLI validation, client geo, risk zones, stats",
+        "Stateless KBLI/zoning compute for the property map — no DB read or "
+        "write, no PII in or out (cleared per-route by the 2026-07-17 audit)",
+        match="exact",
     ),
+    PublicEndpoint(
+        "/api/dashboard/map/gistaru-zone",
+        Category.PREVIEW,
+        "Stateless geo/zone lookup for the property map — no DB read or write "
+        "(cleared per-route by the 2026-07-17 audit)",
+        match="exact",
+    ),
+    PublicEndpoint(
+        "/api/dashboard/map/analyze-investment",
+        Category.PREVIEW,
+        "Stateless investment compute — verified no DB write (cleared per-route "
+        "by the 2026-07-17 audit). Its KBLI block degrades to state=ERROR in "
+        "prod because the dataset is not in the image (kbli-navigator L2.11b)",
+        match="exact",
+    ),
+    # `POST /api/dashboard/map/analytics/log-lookup` is DELIBERATELY absent: it
+    # is the one route here that WRITES (CREATE TABLE IF NOT EXISTS + INSERT),
+    # and it attributed each row to a `user_email` taken from the request body,
+    # so anonymous access meant an unauthenticated writer could file lookups
+    # under any employee's name. The 2026-07-17 audit cleared it as "telemetry
+    # insert only, same shape as /api/metrics/frontend" — but that endpoint
+    # carries no PII, and an email IS an identifier, so the shapes were never
+    # the same. It now takes the acting email from the authenticated principal.
+    # Measured before closing it (prod, 2026-08-12): 5 rows, 1 distinct email,
+    # all written 2026-03-02 and none since — no live consumer to break.
 )
 
 _FUNNEL = (
@@ -542,8 +595,7 @@ _VISA_ORACLE = (
     PublicEndpoint(
         "/api/visa/voa",
         Category.VISA_ORACLE,
-        "GARUDA VOA request funnel submission — anonymous eligibility + Safe "
-        "Clock verdict, no PII",
+        "GARUDA VOA request funnel submission — anonymous eligibility + Safe Clock verdict, no PII",
         match="exact",
     ),
     PublicEndpoint(

--- a/apps/backend-rag/backend/app/routers/dashboard.py
+++ b/apps/backend-rag/backend/app/routers/dashboard.py
@@ -12,9 +12,11 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
+from backend.app.dependencies import get_current_user
+from backend.app.deps.crm_access import get_crm_user_filter
 from backend.services.kbli_eye import KBLIEye
 
 logger = logging.getLogger(__name__)
@@ -44,7 +46,12 @@ class ValidatePropertyRequest(BaseModel):
 
 
 class LogLookupRequest(BaseModel):
-    user_email: str
+    # `user_email` REMOVED 2026-08-12: this route was anonymously reachable via
+    # the `/api/dashboard/map/` prefix entry, so the acting identity arrived from
+    # the request BODY — any caller could file a lookup under any employee's
+    # name. The email now comes from the authenticated principal, and the field
+    # is gone from the schema so forgery is impossible by construction rather
+    # than by a validation rule someone can relax later.
     property_code: str | None = None
     kbli_code: str | None = None
     location: str | None = None
@@ -801,26 +808,49 @@ async def gistaru_zone_lookup(req: GistaruLookupRequest) -> dict[str, Any]:
 
 
 @router.get("/clients/geo")
-async def get_clients_geo(request: Request) -> dict[str, Any]:
+async def get_clients_geo(
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
     """
     Returns active clients with address info for CRM map layer.
     Uses asyncpg pool from app state.
+
+    Authorization is TWO layers and both are load-bearing (P0, 2026-08-12):
+
+    1. A principal is required. Until today this took only `request: Request`,
+       and `/api/dashboard/map/` was a prefix entry in PUBLIC_ENDPOINTS — so an
+       anonymous GET from the public internet returned 500 client rows with
+       names, phones, emails and addresses. Measured live, not inferred.
+    2. The CRM ownership filter still applies to the authenticated caller. A
+       team member may only see rows where `assigned_to` matches
+       (`CLAUDE.md` §13); admins get the unfiltered set. Removing the public
+       entry alone would have left every authenticated team member able to read
+       all 1,244 clients from a route that exists to draw a map.
     """
     pool = getattr(request.app.state, "db_pool", None)
     if pool is None:
         logger.warning("Dashboard clients/geo: db_pool not available")
         return {"clients": [], "error": "Database pool not available"}
 
+    assigned_filter = get_crm_user_filter(current_user)
+    params: list[Any] = []
+    where_clause = "WHERE status = 'active'"
+    if assigned_filter:
+        where_clause = "WHERE status = 'active' AND assigned_to = $1"
+        params = [assigned_filter]
+
     try:
         async with pool.acquire() as conn:
             rows = await conn.fetch(
-                """
+                f"""
                 SELECT id, full_name, email, phone, status, address
                 FROM clients
-                WHERE status = 'active'
+                {where_clause}
                 ORDER BY full_name
                 LIMIT 500
                 """,
+                *params,
             )
             clients: list[dict[str, Any]] = [
                 {
@@ -880,11 +910,22 @@ async def get_risk_zones() -> dict[str, list[dict[str, Any]]]:
 
 
 @router.post("/analytics/log-lookup")
-async def log_lookup(req: LogLookupRequest, request: Request) -> dict[str, Any]:
+async def log_lookup(
+    req: LogLookupRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> dict[str, Any]:
     """
     Log a map lookup event for analytics tracking.
     Creates the analytics table on first use (idempotent).
+
+    The acting email comes from the authenticated principal, NEVER from the
+    request body: this route both writes to the database and names a person, so
+    an anonymous caller with a body-supplied email could attribute lookups to
+    any employee. It is deliberately NOT in PUBLIC_ENDPOINTS — see the comment
+    on the removed `/api/dashboard/map/` prefix entry there.
     """
+    acting_email = (current_user.get("email") or "").strip().lower() or None
     pool = getattr(request.app.state, "db_pool", None)
     if pool is None:
         logger.warning("Dashboard analytics/log: db_pool not available")
@@ -911,17 +952,17 @@ async def log_lookup(req: LogLookupRequest, request: Request) -> dict[str, Any]:
                     (user_email, property_code, kbli_code, location, notes)
                 VALUES ($1, $2, $3, $4, $5)
                 """,
-                req.user_email,
+                acting_email,
                 req.property_code,
                 req.kbli_code,
                 req.location,
                 req.notes,
             )
-            logger.info(
-                "Dashboard analytics logged: user=%s kbli=%s",
-                req.user_email,
-                req.kbli_code,
-            )
+            # The email is deliberately NOT logged: Sentry's LoggingIntegration
+            # turns every logger call into a breadcrumb, and its redaction works
+            # by KEY, so an identifier interpolated into a MESSAGE ships in the
+            # clear (measured 2026-08-02). The kbli code is not an identifier.
+            logger.info("Dashboard analytics logged: kbli=%s", req.kbli_code)
             return {"logged": True}
     except Exception as e:
         logger.error("Dashboard analytics/log failed: %s", e, exc_info=True)

--- a/apps/backend-rag/backend/tests/security/test_dashboard_map_not_public.py
+++ b/apps/backend-rag/backend/tests/security/test_dashboard_map_not_public.py
@@ -1,0 +1,137 @@
+"""The dashboard-map router must never be publicly reachable, and its client
+route must never return rows the caller does not own.
+
+THE DEFECT THIS EXISTS TO CATCH (measured live 2026-08-12, not inferred):
+
+`/api/dashboard/map/` was a PREFIX entry in PUBLIC_ENDPOINTS, described as
+"Streamlit dashboard — KBLI validation, client geo, risk zones, stats". Every
+route the dashboard router mounts therefore inherited public access, and one of
+them — `GET /clients/geo` — ran
+
+    SELECT id, full_name, email, phone, status, address
+    FROM clients WHERE status = 'active' ORDER BY full_name LIMIT 500
+
+taking only `request: Request`: no principal, no ownership filter. An anonymous
+GET against production answered **HTTP 200 with 500 client rows** — 500 names,
+274 phones, 164 emails, 110 addresses — from the public internet.
+
+Two properties are pinned here because the fix has two halves and either one
+alone leaves a hole:
+
+1. The PREFIX is gone, so no future route on this router is born public. Pinning
+   only `/clients/geo` would let the next handler inherit the same exposure —
+   the blanket prefix was the defect, not just the one route it exposed. The
+   write route `POST /analytics/log-lookup` (which accepted a caller-supplied
+   `user_email`, i.e. forgeable attribution) is pinned for the same reason.
+2. The ownership filter applies to the AUTHENTICATED caller. Removing the public
+   entry alone would still let any team member read all clients from a route
+   that exists to draw a map, which is the CRM RBAC rule in CLAUDE.md §13
+   ("Team = only assigned_to matches") routed around one layer lower.
+
+INNOCENCE matters as much as guilt here: a test that merely asserted "nothing is
+public" would pass on an emptied registry, and a test that asserted "the query
+always filters" would pass on a build that blinds admins. Both are checked.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _fake_pool_capturing_sql() -> tuple[MagicMock, dict]:
+    """A pool whose conn records the SQL and params it was handed."""
+    captured: dict = {}
+
+    async def _fetch(sql, *params):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    acm = MagicMock()
+    acm.__aenter__ = AsyncMock(return_value=conn)
+    acm.__aexit__ = AsyncMock(return_value=False)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=acm)
+    return pool, captured
+
+
+class TestPrefixIsNotPublic:
+    """GUILT — the registry must not hand this router out anonymously."""
+
+    def test_clients_geo_is_not_a_public_endpoint(self) -> None:
+        from backend.app.auth.public_endpoints import find_entry
+
+        entry = find_entry("/api/dashboard/map/clients/geo")
+        assert entry is None, (
+            "GET /api/dashboard/map/clients/geo is publicly reachable again. "
+            "It returns names, emails, phones and addresses of up to 500 active "
+            f"clients. Registry entry that matched: {entry}"
+        )
+
+    def test_the_whole_prefix_is_not_public(self) -> None:
+        from backend.app.auth.public_endpoints import find_entry
+
+        # The write route: it accepts a caller-supplied `user_email`, so public
+        # access means forgeable attribution on top of an unauthenticated write.
+        assert find_entry("/api/dashboard/map/analytics/log-lookup") is None
+        # And the bare prefix itself, which is how the defect was expressed.
+        assert find_entry("/api/dashboard/map/") is None
+
+    def test_a_genuinely_public_endpoint_is_still_public(self) -> None:
+        """INNOCENCE — the two assertions above must not be passing because the
+        registry was emptied or `find_entry` stopped matching anything."""
+        from backend.app.auth.public_endpoints import find_entry
+
+        assert find_entry("/health") is not None
+
+
+class TestClientsGeoScopesToTheCaller:
+    """GUILT + INNOCENCE on the second half of the fix."""
+
+    @pytest.mark.asyncio
+    async def test_non_admin_query_is_scoped_to_assigned_to(self) -> None:
+        from backend.app.routers.dashboard import get_clients_geo
+
+        pool, captured = _fake_pool_capturing_sql()
+        request = MagicMock()
+        request.app.state.db_pool = pool
+
+        await get_clients_geo(request, current_user={"email": "Team.Member@balizero.com"})
+
+        assert "assigned_to = $1" in captured["sql"], (
+            "a non-admin caller received an unscoped client query — the CRM "
+            f"ownership filter is not applied. SQL: {captured['sql']}"
+        )
+        assert captured["params"] == ("team.member@balizero.com",)
+
+    @pytest.mark.asyncio
+    async def test_admin_query_is_not_scoped(self) -> None:
+        """INNOCENCE — admins legitimately see the whole book (CLAUDE.md §13);
+        a cure that filtered everyone would break the map for its actual users
+        and would still pass the guilt test above."""
+        from backend.app.routers.dashboard import get_clients_geo
+
+        pool, captured = _fake_pool_capturing_sql()
+        request = MagicMock()
+        request.app.state.db_pool = pool
+
+        await get_clients_geo(request, current_user={"email": "zero@balizero.com"})
+
+        assert "assigned_to" not in captured["sql"]
+        assert captured["params"] == ()
+
+    @pytest.mark.asyncio
+    async def test_handler_requires_a_principal(self) -> None:
+        """GUILT — the signature must carry a resolved principal, so removing the
+        dependency (not just the registry entry) turns this red too."""
+        import inspect
+
+        from backend.app.routers.dashboard import get_clients_geo
+
+        params = inspect.signature(get_clients_geo).parameters
+        assert "current_user" in params, (
+            "get_clients_geo lost its principal — it would answer whoever the "
+            "middleware lets through, which is how this became a P0."
+        )

--- a/apps/backend-rag/backend/tests/security/test_mutating_routes_are_gated.py
+++ b/apps/backend-rag/backend/tests/security/test_mutating_routes_are_gated.py
@@ -116,15 +116,18 @@ class KnownUngatedMutation:
 INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
     # ── Auth flows: must be reachable BEFORE the caller has a credential ──
     IntentionalPublicMutation(
-        "POST", "/api/auth/login",
+        "POST",
+        "/api/auth/login",
         "Login endpoint — cannot require the credential it is issuing.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/auth/team/login",
+        "POST",
+        "/api/auth/team/login",
         "Team member login — same as above, initial authentication step.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/auth/request-magic-link",
+        "POST",
+        "/api/auth/request-magic-link",
         "Passwordless magic-link request (FASE 6) — enumeration-safe by design "
         "per public_endpoints.py; an unauthenticated client asks for a link.",
     ),
@@ -137,7 +140,8 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
     #    design), but see the ledger's "claimed-vs-actual" section + PENDING-ARMS
     #    — the verification gap is the real, separate, higher-priority issue.
     IntentionalPublicMutation(
-        "POST", "/webhook/whatsapp",
+        "POST",
+        "/webhook/whatsapp",
         "Meta WhatsApp webhook. VERIFIED 2026-07-17: whatsapp_chat.py "
         "_verify_whatsapp_signature DOES check X-Hub-Signature-256 HMAC-SHA256 "
         "when WHATSAPP_APP_SECRET is set — BUT its own docstring says "
@@ -147,7 +151,8 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
         "state, but a landmine — see PENDING-ARMS.",
     ),
     IntentionalPublicMutation(
-        "POST", "/webhook/instagram",
+        "POST",
+        "/webhook/instagram",
         "Meta Instagram webhook. VERIFIED 2026-07-17: instagram_chat.py's "
         "GET handshake DOES check INSTAGRAM_VERIFY_TOKEN, but the POST "
         "handler (webhook_router.post, line 167) has ZERO signature check — "
@@ -155,7 +160,8 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
         "payload at all. The registry reason overclaims — see PENDING-ARMS.",
     ),
     IntentionalPublicMutation(
-        "POST", "/webhook/telegram",
+        "POST",
+        "/webhook/telegram",
         "Telegram bot webhook. VERIFIED 2026-07-17: telegram_webhook.py's "
         "POST handler (line 252) has NO secret-token check (Telegram's own "
         "X-Telegram-Bot-Api-Secret-Token mechanism is never verified) — any "
@@ -164,100 +170,117 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
     ),
     # ── Bridge (Pro<->Fly): X-Bridge-Auth hmac.compare_digest in-router ──
     IntentionalPublicMutation(
-        "POST", "/api/bridge/ingest/article",
+        "POST",
+        "/api/bridge/ingest/article",
         "Pro<->Fly bridge (Phase 1 Sinapsi) — X-Bridge-Auth hmac.compare_digest "
         "against BRIDGE_API_KEY, rejects unauthorized with 401/503 in-router.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/bridge/ingest/enrichment",
+        "POST",
+        "/api/bridge/ingest/enrichment",
         "Same bridge HMAC auth as ingest/article.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/bridge/intake-gate/doc-counts",
+        "POST",
+        "/api/bridge/intake-gate/doc-counts",
         "Same bridge HMAC auth as ingest/article.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/bridge/wa-media/ack",
+        "POST",
+        "/api/bridge/wa-media/ack",
         "Same bridge HMAC auth as ingest/article.",
     ),
     # ── wa-mirror / Intel Lake: scoped X-*-Key headers checked in-router ──
     IntentionalPublicMutation(
-        "POST", "/api/crm/clients/upsert-by-phone",
+        "POST",
+        "/api/crm/clients/upsert-by-phone",
         "wa-mirror CRM lead upsert — X-CRM-Write-Key + "
         "WA_MIRROR_CRM_WRITE_ENABLED checked in-router (crm_clients.py).",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/crm/internal/clients/{client_id}/documents/upload",
-        "wa-mirror intake document upload — same X-CRM-Write-Key gate as "
-        "upsert-by-phone.",
+        "POST",
+        "/api/crm/internal/clients/{client_id}/documents/upload",
+        "wa-mirror intake document upload — same X-CRM-Write-Key gate as upsert-by-phone.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/intel/lake/observations",
-        "Intel Lake ingest — X-Producer-Token checked in-router "
-        "(env INTEL_LAKE_PRODUCER_TOKEN).",
+        "POST",
+        "/api/intel/lake/observations",
+        "Intel Lake ingest — X-Producer-Token checked in-router (env INTEL_LAKE_PRODUCER_TOKEN).",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/intel/lake/observations-batch",
+        "POST",
+        "/api/intel/lake/observations-batch",
         "Same X-Producer-Token gate as observations.",
     ),
     # ── HR: per-incident token IS the auth (secrets.compare_digest) ──
     IntentionalPublicMutation(
-        "POST", "/api/hr/late-reply/{incident_id}",
+        "POST",
+        "/api/hr/late-reply/{incident_id}",
         "Late check-in reply form — per-incident token via "
         "secrets.compare_digest, no PII collected. Token IS the auth.",
     ),
     # ── Client portal: token-based, pre-account by design ──
     IntentionalPublicMutation(
-        "POST", "/api/portal/invite/complete",
+        "POST",
+        "/api/portal/invite/complete",
         "Client registration completion — the invite token is the "
         "credential; there is no account yet to authenticate as.",
     ),
     # ── Funnel / lead-gen: anonymous-by-design, no PII beyond session_id ──
     IntentionalPublicMutation(
-        "POST", "/api/lead/capture",
+        "POST",
+        "/api/lead/capture",
         "Anonymous WhatsApp handoff CTA — writes lead_intents "
         "(source/context/utm/fingerprint only, no PII), 8KB cap in-router.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/funnel/session/touch",
+        "POST",
+        "/api/funnel/session/touch",
         "Pre-auth lead cookie touch — anonymous UUID, no PII.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/funnel/session/convert",
+        "POST",
+        "/api/funnel/session/convert",
         "Lead->client conversion bridge invoked by the portal login flow "
         "itself (session_id + client_id only).",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/analytics/funnel-event",
+        "POST",
+        "/api/analytics/funnel-event",
         "11 whitelisted funnel events (packages/core/analytics/funnel-view.ts) "
         "— session_id only, no PII.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/prime/v2/analyze",
+        "POST",
+        "/api/prime/v2/analyze",
         "PRIME NEXUS Layer 2 — explicitly declared 'public, rate-limited' "
         "investment analysis over public zone data.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/prime/v2/resolve",
+        "POST",
+        "/api/prime/v2/resolve",
         "PRIME NEXUS Layer 1 — explicitly declared public spatial "
         "resolution over public zone data.",
     ),
     # ── Anonymous product quizzes: stateless scoring / IP-hash rate limit ──
     IntentionalPublicMutation(
-        "POST", "/api/v1/visa-oracle/recommend",
+        "POST",
+        "/api/v1/visa-oracle/recommend",
         "Anonymous visa quiz — pure scoring logic, no user data persisted.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/v1/visa-oracle/chat",
+        "POST",
+        "/api/v1/visa-oracle/chat",
         "Anonymous visa Q&A — rate-limited by IP hash, no PII collected.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/v1/visa-oracle/handoff",
-        "WhatsApp/Telegram handoff link builder — no state mutation beyond "
-        "a notification.",
+        "POST",
+        "/api/v1/visa-oracle/handoff",
+        "WhatsApp/Telegram handoff link builder — no state mutation beyond a notification.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/v1/kbli-notebook/chat",
+        "POST",
+        "/api/v1/kbli-notebook/chat",
         "KBLI Explorer — public business-classification chat, no PII.",
     ),
     # ── Visa Check v1 funnel (routers/visa_check.py): anonymous wizard,
@@ -265,21 +288,25 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
     #    mounted but never registered in PUBLIC_ENDPOINTS). The result-page
     #    hash IS the access token; per-IP rate-limited via the /api/ bucket. ──
     IntentionalPublicMutation(
-        "POST", "/api/visa/check/start",
+        "POST",
+        "/api/visa/check/start",
         "Branch selector — pure yes/no routing, nothing persisted.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/visa/clock",
+        "POST",
+        "/api/visa/clock",
         "Clock submission — anonymous overstay-timeline insert "
         "(visa_type/entry_date/client_fingerprint only, no PII).",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/visa/match",
+        "POST",
+        "/api/visa/match",
         "Match submission — anonymous visa-recommendation insert "
         "(nationality/purpose/duration/budget only, no PII).",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/visa/voa",
+        "POST",
+        "/api/visa/voa",
         "VOA request submission — anonymous B1 eligibility insert "
         "(case type/nationality/dates/purpose/travellers/self-pay only, no PII). "
         "Same shape and rationale as the visa/match and visa/clock siblings above: "
@@ -289,7 +316,8 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
     #    anonymous by design (the v2 interview runs pre-account). Engine
     #    evaluation + SHADOW audit row; abuse controls verified in-router. ──
     IntentionalPublicMutation(
-        "POST", "/api/visa-oracle/evaluate",
+        "POST",
+        "/api/visa-oracle/evaluate",
         "Visa Oracle v2 evaluate read-path (W1) — anonymous canonical-facts "
         "evaluation, mode=CURATED envelope (SHADOW era). Controls: dedicated "
         "30/min rate-limit bucket, 32KB body cap, application/json-only, "
@@ -299,23 +327,27 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
     ),
     # ── Marketing: explicit registry rows, standard opt-in/opt-out shape ──
     IntentionalPublicMutation(
-        "POST", "/api/blog/ask",
+        "POST",
+        "/api/blog/ask",
         "AskZantara widget on public blog articles — public Q&A feature, "
         "explicit registry row (shadowed by the broader /api/blog/ prefix "
         "match, but the specific row documents deliberate intent).",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/blog/newsletter/subscribe",
+        "POST",
+        "/api/blog/newsletter/subscribe",
         "Public marketing opt-in — explicit registry row.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/blog/newsletter/confirm",
+        "POST",
+        "/api/blog/newsletter/confirm",
         "Double opt-in confirmation — DOES check a real confirmation_token "
         "column server-side (newsletter.py ~line 304-320), unlike its "
         "unsubscribe sibling below.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/blog/newsletter/unsubscribe",
+        "POST",
+        "/api/blog/newsletter/unsubscribe",
         "Opt-out — legal requirement to stay reachable without a session. "
         "VERIFIED 2026-07-17: the registry reason says 'token-based "
         "verification' but UnsubscribeRequest.token (newsletter.py:141) is "
@@ -326,57 +358,71 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
         "'token-based' claim is currently false — see PENDING-ARMS.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/news/subscribe",
+        "POST",
+        "/api/news/subscribe",
         "Same public opt-in shape as /api/blog/newsletter/subscribe "
         "(news.py:480) — no auth Depends, but the action itself (add an "
         "email to a mailing list) carries the same risk profile as the "
         "already-explicit blog equivalent.",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/news/unsubscribe",
+        "POST",
+        "/api/news/unsubscribe",
         "Same public opt-out shape as /api/blog/newsletter/unsubscribe "
         "(news.py:512) — legal requirement to stay reachable unauthenticated.",
     ),
     # ── Observability: no-PII, best-effort ingestion, explicit registry row ──
     IntentionalPublicMutation(
-        "POST", "/api/metrics/frontend",
+        "POST",
+        "/api/metrics/frontend",
         "Best-effort frontend browser metrics ingestion — no PII, no auth "
         "header, explicit registry row.",
     ),
-    # ── Streamlit public map/KBLI dashboard: read-only compute or telemetry,
-    #    already covered in spirit by the /api/dashboard/map/ registry reason
-    #    ("KBLI validation, client geo, risk zones, stats") ──
+    # ── Streamlit public map/KBLI dashboard: read-only compute only.
+    #    These three now carry their OWN per-route entries in PUBLIC_ENDPOINTS.
+    #    The `/api/dashboard/map/` PREFIX entry that used to cover them was
+    #    removed on 2026-08-12 (P0): it also made `GET .../clients/geo` public,
+    #    and that route answered an anonymous request with 500 client rows.
+    #    "Covered in spirit by the prefix reason" was the whole problem — a
+    #    reason string describing four routes cannot gate a fifth one. ──
     IntentionalPublicMutation(
-        "POST", "/api/dashboard/map/validate-property",
+        "POST",
+        "/api/dashboard/map/validate-property",
         "Stateless KBLI compliance check (dashboard.py:747) — no DB write, "
         "returns an audit verdict only. Matches the registry reason "
         "verbatim ('KBLI validation').",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/dashboard/map/gistaru-zone",
+        "POST",
+        "/api/dashboard/map/gistaru-zone",
         "Stateless GISTARU RDTR zone lookup (dashboard.py:778) — no DB "
         "write, read-only geo compute. Matches registry reason "
         "('client geo').",
     ),
     IntentionalPublicMutation(
-        "POST", "/api/dashboard/map/analyze-investment",
+        "POST",
+        "/api/dashboard/map/analyze-investment",
         "Stateless BATARA+KBLI+ROI compute (dashboard.py:994, verified: no "
         "INSERT/UPDATE in the handler) — matches registry reason "
         "('risk zones, stats').",
     ),
-    IntentionalPublicMutation(
-        "POST", "/api/dashboard/map/analytics/log-lookup",
-        "Telemetry-only insert into analytics_map_lookups (dashboard.py:882) "
-        "— same shape/risk as the already-explicit /api/metrics/frontend "
-        "(no PII beyond an optional user_email field the caller supplies "
-        "voluntarily, no read-back exposed here).",
-    ),
+    # REMOVED 2026-08-12 — `POST /api/dashboard/map/analytics/log-lookup` is no
+    # longer public, so leaving the row here would fail the anti-decay gate
+    # (test_no_stale_justified_entries). Its justification was also wrong on its
+    # own terms: "no PII beyond an optional user_email field the caller supplies
+    # voluntarily" describes an EMAIL — an identifier — as not-PII, and
+    # "voluntarily" is doing the work of "unverifiably", since an anonymous
+    # caller supplying the acting identity is forgeable attribution, not
+    # telemetry. It is now gated by Depends(get_current_user) and takes the
+    # email from the principal. The comparison to /api/metrics/frontend never
+    # held: that endpoint names no person.
     # ── Admin mutations that are PUBLIC at the middleware layer but are
     #    INDEPENDENTLY re-gated inside the router via a real Depends() that
     #    does not rely on request.state.user — verified 2026-07-17 by reading
     #    the dependency chain, not assumed from the docstring. ──
     IntentionalPublicMutation(
-        "POST", "/api/knowledge/visa/",
+        "POST",
+        "/api/knowledge/visa/",
         "Docstring says 'ADMIN ONLY' — VERIFIED: Depends(get_admin_user) -> "
         "Depends(get_current_user) (backend/app/deps/auth.py:29) falls back "
         "to independently validating the Authorization Bearer JWT itself "
@@ -388,11 +434,13 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
         "PENDING-ARMS security hole.",
     ),
     IntentionalPublicMutation(
-        "PUT", "/api/knowledge/visa/{visa_id}",
+        "PUT",
+        "/api/knowledge/visa/{visa_id}",
         "Same Depends(get_admin_user) verified chain as POST /api/knowledge/visa/.",
     ),
     IntentionalPublicMutation(
-        "POST", "/preview/upload",
+        "POST",
+        "/preview/upload",
         "Docstring says scraper-only — VERIFIED: Depends(verify_internal_api_key) "
         "(preview.py:46) is a real in-router dependency, independent of the "
         "middleware's public-path skip.",
@@ -409,39 +457,51 @@ INTENTIONALLY_PUBLIC_MUTATIONS: tuple[IntentionalPublicMutation, ...] = (
 # forcing the delete). Full detail + severity: the ledger PENDING-ARMS lines.
 KNOWN_UNGATED_PUBLIC_MUTATIONS: tuple[KnownUngatedMutation, ...] = (
     KnownUngatedMutation(
-        "POST", "/api/news", "operator[business]",
+        "POST",
+        "/api/news",
+        "operator[business]",
         "ledger:PENDING-ARMS news.py",
         "news.py:290 create_news — zero Depends beyond DB pool; INSERTs "
         "news_items with status='approved' (auto-approved). Anyone can inject "
         "content onto the public balizero.com news feed. HIGH.",
     ),
     KnownUngatedMutation(
-        "POST", "/api/news/bulk", "operator[business]",
+        "POST",
+        "/api/news/bulk",
+        "operator[business]",
         "ledger:PENDING-ARMS news.py",
         "news.py:351 create_news_bulk — bulk version of the above, N articles "
         "per call, same zero-auth. HIGH.",
     ),
     KnownUngatedMutation(
-        "POST", "/api/news/{news_id}/image", "operator[business]",
+        "POST",
+        "/api/news/{news_id}/image",
+        "operator[business]",
         "ledger:PENDING-ARMS news.py",
         "news.py:414 update_news_image — anyone can overwrite the image_url of "
         "ANY news item with an arbitrary URL (defacement/hotlink). HIGH.",
     ),
     KnownUngatedMutation(
-        "PATCH", "/api/news/{news_id}/status", "operator[business]",
+        "PATCH",
+        "/api/news/{news_id}/status",
+        "operator[business]",
         "ledger:PENDING-ARMS news.py",
         "news.py:442 update_news_status — anyone can flip ANY news item between "
         "pending/approved/rejected/archived (unpublish live / approve pending). HIGH.",
     ),
     KnownUngatedMutation(
-        "POST", "/api/blog/newsletter/log", "operator[business]",
+        "POST",
+        "/api/blog/newsletter/log",
+        "operator[business]",
         "ledger:PENDING-ARMS newsletter.py",
         "newsletter.py:564 log_newsletter_send — docstring says '(admin "
         "endpoint)' but zero Depends; anyone can insert fake newsletter_send_log "
         "rows (pollutes internal delivery reporting). MEDIUM.",
     ),
     KnownUngatedMutation(
-        "PATCH", "/api/blog/newsletter/preferences", "operator[business]",
+        "PATCH",
+        "/api/blog/newsletter/preferences",
+        "operator[business]",
         "ledger:PENDING-ARMS newsletter.py",
         "newsletter.py:434 update_preferences — zero Depends; anyone who knows/"
         "guesses a subscriber email or numeric id can change their "
@@ -457,7 +517,9 @@ _KNOWN_UNGATED_INDEX: dict[tuple[str, str], KnownUngatedMutation] = {
     (e.method, e.path): e for e in KNOWN_UNGATED_PUBLIC_MUTATIONS
 }
 # A public mutating route is "accounted for" if it is in EITHER registry.
-_ACCOUNTED: frozenset[tuple[str, str]] = frozenset(_JUSTIFIED_INDEX) | frozenset(_KNOWN_UNGATED_INDEX)
+_ACCOUNTED: frozenset[tuple[str, str]] = frozenset(_JUSTIFIED_INDEX) | frozenset(
+    _KNOWN_UNGATED_INDEX
+)
 
 # Structural heuristic for an auth-principal dependency name (subset of the
 # live inventory used by test_route_authz_coverage.py). Used ONLY by the
@@ -604,7 +666,9 @@ def test_known_ungated_entries_are_still_live_public_and_ungated(app: FastAPI) -
     public, or (c) has gained a real auth ``Depends`` (i.e. it got fixed). This
     forbids the list from silently outliving the holes it records, so it can
     only shrink toward zero as Zero adjudicates each one."""
-    live: dict[tuple[str, str], object] = {(m, path): route for m, path, route in _iter_mutating(app)}
+    live: dict[tuple[str, str], object] = {
+        (m, path): route for m, path, route in _iter_mutating(app)
+    }
 
     stale: list[str] = []
     for e in KNOWN_UNGATED_PUBLIC_MUTATIONS:
@@ -614,7 +678,9 @@ def test_known_ungated_entries_are_still_live_public_and_ungated(app: FastAPI) -
             stale.append(f"{e.method} {e.path} — route no longer exists (delete the entry)")
             continue
         if find_entry(e.path) is None:
-            stale.append(f"{e.method} {e.path} — no longer public (prefix narrowed → delete the entry)")
+            stale.append(
+                f"{e.method} {e.path} — no longer public (prefix narrowed → delete the entry)"
+            )
             continue
         if _route_has_auth_dep(route):
             stale.append(
@@ -637,11 +703,11 @@ def test_no_stale_justified_entries(app: FastAPI) -> None:
     """ANTI-DECAY: a justified-safe row whose route no longer exists, or is no
     longer public, is stale — delete it (mirrors route_risk_registry.py's own
     `test_no_dead_registry_entries`)."""
-    live_public = {
-        (m, path) for m, path, _ in _iter_mutating(app) if find_entry(path) is not None
-    }
+    live_public = {(m, path) for m, path, _ in _iter_mutating(app) if find_entry(path) is not None}
     stale = [
-        f"{e.method} {e.path}" for e in INTENTIONALLY_PUBLIC_MUTATIONS if (e.method, e.path) not in live_public
+        f"{e.method} {e.path}"
+        for e in INTENTIONALLY_PUBLIC_MUTATIONS
+        if (e.method, e.path) not in live_public
     ]
     assert not stale, (
         "INTENTIONALLY_PUBLIC_MUTATIONS entries that match no LIVE public "

--- a/apps/backend-rag/backend/tests/unit/routers/test_dashboard.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_dashboard.py
@@ -406,7 +406,10 @@ class TestClientsGeo:
         request = MagicMock()
         request.app.state.db_pool = pool
 
-        result = await get_clients_geo(request)
+        # An admin principal: the map's actual audience, and the case that must
+        # keep returning the whole book (ownership scoping is covered by
+        # tests/security/test_dashboard_map_not_public.py).
+        result = await get_clients_geo(request, current_user={"email": "zero@balizero.com"})
         assert result["total"] == 1
         assert len(result["clients"]) == 1
 
@@ -417,7 +420,7 @@ class TestClientsGeo:
         request = MagicMock()
         request.app.state.db_pool = None
 
-        result = await get_clients_geo(request)
+        result = await get_clients_geo(request, current_user={"email": "zero@balizero.com"})
         assert result["clients"] == []
         assert "error" in result
 
@@ -436,7 +439,7 @@ class TestClientsGeo:
         request = MagicMock()
         request.app.state.db_pool = pool
 
-        result = await get_clients_geo(request)
+        result = await get_clients_geo(request, current_user={"email": "zero@balizero.com"})
         assert "error" in result
 
 
@@ -484,8 +487,8 @@ class TestLogLookup:
         request = MagicMock()
         request.app.state.db_pool = pool
 
-        req = LogLookupRequest(user_email="test@balizero.com", kbli_code="55111")
-        result = await log_lookup(req, request)
+        req = LogLookupRequest(kbli_code="55111")
+        result = await log_lookup(req, request, current_user={"email": "zero@balizero.com"})
         assert result["logged"] is True
 
     @pytest.mark.asyncio
@@ -495,8 +498,8 @@ class TestLogLookup:
         request = MagicMock()
         request.app.state.db_pool = None
 
-        req = LogLookupRequest(user_email="test@balizero.com")
-        result = await log_lookup(req, request)
+        req = LogLookupRequest()
+        result = await log_lookup(req, request, current_user={"email": "zero@balizero.com"})
         assert result["logged"] is False
 
     @pytest.mark.asyncio
@@ -514,7 +517,9 @@ class TestLogLookup:
         request = MagicMock()
         request.app.state.db_pool = pool
 
-        result = await log_lookup(LogLookupRequest(user_email="t@b.com"), request)
+        result = await log_lookup(
+            LogLookupRequest(), request, current_user={"email": "zero@balizero.com"}
+        )
         assert result["logged"] is False
 
 
@@ -745,8 +750,12 @@ class TestModuleConstants:
         vp = ValidatePropertyRequest(kbli_code="55111")
         assert vp.is_pma is True
 
-        ll = LogLookupRequest(user_email="x@y.com")
-        assert ll.user_email == "x@y.com"
+        # `user_email` was REMOVED from this model on 2026-08-12: the acting
+        # identity now comes from the authenticated principal, never the body.
+        # Asserting its absence is the point — a body field cannot come back
+        # without turning this red.
+        ll = LogLookupRequest(kbli_code="55111")
+        assert not hasattr(ll, "user_email")
 
         ai = AnalyzeInvestmentRequest(lat=-8.0, lon=115.0)
         assert ai.lat == -8.0

--- a/apps/backend-rag/backend/tests/unit/routers/test_dashboard_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_dashboard_coverage.py
@@ -23,11 +23,39 @@ from httpx import ASGITransport, AsyncClient
 
 @pytest.fixture
 def app_with_overrides():
-    """Return FastAPI app with minimal dependency overrides (no auth/db needed for dashboard)."""
+    """Return the FastAPI app.
+
+    NOTE (2026-08-12): this fixture used to say "no auth needed for dashboard".
+    That was never a property of the router — it was a property of the
+    `/api/dashboard/map/` PREFIX entry in PUBLIC_ENDPOINTS, which made every
+    route here anonymous, `GET /clients/geo` included. That route answered an
+    anonymous request with 500 client rows, so the prefix is gone (P0) and every
+    route on this router now requires a credential. Tests that exercise handler
+    branches must present one — see `auth_headers`.
+    """
     from backend.app.main_cloud import app
 
     yield app
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth_headers(monkeypatch):
+    """Headers that authenticate through the REAL HybridAuthMiddleware.
+
+    Deliberately not a `dependency_overrides` shim: the middleware rejects
+    before dependencies resolve, so an override would leave these tests
+    measuring a 401. Configuring the admin key and sending `X-Debug-Key`
+    exercises the same code path a real caller does, and yields a principal
+    with `role: "admin"` — a CRM admin by `is_crm_admin`, so `/clients/geo`
+    returns the whole book (ownership scoping for non-admins is asserted in
+    tests/security/test_dashboard_map_not_public.py).
+    """
+    from backend.app.core.config import settings
+
+    key = "test-admin-key-dashboard-coverage"
+    monkeypatch.setattr(settings, "admin_api_key", key, raising=False)
+    return {"X-Debug-Key": key}
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +227,7 @@ class TestGistaruZone:
 
 class TestClientsGeo:
     @pytest.mark.asyncio
-    async def test_clients_geo_success(self, app_with_overrides):
+    async def test_clients_geo_success(self, app_with_overrides, auth_headers):
         """Returns clients list when DB pool is available."""
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
@@ -226,7 +254,7 @@ class TestClientsGeo:
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/clients/geo")
+            response = await ac.get("/api/dashboard/map/clients/geo", headers=auth_headers)
 
         assert response.status_code == 200
         data = response.json()
@@ -234,14 +262,14 @@ class TestClientsGeo:
         assert data["total"] == 1
 
     @pytest.mark.asyncio
-    async def test_clients_geo_no_pool(self, app_with_overrides):
+    async def test_clients_geo_no_pool(self, app_with_overrides, auth_headers):
         """Returns empty clients list with error when DB pool is unavailable."""
         app_with_overrides.state.db_pool = None
 
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/clients/geo")
+            response = await ac.get("/api/dashboard/map/clients/geo", headers=auth_headers)
 
         assert response.status_code == 200
         data = response.json()
@@ -249,7 +277,7 @@ class TestClientsGeo:
         assert "error" in data
 
     @pytest.mark.asyncio
-    async def test_clients_geo_db_error(self, app_with_overrides):
+    async def test_clients_geo_db_error(self, app_with_overrides, auth_headers):
         """Returns empty clients with error string when DB raises exception."""
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
@@ -263,7 +291,7 @@ class TestClientsGeo:
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/clients/geo")
+            response = await ac.get("/api/dashboard/map/clients/geo", headers=auth_headers)
 
         assert response.status_code == 200
         data = response.json()
@@ -277,12 +305,14 @@ class TestClientsGeo:
 
 class TestRiskZones:
     @pytest.mark.asyncio
-    async def test_risk_zones_structure(self, app_with_overrides):
+    async def test_risk_zones_structure(self, app_with_overrides, auth_headers):
         """Returns static risk zones with correct structure."""
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/compliance/risk-zones")
+            response = await ac.get(
+                "/api/dashboard/map/compliance/risk-zones", headers=auth_headers
+            )
 
         assert response.status_code == 200
         data = response.json()
@@ -291,12 +321,14 @@ class TestRiskZones:
         assert len(data["zones"]) == 3
 
     @pytest.mark.asyncio
-    async def test_risk_zones_levels(self, app_with_overrides):
+    async def test_risk_zones_levels(self, app_with_overrides, auth_headers):
         """Risk zones contain HIGH, MEDIUM, LOW levels."""
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/compliance/risk-zones")
+            response = await ac.get(
+                "/api/dashboard/map/compliance/risk-zones", headers=auth_headers
+            )
 
         data = response.json()
         levels = {z["level"] for z in data["zones"]}
@@ -309,36 +341,106 @@ class TestRiskZones:
 
 
 class TestAnalyticsLogLookup:
-    @pytest.mark.asyncio
-    async def test_log_lookup_success(self, app_with_overrides):
-        """Logs a lookup event and returns logged=True."""
-        mock_pool = MagicMock()
+    """This route stopped being anonymous on 2026-08-12 (P0).
+
+    It was reachable through the `/api/dashboard/map/` PREFIX entry in
+    PUBLIC_ENDPOINTS, and it both WRITES to the database and names a person —
+    the acting `user_email` arrived in the request BODY, so any caller could
+    file lookups under any employee's name. The fixture's promise of "no auth
+    needed for dashboard" was a description of that prefix, not of this route.
+    """
+
+    @staticmethod
+    def _pool_capturing_params(app):
+        """A pool whose conn records the params each execute() received."""
+        captured: list[tuple] = []
+
+        async def _execute(sql, *params):
+            captured.append(params)
+
         mock_conn = AsyncMock()
-        mock_conn.execute = AsyncMock(return_value=None)
+        mock_conn.execute = AsyncMock(side_effect=_execute)
         acquire_cm = MagicMock()
         acquire_cm.__aenter__ = AsyncMock(return_value=mock_conn)
         acquire_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_pool = MagicMock()
         mock_pool.acquire = MagicMock(return_value=acquire_cm)
-        app_with_overrides.state.db_pool = mock_pool
+        app.state.db_pool = mock_pool
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_log_lookup_success(self, app_with_overrides, auth_headers):
+        """Logs a lookup event and returns logged=True."""
+        self._pool_capturing_params(app_with_overrides)
 
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
             response = await ac.post(
                 "/api/dashboard/map/analytics/log-lookup",
-                json={
-                    "user_email": "user@test.com",
-                    "kbli_code": "55203",
-                    "location": "Bali",
-                },
+                json={"kbli_code": "55203", "location": "Bali"},
+                headers=auth_headers,
             )
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["logged"] is True
+        assert response.json()["logged"] is True
 
     @pytest.mark.asyncio
-    async def test_log_lookup_no_pool(self, app_with_overrides):
+    async def test_a_body_supplied_email_is_not_the_attributed_identity(
+        self, app_with_overrides, auth_headers
+    ):
+        """GUILT: the forgeable field is inert.
+
+        `user_email` is gone from the model, so Pydantic ignores it — but
+        "ignored" has to be PROVEN at the INSERT, not assumed from the schema:
+        the whole defect was that this string became the attributed identity.
+        """
+        captured = self._pool_capturing_params(app_with_overrides)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_overrides), base_url="http://test"
+        ) as ac:
+            response = await ac.post(
+                "/api/dashboard/map/analytics/log-lookup",
+                json={"user_email": "victim@balizero.com", "kbli_code": "55203"},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        inserts = [p for p in captured if p]
+        assert inserts, "the INSERT never ran — this test would pass vacuously"
+        attributed = inserts[-1][0]
+        # `auth_headers` authenticates as the admin-key principal, whose email
+        # the middleware sets to "admin@internal" — the point is that the
+        # attributed value tracks the PRINCIPAL, whoever it is, never the body.
+        assert attributed == "admin@internal", (
+            "the acting identity came from somewhere other than the principal"
+        )
+        assert attributed != "victim@balizero.com", (
+            "a body-supplied email was attributed the lookup — forgeable attribution is back"
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_lookup_rejects_anonymous(self, app_with_overrides):
+        """GUILT: no principal, no write. This is the P0 half at the HTTP layer."""
+        app_with_overrides.dependency_overrides.clear()
+        captured = self._pool_capturing_params(app_with_overrides)
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_overrides), base_url="http://test"
+        ) as ac:
+            response = await ac.post(
+                "/api/dashboard/map/analytics/log-lookup",
+                json={"user_email": "anyone@balizero.com", "kbli_code": "55203"},
+            )
+
+        assert response.status_code in (401, 403), (
+            f"an anonymous caller reached a DB-writing route (got {response.status_code})"
+        )
+        assert captured == [], "an unauthenticated request still wrote to the DB"
+
+    @pytest.mark.asyncio
+    async def test_log_lookup_no_pool(self, app_with_overrides, auth_headers):
         """Returns logged=False when DB pool unavailable."""
         app_with_overrides.state.db_pool = None
 
@@ -347,23 +449,12 @@ class TestAnalyticsLogLookup:
         ) as ac:
             response = await ac.post(
                 "/api/dashboard/map/analytics/log-lookup",
-                json={"user_email": "user@test.com"},
+                json={"kbli_code": "55203"},
+                headers=auth_headers,
             )
 
         assert response.status_code == 200
         assert response.json()["logged"] is False
-
-    @pytest.mark.asyncio
-    async def test_log_lookup_missing_email(self, app_with_overrides):
-        """Missing required user_email → 422."""
-        async with AsyncClient(
-            transport=ASGITransport(app=app_with_overrides), base_url="http://test"
-        ) as ac:
-            response = await ac.post(
-                "/api/dashboard/map/analytics/log-lookup",
-                json={"kbli_code": "55203"},
-            )
-        assert response.status_code == 422
 
 
 # ---------------------------------------------------------------------------
@@ -373,7 +464,7 @@ class TestAnalyticsLogLookup:
 
 class TestDashboardStats:
     @pytest.mark.asyncio
-    async def test_stats_success(self, app_with_overrides):
+    async def test_stats_success(self, app_with_overrides, auth_headers):
         """Returns aggregate stats with correct keys."""
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
@@ -387,7 +478,7 @@ class TestDashboardStats:
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/stats")
+            response = await ac.get("/api/dashboard/map/stats", headers=auth_headers)
 
         assert response.status_code == 200
         data = response.json()
@@ -396,14 +487,14 @@ class TestDashboardStats:
         assert "map_lookups_24h" in data
 
     @pytest.mark.asyncio
-    async def test_stats_no_pool(self, app_with_overrides):
+    async def test_stats_no_pool(self, app_with_overrides, auth_headers):
         """Returns zeros with error when pool unavailable."""
         app_with_overrides.state.db_pool = None
 
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/stats")
+            response = await ac.get("/api/dashboard/map/stats", headers=auth_headers)
 
         assert response.status_code == 200
         data = response.json()
@@ -411,7 +502,7 @@ class TestDashboardStats:
         assert "error" in data
 
     @pytest.mark.asyncio
-    async def test_stats_db_error(self, app_with_overrides):
+    async def test_stats_db_error(self, app_with_overrides, auth_headers):
         """Returns zeros with error string when DB raises exception."""
         mock_pool = MagicMock()
         mock_conn = AsyncMock()
@@ -425,7 +516,7 @@ class TestDashboardStats:
         async with AsyncClient(
             transport=ASGITransport(app=app_with_overrides), base_url="http://test"
         ) as ac:
-            response = await ac.get("/api/dashboard/map/stats")
+            response = await ac.get("/api/dashboard/map/stats", headers=auth_headers)
 
         assert response.status_code == 200
         data = response.json()

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 695 services · 1348 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 695 services · 1349 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).


### PR DESCRIPTION
## What was open

`GET /api/dashboard/map/clients/geo` answered an **anonymous** request from the public internet with **HTTP 200 and 500 active-client rows**. Measured live against `nuzantara-rag` immediately before this PR (counts only recorded; payload deleted, no values transcribed — SYMBIOSIS Law 2):

```
HTTP 200 · 66,229 bytes · 500 client rows
keys per row: address, email, full_name, id, phone, status
```

The handler took `request: Request` and nothing else — no principal, no ownership filter — and ran `SELECT id, full_name, email, phone, status, address FROM clients WHERE status = 'active' ORDER BY full_name LIMIT 500`.

## The cause was not that route

It was a **PREFIX** entry `/api/dashboard/map/` in `PUBLIC_ENDPOINTS`. `backend/middleware/hybrid_auth.py:206` treats a registry match as *skip auth entirely*, so **every** route the dashboard router mounts inherited a zero-credential bypass — 7 routes, two of which reach the `clients` table. The prefix, not the handler, was the gate; removing it is the enforcement.

## Why the existing gates were green

Two independent reasons, and both are more interesting than the bug:

1. **`test_route_authz_coverage.py` accepts membership in `PUBLIC_ENDPOINTS` as a valid authorization posture.** So the blanket prefix *was* the four POSTs' declared posture — the guard was satisfied by the very thing that was the vulnerability. Measured: that gate **passes on `main`** and only goes red on this branch, because removing the prefix unmasked the four POSTs that never had a posture of their own.
2. **The 2026-07-17 mutating-routes audit read this exact router** (`research/operations/2026-07-17-mutating-routes-authz-ledger.md`, its own line 13 lists `dashboard.py` as read) and justified its POSTs one by one — but never named the GET, because its scope was *mutating methods*. The client book was invisible to an audit that read the file it lives in. **The scope was the METHOD, not the DATA.**

## The cure — three halves, because any one alone leaves a hole

1. **The prefix is gone.** The three stateless-compute POSTs that legitimately were public keep that posture through **per-route `match="exact"` entries** — the granularity the 2026-07-17 audit had already written its verdicts at, which the prefix silently over-delivered. A router that can reach `clients` never sits behind a prefix again.
2. **`/clients/geo` resolves a principal and applies the CRM ownership filter** (`get_crm_user_filter`): admins keep the whole book (the map's actual audience), a team member sees only `assigned_to` rows. Without this, removing the public entry would still let any team member read all 1,244 clients from a route that exists to draw a map — CLAUDE.md §13 routed around one layer lower.
3. **`POST /analytics/log-lookup` is no longer public.** It is the one route here that *writes* (`CREATE TABLE IF NOT EXISTS` + `INSERT`) and it *names a person*: the acting `user_email` arrived in the request **body**, so an anonymous caller could file lookups under any employee's name. The field is removed from the model and the email comes from the authenticated principal — forgery impossible by construction, not by a validation rule someone can relax later. Measured before closing it (prod): **5 rows, 1 distinct email, all written 2026-03-02 and none since** — no live consumer to break.

Also fixed: the handler interpolated the acting email into a log **message**. Sentry's `LoggingIntegration` turns every logger call into a breadcrumb and its redaction works by **key**, so an identifier in a message ships in the clear (measured 2026-08-02).

## Verification

**Mutation-proved 3/3**, each mutant confirmed present *on disk* before being judged — a first attempt "survived" only because the patch never applied (the line is indented 4 spaces, my replacement string had 8). A surviving mutant that is really a mis-applied patch is a probe measuring its own poverty:

| mutant | result |
|---|---|
| restore the `/api/dashboard/map/` prefix | 3 tests red, incl. the public-mutation gate |
| disarm the ownership filter | non-admin scoping test red |
| attribute from the request body again | forgery test red |

New corpus `tests/security/test_dashboard_map_not_public.py` carries **guilt and innocence**: `/health` must stay public (an emptied registry would satisfy every guilt assertion) and the admin query must stay unscoped (a cure that filtered everyone would satisfy them too).

`118 tests green (RC=0)` across the six affected files, plus the **full backend suite green in the pre-push gate**.

## Class audit — one prefix cured is not the disease closed

48 of 75 registry entries are prefix matches. Four cover a handler that touches a PII-bearing table, and each covers exactly **one** route — the one the prefix names (`/api/auth/login` → `team_members`, necessarily public; three OAuth/Drive callbacks → `google_drive_tokens`). No other blanket-prefix-over-a-router. **Declared limit:** the probe only sees SQL written inline in the handler, so a router delegating to a service layer is invisible to it — this is a floor, not a ceiling.

## Scope notes

- The stale `INTENTIONALLY_PUBLIC_MUTATIONS` row for `log-lookup` is deleted: its own anti-decay gate (`test_no_stale_justified_entries`) demanded it, and its justification called an email "no PII" and "voluntarily" supplied — which was doing the work of *unverifiably*.
- `docs_sync.py` regen rides in the same commit, not a follow-up (W86).
- `public_endpoints.py` carries 7 lines of `ruff-format` churn that **predate this branch** (verified against `origin/main`); pre-commit formats any staged file, so it could not be committed without them.
- Measured but deliberately NOT widened into here: `GET /api/admin/drive/health` is public by design (an external monitor keys on it) and returns an internal email plus token timestamps — minor disclosure, its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)