### PR TITLE
fix(visa-oracle): stop the sr-only tree nav from going blank on "Not sure?" category

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/LivingTree.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/LivingTree.test.tsx
@@ -31,3 +31,77 @@ describe("LivingTree visible breadcrumb", () => {
     expect(onEditQuestion).toHaveBeenCalledWith("overstay_days");
   });
 });
+
+describe("LivingTree sr-only progress nav (category answered 'Not sure?')", () => {
+  // Live defect, measured on balizero.com/visa-oracle: at the length-of-stay
+  // step, after answering "category" with the NotSure affordance
+  // (facts.category === "unsure" — flowReducer's SKIP action, a real,
+  // reachable interview path, tree.ts `notSure: { mode: "human-review" }`),
+  // `nav.oracle-sr-only` rendered as a completely empty `<ol>` and the step
+  // never reappeared in later steps' trail. `getTreeSteps` (flow.ts) never
+  // takes a language, so the mechanism is not translation-specific — GUILT
+  // reproduces on the Indonesian interface as measured; INNOCENCE pins
+  // that English's already-correct rendering (both the ordinary "unsure"
+  // case and a ordinary answered-category case) is unaffected by the fix.
+  const UNSURE_CATEGORY_FACTS = {
+    in_indonesia: "no",
+    overstay_days: "0",
+    nationalities: "IT",
+    birth_date: "1990-02-03",
+    category: "unsure",
+    trip_scope: "single",
+  };
+  const current = { kind: "question" as const, questionId: "stay_days" };
+
+  it("GUILT: the Indonesian sr-only nav names the current step instead of rendering empty", () => {
+    render(
+      <LivingTree
+        language="id"
+        current={current}
+        facts={UNSURE_CATEGORY_FACTS}
+        onEditQuestion={vi.fn()}
+      />,
+    );
+    const srNav = screen.getByRole("navigation", {
+      name: "Jalur Anda sejauh ini",
+    });
+    expect(srNav.textContent).not.toBe("");
+    expect(within(srNav).getByText(/Lama tinggal/)).toBeInTheDocument();
+    expect(within(srNav).getByText(/langkah saat ini/)).toBeInTheDocument();
+  });
+
+  it("INNOCENCE: the English sr-only nav is unaffected — both under the same 'unsure' facts and on the ordinary answered-category path", () => {
+    const { unmount } = render(
+      <LivingTree
+        language="en"
+        current={current}
+        facts={UNSURE_CATEGORY_FACTS}
+        onEditQuestion={vi.fn()}
+      />,
+    );
+    const srNavUnsure = screen.getByRole("navigation", {
+      name: "Your path so far",
+    });
+    expect(srNavUnsure.textContent).not.toBe("");
+    expect(within(srNavUnsure).getByText(/Length of stay/)).toBeInTheDocument();
+    unmount();
+
+    // Regression pin: an ordinary, already-answered category (not "unsure")
+    // — the shape every prior test in this file exercised — must render
+    // identically to before this fix.
+    render(
+      <LivingTree
+        language="en"
+        current={current}
+        facts={{ ...UNSURE_CATEGORY_FACTS, category: "tourism" }}
+        onEditQuestion={vi.fn()}
+      />,
+    );
+    const srNavReal = screen.getByRole("navigation", {
+      name: "Your path so far",
+    });
+    expect(
+      within(srNavReal).getByText(/Length of stay: current step/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.test.ts
@@ -430,6 +430,67 @@ describe("editing, pruning and branch projection", () => {
     ).toEqual([{ key: "study", status: "done" }]);
   });
 
+  it("GUILT: answering category with 'Not sure?' still projects the live question into the trunk", () => {
+    // Reproduces the live defect (measured on balizero.com/visa-oracle,
+    // Indonesian interface, "Berapa hari Anda berencana tinggal?" step):
+    // the category question has `notSure: { mode: "human-review" }`
+    // (tree.ts), so a real interview can leave `facts.category === "unsure"`
+    // via flowReducer's SKIP action — not a synthetic value. Before the fix,
+    // `behavioralSteps` bailed to `[]` whenever `category` wasn't a real
+    // `CategoryKey`, so the live node ("stay_days") was absent from
+    // `getTreeSteps`'s `order` array, `currentIdx` came back -1, and EVERY
+    // trunk step — including ones already answered — read "pending". That
+    // is what emptied the sr-only nav `<ol>` entirely (not a missing
+    // translation: `getTreeSteps` never takes a language).
+    let state = startOffshore();
+    expectQuestion(state, "category");
+    state = reduce(state, { type: "SKIP", questionId: "category" });
+    expect(state.facts.category).toBe("unsure");
+    state = answer(state, "trip_scope", "single");
+    expectQuestion(state, "stay_days");
+
+    const { trunk } = getTreeSteps(
+      state.history[state.history.length - 1],
+      state.facts,
+    );
+    const stayDays = trunk.find((s) => s.id === "stay_days");
+    expect(stayDays).toEqual({
+      id: "stay_days",
+      labelI18nKey: "tree.stay_days",
+      status: "current",
+    });
+    // Every step already answered on the way here must read "done", not
+    // "pending" — the whole-nav-blank symptom was every step (not just
+    // "stay_days") losing its real status because `currentIdx` was -1.
+    const alreadyAnswered = ["framing", "in_indonesia", "overstay_days"];
+    for (const id of alreadyAnswered) {
+      expect(trunk.find((s) => s.id === id)?.status).not.toBe("pending");
+    }
+    expect(trunk.find((s) => s.id === "category")?.status).toBe("done");
+  });
+
+  it("INNOCENCE: a real category's trunk projection is unaffected by the 'unsure' fix", () => {
+    // Same shape as the CATEGORY_CASES branches above (tourism: stay_days
+    // then entry_pattern) — pins that delegating `behavioralSteps` straight
+    // to `getCategoryQuestionIds` did not change anything for an actual
+    // `CategoryKey`, only for the "unsure" fallback it previously mishandled.
+    let state = startOffshore("tourism");
+    state = answer(state, "trip_scope", "single");
+    expectQuestion(state, "stay_days");
+
+    const { trunk } = getTreeSteps(
+      state.history[state.history.length - 1],
+      state.facts,
+    );
+    expect(trunk.find((s) => s.id === "stay_days")).toEqual({
+      id: "stay_days",
+      labelI18nKey: "tree.stay_days",
+      status: "current",
+    });
+    expect(trunk.find((s) => s.id === "category")?.status).toBe("done");
+    expect(trunk.find((s) => s.id === "entry_pattern")?.status).toBe("pending");
+  });
+
   it("only completed question steps are editable", () => {
     expect(
       isEditableTreeStep({

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/flow.ts
@@ -10,7 +10,6 @@
 
 import { useCallback, useEffect, useMemo, useReducer } from "react";
 import {
-  BEHAVIORAL_CATEGORIES,
   CATEGORY_KEYS,
   QUESTIONS,
   REVIEW_GATE_ITEMS,
@@ -842,8 +841,25 @@ export function isEditableTreeStep(step: TreeStep): boolean {
 function behavioralSteps(
   facts: OracleFacts,
 ): { id: string; labelI18nKey: string }[] {
-  const category = facts.category as CategoryKey | undefined;
-  if (!category || !BEHAVIORAL_CATEGORIES.has(category)) return [];
+  // Trunk entries only make sense once "category" has an answer at all —
+  // before that, computeNextNode can't have routed past it either. But the
+  // answer doesn't have to be a real `CategoryKey`: the category question
+  // has `notSure: { mode: "human-review" }` (tree.ts), so a real interview
+  // can leave `facts.category === "unsure"` (flowReducer's SKIP action,
+  // reachable from any language's "Not sure?" affordance). `getCategoryQuestionIds`
+  // is already the graph's single source of truth for "what comes next" in
+  // that case too — it falls back to `["stay_days"]` for any category that
+  // isn't a recognized `CategoryKey` (tree.ts, same fallback `computeNextNode`'s
+  // "trip_scope" case relies on). The old `BEHAVIORAL_CATEGORIES.has(category)`
+  // guard here duplicated that check and disagreed with it: for "unsure" it
+  // returned `[]` while `getCategoryQuestionIds` still returns `["stay_days"]`,
+  // so the live node (e.g. "stay_days") was absent from `order` in
+  // `getTreeSteps` above — `currentIdx` came back -1, every trunk entry read
+  // "pending", and the sr-only nav rendered a completely empty `<ol>` for
+  // that step (and every step after it) — language-independent; the same
+  // empty nav reproduces in English under the identical fact-state. Delegate
+  // to `getCategoryQuestionIds` unconditionally instead of re-deciding here.
+  if (facts.category === undefined) return [];
   return getCategoryQuestionIds(facts).map((id) => ({
     id,
     labelI18nKey: `tree.${id}`,


### PR DESCRIPTION
## What

At the length-of-stay step, `nav.oracle-sr-only` (the screen-reader-only
progress landmark rendered by `LivingTree`) went completely empty — and the
step then dropped out of the trail on every step after it. Measured live on
`balizero.com/visa-oracle`, Indonesian interface, "Berapa hari Anda
berencana tinggal?" step: `textContent` `""`, `outerHTML.length` 78 against
253–374 on neighbouring steps.

## Root cause

Not a missing translation (`tree.stay_days`/`tree.tourism_duration` already
have Indonesian values). The category question allows a "Not sure?" answer
(`notSure: { mode: "human-review" }`, `tree.ts`), which `flowReducer`'s
`SKIP` action records as `facts.category === "unsure"` — a real, reachable
value, not a `CategoryKey`.

`flow.ts::behavioralSteps` bailed to `[]` whenever `category` wasn't a
recognized `CategoryKey`, while `getCategoryQuestionIds` — the graph's own
single source of truth for "what comes next", already used by
`computeNextNode` — falls back to `["stay_days"]` for that same case. That
mismatch meant the live question id was absent from `getTreeSteps`'s
`order` array, so `currentIdx` came back `-1` and **every** trunk step,
including ones already answered, read `"pending"` — emptying the nav's
`<ol>` entirely.

The mechanism never takes a language parameter, so it is not
Indonesian-specific: a targeted repro against production confirmed the
identical empty nav in **English** under the same "unsure" category
answer. The live measurement happened to be Indonesian only because of
which button a specific walk clicked, not because of any locale branch.

## Fix

`behavioralSteps` now delegates unconditionally to `getCategoryQuestionIds`
once `category` has any answer at all (real or "unsure"), instead of
re-deciding with a duplicate, disagreeing check.

## Tests

`flow.test.ts` + `LivingTree.test.tsx`:
- **GUILT**: after answering category "Not sure?", the live question is
  present in the trunk/nav with the correct label and status (both the
  language-neutral `getTreeSteps` projection and the rendered Indonesian
  DOM).
- **INNOCENCE**: the ordinary answered-category path (both languages) is
  unaffected by the fix.

Reverting the fix locally fails all 3 guilt assertions — confirms the
tests are not vacuous.

## Verification

- Full `visa-oracle` vitest suite: **37 files / 429 tests green**.
- `eslint` clean, `prettier --check` clean, `tsc --noEmit` clean.
- Re-ran the team's Playwright walker (with the mandatory
  `**/api/visa-oracle/evaluate*` abort intact) against a local `next dev`
  build, replaying the exact Indonesian click path that reproduced the
  live defect: the previously-empty nav at "Berapa hari Anda berencana
  tinggal?" now reads `"Lama tinggal: langkah saat ini"` and correctly
  persists as `"Lama tinggal: sudah dijawab"` on the next step. The
  English happy-path walk (real category) is byte-for-byte unchanged from
  the pre-fix production walk.
- **Not verified**: production itself — this PR does not deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)