### PR TITLE
fix(organ-conformance): judge content genes on the payload, not the runner

### DIFF
--- a/infra/organ-conformance/check_organ_conformance.py
+++ b/infra/organ-conformance/check_organ_conformance.py
@@ -33,6 +33,7 @@ import plistlib
 import re
 import subprocess
 import sys
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Optional
 
@@ -126,12 +127,69 @@ def _pair_declared(pairs: dict[str, Any], token: str) -> bool:
     return False
 
 
-def _repo_relative_path(path: Path, repo_root: Path) -> Optional[str]:
-    """Return a normalized repo-relative path, or None for external files."""
-    try:
-        return path.resolve().relative_to(repo_root.resolve()).as_posix()
-    except ValueError:
+@lru_cache(maxsize=None)
+def _repo_alias_roots(repo_root: Path) -> tuple[Path, ...]:
+    """Return exact filesystem roots that identify this Git repository.
+
+    A launchd plist can name the canonical checkout while the gate runs from a
+    linked worktree. Git's common directory identifies that canonical checkout;
+    preserving the complete relative path lets the checker inspect the current
+    worktree's file without any basename widening.
+    """
+    resolved_root = repo_root.resolve()
+    roots = [resolved_root]
+    out = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(resolved_root),
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode == 0:
+        common_dir = Path(out.stdout.strip()).resolve()
+        if common_dir.name == ".git" and common_dir.parent not in roots:
+            roots.append(common_dir.parent)
+    return tuple(roots)
+
+
+def _resolve_repo_file_strict(arg: str, repo_root: Path, ka_mod: Any) -> Optional[Path]:
+    """Resolve a direct path token only when its canonical file is in the repo.
+
+    Unlike keepalive's compatibility resolver, this intentionally has no
+    basename bridge. Relative paths are rooted at the repository; absolute
+    paths, ``.``/``..`` segments, and symlinks are canonicalized before the
+    repository-boundary check.
+    """
+    if not ka_mod._looks_like_path(arg) or arg.startswith("~"):
         return None
+
+    resolved_root = repo_root.resolve()
+    token_path = Path(arg)
+    if token_path.is_absolute():
+        relative: Optional[Path] = None
+        for alias_root in _repo_alias_roots(resolved_root):
+            try:
+                relative = token_path.relative_to(alias_root)
+                break
+            except ValueError:
+                continue
+        if relative is None:
+            return None
+        candidate = resolved_root / relative
+    else:
+        candidate = resolved_root / token_path
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved if resolved.is_file() else None
 
 
 def _resolve_content_wrapper(
@@ -149,34 +207,49 @@ def _resolve_content_wrapper(
     later path-like token is itself the executable content and stays selected.
     """
     wrapper, reason = ka_mod.resolve_wrapper(argv, repo_root, basename_index)
-    if (
-        wrapper is None
-        or _repo_relative_path(wrapper, repo_root) not in KNOWN_CONTENT_RUNNERS
-    ):
-        return wrapper, reason
 
-    runner_index: Optional[int] = None
+    # Runner recognition is deliberately independent of keepalive's basename
+    # compatibility bridge. The first argv file that resolves strictly inside
+    # this repo is what launchd hands to its interpreter; only exact canonical
+    # equality with a declared runner opens the payload hop.
+    strict_wrapper_index: Optional[int] = None
+    strict_wrapper: Optional[Path] = None
     for index, arg in enumerate(argv):
-        candidate, _ = ka_mod.resolve_wrapper([arg], repo_root, basename_index)
-        if candidate is not None and candidate.resolve() == wrapper.resolve():
-            runner_index = index
+        candidate = _resolve_repo_file_strict(arg, repo_root, ka_mod)
+        if candidate is not None:
+            strict_wrapper_index = index
+            strict_wrapper = candidate
             break
 
-    if runner_index is None:  # pragma: no cover - resolver consistency guard
+    known_runner_paths = {
+        candidate
+        for relative in KNOWN_CONTENT_RUNNERS
+        if (candidate := _resolve_repo_file_strict(relative, repo_root, ka_mod))
+        is not None
+    }
+    if strict_wrapper is None or strict_wrapper not in known_runner_paths:
         return wrapper, reason
 
+    if strict_wrapper_index is None:  # pragma: no cover - assignment invariant
+        return strict_wrapper, reason
+
     payload_token = next(
-        (arg for arg in argv[runner_index + 1 :] if ka_mod._looks_like_path(arg)),
+        (
+            arg
+            for arg in argv[strict_wrapper_index + 1 :]
+            if ka_mod._looks_like_path(arg)
+        ),
         None,
     )
     if payload_token is None:
-        return wrapper, reason
+        return strict_wrapper, reason
 
-    payload, payload_reason = ka_mod.resolve_wrapper(
-        [payload_token], repo_root, basename_index
-    )
+    payload = _resolve_repo_file_strict(payload_token, repo_root, ka_mod)
     if payload is None:
-        return None, f"known-runner payload {payload_reason}"
+        return (
+            None,
+            f"known-runner payload not-resolvable-in-repo: {payload_token}",
+        )
     return payload, None
 
 

--- a/infra/organ-conformance/check_organ_conformance.py
+++ b/infra/organ-conformance/check_organ_conformance.py
@@ -23,6 +23,7 @@ Usage:
   python3 infra/organ-conformance/check_organ_conformance.py [--json] [--repo ROOT]
   python3 infra/organ-conformance/check_organ_conformance.py --update-baseline
 """
+
 from __future__ import annotations
 
 import argparse
@@ -41,11 +42,18 @@ REGISTRY_REL = "apps/organism/organism/organs_registry.yaml"
 PAIRS_REL = "infra/home-fork/declared-pairs.json"
 KEEPALIVE_LINT_REL = "scripts/lint_plist_keepalive.py"
 
+# Generic launchd runners whose argv contract is ``runner payload [args...]``.
+# Content genes belong to the payload, not to the receipt/process supervisor.
+# Match repo-relative paths exactly: similarly named payloads are ordinary wrappers.
+KNOWN_CONTENT_RUNNERS: frozenset[str] = frozenset({"scripts/cron-runner.sh"})
+
 # --- gene detection patterns (definitions live in genes.json; logic lives here) ---
 RE_HEARTBEAT = re.compile(r"organism_heartbeat|\.organism/last_seen|heartbeat\(\)\s*\{")
 RE_KILL_SWITCH = re.compile(r"\b[A-Z][A-Z0-9_]*_ENABLED\b")
 RE_SET_U = re.compile(r"^\s*set\s+-[a-zA-Z]*u", re.MULTILINE)
-RE_CLAUDE_SPAWN = re.compile(r"claude[\"']?\s+-p\b|CLAUDE_BIN[\"']?\s+-p\b|\bclaude\b.*--print\b")
+RE_CLAUDE_SPAWN = re.compile(
+    r"claude[\"']?\s+-p\b|CLAUDE_BIN[\"']?\s+-p\b|\bclaude\b.*--print\b"
+)
 RE_STRICT_MCP = re.compile(r"--strict-mcp-config")
 RE_STDIN_NULL = re.compile(r"<\s*/dev/null")
 RE_TCC_STRATEGY = re.compile(r"SSH_CONNECTION|TRAMPOLINED|ssh\s+.*localhost")
@@ -70,11 +78,21 @@ def _git_tracked_plists(repo_root: Path, roots: list[str]) -> list[Path]:
     # scanned too — an author running the gate before `git add` would otherwise get
     # a false green on the very organ being born (found live 2026-07-06, pro.healer).
     out = subprocess.run(
-        ["git", "-C", str(repo_root), "ls-files", "--cached", "--others",
-         "--exclude-standard", "--"]
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+        ]
         + [f"{r}/**/*.plist" for r in roots]
         + [f"{r}/*.plist" for r in roots],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     seen: set[str] = set()
     paths: list[Path] = []
@@ -96,14 +114,70 @@ def _first_path_token(argv: list[str]) -> Optional[str]:
 def _pair_declared(pairs: dict[str, Any], token: str) -> bool:
     """True if a HOME payload token matches a declared live pair (tail match:
     '~/scripts/x.sh' and '/Users/u/scripts/x.sh' both end 'scripts/x.sh')."""
+
     def _tail(p: str) -> str:
         p = re.sub(r"^(~|\$HOME|/Users/[^/]+)/", "", p)
         return p
+
     token_tail = _tail(token)
     for pair in pairs.get("pairs", []):
         if _tail(str(pair.get("live", ""))) == token_tail:
             return True
     return False
+
+
+def _repo_relative_path(path: Path, repo_root: Path) -> Optional[str]:
+    """Return a normalized repo-relative path, or None for external files."""
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
+def _resolve_content_wrapper(
+    argv: list[str],
+    repo_root: Path,
+    basename_index: dict[str, list[Path]],
+    ka_mod: Any,
+) -> tuple[Optional[Path], Optional[str]]:
+    """Resolve the file whose content genes describe the organ's behavior.
+
+    KeepAlive lint intentionally classifies the first repo-resolvable file that
+    launchd spawns. This gate has a different entity boundary: for an explicit
+    generic runner, it must inspect the next path-like argv token (the payload).
+    A declared but unresolvable payload remains fail-closed; a runner with no
+    later path-like token is itself the executable content and stays selected.
+    """
+    wrapper, reason = ka_mod.resolve_wrapper(argv, repo_root, basename_index)
+    if (
+        wrapper is None
+        or _repo_relative_path(wrapper, repo_root) not in KNOWN_CONTENT_RUNNERS
+    ):
+        return wrapper, reason
+
+    runner_index: Optional[int] = None
+    for index, arg in enumerate(argv):
+        candidate, _ = ka_mod.resolve_wrapper([arg], repo_root, basename_index)
+        if candidate is not None and candidate.resolve() == wrapper.resolve():
+            runner_index = index
+            break
+
+    if runner_index is None:  # pragma: no cover - resolver consistency guard
+        return wrapper, reason
+
+    payload_token = next(
+        (arg for arg in argv[runner_index + 1 :] if ka_mod._looks_like_path(arg)),
+        None,
+    )
+    if payload_token is None:
+        return wrapper, reason
+
+    payload, payload_reason = ka_mod.resolve_wrapper(
+        [payload_token], repo_root, basename_index
+    )
+    if payload is None:
+        return None, f"known-runner payload {payload_reason}"
+    return payload, None
 
 
 def analyze_plist(
@@ -117,7 +191,13 @@ def analyze_plist(
 ) -> dict[str, Any]:
     """Return {path, label, missing: [gene..], advisory: [gene..], notes: [..]}."""
     rel = str(plist_path.relative_to(repo_root))
-    result: dict[str, Any] = {"path": rel, "label": None, "missing": [], "advisory": [], "notes": []}
+    result: dict[str, Any] = {
+        "path": rel,
+        "label": None,
+        "missing": [],
+        "advisory": [],
+        "notes": [],
+    }
 
     try:
         payload = plistlib.loads(plist_path.read_bytes())
@@ -159,12 +239,16 @@ def analyze_plist(
         result["missing"].append("G3_declared_pair")
 
     # Resolve wrapper text (repo canon) for content genes
-    wrapper, reason = ka_mod.resolve_wrapper(argv, repo_root, basename_index)
+    wrapper, reason = _resolve_content_wrapper(argv, repo_root, basename_index, ka_mod)
     text = ""
     if wrapper is not None:
         try:
             text = wrapper.read_text(encoding="utf-8", errors="replace")
-            result["wrapper"] = str(wrapper.relative_to(repo_root)) if wrapper.is_relative_to(repo_root) else str(wrapper)
+            result["wrapper"] = (
+                str(wrapper.relative_to(repo_root))
+                if wrapper.is_relative_to(repo_root)
+                else str(wrapper)
+            )
         except OSError:
             result["notes"].append(f"wrapper unreadable: {wrapper}")
     elif ka_mod._has_inline_shell_flag(argv):
@@ -172,10 +256,14 @@ def analyze_plist(
         text = " ".join(argv)
         result["wrapper"] = "<inline>"
     else:
-        result["notes"].append(f"wrapper unresolved ({reason}) — content genes unverifiable")
+        result["notes"].append(
+            f"wrapper unresolved ({reason}) — content genes unverifiable"
+        )
 
     if text:
-        is_bash = "<inline>" in str(result.get("wrapper", "")) or str(result.get("wrapper", "")).endswith(".sh")
+        is_bash = "<inline>" in str(result.get("wrapper", "")) or str(
+            result.get("wrapper", "")
+        ).endswith(".sh")
         if not RE_HEARTBEAT.search(text):
             result["missing"].append("G2_heartbeat")
         if not RE_KILL_SWITCH.search(text):
@@ -210,7 +298,9 @@ def run(repo_root: Path) -> dict[str, Any]:
         return {"errors": [f"genes.json unreadable: {exc}"], "exit": 4}
 
     registry_path = repo_root / REGISTRY_REL
-    registry_text = registry_path.read_text(encoding="utf-8") if registry_path.exists() else ""
+    registry_text = (
+        registry_path.read_text(encoding="utf-8") if registry_path.exists() else ""
+    )
     if not registry_text:
         return {"errors": [f"registry missing: {REGISTRY_REL}"], "exit": 4}
 
@@ -241,7 +331,13 @@ def run(repo_root: Path) -> dict[str, Any]:
 
     for plist_path in sorted(plists):
         organ = analyze_plist(
-            plist_path, repo_root, ka_mod, ka_index, registry_text, pairs, keepalive_failed
+            plist_path,
+            repo_root,
+            ka_mod,
+            ka_index,
+            registry_text,
+            pairs,
+            keepalive_failed,
         )
         organs.append(organ)
         if "malformed" in organ:
@@ -308,7 +404,9 @@ def update_baseline(repo_root: Path) -> int:
 
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Organ conformance-at-birth gate")
-    parser.add_argument("--repo", default=None, help="repo root (default: git toplevel of this file)")
+    parser.add_argument(
+        "--repo", default=None, help="repo root (default: git toplevel of this file)"
+    )
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--update-baseline", action="store_true")
     args = parser.parse_args(argv)
@@ -318,7 +416,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     else:
         out = subprocess.run(
             ["git", "-C", str(HERE), "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=False,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         repo_root = Path(out.stdout.strip() or ".").resolve()
 

--- a/infra/organ-conformance/tests/test_runner_aware_resolution.py
+++ b/infra/organ-conformance/tests/test_runner_aware_resolution.py
@@ -1,0 +1,144 @@
+"""Proof that content genes are resolved behind explicit generic runners."""
+
+from __future__ import annotations
+
+import importlib.util
+import plistlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+HERE = Path(__file__).resolve().parents[1]
+REPO_ROOT = HERE.parent.parent
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_organ_conformance_runner_tests", HERE / "check_organ_conformance.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+coc = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(coc)
+
+GOOD_WRAPPER = """#!/bin/bash
+set -u
+[ "${TEST_ORGAN_ENABLED:-true}" = "false" ] && exit 0
+heartbeat() {
+    :
+}
+"""
+
+BAD_WRAPPER = """#!/bin/bash
+echo "no content genes"
+"""
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    for relative in ("scripts", "apps/foo", "infra/launchagents"):
+        (repo / relative).mkdir(parents=True)
+    return repo
+
+
+def _write_script(repo: Path, relative: str, content: str) -> Path:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _analyze(fixture_repo: Path, argv: list[str]) -> dict[str, Any]:
+    plist_path = fixture_repo / "infra/launchagents/com.test.runner-aware.plist"
+    label = "com.test.runner-aware"
+    plist_path.write_bytes(plistlib.dumps({"Label": label, "ProgramArguments": argv}))
+    ka_mod = coc._load_keepalive_module(REPO_ROOT)
+    basename_index = ka_mod.build_basename_index(
+        [fixture_repo / "scripts", fixture_repo / "apps", fixture_repo / "infra"],
+        [],
+    )
+    return coc.analyze_plist(
+        plist_path,
+        fixture_repo,
+        ka_mod,
+        basename_index,
+        registry_text=label,
+        pairs={"pairs": []},
+        keepalive_failed=set(),
+    )
+
+
+def test_guilt_runner_with_gene_less_payload_flags_payload(fixture_repo: Path) -> None:
+    runner = _write_script(fixture_repo, "scripts/cron-runner.sh", GOOD_WRAPPER)
+    payload = _write_script(fixture_repo, "apps/foo/payload.sh", BAD_WRAPPER)
+
+    organ = _analyze(fixture_repo, ["/bin/bash", str(runner), str(payload)])
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert "cron-runner.sh" not in organ["wrapper"]
+    assert {"G2_heartbeat", "G5_kill_switch"} <= set(organ["missing"])
+
+
+def test_innocence_runner_with_compliant_payload_uses_payload(
+    fixture_repo: Path,
+) -> None:
+    runner = _write_script(fixture_repo, "scripts/cron-runner.sh", BAD_WRAPPER)
+    payload = _write_script(fixture_repo, "apps/foo/payload.sh", GOOD_WRAPPER)
+
+    organ = _analyze(fixture_repo, ["/bin/bash", str(runner), str(payload)])
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]
+
+
+def test_innocence_non_runner_wrapper_keeps_current_resolution(
+    fixture_repo: Path,
+) -> None:
+    wrapper = _write_script(fixture_repo, "scripts/some-wrapper.sh", GOOD_WRAPPER)
+    ignored = _write_script(fixture_repo, "apps/foo/ignored.sh", BAD_WRAPPER)
+
+    organ = _analyze(fixture_repo, ["/bin/bash", str(wrapper), str(ignored)])
+
+    assert organ["wrapper"] == "scripts/some-wrapper.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]
+
+
+def test_overmatch_same_basename_at_other_path_is_not_runner(
+    fixture_repo: Path,
+) -> None:
+    wrapper = _write_script(fixture_repo, "apps/foo/cron-runner.sh", GOOD_WRAPPER)
+    ignored = _write_script(fixture_repo, "apps/foo/ignored.sh", BAD_WRAPPER)
+
+    organ = _analyze(fixture_repo, ["/bin/bash", str(wrapper), str(ignored)])
+
+    assert organ["wrapper"] == "apps/foo/cron-runner.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]
+
+
+def test_runner_only_analyzes_runner_itself(fixture_repo: Path) -> None:
+    runner = _write_script(fixture_repo, "scripts/cron-runner.sh", GOOD_WRAPPER)
+
+    organ = _analyze(fixture_repo, ["/bin/bash", str(runner)])
+
+    assert organ["wrapper"] == "scripts/cron-runner.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]
+
+
+def test_unresolvable_first_payload_after_runner_stays_fail_closed(
+    fixture_repo: Path,
+) -> None:
+    runner = _write_script(fixture_repo, "scripts/cron-runner.sh", GOOD_WRAPPER)
+    decoy = _write_script(fixture_repo, "apps/foo/decoy.sh", GOOD_WRAPPER)
+    missing_payload = fixture_repo / "apps/foo/missing.sh"
+
+    organ = _analyze(
+        fixture_repo,
+        ["/bin/bash", str(runner), str(missing_payload), str(decoy)],
+    )
+
+    assert "wrapper" not in organ
+    assert {"G2_heartbeat", "G5_kill_switch"} <= set(organ["missing"])
+    assert any("known-runner payload not-resolvable" in note for note in organ["notes"])

--- a/infra/organ-conformance/tests/test_runner_aware_resolution.py
+++ b/infra/organ-conformance/tests/test_runner_aware_resolution.py
@@ -91,6 +91,31 @@ def test_innocence_runner_with_compliant_payload_uses_payload(
     assert "G5_kill_switch" not in organ["missing"]
 
 
+@pytest.mark.parametrize(
+    "runner_token",
+    [
+        "scripts/cron-runner.sh",
+        "./scripts/cron-runner.sh",
+        pytest.param(None, id="absolute-inside-repo"),
+    ],
+)
+def test_innocence_legitimate_runner_spellings_use_payload_genes(
+    fixture_repo: Path,
+    runner_token: str | None,
+) -> None:
+    runner = _write_script(fixture_repo, "scripts/cron-runner.sh", BAD_WRAPPER)
+    payload = _write_script(fixture_repo, "apps/foo/payload.sh", GOOD_WRAPPER)
+
+    organ = _analyze(
+        fixture_repo,
+        ["/bin/bash", runner_token or str(runner), str(payload)],
+    )
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]
+
+
 def test_innocence_non_runner_wrapper_keeps_current_resolution(
     fixture_repo: Path,
 ) -> None:
@@ -142,3 +167,96 @@ def test_unresolvable_first_payload_after_runner_stays_fail_closed(
     assert "wrapper" not in organ
     assert {"G2_heartbeat", "G5_kill_switch"} <= set(organ["missing"])
     assert any("known-runner payload not-resolvable" in note for note in organ["notes"])
+
+
+def test_guilt_external_payload_basename_collision_stays_fail_closed(
+    fixture_repo: Path,
+    tmp_path: Path,
+) -> None:
+    runner = _write_script(fixture_repo, "scripts/cron-runner.sh", GOOD_WRAPPER)
+    _write_script(fixture_repo, "apps/foo/run.sh", GOOD_WRAPPER)
+    external_payload = tmp_path / "outside" / "run.sh"
+    external_payload.parent.mkdir()
+    external_payload.write_text(BAD_WRAPPER, encoding="utf-8")
+
+    organ = _analyze(
+        fixture_repo,
+        ["/bin/bash", str(runner), str(external_payload)],
+    )
+
+    assert "wrapper" not in organ
+    assert {"G2_heartbeat", "G5_kill_switch"} <= set(organ["missing"])
+    assert any(
+        f"known-runner payload not-resolvable-in-repo: {external_payload}" in note
+        for note in organ["notes"]
+    )
+
+
+def test_guilt_duplicate_runner_basename_does_not_hide_real_runner(
+    fixture_repo: Path,
+) -> None:
+    decoy = _write_script(
+        fixture_repo,
+        "apps/aaa/cron-runner.sh",
+        GOOD_WRAPPER,
+    )
+    runner = _write_script(fixture_repo, "scripts/cron-runner.sh", GOOD_WRAPPER)
+    payload = _write_script(fixture_repo, "apps/foo/payload.sh", BAD_WRAPPER)
+    assert str(decoy) < str(runner)
+
+    organ = _analyze(fixture_repo, ["/bin/bash", str(runner), str(payload)])
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert {"G2_heartbeat", "G5_kill_switch"} <= set(organ["missing"])
+
+
+@pytest.mark.parametrize("via_symlink", [False, True])
+def test_innocence_runner_normalizes_dotdot_and_symlinks(
+    fixture_repo: Path,
+    via_symlink: bool,
+) -> None:
+    _write_script(fixture_repo, "scripts/cron-runner.sh", BAD_WRAPPER)
+    payload = _write_script(fixture_repo, "apps/foo/payload.sh", GOOD_WRAPPER)
+    if via_symlink:
+        runner_alias = fixture_repo / "apps/runner-link.sh"
+        runner_alias.symlink_to("../scripts/cron-runner.sh")
+        runner_token = "apps/runner-link.sh"
+    else:
+        runner_token = "apps/foo/../../scripts/cron-runner.sh"
+
+    organ = _analyze(
+        fixture_repo,
+        ["/bin/bash", runner_token, str(payload)],
+    )
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]
+
+
+def test_innocence_canonical_checkout_alias_maps_exact_paths_to_worktree(
+    fixture_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_script(fixture_repo, "scripts/cron-runner.sh", BAD_WRAPPER)
+    _write_script(fixture_repo, "apps/foo/payload.sh", GOOD_WRAPPER)
+    canonical_checkout = tmp_path / "canonical-checkout"
+    monkeypatch.setattr(
+        coc,
+        "_repo_alias_roots",
+        lambda repo_root: (repo_root.resolve(), canonical_checkout.resolve()),
+    )
+
+    organ = _analyze(
+        fixture_repo,
+        [
+            "/bin/bash",
+            str(canonical_checkout / "scripts/cron-runner.sh"),
+            str(canonical_checkout / "apps/foo/payload.sh"),
+        ],
+    )
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]


### PR DESCRIPTION
The gate resolved the FIRST repo-resolvable argv token, so any organ routed through `scripts/cron-runner.sh` had its G2/G5 genes grepped in the runner (0 matches) instead of the payload wrapper. Measured on PR #4126: payload carries 1 heartbeat + 2 kill-switch matches, runner 0+0.

The checker now re-resolves onto the next path token behind an explicit known-runner list (repo-relative path equality, no basename matching), keeps fail-closed for unresolvable payloads, and leaves lint_plist_keepalive semantics byte-identical. 6 guilt+innocence tests incl. an over-match guard and runner-only argv. Guard change: auto-merge deliberately NOT armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)