### PR TITLE
fix(ops): bisect queue_baseline_probe past GitHub's 1,000-run pagination cap

### DIFF
--- a/scripts/queue_baseline_probe.py
+++ b/scripts/queue_baseline_probe.py
@@ -107,9 +107,25 @@ is empty; any non-empty `errors` list makes the process exit 1 so the wrapper's 
 alerting (W101 discipline) sees the failure.
 
 The workflow-runs endpoint is also census-checked: every paginated response's `total_count` is
-compared with the number of unique run IDs actually fetched. GitHub currently caps this query
-at 1,000 results even when `total_count` is larger; any such shortfall is written to `errors[]`
-and `run_collection.complete=false`, never presented as a complete quiet day.
+compared with the number of unique run IDs actually fetched. GitHub's REST docs state the
+`actions/runs` endpoint "will return up to 1,000 results" for any query using the `created`
+filter (docs.github.com/en/rest/actions/workflow-runs) — confirmed empirically 2026-08-12
+(`fetched=1000 reported_total=10269`, ~90% of that day's PRs unattributed). `--paginate`
+cannot get past this: the cap is server-side per QUERY, not a client pagination limit, so the
+only way past it is to narrow the query itself.
+
+MITIGATION — time-window bisection (see `_fetch_runs_window` / `list_workflow_runs`): whenever
+a window's raw fetch hits the documented cap (>= PAGE_CAP items) while its own `total_count`
+reports more, the window is split into two equal halves by `created` timestamp and each half is
+fetched independently, recursing until every leaf window's fetch is complete. Runs are deduped
+by id across sibling windows (dict keyed by run id), so any inclusive-boundary overlap between
+adjacent windows costs nothing. Recursion is bounded (`MAX_BISECT_DEPTH`, `MIN_WINDOW_SECONDS`):
+a leaf window still short after being split down to that bound is a genuine, reported shortfall
+— written to `errors[]` exactly like before, never silently dropped (scar family #2, and W97:
+a list consumed as complete must actually be complete). A shortfall NOT explained by the
+documented cap (raw fetch below `PAGE_CAP` yet still short of `total_count` — a data anomaly,
+not a capacity limit) is reported immediately without attempting to bisect, since a narrower
+window cannot return more than a wider one already did in that case.
 """
 
 from __future__ import annotations
@@ -159,6 +175,21 @@ BOT_LOGIN_ALLOWLIST = (
 
 GH_TIMEOUT_LIST_RUNS = 120
 GH_TIMEOUT_SHORT = 30
+
+# GitHub REST docs: the `actions/runs` endpoint returns "up to 1,000 results" for any query
+# using the `created` filter (docs.github.com/en/rest/actions/workflow-runs) — a server-side
+# cap per query, not a client-side pagination limit. Empirically confirmed 2026-08-12
+# (fetched=1000 reported_total=10269). A window whose raw fetch reaches this many items while
+# total_count reports more MUST be bisected — no amount of extra `--paginate` will get past it.
+PAGE_CAP = 1000
+
+# Bisection safety bound (scar W97 — never a silent truncation): a window still short of its
+# own total_count after being split this many times is reported as a genuine shortfall in
+# errors[], not silently dropped. depth=10 on a 24h day bottoms out at ~84s windows — ample
+# for any CI burst this repo has produced to date; MIN_WINDOW_SECONDS is a second, independent
+# floor so a pathological clock/interval bug can't recurse below whole-second granularity.
+MAX_BISECT_DEPTH = 10
+MIN_WINDOW_SECONDS = 1
 
 
 # ---------------------------------------------------------------------------
@@ -324,17 +355,25 @@ def _parse_concatenated_json(text: str) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def list_workflow_runs(
+def _fetch_runs_window(
     repo: str,
-    day: date,
-) -> tuple[list[dict[str, Any]], int | None, list[str]]:
-    """Workflow runs created on `day` (UTC), with an explicit census check.
+    start: datetime,
+    end: datetime,
+) -> tuple[dict[int, dict[str, Any]], list[dict[str, Any]], int | None, int, list[str]]:
+    """Fetch every page `gh api --paginate` will give us for one `[start, end]` UTC window
+    (both ends inclusive, matching GitHub's `created` range-qualifier semantics).
 
-    Returns `(unique_runs, reported_total, errors)`. GitHub can stop pagination at a
-    server-side cap while still reporting a larger `total_count`; that is a partial record,
-    not success, and is therefore returned as an error.
+    Pure I/O primitive — does not decide whether the window needs to be split further; that
+    decision (and the resulting recursion) belongs to `list_workflow_runs` so this stays a
+    single, independently testable fetch. Returns
+    `(runs_by_id, runs_without_id, reported_total, raw_item_count, errors)` where
+    `raw_item_count` is the number of `workflow_runs` entries actually returned across all
+    pages BEFORE dedup — the number PAGE_CAP is measured against, since GitHub's documented
+    1,000-result cap is on items served, not on the dedup'd id count a duplicate-emitting page
+    could shrink it to (see `_parse_concatenated_json`'s docstring on that duplicate-page
+    quirk).
     """
-    created_query = f"{day.isoformat()}..{day.isoformat()}"
+    created_query = f"{start.strftime('%Y-%m-%dT%H:%M:%SZ')}..{end.strftime('%Y-%m-%dT%H:%M:%SZ')}"
     cmd = [
         "gh", "api", f"repos/{repo}/actions/runs",
         "-X", "GET",
@@ -346,18 +385,18 @@ def list_workflow_runs(
     try:
         proc = _run_gh(cmd, timeout=GH_TIMEOUT_LIST_RUNS)
     except subprocess.TimeoutExpired as exc:
-        return [], None, [f"list_workflow_runs timeout: {exc}"]
+        return {}, [], None, 0, [f"list_workflow_runs timeout window={created_query}: {exc}"]
     except OSError as exc:
-        return [], None, [f"list_workflow_runs OSError: {exc}"]
+        return {}, [], None, 0, [f"list_workflow_runs OSError window={created_query}: {exc}"]
     if proc.returncode != 0:
-        return [], None, [
-            f"list_workflow_runs failed rc={proc.returncode} "
+        return {}, [], None, 0, [
+            f"list_workflow_runs failed window={created_query} rc={proc.returncode} "
             f"stderr={proc.stderr.strip()[:400]}"
         ]
     try:
         pages = _parse_concatenated_json(proc.stdout)
     except json.JSONDecodeError as exc:
-        return [], None, [f"list_workflow_runs bad JSON: {exc}"]
+        return {}, [], None, 0, [f"list_workflow_runs bad JSON window={created_query}: {exc}"]
 
     reported_totals = {
         int(page["total_count"])
@@ -371,28 +410,103 @@ def list_workflow_runs(
     positive_reported_totals = {total for total in reported_totals if total > 0}
     if len(positive_reported_totals) > 1:
         errors.append(
-            "list_workflow_runs inconsistent positive total_count values across pages: "
-            f"{sorted(positive_reported_totals)}"
+            "list_workflow_runs inconsistent positive total_count values across pages "
+            f"window={created_query}: {sorted(positive_reported_totals)}"
         )
     if reported_total is None:
-        errors.append("list_workflow_runs response missing integer total_count")
+        errors.append(f"list_workflow_runs response missing integer total_count window={created_query}")
 
     runs_by_id: dict[int, dict[str, Any]] = {}
     runs_without_id: list[dict[str, Any]] = []
+    raw_item_count = 0
     for page in pages:
         for run in page.get("workflow_runs") or []:
+            raw_item_count += 1
             run_id = run.get("id") if isinstance(run, dict) else None
             if isinstance(run_id, int):
                 runs_by_id[run_id] = run
             elif isinstance(run, dict):
                 runs_without_id.append(run)
-    runs = [*runs_by_id.values(), *runs_without_id]
-    if reported_total is not None and len(runs) < reported_total:
-        errors.append(
-            "list_workflow_runs pagination shortfall: "
-            f"fetched={len(runs)} reported_total={reported_total}; record is partial"
+    return runs_by_id, runs_without_id, reported_total, raw_item_count, errors
+
+
+def list_workflow_runs(
+    repo: str,
+    day: date,
+) -> tuple[list[dict[str, Any]], int | None, list[str]]:
+    """Workflow runs created on `day` (UTC), with an explicit census check.
+
+    Returns `(unique_runs, reported_total, errors)`. `reported_total` is the day's real total
+    (from the initial, unsplit day-wide query — bisection never changes what "the day's total"
+    means, only how many requests it takes to actually fetch it).
+
+    GitHub's `actions/runs` list endpoint returns "up to 1,000 results" for any query using
+    the `created` filter (module docstring) — a cap on the QUERY, so `--paginate` alone cannot
+    get past it. Whenever a window's raw fetch hits that cap (`>= PAGE_CAP`) while its own
+    `total_count` says there is more, the window is bisected by `created` timestamp and each
+    half is fetched independently, recursing until every leaf is fully resolved or the
+    recursion bound (`MAX_BISECT_DEPTH` / `MIN_WINDOW_SECONDS`) is hit. A shortfall NOT
+    explained by the cap (raw fetch below `PAGE_CAP`, yet still short of `total_count` — e.g. a
+    data anomaly) is reported immediately without attempting to bisect: a narrower window
+    cannot return more than a wider one already failed to.
+    """
+    day_start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
+    day_end = day_start + timedelta(days=1, seconds=-1)  # 23:59:59, inclusive-inclusive range
+
+    runs_by_id: dict[int, dict[str, Any]] = {}
+    runs_without_id: list[dict[str, Any]] = []
+    errors: list[str] = []
+    day_reported_total: list[int | None] = [None]  # set once, from the depth-0 (whole-day) fetch
+
+    def _collect(start: datetime, end: datetime, depth: int) -> None:
+        window_runs, window_no_id, reported_total, raw_count, window_errors = _fetch_runs_window(
+            repo, start, end
         )
-    return runs, reported_total, errors
+        errors.extend(window_errors)
+        if depth == 0:
+            day_reported_total[0] = reported_total
+        runs_by_id.update(window_runs)
+        runs_without_id.extend(window_no_id)
+
+        unique_count = len(window_runs) + len(window_no_id)
+        if reported_total is None or unique_count >= reported_total:
+            return  # this window is fully accounted for (or totally unknown — nothing more to do)
+
+        if raw_count < PAGE_CAP:
+            # Short of total_count but never even reached the documented cap — not a
+            # capacity problem, bisecting cannot help. Depth-0 keeps the exact historical
+            # message shape (no window suffix) since that IS the whole-day window.
+            if depth == 0:
+                errors.append(
+                    "list_workflow_runs pagination shortfall: "
+                    f"fetched={unique_count} reported_total={reported_total}; record is partial"
+                )
+            else:
+                errors.append(
+                    "list_workflow_runs pagination shortfall: "
+                    f"fetched={unique_count} reported_total={reported_total} "
+                    f"window={start.isoformat()}..{end.isoformat()}; record is partial"
+                )
+            return
+
+        window_seconds = (end - start).total_seconds()
+        if depth >= MAX_BISECT_DEPTH or window_seconds <= MIN_WINDOW_SECONDS:
+            errors.append(
+                "list_workflow_runs pagination shortfall even after bisection: "
+                f"fetched={unique_count} reported_total={reported_total} "
+                f"window={start.isoformat()}..{end.isoformat()} depth={depth}; "
+                "window not further splittable"
+            )
+            return
+
+        mid = start + (end - start) / 2
+        _collect(start, mid, depth + 1)
+        _collect(mid, end, depth + 1)
+
+    _collect(day_start, day_end, 0)
+
+    runs = [*runs_by_id.values(), *runs_without_id]
+    return runs, day_reported_total[0], errors
 
 
 def fetch_run_timing_minutes(

--- a/scripts/tests/test_queue_baseline_probe.py
+++ b/scripts/tests/test_queue_baseline_probe.py
@@ -29,7 +29,7 @@ import importlib.util
 import json
 import subprocess
 import sys
-from datetime import date
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from types import ModuleType
 
@@ -193,6 +193,148 @@ def test_list_workflow_runs_combines_all_pages_and_deduplicates_ids(monkeypatch)
 
     assert [run["id"] for run in fetched] == [1, 2, 3]
     assert reported_total == 3
+    assert errors == []
+
+
+def _parse_created_window(cmd: list[str]) -> tuple[datetime, datetime]:
+    """Recover the `[start, end]` UTC window `list_workflow_runs` sent, for fakes that need
+    to answer differently per window (the bisection tests below) rather than ignoring `cmd`
+    like the fixtures above.
+    """
+    for i, tok in enumerate(cmd):
+        if tok == "-f" and cmd[i + 1].startswith("created="):
+            value = cmd[i + 1].split("=", 1)[1]
+            start_s, end_s = value.split("..")
+            fmt = "%Y-%m-%dT%H:%M:%SZ"
+            return (
+                datetime.strptime(start_s, fmt).replace(tzinfo=timezone.utc),
+                datetime.strptime(end_s, fmt).replace(tzinfo=timezone.utc),
+            )
+    raise AssertionError(f"no created= filter found in cmd: {cmd}")
+
+
+def test_list_workflow_runs_bisects_past_the_1000_result_cap(monkeypatch):
+    """Guilt: a day with 2,500 runs (real GitHub caps `created`-filtered queries at 1,000,
+    per docs.github.com/en/rest/actions/workflow-runs) must still yield ALL of them, with an
+    empty pagination error — recovered via recursive time-window bisection, not a single
+    `--paginate` call.
+    """
+    day = date(2026, 8, 12)
+    total_runs = 2500
+    day_start = datetime(2026, 8, 12, tzinfo=timezone.utc)
+    # Evenly spread across the day so each bisection level's two halves split ~evenly.
+    step_seconds = 86400 / total_runs
+    all_runs = [
+        (i + 1, day_start + timedelta(seconds=i * step_seconds)) for i in range(total_runs)
+    ]
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        assert cmd[0] == "gh"
+        assert cmd[2] == f"repos/{qbp.DEFAULT_REPO}/actions/runs"
+        start, end = _parse_created_window(cmd)
+        matched = [(rid, ts) for rid, ts in all_runs if start <= ts <= end]
+        capped = matched[: qbp.PAGE_CAP]  # GitHub's real server-side behavior: total_count is
+        # honest, the served items are capped.
+        payload = {
+            "total_count": len(matched),
+            "workflow_runs": [_mk_run(rid, "push") for rid, _ts in capped],
+        }
+        return _proc(cmd, 0, json.dumps(payload))
+
+    monkeypatch.setattr(qbp.subprocess, "run", fake_run)
+
+    fetched, reported_total, errors = qbp.list_workflow_runs(qbp.DEFAULT_REPO, day)
+
+    assert reported_total == total_runs
+    assert sorted(run["id"] for run in fetched) == list(range(1, total_runs + 1))
+    assert errors == []
+
+
+def test_list_workflow_runs_gives_up_visibly_when_even_bisection_cannot_resolve(monkeypatch):
+    """Guilt (safety bound): a pathologically dense day that STILL reports more than
+    PAGE_CAP at every window, all the way down to the recursion bound, must never loop
+    forever and must never claim completeness — errors[] stays non-empty and main()'s exit
+    code is non-zero (W101 discipline), never a silent partial-as-complete record.
+    """
+    day = date(2026, 8, 12)
+    monkeypatch.setattr(qbp, "MAX_BISECT_DEPTH", 3)  # keep the test fast; still exercises the
+    # real recursive code path and the real fail-visible guard.
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        assert cmd[0] == "gh"
+        if cmd[2] == f"repos/{qbp.DEFAULT_REPO}/actions/runs":
+            # Every window, no matter how narrow, reports far more than it can serve.
+            payload = {
+                "total_count": 999_999,
+                "workflow_runs": [_mk_run(i, "push") for i in range(qbp.PAGE_CAP)],
+            }
+            return _proc(cmd, 0, json.dumps(payload))
+        raise AssertionError(f"unexpected gh invocation: {cmd}")
+
+    monkeypatch.setattr(qbp.subprocess, "run", fake_run)
+
+    fetched, reported_total, errors = qbp.list_workflow_runs(qbp.DEFAULT_REPO, day)
+
+    assert reported_total == 999_999
+    assert len(fetched) < reported_total
+    assert errors != []
+    assert any("even after bisection" in e for e in errors)
+
+
+def test_list_workflow_runs_gives_up_end_to_end_via_main_nonzero_exit(tmp_path, monkeypatch):
+    """Same pathological-density scenario as above, exercised through main() end to end:
+    the record is still written (never skipped), but the wrapper's rc-based alerting must
+    see the failure (W101 discipline) — never a green run silently sitting on a partial day.
+    """
+    day = date(2026, 8, 12)
+    monkeypatch.setattr(qbp, "MAX_BISECT_DEPTH", 2)
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        assert cmd[0] == "gh"
+        if cmd[1] == "api" and len(cmd) > 2 and cmd[2] == f"repos/{qbp.DEFAULT_REPO}/actions/runs":
+            payload = {"total_count": 999_999, "workflow_runs": [_mk_run(i, "push") for i in range(qbp.PAGE_CAP)]}
+            return _proc(cmd, 0, json.dumps(payload))
+        if cmd[1] == "api" and len(cmd) > 2 and cmd[2].endswith("/timing"):
+            return _proc(cmd, 1, "", "not needed for this test")
+        if cmd[1] == "pr" and cmd[2] == "list":
+            return _proc(cmd, 0, json.dumps([]))
+        raise AssertionError(f"unexpected gh invocation: {cmd}")
+
+    monkeypatch.setattr(qbp.subprocess, "run", fake_run)
+
+    out_dir = tmp_path / "baseline"
+    rc = qbp.main(["--repo", qbp.DEFAULT_REPO, "--date", day.isoformat(), "--out-dir", str(out_dir)])
+
+    assert rc == 1
+    record_path = out_dir / f"{day.isoformat()}.json"
+    assert record_path.exists()
+    on_disk = json.loads(record_path.read_text())
+    assert on_disk["errors"] != []
+    assert on_disk["run_collection"]["complete"] is False
+
+
+def test_list_workflow_runs_innocence_below_cap_is_not_bisected(monkeypatch):
+    """Innocence: a window whose raw fetch stays below PAGE_CAP is never split, regardless
+    of how narrow the theoretical windows would be — single-window behavior is unchanged
+    from before bisection existed (mirrors
+    test_list_workflow_runs_combines_all_pages_and_deduplicates_ids but pinned explicitly
+    against PAGE_CAP so a future change to that constant can't silently make this drift).
+    """
+    day = date(2026, 8, 12)
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        calls.append(cmd)
+        payload = {"total_count": 42, "workflow_runs": [_mk_run(i, "push") for i in range(42)]}
+        return _proc(cmd, 0, json.dumps(payload))
+
+    monkeypatch.setattr(qbp.subprocess, "run", fake_run)
+
+    fetched, reported_total, errors = qbp.list_workflow_runs(qbp.DEFAULT_REPO, day)
+
+    assert len(calls) == 1  # exactly one window fetched — no bisection attempted
+    assert reported_total == 42
+    assert len(fetched) == 42
     assert errors == []
 
 


### PR DESCRIPTION
## Summary

- The Merge-OS Wave-1 baseline organ (`scripts/queue_baseline_probe.py`) self-declared its 2026-08-12 record partial: `list_workflow_runs pagination shortfall: fetched=1000 reported_total=10269; record is partial`. Billed-minutes/PR was only computed for 4 of 48 merged PRs that day and slot-utilization (4.16%) was unusable — blocking Wave-1 acceptance (7 clean daily records). Reference: `research/operations/2026-08-14-merge-os-v3-research-council.md` §1 and §5 ("NEW: baseline pagination shortfall").
- Root cause, confirmed against GitHub's own docs (docs.github.com/en/rest/actions/workflow-runs): the `actions/runs` list endpoint returns **"up to 1,000 results"** for any query using the `created` filter — a server-side cap on the *query*, not a client-side `--paginate` limit. No amount of extra pagination gets past it; only narrowing the query does.
- `list_workflow_runs` now recursively **bisects the day's UTC window by `created` timestamp** whenever a window's raw fetch hits the documented cap (`PAGE_CAP = 1000`) while its own `total_count` reports more, deduping runs by id across sibling windows.
- The existing fail-visible design (scar family #2 / W97 — a list consumed as complete must be complete) is preserved and extended: a window still short after the recursion bound (`MAX_BISECT_DEPTH=10` / `MIN_WINDOW_SECONDS=1`) lands a `"pagination shortfall even after bisection"` entry in `errors[]`, never a silent truncation. A shortfall *not* explained by the cap (raw fetch below `PAGE_CAP`, still short) is reported immediately without bisecting, since a narrower window cannot return more than a wider one already failed to.

## Test plan

- [x] All 24 pre-existing tests in `scripts/tests/test_queue_baseline_probe.py` pass unchanged (verified byte-for-byte error-string compatibility for the non-bisected shortfall path).
- [x] New guilt test: a synthetic day of 2,500 runs (realistically exceeding the 1,000 cap) is fully recovered via bisection — `errors == []`, all 2,500 ids fetched.
- [x] New guilt test (safety bound): a pathologically dense day that reports far more than fetchable at every window depth gives up visibly at `MAX_BISECT_DEPTH` — `errors != []`, contains `"even after bisection"`.
- [x] Same scenario end-to-end via `main()` — exits non-zero (rc=1), record still written to disk, `run_collection.complete == False`.
- [x] New innocence test: a window below `PAGE_CAP` is never bisected (exactly 1 `gh` call), pinning single-window behavior as unchanged.

```
$ python3 -m pytest scripts/tests/test_queue_baseline_probe.py -q
............................
28 passed in 0.12s
```

Scope: only `scripts/queue_baseline_probe.py` and its test file. Did not touch `.github/workflows/tests.yml` (owned by sibling PR #4181), any other workflow, or plist/wrapper files, per mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>