### PR TITLE
chore(proxy): remove unreachable robots.txt override in app-domain block

### DIFF
--- a/apps/mouth/src/proxy.ts
+++ b/apps/mouth/src/proxy.ts
@@ -445,17 +445,6 @@ export function proxy(request: NextRequest) {
       return NextResponse.rewrite(rewriteUrl);
     }
 
-    // SEO: Block indexing for zantara subdomain (internal app)
-    // robots.txt override
-    if (pathname === "/robots.txt") {
-      return new NextResponse("User-agent: *\nDisallow: /", {
-        headers: {
-          "Content-Type": "text/plain",
-          "Cache-Control": "public, max-age=3600",
-        },
-      });
-    }
-
     // Add X-Robots-Tag header to all responses from zantara subdomain
     response.headers.set("X-Robots-Tag", "noindex, nofollow");
 


### PR DESCRIPTION
## 1. Insight
The robots.txt override inside the app-domain block is unreachable. proxy.ts:170 returns early for any pathname containing a dot, and /robots.txt contains one — so the block at 449 never executes. Its comment claims it serves the zantara subdomain, but it sits inside `if (isAppDomain)`, which is kita.balizero.com. Two things wrong at once: unreachable, and mislabelled.

## 2. Studio
No visual change to end users. No behavioural change of any kind — this removes code that has never executed. Zone: VERDE, apps/mouth/src/proxy.ts only.

## 3. Source
- apps/mouth/src/proxy.ts:447-457 (removed)

## 4. Methodology
Measured rather than read: fetched the live surface on both hosts before touching code. Read origin/main rather than local checkout. Confirmed the early return at 170 catches /robots.txt before the block can be reached.

## 5. Raw Observations
On served commit 9894a431c3, repo at 59a3d3359:

- zantara.balizero.com/robots.txt → 200, serves the public balizero.com robots.txt (Allow: /)
- proxy.ts:170 `pathname.includes(".")` → returns NextResponse.next() before line 449
- apps/mouth/src/app/robots.ts exists — that is what actually serves robots.txt for every host

Positive control, proving the X-Robots-Tag line below the removed block is live and must stay:
- kita.balizero.com/login → x-robots-tag: noindex, nofollow (present)
- zantara.balizero.com/login → x-robots-tag absent

## 6. Reasoning Path
Fixing the matcher was rejected: the block would still be unreachable because of line 170, and the PR would produce a green CI with zero effect — a false entry in the ledger. Removing it is the honest change. The X-Robots-Tag line immediately after is left untouched: the positive control above proves it is doing real work for kita.balizero.com.

## 7. Risk
None measurable. The removed code has never run. The line count drops by 11 with no reachable path affected. If anything relied on it, that reliance was already broken.

## 8. Implication
Removes a false signal from the codebase. Anyone reading proxy.ts would otherwise conclude zantara.balizero.com has a robots.txt override, which it does not. Actual zantara robots.txt handling belongs in apps/mouth/src/app/robots.ts and is tracked separately.

## 9. Recommendation
Merge as-is. The zantara X-Robots-Tag gap is a separate PR — not folded in here.

## 10. Next Action
After merge and promote, confirm the positive control still holds:
curl -sI -A '<browser UA>' https://kita.balizero.com/login | grep -i x-robots-tag  → expect noindex, nofollow
