### PR TITLE
fix(cron): errexit decapitated cron-wrapper's alert path, so a job that named no reason failed in silence (W101)

### DIFF
--- a/scripts/cron-wrapper.sh
+++ b/scripts/cron-wrapper.sh
@@ -281,7 +281,12 @@ if [ $EXIT_CODE -ne 0 ]; then
     # Prefer the sentence the job named for itself over five lines of raw tail;
     # fall back to the tail when it did not name one. The receipt above keeps
     # the raw tail either way — only this human-facing body changes.
-    LAST_LINES=$(printf '%s' "$OUTPUT" | grep -a "^${CRON_ALERT_MARKER}" | tail -1)
+    # `|| LAST_LINES=""` is load-bearing, not defensive style. This file runs under
+    # `set -euo pipefail` (line 21): when the job named no sentence, `grep` exits 1,
+    # pipefail propagates it, and a NAKED assignment aborts the whole script right
+    # here — before send_telegram below. The else-branch that falls back to the raw
+    # tail was unreachable on exactly the path it exists for (W101).
+    LAST_LINES=$(printf '%s' "$OUTPUT" | grep -a "^${CRON_ALERT_MARKER}" | tail -1) || LAST_LINES=""
     if [ -n "$LAST_LINES" ]; then
         LAST_LINES="${LAST_LINES#"$CRON_ALERT_MARKER"}"
         LAST_LINES="${LAST_LINES# }"

--- a/scripts/test_cron_single_voice.sh
+++ b/scripts/test_cron_single_voice.sh
@@ -165,6 +165,25 @@ run_under_runner
 check "un invio"                                "$(yes_if "$(sends)" 1)"
 check "il corpo e' la coda grezza (fallback)"   "$(body_has "$NOISE")"
 
+echo "SIMMETRIA — lo stesso payload muto, ma sotto cron-wrapper (W101, 2026-08-12)"
+# INNOCENZA 3 qui sopra gira SOLO sotto cron-runner, che ha `set -uo pipefail`.
+# cron-wrapper ha `set -euo pipefail`, e la riga che rilegge il marcatore e' una
+# pipeline NUDA: senza marcatore `grep` esce 1, pipefail lo propaga, errexit aborta
+# lo script PRIMA di send_telegram. Il ramo di fallback alla coda grezza esisteva,
+# non poteva scattare.
+#
+# Misurato vivo su Mini prima della cura: visa-oracle-retention e' fallito 31 volte
+# di fila in ~8h (exit 75 dal suo shim, che non stampa il marcatore) e nello spool
+# Telegram della macchina compare ZERO volte — mentre 8 altre sorgenti ci arrivavano,
+# quindi il gateway funzionava. Il caso-che-funziona (col marcatore) era gia' provato
+# sotto ENTRAMBI i wrapper; il caso-che-rompe sotto uno solo. Un corpus asimmetrico
+# copre la forma, non la classe: e' la lezione W107 ripetuta dentro il test scritto
+# per chiuderla.
+PAYLOAD_BODY=':' build_world
+run_under_wrapper 0
+check "un invio anche senza marcatore"          "$(yes_if "$(sends)" 1)"
+check "il corpo e' la coda grezza (fallback)"   "$(body_has "$NOISE")"
+
 echo "INNOCENZA 4 — un job che riesce non dice niente"
 PAYLOAD_BODY=':' build_world
 JOB_EXIT=0 run_under_runner


### PR DESCRIPTION
## What broke

`scripts/cron-wrapper.sh` runs under `set -euo pipefail` (line 21). Its alert block re-reads the job's self-named sentence with a **naked pipeline assignment**:

```bash
LAST_LINES=$(printf '%s' "$OUTPUT" | grep -a "^${CRON_ALERT_MARKER}" | tail -1)
```

When the failing job printed no `CRON_ALERT_P0:` line, `grep` exits 1, `pipefail` propagates it, and `errexit` aborts the script **there** — before `send_telegram` a dozen lines below. The `else` branch that falls back to the raw tail was unreachable on the exact path it exists for. W101, again.

## Measured, not inferred

Live on Mini: `visa-oracle-retention` failed **31 times in a row over ~8h** (exit 75 from its tunnel shim, which prints no marker), and the string `visa-oracle-retention` appears **zero times anywhere in that machine's Telegram spool** — while 8 other sources landed in the same spool over the same window, so the gateway itself was healthy.

Reproduced in isolation by running the wrapper in a fake world with a fake `tg_notify.py` sibling and an isolated `HOME`:

| case | result |
|---|---|
| failing job, **no** `CRON_ALERT_P0:` marker | **gateway never invoked** |
| failing job, **with** the marker | gateway invoked |

## Why it stayed hidden

The twin `cron-runner.sh` carries `set -uo pipefail` — **no `-e`** — with the same construct at its line 126, so it degrades to the fallback and alarms. Pro's spool is full of `cron:*` messages from it. **The two wrappers differ by one letter, and that letter is the difference between having a voice and not having one.** W107 classified `cron-wrapper` as the healthy twin that alarmed; it alarms only when the payload happens to name its own reason.

## Class audit, not a point fix

Of the six command-substitution-with-pipeline assignments in this file (lines 104, 135, 245, 259, 284, 289), **284 is the only one whose pipeline can exit non-zero** — `cat` is `|| echo ""`-guarded, `tail` and `tr` always succeed. So the single-site fix is the whole class here.

## Corpus

`scripts/test_cron_single_voice.sh` already **claimed** to cover this — its header says *"GUILT ×2 — under EACH alarming wrapper (cron-runner, cron-wrapper)"* — but the no-marker case (INNOCENZA 3) ran only under `cron-runner`. The case that **works** was proven under both wrappers; the case that **breaks** under one. An asymmetric corpus covers the shape, not the class — the W107 lesson repeating inside the test written to close it.

Added a symmetric `SIMMETRIA` block: same mute payload, under `cron-wrapper`.

- RED against the unfixed wrapper: **34 ok / 2 FAIL**
- green after: **36 ok / 0 FAIL**

Mutation-verified by construction. Siblings unaffected: `test_cron_runner_alert.sh` 20 ok, `test_cron_state_alert.sh` 11 pass.

## Blast radius restored

23 `cron-wrapper` invocations on Pro + 1 on Mini.

## Related, shipped out-of-band

The Mini-side cause of the 8h outage (flyctl's 720h client-side login clock rejecting a token that still authenticates) is cured separately on that machine: an app-scoped `FLY_API_TOKEN` in `~/.nuzantara-secrets.env` (the env path skips the clock) plus a rewritten tunnel shim that names which credential source it accepted, separates credential-refusal from proxy-failure, and emits `CRON_ALERT_P0:` — so it has a voice even where this fix has not landed yet. Those files are local, non-repo, Mini-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)