### PR TITLE
fix(seo): host-aware robots.txt — zantara gets Disallow: /

### DIFF
--- a/apps/mouth/src/app/robots.ts
+++ b/apps/mouth/src/app/robots.ts
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import type { MetadataRoute } from "next";
 
 // In robots.txt semantics a crawler obeys ONLY the most specific matching
@@ -41,7 +42,26 @@ const DISALLOW = [
   "/_next/",
 ];
 
-export default function robots(): MetadataRoute.Robots {
+// Hosts that serve the internal app surface. These must never be crawled:
+// the pages sit behind login, so what leaks is the subdomain's existence
+// and its route structure, not content. proxy.ts already sets
+// X-Robots-Tag: noindex, nofollow on these hosts (proxy.ts:366, :369, :449)
+// — this closes the robots.txt layer, which is served by this file for
+// every host and until now returned the public site's rules verbatim.
+const INTERNAL_HOSTS = new Set([
+  "zantara.balizero.com",
+  "www.zantara.balizero.com",
+]);
+
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const host = (await headers()).get("host")?.toLowerCase() ?? "";
+
+  if (INTERNAL_HOSTS.has(host)) {
+    return {
+      rules: [{ userAgent: "*", disallow: "/" }],
+    };
+  }
+
   return {
     rules: [
       // ── Standard crawlers ─────────────────────────────


### PR DESCRIPTION
## 1. Insight
robots.txt is served by a single file for every host on this deployment, and until now it returned the public site's rules verbatim on all of them. zantara.balizero.com — the internal app surface — was therefore telling every crawler `Allow: /`. The X-Robots-Tag layer was closed in #4106; this closes the robots.txt layer, which is the other half of the same protection.

## 2. Studio
No visual change to end users. This changes the body of /robots.txt on zantara.balizero.com only. All other hosts keep byte-identical output. Zone: VERDE, apps/mouth/src/app/robots.ts only.

## 3. Source
- apps/mouth/src/app/robots.ts — +21 / −1

## 4. Methodology
Found the layer that actually serves the response rather than the one that looks like it should. proxy.ts had a robots.txt override, but it is unreachable (removed in #4105) — app/robots.ts is what answers every request. Read from origin/main, not local checkout. Verified the resulting output by fetching the URL under both hosts, not by reading the code.

## 5. Raw Observations
Before, on served commit 1305870b6c — all three hosts return identical output:

- balizero.com/robots.txt → `User-Agent: *` / `Allow: /` / `Allow: /_next/static/`
- zantara.balizero.com/robots.txt → same three lines
- kita.balizero.com/robots.txt → same three lines

Local verification on this branch, dev server, Host header varied:

- `curl localhost:3000/robots.txt` → `User-Agent: *` + full public rules
- `curl -H "Host: zantara.balizero.com" localhost:3000/robots.txt` → `User-Agent: *` + `Disallow: /`

Typecheck: `npx tsc --noEmit` → clean, no output.
Build: UNVERIFIED locally — `npm run build` failed with ETIMEDOUT fetching League Spartan from Google Fonts (142.250.9.95:443). Network condition on this machine, not a code error. CI is the gate.

## 6. Reasoning Path
Two options were open: intercept before the early return in proxy.ts, or handle it in the layer that already owns robots.txt. The second has fewer side effects — proxy.ts:170 returns early for any path with a dot, so an override there would need the early return itself modified, which touches every static asset request. app/robots.ts touches nothing else.

Only zantara is in INTERNAL_HOSTS. kita.balizero.com was deliberately left out: it was not part of this instruction, and adding it would widen the scope of a PR that is meant to be isolated.

## 7. Risk
Reading `headers()` makes /robots.txt a dynamic route — it is no longer generated statically at build time. That trade-off is deliberate: one file cannot serve different rules per host without knowing the host. The cost is one server render per robots.txt request, which crawlers fetch rarely.

The public rules object is untouched — the diff adds a guard clause above it and changes the function signature to async. If the guard does not match, execution falls through to exactly the same return as before.

## 8. Implication
Closes the second of the two protection layers on the internal app subdomain. What was leaking is the subdomain's existence and its route structure, not content — the pages sit behind login. Real, not urgent, and now closed at both layers.

## 9. Recommendation
Do not merge without owner approval. Per instruction, auto-merge is not armed and this PR stops at ready-for-owner-review.

## 10. Next Action
After approval, merge and promote, then verify on the served surface — three fetches, the third being the positive control:

curl -s -A '<Googlebot UA>' https://zantara.balizero.com/robots.txt | head -3   → expect `User-Agent: *` / `Disallow: /`
curl -s -A '<Googlebot UA>' https://balizero.com/robots.txt | head -3          → must be unchanged
curl -s -A '<Googlebot UA>' https://kita.balizero.com/robots.txt | head -3     → must be unchanged
