### PR TITLE
fix(organ-conformance): resolve canonical fleet checkout roots so the verdict does not depend on where the gate runs

### DIFF
--- a/infra/organ-conformance/check_organ_conformance.py
+++ b/infra/organ-conformance/check_organ_conformance.py
@@ -48,6 +48,15 @@ KEEPALIVE_LINT_REL = "scripts/lint_plist_keepalive.py"
 # Match repo-relative paths exactly: similarly named payloads are ordinary wrappers.
 KNOWN_CONTENT_RUNNERS: frozenset[str] = frozenset({"scripts/cron-runner.sh"})
 
+# Repository identity aliases are resolver policy, not organism gene data, so
+# they live beside the resolver rather than in genes.json. Keeping this small,
+# exact trust boundary in code makes its validation and its guilt/innocence
+# tests change atomically; no basename or user-home pattern is accepted.
+CANONICAL_FLEET_CHECKOUT_ROOTS: tuple[Path, ...] = (
+    Path("/Users/nuzantara/nuzantara"),  # Pro and Mini
+    Path("/Users/balizero/nuzantara"),  # Air-M5
+)
+
 # --- gene detection patterns (definitions live in genes.json; logic lives here) ---
 RE_HEARTBEAT = re.compile(r"organism_heartbeat|\.organism/last_seen|heartbeat\(\)\s*\{")
 RE_KILL_SWITCH = re.compile(r"\b[A-Z][A-Z0-9_]*_ENABLED\b")
@@ -133,11 +142,16 @@ def _repo_alias_roots(repo_root: Path) -> tuple[Path, ...]:
 
     A launchd plist can name the canonical checkout while the gate runs from a
     linked worktree. Git's common directory identifies that canonical checkout;
-    preserving the complete relative path lets the checker inspect the current
-    worktree's file without any basename widening.
+    the declared fleet roots identify it when the gate runs elsewhere (including
+    CI). Preserving the complete relative path lets the checker inspect the
+    current tree's file without any basename widening.
     """
     resolved_root = repo_root.resolve()
     roots = [resolved_root]
+    for fleet_root in CANONICAL_FLEET_CHECKOUT_ROOTS:
+        resolved_fleet_root = fleet_root.resolve()
+        if resolved_fleet_root not in roots:
+            roots.append(resolved_fleet_root)
     out = subprocess.run(
         [
             "git",

--- a/infra/organ-conformance/tests/test_runner_aware_resolution.py
+++ b/infra/organ-conformance/tests/test_runner_aware_resolution.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib.util
 import plistlib
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +33,11 @@ BAD_WRAPPER = """#!/bin/bash
 echo "no content genes"
 """
 
+FLEET_CHECKOUT_ROOTS = (
+    Path("/Users/nuzantara/nuzantara"),
+    Path("/Users/balizero/nuzantara"),
+)
+
 
 @pytest.fixture
 def fixture_repo(tmp_path: Path) -> Path:
@@ -47,8 +54,16 @@ def _write_script(repo: Path, relative: str, content: str) -> Path:
     return path
 
 
+def _write_runner_tree(repo: Path, payload_body: str = GOOD_WRAPPER) -> None:
+    for relative in ("scripts", "apps/foo", "infra/launchagents"):
+        (repo / relative).mkdir(parents=True, exist_ok=True)
+    _write_script(repo, "scripts/cron-runner.sh", BAD_WRAPPER)
+    _write_script(repo, "apps/foo/payload.sh", payload_body)
+
+
 def _analyze(fixture_repo: Path, argv: list[str]) -> dict[str, Any]:
     plist_path = fixture_repo / "infra/launchagents/com.test.runner-aware.plist"
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
     label = "com.test.runner-aware"
     plist_path.write_bytes(plistlib.dumps({"Label": label, "ProgramArguments": argv}))
     ka_mod = coc._load_keepalive_module(REPO_ROOT)
@@ -260,3 +275,159 @@ def test_innocence_canonical_checkout_alias_maps_exact_paths_to_worktree(
     assert organ["wrapper"] == "apps/foo/payload.sh"
     assert "G2_heartbeat" not in organ["missing"]
     assert "G5_kill_switch" not in organ["missing"]
+
+
+@pytest.mark.parametrize("canonical_checkout", FLEET_CHECKOUT_ROOTS)
+def test_guilt_canonical_fleet_runner_uses_payload_under_synthetic_root(
+    fixture_repo: Path,
+    canonical_checkout: Path,
+) -> None:
+    """The old verdict inspected cron-runner under a non-alias root.
+
+    fixture_repo is intentionally not a linked worktree of this repository,
+    so no git-common-dir accident can make the canonical fleet path resolvable.
+    """
+    _write_runner_tree(fixture_repo)
+
+    organ = _analyze(
+        fixture_repo,
+        [
+            "/bin/bash",
+            str(canonical_checkout / "scripts/cron-runner.sh"),
+            str(canonical_checkout / "apps/foo/payload.sh"),
+        ],
+    )
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert "G2_heartbeat" not in organ["missing"]
+    assert "G5_kill_switch" not in organ["missing"]
+
+
+def test_innocence_fleet_alias_set_is_small_exact_and_auditable() -> None:
+    assert coc.CANONICAL_FLEET_CHECKOUT_ROOTS == FLEET_CHECKOUT_ROOTS
+
+
+def test_innocence_canonical_fleet_payload_without_gene_still_fails(
+    fixture_repo: Path,
+) -> None:
+    _write_runner_tree(fixture_repo, payload_body=BAD_WRAPPER)
+
+    organ = _analyze(
+        fixture_repo,
+        [
+            "/bin/bash",
+            "/Users/nuzantara/nuzantara/scripts/cron-runner.sh",
+            "/Users/nuzantara/nuzantara/apps/foo/payload.sh",
+        ],
+    )
+
+    assert organ["wrapper"] == "apps/foo/payload.sh"
+    assert {"G2_heartbeat", "G5_kill_switch"} <= set(organ["missing"])
+
+
+def test_guilt_missing_canonical_fleet_payload_stays_fail_closed_and_names_token(
+    fixture_repo: Path,
+) -> None:
+    _write_runner_tree(fixture_repo)
+    missing_token = "/Users/nuzantara/nuzantara/apps/foo/missing.sh"
+
+    organ = _analyze(
+        fixture_repo,
+        [
+            "/bin/bash",
+            "/Users/nuzantara/nuzantara/scripts/cron-runner.sh",
+            missing_token,
+        ],
+    )
+
+    assert "wrapper" not in organ
+    assert {"G2_heartbeat", "G5_kill_switch"} <= set(organ["missing"])
+    assert any(missing_token in note for note in organ["notes"])
+
+
+@pytest.mark.parametrize(
+    "external_token",
+    [
+        "/opt/homebrew/bin/something",
+        "/Users/nuzantara/other-repo/x.sh",
+    ],
+)
+def test_innocence_external_absolute_tokens_are_not_fleet_aliases(
+    fixture_repo: Path,
+    external_token: str,
+) -> None:
+    _write_script(fixture_repo, f"apps/foo/{Path(external_token).name}", GOOD_WRAPPER)
+    ka_mod = coc._load_keepalive_module(REPO_ROOT)
+
+    resolved = coc._resolve_repo_file_strict(external_token, fixture_repo, ka_mod)
+
+    assert resolved is None
+
+
+def test_verdict_is_identical_from_main_linked_and_synthetic_roots(
+    tmp_path: Path,
+) -> None:
+    """One closed fixture tree has one verdict, independent of git topology."""
+    main_checkout = tmp_path / "main-checkout"
+    _write_runner_tree(main_checkout)
+    subprocess.run(["git", "init", "-q", str(main_checkout)], check=True)
+    subprocess.run(
+        ["git", "-C", str(main_checkout), "add", "-A"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(main_checkout),
+            "-c",
+            "user.name=Organ Conformance Test",
+            "-c",
+            "user.email=organ-conformance@example.invalid",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    linked_worktree = tmp_path / "linked-worktree"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(main_checkout),
+            "worktree",
+            "add",
+            "--detach",
+            str(linked_worktree),
+            "HEAD",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    synthetic_root = tmp_path / "synthetic-root"
+    shutil.copytree(
+        main_checkout,
+        synthetic_root,
+        ignore=shutil.ignore_patterns(".git"),
+    )
+    subprocess.run(["git", "init", "-q", str(synthetic_root)], check=True)
+
+    argv = [
+        "/bin/bash",
+        "/Users/nuzantara/nuzantara/scripts/cron-runner.sh",
+        "/Users/nuzantara/nuzantara/apps/foo/payload.sh",
+    ]
+    verdicts = [
+        _analyze(root, argv)
+        for root in (main_checkout, linked_worktree, synthetic_root)
+    ]
+
+    assert [
+        (verdict.get("wrapper"), verdict["missing"], verdict["notes"])
+        for verdict in verdicts
+    ] == [("apps/foo/payload.sh", [], [])] * 3


### PR DESCRIPTION
## Problem

`infra/organ-conformance/check_organ_conformance.py` resolves a launchd plist's payload by accepting an absolute token only when it is relative to a "repo alias root": `repo_root` plus the parent of `git rev-parse --git-common-dir`.

Fleet Macs run plists with absolute paths like `/Users/nuzantara/nuzantara/infra/launchagents/wrappers/<x>.sh`. On those machines that prefix is an alias root, so the payload is found, the runner→payload hop happens, and the genes are found. In GitHub Actions the checkout is `/home/runner/work/Teman2/Teman2`, no alias root ever equals the fleet path, resolution returns `None`, and the checker falls back to the runner `scripts/cron-runner.sh` — which does not carry `G2_heartbeat` or `G5_kill_switch`. The same tree therefore gets a different verdict depending on where the gate runs, and the development machine cannot reproduce the CI red.

## Fix

Declare `/Users/nuzantara/nuzantara` and `/Users/balizero/nuzantara` as canonical fleet checkout roots. No basename bridge is introduced (that would undo #4129). An unresolvable declared payload stays fail-closed.

## Verification

```
$ /Users/nuzantara/nuzantara/.venv/bin/python -m pytest infra/organ-conformance/tests/test_runner_aware_resolution.py -q
......................
22 passed in 0.43s

$ python3 infra/organ-conformance/check_organ_conformance.py ; echo RC=$?
✓ organ conformance: 162 plists scanned, 121 grandfathered (report-only), 0 regressions, 0 non-conformant births
RC=0
```

Concrete victim unblocked: PR #4126 (`feat(kbli): arm daily surface-conformance detector on Pro`) was red on "Every organ is born with its genes" for `com.nuzantara.kbli-surface-conformance.daily.plist` missing `['G2_heartbeat','G5_kill_switch']`, while its payload demonstrably has both (`KBLI_SURFACE_CONFORMANCE_ENABLED` twice, plus `write_heartbeat` on success, failure, and kill-switch paths).
