### PR TITLE
retire(analytics): remove dead visa quiz tracking functions

### DIFF
--- a/apps/mouth/src/lib/analytics.test.ts
+++ b/apps/mouth/src/lib/analytics.test.ts
@@ -138,36 +138,6 @@ describe("analytics", () => {
     expect(body).not.toHaveProperty("user_id");
   });
 
-  it("dispatches Visa Oracle funnel events to GA4 and the core funnel bus", async () => {
-    const gtag = vi.fn();
-    (window as typeof window & { gtag?: typeof gtag }).gtag = gtag;
-    const { trackVisaQuizCompleted } = await loadAnalytics();
-
-    trackVisaQuizCompleted({
-      nationality: "Italy",
-      purpose: "business",
-      duration: "12 months",
-      family: "yes",
-    });
-
-    expect(gtag).toHaveBeenCalledWith("event", "visa_quiz_completed", {
-      event_category: "VisaOracle",
-      nationality: "Italy",
-      purpose: "business",
-      duration: "12 months",
-      family: "yes",
-    });
-    expect(trackFunnelEventMock).toHaveBeenCalledWith("visa_quiz_completed", {
-      sessionId: "core-session-id",
-      payload: {
-        nationality: "Italy",
-        purpose: "business",
-        duration: "12 months",
-        family: "yes",
-      },
-    });
-  });
-
   it("dispatches typed funnel CTA events with extra payload", async () => {
     const gtag = vi.fn();
     (window as typeof window & { gtag?: typeof gtag }).gtag = gtag;

--- a/apps/mouth/src/lib/analytics.ts
+++ b/apps/mouth/src/lib/analytics.ts
@@ -286,47 +286,6 @@ export function trackLeadWhatsAppCTA(
 
 // --- Visa Oracle ---
 
-/** Track quiz completion with answers */
-export function trackVisaQuizCompleted(answers: {
-  nationality: string;
-  purpose: string;
-  duration: string;
-  family: string;
-}): void {
-  sendGA4Event("visa_quiz_completed", {
-    event_category: "VisaOracle",
-    nationality: answers.nationality,
-    purpose: answers.purpose,
-    duration: answers.duration,
-    family: answers.family,
-  });
-  trackEvent("visa_quiz_completed", answers);
-  void trackFunnelEvent("visa_quiz_completed", {
-    sessionId: getOrCreateSessionId(),
-    payload: answers,
-  });
-}
-
-/** Track visa recommendation result viewed */
-export function trackVisaResultViewed(
-  topVisa: string,
-  visaCount: number,
-): void {
-  sendGA4Event("visa_result_viewed", {
-    event_category: "VisaOracle",
-    top_visa: topVisa,
-    visa_count: visaCount,
-  });
-  trackEvent("visa_result_viewed", {
-    top_visa: topVisa,
-    visa_count: visaCount,
-  });
-  void trackFunnelEvent("visa_result_viewed", {
-    sessionId: getOrCreateSessionId(),
-    payload: { top_visa: topVisa, visa_count: visaCount },
-  });
-}
-
 /** Track chat question sent in Visa Oracle */
 export function trackVisaChatQuestion(remaining: number): void {
   sendGA4Event("visa_chat_question", {


### PR DESCRIPTION
## Insight
WIRE/RETIRE audit (13 Aug 2026) found 7 track* functions with zero call-sites. This PR retires 2 confirmed dead: no visa quiz surface exists in the codebase; visa funnel uses chat (VisaChat.tsx), not quiz format.

## Studio
No visual change to end users. Removed from apps/mouth/src/lib/analytics.ts and corresponding test block in analytics.test.ts. No component touches, no route changes, no broken imports.

## Source
grep -rn trackVisaQuizCompleted apps/mouth/src --include=*.ts --include=*.tsx | grep -v analytics | grep -v .test. returned 0 results. Same for trackVisaResultViewed. Verified 13 Aug 2026 on origin/main baf387b7f.

## Methodology
Full call-site scan across apps/mouth/src before deletion. TypeScript noEmit confirmed clean. Pre-commit hook caught orphaned test — removed in same commit.

## Raw Observations
trackVisaQuizCompleted (line 290): 0 call-sites. trackVisaResultViewed (line 311): 0 call-sites. Visa Oracle funnel confirmed using trackVisaChatQuestion and trackVisaWhatsAppCTA, both live in VisaChat.tsx lines 77 and 95.

## Reasoning Path
No surface means no event means dead code that misleads future audits. Antonello flagged 10 functions with 0 call-sites. This closes 2 of 7 with confirmed zero-surface verdict.

## Risk
Minimal. TypeScript noEmit clean, test file updated atomically. CI is authoritative gate for build.

## Implication
analytics.ts reduces from 34 to 32 exported track* functions. Remaining 5 WIRE tasks (trackLeadCreated, trackDocumentUploaded, trackPortalLogin, trackPropertyArticleCTA, trackPropertyChatQuestion) follow in separate PRs.

## Recommendation
Merge. CI is the authoritative gate.

## Next Action
Wire trackLeadCreated in WhatsAppLeadButton.tsx — highest KPI priority, tied to bonus performance definition for PKWTT meeting tomorrow.