### PR TITLE
fix(portal): stop client page auto-scrolling on initial message load

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.tsx
@@ -26,6 +26,8 @@ export function PortalMessages({
   const [newMessage, setNewMessage] = useState("");
   const [isSending, setIsSending] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const hasSeenData = useRef(false);
+  const prevMessageCountRef = useRef(0);
 
   const loadMessages = async () => {
     try {
@@ -51,7 +53,18 @@ export function PortalMessages({
   }, [clientId]);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (messages.length === 0) return;
+
+    if (!hasSeenData.current) {
+      hasSeenData.current = true;
+      prevMessageCountRef.current = messages.length;
+      return;
+    }
+
+    if (messages.length > prevMessageCountRef.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+    prevMessageCountRef.current = messages.length;
   }, [messages]);
 
   const handleSend = async () => {


### PR DESCRIPTION
## Insight
Reported by Adit (Supervisor Lead Setup) 13 Aug 2026: opening any client profile page scrolls the viewport down on its own. Users land mid-page instead of at the top.

## Studio
Client profile pages at kita.balizero.com/clients/[id] now open at the top instead of jumping to the messages section. Changed in apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.tsx — VERDE zone. No layout, styling, or content change.

## Source
PortalMessages.tsx lines 53-55: useEffect calling scrollIntoView on [messages] dependency, no mount guard.

## Methodology
Read-only grep across apps/mouth/src/app/(workspace)/clients for scrollIntoView, autoFocus, scrollTo, focus() — five candidates found, one confirmed as root cause by dependency analysis.

## Raw Observations
messages state initializes as an empty array (line 22). loadMessages() resolves and calls setMessages(data), changing [] to [N]. The [messages] effect fires on that transition and scrolls. Polling every 30s re-sets messages, firing the effect again on each tick.

## Reasoning Path
Two distinct triggers needed separate guards. hasSeenData suppresses the initial population scroll — the bug Adit reported. prevMessageCountRef suppresses polling ticks that return an unchanged count. Using only one leaves the other bug open: an earlier iteration used prevMessageCountRef alone and still scrolled on initial load; a second used hasSeenData alone and scrolled every 30 seconds.

## Risk
Low, contained to one component. Scroll-on-new-message is preserved for both inbound polling and outbound send.

## Implication
No other component depends on these refs. Four other scroll or focus call sites exist in the clients workspace and are unaffected.

## Recommendation
Merge. Verifiable by opening any client profile page.

## Next Action
Ask Adit to confirm the page opens at the top. Remaining reported bugs tracked separately in Todoist: truncated address, stale passport warning, document count mismatch, passport validity formatting.