### PR TITLE
test(portal): cover both scroll guards in PortalMessages

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.test.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * PortalMessages — scroll-guard coverage.
+ *
+ * PR #4152 (commit ac1a3b21a, "stop client page auto-scrolling on initial
+ * message load") added two guards to the scroll effect at
+ * apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.tsx:55-68
+ * and shipped with zero test files — before or after. The guards are:
+ *
+ *   GUARD-A  line 58  `!hasSeenData.current`          -> first data arrival never scrolls
+ *   GUARD-B  line 64  `length > prevMessageCountRef`  -> only a GROWN count scrolls
+ *
+ * Two guards, two different bugs. Deleting either one leaves the other bug
+ * open, so each guard gets a guilt test, and the feature itself gets two
+ * innocence tests:
+ *
+ *   (a) guilt      first load must NOT scroll        -> dies if GUARD-A is removed
+ *   (b) guilt      same-count poll must NOT scroll   -> dies if GUARD-B is removed
+ *   (c) innocence  a new incoming message MUST scroll
+ *   (d) innocence  sending your own message MUST scroll
+ *
+ * (c) and (d) are what stop the next reader from "simplifying" one guard
+ * away because it looks redundant: with both guards gone the component still
+ * scrolls on new messages, so guilt tests alone would let a change that
+ * breaks the actual feature look green.
+ *
+ * (a) deliberately loads >= 1 message. GUARD-0 (line 56, `length === 0`)
+ * returns before GUARD-A ever runs, so an empty first load would make (a)
+ * pass without exercising GUARD-A at all — green while testing nothing.
+ *
+ * (a) turns out to cover GUARD-0 as well: deleting line 56 also kills it.
+ * The initial render carries an empty `messages`, so without GUARD-0 that
+ * render spends the `hasSeenData` flag, and the first real batch then falls
+ * straight through to GUARD-B (2 > 0) and scrolls. GUARD-0 is what makes
+ * GUARD-A land on the first DATA rather than the first RENDER — it is not
+ * a decorative early-out.
+ *
+ * Timer pattern (fake timers + advanceTimersByTimeAsync inside act) is taken
+ * from src/components/portal/PortalBottomNav.test.tsx:177-202, which polls the
+ * same 30s interval. Neither test file in this directory uses timers at all,
+ * so the prior art comes from a file that is already green elsewhere in the
+ * repo rather than from a new style introduced by this PR.
+ *
+ * scrollIntoView is already stubbed globally at src/test/setup.tsx:133
+ * (`Element.prototype.scrollIntoView = vi.fn()`). That stub is one vi.fn()
+ * shared across files, so the handle is re-read and cleared explicitly in
+ * beforeEach rather than trusting vi.clearAllMocks() alone.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { PortalMessages } from "./PortalMessages";
+import { api } from "@/lib/api";
+import type { PortalMessageThread } from "@/lib/api/crm/crm.types";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    crm: {
+      getPortalMessages: vi.fn(),
+      sendPortalMessage: vi.fn(),
+      markPortalMessageRead: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+const CLIENT_ID = 42;
+const CLIENT_NAME = "Test Client";
+const POLL_INTERVAL_MS = 30000; // PortalMessages.tsx:51
+
+// direction "team_to_client" keeps the mark-as-read branch (PortalMessages.tsx:38)
+// out of the picture entirely — it only fires for unread client_to_team rows.
+const makeMessage = (id: number): PortalMessageThread => ({
+  id,
+  content: `Portal message ${id}`,
+  direction: "team_to_client",
+  sent_by: "agent@balizero.com",
+  read_at: "2026-08-14T02:00:00Z",
+  created_at: "2026-08-14T01:00:00Z",
+});
+
+const TWO_MESSAGES = [makeMessage(1), makeMessage(2)];
+const THREE_MESSAGES = [makeMessage(1), makeMessage(2), makeMessage(3)];
+
+/**
+ * Queue one response batch per call, last batch repeating.
+ *
+ * Each call returns a FRESH array. This is not cosmetic: the real
+ * getPortalMessages parses a new JSON payload every poll, so `setMessages`
+ * always receives a new object identity and the `[messages]` effect always
+ * re-runs. Handing back one shared array object instead makes setMessages an
+ * Object.is no-op — React skips the re-render, the effect never fires, and a
+ * test for GUARD-B would pass without ever reaching GUARD-B. Measured: with a
+ * shared array, deleting GUARD-B killed 0 tests; with a fresh array it kills
+ * exactly the poll test.
+ */
+const respondWith = (...batches: PortalMessageThread[][]) => {
+  let call = 0;
+  vi.mocked(api.crm.getPortalMessages).mockImplementation(async () => {
+    const batch = batches[Math.min(call, batches.length - 1)];
+    call += 1;
+    return { messages: [...batch], total: batch.length };
+  });
+};
+
+/** Rendered message bodies — PortalMessages.tsx:163 renders one <p> per message. */
+const renderedMessageCount = () =>
+  screen.queryAllByText(/^Portal message \d+$/).length;
+
+const advance = async (ms: number) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+};
+
+const renderComponent = () =>
+  render(<PortalMessages clientId={CLIENT_ID} clientName={CLIENT_NAME} />);
+
+describe("PortalMessages scroll guards", () => {
+  let scrollSpy: Mock;
+
+  beforeEach(() => {
+    // Premise check: every assertion below is meaningless if the global stub
+    // is not a mock. Fail loudly here instead of silently asserting nothing.
+    if (!vi.isMockFunction(Element.prototype.scrollIntoView)) {
+      throw new Error(
+        "premise broken: Element.prototype.scrollIntoView is not a vi.fn(). " +
+          "Expected the global stub at apps/mouth/src/test/setup.tsx:133.",
+      );
+    }
+    scrollSpy = Element.prototype.scrollIntoView as unknown as Mock;
+
+    vi.clearAllMocks();
+    scrollSpy.mockClear(); // explicit: the stub is shared across test files
+
+    vi.mocked(api.crm.getPortalMessages).mockReset();
+    vi.mocked(api.crm.sendPortalMessage).mockReset();
+    vi.mocked(api.crm.markPortalMessageRead).mockReset();
+    vi.mocked(api.crm.markPortalMessageRead).mockResolvedValue(undefined);
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("first load does not scroll", async () => {
+    respondWith(TWO_MESSAGES);
+
+    renderComponent();
+    await advance(100);
+
+    // Premise: messages actually arrived and rendered. Without this the test
+    // would also pass on an empty load, where GUARD-0 short-circuits and
+    // GUARD-A is never reached.
+    expect(renderedMessageCount()).toBe(2);
+    expect(api.crm.getPortalMessages).toHaveBeenCalledWith(CLIENT_ID);
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it("a poll returning the same count does not scroll", async () => {
+    respondWith(TWO_MESSAGES);
+
+    renderComponent();
+    await advance(100);
+
+    expect(renderedMessageCount()).toBe(2);
+    const callsAfterFirstLoad = vi.mocked(api.crm.getPortalMessages).mock.calls
+      .length;
+    expect(callsAfterFirstLoad).toBeGreaterThanOrEqual(1);
+
+    // The first load owns its own claim in test (a); this test owns the poll.
+    scrollSpy.mockClear();
+
+    await advance(POLL_INTERVAL_MS);
+
+    // Premise: the poll really fired and the count really stayed the same.
+    // "Did not scroll" proves nothing if nothing happened.
+    expect(
+      vi.mocked(api.crm.getPortalMessages).mock.calls.length,
+    ).toBeGreaterThan(callsAfterFirstLoad);
+    expect(renderedMessageCount()).toBe(2);
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+
+  it("a new incoming message scrolls", async () => {
+    respondWith(TWO_MESSAGES, THREE_MESSAGES);
+
+    renderComponent();
+    await advance(100);
+
+    expect(renderedMessageCount()).toBe(2);
+    scrollSpy.mockClear();
+
+    await advance(POLL_INTERVAL_MS);
+
+    expect(renderedMessageCount()).toBe(3);
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  it("sending your own message scrolls", async () => {
+    respondWith(TWO_MESSAGES, THREE_MESSAGES);
+    vi.mocked(api.crm.sendPortalMessage).mockResolvedValue(makeMessage(3));
+
+    renderComponent();
+    await advance(100);
+
+    expect(renderedMessageCount()).toBe(2);
+    scrollSpy.mockClear();
+
+    // The Send button is disabled while newMessage is empty
+    // (PortalMessages.tsx:206), and handleSend returns early on a blank input
+    // (PortalMessages.tsx:71) — so the input has to be filled first. The real
+    // chain runs from here: handleSend -> sendPortalMessage -> loadMessages.
+    fireEvent.change(screen.getByPlaceholderText(`Message ${CLIENT_NAME}...`), {
+      target: { value: "Reply from team" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    await advance(100);
+
+    expect(api.crm.sendPortalMessage).toHaveBeenCalledWith(
+      CLIENT_ID,
+      "Reply from team",
+    );
+    expect(renderedMessageCount()).toBe(3);
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Insight

`PortalMessages` carries two scroll guards and, until this PR, zero tests. The two guards are not redundant: each one blocks a different bug, and deleting either leaves the other bug open. Mutation testing proves the separation — each guard, deleted on its own, kills exactly one test and no more.

It also proved my first version of the poll test wrong. That test was green, rendered the right number of messages, and confirmed the poll fired — and still never reached the guard it claimed to cover. The mutation is what caught it; the premise checks did not.

## Studio

No visual change to end users. This adds test coverage for two existing scroll guards in the client portal message list.

## Source

- Component under test: `apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.tsx`
  - GUARD-0, line 56 — `if (messages.length === 0) return;`
  - GUARD-A, lines 58-62 — `if (!hasSeenData.current) { ...; return; }`
  - GUARD-B, line 64 — `if (messages.length > prevMessageCountRef.current)`
  - scroll call site, line 65 — `messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })`
  - poll interval, line 51 — `setInterval(loadMessages, 30000)`
  - send chain, lines 70-83 — `handleSend` -> `sendPortalMessage` (74) -> `await loadMessages()` (76)
- Guards introduced by: commit `ac1a3b21a` — `fix(portal): stop client page auto-scrolling on initial message load (#4152)`
- New file: `apps/mouth/src/app/(workspace)/clients/[id]/components/PortalMessages.test.tsx` (239 lines)
- Timer prior art: `apps/mouth/src/components/portal/PortalBottomNav.test.tsx:177-202`
- Mock/assertion prior art: `apps/mouth/src/app/(workspace)/clients/[id]/components/PassportCard.test.tsx`, `.../BusinessStoryPanel.test.tsx`
- Global scroll stub: `apps/mouth/src/test/setup.tsx:133`
- Parent-page mock that provides no coverage: `apps/mouth/src/app/(workspace)/clients/[id]/page.test.tsx:97-98`
- eslint ignore pattern: `apps/mouth/eslint.config.mjs:15`

## Methodology

1. Read the component and both existing tests in its directory at `origin/main`, not from a summary.
2. Wrote four tests — two guilt, two innocence — each named for its claim rather than its mechanism.
3. Added a premise check to every test: assert the messages actually rendered, and for the poll test assert the poll actually fired. A test that passes because nothing happened is not a test.
4. Ran a vacuity probe: forced every fixture to return zero messages and confirmed all four tests fail.
5. Mutated each guard one at a time, ran the suite, restored, and verified the component was byte-identical after every restore.
6. Added a third mutation for GUARD-0, which nobody asked to be covered, to find out whether it was load-bearing.

Timer handling uses fake timers with `advanceTimersByTimeAsync` inside `act`, taken from `PortalBottomNav.test.tsx:177-202`, which polls the same 30s interval. Neither test file in this directory uses timers at all, so the prior art comes from a file already green elsewhere in the repo rather than from a new style introduced here.

The scroll stub at `src/test/setup.tsx:133` is one `vi.fn()` shared across test files, so the handle is re-read and cleared explicitly in `beforeEach` instead of relying on `vi.clearAllMocks()` alone. `beforeEach` also throws if that stub is not a mock function, so the suite fails loudly rather than asserting against nothing.

## Raw Observations

Measured on branch `sancho/portal-messages-scroll-tests`, commit `b1520bf3d`, based on `origin/main` = `d01c2b355`, re-measured while writing this body and still level with it. One commit ahead of `origin/main`, not pushed.

The whole mutation matrix below was re-run a second time against the final committed file, after the pre-commit hook required a prettier reformat of one `fireEvent.change` call. Identical results both times. The numbers describe the artifact that ships, not an earlier draft of it.

**Baseline** — 4 of 4 tests pass, exit 0.

**Mutation results** (one mutation at a time, component restored and sha-verified between each):

| Mutation | Site | Tests fallen | Which test |
|---|---|---|---|
| Mutasi-1: delete GUARD-A | lines 58-62 | **1 of 4** | `first load does not scroll` |
| Mutasi-2: scroll unconditionally | lines 64-66 | **1 of 4** | `a poll returning the same count does not scroll` |
| Mutasi-3: delete GUARD-0 | line 56 | **1 of 4** | `first load does not scroll` |

Every mutation killed exactly one test. No mutation killed zero, and none killed more than one, so the tests do not overlap.

**Mutasi-2 first returned 0 of 4, and the fix was to the test, not the component.** The first version of the poll test reused one module-level array object for every mocked response. `setMessages` received the same object identity each poll, React skipped the re-render by `Object.is`, and the `[messages]` effect never ran — so the test never reached GUARD-B and passed for the wrong reason. This was invisible to the premise checks already in place: 2 messages did render, and the poll call count did grow. Only the mutation exposed it. The mock now returns a fresh array per call, which is what the real `getPortalMessages` does on every poll since it parses a new JSON payload. With that single change and the same mutation applied, Mutasi-2 went from 0 fallen to exactly 1.

**Vacuity probe** — with every fixture forced to zero messages, **4 of 4 tests fail** (exit 1). Run once against the first version of the test and again against the final version. No test is green when nothing renders.

**Rendered message counts** (asserted, not merely observed):

| Test | After first load | After the event |
|---|---|---|
| (a) first load does not scroll | 2 | — |
| (b) same-count poll does not scroll | 2 | 2 |
| (c) new incoming message scrolls | 2 | 3 |
| (d) sending your own message scrolls | 2 | 3 |

**Positive control for "zero tests before"** — "zero" only means something if the directory is otherwise tested:

- Directory `apps/mouth/src/app/(workspace)/clients/[id]/components/` at `origin/main`, **top level**: 2 `.test.tsx` (`PassportCard.test.tsx`, `BusinessStoryPanel.test.tsx`) against 17 non-test `.tsx`.
- Same directory **recursively**: 3 `.test.tsx` (adds `modals/EditClientModal.test.tsx`) against 34 non-test `.tsx`. Both figures are given because they differ in scope; the recursive one is the honest answer to "does this directory have tests".
- `git log --all --diff-filter=A -- '*PortalMessages.test.tsx'` returns **empty** — no such file has ever existed in any branch, at any point in history.
- `git show --stat ac1a3b21a` — **1 file changed, 14 insertions(+), 1 deletion(-)**. PR #4152 shipped both guards with no test file.
- `apps/mouth/src/app/(workspace)/clients/[id]/page.test.tsx:97-98` does mention `PortalMessages`, but replaces it with `PortalMessages: () => <div data-testid="PortalMessages" />`. It is a stub, so it exercises none of the guards. "Zero coverage before" survives that reference intact.

A `git grep -n 'PortalMessages' origin/main` returns 15 lines across 8 files, but only 4 lines across 2 files refer to this component as an entity (definition, import, render, and the two mock lines). The rest are substring collisions with `getPortalMessages` and `usePortalMessages`, the latter being an unrelated portal-side hook.

**Suite and build**

- `npx vitest run 'src/app/(workspace)/clients/[id]/components/'` — **13 passed (13), 4 files passed, exit 0**.
- `npm run build` — **exit 0**.
- The build regenerated the tracked 25 MB artifact `apps/mouth/public/llms-full.txt` (1841 insertions, 1796 deletions). Restored with `git restore`; it is not in this commit. Final `git diff --stat` on tracked files is empty.
- `git status -s` before commit shows exactly one entry: the new untracked test file. `git show --stat HEAD` after commit: **1 file changed, 239 insertions(+)**, and `PortalMessages.tsx` is byte-identical between `origin/main` and `HEAD` (sha `e74b2b2d…` both sides).
- Pre-commit hooks passed, including `tsc --noEmit` on `apps/mouth`. One note: the repo's anti-reward-hacking test lint reported `no staged test files — nothing to check` for a staged `.test.tsx` — it covers Python tests only, so it gave this PR no signal either way.

**Lint — what was run, what was not, and what it is worth here**

`npm run lint` (which is `eslint .`) was **not** run, per the operating note that it crashes on this machine. I did not reproduce that full-suite crash, so I am not asserting it second-hand. What I did measure:

- `apps/mouth/eslint.config.mjs:15` ignores `src/**/*.test.{ts,tsx}`. This PR's only file is a `.test.tsx`, so eslint has **zero scope** over it either way. Running `npx eslint` on it exits 0 with `File ignored because of a matching ignore pattern` — a vacuous green, not a pass.
- Forced with `--no-ignore`, eslint **does** crash on this machine, exit 2: `TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function`, at `node_modules/eslint-plugin-react/lib/util/version.js:31`, ESLint 10.3.0.
- The identical crash occurs on `PassportCard.test.tsx` and on `VisaCard.tsx`, two files this PR does not touch. The failure is `eslint-plugin-react` being incompatible with ESLint 10, i.e. environmental, not caused by this diff.
- Note for the record: the measured error differs from the `scopeManager.addGlobals` string I was given. I am reporting what I observed rather than repeating the string I was handed.

Net: skipping lint costs this PR nothing, because the project's own eslint config excludes test files from linting entirely.

## Reasoning Path

Two guards means two independent bugs, so guilt tests alone are half the job.

(a) and (b) are guilt. They pin the bug PR #4152 fixed: the list must not jump on first paint, and must not jump when a poll returns the same messages it already showed.

(c) and (d) are innocence, and they are what hold the line for the next reader. Each guard, looked at alone, reads as redundant — GUARD-A appears to be a special case of GUARD-B, since on the first load `prevMessageCountRef` is 0 anyway. Someone will eventually delete one to tidy up. With only guilt tests, deleting **both** guards would still leave the suite green, because a component that never scrolls passes every "does not scroll" assertion. (c) and (d) make that impossible: the list still has to scroll when a message actually arrives, and when you send one yourself. Guilt and innocence together mean any simplification has to preserve the behaviour, not just the absence of it.

(d) matters separately because the send path reaches the scroll effect by a different route than the poll: `handleSend` -> `sendPortalMessage` -> `await loadMessages()`, which raises the count by one. It runs through the real chain — fill the input, click Send — rather than invoking a scroll handler directly, since calling the handler would test the test and not the component. The Send button is disabled while the input is empty (line 206) and `handleSend` returns early on a blank input (line 71), so the input has to be filled first.

(a) deliberately loads at least one message. GUARD-0 at line 56 returns before GUARD-A is ever reached, so an empty first load would let (a) pass without exercising GUARD-A at all — green while testing nothing. The mutation confirms the point in the other direction: with a non-empty load, deleting GUARD-A does kill (a).

## Risk

1. **The poll tests depend on the mock returning a fresh array per call, and that dependency is load-bearing but easy to undo.** Anyone who "simplifies" `respondWith` back to a shared constant silently disarms the GUARD-B test — it will stay green while covering nothing, exactly as measured here. The helper carries a comment saying so, but a comment is not enforcement, and nothing in CI would catch the regression.
2. Fake timers with `shouldAdvanceTime: true` are borrowed from a green sibling but are timing-sensitive by nature; a future change to the 30s poll interval in the component would need `POLL_INTERVAL_MS` in the test updated with it. The constant is named and commented with the source line, but the two are not linked programmatically.
3. Coverage stops at the guards. Nothing here asserts scroll *position*, only that `scrollIntoView` was or was not called — jsdom cannot lay out, and the global stub is a no-op.

## Implication

The two guards are now pinned independently: a change that removes either one turns exactly one test red, and the failing test names the behaviour that broke. The component is untouched, so there is no behavioural risk to weigh.

The wider implication is about the premise checks. Asserting that data rendered and that the poll fired was not enough — the poll test satisfied both and still never reached its guard. What exposed it was deleting the guard and finding that nothing turned red. On this evidence, a guard test should not be trusted until the guard has been deleted and the test has been watched to fail.

## Recommendation

Two findings are larger than this PR and are raised here rather than smuggled into the diff:

1. **GUARD-0 at line 56 is load-bearing and undocumented.** Mutasi-3 deleted it and `first load does not scroll` went red. The reason is not obvious: the initial render carries an empty `messages`, so without GUARD-0 that render spends the `hasSeenData` flag, and the first real batch then falls straight through to GUARD-B (2 > 0) and scrolls. GUARD-0 is what makes GUARD-A land on the first *data* rather than the first *render* — it is not a decorative early-out and should not be removed as one. It is already covered by test (a), so no fifth test is added here; it is worth a one-line comment in the component, which belongs in its own change.
2. **`Clock` is imported at line 8 of `PortalMessages.tsx` and used nowhere in the body** (`<Clock` appears 0 times). A dead import. Not removed here because this PR must not touch the component, and because eslint currently cannot flag it — `eslint .` crashes on this machine and, even working, `src/**/*.test.{ts,tsx}` is ignored while the component itself would only be caught by a full-suite run.

A third, smaller item: the eslint toolchain in `apps/mouth` is broken against ESLint 10.3.0 (`eslint-plugin-react` incompatibility, `version.js:31`). Whatever the CI runner does today, the local gate gives no signal, so it is worth confirming whether CI lints this app at all.

## Next Action

1. Review the mutation table above — that is the load-bearing evidence, more than the diff itself.
2. Push manually and open the PR. The branch is `sancho/portal-messages-scroll-tests` off `origin/main` = `d01c2b355`. Not pushed, not armed, not merged.
3. Confirm CI runs `apps/mouth` vitest on this path; locally the directory is 13 passed (13).
4. If the two recommendations are accepted, raise them as separate items — a comment on GUARD-0, and the dead `Clock` import.
