### PR TITLE
chore(security): redact the live Telegram bot token from two archived docs

### DIFF
--- a/docs/archive/2026-07-orphans/superpowers/plans/2026-03-27-sentinel-v2-dlq-autopilot.md
+++ b/docs/archive/2026-07-orphans/superpowers/plans/2026-03-27-sentinel-v2-dlq-autopilot.md
@@ -1184,7 +1184,7 @@ Create `~/Library/LaunchAgents/com.nuzantara.dlq-autopilot.plist`:
         <key>HOME</key>
         <string>/Users/nuzantara</string>
         <key>TELEGRAM_BOT_TOKEN</key>
-        <string>8295471667:AAHglwz8p8LxFnDgctmXuCs5aZa6lY78QO8</string>
+        <string>${TELEGRAM_BOT_TOKEN}</string>
         <key>TELEGRAM_ADMIN_CHAT_ID</key>
         <string>1813875994</string>
     </dict>

--- a/docs/archive/2026-07-orphans/superpowers/specs/2026-03-27-sentinel-v2-dlq-autopilot-design.md
+++ b/docs/archive/2026-07-orphans/superpowers/specs/2026-03-27-sentinel-v2-dlq-autopilot-design.md
@@ -773,7 +773,7 @@ cat ~/.agent/decisions/state/dlq_autopilot.last.json
         <key>HOME</key>
         <string>/Users/nuzantara</string>
         <key>TELEGRAM_BOT_TOKEN</key>
-        <string>8295471667:AAHglwz8p8LxFnDgctmXuCs5aZa6lY78QO8</string>
+        <string>${TELEGRAM_BOT_TOKEN}</string>
         <key>TELEGRAM_ADMIN_CHAT_ID</key>
         <string>1813875994</string>
     </dict>


### PR DESCRIPTION
## 1. What
Two archived superpowers docs carry the **real** @Balizerobot token in a plist snippet, on the default branch of a **public** repo. Replaced with `${TELEGRAM_BOT_TOKEN}` — which is what the surrounding prose already tells the reader to use.

## 2. How it was found
Not by a scanner. While rotating the bot on Zero's order I ran the census I would have wanted the scanner to run:

```
git grep -IE "[0-9]{8,12}:[A-Za-z0-9_-]{35}"
```

Three hits. One is a declared fixture (`FAKE_TOKEN`, `# noqa: S105`, in `test_telegram_token_never_reaches_a_log.py` — the test whose whole subject is that this value must not leak). The other two are these.

Cross-checked against the live surface: the value in these files is byte-identical to `TELEGRAM_BOT_TOKEN` in `~/.nuzantara-secrets.env` on **both** Pro and Mini, and `getMe` on it answers `@Balizerobot`, id `8295471667`. It is not a stale copy.

## 3. Why this is a redaction and not a rotation
The value is in the history of a public repo and must be treated as burned. It is being replaced at the source — @Balizerobot is being decommissioned in favour of a new bot — and this PR removes the copy still served from the default branch. Correcting forward, per the 2026-07-27 ruling on committed credentials.

## 4. The hole this went through (NOT fixed here — separate concern, separate PR)
Nothing objected to this file for months, and nothing would object today:

- `.husky/pre-commit` "Golden Rule #6" runs **only on staged Python files** (`PY_FILES`) and matches only assignment shapes (`api_key = "..."`). A bare token inside a markdown code fence or a plist `<string>` cannot match either condition.
- `Detect Secrets` in CI is green on every PR that carried it.

So the class is: *a Telegram bot token can sit on the public default branch and no guard has an opinion.* Fixing that means a new guard, which needs its own guilt+innocence corpus, and does not belong in a redaction diff.

## 5. Risk
Documentation only, in `docs/archive/`. No code path reads these files. `git grep` for the token pattern on this branch now returns only the declared fixture.