### PR TITLE
fix(visa-engine): label internal evaluate probes as synthetic by default

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/probe_evaluate.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/probe_evaluate.py
@@ -1,0 +1,358 @@
+"""Manual/ceremony probe wrapper for ``POST /api/visa-oracle/evaluate``.
+
+Every hand-run smoke against the evaluate endpoint that omits the
+``traffic_source`` query param lands as ``traffic_source=real`` by design
+(the router's default -- see ``app/routers/visa_oracle_evaluate.py``'s module
+docstring, and it is CORRECT for organic end-user traffic). But an operator
+probe is not organic traffic: `shadow_evidence.py`'s G-a-vol gate reserves
+``real`` for genuine adoption evidence, and every prior arming/prove-live
+ceremony that skipped the query param contaminated that ledger (3 rows
+2026-07-26, 4 rows 2026-08-10, 2 rows + 1 rejected 422 on 2026-08-11 --
+``.agents/skills/visaoracle/{SKILL,CURRENT_STATE}.md``).
+
+This CLI closes that gap for the manual path: it defaults to
+``traffic_source=synthetic_driver`` plus the ``X-Visa-Driver-Token`` header
+(read from the W4 gold-corpus replay driver credential file, never printed,
+logged, or committed), so a probe run through this wrapper cannot silently
+land as ``real``. Missing/loose token file is a hard, fail-closed error --
+never a silent fallback to ``real``.
+
+Usage (from ``apps/backend-rag``)::
+
+    PYTHONPATH=. .venv/bin/python -m backend.scripts.visa_engine.probe_evaluate \\
+      --url https://nuzantara-rag.fly.dev/api/visa-oracle/evaluate \\
+      --payload /path/to/facts.json
+
+Payload can also be piped on stdin (omit ``--payload``). The driver token is
+read by default from ``~/.config/nuzantara/visa-signing/driver-token`` (the
+same custody location as the signing keys -- see
+``docs/runbooks/visa-engine-key-ceremony.md`` and
+``reference_visa_oracle_signing_key_lives_on_m5_2026_08_10.md``); override
+with ``--driver-token-file`` or ``$VISA_ENGINE_DRIVER_TOKEN_FILE``.
+
+For the rare legitimate case a probe must exercise the exact real-caller
+code path, pass ``--as-real-i-know-what-i-am-doing`` explicitly -- it is loud
+(prints a warning banner) and never the default.
+
+This module never imports the FastAPI app; it is a pure HTTP client CLI,
+offline-ops posture like its ``visa_engine`` script siblings
+(``sign_pack.py``, ``activate_pack.py``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("visa_engine.probe_evaluate")
+
+#: Direct backend URL (bypasses the balizero.com proxy) -- override with
+#: --url or $VISA_ORACLE_PROBE_URL for a different environment/proxy.
+DEFAULT_URL = "https://nuzantara-rag.fly.dev/api/visa-oracle/evaluate"
+URL_ENV = "VISA_ORACLE_PROBE_URL"
+
+DEFAULT_DRIVER_TOKEN_FILE = Path.home() / ".config" / "nuzantara" / "visa-signing" / "driver-token"
+DRIVER_TOKEN_FILE_ENV = "VISA_ENGINE_DRIVER_TOKEN_FILE"
+DRIVER_TOKEN_HEADER = "X-Visa-Driver-Token"
+
+#: Migration 256's CHECK classes, verbatim (mirrors
+#: ``shadow_evidence.SYNTHETIC_TRAFFIC_SOURCES`` -- not imported directly so
+#: this offline CLI never imports the FastAPI app's dependency graph).
+SYNTHETIC_TRAFFIC_SOURCES = frozenset({"synthetic_gold", "synthetic_driver"})
+REAL_TRAFFIC_SOURCE = "real"
+ALL_TRAFFIC_SOURCES = frozenset({REAL_TRAFFIC_SOURCE, *SYNTHETIC_TRAFFIC_SOURCES})
+DEFAULT_SYNTHETIC_TRAFFIC_SOURCE = "synthetic_driver"
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+#: Group/other permission bits -- a token file must be chmod 0600 or
+#: stricter (same posture as sign_pack.py's key-file check, cicatrix
+#: family #4 "secret in the clear").
+_GROUP_OTHER_BITS = stat.S_IRWXG | stat.S_IRWXO
+
+
+class ProbeEvaluateError(RuntimeError):
+    """A fail-closed condition this CLI refuses to proceed past."""
+
+
+def _check_token_file_permissions(path: Path, mode: int) -> None:
+    if mode & _GROUP_OTHER_BITS:
+        raise ProbeEvaluateError(
+            f"driver token file {path} has mode {oct(mode)} -- refusing to read a "
+            "group/other-accessible secret. `chmod 0600` it first."
+        )
+
+
+def _load_driver_token(path: Path) -> str:
+    """Load the W4 driver credential from disk.
+
+    Fail-closed on every irregular shape (missing, loose permissions, not a
+    regular file, empty) -- NEVER falls back to omitting the header, which
+    would resurface as a 400 from the server rather than a clear local
+    error, and never logs or returns the token in an exception message.
+    """
+
+    try:
+        file_stat = path.stat()
+    except FileNotFoundError as exc:
+        raise ProbeEvaluateError(
+            f"driver token file not found: {path} -- refusing to fall back to "
+            "traffic_source=real. Provision the file (see "
+            "docs/runbooks/visa-engine-key-ceremony.md) or pass "
+            "--as-real-i-know-what-i-am-doing explicitly if this probe truly must "
+            "run as real traffic."
+        ) from exc
+    except OSError as exc:
+        raise ProbeEvaluateError(f"cannot stat driver token file {path}: {exc}") from exc
+
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise ProbeEvaluateError(f"driver token file {path} is not a regular file")
+    _check_token_file_permissions(path, file_stat.st_mode)
+
+    try:
+        token = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise ProbeEvaluateError(f"cannot read driver token file {path}: {exc}") from exc
+
+    if not token:
+        raise ProbeEvaluateError(f"driver token file {path} is empty")
+    return token
+
+
+def _load_payload(payload_arg: str | None) -> dict[str, Any]:
+    """Load the request body JSON from ``--payload`` file, or stdin if omitted."""
+
+    if payload_arg is None:
+        raw = sys.stdin.read()
+        source = "<stdin>"
+    else:
+        try:
+            raw = Path(payload_arg).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ProbeEvaluateError(f"cannot read payload file {payload_arg}: {exc}") from exc
+        source = payload_arg
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProbeEvaluateError(f"payload from {source} is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ProbeEvaluateError(f"payload from {source} must be a JSON object")
+    return parsed
+
+
+def resolve_traffic_source(args: argparse.Namespace) -> str:
+    """Decide the ``traffic_source`` query value. Pure function, no I/O.
+
+    Without ``--as-real-i-know-what-i-am-doing``: only the two synthetic classes
+    are reachable, defaulting to ``synthetic_driver``. Requesting ``real``
+    (or anything outside the synthetic set) without the override flag is
+    REJECTED here -- it is never silently promoted to a synthetic value,
+    the caller must pass the loud flag to explicitly opt into landing as
+    real traffic.
+
+    With ``--as-real-i-know-what-i-am-doing``: any accepted class is reachable
+    (default ``real``) -- the flag only WIDENS the allowed set, it never
+    narrows what ``--traffic-source`` can request, and a synthetic class
+    requested alongside it still requires the driver token (matching the
+    server's own contract: the flag is about caller intent, not about
+    bypassing the server's synthetic-class gate).
+    """
+
+    requested = args.traffic_source
+    if args.as_real_i_know_what_i_am_doing:
+        return requested or REAL_TRAFFIC_SOURCE
+    if requested is None:
+        return DEFAULT_SYNTHETIC_TRAFFIC_SOURCE
+    if requested not in SYNTHETIC_TRAFFIC_SOURCES:
+        raise ProbeEvaluateError(
+            f"--traffic-source {requested!r} requires --as-real-i-know-what-i-am-doing "
+            f"(only {sorted(SYNTHETIC_TRAFFIC_SOURCES)} are accepted without it)"
+        )
+    return requested
+
+
+def build_query_params(args: argparse.Namespace, traffic_source: str) -> dict[str, str]:
+    params = {"traffic_source": traffic_source}
+    if args.request_category:
+        params["request_category"] = args.request_category
+    return params
+
+
+def build_headers(args: argparse.Namespace, traffic_source: str) -> dict[str, str]:
+    """Resolve request headers. Reads the driver-token file when the
+    resolved ``traffic_source`` is synthetic -- the only I/O this function
+    performs, and it is exactly the fail-closed path under test.
+    """
+
+    headers = {"Content-Type": "application/json"}
+    if traffic_source in SYNTHETIC_TRAFFIC_SOURCES:
+        token_path = Path(args.driver_token_file).expanduser()
+        headers[DRIVER_TOKEN_HEADER] = _load_driver_token(token_path)
+    if args.idempotency_key:
+        headers["Idempotency-Key"] = args.idempotency_key
+    return headers
+
+
+async def _post_evaluate(
+    *,
+    url: str,
+    params: dict[str, str],
+    headers: dict[str, str],
+    payload: dict[str, Any],
+    timeout: float,
+) -> httpx.Response:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        return await client.post(url, params=params, headers=headers, json=payload)
+
+
+def _summarize_response(response: httpx.Response) -> str:
+    lines = [f"HTTP {response.status_code}"]
+    try:
+        body = response.json()
+    except ValueError:
+        lines.append(f"non-JSON body ({len(response.content)} bytes)")
+        return "\n".join(lines)
+
+    if not isinstance(body, dict):
+        lines.append(f"unexpected body shape: {type(body).__name__}")
+        return "\n".join(lines)
+
+    mode = body.get("mode")
+    decision = body.get("decision")
+    decision = decision if isinstance(decision, dict) else {}
+    state = decision.get("state")
+    lines.append(f"mode={mode!r} state={state!r}")
+
+    rule_pack = decision.get("rule_pack")
+    if isinstance(rule_pack, dict):
+        lines.append(
+            "rule_pack: sequence={!r} version={!r} rule_pack_id={!r}".format(
+                rule_pack.get("sequence"),
+                rule_pack.get("version"),
+                rule_pack.get("rule_pack_id"),
+            )
+        )
+    else:
+        lines.append("rule_pack: none (e.g. TEMPORARILY_UNAVAILABLE / no active pack)")
+
+    return "\n".join(lines)
+
+
+def run(args: argparse.Namespace) -> int:
+    try:
+        traffic_source = resolve_traffic_source(args)
+        payload = _load_payload(args.payload)
+        params = build_query_params(args, traffic_source)
+        headers = build_headers(args, traffic_source)
+    except ProbeEvaluateError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    if args.as_real_i_know_what_i_am_doing:
+        logger.warning(
+            "!!! sending traffic_source=%s -- this call WILL land in the shadow "
+            "ledger as if it were organic end-user traffic !!!",
+            traffic_source,
+        )
+
+    try:
+        response = asyncio.run(
+            _post_evaluate(
+                url=args.url,
+                params=params,
+                headers=headers,
+                payload=payload,
+                timeout=args.timeout,
+            )
+        )
+    except httpx.HTTPError:
+        # Do not log the exception text: a transport/proxy exception can
+        # reflect request data, including the driver-token header.
+        logger.error("request to Visa Oracle evaluate endpoint failed")
+        return 3
+
+    # The endpoint never returns the driver token, but a misbehaving proxy
+    # must not turn that contract into a CLI secret leak.  Redact the exact
+    # credential from the deliberately small human-facing summary as a final
+    # defense in depth.
+    summary = _summarize_response(response)
+    driver_token = headers.get(DRIVER_TOKEN_HEADER)
+    if driver_token:
+        summary = summary.replace(driver_token, "[REDACTED]")
+    print(summary)
+    return 0 if response.status_code == 200 else 1
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Probe wrapper for POST /api/visa-oracle/evaluate. Defaults to "
+            "traffic_source=synthetic_driver + X-Visa-Driver-Token so manual "
+            "smoke/ceremony calls never land as traffic_source=real in the "
+            "shadow ledger."
+        )
+    )
+    parser.add_argument(
+        "--url",
+        default=os.environ.get(URL_ENV, DEFAULT_URL),
+        help=f"Evaluate endpoint URL (default: {DEFAULT_URL}, env {URL_ENV})",
+    )
+    parser.add_argument(
+        "--payload",
+        default=None,
+        help="Path to a JSON ApplicantFacts body; reads stdin if omitted",
+    )
+    parser.add_argument(
+        "--traffic-source",
+        default=None,
+        choices=sorted(ALL_TRAFFIC_SOURCES),
+        help=(
+            "Query traffic_source. Default (without --as-real-i-know-what-i-am-doing): "
+            f"{DEFAULT_SYNTHETIC_TRAFFIC_SOURCE}."
+        ),
+    )
+    parser.add_argument(
+        "--driver-token-file",
+        default=os.environ.get(DRIVER_TOKEN_FILE_ENV, str(DEFAULT_DRIVER_TOKEN_FILE)),
+        help=f"Path to the driver token file (default: {DEFAULT_DRIVER_TOKEN_FILE})",
+    )
+    parser.add_argument("--request-category", default=None)
+    parser.add_argument("--idempotency-key", default=None)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--as-real-i-know-what-i-am-doing",
+        action="store_true",
+        help=(
+            "DANGEROUS: allow traffic_source=real (or any class) for this probe. "
+            "The probe WILL be counted as organic end-user traffic by the shadow "
+            "evidence ledger. Only for the rare case a probe must exercise the "
+            "exact real-caller code path. Prints a loud warning before sending."
+        ),
+    )
+    return parser
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments using the same offline-ops convention as siblings."""
+
+    return _build_arg_parser().parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    args = _parse_args(argv)
+    return run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_probe_evaluate.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_probe_evaluate.py
@@ -1,0 +1,172 @@
+"""Unit tests for the internal Visa Oracle evaluate probe wrapper.
+
+The wrapper is deliberately tested through its mocked HTTP seam.  These tests
+must never call the deployed endpoint: a real call would write a shadow-ledger
+row and could corrupt activation-gate evidence.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from backend.scripts.visa_engine import probe_evaluate
+
+
+class _Response:
+    def __init__(self, body: dict[str, Any], *, status_code: int = 200) -> None:
+        self._body = body
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+def _write_token(path: Path, token: str = "test-driver-token-never-log") -> str:
+    path.write_text(f"{token}\n", encoding="utf-8")
+    path.chmod(0o600)
+    return token
+
+
+def _write_payload(path: Path) -> None:
+    path.write_text('{"facts": {}}', encoding="utf-8")
+
+
+def test_parse_args_defaults_to_synthetic_driver() -> None:
+    args = probe_evaluate._parse_args(["--payload", "facts.json"])
+
+    assert args.traffic_source is None
+    assert args.as_real_i_know_what_i_am_doing is False
+    assert probe_evaluate.resolve_traffic_source(args) == "synthetic_driver"
+
+
+def test_real_traffic_source_requires_the_loud_opt_out() -> None:
+    args = probe_evaluate._parse_args(["--payload", "facts.json", "--traffic-source", "real"])
+
+    with pytest.raises(probe_evaluate.ProbeEvaluateError, match="as-real-i-know-what-i-am-doing"):
+        probe_evaluate.resolve_traffic_source(args)
+
+    opted_out = probe_evaluate._parse_args(
+        [
+            "--payload",
+            "facts.json",
+            "--as-real-i-know-what-i-am-doing",
+        ]
+    )
+    assert probe_evaluate.resolve_traffic_source(opted_out) == "real"
+
+
+def test_absent_token_file_fails_closed_without_network_call(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = tmp_path / "facts.json"
+    _write_payload(payload)
+    absent_token = tmp_path / "missing-driver-token"
+    called = False
+
+    async def no_network(**_kwargs: object) -> _Response:
+        nonlocal called
+        called = True
+        raise AssertionError("network must not be called when token custody fails")
+
+    monkeypatch.setattr(probe_evaluate, "_post_evaluate", no_network)
+    args = probe_evaluate._parse_args(
+        ["--payload", str(payload), "--driver-token-file", str(absent_token)]
+    )
+
+    with caplog.at_level(logging.ERROR, logger="visa_engine.probe_evaluate"):
+        assert probe_evaluate.run(args) == 2
+
+    assert called is False
+    assert "refusing to fall back to traffic_source=real" in caplog.text
+
+
+def test_synthetic_probe_constructs_authenticated_request_and_reports_pack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    token = _write_token(tmp_path / "driver-token")
+    payload_path = tmp_path / "facts.json"
+    _write_payload(payload_path)
+    captured: dict[str, object] = {}
+
+    async def fake_post(**kwargs: object) -> _Response:
+        captured.update(kwargs)
+        return _Response(
+            {
+                "mode": "CURATED",
+                "decision": {
+                    "state": "SUPPORTED_CANDIDATES",
+                    "rule_pack": {
+                        "rule_pack_id": "00000000-0000-0000-0000-000000000007",
+                        "sequence": 7,
+                        "version": "2026.8.11",
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(probe_evaluate, "_post_evaluate", fake_post)
+    argv = [
+        "--url",
+        "https://probe.example.test/api/visa-oracle/evaluate",
+        "--payload",
+        str(payload_path),
+        "--driver-token-file",
+        str(tmp_path / "driver-token"),
+        "--request-category",
+        "tourism",
+    ]
+    args = probe_evaluate._parse_args(argv)
+
+    with caplog.at_level(logging.INFO, logger="visa_engine.probe_evaluate"):
+        assert probe_evaluate.run(args) == 0
+
+    assert captured == {
+        "url": "https://probe.example.test/api/visa-oracle/evaluate",
+        "params": {"traffic_source": "synthetic_driver", "request_category": "tourism"},
+        "headers": {
+            "Content-Type": "application/json",
+            "X-Visa-Driver-Token": token,
+        },
+        "payload": {"facts": {}},
+        "timeout": 30.0,
+    }
+    output = capsys.readouterr().out
+    assert "state='SUPPORTED_CANDIDATES'" in output
+    assert "sequence=7" in output
+    assert "version='2026.8.11'" in output
+    assert token not in argv
+    assert token not in output
+    assert token not in caplog.text
+
+
+def test_transport_error_never_logs_driver_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    token = _write_token(tmp_path / "driver-token")
+    payload = tmp_path / "facts.json"
+    _write_payload(payload)
+
+    async def token_reflecting_transport_error(**_kwargs: object) -> _Response:
+        raise httpx.ConnectError(f"proxy reflected secret {token}")
+
+    monkeypatch.setattr(probe_evaluate, "_post_evaluate", token_reflecting_transport_error)
+    args = probe_evaluate._parse_args(
+        ["--payload", str(payload), "--driver-token-file", str(tmp_path / "driver-token")]
+    )
+
+    with caplog.at_level(logging.ERROR, logger="visa_engine.probe_evaluate"):
+        assert probe_evaluate.run(args) == 3
+
+    assert token not in caplog.text

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -4,7 +4,7 @@
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
 <!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 695 services · 1357 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
+`330 routers · 695 services · 1358 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
 <!-- DOCSYNC:QUICK_NUMBERS_END -->
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).

--- a/research/visa/2026-07-24-shadow-arming-runbook.md
+++ b/research/visa/2026-07-24-shadow-arming-runbook.md
@@ -44,15 +44,32 @@ ssh pro 'bash -lc "fly secrets set -a nuzantara-rag \
 
 ## Smoke (after redeploy)
 
-1. **No-pack behavior (pre-activation only):** `POST /api/visa-oracle/evaluate` with a
-   minimal valid facts body → expect 200 TEMP shape, `retryable=true`, and **zero** new rows
-   in `visa_decisions`.
-2. **First real row (post-activation):** same call → 200 ENGINE-mode-available response
-   (`mode=CURATED` until ENFORCE is a thing), one `visa_decisions` row with
-   `engine_surface='RECOMMEND'`, `engine_mode='SHADOW'`, `traffic_source='real'`, derived
-   `request_category`, 32-byte fingerprint, `ruleset_activation_id` set.
-3. **Driver check:** same call with `?traffic_source=synthetic_gold` WITHOUT the token →
-   400; with `X-Visa-Driver-Token` → row with `traffic_source='synthetic_gold'`.
+Every operator-run evaluate probe MUST use the wrapper below. It defaults to
+`traffic_source=synthetic_driver` and obtains `X-Visa-Driver-Token` only from the
+0600 custody file; it refuses to send if that file is absent or unreadable. Never use a bare
+`curl` for this endpoint. From `apps/backend-rag`:
+
+```bash
+PYTHONPATH=. .venv/bin/python -m backend.scripts.visa_engine.probe_evaluate \
+  --payload /secure/path/to/minimal-valid-applicant-facts.json
+```
+
+The helper prints the terminal decision state and active RulePack sequence/version. It reads
+the payload from standard input when `--payload` is omitted. `--as-real-i-know-what-i-am-doing`
+is a deliberately loud, exceptional opt-out for a genuinely real-caller test; routine smoke
+must never use it.
+
+1. **No-pack behavior (pre-activation only):** run the helper with a minimal valid facts body
+   → expect 200 TEMP shape, `retryable=true`, and **zero** new rows in `visa_decisions`.
+2. **First synthetic probe (post-activation):** same helper call → 200 ENGINE-mode-available
+   response (`mode=CURATED` until ENFORCE is a thing), one `visa_decisions` row with
+   `engine_surface='RECOMMEND'`, `engine_mode='SHADOW'`,
+   `traffic_source='synthetic_driver'`, derived `request_category`, 32-byte fingerprint, and
+   `ruleset_activation_id` set. It is breadth-only evidence: only organic end-user traffic may
+   create a `traffic_source='real'` row for G-a volume.
+3. **Driver check:** the helper's successful probe is the token-authenticated synthetic check;
+   endpoint tests cover rejection of a missing or invalid token without a manual bare-curl
+   ceremony.
 4. **Collector read-back:** `scripts/visa_shadow_evidence.py` (read-only) shows the rows in
    the right G-a-vol / G-a-breadth buckets.
 


### PR DESCRIPTION
## Why

Every internal ceremony / prove-live probe so far hit `POST /api/visa-oracle/evaluate` with a bare curl. The endpoint's `traffic_source` default is `real` (correct for organic traffic), so each probe landed labelled as an organic end-user request and was counted by the **G-a-vol** ENFORCE-gate criterion.

Known contaminated rows: 3 on 2026-07-26, 4 at the seq-6 ceremony on 2026-08-10, 2 (plus one 422) at the seq-7 ceremony on 2026-08-11, on top of the 1,464-row burst of 2026-07-27. Each ceremony recorded the problem in prose afterwards; none cured it. This is the structural cure.

## What

- `probe_evaluate.py`: internal probe wrapper. Defaults to `traffic_source=synthetic_driver` with `X-Visa-Driver-Token` read from the custody file. **Fails closed** when the token file is absent instead of silently degrading to `real`; the token never reaches argv or logs. One explicit, loud opt-out flag remains for the rare deliberate case.
- 5 unit tests, network fully mocked, including an assertion that the token never appears in argv or output.
- The re-runnable smoke in the shadow-arming runbook now uses the helper. Historical ceremony receipts are deliberately untouched — they are the historical record.

## Out of scope

No DB backfill and no re-labelling of the already-contaminated rows: that is an operator decision, not a side effect of this PR.

## Verification

- `pytest backend/tests/scripts/visa_engine/test_probe_evaluate.py` → 5 passed (re-run independently by the orchestrator, not taken on the implementer's report).
- `ruff check` / `ruff format --check` clean; full pre-commit gate green.
- Generator≠grader: written by Codex GPT-5.6, verified and shipped by a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)