### PR TITLE
fix(seo): read aggregateRating from trust-figures

### DIFF
--- a/apps/mouth/src/components/seo/JsonLd.test.tsx
+++ b/apps/mouth/src/components/seo/JsonLd.test.tsx
@@ -1,0 +1,95 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { GOOGLE_RATING, GOOGLE_REVIEW_COUNT } from "@/lib/trust-figures";
+import { AggregateRatingJsonLd } from "./JsonLd";
+
+/**
+ * AggregateRatingJsonLd is rendered from the ROOT layout
+ * (apps/mouth/src/app/layout.tsx:254), so this block ships on every page —
+ * including pages that show no review figure at all.
+ *
+ * It used to carry its own hand-typed rating and count. Measured live on
+ * 2026-08-14 at age:0 / x-vercel-cache: MISS, https://balizero.com/ served —
+ * in ONE response — a trust bar rendered from trust-figures.ts beside a
+ * JSON-LD block claiming a higher rating from a larger count. Same page, two
+ * different claims, and the schema one is the claim Google reads.
+ *
+ * These tests assert against the imported constants, never against the
+ * figures written out. A test that re-types the number is another copy of
+ * the defect wearing a green tick — and the guards in
+ * src/lib/trust-figures.test.ts enforce that on this file too: an earlier
+ * draft of this very comment quoted the figures and was correctly rejected.
+ *
+ * Declared limit: this proves the schema and the module agree. It cannot
+ * prove either is CURRENT — the Google listing is external and nothing in
+ * this repo re-reads it. MEASURED_ON in trust-figures.ts is what makes that
+ * staleness visible.
+ */
+
+/** Extract the JSON-LD payload the component embeds in its <script> tag.
+ *
+ * String ops, not a regex on HTML: CodeQL's js/bad-tag-filter flags a
+ * hand-rolled `<script>...</script>` regex as unsound. Same approach as
+ * apps/mouth/src/components/kbli/KBLIStructuredData.test.tsx.
+ */
+function aggregateRatingSchema(): Record<string, unknown> {
+  const html = renderToStaticMarkup(<AggregateRatingJsonLd />);
+  const openTag = html.indexOf("<script");
+  const start = html.indexOf(">", openTag) + 1;
+  const end = html.lastIndexOf("</script>");
+  expect(openTag).toBeGreaterThanOrEqual(0);
+  expect(start).toBeGreaterThan(0);
+  expect(end).toBeGreaterThanOrEqual(0);
+  return JSON.parse(html.slice(start, end));
+}
+
+function ratingBlock(): Record<string, unknown> {
+  const rating = aggregateRatingSchema().aggregateRating;
+  // Guard the premise: if the shape moved, every assertion below would pass
+  // vacuously against `undefined`.
+  expect(rating, "schema has no aggregateRating block").toBeTypeOf("object");
+  return rating as Record<string, unknown>;
+}
+
+describe("AggregateRatingJsonLd reads its figures from trust-figures", () => {
+  it("guilt: ratingValue is the module's rating, not a second copy", () => {
+    expect(ratingBlock().ratingValue).toBe(GOOGLE_RATING);
+  });
+
+  it("guilt: ratingCount and reviewCount are the module's count", () => {
+    const rating = ratingBlock();
+    expect(rating.ratingCount).toBe(String(GOOGLE_REVIEW_COUNT));
+    expect(rating.reviewCount).toBe(String(GOOGLE_REVIEW_COUNT));
+  });
+
+  it("guilt: schema.org wants strings, so the count is converted, not coerced", () => {
+    const rating = ratingBlock();
+    expect(typeof rating.ratingCount).toBe("string");
+    expect(typeof rating.reviewCount).toBe("string");
+    expect(typeof rating.ratingValue).toBe("string");
+  });
+
+  it("innocence: the scale constants are untouched", () => {
+    // bestRating/worstRating describe schema.org's 1-5 scale. They are not
+    // measurements and must NOT follow the Google figures.
+    const rating = ratingBlock();
+    expect(rating.bestRating).toBe("5");
+    expect(rating.worstRating).toBe("1");
+    expect(rating["@type"]).toBe("AggregateRating");
+  });
+
+  it("innocence: the surrounding schema is unchanged", () => {
+    const schema = aggregateRatingSchema();
+    expect(schema["@context"]).toBe("https://schema.org");
+    expect(schema["@type"]).toBe("ProfessionalService");
+    expect(schema.name).toBe("Bali Zero");
+    expect(schema.priceRange).toBe("$$");
+    expect(schema.address).toEqual({
+      "@type": "PostalAddress",
+      addressLocality: "Bali",
+      addressCountry: "ID",
+    });
+    expect(typeof schema.url).toBe("string");
+    expect(typeof schema["@id"]).toBe("string");
+  });
+});

--- a/apps/mouth/src/components/seo/JsonLd.tsx
+++ b/apps/mouth/src/components/seo/JsonLd.tsx
@@ -6,6 +6,7 @@
  * to ensure JSON-LD is present in the static HTML for Googlebot and validators.
  */
 
+import { GOOGLE_RATING, GOOGLE_REVIEW_COUNT } from "@/lib/trust-figures";
 import { WA_NUMBER } from "@/lib/whatsapp-utm";
 
 const baseUrl = process.env.NEXT_PUBLIC_PUBLIC_URL || "https://balizero.com";
@@ -341,11 +342,18 @@ export function AggregateRatingJsonLd() {
     url: baseUrl,
     aggregateRating: {
       "@type": "AggregateRating",
-      ratingValue: "5.0",
+      // Read off the same module the visible pages read, so the rich snippet
+      // and the page cannot disagree. Before this these three fields were
+      // hand-typed here and had drifted: the schema claimed a higher rating
+      // from a larger count than the trust bar rendered beside it, in the
+      // same HTTP response. Figures live in src/lib/trust-figures.ts.
+      ratingValue: GOOGLE_RATING,
+      // bestRating/worstRating are schema.org scale constants, not measured
+      // figures: they stay literal on purpose.
       bestRating: "5",
       worstRating: "1",
-      ratingCount: "700",
-      reviewCount: "700",
+      ratingCount: String(GOOGLE_REVIEW_COUNT),
+      reviewCount: String(GOOGLE_REVIEW_COUNT),
     },
     priceRange: "$$",
     address: {

--- a/apps/mouth/src/lib/trust-figures.test.ts
+++ b/apps/mouth/src/lib/trust-figures.test.ts
@@ -70,6 +70,60 @@ describe("trust-figures is the only source of the Google figures", () => {
     expect(offenders).toEqual([]);
   });
 
+  // The two guards above match the PROSE form — a number followed by the word
+  // "reviews", or a number followed by a star. Structured data writes the same
+  // claim the other way round, as a key: `reviewCount: "700"`. That is why
+  // JsonLd.tsx kept a hand-typed 700 (and a ratingValue of 5.0 against the
+  // page's 4.9) straight through the PR that added these guards — the guard
+  // that let the defect past was part of the defect. These two add the key
+  // form; they do not replace the prose form, which still catches the shape
+  // a page renders.
+  it("no file hard-codes the count as a schema key", () => {
+    const offenders = FILES.filter((f) =>
+      // Requires a literal number after the colon, so `String(GOOGLE_REVIEW_COUNT)`
+      // passes. Two digits minimum, so a `reviewCount: 0` default passes too —
+      // the workspace sidebar has a prop of the same name that counts documents,
+      // and a homonym is not a claim about Google.
+      /(ratingCount|reviewCount)\s*:\s*"?\d{2,5}"?/.test(
+        readFileSync(f, "utf8"),
+      ),
+    ).map((f) => f.slice(SRC.length + 1));
+    expect(offenders).toEqual([]);
+  });
+
+  it("no file hard-codes the rating as a schema key", () => {
+    const offenders = FILES.filter((f) =>
+      /ratingValue\s*:\s*"?\d\.\d"?/.test(readFileSync(f, "utf8")),
+    ).map((f) => f.slice(SRC.length + 1));
+    expect(offenders).toEqual([]);
+  });
+
+  it("innocence: the new key-form guards do not fire on the cured shapes", () => {
+    // Measured against the exact strings the cure introduces, plus the
+    // schema.org scale constants and the workspace homonym. A guard that
+    // trips on its own remedy teaches the next person to delete it.
+    const key = /(ratingCount|reviewCount)\s*:\s*"?\d{2,5}"?/;
+    const star = /ratingValue\s*:\s*"?\d\.\d"?/;
+    for (const cured of [
+      'import { GOOGLE_RATING, GOOGLE_REVIEW_COUNT } from "@/lib/trust-figures";',
+      "      ratingValue: GOOGLE_RATING,",
+      "      ratingCount: String(GOOGLE_REVIEW_COUNT),",
+      "      reviewCount: String(GOOGLE_REVIEW_COUNT),",
+      '      bestRating: "5",',
+      '      worstRating: "1",',
+      "  reviewCount?: number;",
+      "  reviewCount = 0,",
+      "  reviewCount={gateStatus?.sections?.documents?.count ?? 0}",
+    ]) {
+      expect(key.test(cured), `key guard fired on: ${cured}`).toBe(false);
+      expect(star.test(cured), `star guard fired on: ${cured}`).toBe(false);
+    }
+    // guilt: the shapes they must still catch
+    expect(key.test('      ratingCount: "700",')).toBe(true);
+    expect(key.test('      reviewCount: "700",')).toBe(true);
+    expect(star.test('      ratingValue: "5.0",')).toBe(true);
+  });
+
   it("no file re-declares the Maps URL", () => {
     // Declared limit: this bans every maps.app.goo.gl short-link, not just
     // ours. A future page that legitimately links a DIFFERENT Google listing


### PR DESCRIPTION
## Insight

The homepage publishes two different ratings in the same HTTP response. The trust bar renders `4.9 ★ · 693 Reviews` from `apps/mouth/src/lib/trust-figures.ts`; the JSON-LD block a few kilobytes above it claims a perfect `5.0` from `700`. The schema one is the claim Google reads and turns into stars in the search result, so the number we have never verified is the number that reaches people who have not visited the site yet.

PR #4170 (merge commit `ad1ecbc9e4c26cd43f31598952d3ce24dd2035a2`, timeline `2026-08-14T03:49:11Z`) consolidated the five React surfaces into one module. It did not reach `JsonLd.tsx`, and — this is the load-bearing part — the anti-hardcode guard it shipped *could not* have caught it. That guard matches the prose form, a number followed by the word "reviews". Structured data writes the same claim the other way round, as a key: `reviewCount: "700"`. The guard that let this defect past is part of the defect, so this PR widens it in the same change.

## Studio

No visual change to end users. This is a structured-data change to the JSON-LD `aggregateRating` block rendered from the root layout.

## Source

- `apps/mouth/src/components/seo/JsonLd.tsx:344` — `ratingValue: "5.0"`
- `apps/mouth/src/components/seo/JsonLd.tsx:345` — `bestRating: "5"` (left literal)
- `apps/mouth/src/components/seo/JsonLd.tsx:346` — `worstRating: "1"` (left literal)
- `apps/mouth/src/components/seo/JsonLd.tsx:347` — `ratingCount: "700"`
- `apps/mouth/src/components/seo/JsonLd.tsx:348` — `reviewCount: "700"`
- `apps/mouth/src/components/seo/JsonLd.tsx:335-365` — `AggregateRatingJsonLd()`, server component, one pre-existing import
- `apps/mouth/src/app/layout.tsx:254` — `<AggregateRatingJsonLd />`, root layout, therefore every page
- `apps/mouth/src/lib/trust-figures.ts:34` — `GOOGLE_RATING = "4.9"`
- `apps/mouth/src/lib/trust-figures.ts:37` — `GOOGLE_REVIEW_COUNT = 693`
- `apps/mouth/src/lib/trust-figures.test.ts:57-71` — the two prose-form guards
- `apps/mouth/src/lib/trust-figures.test.ts:31-48` — `walk()`, `.ts/.tsx` under `app|components|lib` only

## Methodology

1. Read both files whole off `origin/main` rather than from memory; line numbers below are the measured ones, and three of them differ from the ones I was given.
2. Mapped every consumer with `git grep`, reporting counts in lines and files.
3. Ran the two existing guard regexes against the real contents of `JsonLd.tsx` in Python to see whether they fire — rather than reasoning about whether they should.
4. Probed each candidate replacement regex against a fixed corpus of guilt and innocence strings *before* writing it into the test, then swept both patterns over all 1365 files `walk()` actually scans.
5. Mutation-verified all three assertions by reverting each cured line one at a time and recording exactly which tests fall.
6. Measured the live surface with a cache-buster and read `age` / `x-vercel-cache` together with the body, so a `HIT` could not be mistaken for evidence.

## Raw Observations

Live, `https://balizero.com/?cb=<epoch>`, measured 2026-08-14T07:42:40Z, `age: 0`, `x-vercel-cache: MISS` — a fresh render, not a cached one. Served deployment `dpl_7j4iWX9dzFGoeARQUY7x8v9qx7Bz`:

```
JSON-LD block :  "ratingValue":"5.0"  "ratingCount":"700"  "reviewCount":"700"
                 "bestRating":"5"     "worstRating":"1"
visible HTML  :  4.9 ★ · 693 Reviews
```

One response, two claims.

Static counts, unit = LINES unless stated:

- `ratingValue|ratingCount|reviewCount` across `apps` + `packages`: **22 lines** in **11 files**. Only **3** are schema.org — `JsonLd.tsx:344/347/348`. The rest are homonyms: a `reviewCount` prop on the workspace sidebar counting documents, plus the `trust-figures` module and its test.
- `aggregateRating|AggregateRating`: **8 lines** in **3 files**. Rendered once, from the root layout.
- Sibling files swept for safety: `DynamicJsonLd.tsx` has no rating fields at all; `EnhancedJsonLd.tsx` has only `lastReviewed`/`reviewedBy`, which is Article schema. The `aggregateRating` surface is exactly one file.

Positive control, so the zeros below can be trusted — the same pattern shape returns non-zero in both directions:

- `(review|Reviews)[^0-9]{0,20}693` → **4 lines** (`trust-figures.ts:37` + its test at 93/95/96)
- `(review|Reviews)[^0-9]{0,20}700` → **6 lines** (`JsonLd.tsx:348` + five locale files)

The existing guards run against the real file contents, in Python, before any change:

```
guard /\b\d{3,4}\s*(Google\s+)?[Rr]eviews?\b/  vs JsonLd.tsx : False  (no match)
guard /\b\d\.\d\s*★/                           vs JsonLd.tsx : False  (no match)
control '693 Google reviews'                                 : True   <- guard is capable
control '4.9 ★'                                              : True   <- guard is capable
control 'reviewCount: "700",'                                : False  <- the blind spot
```

The new key-form patterns, probed against 11 innocence strings and 3 guilt strings before being written into the test — 11/11 pass, 3/3 catch:

```
(ratingCount|reviewCount)\s*:\s*"?\d{2,5}"?
  catches : ratingCount: "700",   reviewCount: "700",
  passes  : String(GOOGLE_REVIEW_COUNT) · GOOGLE_REVIEW_COUNT import · bestRating: "5"
            worstRating: "1" · reviewCount?: number; · reviewCount = 0,
            reviewCount={gateStatus?.sections?.documents?.count ?? 0}
            GOOGLE_REVIEW_COUNT = 693 · export const reviewCount = (): string =>
ratingValue\s*:\s*"?\d\.\d"?
  catches : ratingValue: "5.0",
  passes  : ratingValue: GOOGLE_RATING,  + all of the above
```

Swept over the corpus `walk()` really scans — **1365 files** — both new patterns return **0 offenders** on this branch, and both match the pre-change `JsonLd.tsx`.

Mutation verification, unit = TESTS:

| mutation | tests that fall | which |
|---|---|---|
| `ratingCount` back to literal `"700"` | **2** | `guilt: ratingCount and reviewCount are the module's count` · `no file hard-codes the count as a schema key` |
| `ratingValue` back to literal `"5.0"` | **2** | `guilt: ratingValue is the module's rating, not a second copy` · `no file hard-codes the rating as a schema key` |
| `bestRating` changed to `"6"` | **1** | `innocence: the scale constants are untouched` |

Two rather than one on the first two mutations is the intended shape, not noise: one assertion proves the rendered schema changed, the other proves the widened guard now sees the key form. The third mutation moves a constant that is *not* a measured figure, and correctly trips only the innocence test — neither guard fires on it.

While writing this, the guards caught **me**, in two files: an earlier draft of the explanatory comment in `JsonLd.tsx` and of the docstring in `JsonLd.test.tsx` quoted the figures in prose, and the pre-existing prose guard rejected both. I rewrote the prose. I did not add a filename exemption — a guard that gets an exception carved for its own author is a guard that stops working.

## Reasoning Path

The narrow fix is three lines in `JsonLd.tsx`. I widened the guard as well, in the same PR, because the two are one defect. A hand-typed copy survived a refactor whose stated purpose was to remove hand-typed copies, and it survived precisely where the guard was blind. Ship only the three lines and the same class walks back in through the same hole the next time someone writes structured data — and it will read as covered, because a test with that name exists.

I did not touch `bestRating` or `worstRating`. They describe schema.org's 1-5 scale, not anything we measured off a listing; binding them to the Google figures would be a second error dressed as consistency.

`String(GOOGLE_REVIEW_COUNT)` is explicit rather than leaning on `JSON.stringify` coercion, because schema.org expects strings and a silent numeric would be a different payload. `GOOGLE_RATING` is already a string and is passed through unwrapped.

The new tests import the constants and never re-type `4.9` or `693`. A test that spells the number out is a fourth copy of the defect wearing a green tick.

## Risk

- **Google may keep serving the old rich snippet for weeks.** Re-crawl is on their schedule, not ours, so a `5.0` with `700` reviews can persist in search results after this merges. Nothing here is broken if that happens; it just means the fix is not observable in the SERP on merge day. If it matters commercially, request re-indexing in Search Console.
- **The rating in search results will drop from 5.0 to 4.9 once re-crawled.** That is the point — the 5.0 was never measured — but it is a visible change to a marketing surface, so it should not arrive as a surprise.
- **This does not make the figures current.** It makes them singular. The listing is external and nothing in this repo re-reads it; `MEASURED_ON` is what keeps the staleness visible.
- **Branch base.** Cut from `d5f34fe53b6c1b0332d5780417c79ed6cb971ecf`; `origin/main` has since moved to `7e69cab001a9a9d0d7ef8bdf30ded5be72f63262`. No overlapping files, but it will want an update-branch before the queue.

## Implication

Every page on `balizero.com` currently ships an unverified `aggregateRating`. That is the surface search engines and AI answer engines read, and it is the one surface nobody looks at when checking whether the site "says the right number", because it is invisible in the browser. After this, the schema and the page cannot disagree: they read the same constant, and the guard fails the build if a future edit re-types either shape.

## Recommendation

Raise the five locale files as a **separate PR, and propose deletion rather than runtime interpolation**.

`services.reviews.reviewCount` holds `"700+"` at line 174 of `en`, `fr`, `id`, `it`, `ru`, with **zero measured readers**:

```
'onGoogleMaps' (unique sibling key, same block) -> 0 lines
'services\.reviews|reviews\.reviewCount'        -> 0 lines
t("services.…                                   -> 0 lines
```

Positive control that the tool can see `t()` calls at all: **159 call sites** of `t("namespace.key")`, across `garudaVoa` (101), `secondHome` (25), `commandPalette` (17), `LicensingSection` (14), `page` (12), `common` (9), `portal` (4), `chat` (3). `services` does not appear among them. `useTranslation()` is called 13 times and **always without a namespace argument**, so there is no `useTranslation("services")` + `t("reviews.reviewCount")` path either.

Wiring dead keys to a live constant would make five stale strings look maintained. Deleting them removes a claim nobody renders.

## Next Action

Antonello reviews and merges. Auto-merge is not armed and this is not promoted.

Local verification is reported honestly rather than as a checkmark:

- `npx vitest run src/components/seo/ src/lib/trust-figures.test.ts` — **17 passed / 3 files**, plus the three mutations above.
- `npm run lint` — **crashes before linting anything**: `TypeError: scopeManager.addGlobals is not a function`, ESLint 10.3.0. Pre-existing and environmental, not from this diff: `npx eslint src/components/seo/AnswerBox.tsx`, a file this PR does not touch, crashes too (in `eslint-plugin-react`). No workflow under `.github/workflows/` runs `npm run lint` for `apps/mouth`, so this is a local tooling break worth its own item, not a gate this PR is dodging.
- `npm run build` — result recorded in the PR thread; the build script regenerates `llms-full.txt` as a side effect, which is deliberately kept out of this commit.
