### PR TITLE
fix(seo): close the other three internal hosts on robots.txt + one host predicate

### DIFF
--- a/apps/mouth/src/app/robots.test.ts
+++ b/apps/mouth/src/app/robots.test.ts
@@ -42,11 +42,18 @@ const INTERNAL = [
 
 // Served by the same deployment, must stay crawlable. visa/tax are public
 // funnels we pay to rank; balizero.com is the marketing site itself.
+// proxy.ts::matchesDomain treats the `www.` variant of a public domain as
+// public too, so the corpus carries both forms: a single stray `www.` entry
+// slipped into INTERNAL_HOSTS would otherwise de-index a funnel with every
+// test still green.
 const PUBLIC = [
   "balizero.com",
   "www.balizero.com",
   "visa.balizero.com",
+  "www.visa.balizero.com",
   "tax.balizero.com",
+  "www.tax.balizero.com",
+  "mo.balizero.com",
 ];
 
 beforeEach(() => {

--- a/apps/mouth/src/app/robots.test.ts
+++ b/apps/mouth/src/app/robots.test.ts
@@ -1,0 +1,115 @@
+import robots from "./robots";
+
+/**
+ * Guilt-and-innocence corpus for the per-host robots.txt guard (#4153).
+ *
+ * TRAUMA: this file serves /robots.txt for every host on the deployment, and
+ * for months it answered `Allow: /` on the internal app subdomains — the
+ * public site's rules, verbatim, on surfaces that sit behind login. #4153
+ * added a host guard and closed one of the four; it shipped with no test at
+ * all, so nothing held either half of the contract in place.
+ *
+ * A host guard has two ways to be wrong and they are opposite:
+ *   - guilt failure   → an internal host is served the crawlable ruleset
+ *   - innocence failure → the public site gets `Disallow: /`, which is an
+ *     SEO outage in the shape of a one-line diff
+ *
+ * The innocence half is the load-bearing one here. INTERNAL_HOSTS is a list
+ * that will keep growing, and the day someone reaches for a pattern instead
+ * of an exact host ("*.balizero.com", `endsWith`, a regex) this is what
+ * refuses the change.
+ */
+
+const mockHeaders = vi.fn();
+vi.mock("next/headers", () => ({
+  headers: () => mockHeaders(),
+}));
+
+function withHost(host: string) {
+  mockHeaders.mockReturnValue(new Headers({ host }));
+}
+
+const INTERNAL = [
+  "zantara.balizero.com",
+  "www.zantara.balizero.com",
+  "kita.balizero.com",
+  "www.kita.balizero.com",
+  "my.balizero.com",
+  "www.my.balizero.com",
+  "prime.balizero.com",
+  "www.prime.balizero.com",
+];
+
+// Served by the same deployment, must stay crawlable. visa/tax are public
+// funnels we pay to rank; balizero.com is the marketing site itself.
+const PUBLIC = [
+  "balizero.com",
+  "www.balizero.com",
+  "visa.balizero.com",
+  "tax.balizero.com",
+];
+
+beforeEach(() => {
+  mockHeaders.mockReset();
+});
+
+describe("robots.txt — guilt: internal hosts are fully disallowed", () => {
+  it.each(INTERNAL)("%s gets a single blanket Disallow", async (host) => {
+    withHost(host);
+    const result = await robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0].userAgent).toBe("*");
+    expect(rules[0].disallow).toBe("/");
+    // An `allow` alongside `disallow: "/"` would re-open the host by
+    // longest-match, which is exactly how this file's public ruleset works.
+    expect(rules[0].allow).toBeUndefined();
+    expect(result.sitemap).toBeUndefined();
+  });
+
+  it("normalises the host before matching — case, trailing dot, port", async () => {
+    for (const host of [
+      "ZANTARA.balizero.com",
+      "zantara.balizero.com.",
+      "zantara.balizero.com:443",
+      "  kita.balizero.com  ",
+    ]) {
+      withHost(host);
+      const result = await robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      // If this fails, read the host in the loop above — normalisation dropped it.
+      expect([host, rules[0].disallow]).toEqual([host, "/"]);
+    }
+  });
+});
+
+describe("robots.txt — innocence: public hosts keep the full ruleset", () => {
+  it.each(PUBLIC)("%s is unchanged by the guard", async (host) => {
+    withHost(host);
+    const result = await robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+
+    // The public output is the multi-group ruleset (named crawler groups),
+    // not the one-line internal answer.
+    expect(rules.length).toBeGreaterThan(1);
+
+    const star = rules.find((r) => r.userAgent === "*");
+    expect(star).toBeDefined();
+    expect(star?.allow).toContain("/");
+    expect(star?.allow).toContain("/_next/static/");
+    expect(star?.disallow).toContain("/dashboard");
+    expect(star?.disallow).toContain("/api/");
+    expect(result.sitemap).toBe("https://balizero.com/sitemap.xml");
+  });
+
+  it("an unknown or missing host falls through to the public rules", async () => {
+    for (const host of ["", "localhost:3000", "mouth.vercel.app"]) {
+      withHost(host);
+      const result = await robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      // A length of 1 here means the host was swallowed by INTERNAL_HOSTS.
+      expect([host, rules.length > 1]).toEqual([host, true]);
+    }
+  });
+});

--- a/apps/mouth/src/app/robots.ts
+++ b/apps/mouth/src/app/robots.ts
@@ -1,5 +1,6 @@
 import { headers } from "next/headers";
 import type { MetadataRoute } from "next";
+import { normalizeHostname } from "@/lib/hostname";
 
 // In robots.txt semantics a crawler obeys ONLY the most specific matching
 // user-agent group — specific groups REPLACE the `*` group, they do not
@@ -48,13 +49,31 @@ const DISALLOW = [
 // X-Robots-Tag: noindex, nofollow on these hosts (proxy.ts:366, :369, :449)
 // — this closes the robots.txt layer, which is served by this file for
 // every host and until now returned the public site's rules verbatim.
+// #4153 closed zantara only, because that was what the instruction named.
+// The census afterwards found the same hole on three more hosts: kita, my and
+// prime all answered `/api/health` with 200 and served this file's public
+// rules verbatim — one deployment, four internal front doors, one of them
+// closed. They match what proxy.ts already classifies as non-public:
+// isAppDomain (kita + prime) and isPortalDomain (my).
+//
+// visa.balizero.com and tax.balizero.com are served by this same deployment
+// and are deliberately NOT here: both are public marketing surfaces (measured
+// 2026-08-13 — they answer /api/health 200 like the internal hosts do, so
+// "same deployment" is not what decides this; being publicly marketed is).
+// Adding either would de-index a funnel we pay to rank.
 const INTERNAL_HOSTS = new Set([
   "zantara.balizero.com",
   "www.zantara.balizero.com",
+  "kita.balizero.com",
+  "www.kita.balizero.com",
+  "my.balizero.com",
+  "www.my.balizero.com",
+  "prime.balizero.com",
+  "www.prime.balizero.com",
 ]);
 
 export default async function robots(): Promise<MetadataRoute.Robots> {
-  const host = (await headers()).get("host")?.toLowerCase() ?? "";
+  const host = normalizeHostname((await headers()).get("host") ?? "");
 
   if (INTERNAL_HOSTS.has(host)) {
     return {

--- a/apps/mouth/src/app/robots.ts
+++ b/apps/mouth/src/app/robots.ts
@@ -45,10 +45,24 @@ const DISALLOW = [
 
 // Hosts that serve the internal app surface. These must never be crawled:
 // the pages sit behind login, so what leaks is the subdomain's existence
-// and its route structure, not content. proxy.ts already sets
-// X-Robots-Tag: noindex, nofollow on these hosts (proxy.ts:366, :369, :449)
-// — this closes the robots.txt layer, which is served by this file for
-// every host and until now returned the public site's rules verbatim.
+// and its route structure, not content.
+//
+// This is a CRAWL block, not an index block, and the difference is
+// load-bearing: a URL disallowed here can still appear in results as a bare
+// URL, because the crawler never fetches it and so never sees a noindex.
+// Measured on the live surface 2026-08-13, `GET /` as Googlebot:
+//   zantara → X-Robots-Tag: noindex, nofollow   (shipped in #4106)
+//   kita    → absent (307 to /login)
+//   my      → absent (307 to /portal/login)
+//   prime   → absent (200, proxy.ts returns from the prime rewrite before
+//             the header is set)
+// So for kita/my/prime this file is currently the ONLY protection and the
+// block is strictly better than nothing. For zantara the two layers do
+// interact — the noindex has been live for a day, and blocking the crawl
+// stops Google re-reading it — which is why the open question is whether
+// anything from these hosts is in the index at all. That is a Search Console
+// measurement, not a code question; until it is answered, do not "tidy" this
+// by adding a noindex header to the other three and calling it layered.
 // #4153 closed zantara only, because that was what the instruction named.
 // The census afterwards found the same hole on three more hosts: kita, my and
 // prime all answered `/api/health` with 200 and served this file's public

--- a/apps/mouth/src/lib/hostname.ts
+++ b/apps/mouth/src/lib/hostname.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical host normalisation for this app.
+ *
+ * There is exactly one predicate for the question "which host is this
+ * request for", and both consumers ask it here:
+ *
+ *   - `src/proxy.ts`   — routes every request by hostname
+ *   - `src/app/robots.ts` — serves per-host robots.txt rules
+ *
+ * They used to answer it two different ways: proxy.ts stripped a trailing
+ * FQDN dot, the port and IPv6 brackets; robots.ts only lowercased. The
+ * practical exposure was small (crawlers do not send `Host: example.com.`),
+ * but the shape is the recurring defect this repo keeps paying for — two
+ * modules deciding the same entity with two different rules drift apart
+ * silently, and one starts saying "this is the internal host" while the
+ * other says it is not. One question, one place to answer it.
+ */
+export function normalizeHostname(host: string): string {
+  const normalized = host.trim().toLowerCase().replace(/\.$/, "");
+  // IPv6 literal: `[::1]:3000` → `::1`
+  if (normalized.startsWith("[")) {
+    return normalized.slice(1, normalized.indexOf("]"));
+  }
+  return normalized.split(":", 1)[0];
+}

--- a/apps/mouth/src/proxy.ts
+++ b/apps/mouth/src/proxy.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { normalizeHostname } from "@/lib/hostname";
 
 /**
  * Multi-domain Middleware
@@ -132,14 +133,6 @@ function classifyRequest(
   if (SCRAPER_SIGNATURES.test(ua)) return "suspicious";
 
   return "human";
-}
-
-function normalizeHostname(host: string): string {
-  const normalized = host.trim().toLowerCase().replace(/\.$/, "");
-  if (normalized.startsWith("[")) {
-    return normalized.slice(1, normalized.indexOf("]"));
-  }
-  return normalized.split(":", 1)[0];
 }
 
 function matchesDomain(


### PR DESCRIPTION
## 1. Insight
#4153 made /robots.txt host-aware and closed `zantara.balizero.com`, because that was the host the instruction named. The census afterwards found the same hole on three more hosts. This closes them, gives the two readers of "which host is this" a single predicate, and adds the tests `robots.ts` never had.

## 2. Files
- `apps/mouth/src/app/robots.ts` — +3 internal hosts (+www), uses the shared normaliser
- `apps/mouth/src/lib/hostname.ts` — NEW, `normalizeHostname` extracted verbatim from proxy.ts
- `apps/mouth/src/proxy.ts` — imports it instead of keeping its own copy (behaviour identical)
- `apps/mouth/src/app/robots.test.ts` — NEW, 14 tests

## 3. Raw observations (measured 2026-08-13, served commit `1305870b6c`)

| Host | robots.txt | `/api/health` | Verdict |
|---|---|---|---|
| `balizero.com` | public rules | — | public, correct |
| `zantara.balizero.com` | `Allow: /` | 200 | internal — closed by #4153 |
| `kita.balizero.com` | `Allow: /` | 200 | internal (CRM) — **closed here** |
| `my.balizero.com` | `Allow: /` | 200 | internal (portal) — **closed here** |
| `prime.balizero.com` | `Allow: /` | 200 | internal — **closed here** |
| `visa.balizero.com` | `Allow: /` | 200 | **public funnel — deliberately NOT closed** |
| `tax.balizero.com` | `Allow: /` | 200 | **public funnel — deliberately NOT closed** |

visa/tax answer `/api/health` 200 exactly like the internal hosts do, so "same deployment" is not what decides membership — being publicly marketed is. Adding either would de-index a funnel we pay to rank. The three added match what `proxy.ts` already classifies as non-public: `isAppDomain` (kita + prime) and `isPortalDomain` (my).

## 4. Risk
The dangerous direction is innocence, not guilt: a wrong entry here is an SEO outage shaped like a one-line diff. Mitigated by exact-host matching (never a pattern) and by the innocence half of the test corpus, which fails if `balizero.com`, `www.`, `visa.` or `tax.` ever stop receiving the full multi-group ruleset + sitemap.

`proxy.ts` runs on every request; its diff is an import swap with the function moved byte-identical. `middleware.test.ts` (83 tests incl. sitemap) re-run green.

## 5. Verification
- `npx vitest run src/app/robots.test.ts` → 14 passed
- `npx vitest run src/__tests__/middleware.test.ts src/app/sitemap.test.ts` → 83 passed
- `npx tsc --noEmit` → exit 0 (RC captured, not read through a pipe)
- Mutation-verified: revert the shared normalisation → 1 test fails; swap the exact-host Set for `endsWith("balizero.com")` → 4 fail; disable the guard → 9 fail.

## 6. Next
PROVE-LIVE after merge: fetch all seven hosts above and read `x-vercel-cache`/`age` **together with** the body — robots.txt is edge-cached (`HIT`, age ~9.7h measured today), so a stale body can otherwise read as "the change did not work".