### PR TITLE
feat(infra): stop paying the backend suite for hook-only and guard-registry diffs

### DIFF
--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -176,6 +176,41 @@ belt-and-suspenders basename net for the requirements family.
   today's layout — a guilt test that only asserts the current tree stops
   being a guilt test the moment the tree moves.
 
+v10 EXTENSION (2026-08-12): two directory rules added — `infra/claude-hooks`
+(.py) and `infra/guard-conformance` (.json) — for PR #4125-shaped diffs that
+touch only the claude-hooks test/guard corpus and its conformance registry.
+
+  Measured, not assumed, safe: `grep -rn "claude_hooks\\|claude-hooks" apps/`
+  returns exactly two hits repo-wide, and BOTH are prose, not imports — a
+  docstring in
+  `apps/backend-rag/backend/tests/unit/services/sota_loop/test_m13_weekly_repo_root.py`
+  (~line 16) and a comment in
+  `apps/backend-rag/backend/services/sota_loop/m13_weekly.py` (~line 48),
+  each explaining why their own git-root derivation deliberately differs
+  from the hook's. No conftest anywhere under `apps/` adds `infra/` to
+  `sys.path`, so nothing collected by `pytest backend/tests/` can import a
+  module from either new prefix.
+
+  Coverage is not lost by skipping the backend suite for these paths —
+  three CI workflows already run the claude-hooks corpus independently of
+  this classifier: `guard-conformance.yml`, `hook-innocence-gate.yml`,
+  `kbli-filiera-vault-compilers.yml`. `skip-backend` only ever skips
+  `pytest backend/tests/` (see `.husky/pre-push`); it has no power to
+  disarm any of those three.
+
+  INVESTIGATED AND REJECTED (v10): a blanket `scripts/**/*.py` covering the
+  repo-root `scripts/` tree wholesale, on the theory that if the
+  claude-hooks test/tooling scripts are safe, the rest of `scripts/` should
+  be too. Rejected — the backend suite PROVABLY imports `scripts.*`: ~20
+  files under `apps/backend-rag/backend/tests/unit/scripts/` do
+  `from scripts.curated_qa_harvest import ...`,
+  `from scripts.drive_token_watchdog import ...`, and similar. Allowlisting
+  `scripts/**` would be a textbook W82 under-match (cicatrix-superscar.md
+  #3): a change to one of those scripts would skip the very suite that
+  tests it. The existing `scripts/tests` (.py/.sh) and `scripts/ci` (.sh)
+  entries keep their narrower, previously-measured scope, unchanged by this
+  extension.
+
 CONTRACT
 --------
 Input:  a list of repo-relative file paths, one per line, via:
@@ -325,7 +360,16 @@ VERDICT_SKIP = "skip-backend"
 # family added to NEVER_INNOCENT_BASENAMES so the newly-admitted suffix cannot
 # later be broadened into a manifest a backend test actually reads (W98).
 # Measurement in the module-docstring "v9 EXTENSION" section above.
-ALLOWLIST_VERSION = 9
+# v10 (2026-08-12): added infra/claude-hooks (.py) and infra/guard-
+# conformance (.json) — two directory classes measured (not assumed)
+# structurally incapable of affecting `pytest backend/tests/`, and already
+# independently covered by three dedicated CI workflows
+# (guard-conformance.yml, hook-innocence-gate.yml,
+# kbli-filiera-vault-compilers.yml). Rejected in the same change: a blanket
+# `scripts/**/*.py` widening, which the backend suite provably imports from
+# (~20 files under apps/backend-rag/backend/tests/unit/scripts/).
+# Measurement in the module-docstring "v10 EXTENSION" section above.
+ALLOWLIST_VERSION = 10
 
 # ---------------------------------------------------------------------------
 # NEVER_INNOCENT_EXACT_PATHS — checked FIRST, unconditionally, before any
@@ -748,6 +792,10 @@ ALLOWLIST_PREFIX_SUFFIX_PAIRS: tuple[tuple[str, tuple[str, ...]], ...] = (
     # v7 directory additions. File-shaped v6/v7 additions live in
     # ALLOWLIST_EXACT_PATHS as of v8.
     ("scripts", (".md",)),
+    # v10: infra/claude-hooks (.py) + infra/guard-conformance (.json) — see
+    # the module docstring's "v10 EXTENSION" section.
+    ("infra/claude-hooks", (".py",)),
+    ("infra/guard-conformance", (".json",)),
 )
 
 

--- a/scripts/tests/test_prepush_classify.py
+++ b/scripts/tests/test_prepush_classify.py
@@ -1834,3 +1834,108 @@ def test_edge_v9_added_no_second_allowlist_mechanism() -> None:
     for _prefix, suffixes in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS:
         assert suffixes, "no bare-prefix (suffix-less) entry may exist"
         assert all(s.startswith(".") for s in suffixes)
+
+
+# ===========================================================================
+# v10 (2026-08-12) — infra/claude-hooks (.py) + infra/guard-conformance
+# (.json), two new directory entries.
+#
+# Trigger: PR #4125-shaped diffs — touching only the claude-hooks
+# test/guard corpus and its conformance registry — forced `full` under v9
+# despite zero runtime coupling to `pytest backend/tests/` (measured: the
+# only two `apps/`-tree hits for "claude-hooks" are prose, not imports; no
+# conftest adds `infra/` to sys.path) and despite three CI workflows
+# (guard-conformance.yml, hook-innocence-gate.yml,
+# kbli-filiera-vault-compilers.yml) already running that corpus
+# independently of this classifier. See the module docstring's
+# "v10 EXTENSION" section for the full measurement.
+# ===========================================================================
+
+
+def test_innocence_real_pr_4125_file_set_skips() -> None:
+    """PR #4125's actual file set, verbatim.
+
+    Under v9 this returned `full`. `.github/workflows/guard-conformance.yml`
+    and `infra/home-fork/declared-pairs.json` were ALREADY allowlisted (the
+    `.github/workflows` and `infra/home-fork` entries predate v10) — the two
+    new `infra/claude-hooks` (.py) and `infra/guard-conformance` (.json)
+    pairs are the whole delta that flips this set to skip-backend.
+    """
+    verdict, unknown = pc.classify(
+        [
+            ".claude/skills/modus/PENDING-ARMS.md",
+            ".github/workflows/guard-conformance.yml",
+            "infra/claude-hooks/orchestrate_gate.py",
+            "infra/claude-hooks/test_hook_innocence.py",
+            "infra/claude-hooks/test_orchestrate_gate_disarm_notice.py",
+            "infra/claude-hooks/test_orchestrate_gate_vocab.py",
+            "infra/guard-conformance/registry.json",
+            "infra/home-fork/declared-pairs.json",
+        ]
+    )
+    assert verdict == pc.VERDICT_SKIP
+    assert unknown == []
+
+
+def test_guilt_claude_hooks_mixed_with_backend_forces_full() -> None:
+    """Composition: one innocent claude-hooks file does not launder a real
+    backend file riding along in the same push."""
+    verdict, unknown = pc.classify(
+        ["infra/claude-hooks/x.py", "apps/backend-rag/backend/main.py"]
+    )
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == ["apps/backend-rag/backend/main.py"]
+
+
+def test_guilt_scripts_root_py_still_forces_full() -> None:
+    """The v10 REJECTED widening (blanket scripts/**/*.py) stays rejected —
+    infra/claude-hooks admitting .py must not spill onto root scripts/*.py,
+    which the backend suite provably imports from
+    (scripts.curated_qa_harvest, scripts.drive_token_watchdog, ...)."""
+    path = "scripts/curated_qa_harvest.py"
+    verdict, unknown = pc.classify([path])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [path]
+
+
+def test_guilt_claude_hooks_wrong_suffix_forces_full() -> None:
+    """Suffix scoping holds: infra/claude-hooks admits `.py` only, not
+    `.sh`."""
+    path = "infra/claude-hooks/run.sh"
+    verdict, unknown = pc.classify([path])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [path]
+
+
+def test_guilt_guard_conformance_wrong_suffix_forces_full() -> None:
+    """Suffix scoping holds: infra/guard-conformance admits `.json` only,
+    not `.py`."""
+    path = "infra/guard-conformance/check.py"
+    verdict, unknown = pc.classify([path])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [path]
+
+
+def test_guilt_claude_hooks_traversal_escape_forces_full() -> None:
+    """HARDENING-2 still holds for the two new v10 prefixes: `..` cannot
+    escape infra/claude-hooks back onto a real backend file."""
+    path = "infra/claude-hooks/../../apps/backend-rag/backend/main.py"
+    verdict, unknown = pc.classify([path])
+    assert verdict == pc.VERDICT_FULL
+    assert unknown == [path]
+
+
+def test_allowlist_version_bumped_to_10_for_the_claude_hooks_entries() -> None:
+    """The skip-banner logs the version that approved a skip; a rules change
+    without a bump makes the log line unattributable."""
+    assert pc.ALLOWLIST_VERSION >= 10
+    assert ("infra/claude-hooks", (".py",)) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+    assert ("infra/guard-conformance", (".json",)) in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS
+
+
+def test_edge_v10_added_no_second_allowlist_mechanism() -> None:
+    """v10 added two suffix-scoped directory entries. It must not have
+    introduced a third matching path (the v1 bare-prefix mistake)."""
+    for _prefix, suffixes in pc.ALLOWLIST_PREFIX_SUFFIX_PAIRS:
+        assert suffixes, "no bare-prefix (suffix-less) entry may exist"
+        assert all(s.startswith(".") for s in suffixes)


### PR DESCRIPTION
## What

Two entries added to the pre-push classifier's allowlist (`ALLOWLIST_VERSION` 9 → 10):

    ("infra/claude-hooks",      (".py",))
    ("infra/guard-conformance", (".json",))

## Why it is safe

The backend pytest suite has **zero runtime coupling** to `infra/claude-hooks`. `grep -rn "claude_hooks\|claude-hooks" apps/` returns exactly two hits and **both are prose, not imports**: a docstring in `backend/tests/unit/services/sota_loop/test_m13_weekly_repo_root.py` and a comment in `backend/services/sota_loop/m13_weekly.py`, each explaining why their git derivation deliberately differs from the hook's. No conftest under `apps/` puts `infra/` on `sys.path`.

Coverage is not lost: three CI workflows already run the claude-hooks corpus — `guard-conformance.yml`, `hook-innocence-gate.yml`, `kbli-filiera-vault-compilers.yml`. `skip-backend` gates only `pytest backend/tests/`; it does not disarm any of them.

## What was deliberately NOT widened

`scripts/**/*.py` — and this is recorded in the module docstring as a rejected widening, because it is the obvious next request and it is **unsafe**. The backend suite provably imports `scripts.*` from ~20 files under `apps/backend-rag/backend/tests/unit/scripts/` (`from scripts.curated_qa_harvest import ...`, `from scripts.drive_token_watchdog import ...`). Allowlisting `scripts/` would be a W82 under-match: a change to a script would skip the very suite that tests it.

## Measured effect, stated honestly

This flips **#4125-shaped diffs** (hook + guard-registry only) from `full` to `skip-backend`. On the seven PRs open when this was measured it moves exactly one — #4123 still correctly pays the suite for `scripts/arsenal_probe.py`, #4089 for real backend files. Two of the seven already skipped. Note that `.github/workflows/*.yml` and `infra/home-fork/*.json` were **already** allowlisted; the two new pairs are the whole delta.

## Verification

`scripts/tests/test_prepush_classify.py`: **158 passed**. Guilt case is the real #4125 file set → `skip-backend` with an empty blocker list. Innocence cases, all still `full`: a hook file mixed with a real backend file; the rejected `scripts/**` widening; wrong suffix under each new prefix; and a `..` traversal escape.

Mutation-verified independently of the authoring lane: removing just the two tuple lines turns **exactly 3 tests red**, then restore → 158 green again.