### PR TITLE
fix(jules): the arm was aimed at a repo Jules stopped being able to see

### DIFF
--- a/docs/runbooks/jules-dispatch.md
+++ b/docs/runbooks/jules-dispatch.md
@@ -25,7 +25,16 @@ the patch is evidence, the landing lane is ours.
 
 ```bash
 python3 scripts/jules_dispatch.py list-sources
-python3 scripts/jules_dispatch.py new --prompt "..." [--source sources/github/Balizero1987/Teman2] [--branch main] [--title ...]
+python3 scripts/jules_dispatch.py new --prompt "..." [--source sources/github/Bali-Zero/Teman2] [--branch main] [--title ...]
+# `new` first checks the source is one Jules can actually see and REFUSES (exit 3)
+# with the visible list if it is not. Escape: --skip-source-check.
+#
+# 2026-08-12 — if that refusal fires naming only unrelated repos, the cause is
+# almost certainly this: the repo moved from the personal account `Balizero1987`
+# to the `Bali-Zero` ORG, and a GitHub App installation does NOT follow a repo
+# transfer. Re-install the app on the owning org and grant it the repo:
+#   https://github.com/apps/google-labs-jules/installations/new
+# then re-run `list-sources` — the fix is on GitHub's side, never in this file.
 python3 scripts/jules_dispatch.py status sessions/<id>
 python3 scripts/jules_dispatch.py activities sessions/<id> [--limit 30]
 python3 scripts/jules_dispatch.py --selftest   # offline guilt+innocence (6 checks)

--- a/scripts/jules_dispatch.py
+++ b/scripts/jules_dispatch.py
@@ -39,7 +39,17 @@ import urllib.error
 import urllib.request
 
 BASE = "https://jules.googleapis.com/v1alpha"
-DEFAULT_SOURCE = "sources/github/Balizero1987/Teman2"
+# The repo was transferred from the personal account `Balizero1987` to the
+# `Bali-Zero` ORGANISATION. git and the GitHub API follow that with a redirect,
+# so nothing local broke and nobody noticed — but **a GitHub App installation
+# does not follow a transfer**: it stays bound to the account it was installed
+# on. Jules' installation sat on `Balizero1987`, so the moment Teman2 left that
+# account Jules stopped being able to see it, and every dispatch aimed here was
+# aimed at nothing. Measured 2026-08-12: `list-sources` returned four unrelated
+# repos (last pushed February and April) and not this one, while the arm itself
+# was healthy — selftest 6/6, API rc=0. Six weeks idle, zero alarms, because
+# nothing calls this arm on a schedule.
+DEFAULT_SOURCE = "sources/github/Bali-Zero/Teman2"
 DEFAULT_BRANCH = "main"
 KEYCHAIN_SERVICE = "jules-api-key"
 TIMEOUT_S = 30
@@ -121,7 +131,44 @@ def cmd_list_sources(key: str, as_json: bool) -> int:
     return 0
 
 
+def visible_sources(key: str) -> set[str] | None:
+    """Source names Jules can currently see, or None if that is unknowable.
+
+    ADVISORY, never authoritative. `api_call` reports and `sys.exit(1)`s on any
+    HTTP or network failure, which is the right behaviour for a command the
+    caller asked for — but this lookup is a pre-flight the caller did NOT ask
+    for, and a transient blip must not turn into a refusal to work. So the exit
+    is caught and converted to "unknowable": scar W106b — a guard that cannot
+    verify must say so, not render a verdict. The POST that follows remains the
+    real authority; this only buys a legible error instead of an opaque one.
+    """
+    try:
+        data = api_call("GET", "sources", key)
+    except SystemExit:
+        return None
+    return {s.get("name") for s in data.get("sources", []) if s.get("name")}
+
+
 def cmd_new(key: str, args: argparse.Namespace) -> int:
+    # Pre-flight: refuse a source Jules cannot see. Without this the arm sat
+    # six weeks pointed at a repo that had moved organisation, and the only
+    # symptom was an opaque API error nobody was there to read.
+    if not args.skip_source_check:
+        known = visible_sources(key)
+        if known is None:
+            print("jules_dispatch: [warn] could not list sources — dispatching "
+                  "UNVERIFIED (the POST below is the real check)", file=sys.stderr)
+        elif args.source not in known:
+            print(f"jules_dispatch: REFUSING — Jules cannot see {args.source!r}.",
+                  file=sys.stderr)
+            print("It currently sees:", file=sys.stderr)
+            for name in sorted(known):
+                print(f"  {name}", file=sys.stderr)
+            print("First thing to check: a GitHub App installation does NOT follow a "
+                  "repo transfer between accounts/orgs. Re-install the app on the "
+                  "owning org and grant it this repo, then re-run list-sources.",
+                  file=sys.stderr)
+            return 3
     body = {
         "prompt": args.prompt,
         "sourceContext": {
@@ -222,6 +269,8 @@ def main() -> int:
     p_new.add_argument("--branch", default=DEFAULT_BRANCH)
     p_new.add_argument("--title", default="")
     p_new.add_argument("--require-plan-approval", action="store_true")
+    p_new.add_argument("--skip-source-check", action="store_true",
+                       help="dispatch without checking the source is visible to Jules")
     p_new.add_argument("--json", action="store_true")
 
     p_st = sub.add_parser("status")

--- a/scripts/tests/test_jules_dispatch.py
+++ b/scripts/tests/test_jules_dispatch.py
@@ -118,3 +118,79 @@ def test_api_call_5xx_retries_then_succeeds(monkeypatch):
     monkeypatch.setattr(jd.time, "sleep", lambda *_: None)
     assert jd.api_call("GET", "sources", "k") == {"after": "retry"}
     assert calls["n"] == 2
+
+
+# --------------------------------------------- source pre-flight (2026-08-12)
+# Why this guard exists: the repo was transferred from the personal account
+# `Balizero1987` to the `Bali-Zero` org. A GitHub App installation does NOT
+# follow a transfer, so Jules silently lost sight of the repo while the arm
+# stayed healthy. Six weeks of dispatches aimed at nothing, no alarm, because
+# the only symptom was an opaque API error nobody was there to read.
+
+
+def _new_args(**over):
+    import argparse
+    base = dict(prompt="p", source=jd.DEFAULT_SOURCE, branch="main", title="",
+                require_plan_approval=False, skip_source_check=False, json=False)
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def _recording_api(sources, post_result=None, sources_raises=False):
+    """Stub api_call; returns (fn, calls) so a test can assert what was sent."""
+    calls = []
+
+    def fake(method, path, key, body=None):
+        calls.append((method, path))
+        if path == "sources":
+            if sources_raises:
+                raise SystemExit(1)  # what the real api_call does on HTTP/network failure
+            return {"sources": [{"name": s} for s in sources]}
+        return post_result or {"name": "sessions/x", "state": "QUEUED"}
+
+    return fake, calls
+
+
+def test_guilt_refuses_source_jules_cannot_see(monkeypatch, capsys):
+    fake, calls = _recording_api(["sources/github/Someone/Else"])
+    monkeypatch.setattr(jd, "api_call", fake)
+    rc = jd.cmd_new("k", _new_args(source="sources/github/Balizero1987/Teman2"))
+    assert rc == 3, "a source Jules cannot see must be refused, not dispatched"
+    assert ("POST", "sessions") not in calls, "refusal must happen BEFORE the POST"
+    err = capsys.readouterr().err
+    assert "REFUSING" in err and "sources/github/Someone/Else" in err, \
+        "the refusal must name what Jules CAN see, or it is not actionable"
+
+
+def test_innocence_visible_source_dispatches(monkeypatch):
+    fake, calls = _recording_api([jd.DEFAULT_SOURCE])
+    monkeypatch.setattr(jd, "api_call", fake)
+    rc = jd.cmd_new("k", _new_args())
+    assert rc == 0
+    assert ("POST", "sessions") in calls, "a visible source must still dispatch"
+
+
+def test_cannot_verify_warns_and_still_dispatches(monkeypatch, capsys):
+    # W106b: "I could not check" is not "it is wrong". A network blip on an
+    # advisory pre-flight must not become a refusal to work.
+    fake, calls = _recording_api([], sources_raises=True)
+    monkeypatch.setattr(jd, "api_call", fake)
+    rc = jd.cmd_new("k", _new_args())
+    assert rc == 0
+    assert ("POST", "sessions") in calls
+    assert "UNVERIFIED" in capsys.readouterr().err, \
+        "an unverifiable pre-flight must say so out loud, never pass silently"
+
+
+def test_skip_flag_does_not_even_look(monkeypatch):
+    fake, calls = _recording_api([])
+    monkeypatch.setattr(jd, "api_call", fake)
+    rc = jd.cmd_new("k", _new_args(skip_source_check=True))
+    assert rc == 0
+    assert ("GET", "sources") not in calls, "--skip-source-check must skip the lookup"
+
+
+def test_default_source_names_the_org_not_the_personal_account():
+    # Pins the 2026-08-12 transfer. If this ever reads Balizero1987 again the
+    # arm is aimed at a repo Jules cannot see.
+    assert jd.DEFAULT_SOURCE == "sources/github/Bali-Zero/Teman2"


### PR DESCRIPTION
## What happened

The Jules async-implementer arm was proven on **2026-07-06** — three PRs merged the same day (#2038, #2044, #2045), the last one on a fully autonomous loop — and then went quiet for six weeks.

It was never broken. Measured today: `--selftest` 6/6, API answers `rc=0`.

**It had lost its target.** The repo was transferred from the personal account `Balizero1987` to the `Bali-Zero` organisation. git and the GitHub API follow that with a redirect, so nothing local broke and nobody noticed — but **a GitHub App installation does not follow a transfer**: it stays bound to the account it was installed on. `list-sources` returned four unrelated repos (last pushed February and April) and not this one, so every dispatch aimed at `DEFAULT_SOURCE` was aimed at nothing.

No alarm for six weeks, because nothing calls this arm on a schedule and the only symptom was an opaque API error with nobody there to read it.

## Changes

- `DEFAULT_SOURCE` names the org, **pinned by a test** so it cannot drift back.
- `new` pre-flights the source against what Jules can actually see and **refuses (exit 3)**, listing the visible sources and naming the transfer as the first thing to check. Escape hatch `--skip-source-check`.
- The pre-flight is **advisory about its own failure**: `api_call` `sys.exit(1)`s on any HTTP/network error, so the lookup catches that and degrades to *unknowable* with a loud `UNVERIFIED` warning rather than refusing to work — scar **W106b**, a guard that cannot verify must say so, not render a verdict. The POST stays the real authority; this only buys a legible error instead of an opaque one.
- Runbook carries the same diagnosis so the next reader does not re-derive it.

## Verification

Corpus (5 new, 15 total, all green):

| case | asserts |
|---|---|
| guilt | invisible source refused **before** the POST, and the message names what IS visible |
| innocence | a visible source still dispatches |
| cannot-verify | lookup failure warns `UNVERIFIED` and still dispatches |
| skip flag | `--skip-source-check` performs no lookup at all |
| org pin | `DEFAULT_SOURCE` cannot silently return to the personal account |

**Mutation-verified**: neutering the refusal branch (`elif False:`) kills exactly `test_guilt_refuses_source_jules_cannot_see`, 14 pass; restoring it returns 15/15.

**PROVE-LIVE**: the operator installed the app on the org while this was in flight — `list-sources` now returns `sources/github/Bali-Zero/Teman2`, byte-identical to the new `DEFAULT_SOURCE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)