### PR TITLE
feat(ci): add daily schedule to security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,14 @@ on:
     types: [opened, synchronize, reopened]
   merge_group:
   schedule:
+    # Daily backstop, 19:17 UTC = 03:17 WITA next day. Prerequisite for a
+    # later PR to remove this workflow's `push: main` trigger (Merge-OS v3
+    # build order step 2 — research/operations/2026-08-14-merge-os-v3-research-council.md
+    # §6): that dedupe only lands after this schedule has produced at least
+    # one green scheduled run, so there is never a window with no confirmed
+    # backstop. The weekly Sunday entry stays until then — two schedules
+    # overlapping is harmless.
+    - cron: "17 19 * * *" # Daily security backstop, 03:17 WITA
     - cron: "0 0 * * 0" # Weekly scan on Sunday
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Adds a daily security scan schedule (`17 19 * * *` = 03:17 WITA) to `.github/workflows/security.yml`, alongside the existing weekly Sunday schedule.
- Merge-OS v3 build order step 2 (`research/operations/2026-08-14-merge-os-v3-research-council.md` §6): this is the prerequisite that later allows removing this workflow's `push: main` trigger — that dedupe only lands after the daily schedule has produced at least one green scheduled run, so there is never a window with no confirmed backstop. **This PR does NOT touch `push: main`** — that is a separate, later PR.
- Verified no job in this workflow discriminates on the specific cron string (`if: github.event.schedule == ...`) or on `github.event_name` in a way that would exclude `schedule` — every job runs identically regardless of which schedule entry fired it. No `paths:` filter exists on the workflow. This avoids the "schedule fires but zero jobs run" theater failure mode.

## Test plan
- [x] `actionlint .github/workflows/security.yml` → clean (rc 0)
- [x] `git diff --stat` → 1 file changed, 8 insertions(+), 0 deletions — touches only the `schedule:` block
- [x] Confirmed no `paths:` filter and no job/step gates on the schedule's cron string
- [ ] First scheduled run at 03:17 WITA fires all 7 jobs (to be confirmed post-merge, live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)