### PR TITLE
chore(gitignore): ignore .qwen/ local CLI state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ google_credentials.json
 # Codex CLI local config: MCP server map + hooks carrying absolute /Users
 # paths and Keychain/secret references — machine-local, never versioned.
 .codex/
+# Qwen CLI local config (permissions, computer-use settings) — same class
+# as .codex/.gemini/ above: machine-local, never versioned.
+.qwen/
 .libs/
 **/.claude/settings.local.json
 **/.claude/locks/


### PR DESCRIPTION
## What
Adds `.qwen/` to `.gitignore`, next to the existing `.codex/` and `.gemini/` entries.

## Why
Qwen CLI drops project-local settings (permissions, computer-use config) into `.qwen/` at the repo root — machine-local state, never meant to be versioned. It was showing up as an untracked file (`?? .qwen/`) in `git status` on M5.

Investigated the "process holding it open" concern: the file handle on `~/nuzantara/.qwen/` belongs to `com.apple.Virtualization.VirtualMachine` (a macOS system process, PPID 1), not a live Qwen CLI process — it has read-only handles open across the whole repo tree (all worktrees), consistent with routine system-level file watching/indexing, not a lock. The actual live Qwen CLI process (`cua-driver serve`) runs out of the user's home `~/.qwen/`, unrelated to this repo directory. No process needed to be killed; this is a pure hygiene fix.

## Test plan
- `git check-ignore -v .qwen/settings.json` → matches the new pattern
- Pre-commit/pre-push hooks passed clean (docs-only, allowlisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)