### PR TITLE
fix(hooks): promote the live ~/.claude carve-outs into the repo — the installer was deleting them

### DIFF
--- a/infra/claude-hooks/host_boundary.py
+++ b/infra/claude-hooks/host_boundary.py
@@ -54,6 +54,21 @@ PROTECTED_FILES = [
     _HOME / ".zshenv",
     _HOME / ".zshrc",
 ]
+
+# --- CARVE-OUT (2026-06-16): liberati dentro ~/.claude perché NON sono control-plane né credenziali.
+# scripts/ = strumenti dell'agente · projects/.../memory/ = la sua memoria. Scriverci non disarma
+# guardrail (hooks/settings restano blindati) né tocca secret. Risolve l'over-block "tutto ~/.claude e' sacro".
+UNPROTECTED_SUBPATHS = [
+    _HOME / ".claude" / "scripts",
+    _HOME / ".claude" / "projects",      # la memoria (MEMORY.md + i .md) vive qui
+    _HOME / ".claude" / "venvs",
+    # CARVE-OUT (2026-06-23): output di apprendimento agent WR2 (proposte amendment, lessons
+    # Reflexion, observations). NON control-plane — sono i RISULTATI che gli agent DEVONO scrivere.
+    # L'over-block faceva girare ig-metrics-analyst/reflexion senza persistere l'output.
+    _HOME / ".claude" / "skills" / "bali-zero-brand" / "_proposed-amendments",
+    _HOME / ".claude" / "skills" / "bali-zero-brand" / "_lessons",
+    _HOME / ".claude" / "skills" / "bali-zero-brand" / "_observations",
+]
 # Secret-ISH read targets → WARN only (visibility, not block).
 SECRET_READ_HINTS = (
     ".env", "secrets", "id_rsa", "id_ed25519", "credentials",
@@ -139,6 +154,16 @@ def _resolve_target(path_str: str, cwd: str) -> pathlib.Path | None:
 
 def _is_protected(resolved: pathlib.Path) -> bool:
     """True if a resolved path is a protected file or under a protected dir."""
+    # carve-out: scripts/memory/venvs sotto ~/.claude sono mani+quaderno, non cervello+chiavi
+    for u in UNPROTECTED_SUBPATHS:
+        try:
+            if resolved == u or resolved.is_relative_to(u):
+                return False
+        except AttributeError:
+            try:
+                resolved.relative_to(u); return False
+            except ValueError:
+                pass
     if resolved in PROTECTED_FILES:
         return True
     for d in PROTECTED_DIRS:

--- a/infra/claude-hooks/test_host_boundary_carveout.py
+++ b/infra/claude-hooks/test_host_boundary_carveout.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Pin the ~/.claude carve-outs in host_boundary.py — both halves.
+
+Why this exists: the carve-outs (`UNPROTECTED_SUBPATHS`) lived ONLY in the live
+copy at ~/.claude/hooks/ from 2026-06-16 until they were promoted to the repo on
+2026-08-12 — seven weeks in which `install_phase_aware.sh`, the sanctioned way to
+deploy these hooks, would have overwritten them with the repo's version and
+silently re-blocked the agent's own memory directory. The installer was a mine on
+the path it is documented as.
+
+`test_host_boundary.py` passes with or without the carve-out — it never names it.
+So the promotion alone would leave them unpinned, one tidy-up away from vanishing
+again. This file asserts both directions, because a carve-out is a guard with the
+sign inverted and wants its own guilt and innocence:
+
+  innocence — the freed subpaths are writable. These are the agent's hands and
+              notebook: ~/.claude/scripts, its memory under projects/, the WR2
+              learning outputs. Blocking them does not protect anything; it just
+              makes agents run and lose their work.
+  guilt     — the control plane is STILL blocked. hooks/ and settings.json are
+              the brain and the keys. If a future widening lets those through,
+              the carve-out has eaten the guard it was carved out of.
+
+Run directly, or under pytest.
+"""
+import json
+import pathlib
+import subprocess
+import sys
+
+HOOK = pathlib.Path(__file__).resolve().parent / "host_boundary.py"
+HOME = pathlib.Path.home()
+
+# (path, expected_rc, why). 0 = allowed through, 2 = blocked.
+CASES = [
+    # ── innocence: the agent's hands and notebook ───────────────────────────
+    (HOME / ".claude" / "projects" / "-Users-x-y" / "memory" / "a-note.md", 0,
+     "the agent's memory — every `mem save` writes here"),
+    (HOME / ".claude" / "scripts" / "helper.sh", 0, "the agent's own tools"),
+    (HOME / ".claude" / "venvs" / "x" / "pyvenv.cfg", 0, "agent venvs"),
+    # The three WR2 entries below pass, but NOT because the carve-out frees
+    # them: measured 2026-08-12, ~/.claude/skills/bali-zero-brand is a symlink
+    # to ~/nuzantara/skills/bali-zero-brand, so these paths resolve OUTSIDE
+    # ~/.claude and were never protected in the first place. They are inert
+    # entries today and would only start doing work if that symlink went away.
+    # Kept, and asserted, so the fact is recorded where the next reader looks.
+    (HOME / ".claude" / "skills" / "bali-zero-brand" / "_lessons" / "l.md", 0,
+     "WR2 Reflexion output (allowed via the repo symlink, not via the carve-out)"),
+    (HOME / ".claude" / "skills" / "bali-zero-brand" / "_proposed-amendments" / "a.md", 0,
+     "WR2 amendment proposals (same symlink)"),
+    (HOME / ".claude" / "skills" / "bali-zero-brand" / "_observations" / "o.md", 0,
+     "WR2 observations (same symlink)"),
+
+    # ── guilt: the control plane and the keys stay shut ─────────────────────
+    (HOME / ".claude" / "hooks" / "orchestrate_gate.py", 2,
+     "a hook — writing it disarms guardrails"),
+    (HOME / ".claude" / "settings.json", 2, "the control plane itself"),
+    # NOT a guilt case, and the first draft of this file wrongly asserted it
+    # was: a curated skill body under that symlink is repo content, not the
+    # agent control plane, so host_boundary is right to pass it. What guards it
+    # is the worktree-isolation hook, a different guard with a different job.
+    # Recorded as an explicit 0 so nobody "fixes" host_boundary to block it.
+    (HOME / ".claude" / "skills" / "bali-zero-brand" / "SKILL.md", 0,
+     "repo content behind a symlink — guarded by worktree isolation, not this hook"),
+    (HOME / ".claude" / "CLAUDE.md", 2, "global instructions"),
+]
+
+
+def _rc(path: pathlib.Path) -> int:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": str(path)}}
+    return subprocess.run([sys.executable, str(HOOK)], input=json.dumps(payload),
+                          capture_output=True, text=True).returncode
+
+
+def test_carveouts_are_writable_and_control_plane_is_not():
+    bad = []
+    for path, expect, why in CASES:
+        got = _rc(path)
+        if got != expect:
+            bad.append(f"{path} -> rc={got}, want {expect} ({why})")
+    assert not bad, "host_boundary carve-out drifted:\n  " + "\n  ".join(bad)
+
+
+if __name__ == "__main__":
+    failures = 0
+    for path, expect, why in CASES:
+        got = _rc(path)
+        ok = got == expect
+        failures += 0 if ok else 1
+        verdict = "allowed" if expect == 0 else "blocked"
+        print(f"  [{'OK  ' if ok else 'FAIL'}] rc={got} want={expect} ({verdict}) — {why}")
+    print()
+    print("PASS — host_boundary carve-out pinned" if not failures else f"FAIL ({failures})")
+    sys.exit(1 if failures else 0)

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -222,7 +222,11 @@
         },
         "infra/claude-hooks/host_boundary.py": {
           "symbols": {},
-          "tests": ["infra/claude-hooks/test_host_boundary.py"]
+          "tests": [
+            "infra/claude-hooks/test_host_boundary.py",
+            "infra/claude-hooks/test_host_boundary_carveout.py"
+          ],
+          "note": "The carve-out half (UNPROTECTED_SUBPATHS) lived only in the live ~/.claude copy from 2026-06-16 until it was promoted on 2026-08-12; test_host_boundary.py never named it, so it passed with or without. test_host_boundary_carveout.py pins both directions — the freed subpaths stay writable, the control plane stays shut — and is mutation-verified: emptying UNPROTECTED_SUBPATHS kills exactly the three cases that carry weight (memory, scripts, venvs)."
         },
         "infra/claude-hooks/_phase.py": {
           "symbols": {},

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -405,6 +405,12 @@
       "machines": ["all"]
     },
     {
+      "live": "~/.claude/hooks/host_boundary.py",
+      "repo": "infra/claude-hooks/host_boundary.py",
+      "_note": "Undeclared until 2026-08-12, and the live copy had carried 25 lines of ~/.claude carve-outs since 2026-06-16 that the repo never saw — live work never promoted, the dangerous direction of superscar #1. install_phase_aware.sh, the sanctioned deploy path, would have overwritten them and silently re-blocked the agent's own memory directory. Promoted and pinned by test_host_boundary_carveout.py.",
+      "machines": ["all"]
+    },
+    {
       "live": "~/.claude/hooks/runtime_state_allowlist.json",
       "repo": "infra/claude-hooks/runtime_state_allowlist.json",
       "_note": "DATA read by worktree_isolation.py (the ff-only exception's per-machine allowlist). install_worktree_hooks.sh deploys it as 644 alongside the two .py hooks.",


### PR DESCRIPTION
## Found while following my own instructions

I told Zero to run `install_phase_aware.sh` before arming the orchestrate gate. Before running it I measured the five files it copies. One of them, `host_boundary.py`, differed from **both** the repo and `origin/main` — the live copy carries **25 lines of carve-outs** dated 2026-06-16 and 2026-06-23 that the repo has never seen.

They free exactly the agent's hands and notebook, and nothing else: `~/.claude/scripts`, `~/.claude/projects` (where **every `mem save` writes**), `~/.claude/venvs`, plus three WR2 learning dirs. Hooks, `settings.json` and credentials stay shut.

So the sanctioned deploy path would have copied the repo's version over the live one and **silently re-blocked the agent's own memory directory**. It has been a mine on the path it is documented as, armed for seven weeks. This promotes the live copy verbatim — live and repo are now byte-identical.

## Why it hid, and the two things that fix that

- **`test_host_boundary.py` never names the carve-out**, so it passes with or without it. Added `test_host_boundary_carveout.py`, asserting both halves — because a carve-out is a guard with the sign inverted and wants its own guilt and innocence: the freed subpaths must stay writable, and `hooks/` + `settings.json` must stay blocked. **Mutation-verified**: emptying `UNPROTECTED_SUBPATHS` kills exactly the three cases that carry weight (memory, scripts, venvs).
- **The HOME↔repo pair was undeclared**, which is precisely why the HOME-fork lint reported clean over a file it was not looking at (W107 — census the producers, not the one that bit you). Declared here.

## Two things measured while writing the test, recorded in it

**Three of the six carve-out entries are inert today.** `~/.claude/skills/bali-zero-brand` is a symlink into the repo, so those paths resolve *outside* `~/.claude` and were never protected in the first place. They would start doing work again if the symlink went away. Kept and asserted so the fact lives where the next reader looks — and it is exactly why the mutation kills three cases and not six.

**The first draft of my own test was wrong**, and the failing case is what taught me the above: it asserted that a curated `SKILL.md` under that path is blocked. It is not, and it should not be — behind the symlink it is repo content, guarded by worktree isolation, a different guard with a different job. Recorded as an explicit pass so nobody "fixes" `host_boundary` to block it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)