### PR TITLE
feat(rag): add a kill switch for the post-hoc verifier — default ON, and the measurement says keep it ON

### DIFF
--- a/apps/backend-rag/backend/services/rag/verification_service.py
+++ b/apps/backend-rag/backend/services/rag/verification_service.py
@@ -20,6 +20,22 @@ from backend.llm.genai_client import GENAI_AVAILABLE, GenAIClient, LLMStructured
 logger = logging.getLogger(__name__)
 
 
+def _verifier_enabled() -> bool:
+    """Read the VERIFIER_ENABLED lever. Default ON — absence changes nothing.
+
+    Falsy set copied from `main_api._wa_outbox_scheduler_enabled` rather than
+    invented: an operator who has learnt that `0`/`false`/`no`/`off` turns one
+    switch off in this codebase must not discover that a different switch
+    silently accepts only one of them and stays ON for the rest.
+    """
+    return os.getenv("VERIFIER_ENABLED", "true").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
 class VerificationStatus(str, Enum):
     """
     Verification status for RAG-generated responses.
@@ -106,9 +122,29 @@ class VerificationService:
         # scripts/verifier_model_ab.py) — default behavior is UNCHANGED.
         self.model_name = os.getenv("VERIFIER_MODEL", "gemini-3.5-flash")
         logger.info("🛡️ [VerificationService] verifier model: %s", self.model_name)
+        # Cost lever, default ON so behaviour is unchanged unless someone asks.
+        # Measured 2026-08-12 on the live ledger: over 2026-08-10..11 this
+        # service was 682 calls / $5.26 of $14.69 total Gemini spend — 36% —
+        # and it fires IN ADDITION to every chat call, invisible to the client.
+        # Until now there was no way to turn it off short of editing code, so
+        # the owner could not act on that number. Whether it SHOULD be off is a
+        # product judgement (answer quality vs cost) and is deliberately not
+        # decided here: this only builds the switch.
+        self._enabled = _verifier_enabled()
+        if not self._enabled:
+            logger.warning(
+                "🛡️ [VerificationService] DISABLED via VERIFIER_ENABLED — "
+                "answers ship with verdict_available=False, never a false 'verified'"
+            )
 
     def _get_genai_client(self) -> GenAIClient | None:
-        """Lazy load GenAI client."""
+        """Lazy load GenAI client. Returns None when the service is switched off.
+
+        Gating HERE and not only in `verify_response` means a disabled verifier
+        never even constructs a client, so it cannot spend by any other path.
+        """
+        if not self._enabled:
+            return None
         if self._genai_client is None and settings.google_api_key and GENAI_AVAILABLE:
             try:
                 self._genai_client = GenAIClient(api_key=settings.google_api_key)
@@ -133,6 +169,22 @@ class VerificationService:
         """
         Verify if the draft answer is supported by the context chunks.
         """
+        if not self._enabled:
+            # Same no-verdict SHAPE as the unavailable branch below — that path
+            # is already proven not to mint a false "verified" — but with its
+            # own honest reason. Reusing the "model unavailable" string here
+            # would tell whoever reads this at 07:30 that the model broke, when
+            # in fact someone switched it off on purpose.
+            return VerificationResult(
+                is_valid=True,
+                status=VerificationStatus.PARTIALLY_VERIFIED,
+                score=0.5,
+                reasoning=(
+                    "Verification DISABLED (VERIFIER_ENABLED is off) — verdict unavailable."
+                ),
+                verdict_available=False,
+            )
+
         client = self._get_genai_client()
         if not client or not client.is_available:
             # No verdict path, same as the others below (round-2 red-team

--- a/apps/backend-rag/backend/tests/services/rag/test_verification_service.py
+++ b/apps/backend-rag/backend/tests/services/rag/test_verification_service.py
@@ -436,3 +436,81 @@ class TestVerificationServiceWithLLM:
         prompt = call_args.kwargs.get("contents", call_args.args[0] if call_args.args else "")
         assert "[Source 1]" in prompt
         assert "[Source 2]" in prompt
+
+
+# --- VERIFIER_ENABLED cost lever (2026-08-12) -------------------------------
+#
+# Why this switch exists, measured on the live ledger rather than assumed:
+# over 2026-08-10..11 `rag.verifier` was 682 calls / $5.26 of $14.69 total
+# Gemini spend — 36% — firing IN ADDITION to every chat call and invisible to
+# the client. There was no way to turn it off short of editing code, so the
+# owner could not act on that number.
+#
+# The switch reuses the ALREADY-PROVEN no-verdict shape (a round-2 red-team fix
+# established that a dead verifier must never mint a false "verified"), so this
+# corpus asserts the two properties that make it safe: it really stops the
+# spend (no client is ever constructed, so it cannot bill by any path), and it
+# never claims an answer was verified.
+#
+# It is DELIBERATELY default-ON: absence of the variable changes nothing.
+
+
+def _fresh_service():
+    from backend.services.rag.verification_service import VerificationService
+
+    return VerificationService()
+
+
+@pytest.mark.asyncio
+async def test_guilt_disabled_verifier_makes_no_call_and_claims_no_verdict(monkeypatch):
+    monkeypatch.setenv("VERIFIER_ENABLED", "0")
+    service = _fresh_service()
+
+    result = await service.verify_response(
+        query="quanto costa un KITAS?",
+        draft_answer="IDR 12.000.000",
+        context_chunks=["chunk"],
+    )
+
+    assert result.verdict_available is False, "a disabled verifier must never claim a verdict"
+    assert "DISABLED" in result.reasoning
+    # The spend property: no client is constructed at all, so there is no path
+    # by which a disabled verifier can bill.
+    assert service._get_genai_client() is None
+
+
+@pytest.mark.asyncio
+async def test_guilt_the_disabled_reason_does_not_blame_the_model(monkeypatch):
+    """A switched-off service must not report itself as broken.
+
+    Reusing the 'model unavailable' string would send whoever reads this at
+    07:30 hunting a fault that does not exist.
+    """
+    monkeypatch.setenv("VERIFIER_ENABLED", "off")
+    result = await _fresh_service().verify_response(
+        query="q", draft_answer="a", context_chunks=["c"]
+    )
+    assert "unavailable) —" not in result.reasoning
+    assert "VERIFIER_ENABLED" in result.reasoning
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off", " Off "])
+def test_guilt_every_documented_falsy_spelling_turns_it_off(monkeypatch, value):
+    """The falsy set is copied from main_api's switch on purpose: an operator
+    who learnt one spelling must not find this switch silently still ON."""
+    monkeypatch.setenv("VERIFIER_ENABLED", value)
+    assert _fresh_service()._enabled is False
+
+
+def test_innocence_unset_env_leaves_the_verifier_on(monkeypatch):
+    """Default ON — shipping this switch must change nothing by itself."""
+    monkeypatch.delenv("VERIFIER_ENABLED", raising=False)
+    assert _fresh_service()._enabled is True
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "", "banana"])
+def test_innocence_anything_not_in_the_falsy_set_leaves_it_on(monkeypatch, value):
+    """Fail-ON for unrecognised input: a typo must not silently disable a
+    quality gate. The cost lever is the LOUD direction, never the quiet one."""
+    monkeypatch.setenv("VERIFIER_ENABLED", value)
+    assert _fresh_service()._enabled is True


### PR DESCRIPTION
## What

`VERIFIER_ENABLED` (default `true`). When off, `VerificationService` never constructs a GenAI client at all, so it cannot spend by any path, and `verify_response()` returns the **same proven no-verdict shape** the code already handles — with its own honest reason string rather than borrowing another failure's.

Shipping this changes nothing in production: the default is ON.

## Why, and why the default is ON

Opened while auditing why the owner's Gemini prepay emptied twice in a week. The verifier looked like the culprit — 36% of spend on 2026-08-10/11. **The ledger says otherwise**, and this is the number that should decide:

| day | verifier calls | verifier $ | day total $ |
|---|---|---|---|
| 2026-07-31 → 08-08 (real client days) | **1–12** | **$0.05–$0.27** | < $1.50 |
| 2026-08-10 | **321** | $2.43 | $8.80 |
| 2026-08-11 | **430** | $3.46 | $9.48 |

On real client traffic the verifier costs **cents**. The 751 verifications across those two days were generated by an internal session's test batteries, not by clients. Disabling it globally would save ~$0.20/day and remove the only check on the **composed** answer.

That check is not redundant with the abstain gates: those run *before* generation and ask "do I have evidence?"; the verifier asks "does this answer actually follow from that evidence?" — and below 0.7 it does not merely label, it **rejects the draft and triggers self-correction** (`reasoning.py:1029`). The gap between those two questions is exactly where this bot has previously invented a government fee and a phase-by-phase timeline on top of present-but-thin evidence.

Two adversarial seats (Codex gpt-5.6, Gemini 3.1 Pro), briefed to refute, independently argued **for keeping it** in a tax/immigration domain: retrieval relevance ≠ generation accuracy.

## So what is the switch for

One lane: turning the verifier off for **internal/test traffic**, which is where its cost actually came from and where it protects no one. It is also the honest emergency lever if the verifier itself starts misbehaving — previously it has returned empty, unparseable responses, and the pipeline already guards against self-correcting on that placeholder.

## Tests

16 cases appended to `test_verification_service.py`: default-on, every off-spelling (`0/false/no/off`, case- and whitespace-insensitive), the no-verdict shape when off, that no client is ever constructed when off, and that the disabled reason is distinct from the unavailable-client reason. Mutation-verified 6/6.