### PR TITLE
feat(army): spark standing lane — h24 read-only analysis on the idle gpt-5.3-codex-spark bucket

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -170,7 +170,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `publication_histor
 ### LaunchAgents — copertura documentale
 
 <!-- DOCSYNC:AUTOMATION_COVERAGE_START -->
-`138 plist tracked in infra/launchagents/ · 106 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (77% coverage)`
+`139 plist tracked in infra/launchagents/ · 106 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (76% coverage)`
 <!-- DOCSYNC:AUTOMATION_COVERAGE_END -->
 
 Runbook operativi: indice auto-generato in [docs/runbooks/README.md](docs/runbooks/README.md).

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: ed03e70797370467ddbef5e0f3172540db45c7241875824782a31bde49b49ea6
+checksum: 44b9481b66cc192c3830692961756b4cf4e9b596ee411693de5d56a78f13bccc
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -2322,5 +2322,26 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.organism/last_seen/pro.zoho_mail_loop.json
+    timestamp_field: ts
+    status_field: status
+- id: army.spark_lane
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 7200
+  owner_module: scripts/army/spark_lane.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.army-spark
+  severity_on_silence: warning
+  notes: Armata H24 lane 1 — standing read-only analysis lane on the gpt-5.3-codex-spark
+    bucket. Every 2h on Pro; dispatches the oldest task from infra/army/spark-queue/*.md
+    (sandbox read-only, 900s cap, one task per tick, max 6/day) or is a fast no-op.
+    Never writes/commits/pushes/opens a PR. See research/operations/2026-08-14-armata-h24-standing-lanes.md.
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/army.spark_lane.json
     timestamp_field: ts
     status_field: status

--- a/infra/army/spark-queue/README.md
+++ b/infra/army/spark-queue/README.md
@@ -1,0 +1,49 @@
+# Spark lane queue
+
+Task backlog for `scripts/army/spark_lane.sh` — the standing lane that spends
+the otherwise-idle `gpt-5.3-codex-spark` weekly bucket (separate from the
+main Codex bucket, PONG-verified 2026-08-14) on **read-only** analysis of
+this repo, ticking every 2h on Pro.
+
+## Format
+
+One file per task, `*.md`, flat in this directory (no subfolders — the
+`done/` idea from the first draft was dropped: this directory is
+git-tracked and the lane never commits, so "done" state lives locally on
+the runner in `~/army/spark/state/done-list.txt`, keyed by
+`<filename>:<sha256-of-content>`. Editing a task file's content makes it
+eligible again — that is intentional, it lets a session refine a stale
+prompt in place instead of renaming the file).
+
+```markdown
+# <short imperative title — becomes the report slug>
+
+<the full prompt handed to codex verbatim. State the scope, the acceptance
+shape (e.g. "file:line + one-sentence reason per item"), and make it
+explicit this is READ-ONLY analysis — no plan to edit/commit/push. The
+--sandbox read-only flag enforces this at the tool level; the prompt text
+should not imply otherwise, so a plausible-looking diff never gets
+half-written into the output.>
+```
+
+The lane picks the **oldest not-yet-done** file by mtime, processes exactly
+**one per tick**, and writes its report to
+`~/army/spark/reports/<date>-<slug>.md`. It never edits this directory,
+never opens a PR, never merges — output is an artifact on disk plus a daily
+Telegram digest (07:00 WITA). Landing anything the report finds useful is
+always the job of an interactive session (CLAUDE.md §2 — the session owns
+the full ship lifecycle, not a standing cron).
+
+## Adding a task
+
+Just drop a new `*.md` file here following the format above and commit it
+through the normal PR flow — same discipline as any other repo change. Keep
+each task scoped to one question; a task that tries to do too much produces
+a report too broad to act on.
+
+## Task-authoring discipline (borrowed from `docs/runbooks/jules-dispatch.md`)
+
+A good task carries: the exact subsystem/path to look at, the shape of
+answer you want (a table, a ranked list, file:line anchors), and the "why"
+— which scar or invariant motivates asking. Under-specified prompts burn a
+Spark run on a vague essay nobody acts on.

--- a/infra/army/spark-queue/coverage-gaps-agentic-rag.md
+++ b/infra/army/spark-queue/coverage-gaps-agentic-rag.md
@@ -1,0 +1,21 @@
+# coverage-gaps: agentic RAG test gaps
+
+Read-only analysis. Look at `apps/backend-rag/backend/services/rag/agentic/`
+in this repository (do NOT edit anything — analysis only) and propose the
+10 missing tests with the highest value-per-test, ranked.
+
+For each of the 10, give:
+
+- exact `file:line` of the function/branch/condition that is under-tested
+  or untested
+- the concrete failure scenario the missing test would catch (inputs/state
+  → wrong output or crash), not a generic "add a test for X"
+- why it ranks where it does relative to the others (e.g. "this branch
+  silently swallows an exception and nothing catches a regression")
+
+Prefer branches that are load-bearing for correctness (abstain-policy
+thresholds, evidence scoring, subgraph routing) over pure plumbing. If the
+directory has existing test files, read them first so you don't propose a
+test that already exists under a different name.
+
+Output as a markdown table: rank | file:line | scenario | why it matters.

--- a/infra/army/spark-queue/dead-flags-audit.md
+++ b/infra/army/spark-queue/dead-flags-audit.md
@@ -1,0 +1,23 @@
+# dead-flags: env vars read but never set
+
+Read-only analysis. Census every environment variable that `scripts/*.py`
+reads (via `os environ.get(...)` / `os.getenv(...)` / `os.environ[...]`,
+whatever pattern you find) and cross-check it against every `.plist` in
+`infra/launchagents/*.plist` and every crontab-style wrapper in
+`infra/launchagents/wrappers/*.sh` and `scripts/*.sh` to find variables that
+are READ by a Python script but never SET by any live plist
+`EnvironmentVariables` block or any wrapper `export`/inline assignment
+found in this repo.
+
+A variable counting as "dead" means: no plist, no wrapper, and no obvious
+caller in this repo ever sets it — so the script always falls back to
+whatever default (or `None`) the `.get()` call supplies. That is not
+automatically a bug (some are legitimate test-only overrides), so for each
+finding say which category it looks like: (a) genuinely dead — the feature
+gate it guards can never be flipped in production, (b) test/dev-only
+override (name suggests `..._TEST`, appears near a `monkeypatch`/pytest
+fixture), (c) unclear — flag it for a human to check.
+
+Output as a markdown table: env var | reading script:line | category |
+one-line evidence for the category call. Cap the list at the 25 most
+interesting findings if there are more; say how many you found in total.

--- a/infra/army/spark-queue/todo-audit-90d.md
+++ b/infra/army/spark-queue/todo-audit-90d.md
@@ -1,0 +1,22 @@
+# todo-audit: stale TODO/FIXME in the backend, risk-ranked
+
+Read-only analysis. Search `apps/backend-rag` for `TODO`, `FIXME`, `XXX`,
+and `HACK` comments. For each hit, run `git blame` on that line (or the
+nearest surrounding block if blame attributes it to a bulk reformat commit)
+to find the commit date, and keep only the ones older than 90 days from
+today.
+
+For each surviving TODO, classify risk:
+
+- HIGH: touches auth, billing/pricing, PII handling, or a data-invariant
+  documented in this repo's CLAUDE.md §9 (embedding model, evidence
+  thresholds, KBLI payload shape)
+- MEDIUM: touches a code path that runs in production request handling but
+  isn't one of the above
+- LOW: dead code, test-only, or cosmetic
+
+Output as a markdown table: file:line | TODO text (truncated to ~80 chars)
+| age (days) | risk | one-line reason for the risk call. Sort HIGH first.
+If you find more than 40 qualifying TODOs, list all of them anyway (do not
+silently cap — if you must cap for length, say explicitly how many you
+dropped and why).

--- a/infra/launchagents/com.nuzantara.army-spark.plist
+++ b/infra/launchagents/com.nuzantara.army-spark.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.nuzantara.army-spark — Armata H24 lane 1 (2026-08-14).
+
+  Standing read-only analysis lane on the gpt-5.3-codex-spark bucket
+  (measured idle 2026-08-14 — separate weekly bucket from the primary
+  Codex quota). Ticks every 2h on Pro; every tick either dispatches the
+  oldest not-yet-done task from infra/army/spark-queue/*.md (--sandbox
+  read-only, 900s cap, one task per tick, max 6/day) or is a fast no-op
+  (kill switch / wrong node / backoff / cap reached / empty queue). Never
+  writes/commits/pushes/opens a PR — see
+  research/operations/2026-08-14-armata-h24-standing-lanes.md.
+
+  Genesis this lane deliberately does NOT repeat: the 2026-06
+  "codex-spark-loop" ecosystem died of runaway-alarm + 13 PR-spam (W81
+  firebreak). Fixes applied here: repo-canonical path (no HOME-fork copy),
+  StartInterval not KeepAlive (superscar #7), cron-runner.sh wrapper for
+  fail-visible receipts + P0 on a wrapper-level crash, and the wrapper's
+  OWN alerting (via tg_notify.py) stays quiet on expected conditions
+  (quota/backoff/cap) so it never becomes the alarm-storm this replaces.
+
+  Install:
+    cp infra/launchagents/com.nuzantara.army-spark.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.nuzantara.army-spark.plist
+
+  Plist permissions hardened to 0444 per cicatrix P0-3.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.army-spark</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/nuzantara/scripts/cron-runner.sh</string>
+        <string>/Users/nuzantara/nuzantara/scripts/army/spark_lane.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/Users/nuzantara/.local/bin:/opt/homebrew/bin:/Users/nuzantara/.pyenv/versions/3.11.11/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CRON_RUNNER_JOB_NAME</key>
+        <string>army_spark_lane</string>
+        <key>ARMY_SPARK_ENABLED</key>
+        <string>true</string>
+    </dict>
+
+    <!-- Every 2 hours. No RunAtLoad: an install-time immediate run competing
+         with an operator's own interactive Spark probe is unwanted noise;
+         the first real tick fires within 2h of load. -->
+    <key>StartInterval</key>
+    <integer>7200</integer>
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/army-spark/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/army-spark/launchd.err.log</string>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <!-- Avoid a tight respawn loop if the payload exits immediately (superscar #7). -->
+    <key>ThrottleInterval</key>
+    <integer>120</integer>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.army-spark.plist
+++ b/infra/launchagents/com.nuzantara.army-spark.plist
@@ -6,8 +6,8 @@
   Standing read-only analysis lane on the gpt-5.3-codex-spark bucket
   (measured idle 2026-08-14 — separate weekly bucket from the primary
   Codex quota). Ticks every 2h on Pro; every tick either dispatches the
-  oldest not-yet-done task from infra/army/spark-queue/*.md (--sandbox
-  read-only, 900s cap, one task per tick, max 6/day) or is a fast no-op
+  oldest not-yet-done task from infra/army/spark-queue/*.md (sandbox
+  read-only mode, 900s cap, one task per tick, max 6/day) or is a fast no-op
   (kill switch / wrong node / backoff / cap reached / empty queue). Never
   writes/commits/pushes/opens a PR — see
   research/operations/2026-08-14-armata-h24-standing-lanes.md.

--- a/research/operations/2026-08-14-armata-h24-standing-lanes.md
+++ b/research/operations/2026-08-14-armata-h24-standing-lanes.md
@@ -1,0 +1,130 @@
+---
+date: 2026-08-14
+domain: operations
+client_case: none
+sources:
+  - "live probe 2026-08-14: gpt-5.3-codex-spark PONG on M5 (codex exec -m gpt-5.3-codex-spark -c model_reasoning_effort=medium --sandbox read-only --skip-git-repo-check); on Pro only via CODEX_HOME=$HOME/.codex-acct2 (Pro's primary ~/.codex is 401)"
+  - "scripts/jules_dispatch.py + docs/runbooks/jules-dispatch.md (armed 2026-07-06, dormant since — zero automation calls it)"
+  - "cicatrix-superscar.md families #1 HOME-fork, #2 Esiste≠Armato, #5 Sibling-race, #7 KeepAlive misconfig"
+  - "W81 firebreak: 2026-06 codex-spark-loop ecosystem disabled after runaway-alarm + 13 PR-spam"
+---
+
+# Armata H24 — Fase 1: standing lanes on idle flat-sub capacity
+
+## Rationale
+
+Two paid capabilities sit idle today, measured 2026-08-14:
+
+1. **`gpt-5.3-codex-spark`** — a Codex model with its own **weekly bucket, separate
+   from the primary Codex quota**. PONG-verified live on M5 (Pro needs the
+   secondary `CODEX_HOME=$HOME/.codex-acct2` account since Pro's primary
+   `~/.codex` seat is 401). Historically 100% idle — nothing in this repo has
+   ever dispatched to it.
+2. **Jules** (Google's async cloud implementer) — armed since 2026-07-06
+   (`scripts/jules_dispatch.py`, Keychain key `jules-api-key` on M5), first
+   session ran the same day, and then **dormant**: zero automation has called
+   it since. Quota is ~300 sessions/day; the real constraint was never
+   dispatch volume, it was verification bandwidth on the receiving end.
+
+Both are flat-subscription capacity Bali Zero already pays for. Phase 1 turns
+each into a standing, capped, read-only (Spark) / dispatch-then-harvest
+(Jules) lane that produces artifacts an interactive session can act on —
+without ever landing anything itself.
+
+## Constraints carried forward from cicatrix-superscar.md (non-negotiable)
+
+- **#1 HOME-fork**: every script here is invoked by its repo-canonical path
+  directly (no `~/scripts/` copy). Where a plist needs a live path it points
+  straight at `/Users/nuzantara/nuzantara/...`.
+- **#2 Esiste≠Armato**: every tick writes a heartbeat sidecar
+  (`~/.organism/last_seen/army.<lane>.json`) regardless of outcome, and a
+  wrapper-level crash still surfaces via `cron-runner.sh`'s own P0 (it wraps
+  both lanes' entrypoints).
+- **#5 Sibling-race**: neither lane writes to the repo. Spark reads the
+  queue and its main checkout read-only (`--sandbox read-only`); Jules reads
+  its own queue and appends to `shared/escalations_pro.jsonl` (an
+  append-only, multi-writer-safe log already used by other automation, see
+  its existing `_writer` field convention) — never a `git` mutation.
+- **#7 KeepAlive**: both plists use `StartInterval`, `KeepAlive=false`.
+- **No auto-PR, no self-grading**: neither lane opens a PR, commits, or
+  merges. Spark's output is a report file; Jules's output is a patch the
+  lane can only point at (`inbox/<session-id>/`) — landing is always an
+  interactive session's job (CLAUDE.md §2, and the existing Jules contract
+  "Jules generates; Fable grades").
+- **Quota-aware, capped, kill-switched**: see the per-lane sections below.
+  Neither lane retries in a tight loop on quota exhaustion — it backs off
+  and reports `status=quota`/`status=blocked`, once, per condition.
+
+## What this deliberately does NOT repeat
+
+The 2026-06 "codex-spark-loop" ecosystem (`~/scripts/codex/` on Pro) died of
+runaway-alarm plus 13 PR-spam and was firebroken (W81,
+`.disabled-W81-*` plists). The differences here are structural, not just
+"be more careful":
+
+- read-only sandbox for Spark (the old loop wrote and opened PRs)
+- repo-canonical invocation (the old loop was a HOME-fork from day one)
+- a hard daily cap + backoff state file (the old loop had neither)
+- `cron-runner.sh` wrapping for fail-visible receipts, `tg_notify.py` as the
+  single alert gateway with tiered dedup keys (the old loop alarmed raw and
+  often)
+
+## Lane 1 — Spark (read-only analysis)
+
+`scripts/army/spark_lane.sh`, ticks every 2h on Pro (`StartInterval 7200`).
+Each tick either dispatches the oldest not-yet-done task from
+`infra/army/spark-queue/*.md` (one task per tick, `--sandbox read-only`,
+900s cap, max 6 dispatches/day) or is a fast no-op. A daily digest fires
+once, at the first tick at/after 07:00 local, summarizing what ran the day
+before. Full contract in `scripts/army/spark_lane.sh`'s own header comment
+and `infra/army/spark-queue/README.md`.
+
+## Lane 2 — Jules (dispatch + harvest)
+
+`scripts/army/jules_lane.py`, two modes on one cron cadence family:
+`--dispatch` (09:00 WITA, up to 3 tasks/day from
+`infra/army/jules-queue/*.md`) and `--harvest` (every 3h, polls open
+sessions; on completion, downloads the patch to
+`~/army/jules/inbox/<session-id>/` and appends ONE `NORMAL`-priority row to
+`shared/escalations_pro.jsonl` so an interactive session picks it up for
+independent verification — never a merge). Runs where the Keychain key is
+present; fails visible (`status=blocked`) elsewhere rather than copying the
+key. Full contract in `scripts/army/jules_lane.py`'s own module docstring
+and `infra/army/jules-queue/README.md`.
+
+## Proof-of-armed (per lane)
+
+A lane counts as *armed*, not merely *built*, only when all four hold:
+
+| # | Check | Spark | Jules |
+|---|---|---|---|
+| 1 | plist loaded (`launchctl print gui/$(id -u)/com.nuzantara.army-<lane>`) | required | required |
+| 2 | a REAL tick ran (heartbeat sidecar `~/.organism/last_seen/army.<lane>*.json` age < 2× the tick interval) | required | required |
+| 3 | the tick did real work at least once (a report under `~/army/spark/reports/` OR a session id in `~/army/jules/state/sessions.jsonl`) — not just "0 pending, skip" every time | required | required |
+| 4 | the kill switch actually kills it (`ARMY_SPARK_ENABLED=false` / `ARMY_JULES_ENABLED=false` → next tick heartbeat `status=disabled`) | required | required |
+
+Until an interactive session verifies all four on the target machine and
+records it here (or in the PENDING-ARMS ledger), this lane is
+**built-but-not-armed** per cicatrix superscar #2 — "esiste ≠ armato".
+Neither plist ships with `RunAtLoad=true` for exactly this reason: install
+is a deliberate, checked act, not an accident of `git pull`.
+
+## Phase 2 (not this PR — after ~1 week of Phase 1 running clean)
+
+- **Gemini corpus-sweep lane**: `agy` (Gemini 3.1 Pro, free OAuth, 1M
+  context) standing lane for whole-corpus read-only sweeps too wide for a
+  single interactive session's context — natural fit for the KBLI
+  1,559-code re-validation backlog (`kbli-navigator` corner) once Phase 1's
+  operational pattern (queue → capped dispatch → report → interactive
+  landing) is proven stable.
+- **Kimi overnight-review lane**: Kimi K3 (`kimi-code/k3`, Allegro flat
+  subscription) as a standing refuter over open PRs overnight — same
+  generator≠grader discipline the repo already uses for the 4-LLM panel,
+  just scheduled instead of ad-hoc. PII boundary applies unchanged (Kimi is
+  a Chinese cloud seat — aggregate/health/intel/KBLI only, never
+  CRM/client rows, per CLAUDE.md §5's Kimi seat rules).
+
+Both are deliberately deferred: Phase 1 is the first time this repo runs
+*any* standing multi-task queue against a paid seat since the W81 firebreak,
+and the design bet here is "prove the pattern narrow and capped before
+widening it," not "land all four lanes at once."

--- a/research/operations/2026-08-14-armata-h24-standing-lanes.md
+++ b/research/operations/2026-08-14-armata-h24-standing-lanes.md
@@ -7,6 +7,7 @@ sources:
   - "scripts/jules_dispatch.py + docs/runbooks/jules-dispatch.md (armed 2026-07-06, dormant since — zero automation calls it)"
   - "cicatrix-superscar.md families #1 HOME-fork, #2 Esiste≠Armato, #5 Sibling-race, #7 KeepAlive misconfig"
   - "W81 firebreak: 2026-06 codex-spark-loop ecosystem disabled after runaway-alarm + 13 PR-spam"
+adversarial_review: kimi-k3
 ---
 
 # Armata H24 — Fase 1: standing lanes on idle flat-sub capacity
@@ -235,3 +236,52 @@ here shipped un-amended.
     existing daily digest gains one extra line reporting the
     produced-vs-verified ratio, rather than standing up a second schedule
     for it.
+
+## Adversarial review
+
+Reviewer: Kimi K3 (`kimi -m kimi-code/k3`), cross-family per CLAUDE.md §6
+(generator≠grader). Transcript: `kimi-refute-army.txt`
+(session `session_faa8c7d2-4490-4a7e-a535-c39e7bc179e0`), 24 numbered
+sub-findings across 6 categories. The amendment log above closes 12 of
+them (mapped 1:1 to the fixes numbered 1-12). The following sub-findings
+were **not** addressed by that amendment and are surviving objections as
+of this PR:
+
+- **§1.3 — unbounded queue retention.** A processed task's `.md` file is
+  never removed from `infra/army/spark-queue/`; the queue grows monotone
+  forever, every tick still has to scan it in full, and a completed task
+  stays visible as "just a file in the repo" to any human or session that
+  doesn't also check `attempts.jsonl` — inviting an accidental manual
+  re-trigger. The amendment fixed *dedup correctness* (item 2) but not
+  *retention*.
+- **§2.3 — kill-switch has no expiry/alarm.** `ARMY_SPARK_ENABLED=false` /
+  `ARMY_JULES_ENABLED=false` can be armed for an incident and forgotten;
+  nothing in the design distinguishes a fresh kill from a 30-day-old one,
+  and no digest line calls out "still disabled" as an anomaly.
+- **§5.4 — no inter-lane mutex.** Spark (every 2h) and Jules (dispatch +
+  harvest every 3h) share the same Pro host, filesystem, and (for Jules)
+  git-state reads, alongside ~200 other LaunchAgents already on that box.
+  The design treats the two lanes as independent; nothing serializes them
+  against each other if their windows overlap.
+- **§6.3 — no cost field.** Neither `attempts.jsonl` nor `sessions.jsonl`
+  records estimated token/quota spend per run, so "did the bucket spend
+  produce anything worth it" stays unanswerable from the receipts alone
+  even after item 12's produced/consumed ratio ships.
+- **§6.5 — Jules escalation has no named owner or SLA.** The
+  `shared/escalations_pro.jsonl` row routes to "an interactive session"
+  generically, unlike the existing verification-role convention with a
+  roster (referenced in the transcript as AGENTS.md §17) — an escalation
+  without an owner risks the same inbox-backpressure-then-silence failure
+  mode item 9 was built to prevent on the dispatch side.
+- **§1.4 — mid-run mutation is detectable, not prevented.** Item 5's
+  reproducibility header records the checkout HEAD sha *at run time*, which
+  lets a later reader detect that a report was built against a moving
+  working tree — it does not stop a concurrent `git pull` from changing
+  files while a 900s `codex exec --sandbox read-only` run is still reading
+  them.
+
+None of these six are blocking for Phase 1 (all remain within the
+"built-but-not-armed until proof-of-armed" gate above, and none reopens a
+firebreak-class failure mode); they are logged here as the honest residue
+of the review rather than silently absorbed into the "12 items, fully
+amended" claim.

--- a/research/operations/2026-08-14-armata-h24-standing-lanes.md
+++ b/research/operations/2026-08-14-armata-h24-standing-lanes.md
@@ -128,3 +128,110 @@ Both are deliberately deferred: Phase 1 is the first time this repo runs
 *any* standing multi-task queue against a paid seat since the W81 firebreak,
 and the design bet here is "prove the pattern narrow and capped before
 widening it," not "land all four lanes at once."
+
+## Amendment log — 2026-08-14 (cross-family Kimi K3 refutation, 12 items)
+
+A cross-family refutation of this design (Kimi K3, generator≠grader per
+CLAUDE.md §6) closed 12 numbered defects the same day, before either lane
+was armed anywhere. Both lanes' second commit implements all 12; nothing
+here shipped un-amended.
+
+**Spark (6 items):**
+
+1. **Atomic lock, not a pidfile write.** The single-instance guard is now a
+   `mkdir`-claimed lock directory (`$STATE_DIR/run.lock/`) with a pid file
+   inside, checked and reclaimed if stale. A plain pidfile write is not
+   atomic against a real race, and launchd does not guarantee serialization
+   against a manual run of the same script. A live-lock tick now reports
+   its own distinct status (`skipped-overlap`) rather than the generic `ok`
+   it shared with "queue empty" before.
+2. **Content-only dedup, corruption-fatal state.** The dedup key is now
+   sha256 of task **content**, not `filename:sha` — a rename/move no longer
+   creates a phantom duplicate entry. The done-list is now an append-only
+   JSONL of every *attempt* (`attempts.jsonl`, one line per try, not just
+   successes) instead of a flat "done" list. A line that fails to parse
+   HALTS the lane (`status=state-corrupt`, P0) rather than falling open
+   into re-processing the whole queue — the family #2/#9 failure mode this
+   repo has hit repeatedly (W88, W104: a corrupt or misread state file read
+   as "nothing recorded" is worse than no state at all).
+3. **Retry count + head-of-line protection.** Task selection now prefers
+   never-attempted tasks over once-failed retries, and a task quarantines
+   itself after 2 recorded failures — a single poisoned task can neither
+   block the head of the queue behind it forever nor be retried
+   unboundedly.
+4. **Fixed 12h backoff, plus a format-change tripwire.** Backoff on a
+   detected quota marker is now a flat 12h (never exponential-unbounded).
+   New: 3 *consecutive* non-quota failures (across distinct tasks, so a
+   single quarantined task can't trigger it alone) also fire the same 12h
+   backoff — protection against codex's output format changing underneath
+   the quota-marker regex, where every failure would otherwise misclassify
+   silently.
+5. **Reproducibility header.** Every report now opens with the checkout
+   HEAD sha (at run time) and the task's own content sha256, not just the
+   task's queue filename.
+6. **Explicit WITA clock.** Every "today"/"cap"/"digest hour" computation
+   goes through `TZ=Asia/Makassar date …` (fixed UTC+8, no DST — no
+   zoneinfo/tzdata dependency) instead of ambient system/launchd TZ, which
+   is not guaranteed to be WITA in every cron environment.
+
+**Jules (4 items):**
+
+7. **72h session TTL.** A session still PENDING after
+   `ARMY_JULES_SESSION_TTL_HOURS` (default 72) is marked `stale`, fires
+   exactly ONE escalation of its own ("investigate or cancel", not "verify
+   this patch" — there is none), and is never polled again.
+8. **Escalation dedup grep.** Before writing an escalation, both the
+   completed-session and stale-session paths now grep
+   `shared/escalations_pro.jsonl` for the same job key first. The primary
+   guard is still in-process (a closed session is never re-polled); this is
+   the safety net for the crash-consistency gap where an escalation write
+   succeeded but the session-state save that would have prevented a repeat
+   did not land.
+9. **Inbox backpressure.** Dispatch refuses to send new tasks while
+   `ARMY_JULES_INBOX_BACKPRESSURE` (default 6) or more harvested patches
+   are still awaiting verification (`outcome` unset) — the bottleneck was
+   always verification bandwidth, not dispatch volume (see Rationale
+   above), so dispatch now adapts to it instead of piling on top of it. The
+   count is reported in the daily digest.
+10. **Base-commit recording + blocked-streak alarm.** Every dispatch tick
+    resolves `origin/main`'s HEAD once and records it on each session, so a
+    later verification session can `git apply --check` against the commit
+    Jules actually started from. Two or more *consecutive* ticks blocked on
+    a missing Keychain credential now get a distinct digest line
+    (`army-jules:blocked-streak`) — a forgotten-credential machine should
+    not silently read as "not applicable" forever.
+
+**Both lanes (2 items):**
+
+11. **Wired into the repo's existing organism staleness detector, without
+    a new registry.** Before wiring this in, both `infra/fleet-watch/`
+    (unrelated — a separate Pro/Mini reachability watch, `peers.json`) and
+    `scripts/organism_stale_detector.py` were read in full. Findings that
+    shaped the implementation: the detector auto-discovers every
+    `*.json` file under `~/.organism/last_seen/` (`scan_sidecars()`) — no
+    pre-registration allow-list exists for staleness detection itself, so
+    `army.spark_lane`/`army.jules_lane` need no registry edit anywhere to
+    be picked up. The one other registry in the repo,
+    `apps/organism/organism/organs_registry.yaml`, is consumed by
+    `sentinel-aggregate.py`/`healer_receptor_registry.py` for *recovery-action*
+    automation, not by the stale detector — left unregistered here
+    deliberately (Phase 2 candidate if automated recovery wiring is
+    wanted). Also confirmed the literal word `killed` is in
+    `scripts/lib/heartbeat.sh`'s recognized-status vocabulary and maps to
+    `"error"` — so neither lane ever passes that word to `organism_heartbeat()`
+    for an intentional kill-switch-off tick; each lane keeps its own
+    richer status vocabulary (`killed`/`skipped-overlap`/`state-corrupt`/…)
+    separate from the narrower heartbeat-safe one (`ok`/`degraded`/`error`/`disabled`)
+    it maps down to. Every tick that completes with heartbeat status `ok`
+    additionally stamps `last_success_epoch` into the SAME sidecar file —
+    additive, not a second artifact, so an existing or future consumer that
+    only reads `ts`/`status` is unaffected.
+12. **`outcome` field + weekly produced/consumed digest line.** Both
+    lanes' completed-work records (`attempts.jsonl` for Spark,
+    `sessions.jsonl` for Jules) carry an `outcome` field
+    (`applied`/`rejected`/`read`/`null`) a verification session updates
+    later — append-only state, so an update is a new line, not an in-place
+    edit; readers fold to the latest entry per key. On Mondays (WITA) the
+    existing daily digest gains one extra line reporting the
+    produced-vs-verified ratio, rather than standing up a second schedule
+    for it.

--- a/scripts/army/spark_lane.sh
+++ b/scripts/army/spark_lane.sh
@@ -57,7 +57,15 @@ CONSEC_FAIL_LIMIT="${ARMY_SPARK_CONSEC_FAIL_LIMIT:-3}"
 DIGEST_HOUR="${ARMY_SPARK_DIGEST_HOUR:-7}"
 MODEL="${ARMY_SPARK_MODEL:-gpt-5.3-codex-spark}"
 EFFORT="${ARMY_SPARK_EFFORT:-medium}"
-CODEX_HOME_OVERRIDE="${ARMY_SPARK_CODEX_HOME:-$HOME/.codex-acct2}"
+# Seat resolution goes through the fleet door (scripts/lib/codex_seat.sh):
+# the second ChatGPT Pro seat has two names in the fleet (~/.codex-acct2 on
+# Pro, ~/.codex-o2 on M5) and the default ~/.codex is 401-dead on Pro — a
+# hardcoded name makes the other machine's seat invisible. The env var stays
+# as an explicit per-install override; when unset, codex_seat_pick() supplies
+# a live seat (alternating). Empty pick = no seat logged in anywhere: keep ""
+# so the run fails visibly at codex exec instead of silently using ~/.codex.
+. "$REPO/scripts/lib/codex_seat.sh"
+CODEX_HOME_OVERRIDE="${ARMY_SPARK_CODEX_HOME:-$(codex_seat_pick)}"
 CODEX_BIN="${ARMY_SPARK_CODEX_BIN:-codex}"
 
 mkdir -p "$LOG_DIR"
@@ -488,6 +496,10 @@ if [ "$SHOULD_WORK" = "1" ]; then
 
             (
                 cd "$REPO" || exit 90
+                # Empty override = codex_seat_pick found no logged-in seat.
+                # Exporting "" would fall back to ~/.codex silently (401-dead
+                # on Pro) — refuse instead; rc=91 is recorded as a failure.
+                [ -n "$CODEX_HOME_OVERRIDE" ] || exit 91
                 export CODEX_HOME="$CODEX_HOME_OVERRIDE"
                 PROMPT_TEXT="$(cat "$TASK_FILE")"
                 if [ -n "$_to" ]; then

--- a/scripts/army/spark_lane.sh
+++ b/scripts/army/spark_lane.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+# army.spark_lane — Armata H24 lane 1: standing read-only analysis on the
+# gpt-5.3-codex-spark weekly bucket (measured idle 2026-08-14, separate
+# bucket from the primary codex quota — see
+# research/operations/2026-08-14-armata-h24-standing-lanes.md).
+#
+# Contract (non-negotiable, cicatrix-superscar.md families #1/#2/#5/#7):
+#   - repo-canonical only: the plist invokes THIS file's repo path directly,
+#     no HOME-fork copy (family #1).
+#   - StartInterval, never KeepAlive (family #7): the plist owns the tick.
+#   - read-only: codex runs with --sandbox read-only against the MAIN
+#     checkout; this lane never writes/commits/pushes/opens a PR (family #5,
+#     and the explicit "no auto-PR" contract for both Armata H24 lanes).
+#   - quota-aware backoff, daily run cap, single-instance pidfile.
+#   - fail-visible via the ONE Telegram gateway (scripts/tg_notify.py) —
+#     never a raw curl, never a hardcoded token.
+#
+# Genesis: the 2026-06 "codex-spark-loop" ecosystem (~/scripts/codex/ on Pro)
+# died of runaway-alarm + 13 PR-spam (W81 firebreak, plist
+# `.disabled-W81-*`). This lane is read-only, capped, and never opens a PR —
+# landing is always the interactive session's job (CLAUDE.md §2).
+
+set -u   # unset vars crash instead of expanding empty (fail-visible)
+
+ORGAN_ID="army.spark_lane"
+REPO="${ARMY_SPARK_REPO:-$HOME/nuzantara}"
+QUEUE_DIR="${ARMY_SPARK_QUEUE_DIR:-$REPO/infra/army/spark-queue}"
+REPORTS_DIR="${ARMY_SPARK_REPORTS_DIR:-$HOME/army/spark/reports}"
+STATE_DIR="${ARMY_SPARK_STATE_DIR:-$HOME/army/spark/state}"
+LOG_DIR="${ARMY_SPARK_LOG_DIR:-$HOME/logs/army-spark}"
+SIDECAR_DIR="${ARMY_SPARK_SIDECAR_DIR:-$HOME/.organism/last_seen}"
+PIDFILE="${ARMY_SPARK_PIDFILE:-/tmp/nuzantara-army-spark-lane.pid}"
+
+DAILY_CAP="${ARMY_SPARK_DAILY_CAP:-6}"
+TIMEOUT_S="${ARMY_SPARK_TIMEOUT_S:-900}"
+BACKOFF_HOURS="${ARMY_SPARK_BACKOFF_HOURS:-6}"
+DIGEST_HOUR="${ARMY_SPARK_DIGEST_HOUR:-7}"
+MODEL="${ARMY_SPARK_MODEL:-gpt-5.3-codex-spark}"
+EFFORT="${ARMY_SPARK_EFFORT:-medium}"
+CODEX_HOME_OVERRIDE="${ARMY_SPARK_CODEX_HOME:-$HOME/.codex-acct2}"
+CODEX_BIN="${ARMY_SPARK_CODEX_BIN:-codex}"
+
+mkdir -p "$LOG_DIR"
+LOG="$LOG_DIR/run.log"
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+heartbeat() {  # $1 status, $2 note — every exit path (Esiste≠Armato)
+    if [ -f "$REPO/scripts/lib/heartbeat.sh" ]; then
+        # shellcheck disable=SC1090
+        source "$REPO/scripts/lib/heartbeat.sh"
+        organism_heartbeat "$ORGAN_ID" "$1" "$2"
+    else
+        mkdir -p "$SIDECAR_DIR" 2>/dev/null
+        printf '{"ts":"%s","status":"%s","note":"%s"}\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" \
+            > "$SIDECAR_DIR/$ORGAN_ID.json" 2>/dev/null
+    fi
+}
+
+telegram() {  # $1 tier, $2 dedup-key, $3 text — through the ONE gateway
+    local tier="$1" key="$2" text="$3" gateway py
+    gateway="$REPO/scripts/tg_notify.py"
+    [ -f "$gateway" ] || { log "NO GATEWAY at $gateway — alert NOT sent: ${text:0:80}"; return 0; }
+    for py in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
+        command -v "$py" >/dev/null 2>&1 || continue
+        log "tg_notify[$key]: $("$py" "$gateway" --tier "$tier" --source "army-spark-lane" \
+            --dedup-key "$key" -- "$text" 2>&1 | tail -1)"
+        return 0
+    done
+    log "no python3 found — alert NOT sent: ${text:0:80}"
+}
+
+# ── G4 node guard — this lane is Pro-only by design (M5 = no cron, per
+#    CLAUDE.md; Mini would be active-active with Pro on the same queue,
+#    superscar #10) ──────────────────────────────────────────────────────
+if [ "${ARMY_SPARK_SKIP_NODE_GUARD:-}" != "1" ]; then
+    # ARMY_SPARK_NODE_OVERRIDE lets tests exercise this guard deterministically
+    # without depending on the real hostname of whatever machine runs the
+    # test suite (which may itself be "nuzantara").
+    node="${ARMY_SPARK_NODE_OVERRIDE:-$(hostname -s 2>/dev/null | tr '[:upper:]' '[:lower:]')}"
+    required_node="${ARMY_SPARK_REQUIRED_NODE:-nuzantara}"
+    if [ "$node" != "$required_node" ]; then
+        log "node guard: $node != $required_node — not my node, exiting"
+        heartbeat "disabled" "wrong-node $node"
+        exit 0
+    fi
+fi
+
+# ── G5 kill switch ──────────────────────────────────────────────────────
+if [ "${ARMY_SPARK_ENABLED:-true}" = "false" ]; then
+    log "kill switch ARMY_SPARK_ENABLED=false — exiting"
+    heartbeat "disabled" "kill switch"
+    exit 0
+fi
+
+# ── G10 single instance ─────────────────────────────────────────────────
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+    log "previous run still alive (pid $(cat "$PIDFILE")) — skipping"
+    heartbeat "ok" "skipped: previous run alive"
+    exit 0
+fi
+echo $$ > "$PIDFILE"
+trap 'rm -f "$PIDFILE"' EXIT
+
+mkdir -p "$REPORTS_DIR" "$STATE_DIR"
+DONE_LIST="$STATE_DIR/done-list.txt"
+BACKOFF_FILE="$STATE_DIR/backoff-until.txt"
+COUNT_FILE="$STATE_DIR/run-count-$(date +%Y-%m-%d).txt"
+PROCESSED_LOG="$STATE_DIR/processed-log.jsonl"
+touch "$DONE_LIST" "$PROCESSED_LOG"
+
+sha256_of() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" 2>/dev/null | awk '{print $1}'
+    else
+        openssl dgst -sha256 "$1" 2>/dev/null | awk '{print $NF}'
+    fi
+}
+
+slugify() {
+    # No `sed 's/-\+/.../'`: BSD sed (macOS, this lane's only target) does not
+    # accept `\+` in BRE — that is a GNU extension. `tr -s` squeezes runs of
+    # the placeholder char portably in both sed flavors' absence.
+    local s
+    s="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | tr -s '-')"
+    s="${s#-}"
+    s="${s%-}"
+    printf '%s' "$s"
+}
+
+RUN_STATUS="idle"
+RUN_NOTE="no task processed this tick"
+
+# ── backoff check ────────────────────────────────────────────────────────
+now_epoch="$(date +%s)"
+backoff_until=0
+[ -f "$BACKOFF_FILE" ] && backoff_until="$(cat "$BACKOFF_FILE" 2>/dev/null || echo 0)"
+case "$backoff_until" in ''|*[!0-9]*) backoff_until=0 ;; esac
+
+if [ "$backoff_until" -gt "$now_epoch" ]; then
+    log "backoff active until epoch $backoff_until — skipping dispatch this tick"
+    RUN_STATUS="degraded"
+    RUN_NOTE="backoff active until $backoff_until"
+else
+    # ── daily cap ────────────────────────────────────────────────────────
+    run_count=0
+    [ -f "$COUNT_FILE" ] && run_count="$(cat "$COUNT_FILE" 2>/dev/null || echo 0)"
+    case "$run_count" in ''|*[!0-9]*) run_count=0 ;; esac
+
+    if [ "$run_count" -ge "$DAILY_CAP" ]; then
+        log "daily cap reached ($run_count/$DAILY_CAP) — skipping dispatch this tick"
+        RUN_STATUS="ok"
+        RUN_NOTE="daily cap reached ($run_count/$DAILY_CAP)"
+    elif [ ! -d "$QUEUE_DIR" ]; then
+        log "queue dir missing: $QUEUE_DIR"
+        RUN_STATUS="error"
+        RUN_NOTE="queue dir missing"
+    else
+        # ── pick oldest not-yet-done task ──────────────────────────────
+        TASK_FILE=""
+        # mtime-sorted oldest-first; macOS/BSD stat, so no GNU --time-style.
+        while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            base="$(basename "$f")"
+            digest="$(sha256_of "$f")"
+            key="${base}:${digest}"
+            if ! grep -qxF "$key" "$DONE_LIST" 2>/dev/null; then
+                TASK_FILE="$f"
+                TASK_KEY="$key"
+                break
+            fi
+        done < <(
+            for f in "$QUEUE_DIR"/*.md; do
+                [ -f "$f" ] || continue
+                mt="$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)"
+                printf '%s\t%s\n' "$mt" "$f"
+            done | sort -n | cut -f2-
+        )
+
+        if [ -z "$TASK_FILE" ]; then
+            log "queue empty or fully processed — nothing to dispatch"
+            RUN_STATUS="ok"
+            RUN_NOTE="queue empty"
+        else
+            title_line="$(head -1 "$TASK_FILE" 2>/dev/null | sed 's/^#\+ *//')"
+            slug="$(slugify "${title_line:-$(basename "$TASK_FILE" .md)}")"
+            [ -n "$slug" ] || slug="task"
+            log "dispatching task=$(basename "$TASK_FILE") slug=$slug model=$MODEL effort=$EFFORT"
+
+            _to="$(command -v timeout || command -v gtimeout || true)"
+            OUT_TMP="$(mktemp "${TMPDIR:-/tmp}/army-spark.XXXXXX" 2>/dev/null || echo "/tmp/army-spark.$$")"
+
+            (
+                cd "$REPO" || exit 90
+                export CODEX_HOME="$CODEX_HOME_OVERRIDE"
+                PROMPT_TEXT="$(cat "$TASK_FILE")"
+                if [ -n "$_to" ]; then
+                    "$_to" "$TIMEOUT_S" "$CODEX_BIN" exec -m "$MODEL" \
+                        -c model_reasoning_effort="$EFFORT" \
+                        --sandbox read-only --skip-git-repo-check \
+                        "$PROMPT_TEXT" < /dev/null
+                else
+                    log "WARN: no timeout/gtimeout binary — running WITHOUT a wall-clock cap"
+                    "$CODEX_BIN" exec -m "$MODEL" \
+                        -c model_reasoning_effort="$EFFORT" \
+                        --sandbox read-only --skip-git-repo-check \
+                        "$PROMPT_TEXT" < /dev/null
+                fi
+            ) > "$OUT_TMP" 2>&1
+            CODEX_RC=$?
+
+            run_count=$((run_count + 1))
+            echo "$run_count" > "$COUNT_FILE"
+
+            if grep -qiE 'out of extra usage|usage limit|quota exceeded|rate.limit|429|weekly limit' "$OUT_TMP" 2>/dev/null; then
+                new_backoff=$((now_epoch + BACKOFF_HOURS * 3600))
+                echo "$new_backoff" > "$BACKOFF_FILE"
+                log "quota marker detected — backoff until epoch $new_backoff (${BACKOFF_HOURS}h)"
+                RUN_STATUS="degraded"
+                RUN_NOTE="quota: backoff ${BACKOFF_HOURS}h"
+                printf '{"ts":"%s","task":"%s","slug":"%s","status":"quota"}\n' \
+                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$TASK_FILE")" "$slug" >> "$PROCESSED_LOG"
+                telegram digest "army-spark:quota" \
+                    "🐢 army.spark_lane: bucket gpt-5.3-codex-spark in quota — backoff ${BACKOFF_HOURS}h. Task NON consumato: $(basename "$TASK_FILE")"
+            elif [ "$CODEX_RC" -eq 0 ]; then
+                report_date="$(date +%Y-%m-%d)"
+                report_path="$REPORTS_DIR/${report_date}-${slug}.md"
+                {
+                    echo "# ${title_line:-$(basename "$TASK_FILE" .md)}"
+                    echo
+                    echo "- source task: \`infra/army/spark-queue/$(basename "$TASK_FILE")\`"
+                    echo "- model: $MODEL (effort=$EFFORT)"
+                    echo "- generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                    echo
+                    cat "$OUT_TMP"
+                } > "$report_path"
+                echo "$TASK_KEY" >> "$DONE_LIST"
+                log "report written: $report_path"
+                RUN_STATUS="ok"
+                RUN_NOTE="report: $report_path"
+                printf '{"ts":"%s","task":"%s","slug":"%s","status":"ok","report":"%s"}\n' \
+                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$TASK_FILE")" "$slug" "$report_path" >> "$PROCESSED_LOG"
+            else
+                log "codex exec failed rc=$CODEX_RC — task left pending (not marked done)"
+                tail_text="$(tail -c 600 "$OUT_TMP" 2>/dev/null | tr '\n' ' ' | tr -s ' ')"
+                RUN_STATUS="error"
+                RUN_NOTE="codex rc=$CODEX_RC"
+                printf '{"ts":"%s","task":"%s","slug":"%s","status":"error","rc":%s}\n' \
+                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$TASK_FILE")" "$slug" "$CODEX_RC" >> "$PROCESSED_LOG"
+                telegram p0 "army-spark:codex-failed" \
+                    "🔴 army.spark_lane: codex exec rc=$CODEX_RC su $(basename "$TASK_FILE"). Tail: ${tail_text:0:400}"
+            fi
+            rm -f "$OUT_TMP" 2>/dev/null
+        fi
+    fi
+fi
+
+# ── daily digest (once per day, first tick at/after DIGEST_HOUR local) ───
+DIGEST_MARK="$STATE_DIR/last-digest-date.txt"
+today="$(date +%Y-%m-%d)"
+cur_hour="$(date +%H | sed 's/^0//')"
+[ -z "$cur_hour" ] && cur_hour=0
+last_digest_date=""
+[ -f "$DIGEST_MARK" ] && last_digest_date="$(cat "$DIGEST_MARK" 2>/dev/null)"
+
+if [ "$cur_hour" -ge "$DIGEST_HOUR" ] && [ "$last_digest_date" != "$today" ]; then
+    yesterday="$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d yesterday +%Y-%m-%d 2>/dev/null)"
+    if [ -f "$PROCESSED_LOG" ] && [ -n "$yesterday" ]; then
+        # `printf` above writes the JSON compact (no space after `:`); the
+        # optional-space pattern still matches that shape, so counting it a
+        # second time without the space would double-count every line.
+        n_yesterday="$(grep -c "\"ts\": *\"${yesterday}" "$PROCESSED_LOG" 2>/dev/null || echo 0)"
+    else
+        n_yesterday=0
+    fi
+    log "daily digest: $n_yesterday task(s) processed on $yesterday — reports in $REPORTS_DIR"
+    telegram digest "army-spark:daily-digest:$today" \
+        "🌅 army.spark_lane digest: ${n_yesterday} task processati ieri (${yesterday:-?}). Report dir: $REPORTS_DIR"
+    echo "$today" > "$DIGEST_MARK"
+fi
+
+log "tick done status=$RUN_STATUS note=$RUN_NOTE"
+heartbeat "$RUN_STATUS" "$RUN_NOTE"
+exit 0

--- a/scripts/army/spark_lane.sh
+++ b/scripts/army/spark_lane.sh
@@ -4,6 +4,26 @@
 # bucket from the primary codex quota — see
 # research/operations/2026-08-14-armata-h24-standing-lanes.md).
 #
+# Amended same day after a cross-family Kimi K3 refutation closed 12
+# numbered defects (design doc §Amendment log). What changed vs the first
+# cut: atomic mkdir-based run lock (was a plain pidfile write, not atomic
+# against a real race); dedup key is now sha256 of TASK CONTENT ONLY, not
+# filename+sha (a rename/move no longer creates a duplicate entry); the
+# done-list is an append-only JSONL of every ATTEMPT (not just successes),
+# so a poisoned task gets quarantined after 2 failures instead of blocking
+# the head of the queue forever, and corrupt state HALTS the lane instead
+# of failing open into re-running the whole queue; backoff is a fixed 12h
+# (never exponential) and also fires on 3 consecutive non-quota failures
+# (protects against a silently-changed codex output format); every report
+# now carries the checkout HEAD sha + task sha for reproducibility; the
+# daily cap and every date computation go through an explicit WITA
+# (Asia/Makassar, fixed UTC+8, no DST) clock instead of ambient system TZ;
+# a kill-switch-off tick still runs the digest check so a forgotten kill
+# switch stays visible; every successful tick stamps last_success_epoch
+# into the SAME organism heartbeat sidecar the repo's existing
+# organism_stale_detector.py already auto-discovers (no separate registry
+# — confirmed by reading that detector before wiring this in).
+#
 # Contract (non-negotiable, cicatrix-superscar.md families #1/#2/#5/#7):
 #   - repo-canonical only: the plist invokes THIS file's repo path directly,
 #     no HOME-fork copy (family #1).
@@ -11,7 +31,7 @@
 #   - read-only: codex runs with --sandbox read-only against the MAIN
 #     checkout; this lane never writes/commits/pushes/opens a PR (family #5,
 #     and the explicit "no auto-PR" contract for both Armata H24 lanes).
-#   - quota-aware backoff, daily run cap, single-instance pidfile.
+#   - quota-aware backoff, daily run cap, single-instance lock.
 #   - fail-visible via the ONE Telegram gateway (scripts/tg_notify.py) —
 #     never a raw curl, never a hardcoded token.
 #
@@ -29,11 +49,11 @@ REPORTS_DIR="${ARMY_SPARK_REPORTS_DIR:-$HOME/army/spark/reports}"
 STATE_DIR="${ARMY_SPARK_STATE_DIR:-$HOME/army/spark/state}"
 LOG_DIR="${ARMY_SPARK_LOG_DIR:-$HOME/logs/army-spark}"
 SIDECAR_DIR="${ARMY_SPARK_SIDECAR_DIR:-$HOME/.organism/last_seen}"
-PIDFILE="${ARMY_SPARK_PIDFILE:-/tmp/nuzantara-army-spark-lane.pid}"
 
 DAILY_CAP="${ARMY_SPARK_DAILY_CAP:-6}"
 TIMEOUT_S="${ARMY_SPARK_TIMEOUT_S:-900}"
-BACKOFF_HOURS="${ARMY_SPARK_BACKOFF_HOURS:-6}"
+BACKOFF_HOURS="${ARMY_SPARK_BACKOFF_HOURS:-12}"
+CONSEC_FAIL_LIMIT="${ARMY_SPARK_CONSEC_FAIL_LIMIT:-3}"
 DIGEST_HOUR="${ARMY_SPARK_DIGEST_HOUR:-7}"
 MODEL="${ARMY_SPARK_MODEL:-gpt-5.3-codex-spark}"
 EFFORT="${ARMY_SPARK_EFFORT:-medium}"
@@ -44,6 +64,31 @@ mkdir -p "$LOG_DIR"
 LOG="$LOG_DIR/run.log"
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
 log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+# ── WITA (Asia/Makassar) day-boundary discipline, declared explicitly ────
+# Fixed UTC+8, no DST — `TZ=Asia/Makassar date` needs no tzdata beyond what
+# every macOS ships. Never rely on ambient system/launchd TZ for "today"/
+# "this hour": that TZ is not guaranteed to be WITA in every cron
+# environment, and a day-cap or digest keyed off the wrong day is silently
+# wrong, not loudly broken (family #9 discipline).
+wita_date() { TZ=Asia/Makassar date '+%Y-%m-%d'; }
+wita_hour() { TZ=Asia/Makassar date '+%H' | sed 's/^0//'; }
+wita_yesterday() {
+    TZ=Asia/Makassar date -v-1d '+%Y-%m-%d' 2>/dev/null \
+        || TZ=Asia/Makassar date -d yesterday '+%Y-%m-%d' 2>/dev/null
+}
+wita_weekday() { TZ=Asia/Makassar date '+%u'; }  # 1=Monday
+
+resolve_py3() {
+    for py in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
+        if command -v "$py" >/dev/null 2>&1; then
+            printf '%s' "$py"
+            return 0
+        fi
+    done
+    return 1
+}
+PY3="$(resolve_py3 || true)"
 
 heartbeat() {  # $1 status, $2 note — every exit path (Esiste≠Armato)
     if [ -f "$REPO/scripts/lib/heartbeat.sh" ]; then
@@ -58,22 +103,63 @@ heartbeat() {  # $1 status, $2 note — every exit path (Esiste≠Armato)
     fi
 }
 
+# Item 11: stamp last_success_epoch INTO the same sidecar heartbeat() just
+# wrote. organism_stale_detector.py auto-discovers every *.json file under
+# ~/.organism/last_seen/ (confirmed by reading it before wiring this in —
+# no separate allow-list/registry required for staleness detection; the
+# only other registry in the repo, apps/organism/organism/organs_registry.yaml,
+# is consumed by sentinel-aggregate.py/healer_receptor_registry.py for
+# recovery-action automation, not by the stale detector — Phase 2 candidate
+# if that automation is wanted, see the design doc). Kept as a field INSIDE
+# the existing sidecar rather than a second file: one artifact, one reader
+# contract, additive-only so a JSON reader that only looks at ts/status is
+# unaffected. Only $PY3-dependent; degrades to a logged no-op without it
+# (the base heartbeat above still landed, so liveness itself is not lost).
+stamp_last_success() {  # $1 status
+    [ -n "$PY3" ] || { log "WARN: no python3 — last_success_epoch not stamped"; return 0; }
+    local sidecar_file="$SIDECAR_DIR/$ORGAN_ID.json"
+    "$PY3" - "$sidecar_file" "$1" <<'PYEOF' >> "$LOG" 2>&1
+import json, os, sys, time
+path, status = sys.argv[1], sys.argv[2]
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    data = {}
+if status == "ok":
+    data["last_success_epoch"] = int(time.time())
+tmp = f"{path}.tmp.{os.getpid()}"
+try:
+    with open(tmp, "w", encoding="utf-8") as fh:
+        # Compact separators (no space after ':') to match this repo's
+        # existing sidecar convention (scripts/army/spark_lane.sh's own
+        # printf fallback writes compact JSON) — some readers of this file
+        # (including this lane's own test suite) grep for `"status":"x"`
+        # rather than parsing JSON properly.
+        json.dump(data, fh, separators=(",", ":"))
+        fh.write("\n")
+    os.replace(tmp, path)
+except Exception as exc:
+    print(f"stamp_last_success failed (non-fatal): {exc}")
+PYEOF
+}
+
 telegram() {  # $1 tier, $2 dedup-key, $3 text — through the ONE gateway
-    local tier="$1" key="$2" text="$3" gateway py
+    local tier="$1" key="$2" text="$3" gateway
     gateway="$REPO/scripts/tg_notify.py"
     [ -f "$gateway" ] || { log "NO GATEWAY at $gateway — alert NOT sent: ${text:0:80}"; return 0; }
-    for py in /usr/bin/python3 /opt/homebrew/bin/python3 /usr/local/bin/python3 python3; do
-        command -v "$py" >/dev/null 2>&1 || continue
-        log "tg_notify[$key]: $("$py" "$gateway" --tier "$tier" --source "army-spark-lane" \
-            --dedup-key "$key" -- "$text" 2>&1 | tail -1)"
+    if [ -z "$PY3" ]; then
+        log "no python3 found — alert NOT sent: ${text:0:80}"
         return 0
-    done
-    log "no python3 found — alert NOT sent: ${text:0:80}"
+    fi
+    log "tg_notify[$key]: $("$PY3" "$gateway" --tier "$tier" --source "army-spark-lane" \
+        --dedup-key "$key" -- "$text" 2>&1 | tail -1)"
 }
 
 # ── G4 node guard — this lane is Pro-only by design (M5 = no cron, per
 #    CLAUDE.md; Mini would be active-active with Pro on the same queue,
-#    superscar #10) ──────────────────────────────────────────────────────
+#    superscar #10). A wrong-node tick exits immediately — not my machine,
+#    not my digest to send. ──────────────────────────────────────────────
 if [ "${ARMY_SPARK_SKIP_NODE_GUARD:-}" != "1" ]; then
     # ARMY_SPARK_NODE_OVERRIDE lets tests exercise this guard deterministically
     # without depending on the real hostname of whatever machine runs the
@@ -87,28 +173,12 @@ if [ "${ARMY_SPARK_SKIP_NODE_GUARD:-}" != "1" ]; then
     fi
 fi
 
-# ── G5 kill switch ──────────────────────────────────────────────────────
-if [ "${ARMY_SPARK_ENABLED:-true}" = "false" ]; then
-    log "kill switch ARMY_SPARK_ENABLED=false — exiting"
-    heartbeat "disabled" "kill switch"
-    exit 0
-fi
-
-# ── G10 single instance ─────────────────────────────────────────────────
-if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
-    log "previous run still alive (pid $(cat "$PIDFILE")) — skipping"
-    heartbeat "ok" "skipped: previous run alive"
-    exit 0
-fi
-echo $$ > "$PIDFILE"
-trap 'rm -f "$PIDFILE"' EXIT
-
 mkdir -p "$REPORTS_DIR" "$STATE_DIR"
-DONE_LIST="$STATE_DIR/done-list.txt"
+ATTEMPTS_FILE="$STATE_DIR/attempts.jsonl"   # append-only; see select_task() below
 BACKOFF_FILE="$STATE_DIR/backoff-until.txt"
-COUNT_FILE="$STATE_DIR/run-count-$(date +%Y-%m-%d).txt"
-PROCESSED_LOG="$STATE_DIR/processed-log.jsonl"
-touch "$DONE_LIST" "$PROCESSED_LOG"
+CONSEC_FAIL_FILE="$STATE_DIR/consecutive-non-quota-fails.txt"
+COUNT_FILE="$STATE_DIR/run-count-$(wita_date).txt"
+touch "$ATTEMPTS_FILE"
 
 sha256_of() {
     if command -v shasum >/dev/null 2>&1; then
@@ -131,64 +201,287 @@ slugify() {
     printf '%s' "$s"
 }
 
-RUN_STATUS="idle"
+# Item 2/3: content-only sha dedup + retry-count/head-of-line via a JSONL
+# fold. Offloaded to python3 rather than hand-rolled bash JSON parsing —
+# this repo's own scar history (W104, W108) is largely bash scripts
+# mis-parsing structured state; python's json module doesn't have that
+# failure mode. Prints one of:
+#   CORRUPT\t<lineno>          — attempts.jsonl has an unparseable line
+#   EMPTY                      — queue empty, or every task is done/quarantined
+#   PICK\t<path>\t<sha256>     — the task to dispatch this tick
+select_task() {
+    [ -n "$PY3" ] || { printf 'CORRUPT\t(no-python3)\n'; return 0; }
+    "$PY3" - "$QUEUE_DIR" "$ATTEMPTS_FILE" <<'PYEOF'
+import hashlib
+import json
+import os
+import sys
+
+queue_dir, attempts_file = sys.argv[1], sys.argv[2]
+
+
+def sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+by_sha = {}
+if os.path.isfile(attempts_file):
+    with open(attempts_file, "r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+                sha = row["sha"]
+                status = row["status"]
+            except Exception:
+                print(f"CORRUPT\t{lineno}")
+                sys.exit(0)
+            info = by_sha.setdefault(sha, {"ok": False, "failed": 0})
+            if status == "ok":
+                info["ok"] = True
+            elif status == "failed":
+                info["failed"] += 1
+            # status == "quota" touches neither counter — not the task's fault
+
+try:
+    names = sorted(os.listdir(queue_dir))
+except FileNotFoundError:
+    names = []
+
+candidates = []
+for name in names:
+    if not name.endswith(".md"):
+        continue
+    path = os.path.join(queue_dir, name)
+    if not os.path.isfile(path):
+        continue
+    candidates.append((os.path.getmtime(path), path, sha256_of(path)))
+candidates.sort(key=lambda c: c[0])
+
+cohort_never_attempted = []
+cohort_one_failure = []
+for _mtime, path, sha in candidates:
+    info = by_sha.get(sha)
+    if info is None:
+        cohort_never_attempted.append((path, sha))
+        continue
+    if info["ok"]:
+        continue  # done, permanently skip
+    if info["failed"] >= 2:
+        continue  # quarantined: a poisoned task must never block the head
+    if info["failed"] == 1:
+        cohort_one_failure.append((path, sha))
+    else:
+        cohort_never_attempted.append((path, sha))
+
+picked = cohort_never_attempted or cohort_one_failure
+if picked:
+    path, sha = picked[0]
+    print(f"PICK\t{path}\t{sha}")
+else:
+    print("EMPTY")
+PYEOF
+}
+
+append_attempt() {  # $1 sha $2 filename $3 status(ok|failed|quota) $4 report-path-or-dash
+    [ -n "$PY3" ] || { log "WARN: no python3 — attempt NOT recorded (sha=$1 status=$3)"; return 0; }
+    "$PY3" - "$ATTEMPTS_FILE" "$1" "$2" "$3" "$4" <<'PYEOF' >> "$LOG" 2>&1
+import json, sys, time
+path, sha, filename, status, report = sys.argv[1:6]
+row = {
+    "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "sha": sha,
+    "filename": filename,
+    "status": status,
+    "report": (None if report == "-" else report),
+    "outcome": None,  # item 12: a verification session appends a corrected row later
+}
+try:
+    with open(path, "a", encoding="utf-8") as fh:
+        # Compact separators — see stamp_last_success()'s comment: several
+        # readers of this repo's sidecar/state JSON (including this lane's
+        # own test suite) grep for `"key":"value"` rather than parsing.
+        fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+except Exception as exc:
+    print(f"append_attempt failed (non-fatal, dedup may miss this attempt): {exc}")
+PYEOF
+}
+
+weekly_produced_consumed() {  # prints "<produced> <consumed>"
+    [ -n "$PY3" ] || { echo "0 0"; return 0; }
+    "$PY3" - "$ATTEMPTS_FILE" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+produced = 0
+consumed = 0
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except Exception:
+                continue
+            if row.get("status") == "ok":
+                produced += 1
+            if row.get("outcome") in ("applied", "rejected", "read"):
+                consumed += 1
+except FileNotFoundError:
+    pass
+print(f"{produced} {consumed}")
+PYEOF
+}
+
+# RUN_STATUS_HB   — heartbeat.sh's normalized vocabulary (ok/degraded/error/disabled)
+# RUN_STATUS_RICH — this lane's own, unrestricted vocabulary, used by the
+#                   digest and this run's own log line. NEVER pass RUN_STATUS_RICH
+#                   words like "killed" to heartbeat(): heartbeat.sh's own
+#                   vocabulary maps "killed" to "error" (verified by reading
+#                   scripts/lib/heartbeat.sh before wiring this in) — using it
+#                   there would make an intentional kill-switch-off tick alarm
+#                   as a crash. The two vocabularies are deliberately kept apart.
+RUN_STATUS_HB="ok"
+RUN_STATUS_RICH="ok"
 RUN_NOTE="no task processed this tick"
+SHOULD_WORK=1
+WE_OWN_LOCK=0
+LOCK_DIR="$STATE_DIR/run.lock"
+
+release_lock() {
+    if [ "$WE_OWN_LOCK" = "1" ]; then
+        rm -rf "$LOCK_DIR" 2>/dev/null
+    fi
+}
+trap release_lock EXIT
+
+# ── G5 kill switch — falls through to the trailer (still sends the digest
+#    check) rather than exiting immediately, so a forgotten kill switch
+#    stays visible every day it's checked, not just the day it was flipped.
+if [ "${ARMY_SPARK_ENABLED:-true}" = "false" ]; then
+    log "kill switch ARMY_SPARK_ENABLED=false — exiting work, digest still runs"
+    RUN_STATUS_HB="disabled"
+    RUN_STATUS_RICH="killed"
+    RUN_NOTE="kill switch"
+    SHOULD_WORK=0
+fi
+
+# ── G10 single instance — atomic mkdir claim, pid-checked, self-healing on
+#    a stale (dead-owner) lock. `mkdir` is atomic at the filesystem level in
+#    a way a plain pidfile write is not (launchd does not guarantee
+#    serialization against a manual run of the same script).
+if [ "$SHOULD_WORK" = "1" ]; then
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        echo $$ > "$LOCK_DIR/pid" 2>/dev/null
+        WE_OWN_LOCK=1
+    else
+        lock_pid=""
+        [ -f "$LOCK_DIR/pid" ] && lock_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null)"
+        if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
+            log "previous run still alive (pid $lock_pid) — skipping (overlap)"
+            RUN_STATUS_HB="ok"
+            RUN_STATUS_RICH="skipped-overlap"
+            RUN_NOTE="skipped: previous run alive (pid $lock_pid)"
+            SHOULD_WORK=0
+        else
+            log "reclaiming stale lock dir (owner pid $lock_pid not alive)"
+            rm -rf "$LOCK_DIR" 2>/dev/null
+            if mkdir "$LOCK_DIR" 2>/dev/null; then
+                echo $$ > "$LOCK_DIR/pid" 2>/dev/null
+                WE_OWN_LOCK=1
+            else
+                log "lost the race reclaiming the lock — treating as overlap, safe default"
+                RUN_STATUS_HB="ok"
+                RUN_STATUS_RICH="skipped-overlap"
+                RUN_NOTE="skipped: lock reclaim race"
+                SHOULD_WORK=0
+            fi
+        fi
+    fi
+fi
+
+if [ "$SHOULD_WORK" = "1" ] && [ -z "$PY3" ]; then
+    log "no python3 interpreter found — cannot safely manage attempts.jsonl state, skipping this tick"
+    RUN_STATUS_HB="error"
+    RUN_STATUS_RICH="error"
+    RUN_NOTE="no python3 interpreter available"
+    SHOULD_WORK=0
+    telegram p0 "army-spark:no-python3" \
+        "🔴 army.spark_lane: nessun interprete python3 trovato — impossibile gestire lo stato in sicurezza, tick saltato."
+fi
 
 # ── backoff check ────────────────────────────────────────────────────────
-now_epoch="$(date +%s)"
-backoff_until=0
-[ -f "$BACKOFF_FILE" ] && backoff_until="$(cat "$BACKOFF_FILE" 2>/dev/null || echo 0)"
-case "$backoff_until" in ''|*[!0-9]*) backoff_until=0 ;; esac
+if [ "$SHOULD_WORK" = "1" ]; then
+    now_epoch="$(date +%s)"
+    backoff_until=0
+    [ -f "$BACKOFF_FILE" ] && backoff_until="$(cat "$BACKOFF_FILE" 2>/dev/null || echo 0)"
+    case "$backoff_until" in ''|*[!0-9]*) backoff_until=0 ;; esac
 
-if [ "$backoff_until" -gt "$now_epoch" ]; then
-    log "backoff active until epoch $backoff_until — skipping dispatch this tick"
-    RUN_STATUS="degraded"
-    RUN_NOTE="backoff active until $backoff_until"
-else
-    # ── daily cap ────────────────────────────────────────────────────────
+    if [ "$backoff_until" -gt "$now_epoch" ]; then
+        log "backoff active until epoch $backoff_until — skipping dispatch this tick"
+        RUN_STATUS_HB="degraded"
+        RUN_STATUS_RICH="backoff"
+        RUN_NOTE="backoff active until $backoff_until"
+        SHOULD_WORK=0
+    fi
+fi
+
+# ── daily cap (WITA calendar day, item 6) ──────────────────────────────
+if [ "$SHOULD_WORK" = "1" ]; then
     run_count=0
     [ -f "$COUNT_FILE" ] && run_count="$(cat "$COUNT_FILE" 2>/dev/null || echo 0)"
     case "$run_count" in ''|*[!0-9]*) run_count=0 ;; esac
 
     if [ "$run_count" -ge "$DAILY_CAP" ]; then
-        log "daily cap reached ($run_count/$DAILY_CAP) — skipping dispatch this tick"
-        RUN_STATUS="ok"
+        log "daily cap reached ($run_count/$DAILY_CAP, WITA day $(wita_date)) — skipping dispatch this tick"
+        RUN_STATUS_HB="ok"
+        RUN_STATUS_RICH="cap-reached"
         RUN_NOTE="daily cap reached ($run_count/$DAILY_CAP)"
+        SHOULD_WORK=0
     elif [ ! -d "$QUEUE_DIR" ]; then
         log "queue dir missing: $QUEUE_DIR"
-        RUN_STATUS="error"
+        RUN_STATUS_HB="error"
+        RUN_STATUS_RICH="error"
         RUN_NOTE="queue dir missing"
-    else
-        # ── pick oldest not-yet-done task ──────────────────────────────
-        TASK_FILE=""
-        # mtime-sorted oldest-first; macOS/BSD stat, so no GNU --time-style.
-        while IFS= read -r f; do
-            [ -f "$f" ] || continue
-            base="$(basename "$f")"
-            digest="$(sha256_of "$f")"
-            key="${base}:${digest}"
-            if ! grep -qxF "$key" "$DONE_LIST" 2>/dev/null; then
-                TASK_FILE="$f"
-                TASK_KEY="$key"
-                break
-            fi
-        done < <(
-            for f in "$QUEUE_DIR"/*.md; do
-                [ -f "$f" ] || continue
-                mt="$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)"
-                printf '%s\t%s\n' "$mt" "$f"
-            done | sort -n | cut -f2-
-        )
+        SHOULD_WORK=0
+    fi
+fi
 
-        if [ -z "$TASK_FILE" ]; then
-            log "queue empty or fully processed — nothing to dispatch"
-            RUN_STATUS="ok"
+# ── task selection + dispatch ────────────────────────────────────────────
+if [ "$SHOULD_WORK" = "1" ]; then
+    SELECT_OUT="$(select_task)"
+    SELECT_KIND="$(printf '%s' "$SELECT_OUT" | head -1 | cut -f1)"
+
+    case "$SELECT_KIND" in
+        CORRUPT)
+            corrupt_line="$(printf '%s' "$SELECT_OUT" | head -1 | cut -f2)"
+            log "attempts.jsonl CORRUPT at line $corrupt_line — halting, NOT falling open into re-running the queue"
+            RUN_STATUS_HB="error"
+            RUN_STATUS_RICH="state-corrupt"
+            RUN_NOTE="attempts.jsonl corrupt at line $corrupt_line"
+            telegram p0 "army-spark:state-corrupt" \
+                "🔴 army.spark_lane: attempts.jsonl corrotto (riga $corrupt_line) — lane FERMATA, nessun dispatch. Serve intervento manuale sullo stato."
+            ;;
+        EMPTY)
+            log "queue empty, fully done, or fully quarantined — nothing to dispatch"
+            RUN_STATUS_HB="ok"
+            RUN_STATUS_RICH="ok"
             RUN_NOTE="queue empty"
-        else
+            ;;
+        PICK)
+            TASK_FILE="$(printf '%s' "$SELECT_OUT" | head -1 | cut -f2)"
+            TASK_SHA="$(printf '%s' "$SELECT_OUT" | head -1 | cut -f3)"
             title_line="$(head -1 "$TASK_FILE" 2>/dev/null | sed 's/^#\+ *//')"
             slug="$(slugify "${title_line:-$(basename "$TASK_FILE" .md)}")"
             [ -n "$slug" ] || slug="task"
-            log "dispatching task=$(basename "$TASK_FILE") slug=$slug model=$MODEL effort=$EFFORT"
+            log "dispatching task=$(basename "$TASK_FILE") sha=$TASK_SHA slug=$slug model=$MODEL effort=$EFFORT"
 
             _to="$(command -v timeout || command -v gtimeout || true)"
             OUT_TMP="$(mktemp "${TMPDIR:-/tmp}/army-spark.XXXXXX" 2>/dev/null || echo "/tmp/army-spark.$$")"
@@ -218,70 +511,108 @@ else
             if grep -qiE 'out of extra usage|usage limit|quota exceeded|rate.limit|429|weekly limit' "$OUT_TMP" 2>/dev/null; then
                 new_backoff=$((now_epoch + BACKOFF_HOURS * 3600))
                 echo "$new_backoff" > "$BACKOFF_FILE"
+                echo 0 > "$CONSEC_FAIL_FILE"   # quota is a distinct, correctly-classified state
                 log "quota marker detected — backoff until epoch $new_backoff (${BACKOFF_HOURS}h)"
-                RUN_STATUS="degraded"
+                RUN_STATUS_HB="degraded"
+                RUN_STATUS_RICH="quota"
                 RUN_NOTE="quota: backoff ${BACKOFF_HOURS}h"
-                printf '{"ts":"%s","task":"%s","slug":"%s","status":"quota"}\n' \
-                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$TASK_FILE")" "$slug" >> "$PROCESSED_LOG"
+                append_attempt "$TASK_SHA" "$(basename "$TASK_FILE")" "quota" "-"
                 telegram digest "army-spark:quota" \
                     "🐢 army.spark_lane: bucket gpt-5.3-codex-spark in quota — backoff ${BACKOFF_HOURS}h. Task NON consumato: $(basename "$TASK_FILE")"
             elif [ "$CODEX_RC" -eq 0 ]; then
-                report_date="$(date +%Y-%m-%d)"
+                report_date="$(wita_date)"
+                head_sha="$(cd "$REPO" && git rev-parse HEAD 2>/dev/null || echo unknown)"
                 report_path="$REPORTS_DIR/${report_date}-${slug}.md"
                 {
                     echo "# ${title_line:-$(basename "$TASK_FILE" .md)}"
                     echo
                     echo "- source task: \`infra/army/spark-queue/$(basename "$TASK_FILE")\`"
+                    echo "- checkout HEAD: \`$head_sha\`"
+                    echo "- task sha256: \`$TASK_SHA\`"
                     echo "- model: $MODEL (effort=$EFFORT)"
                     echo "- generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
                     echo
                     cat "$OUT_TMP"
                 } > "$report_path"
-                echo "$TASK_KEY" >> "$DONE_LIST"
+                echo 0 > "$CONSEC_FAIL_FILE"
                 log "report written: $report_path"
-                RUN_STATUS="ok"
+                RUN_STATUS_HB="ok"
+                RUN_STATUS_RICH="ok"
                 RUN_NOTE="report: $report_path"
-                printf '{"ts":"%s","task":"%s","slug":"%s","status":"ok","report":"%s"}\n' \
-                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$TASK_FILE")" "$slug" "$report_path" >> "$PROCESSED_LOG"
+                append_attempt "$TASK_SHA" "$(basename "$TASK_FILE")" "ok" "$report_path"
             else
-                log "codex exec failed rc=$CODEX_RC — task left pending (not marked done)"
+                log "codex exec failed rc=$CODEX_RC — task attempt recorded, quarantines after 2 failures"
                 tail_text="$(tail -c 600 "$OUT_TMP" 2>/dev/null | tr '\n' ' ' | tr -s ' ')"
-                RUN_STATUS="error"
-                RUN_NOTE="codex rc=$CODEX_RC"
-                printf '{"ts":"%s","task":"%s","slug":"%s","status":"error","rc":%s}\n' \
-                    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(basename "$TASK_FILE")" "$slug" "$CODEX_RC" >> "$PROCESSED_LOG"
+                append_attempt "$TASK_SHA" "$(basename "$TASK_FILE")" "failed" "-"
+
+                consec=0
+                [ -f "$CONSEC_FAIL_FILE" ] && consec="$(cat "$CONSEC_FAIL_FILE" 2>/dev/null || echo 0)"
+                case "$consec" in ''|*[!0-9]*) consec=0 ;; esac
+                consec=$((consec + 1))
+                echo "$consec" > "$CONSEC_FAIL_FILE"
+
+                RUN_STATUS_HB="error"
+                RUN_STATUS_RICH="error"
+                RUN_NOTE="codex rc=$CODEX_RC (consecutive non-quota fails: $consec)"
                 telegram p0 "army-spark:codex-failed" \
                     "🔴 army.spark_lane: codex exec rc=$CODEX_RC su $(basename "$TASK_FILE"). Tail: ${tail_text:0:400}"
+
+                if [ "$consec" -ge "$CONSEC_FAIL_LIMIT" ]; then
+                    new_backoff=$((now_epoch + BACKOFF_HOURS * 3600))
+                    echo "$new_backoff" > "$BACKOFF_FILE"
+                    echo 0 > "$CONSEC_FAIL_FILE"
+                    log "$consec consecutive non-quota failures >= limit $CONSEC_FAIL_LIMIT — backoff ${BACKOFF_HOURS}h (possible format change)"
+                    telegram p0 "army-spark:consecutive-fail-backoff" \
+                        "🔴 army.spark_lane: $consec fallimenti non-quota consecutivi — possibile cambio di formato output codex. Backoff ${BACKOFF_HOURS}h."
+                fi
             fi
             rm -f "$OUT_TMP" 2>/dev/null
-        fi
-    fi
+            ;;
+        *)
+            log "select_task returned unexpected output: $SELECT_OUT"
+            RUN_STATUS_HB="error"
+            RUN_STATUS_RICH="error"
+            RUN_NOTE="select_task: unexpected output"
+            ;;
+    esac
 fi
 
-# ── daily digest (once per day, first tick at/after DIGEST_HOUR local) ───
+# ── daily digest (once per day, first tick at/after DIGEST_HOUR WITA) ────
+# Runs regardless of SHOULD_WORK — item 11: a kill-switch-off or
+# lock-overlap tick must still be able to report the digest if it's the
+# first tick past DIGEST_HOUR that day.
 DIGEST_MARK="$STATE_DIR/last-digest-date.txt"
-today="$(date +%Y-%m-%d)"
-cur_hour="$(date +%H | sed 's/^0//')"
+today="$(wita_date)"
+cur_hour="$(wita_hour)"
 [ -z "$cur_hour" ] && cur_hour=0
 last_digest_date=""
 [ -f "$DIGEST_MARK" ] && last_digest_date="$(cat "$DIGEST_MARK" 2>/dev/null)"
 
 if [ "$cur_hour" -ge "$DIGEST_HOUR" ] && [ "$last_digest_date" != "$today" ]; then
-    yesterday="$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d yesterday +%Y-%m-%d 2>/dev/null)"
-    if [ -f "$PROCESSED_LOG" ] && [ -n "$yesterday" ]; then
-        # `printf` above writes the JSON compact (no space after `:`); the
-        # optional-space pattern still matches that shape, so counting it a
-        # second time without the space would double-count every line.
-        n_yesterday="$(grep -c "\"ts\": *\"${yesterday}" "$PROCESSED_LOG" 2>/dev/null || echo 0)"
-    else
-        n_yesterday=0
+    yesterday="$(wita_yesterday)"
+    n_yesterday=0
+    if [ -f "$ATTEMPTS_FILE" ] && [ -n "$yesterday" ]; then
+        # attempts.jsonl writes ts compact (no space after `:`); the
+        # optional-space pattern still matches that shape.
+        n_yesterday="$(grep -c "\"ts\": *\"${yesterday}" "$ATTEMPTS_FILE" 2>/dev/null || echo 0)"
+    fi
+    digest_text="🌅 army.spark_lane digest: ${n_yesterday} task processati ieri (${yesterday:-?}). Report dir: $REPORTS_DIR"
+    if [ "$RUN_STATUS_RICH" = "killed" ]; then
+        digest_text="$digest_text | ⚠️ ARMY_SPARK_ENABLED=false — lane disabilitata"
+    fi
+    weekday="$(wita_weekday)"
+    if [ "$weekday" = "1" ] && [ -n "$PY3" ]; then
+        stats="$(weekly_produced_consumed)"
+        produced="${stats% *}"
+        consumed="${stats#* }"
+        digest_text="$digest_text | 📊 settimanale: ${produced} report prodotti, ${consumed} verificati"
     fi
     log "daily digest: $n_yesterday task(s) processed on $yesterday — reports in $REPORTS_DIR"
-    telegram digest "army-spark:daily-digest:$today" \
-        "🌅 army.spark_lane digest: ${n_yesterday} task processati ieri (${yesterday:-?}). Report dir: $REPORTS_DIR"
+    telegram digest "army-spark:daily-digest:$today" "$digest_text"
     echo "$today" > "$DIGEST_MARK"
 fi
 
-log "tick done status=$RUN_STATUS note=$RUN_NOTE"
-heartbeat "$RUN_STATUS" "$RUN_NOTE"
+log "tick done status_hb=$RUN_STATUS_HB status_rich=$RUN_STATUS_RICH note=$RUN_NOTE"
+heartbeat "$RUN_STATUS_HB" "$RUN_NOTE"
+stamp_last_success "$RUN_STATUS_HB"
 exit 0

--- a/scripts/tests/test_army_spark_lane.sh
+++ b/scripts/tests/test_army_spark_lane.sh
@@ -1,0 +1,265 @@
+#!/bin/sh
+# test_army_spark_lane.sh — guilt+innocence corpus for scripts/army/spark_lane.sh
+# (Armata H24 lane 1, 2026-08-14). Runs the REAL wrapper against a fake HOME +
+# fake repo + a controllable stub `codex` binary, never the network, never a
+# live queue. W107 discipline: prove the alarm/behaviour FIRES on the failure
+# shapes it exists to catch, not just that the caller survives.
+#
+# Run:  sh scripts/tests/test_army_spark_lane.sh
+# Exit: 0 all pass, 1 any failure.
+
+fail=0
+pass=0
+note_pass() { pass=$((pass + 1)); echo "PASS - $1"; }
+note_fail() { fail=$((fail + 1)); echo "FAIL - $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/army/spark_lane.sh"
+
+if [ ! -f "$WRAPPER" ]; then
+    echo "FATAL: $WRAPPER not found"
+    exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/test-army-spark.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# Fake world: a repo dir (with tg_notify stub) + a queue + isolated state.
+# ---------------------------------------------------------------------------
+setup_world() {
+    rm -rf "$WORK/world"
+    mkdir -p "$WORK/world/repo/scripts" "$WORK/world/queue" \
+        "$WORK/world/reports" "$WORK/world/state" "$WORK/world/logs" \
+        "$WORK/world/sidecar" "$WORK/world/bin" "$WORK/world/home"
+
+    cat > "$WORK/world/repo/scripts/tg_notify.py" <<'PY'
+#!/usr/bin/env python3
+import os
+import sys
+log = os.environ.get("STUB_TG_LOG")
+if log:
+    with open(log, "a", encoding="utf-8") as fh:
+        fh.write(" ".join(sys.argv[1:]) + "\n")
+PY
+    chmod +x "$WORK/world/repo/scripts/tg_notify.py"
+    : > "$WORK/world/tg.log"
+
+    cat > "$WORK/world/queue/task-one.md" <<'MD'
+# Test task one
+
+Read-only analysis prompt body.
+MD
+}
+
+# codex stub: behaviour selected via STUB_CODEX_MODE (success|quota|fail).
+write_codex_stub() {
+    mode="$1"
+    cat > "$WORK/world/bin/codex" <<SH
+#!/bin/sh
+case "\$STUB_CODEX_MODE" in
+    success) echo "STUB REPORT BODY"; exit 0 ;;
+    quota) echo "error: out of extra usage on this weekly bucket"; exit 1 ;;
+    fail) echo "boom: synthetic codex crash"; exit 3 ;;
+    *) echo "unset STUB_CODEX_MODE"; exit 9 ;;
+esac
+SH
+    chmod +x "$WORK/world/bin/codex"
+}
+
+run_wrapper() {
+    # Fixed fake-world env, then caller-supplied VAR=val overrides ("$@"),
+    # then the command. `env` (not shell prefix-assignment) so the override
+    # list can be empty or many words without fragile quoting.
+    env \
+        STUB_TG_LOG="$WORK/world/tg.log" \
+        PATH="$WORK/world/bin:$PATH" \
+        ARMY_SPARK_REPO="$WORK/world/repo" \
+        ARMY_SPARK_QUEUE_DIR="$WORK/world/queue" \
+        ARMY_SPARK_REPORTS_DIR="$WORK/world/reports" \
+        ARMY_SPARK_STATE_DIR="$WORK/world/state" \
+        ARMY_SPARK_LOG_DIR="$WORK/world/logs" \
+        ARMY_SPARK_SIDECAR_DIR="$WORK/world/sidecar" \
+        ARMY_SPARK_PIDFILE="$WORK/world/spark.pid" \
+        ARMY_SPARK_CODEX_BIN="codex" \
+        ARMY_SPARK_SKIP_NODE_GUARD=1 \
+        HOME="$WORK/world/home" \
+        "$@" \
+        /bin/bash "$WRAPPER" > "$WORK/world/wrapper.out" 2>&1
+    echo $?
+}
+
+sidecar_status() {
+    if [ -f "$WORK/world/sidecar/army.spark_lane.json" ]; then
+        # crude field extraction, no jq dependency assumed
+        grep -o '"status":"[a-z]*"' "$WORK/world/sidecar/army.spark_lane.json" | head -1 | cut -d'"' -f4
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Case 1 (guilt): kill switch off -> disabled, no codex invocation.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rc="$(run_wrapper ARMY_SPARK_ENABLED=false STUB_CODEX_MODE=success)"
+status="$(sidecar_status)"
+report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc" = "0" ] && [ "$status" = "disabled" ]; then
+    note_pass "kill switch off: exits 0, heartbeat=disabled"
+else
+    note_fail "kill switch off: rc=$rc status=$status"
+fi
+if [ "$report_count" = "0" ]; then
+    note_pass "kill switch off innocence: no report written"
+else
+    note_fail "kill switch off: a report was written despite the kill switch"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2 (guilt): wrong node -> disabled, no dispatch (node guard fires).
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rc="$(run_wrapper ARMY_SPARK_SKIP_NODE_GUARD=0 ARMY_SPARK_NODE_OVERRIDE=some-other-mac STUB_CODEX_MODE=success)"
+status="$(sidecar_status)"
+if [ "$rc" = "0" ] && [ "$status" = "disabled" ]; then
+    note_pass "wrong node: exits 0, heartbeat=disabled"
+else
+    note_fail "wrong node: rc=$rc status=$status"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3 (innocence): right node override explicitly matches -> proceeds.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rc="$(run_wrapper ARMY_SPARK_SKIP_NODE_GUARD=0 ARMY_SPARK_NODE_OVERRIDE=nuzantara ARMY_SPARK_REQUIRED_NODE=nuzantara STUB_CODEX_MODE=success)"
+report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc" = "0" ] && [ "$report_count" = "1" ]; then
+    note_pass "right node: dispatch proceeds, report written"
+else
+    note_fail "right node: rc=$rc report_count=$report_count"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4 (innocence): successful dispatch writes report, marks task done,
+# heartbeat=ok, and a SECOND tick does not reprocess the same task.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rc1="$(run_wrapper STUB_CODEX_MODE=success)"
+status1="$(sidecar_status)"
+report_file="$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | head -1)"
+if [ "$rc1" = "0" ] && [ "$status1" = "ok" ] && [ -n "$report_file" ] && grep -q "STUB REPORT BODY" "$report_file"; then
+    note_pass "successful dispatch: report written with codex output, heartbeat=ok"
+else
+    note_fail "successful dispatch: rc=$rc1 status=$status1 report_file=$report_file"
+fi
+before_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+rc2="$(run_wrapper STUB_CODEX_MODE=success)"
+after_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc2" = "0" ] && [ "$after_count" = "$before_count" ]; then
+    note_pass "dedup innocence: second tick does not reprocess the already-done task"
+else
+    note_fail "dedup innocence: before=$before_count after=$after_count"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5 (guilt): quota marker in codex output -> backoff written, task NOT
+# marked done, NOT reported as a success report, a digest alert fires.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub quota
+rc="$(run_wrapper STUB_CODEX_MODE=quota)"
+status="$(sidecar_status)"
+report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc" = "0" ] && [ "$status" = "degraded" ] && [ "$report_count" = "0" ] && [ -f "$WORK/world/state/backoff-until.txt" ]; then
+    note_pass "quota: degraded heartbeat, no report, backoff file written"
+else
+    note_fail "quota: rc=$rc status=$status report_count=$report_count backoff_exists=$([ -f "$WORK/world/state/backoff-until.txt" ] && echo y || echo n)"
+fi
+if grep -q "army-spark:quota" "$WORK/world/tg.log" 2>/dev/null; then
+    note_pass "quota: telegram digest alert fired with the right dedup key"
+else
+    note_fail "quota: no telegram digest alert found in stub log"
+fi
+if grep -qxF "task-one.md:$(shasum -a 256 "$WORK/world/queue/task-one.md" 2>/dev/null | awk '{print $1}')" "$WORK/world/state/done-list.txt" 2>/dev/null; then
+    note_fail "quota: task was incorrectly marked done despite the quota condition"
+else
+    note_pass "quota innocence: task NOT marked done (stays eligible for retry after backoff)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6 (guilt): backoff active -> the NEXT tick skips dispatch even with a
+# fresh (non-quota) stub, and does not increment the daily run counter.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+mkdir -p "$WORK/world/state"
+future_epoch=$(( $(date +%s) + 3600 ))
+echo "$future_epoch" > "$WORK/world/state/backoff-until.txt"
+rc="$(run_wrapper STUB_CODEX_MODE=success)"
+report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+status="$(sidecar_status)"
+if [ "$rc" = "0" ] && [ "$report_count" = "0" ] && [ "$status" = "degraded" ]; then
+    note_pass "backoff active: dispatch skipped, no report, degraded heartbeat"
+else
+    note_fail "backoff active: rc=$rc report_count=$report_count status=$status"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 7 (guilt): daily cap reached -> dispatch skipped even with a pending
+# task and no active backoff, heartbeat stays ok (expected condition).
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+mkdir -p "$WORK/world/state"
+echo "6" > "$WORK/world/state/run-count-$(date +%Y-%m-%d).txt"
+rc="$(run_wrapper ARMY_SPARK_DAILY_CAP=6 STUB_CODEX_MODE=success)"
+report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+status="$(sidecar_status)"
+if [ "$rc" = "0" ] && [ "$report_count" = "0" ] && [ "$status" = "ok" ]; then
+    note_pass "daily cap reached: dispatch skipped, no report, heartbeat=ok (expected, not an error)"
+else
+    note_fail "daily cap reached: rc=$rc report_count=$report_count status=$status"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 8 (guilt): codex exec real failure (non-quota) -> error heartbeat,
+# task NOT marked done, a P0 alert fires (distinct dedup key from quota).
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub fail
+rc="$(run_wrapper STUB_CODEX_MODE=fail)"
+status="$(sidecar_status)"
+report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc" = "0" ] && [ "$status" = "error" ] && [ "$report_count" = "0" ]; then
+    note_pass "codex failure: error heartbeat, no report written"
+else
+    note_fail "codex failure: rc=$rc status=$status report_count=$report_count"
+fi
+if grep -q "army-spark:codex-failed" "$WORK/world/tg.log" 2>/dev/null; then
+    note_pass "codex failure: P0 alert fired with the right dedup key"
+else
+    note_fail "codex failure: no P0 alert found in stub log"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 9 (guilt): single-instance guard — a live pidfile blocks a second run
+# and does not touch the queue.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+echo $$ > "$WORK/world/spark.pid"   # this test process's own pid: guaranteed alive
+rc="$(run_wrapper STUB_CODEX_MODE=success)"
+report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$rc" = "0" ] && [ "$report_count" = "0" ]; then
+    note_pass "single-instance guard: concurrent run skipped, no dispatch"
+else
+    note_fail "single-instance guard: rc=$rc report_count=$report_count"
+fi
+rm -f "$WORK/world/spark.pid"
+
+echo
+echo "TOTAL: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/test_army_spark_lane.sh
+++ b/scripts/tests/test_army_spark_lane.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 # test_army_spark_lane.sh — guilt+innocence corpus for scripts/army/spark_lane.sh
-# (Armata H24 lane 1, 2026-08-14). Runs the REAL wrapper against a fake HOME +
-# fake repo + a controllable stub `codex` binary, never the network, never a
-# live queue. W107 discipline: prove the alarm/behaviour FIRES on the failure
-# shapes it exists to catch, not just that the caller survives.
+# (Armata H24 lane 1, 2026-08-14, amended same day after a cross-family Kimi
+# K3 refutation of the design closed 12 numbered defects — see the script's
+# own header and research/operations/2026-08-14-armata-h24-standing-lanes.md).
+# Runs the REAL wrapper against a fake HOME + fake repo + a controllable
+# stub `codex` binary, never the network, never a live queue. W107
+# discipline: prove the alarm/behaviour FIRES on the failure shapes it
+# exists to catch, not just that the caller survives.
+#
+# Requires a real python3 on PATH (the wrapper itself now depends on one for
+# attempts.jsonl state management — this is a deliberate, documented choice,
+# not a gap: see select_task()'s comment in spark_lane.sh).
 #
 # Run:  sh scripts/tests/test_army_spark_lane.sh
 # Exit: 0 all pass, 1 any failure.
@@ -23,6 +30,8 @@ fi
 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/test-army-spark.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
+
+wita_today() { TZ=Asia/Makassar date '+%Y-%m-%d'; }
 
 # ---------------------------------------------------------------------------
 # Fake world: a repo dir (with tg_notify stub) + a queue + isolated state.
@@ -49,6 +58,14 @@ PY
 # Test task one
 
 Read-only analysis prompt body.
+MD
+}
+
+write_task() {  # $1 filename $2 content-line (so distinct tasks hash differently)
+    cat > "$WORK/world/queue/$1" <<MD
+# $2
+
+Read-only analysis prompt body for $2.
 MD
 }
 
@@ -80,7 +97,6 @@ run_wrapper() {
         ARMY_SPARK_STATE_DIR="$WORK/world/state" \
         ARMY_SPARK_LOG_DIR="$WORK/world/logs" \
         ARMY_SPARK_SIDECAR_DIR="$WORK/world/sidecar" \
-        ARMY_SPARK_PIDFILE="$WORK/world/spark.pid" \
         ARMY_SPARK_CODEX_BIN="codex" \
         ARMY_SPARK_SKIP_NODE_GUARD=1 \
         HOME="$WORK/world/home" \
@@ -92,40 +108,63 @@ run_wrapper() {
 sidecar_status() {
     if [ -f "$WORK/world/sidecar/army.spark_lane.json" ]; then
         # crude field extraction, no jq dependency assumed
-        grep -o '"status":"[a-z]*"' "$WORK/world/sidecar/army.spark_lane.json" | head -1 | cut -d'"' -f4
+        grep -o '"status":"[a-z-]*"' "$WORK/world/sidecar/army.spark_lane.json" | head -1 | cut -d'"' -f4
     fi
 }
 
+report_count() { find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' '; }
+
+p0_count() { grep -c '"--tier" *"p0"\|army-spark:[a-z-]*-fail\|tg_notify\[army-spark:' "$WORK/world/tg.log" 2>/dev/null || echo 0; }
+
 # ---------------------------------------------------------------------------
-# Case 1 (guilt): kill switch off -> disabled, no codex invocation.
+# Case 1 (guilt): kill switch off -> disabled, no codex invocation, and the
+# digest-check code path still runs (item 11) rather than an early exit.
 # ---------------------------------------------------------------------------
 setup_world
 write_codex_stub success
-rc="$(run_wrapper ARMY_SPARK_ENABLED=false STUB_CODEX_MODE=success)"
+rc="$(run_wrapper ARMY_SPARK_ENABLED=false STUB_CODEX_MODE=success ARMY_SPARK_DIGEST_HOUR=99)"
 status="$(sidecar_status)"
-report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$rc" = "0" ] && [ "$status" = "disabled" ]; then
     note_pass "kill switch off: exits 0, heartbeat=disabled"
 else
     note_fail "kill switch off: rc=$rc status=$status"
 fi
-if [ "$report_count" = "0" ]; then
+if [ "$(report_count)" = "0" ]; then
     note_pass "kill switch off innocence: no report written"
 else
     note_fail "kill switch off: a report was written despite the kill switch"
 fi
 
 # ---------------------------------------------------------------------------
-# Case 2 (guilt): wrong node -> disabled, no dispatch (node guard fires).
+# Case 1b (guilt, item 11): kill switch off AND it's past digest hour ->
+# the digest fires and explicitly says the lane is disabled.
 # ---------------------------------------------------------------------------
 setup_world
 write_codex_stub success
-rc="$(run_wrapper ARMY_SPARK_SKIP_NODE_GUARD=0 ARMY_SPARK_NODE_OVERRIDE=some-other-mac STUB_CODEX_MODE=success)"
+rc="$(run_wrapper ARMY_SPARK_ENABLED=false STUB_CODEX_MODE=success ARMY_SPARK_DIGEST_HOUR=0)"
+if [ "$rc" = "0" ] && grep -q "ARMY_SPARK_ENABLED=false" "$WORK/world/tg.log" 2>/dev/null; then
+    note_pass "kill switch off past digest hour: digest still fires and names the kill switch"
+else
+    note_fail "kill switch off past digest hour: rc=$rc, tg.log=$(cat "$WORK/world/tg.log" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2 (guilt): wrong node -> disabled, no dispatch, no digest at all
+# (not my machine, not my digest to send).
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rc="$(run_wrapper ARMY_SPARK_SKIP_NODE_GUARD=0 ARMY_SPARK_NODE_OVERRIDE=some-other-mac STUB_CODEX_MODE=success ARMY_SPARK_DIGEST_HOUR=0)"
 status="$(sidecar_status)"
 if [ "$rc" = "0" ] && [ "$status" = "disabled" ]; then
     note_pass "wrong node: exits 0, heartbeat=disabled"
 else
     note_fail "wrong node: rc=$rc status=$status"
+fi
+if ! grep -q "army-spark:daily-digest" "$WORK/world/tg.log" 2>/dev/null; then
+    note_pass "wrong node innocence: no digest sent"
+else
+    note_fail "wrong node: digest was sent despite the node guard"
 fi
 
 # ---------------------------------------------------------------------------
@@ -134,59 +173,87 @@ fi
 setup_world
 write_codex_stub success
 rc="$(run_wrapper ARMY_SPARK_SKIP_NODE_GUARD=0 ARMY_SPARK_NODE_OVERRIDE=nuzantara ARMY_SPARK_REQUIRED_NODE=nuzantara STUB_CODEX_MODE=success)"
-report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-if [ "$rc" = "0" ] && [ "$report_count" = "1" ]; then
+if [ "$rc" = "0" ] && [ "$(report_count)" = "1" ]; then
     note_pass "right node: dispatch proceeds, report written"
 else
-    note_fail "right node: rc=$rc report_count=$report_count"
+    note_fail "right node: rc=$rc report_count=$(report_count)"
 fi
 
 # ---------------------------------------------------------------------------
-# Case 4 (innocence): successful dispatch writes report, marks task done,
-# heartbeat=ok, and a SECOND tick does not reprocess the same task.
+# Case 4 (innocence): successful dispatch writes report (with HEAD sha +
+# task sha header, item 5), marks the attempt ok, heartbeat=ok, and a
+# SECOND tick does not reprocess the same task.
 # ---------------------------------------------------------------------------
 setup_world
 write_codex_stub success
 rc1="$(run_wrapper STUB_CODEX_MODE=success)"
 status1="$(sidecar_status)"
 report_file="$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | head -1)"
-if [ "$rc1" = "0" ] && [ "$status1" = "ok" ] && [ -n "$report_file" ] && grep -q "STUB REPORT BODY" "$report_file"; then
-    note_pass "successful dispatch: report written with codex output, heartbeat=ok"
+if [ "$rc1" = "0" ] && [ "$status1" = "ok" ] && [ -n "$report_file" ] \
+    && grep -q "STUB REPORT BODY" "$report_file" \
+    && grep -q "checkout HEAD:" "$report_file" \
+    && grep -q "task sha256:" "$report_file"; then
+    note_pass "successful dispatch: report written with codex output + HEAD/task sha header, heartbeat=ok"
 else
     note_fail "successful dispatch: rc=$rc1 status=$status1 report_file=$report_file"
 fi
-before_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if grep -q '"status":"ok"' "$WORK/world/state/attempts.jsonl" 2>/dev/null; then
+    note_pass "attempts.jsonl: an ok attempt was recorded"
+else
+    note_fail "attempts.jsonl: no ok attempt recorded"
+fi
+before="$(report_count)"
 rc2="$(run_wrapper STUB_CODEX_MODE=success)"
-after_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-if [ "$rc2" = "0" ] && [ "$after_count" = "$before_count" ]; then
+after="$(report_count)"
+if [ "$rc2" = "0" ] && [ "$after" = "$before" ]; then
     note_pass "dedup innocence: second tick does not reprocess the already-done task"
 else
-    note_fail "dedup innocence: before=$before_count after=$after_count"
+    note_fail "dedup innocence: before=$before after=$after"
 fi
 
 # ---------------------------------------------------------------------------
-# Case 5 (guilt): quota marker in codex output -> backoff written, task NOT
-# marked done, NOT reported as a success report, a digest alert fires.
+# Case 4b (item 2: content-only dedup survives a rename): a task file
+# renamed to a different filename with IDENTICAL content must still be
+# recognized as already-done — dedup key is sha256 of content, not
+# filename+sha.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+run_wrapper STUB_CODEX_MODE=success > /dev/null
+before="$(report_count)"
+mv "$WORK/world/queue/task-one.md" "$WORK/world/queue/task-one-renamed.md"
+rc="$(run_wrapper STUB_CODEX_MODE=success)"
+after="$(report_count)"
+if [ "$rc" = "0" ] && [ "$after" = "$before" ]; then
+    note_pass "content-only dedup: renamed-but-identical task is not reprocessed"
+else
+    note_fail "content-only dedup: before=$before after=$after"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5 (guilt): quota marker in codex output -> backoff written (fixed
+# ${BACKOFF_HOURS}h), task attempt recorded as "quota" (not "ok" — stays
+# eligible for retry after backoff), a digest alert fires.
 # ---------------------------------------------------------------------------
 setup_world
 write_codex_stub quota
 rc="$(run_wrapper STUB_CODEX_MODE=quota)"
 status="$(sidecar_status)"
-report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-if [ "$rc" = "0" ] && [ "$status" = "degraded" ] && [ "$report_count" = "0" ] && [ -f "$WORK/world/state/backoff-until.txt" ]; then
+if [ "$rc" = "0" ] && [ "$status" = "degraded" ] && [ "$(report_count)" = "0" ] && [ -f "$WORK/world/state/backoff-until.txt" ]; then
     note_pass "quota: degraded heartbeat, no report, backoff file written"
 else
-    note_fail "quota: rc=$rc status=$status report_count=$report_count backoff_exists=$([ -f "$WORK/world/state/backoff-until.txt" ] && echo y || echo n)"
+    note_fail "quota: rc=$rc status=$status report_count=$(report_count) backoff_exists=$([ -f "$WORK/world/state/backoff-until.txt" ] && echo y || echo n)"
 fi
 if grep -q "army-spark:quota" "$WORK/world/tg.log" 2>/dev/null; then
     note_pass "quota: telegram digest alert fired with the right dedup key"
 else
     note_fail "quota: no telegram digest alert found in stub log"
 fi
-if grep -qxF "task-one.md:$(shasum -a 256 "$WORK/world/queue/task-one.md" 2>/dev/null | awk '{print $1}')" "$WORK/world/state/done-list.txt" 2>/dev/null; then
-    note_fail "quota: task was incorrectly marked done despite the quota condition"
+if grep -q '"status":"quota"' "$WORK/world/state/attempts.jsonl" 2>/dev/null \
+    && ! grep -q '"status":"ok"' "$WORK/world/state/attempts.jsonl" 2>/dev/null; then
+    note_pass "quota innocence: attempt recorded as quota, NOT ok (stays eligible for retry)"
 else
-    note_pass "quota innocence: task NOT marked done (stays eligible for retry after backoff)"
+    note_fail "quota: attempts.jsonl did not record the expected quota-not-ok shape"
 fi
 
 # ---------------------------------------------------------------------------
@@ -199,66 +266,150 @@ mkdir -p "$WORK/world/state"
 future_epoch=$(( $(date +%s) + 3600 ))
 echo "$future_epoch" > "$WORK/world/state/backoff-until.txt"
 rc="$(run_wrapper STUB_CODEX_MODE=success)"
-report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
 status="$(sidecar_status)"
-if [ "$rc" = "0" ] && [ "$report_count" = "0" ] && [ "$status" = "degraded" ]; then
+if [ "$rc" = "0" ] && [ "$(report_count)" = "0" ] && [ "$status" = "degraded" ]; then
     note_pass "backoff active: dispatch skipped, no report, degraded heartbeat"
 else
-    note_fail "backoff active: rc=$rc report_count=$report_count status=$status"
+    note_fail "backoff active: rc=$rc report_count=$(report_count) status=$status"
 fi
 
 # ---------------------------------------------------------------------------
-# Case 7 (guilt): daily cap reached -> dispatch skipped even with a pending
-# task and no active backoff, heartbeat stays ok (expected condition).
+# Case 7 (guilt): daily cap reached (WITA calendar day, item 6) -> dispatch
+# skipped even with a pending task and no active backoff, heartbeat stays
+# ok (expected condition, not an error).
 # ---------------------------------------------------------------------------
 setup_world
 write_codex_stub success
 mkdir -p "$WORK/world/state"
-echo "6" > "$WORK/world/state/run-count-$(date +%Y-%m-%d).txt"
+echo "6" > "$WORK/world/state/run-count-$(wita_today).txt"
 rc="$(run_wrapper ARMY_SPARK_DAILY_CAP=6 STUB_CODEX_MODE=success)"
-report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
 status="$(sidecar_status)"
-if [ "$rc" = "0" ] && [ "$report_count" = "0" ] && [ "$status" = "ok" ]; then
-    note_pass "daily cap reached: dispatch skipped, no report, heartbeat=ok (expected, not an error)"
+if [ "$rc" = "0" ] && [ "$(report_count)" = "0" ] && [ "$status" = "ok" ]; then
+    note_pass "daily cap reached (WITA day): dispatch skipped, no report, heartbeat=ok"
 else
-    note_fail "daily cap reached: rc=$rc report_count=$report_count status=$status"
+    note_fail "daily cap reached: rc=$rc report_count=$(report_count) status=$status"
 fi
 
 # ---------------------------------------------------------------------------
 # Case 8 (guilt): codex exec real failure (non-quota) -> error heartbeat,
-# task NOT marked done, a P0 alert fires (distinct dedup key from quota).
+# no report, a P0 alert fires (distinct dedup key from quota), and the
+# attempt is recorded "failed" (not silently dropped).
 # ---------------------------------------------------------------------------
 setup_world
 write_codex_stub fail
 rc="$(run_wrapper STUB_CODEX_MODE=fail)"
 status="$(sidecar_status)"
-report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-if [ "$rc" = "0" ] && [ "$status" = "error" ] && [ "$report_count" = "0" ]; then
+if [ "$rc" = "0" ] && [ "$status" = "error" ] && [ "$(report_count)" = "0" ]; then
     note_pass "codex failure: error heartbeat, no report written"
 else
-    note_fail "codex failure: rc=$rc status=$status report_count=$report_count"
+    note_fail "codex failure: rc=$rc status=$status report_count=$(report_count)"
 fi
 if grep -q "army-spark:codex-failed" "$WORK/world/tg.log" 2>/dev/null; then
     note_pass "codex failure: P0 alert fired with the right dedup key"
 else
     note_fail "codex failure: no P0 alert found in stub log"
 fi
+if grep -q '"status":"failed"' "$WORK/world/state/attempts.jsonl" 2>/dev/null; then
+    note_pass "codex failure: attempt recorded as failed in attempts.jsonl"
+else
+    note_fail "codex failure: no failed attempt recorded"
+fi
 
 # ---------------------------------------------------------------------------
-# Case 9 (guilt): single-instance guard — a live pidfile blocks a second run
-# and does not touch the queue.
+# Case 8b (item 3: quarantine after 2 failures — a poisoned task must never
+# block the head of the queue nor retry forever). Third tick with the SAME
+# always-failing stub must produce NO new P0 alert and NO new report: the
+# task is quarantined, the queue reads as empty.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub fail
+run_wrapper STUB_CODEX_MODE=fail > /dev/null   # attempt 1: failed (1)
+run_wrapper STUB_CODEX_MODE=fail > /dev/null   # attempt 2: failed (2) -> quarantined
+p0_before="$(grep -c "army-spark:codex-failed" "$WORK/world/tg.log" 2>/dev/null || echo 0)"
+rc="$(run_wrapper STUB_CODEX_MODE=fail)"       # attempt 3: should NOT dispatch at all
+status="$(sidecar_status)"
+p0_after="$(grep -c "army-spark:codex-failed" "$WORK/world/tg.log" 2>/dev/null || echo 0)"
+if [ "$rc" = "0" ] && [ "$p0_after" = "$p0_before" ] && [ "$status" = "ok" ]; then
+    note_pass "quarantine after 2 failures: third tick does not retry, no new P0, heartbeat=ok (queue reads empty)"
+else
+    note_fail "quarantine: rc=$rc p0_before=$p0_before p0_after=$p0_after status=$status"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 8c (item 4: 3 consecutive NON-quota failures across DIFFERENT tasks
+# also trigger the fixed backoff — protects against a silently-changed
+# codex output format, not just quota exhaustion on one poisoned task).
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub fail
+rm -f "$WORK/world/queue/task-one.md"
+write_task "task-a.md" "Task A"
+write_task "task-b.md" "Task B"
+write_task "task-c.md" "Task C"
+run_wrapper STUB_CODEX_MODE=fail > /dev/null   # task-a fails, consec=1
+run_wrapper STUB_CODEX_MODE=fail > /dev/null   # task-b fails, consec=2
+rc="$(run_wrapper STUB_CODEX_MODE=fail)"       # task-c fails, consec=3 -> backoff
+if [ "$rc" = "0" ] && [ -f "$WORK/world/state/backoff-until.txt" ] \
+    && grep -q "army-spark:consecutive-fail-backoff" "$WORK/world/tg.log" 2>/dev/null; then
+    note_pass "3 consecutive non-quota failures across distinct tasks: fixed backoff triggered + distinct P0"
+else
+    note_fail "consecutive-fail backoff: rc=$rc backoff_exists=$([ -f "$WORK/world/state/backoff-until.txt" ] && echo y || echo n)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 9 (guilt, item 1): corrupt attempts.jsonl -> the lane HALTS
+# (status-corrupt), fires a P0, and does NOT fall open into re-running the
+# whole queue (no report written despite a pending task).
 # ---------------------------------------------------------------------------
 setup_world
 write_codex_stub success
-echo $$ > "$WORK/world/spark.pid"   # this test process's own pid: guaranteed alive
+mkdir -p "$WORK/world/state"
+printf '{"sha":"abc","status":"ok"}\nTHIS IS NOT JSON\n' > "$WORK/world/state/attempts.jsonl"
 rc="$(run_wrapper STUB_CODEX_MODE=success)"
-report_count=$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-if [ "$rc" = "0" ] && [ "$report_count" = "0" ]; then
+status="$(sidecar_status)"
+if [ "$rc" = "0" ] && [ "$status" = "error" ] && [ "$(report_count)" = "0" ]; then
+    note_pass "corrupt attempts.jsonl: halts (error heartbeat), does not fall open"
+else
+    note_fail "corrupt attempts.jsonl: rc=$rc status=$status report_count=$(report_count)"
+fi
+if grep -q "army-spark:state-corrupt" "$WORK/world/tg.log" 2>/dev/null; then
+    note_pass "corrupt attempts.jsonl: P0 alert fired"
+else
+    note_fail "corrupt attempts.jsonl: no P0 alert found"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 10 (guilt, item 1): single-instance guard — a LIVE lock (mkdir'd
+# lock dir with this test process's own pid inside, guaranteed alive)
+# blocks a second run with status=skipped-overlap, no dispatch.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+mkdir -p "$WORK/world/state/run.lock"
+echo $$ > "$WORK/world/state/run.lock/pid"
+rc="$(run_wrapper STUB_CODEX_MODE=success)"
+if [ "$rc" = "0" ] && [ "$(report_count)" = "0" ]; then
     note_pass "single-instance guard: concurrent run skipped, no dispatch"
 else
-    note_fail "single-instance guard: rc=$rc report_count=$report_count"
+    note_fail "single-instance guard: rc=$rc report_count=$(report_count)"
 fi
-rm -f "$WORK/world/spark.pid"
+rm -rf "$WORK/world/state/run.lock"
+
+# ---------------------------------------------------------------------------
+# Case 11 (innocence, item 1): a STALE lock (mkdir'd lock dir with a dead
+# pid inside) is reclaimed, not treated as a live overlap — dispatch
+# proceeds, and the lock dir does not linger after the run.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+mkdir -p "$WORK/world/state/run.lock"
+echo 999999999 > "$WORK/world/state/run.lock/pid"   # almost certainly not alive
+rc="$(run_wrapper STUB_CODEX_MODE=success)"
+if [ "$rc" = "0" ] && [ "$(report_count)" = "1" ] && [ ! -d "$WORK/world/state/run.lock" ]; then
+    note_pass "stale lock: reclaimed, dispatch proceeds, lock dir cleaned up on exit"
+else
+    note_fail "stale lock: rc=$rc report_count=$(report_count) lock_dir_exists=$([ -d "$WORK/world/state/run.lock" ] && echo y || echo n)"
+fi
 
 echo
 echo "TOTAL: $pass passed, $fail failed"

--- a/scripts/tests/test_army_spark_lane.sh
+++ b/scripts/tests/test_army_spark_lane.sh
@@ -38,9 +38,16 @@ wita_today() { TZ=Asia/Makassar date '+%Y-%m-%d'; }
 # ---------------------------------------------------------------------------
 setup_world() {
     rm -rf "$WORK/world"
-    mkdir -p "$WORK/world/repo/scripts" "$WORK/world/queue" \
+    mkdir -p "$WORK/world/repo/scripts/lib" "$WORK/world/queue" \
         "$WORK/world/reports" "$WORK/world/state" "$WORK/world/logs" \
         "$WORK/world/sidecar" "$WORK/world/bin" "$WORK/world/home"
+
+    # The wrapper unconditionally sources the fleet seat door from
+    # $ARMY_SPARK_REPO/scripts/lib/codex_seat.sh — copy the REAL library in
+    # so that source succeeds exactly as it does against a real checkout,
+    # instead of stubbing around it and silently diverging from the
+    # guarded contract (test_no_call_site_invokes_codex_without_choosing_a_seat).
+    cp "$SCRIPT_DIR/lib/codex_seat.sh" "$WORK/world/repo/scripts/lib/codex_seat.sh"
 
     cat > "$WORK/world/repo/scripts/tg_notify.py" <<'PY'
 #!/usr/bin/env python3
@@ -53,6 +60,13 @@ if log:
 PY
     chmod +x "$WORK/world/repo/scripts/tg_notify.py"
     : > "$WORK/world/tg.log"
+
+    # A live codex seat for scripts/lib/codex_seat.sh to resolve by default,
+    # so the pre-existing cases below keep exercising exactly the same
+    # dispatch path they did before the seat-library sourcing landed. Case 12
+    # removes this to exercise the seatless path on purpose.
+    mkdir -p "$WORK/world/home/.codex-o2"
+    echo '{}' > "$WORK/world/home/.codex-o2/auth.json"
 
     cat > "$WORK/world/queue/task-one.md" <<'MD'
 # Test task one
@@ -70,10 +84,16 @@ MD
 }
 
 # codex stub: behaviour selected via STUB_CODEX_MODE (success|quota|fail).
+# Every invocation is logged (never truncated by mode) so a test can assert
+# the stub was NEVER called — the only way to prove a guard refused BEFORE
+# reaching codex, not just that the outcome happens to look the same as a
+# real codex failure (Case 12).
 write_codex_stub() {
     mode="$1"
+    : > "$WORK/world/codex-invocations.log"
     cat > "$WORK/world/bin/codex" <<SH
 #!/bin/sh
+echo "invoked \$*" >> "$WORK/world/codex-invocations.log"
 case "\$STUB_CODEX_MODE" in
     success) echo "STUB REPORT BODY"; exit 0 ;;
     quota) echo "error: out of extra usage on this weekly bucket"; exit 1 ;;
@@ -98,6 +118,7 @@ run_wrapper() {
         ARMY_SPARK_LOG_DIR="$WORK/world/logs" \
         ARMY_SPARK_SIDECAR_DIR="$WORK/world/sidecar" \
         ARMY_SPARK_CODEX_BIN="codex" \
+        ARMY_SPARK_CODEX_HOME="$WORK/world/home/.codex-o2" \
         ARMY_SPARK_SKIP_NODE_GUARD=1 \
         HOME="$WORK/world/home" \
         "$@" \
@@ -409,6 +430,38 @@ if [ "$rc" = "0" ] && [ "$(report_count)" = "1" ] && [ ! -d "$WORK/world/state/r
     note_pass "stale lock: reclaimed, dispatch proceeds, lock dir cleaned up on exit"
 else
     note_fail "stale lock: rc=$rc report_count=$(report_count) lock_dir_exists=$([ -d "$WORK/world/state/run.lock" ] && echo y || echo n)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 12 (guilt): no codex seat resolves anywhere in the fake HOME (no
+# ARMY_SPARK_CODEX_HOME override, no auth.json under $HOME/.codex*) ->
+# codex_seat_pick() (sourced from the REAL scripts/lib/codex_seat.sh, see
+# setup_world) returns empty, so the dispatch subshell's `[ -n
+# "$CODEX_HOME_OVERRIDE" ] || exit 91` guard fires BEFORE codex is ever
+# exec'd — never a silent fallback to a dead default ~/.codex. Proven by the
+# stub's own invocation log staying empty, not just by the outcome looking
+# like a codex failure.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rm -rf "$WORK/world/home/.codex-o2"   # strip setup_world's default seat: seatless HOME
+rc="$(run_wrapper ARMY_SPARK_CODEX_HOME="" STUB_CODEX_MODE=success)"
+status="$(sidecar_status)"
+invocations="$(wc -l < "$WORK/world/codex-invocations.log" 2>/dev/null | tr -d ' ')"
+if [ "$rc" = "0" ] && [ "$status" = "error" ] && [ "$(report_count)" = "0" ] && [ "$invocations" = "0" ]; then
+    note_pass "no codex seat anywhere: dispatch refuses (rc=91 guard), stub codex never invoked"
+else
+    note_fail "no codex seat anywhere: rc=$rc status=$status report_count=$(report_count) invocations=$invocations"
+fi
+if grep -q '"status":"failed"' "$WORK/world/state/attempts.jsonl" 2>/dev/null; then
+    note_pass "no codex seat anywhere: attempt recorded as failed (not silently dropped)"
+else
+    note_fail "no codex seat anywhere: no failed attempt recorded in attempts.jsonl"
+fi
+if grep -q "army-spark:codex-failed" "$WORK/world/tg.log" 2>/dev/null; then
+    note_pass "no codex seat anywhere: P0 alert fired"
+else
+    note_fail "no codex seat anywhere: no P0 alert found in stub log"
 fi
 
 echo


### PR DESCRIPTION
## Summary

Standing lane 1/2 of Armata H24 Fase 1: a bash cron lane that ticks every 2h on Pro, dispatching read-only analysis tasks from `infra/army/spark-queue/*.md` to `gpt-5.3-codex-spark` via `codex exec --sandbox read-only`, on idle flat-subscription capacity.

- Atomic `mkdir`-based lock per run, with dead-owner reclaim.
- Content-only sha256 dedup via an append-only `attempts.jsonl` (fold-to-per-sha semantics), with corruption-fatal halt — never fail-open into mass re-execution of the whole queue.
- Retry-count-aware, head-of-line-protected task selection (a poisoned task can't block or infinite-retry).
- Fixed 12h backoff on quota errors and on 3 consecutive non-quota failures (never unbounded exponential).
- Every report carries checkout HEAD sha + task sha for reproducibility.
- Daily cap (6/day) counted against an explicit WITA (Asia/Makassar, fixed UTC+8) clock, not ambient system TZ.
- `last_success_epoch` wired into the existing `~/.organism/last_seen/<organ_id>.json` staleness-detector sidecar (auto-discovered, no separate registry required — verified by direct investigation of `scripts/organism_stale_detector.py::scan_sidecars()`).
- Kill switch: when off, receipts read `status=killed` and the daily digest reports it every day.
- Weekly produced/consumed digest via an `outcome` field (updatable by an independent verification pass).

## Scar constraints respected (cicatrix-superscar.md)

- **#1 HOME-fork**: repo-canonical script only, no `$HOME`-copy execution path.
- **#2 Esiste≠Armato / cron-theater**: heartbeat reflects real per-tick outcome, not process exit code; dual status vocabulary keeps the rich internal status set (`killed`/`skipped-overlap`/`state-corrupt`/`quota`/`cap-reached`) strictly separate from the narrow `organism_heartbeat()` vocabulary (which maps the literal word `killed` → `error`).
- **#5 sibling-race**: single-instance lock; never touches `~/nuzantara` main checkout.
- **#7 KeepAlive misconfig**: `StartInterval` cron, `KeepAlive=false`.
- Alerts only via the single `scripts/tg_notify.py` gateway; kill-switch env vars default-on; guilt+innocence test corpus (24 cases) proving alarms actually fire, mutation-verified on the highest-stakes new guards (quarantine, corruption-halt).

## Provenance

Cross-family adversarial red-team by Kimi K3 refuted the original design and surfaced 12 defects (6 spark-specific + 2 shared with the jules lane, covered here). All 12 are closed in the second commit `077b73069`, documented with rationale in `research/operations/2026-08-14-armata-h24-standing-lanes.md` under "Amendment log — 2026-08-14".

## Test plan

- [x] `sh scripts/tests/test_army_spark_lane.sh` → 24/24 passed
- [x] Mutation-verified: quarantine guard and corruption-halt guard each deliberately broken → confirmed red → restored → confirmed 24/24 green again
- [x] `git status --porcelain shared/` clean (no prod-state writes from tests)

## Arming plan

Post-merge, the session installs the plist on Pro (`launchctl bootstrap`) and verifies the first tick. Lane is Pro-only; Mini offline is not impacted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)