### PR TITLE
fix(infra): allowlist com.balizero.wr2control as node-local dual-run

### DIFF
--- a/scripts/mini-migration/overlap-detector.sh
+++ b/scripts/mini-migration/overlap-detector.sh
@@ -64,7 +64,17 @@ SYSTEM_FILTER='com\.apple|com\.google|com\.openai|com\.openssh|homebrew\.mxcl|co
 # Two instances share no state and cannot corrupt each other (#10 does not
 # apply). They are LOGGED as allowed-dual (visible, never silent — W82: a
 # suppression you cannot see is a blind spot) but do not alert.
-ALLOWED_DUAL='^com\.balizero\.mlx-server$|^com\.nuzantara\.local-livekit-server$|^com\.nuzantara\.local-livekit-worker$'
+#
+# com.balizero.wr2control (2026-08-12, verified against apps/wr2-control-app):
+# NOT loopback-scoped like the entries above — a different but equally valid
+# justification. Pro runs the app in `work` mode against the LIVE authoritative
+# queue (apps/war-room/output); Mini runs it with `--ambient` (deploy/install-mini.sh,
+# deploy/com.balizero.wr2control.plist) against a DISCONNECTED, one-shot-synced
+# local copy (~/.wr2-warroom-sync/output) for the office-TV editorial wall. Even
+# if a human at the Mini interacts and triggers a write, it lands in that dead-end
+# mirror, never back into Pro's live queue — no shared mutable state, #10 does not
+# apply. Logged as allowed-dual per the same W82 visibility rule.
+ALLOWED_DUAL='^com\.balizero\.mlx-server$|^com\.nuzantara\.local-livekit-server$|^com\.nuzantara\.local-livekit-worker$|^com\.balizero\.wr2control$'
 
 PRO_TMP=$(mktemp -t overlap-pro.XXXX)
 MINI_TMP=$(mktemp -t overlap-mini.XXXX)


### PR DESCRIPTION
## Summary
- `overlap-detector.daily` has flagged `com.balizero.wr2control` as a Pro↔Mini split-brain overlap every day since 2026-08-11.
- It is a deliberate dual-node deploy documented in `apps/wr2-control-app/deploy/`: Pro runs the app against the live authoritative queue (`apps/war-room/output`), Mini runs it with `--ambient` against a disconnected, one-shot-synced local copy (`~/.wr2-warroom-sync/output`, populated by `deploy/install-mini.sh`'s rsync).
- Re-verified this tick by reading `deploy/install-mini.sh` + both plists directly (not taken on the prior session's word): Mini's write target is a local filesystem path with no live network share back to Pro — any write on Mini lands in the dead-end mirror, never back into Pro's queue. Superscar #10 (active-active split-brain) does not apply.
- Adds `com.balizero.wr2control` to `overlap-detector.sh`'s `ALLOWED_DUAL` allowlist (still LOGGED as allowed-dual per W82 — visible, never silently suppressed).
- Resolves the operator[business] question opened 2026-07-11 on this exact label.

## Test plan
- [x] `bash -n scripts/mini-migration/overlap-detector.sh` — syntax OK
- [x] `python3 scripts/docs_sync.py --check` — DOCSYNC OK (no changes)
- [ ] CI (backend suite could not run locally — worktree has no `.venv`; not a regression risk, this is a standalone bash script with no backend-rag coupling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)