### PR TITLE
fix(mini): port live empty-touched-paths self-heal fix (W88)

### DIFF
--- a/scripts/mini/mini-git-pull.sh
+++ b/scripts/mini/mini-git-pull.sh
@@ -386,8 +386,19 @@ if ! git merge-base --is-ancestor HEAD "$TARGET_REF" 2>/dev/null; then
   # paths it did not touch are untouched by this decision; they simply gain
   # the legitimate upstream advance, which is the whole point of the pull.
   # Same clean-tree requirement, same lock, same telegram_alert. Falls
-  # through unchanged if the merge-base is unknown, no paths were touched,
-  # or any touched path still genuinely differs.
+  # through unchanged if the merge-base is unknown or a touched path still
+  # genuinely differs.
+  #
+  # 2026-08-12: zero-touched-paths is ALSO safe, not a fall-through case.
+  # A local-only commit that changes no files (e.g. an empty merge commit
+  # produced when something here merges origin/main instead of
+  # fast-forwarding) has, by definition, nothing to lose on reset — the
+  # `-eq 0 ||` short-circuit below fires before the unsafe
+  # "${TOUCHED_PATHS[@]}" expansion is ever reached. Order matters: bash
+  # 3.2 under `set -u` raises unbound-variable on that expansion when the
+  # array is empty, so the length check MUST be first and MUST short-
+  # circuit (`||`), never `-gt 0 &&` (which silently refused this case
+  # instead of crashing — 850 refused ticks 2026-05-10..2026-08-12).
   if [ "${SELFHEAL_OK:-0}" != "1" ]; then
     MERGE_BASE=$(git merge-base HEAD "$TARGET_REF" 2>/dev/null)
     if [ -n "$MERGE_BASE" ] \
@@ -397,8 +408,8 @@ if ! git merge-base --is-ancestor HEAD "$TARGET_REF" 2>/dev/null; then
       while IFS= read -r -d '' _p; do
         TOUCHED_PATHS+=("$_p")
       done < <(git diff --name-only -z "$MERGE_BASE" HEAD 2>/dev/null)
-      if [ "${#TOUCHED_PATHS[@]}" -gt 0 ] \
-         && git diff --quiet HEAD "$TARGET_REF" -- "${TOUCHED_PATHS[@]}" 2>/dev/null; then
+      if [ "${#TOUCHED_PATHS[@]}" -eq 0 ] \
+         || git diff --quiet HEAD "$TARGET_REF" -- "${TOUCHED_PATHS[@]}" 2>/dev/null; then
         log "  every path HEAD's local-only commit(s) touched already matches $TARGET_REF (ahead+behind shape, ${#TOUCHED_PATHS[@]} path(s)) — attempting narrow self-heal"
         SELFHEAL_OK=0
         if command -v flock >/dev/null 2>&1; then

--- a/scripts/tests/test_mini_git_pull_ahead_behind_selfheal.sh
+++ b/scripts/tests/test_mini_git_pull_ahead_behind_selfheal.sh
@@ -62,7 +62,7 @@ narrow_selfheal_safe() {
   while IFS= read -r -d '' _p; do
     touched+=("$_p")
   done < <(git diff --name-only -z "$merge_base" HEAD 2>/dev/null)
-  [ "${#touched[@]}" -gt 0 ] || return 1
+  [ "${#touched[@]}" -eq 0 ] && return 0
   git diff --quiet HEAD "$target_ref" -- "${touched[@]}" 2>/dev/null
 }
 
@@ -147,9 +147,11 @@ else
   pass "scenario C: uncommitted tracked change correctly refused"
 fi
 
-# --- scenario D: ahead 0 (no local-only commits, TOUCHED_PATHS empty) ----
-# — e.g. a detached/odd state where merge-base equals HEAD. Must refuse
-# (nothing to prove safe; falls through to the existing alert unchanged).
+# --- scenario D: ahead 0 (merge-base equals HEAD, no local-only commits) -
+# HEAD is a pure ancestor of target (a plain fast-forward point). touched
+# is trivially empty (diff of a commit against itself). Resetting here
+# discards NOTHING — HEAD has zero commits not already in target — so this
+# is provably safe too, for the same 2026-08-12 reason as scenario E below.
 REPO_D="$WORKDIR/d"
 mk_repo "$REPO_D"
 (
@@ -161,9 +163,33 @@ mk_repo "$REPO_D"
   git checkout -q master 2>/dev/null || git checkout -q main
 )
 if (cd "$REPO_D" && narrow_selfheal_safe target); then
-  fail "scenario D: should have refused (no local-only touched paths to verify)"
+  pass "scenario D: merge-base==HEAD (pure ancestor, zero local commits) correctly identified as safe"
 else
-  pass "scenario D: empty touched-paths set correctly refused"
+  fail "scenario D: should have detected safety (HEAD has zero commits unique from target, nothing to lose)"
+fi
+
+# --- scenario E: ahead 1 (local-only commit touches ZERO files), behind 1 -
+# the real-world disease this predicate exists to cure (2026-08-12,
+# recurring 2026-07-11..2026-08-11, 850 refused ticks): an empty merge
+# commit (or any --allow-empty local-only commit) leaves TOUCHED_PATHS
+# empty while merge-base != HEAD. Must be identified as safe — there is no
+# content in that commit to discard.
+REPO_E="$WORKDIR/e"
+mk_repo "$REPO_E"
+(
+  cd "$REPO_E"
+  git commit -q --allow-empty -m base
+  BASE=$(git rev-parse HEAD)
+  git commit -q --allow-empty -m "local-only empty merge commit (no file changes)"
+  git checkout -q -b target "$BASE"
+  echo "unrelated" >other.txt
+  git add -A && git commit -q -m "target has 1 legit unrelated commit"
+  git checkout -q master 2>/dev/null || git checkout -q main
+)
+if (cd "$REPO_E" && narrow_selfheal_safe target); then
+  pass "scenario E: local-only commit touching zero files (empty merge) correctly identified as safe"
+else
+  fail "scenario E: should have detected safety (zero-touched-paths empty commit — the documented disease)"
 fi
 
 echo


### PR DESCRIPTION
Ports the exact 2-line fix (`-gt 0 &&` → `-eq 0 ||`) that has been live-patched onto Mini's deployed mini-git-pull.sh by mini-git-pull-bridge.sh since 2026-08-12 (850 refused ticks 2026-05-10..2026-08-12). Once merged+pulled, the bridge's re-apply patch becomes a permanent no-op. Also fixes the mirrored test predicate + scenario D (was over-conservative) + adds scenario E for the documented disease. All 5 mini-git-pull test suites green.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>