### PR TITLE
refactor(mouth): give the Google review figures one source instead of seven copies

### DIFF
--- a/apps/mouth/src/app/(blog)/_components/GoogleReviewsBlock.tsx
+++ b/apps/mouth/src/app/(blog)/_components/GoogleReviewsBlock.tsx
@@ -1,8 +1,5 @@
 import { Star, MapPin, ArrowUpRight } from "lucide-react";
-
-// Canonical Google reviews — same source as homepage SocialProof.
-// If you edit here, also edit apps/mouth/src/app/v2/_components/SocialProof.tsx.
-const GOOGLE_MAPS_URL = "https://maps.app.goo.gl/whiMUTNchcDR5naz8";
+import { GOOGLE_MAPS_URL, ratingWithReviews } from "@/lib/trust-figures";
 
 const REVIEWS = [
   {
@@ -40,7 +37,7 @@ const REVIEWS = [
 export function GoogleReviewsBlock({
   limit = 7,
   eyebrow = "What clients say",
-  title = "4.9 ★ · 627 Google reviews",
+  title = ratingWithReviews(),
 }: {
   limit?: number;
   eyebrow?: string;

--- a/apps/mouth/src/app/(blog)/contact/page.tsx
+++ b/apps/mouth/src/app/(blog)/contact/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Mail, MessageCircle, MapPin, Clock, ArrowRight } from "lucide-react";
 import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
+import { GOOGLE_MAPS_URL } from "@/lib/trust-figures";
 import { RUMAH_VARS, RUMAH_CLASS } from "@/lib/theme/rumahVars";
 
 export const metadata: Metadata = {
@@ -35,7 +36,7 @@ const CHANNELS = [
     icon: MapPin,
     title: "Office",
     value: "Jalan Raya Anyar n.2, Kerobokan, Bali",
-    href: "https://maps.app.goo.gl/whiMUTNchcDR5naz8",
+    href: GOOGLE_MAPS_URL,
     note: "By appointment — tap to open on Google Maps.",
     accent: "#c8102e",
     fill: "solid" as const,

--- a/apps/mouth/src/app/(blog)/services/page.tsx
+++ b/apps/mouth/src/app/(blog)/services/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
+import { ratingBadge, reviewsLabel } from "@/lib/trust-figures";
 import {
   ArrowRight,
   IdCard,
@@ -99,7 +100,7 @@ const SERVICES: Service[] = [
 
 const TRUST_STRIP = [
   { value: "5,000+", label: "Cases handled since 2019" },
-  { value: "4.9 ★", label: "627 Google reviews" },
+  { value: ratingBadge(), label: reviewsLabel() },
   { value: "18+", label: "Licensed specialists" },
   { value: "2006", label: "Year founded" },
 ];

--- a/apps/mouth/src/app/(blog)/team/page.tsx
+++ b/apps/mouth/src/app/(blog)/team/page.tsx
@@ -6,6 +6,7 @@ import { buildWhatsAppLink } from "@/lib/whatsapp-utm";
 import { GoogleReviewsBlock } from "../_components/GoogleReviewsBlock";
 import { RUMAH_VARS, RUMAH_CLASS } from "@/lib/theme/rumahVars";
 import { rosterBySlug, initialsOf } from "@/data/team-roster";
+import { GOOGLE_RATING, reviewsLabel } from "@/lib/trust-figures";
 
 export const metadata: Metadata = {
   title: "Team",
@@ -394,9 +395,9 @@ export default function TeamPage() {
                 style={{ color: "var(--text-primary)" }}
               >
                 <span style={{ color: "#d4a017" }}>★★★★★</span>
-                <span>4.9</span>
+                <span>{GOOGLE_RATING}</span>
                 <span style={{ color: "var(--text-tertiary)" }}>
-                  · 627 Google reviews
+                  {`· ${reviewsLabel()}`}
                 </span>
               </span>
               <span

--- a/apps/mouth/src/app/v2/_components/SocialProof.tsx
+++ b/apps/mouth/src/app/v2/_components/SocialProof.tsx
@@ -3,9 +3,11 @@
 import Image from "next/image";
 import { Star, MapPin, ArrowUpRight, BadgeCheck } from "lucide-react";
 import { rosterBySlug, initialsOf } from "@/data/team-roster";
-
-// Google reviews link — the public Maps URL you shared.
-const GOOGLE_MAPS_URL = "https://maps.app.goo.gl/whiMUTNchcDR5naz8";
+import {
+  GOOGLE_MAPS_URL,
+  ratingWithReviews,
+  reviewCount,
+} from "@/lib/trust-figures";
 
 // Top team members for the homepage. name/role/photo come from the roster SSOT
 // (apps/mouth/src/data/team-roster.ts); this component keeps only the editorial
@@ -244,7 +246,7 @@ export function SocialProof() {
                     className="text-[12px]"
                     style={{ color: "var(--text-tertiary)" }}
                   >
-                    · 627 reviews
+                    {`· ${reviewCount()} reviews`}
                   </span>
                 </div>
               </div>
@@ -455,7 +457,7 @@ export function SocialProof() {
           />
           <TrustItem
             icon={<Star size={14} strokeWidth={0} fill="currentColor" />}
-            label="4.9 ★ · 627 Google reviews"
+            label={ratingWithReviews()}
           />
           <TrustItem
             icon={<MapPin size={14} strokeWidth={2} />}

--- a/apps/mouth/src/components/trust/TrustBar.tsx
+++ b/apps/mouth/src/components/trust/TrustBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Star, Users, ShieldCheck, Clock } from "lucide-react";
+import { ratingBadge, reviewsShort } from "@/lib/trust-figures";
 
 /**
  * TrustBar — CRO quick-win trust proof banner.
@@ -23,7 +24,7 @@ export function TrustBar(): React.ReactElement {
       >
         <span className="inline-flex items-center gap-1">
           <Star size={10} className="fill-current text-[#fbbf24]" />
-          <span>4.9 ★ · 627 Reviews</span>
+          <span>{`${ratingBadge()} · ${reviewsShort()}`}</span>
         </span>
         <span className="opacity-40">·</span>
         <span className="inline-flex items-center gap-1">
@@ -46,7 +47,7 @@ export function TrustBar(): React.ReactElement {
       <div className="flex md:hidden fixed bottom-0 left-0 right-0 z-40 bg-[#12161f]/95 backdrop-blur-md border-t border-white/10 shadow-lg py-2 px-4 items-center justify-center gap-4 flex-wrap text-[9px] leading-tight text-white/70">
         <span className="inline-flex items-center gap-1">
           <Star size={10} className="fill-current text-[#fbbf24]" />
-          <span>4.9 ★ · 627 Reviews</span>
+          <span>{`${ratingBadge()} · ${reviewsShort()}`}</span>
         </span>
         <span className="opacity-40">·</span>
         <span className="inline-flex items-center gap-1">

--- a/apps/mouth/src/lib/trust-figures.test.ts
+++ b/apps/mouth/src/lib/trust-figures.test.ts
@@ -1,0 +1,107 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  GOOGLE_MAPS_URL,
+  GOOGLE_RATING,
+  GOOGLE_REVIEW_COUNT,
+  MEASURED_ON,
+  ratingBadge,
+  ratingWithReviews,
+  reviewCount,
+  reviewsLabel,
+  reviewsShort,
+} from "./trust-figures";
+
+/**
+ * The Google figures were hand-typed in seven places across five files. The
+ * count read 627 while the live listing had reached 693 — not a lie, just a
+ * measurement frozen into a constant with no single place for the correction
+ * to land. This test exists so the next hand-typed copy fails instead of
+ * quietly re-creating that state.
+ *
+ * Declared limit: this cannot tell whether the figures are CURRENT. Nothing in
+ * this repo can — the listing is external and nobody re-reads it on a
+ * schedule. What it can do is keep the number in one place and keep the
+ * measurement date attached to it, so staleness is visible rather than
+ * invisible. Article content under src/content is out of scope: .mdx prose is
+ * not code and cannot import a module.
+ */
+
+const SRC = join(__dirname, "..");
+const SCANNED = ["app", "components", "lib"];
+const SELF = "trust-figures";
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else if (/\.tsx?$/.test(entry) && !entry.includes(SELF)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const FILES = SCANNED.flatMap((d) => walk(join(SRC, d)));
+
+describe("trust-figures is the only source of the Google figures", () => {
+  it("scans a plausible number of files", () => {
+    // A broken walk would return nothing and let every assertion below pass by
+    // having no files to look at.
+    expect(FILES.length).toBeGreaterThan(100);
+  });
+
+  it("no file hard-codes the review count", () => {
+    const offenders = FILES.filter((f) =>
+      // Anchored to the claim, not the digits: `#596275` contains "627" and an
+      // SVG path contains "6.627". Counting digits measures digits.
+      /\b\d{3,4}\s*(Google\s+)?[Rr]eviews?\b/.test(readFileSync(f, "utf8")),
+    ).map((f) => f.slice(SRC.length + 1));
+    expect(offenders).toEqual([]);
+  });
+
+  it("no file hard-codes the star rating next to a star", () => {
+    const offenders = FILES.filter((f) =>
+      /\b\d\.\d\s*★/.test(readFileSync(f, "utf8")),
+    ).map((f) => f.slice(SRC.length + 1));
+    expect(offenders).toEqual([]);
+  });
+
+  it("no file re-declares the Maps URL", () => {
+    // Declared limit: this bans every maps.app.goo.gl short-link, not just
+    // ours. A future page that legitimately links a DIFFERENT Google listing
+    // will trip it. That is the right default — the three copies this found
+    // were all the same listing, and the contact page's was for directions
+    // rather than reviews, which is exactly the kind of second use that reads
+    // as unrelated and drifts. Narrow it when a genuinely different listing
+    // shows up, not before.
+    const offenders = FILES.filter((f) =>
+      readFileSync(f, "utf8").includes("maps.app.goo.gl"),
+    ).map((f) => f.slice(SRC.length + 1));
+    expect(offenders).toEqual([]);
+  });
+
+  it("the measurement date is a real ISO date, not a placeholder", () => {
+    expect(MEASURED_ON).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(Number.isNaN(Date.parse(MEASURED_ON))).toBe(false);
+  });
+
+  it("formats the shapes the surfaces actually use", () => {
+    expect(reviewCount()).toBe("693");
+    expect(ratingBadge()).toBe("4.9 ★");
+    expect(reviewsLabel()).toBe("693 Google reviews");
+    expect(reviewsShort()).toBe("693 Reviews");
+    expect(ratingWithReviews()).toBe("4.9 ★ · 693 Google reviews");
+  });
+
+  it("innocence: the exported values are the ones the formatters use", () => {
+    // If someone changes GOOGLE_REVIEW_COUNT and not the formatters (or vice
+    // versa), the surfaces and the constant would disagree silently.
+    expect(reviewCount()).toBe(GOOGLE_REVIEW_COUNT.toLocaleString("en-US"));
+    expect(ratingBadge()).toContain(GOOGLE_RATING);
+    expect(GOOGLE_MAPS_URL).toMatch(/^https:\/\/maps\.app\.goo\.gl\//);
+  });
+});

--- a/apps/mouth/src/lib/trust-figures.ts
+++ b/apps/mouth/src/lib/trust-figures.ts
@@ -1,0 +1,60 @@
+/**
+ * Single source for the Google Business Profile figures we publish.
+ *
+ * These are external numbers that move on their own. Before this module they
+ * were typed by hand in seven places across five files, which meant they were
+ * true on the day someone typed them and drifted every day after, with nothing
+ * to re-measure them: the count sat at 627 while the live listing had reached
+ * 693. Nobody was wrong — there was simply no place for the correction to land
+ * once, so it never landed at all.
+ *
+ * A single source does not stop the drift. It makes the next correction one
+ * edit instead of seven, and it puts the measurement date next to the number so
+ * a reader can see how old it is.
+ *
+ * HOW TO UPDATE: open the Google Business Profile listing, read the rating and
+ * the review count, change the three fields below together, and move
+ * MEASURED_ON to the day you read them. Do not update one without the others —
+ * a fresh count beside a stale date is worse than an honestly old number.
+ *
+ * NOT covered here: the "5,000+ clients since 2019" claim that appears on other
+ * surfaces. It has no verifiable source in any system we run — the CRM only
+ * goes back to 2025-12-22 and holds 1,886 live records — so it is deliberately
+ * left where it is rather than given a false home in a module named "source".
+ */
+
+/**
+ * Our Google Business Profile. The figures below are read off it, and the
+ * contact page links to it for directions — one listing, two uses, so it lives
+ * here rather than being typed once per purpose.
+ */
+export const GOOGLE_MAPS_URL = "https://maps.app.goo.gl/whiMUTNchcDR5naz8";
+
+/** Star rating shown on the Google listing. */
+export const GOOGLE_RATING = "4.9";
+
+/** Review count shown on the Google listing. */
+export const GOOGLE_REVIEW_COUNT = 693;
+
+/**
+ * The day the two values above were last read off the live listing.
+ * ISO date, and it is a claim like any other: only change it when you looked.
+ */
+export const MEASURED_ON = "2026-08-14";
+
+/** "693" — grouped for locales that need it once the count passes a thousand. */
+export const reviewCount = (): string =>
+  GOOGLE_REVIEW_COUNT.toLocaleString("en-US");
+
+/** "4.9 ★ · 693 Google reviews" */
+export const ratingWithReviews = (): string =>
+  `${GOOGLE_RATING} ★ · ${reviewCount()} Google reviews`;
+
+/** "693 Google reviews" */
+export const reviewsLabel = (): string => `${reviewCount()} Google reviews`;
+
+/** "693 Reviews" — the shorter form the trust bar uses. */
+export const reviewsShort = (): string => `${reviewCount()} Reviews`;
+
+/** "4.9 ★" */
+export const ratingBadge = (): string => `${GOOGLE_RATING} ★`;


### PR DESCRIPTION
## Summary

The trust bar published "627 Reviews" while the live listing had reached 693. Nobody typed a wrong number — the figure was hand-typed in seven places across five files, so it was true the day each was written and there was no single place for a correction to land. It never landed at all.

`apps/mouth/src/lib/trust-figures.ts` now holds the rating, the count, the Business Profile URL and `MEASURED_ON` (2026-08-14, the day the 693 was read), plus the five formatter shapes the surfaces use. All seven call sites import it.

A third copy of the Business Profile URL turned up in the contact page, used for directions rather than reviews — found by the guard, not by the grep that preceded it, because that grep looked for the constant's NAME and the contact page inlined the URL.

The guard (`trust-figures.test.ts`) fails on a hand-typed count, a hand-typed "N.N ★", or a re-declared Maps URL. It carries a file-count floor so a broken walk cannot pass by having nothing to look at, and the count pattern is anchored to the word "review" — counting digits alone matched `#596275` in globals.css.

Declared limits, in the test: it cannot tell whether the figures are CURRENT — the listing is external and nothing here re-reads it on a schedule. What it can do is keep the number in one place with its measurement date attached, so staleness is visible. `.mdx` article prose is out of scope; it cannot import.

## Verification

- `npx tsc --noEmit` → exit 0, no TypeScript errors.
- `npx vitest run src/lib/ src/components/` → 217 test files passed (217), 2056 tests passed (2056), 0 failures.
- The three guard assertions (hand-typed count / hand-typed rating / re-declared Maps URL) were each mutation-verified to fire individually on their own mutation.

## Not in this PR

The "5,000+ clients since 2019" claim on other surfaces is NOT included. The CRM holds 1,886 live records and its earliest `created_at` is 2025-12-22, so nothing we run substantiates it. It is deliberately left where it is rather than given a false home in a module named "source" — that is an open business decision for the owner, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)