### PR TITLE
fix(ci): unbreak main — the token-redaction module was flagged as a Telegram sender

### DIFF
--- a/apps/backend-rag/backend/core/secret_log_redaction.py
+++ b/apps/backend-rag/backend/core/secret_log_redaction.py
@@ -5,7 +5,14 @@ WHY THIS EXISTS (2026-08-12, measured on a live CI run, not hypothesised).
 in `Bali-Zero/Teman2`, whose visibility is **PUBLIC**, so its Actions logs are
 world-readable — contained this line, emitted by httpx at INFO:
 
-    HTTP Request: POST https://api.telegram.org/bot<ID>:<SECRET>/sendMessage "..."
+    HTTP Request: POST https://api.telegram[.]org/bot<ID>:<SECRET>/sendMessage "..."
+
+(The host is written defanged, with brackets around the dot. `lint_tg_direct_senders.py`
+scans for the bare literal on purpose — a mention in a comment counts as a hit, which is
+the safe direction for a rule that says "keep that URL out of non-gateway files". Spelling
+it plainly here made this module read as a Telegram SENDER, which is the opposite of what
+it does, and turned every PR in the queue red. Defanging keeps the module under that guard
+instead of exempting it, so a real send added here later would still be caught.)
 
 Three things had to line up, and they are all ordinary:
 

--- a/scripts/lint_tg_direct_senders.py
+++ b/scripts/lint_tg_direct_senders.py
@@ -58,6 +58,13 @@ GATEWAY_ALLOWLIST = {
     "scripts/lint_tg_direct_senders.py",  # this lint (pattern is its constant)
     "scripts/tests/test_tg_gateway.py",   # the gateway's own test fixtures
     "scripts/tests/test_agent_job_telegram_gateway.py",  # asserts the string's ABSENCE
+    # Same shape as the line above, from the other direction: this test proves the bot
+    # token never survives into a log line, so it needs a fixture URL shaped like the
+    # real one AND it greps the tree for the bare literal itself. A file that polices
+    # the string has to be able to name it. Added 2026-08-12 after #4102 landed and
+    # turned every open PR red — the module it shipped, `secret_log_redaction.py`, was
+    # cured the other way (defanged host), because a redactor has no reason to be exempt.
+    "apps/backend-rag/backend/tests/core/test_telegram_token_never_reaches_a_log.py",
     ".github/workflows/tg-gateway.yml",   # the gateway's own CI job (names it in a comment)
     # The CI arm of the same family. It is NOT a second gateway: tg_notify.py
     # answers to a machine with a spool that a flusher drains later, so its


### PR DESCRIPTION
## Main is red and it is blocking the whole queue

#4102 landed a real security fix (keep the bot token out of public Actions logs) and turned two required checks red **on main**: `gateway (anti-regrowth lint)` and `guard-pins-pytest`. Every open PR inherits both failures. Measured on a main-equivalent tree: `lint_tg_direct_senders.py` exits 1 naming two files, and neither of them sends anything.

## What the lint caught, and why it was right to

The lint scans for the bare literal `api.telegram.org` and counts a mention in a comment as a hit. That over-match is **deliberate and documented in the lint itself** — the rule is "keep that URL out of non-gateway files", and a textual scan is the safe direction for it. So this is not a lint bug. What it flagged:

- **`secret_log_redaction.py`** names the URL once, in a **docstring**, as an example of the log line it redacts. The module whose entire job is deleting that URL from logs read as a module that sends to it.
- **its test** names it twice: a fixture URL that must be shaped like the real one, and a `grep -rl` over the tree — the test *polices* the literal.

## Cured in opposite directions, deliberately

- The module gets the **defanged host** (`api.telegram[.]org`) plus a note saying why. It stays **under** the guard, so a real send added there later is still caught. A redactor has no claim to an exemption.
- The test joins `GATEWAY_ALLOWLIST`, beside `test_agent_job_telegram_gateway.py`, which is already there for the mirror-image reason ("asserts the string's ABSENCE"). A file that polices the string has to be able to name it.

**Not used: `grandfathered.json`.** That register is for real senders awaiting migration and may only shrink against origin/main (W109b). Adding to it would fight the anti-regrowth rule and misfile both files as legacy senders.

## Verification

`lint_tg: clean (8820 files scanned, 144 grandfathered)` — a count, not a blind pass; the lint fails loudly at zero files scanned, which is how I caught my own first attempt at reproducing this in an unpopulated temp tree.

The redaction test suite still passes apart from one case that fails **for an unrelated local reason**: `test_the_credit_sentinel_cli_redacts_on_the_path_that_leaked` spawns a subprocess on the system interpreter, which has no `psutil`. That is an environment artifact of this machine, not of this diff — the docstring cannot reach it — and CI's venv has the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)