### PR TITLE
fix(clients): editable address field + always-visible address section

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/OverviewTab.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/OverviewTab.tsx
@@ -351,17 +351,19 @@ export function OverviewTab({
               )}
 
               {/* Address */}
-              {client.address && (
-                <>
-                  <div className="border-t border-[var(--bz-border)]" />
-                  <div>
-                    <p className="text-[10px] uppercase tracking-wider text-[var(--bz-text-2)]">
-                      Address
-                    </p>
-                    <p className="text-sm font-medium">{client.address}</p>
-                  </div>
-                </>
-              )}
+              <div className="border-t border-[var(--bz-border)]" />
+              <div>
+                <p className="text-[10px] uppercase tracking-wider text-[var(--bz-text-2)]">
+                  Address
+                </p>
+                <p className="text-sm font-medium">
+                  {client.address || (
+                    <span className="text-[var(--bz-text-2)] italic text-xs">
+                      Not provided
+                    </span>
+                  )}
+                </p>
+              </div>
 
               {/* Strategic Recap — primary intelligent auto-summary (bold + distinct) */}
               {(client as any).strategic_recap && (

--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/modals/EditClientModal.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/modals/EditClientModal.tsx
@@ -404,6 +404,18 @@ export function EditClientModal({
           />
         </div>
         <div className="md:col-span-2">
+          <label className="block text-sm font-medium mb-1.5">Address</label>
+          <textarea
+            rows={2}
+            value={formData.address}
+            onChange={(e) =>
+              setFormData({ ...formData, address: e.target.value })
+            }
+            className={inputClass}
+            placeholder="Full residential or business address"
+          />
+        </div>
+        <div className="md:col-span-2">
           <label className="block text-sm font-medium mb-1.5">Tags</label>
           <input
             type="text"


### PR DESCRIPTION
## Insight

Client address was structurally uneditable. The backend accepted `address` on
update, and the Overview tab rendered it — but no input for it existed anywhere
in the UI, so the field could only ever hold whatever ingestion put there.

## Studio

Two user-visible changes:

1. **Edit client modal** now contains an Address textarea. Users can add or
   correct a client address from the application for the first time.
2. **Overview tab** Address section is now always rendered. When empty it shows
   "Not provided", matching the existing treatment of Email and Phone. Before,
   the entire section vanished when the value was empty, which made a missing
   address indistinguishable from a field that does not exist.

Files and zone:
- `apps/mouth/src/app/(workspace)/clients/[id]/components/modals/EditClientModal.tsx` (VERDE)
- `apps/mouth/src/app/(workspace)/clients/[id]/components/OverviewTab.tsx` (VERDE)

No backend change. No new `source=` value, so CI source-parity is unaffected.

## Source

Reported by Adit (Supervisor Lead Setup) on 12 Aug 2026 against
`https://kita.balizero.com/clients/2775?tab=overview` — address could not be
changed from the UI.

## Methodology

Browser inspection of the live client detail page, followed by reading the
modal component, the Overview component, and the backend update handler in
`apps/backend-rag/backend/app/routers/crm_clients.py` to confirm the field was
already accepted server-side.

## Raw Observations

- `EditClientModal.tsx` rendered 12 fields: Full Name, Email, Phone (+ country
  code), Nationality, Passport Number, Passport Expiry, Date of Birth, Lead
  Source, Service Interest, Tags, Assigned To, Status. No address input.
- Form had no `maxLength` on any field.
- `OverviewTab.tsx` wrapped the Address block in `{client.address && (...)}`.
- Backend `update_client` in `crm_clients.py` already accepted `address`.
- `npm run lint`: FAILURE — pre-existing crash (TypeError: scopeManager.addGlobals
  is not a function, ESLint 10.3.0) confirmed identical on clean tree at commit
  49477f415, unrelated to this PR.
- `npx vitest run EditClientModal.test.tsx`: 5/5 PASS (EditClientModal — avatar_url
  update contract).

## Reasoning Path

The missing input and the conditional render are two separate defects that
produce one symptom. Adding the input alone would leave a saved-then-cleared
address invisible; making the section unconditional alone would surface a field
users still could not fill. Both are required for the field to behave like
Email and Phone, and both live in the same user-facing flow, so they belong in
one PR.

## Risk

Low. Additive form field plus removal of a render condition. No schema change,
no API contract change, no shared component touched.

The one behavioural change to note: clients with no address now render an extra
Address row on the Overview card where previously nothing appeared. This is
intended and consistent with Email and Phone.

## Implication

This PR restores the ability to edit the field. It does not fix the value
currently stored.

Investigation found `client.address` on client 2775 truncated to exactly 51
characters, an exact prefix of the 96-character value in
`company_links.registered_address` and the 149-character AI-extracted value.
Truncation therefore occurs at ingestion or at the column, not in this form.
That is tracked separately and is not addressed here.

## Recommendation

Merge. The truncation investigation should not block restoring edit access —
without this PR there is no way to correct an affected record even once the
root cause is known.

## Next Action

1. Merge via `gh pr merge [N] --squash --auto`.
2. Confirm the promoted commit before reporting anything as live.
3. Open the ingestion-truncation investigation, scoped to how many client
   records are affected — not to client 2775 alone.
