### PR TITLE
feat(ci): add suite-growth telemetry + alarm organ (measurement-only)

### DIFF
--- a/infra/launchagents/com.nuzantara.suite-growth-probe.plist.template
+++ b/infra/launchagents/com.nuzantara.suite-growth-probe.plist.template
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Merge-OS v3 build-order step 3 slice 1 — suite-growth telemetry organ,
+     LaunchAgent TEMPLATE.
+
+     research/operations/2026-08-14-merge-os-v3-research-council.md §6 step 3
+     "Suite-growth governance (the dominant lever, C1)" — this slice is
+     telemetry + alarm only, no gate-semantics change.
+
+     NOT INSTALLED BY THIS PR. This is a template only — arming it on Pro
+     (copying to ~/Library/LaunchAgents/, `launchctl bootstrap`, and verifying
+     the first receipt) is a separate ALIGN-FLEET step the orchestrator
+     drives, tracked in .claude/skills/modus/PENDING-ARMS.md (scar family #2
+     "esiste != armato" — built != armed, declared here rather than silently
+     assumed).
+
+     Placeholder <NUZANTARA_USER> must be substituted with the target
+     machine's actual user (nuzantara on Pro/Mini, balizero on M5) at install
+     time — no user-specific path is hardcoded in this template (cf.
+     cicatrix-superscar.md family #1, HOME-fork drift: a plist with someone
+     else's username baked in is exactly that disease).
+
+     03:57 WITA — nightly, after queue-baseline's 03:40 slot (own template,
+     same wrappers dir) with margin, deliberately off the :00/:30 minute
+     marks. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.suite-growth-probe</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/zsh</string>
+        <string>-lc</string>
+        <string>/Users/&lt;NUZANTARA_USER&gt;/nuzantara/infra/launchagents/wrappers/suite-growth-probe.sh &gt;&gt; /Users/&lt;NUZANTARA_USER&gt;/logs/suite-growth-probe.log 2&gt;&amp;1</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>57</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/Users/&lt;NUZANTARA_USER&gt;/logs/suite-growth-probe.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/&lt;NUZANTARA_USER&gt;/logs/suite-growth-probe.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/&lt;NUZANTARA_USER&gt;</string>
+        <key>PATH</key>
+        <string>/Users/&lt;NUZANTARA_USER&gt;/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/infra/launchagents/wrappers/suite-growth-probe.sh
+++ b/infra/launchagents/wrappers/suite-growth-probe.sh
@@ -1,0 +1,161 @@
+#!/bin/zsh
+# suite-growth-probe.sh — Merge-OS v3 step 3 slice 1 telemetry organ wrapper
+# (MEASUREMENT ONLY, no gate-semantics change).
+#
+# Invoked nightly (03:57 WITA, StartCalendarInterval) by
+# com.nuzantara.suite-growth-probe.plist — a TEMPLATE at this commit, NOT
+# installed by this PR. Arming on Pro is a separate ALIGN-FLEET step (scar
+# family #2 "esiste != armato" — built != armed; tracked in
+# .claude/skills/modus/PENDING-ARMS.md).
+#
+# Runs scripts/suite_growth_probe.py over the last 7 days of tests.yml gate
+# runs (push:main + merge_group), which writes its record to
+# ~/.nuzantara-mq/suite-growth/<timestamp>.json. The probe itself dispatches
+# any near-timeout/weekly-growth alert directly through scripts/tg_notify.py
+# (module docstring "ALARM") — this wrapper's OWN alert below fires only when
+# the PROBE ITSELF failed to collect data (a distinct condition from "the
+# probe ran clean and found a growth problem", which is not a wrapper-level
+# failure and must not be conflated with one, scar family #2).
+#
+# Scar discipline this wrapper obeys — copied byte-for-byte in structure from
+# infra/launchagents/wrappers/queue-baseline.sh (research/operations/
+# 2026-08-14-merge-os-v3-research-council.md §6 step 3 names that pattern as
+# the one to model):
+#
+#   - W108 "twentieth wrapper" (2026-07-28): the ALARM's interpreter
+#     (`SYSTEM_PY`) is resolved via `command -v` at the very top of this
+#     script, BEFORE secrets/venv sourcing can shadow PATH — a separate
+#     variable from `VENV_PY` (used for the probe itself), so an alert about
+#     a broken venv never has to run through that same broken venv.
+#   - W108 (16 of 20 wrappers): the probe call runs under `set +e` with its
+#     rc captured into a variable and judged explicitly afterward — never a
+#     bare pipeline under `set -e`/`pipefail` where the capture is dead code
+#     on the only path it exists for (W101).
+#   - W108 (1 of 20 wrappers): `[ -f X ] && source X`, never `source X ||
+#     true` — under `set -e` bash treats a failed `source` as a special
+#     builtin and EXITS; the `||` never runs.
+#   - W104 (2026-07-25): `tg_notify.py` always returns rc=0 (spool-best-effort
+#     contract) — the verdict is read from its printed status line, never
+#     from `$?`.
+#
+# DIFFERS from queue-baseline.sh in one declared way: this probe is NOT
+# stdlib-only (scripts/suite_growth_probe.py module docstring — it best-effort
+# imports PyYAML to read tests.yml's own timeout-minutes). The repo venv is
+# therefore preferred over a bare `set -e` fallback to system python3 unless
+# PyYAML is independently confirmed there too; the probe itself degrades
+# gracefully (declared error in errors[], never a crash) if PyYAML is missing
+# under either interpreter, so this wrapper does not hard-fail on that case —
+# it is visible in the record, not in this wrapper's own exit code.
+
+set -uo pipefail
+
+# --- W108 twentieth-wrapper fix: resolve the ALARM's interpreter FIRST, before
+# any venv/secrets sourcing below can shadow PATH. Deliberately separate from
+# VENV_PY.
+SYSTEM_PY="$(command -v python3 2>/dev/null || echo /usr/bin/python3)"
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+
+REPO_ROOT="${SUITE_GROWTH_REPO_ROOT:-$HOME/nuzantara}"
+REPO_SLUG="${SUITE_GROWTH_REPO_SLUG:-Bali-Zero/Teman2}"
+WORKFLOW="${SUITE_GROWTH_WORKFLOW:-tests.yml}"
+PROBE_SCRIPT="$REPO_ROOT/scripts/suite_growth_probe.py"
+STATE_DIR="$HOME/.nuzantara-mq/suite-growth"
+RECEIPT_DIR="$HOME/.agent/decisions"
+LOG="$HOME/logs/suite-growth-probe.log"
+
+mkdir -p "$STATE_DIR" "$RECEIPT_DIR" "$HOME/logs"
+
+log() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] [suite-growth-probe] $*" >> "$LOG"; }
+
+# [ -f X ] && source X — never `source X || true` (W108: a failed source is a
+# special builtin under `set -e` and EXITS before the `||` ever runs).
+[ -f "$HOME/.nuzantara-secrets.env" ] && set -a && source "$HOME/.nuzantara-secrets.env" && set +a
+
+# Repo-venv interpreter for the probe itself (existence-checked). Unlike
+# queue-baseline.sh's probe, this one is NOT guaranteed stdlib-only (see
+# header) — the repo venv is where PyYAML has actually been measured present
+# (module docstring), so prefer it strongly; system python3 is still a safe
+# fallback because the probe degrades gracefully without PyYAML rather than
+# crashing.
+VENV_PY="$REPO_ROOT/apps/backend-rag/.venv/bin/python3"
+if [ ! -x "$VENV_PY" ]; then
+    VENV_PY="$REPO_ROOT/.venv/bin/python3"
+fi
+if [ ! -x "$VENV_PY" ]; then
+    log "WARN: no repo venv python3 at either candidate path — falling back to system ($SYSTEM_PY); probe degrades gracefully without PyYAML but this is a real capability loss, not a false alarm"
+    VENV_PY="$SYSTEM_PY"
+fi
+
+if [ ! -f "$PROBE_SCRIPT" ]; then
+    log "FATAL: probe script missing at $PROBE_SCRIPT — cannot run"
+    exit 78
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    log "FATAL: gh CLI not on PATH — the probe cannot make a single API call without it"
+    exit 78
+fi
+
+# --- run the probe; rc captured then judged (W101 discipline: no bare
+# pipeline under `set -e`, capture is never dead code) ---
+set +e
+"$VENV_PY" "$PROBE_SCRIPT" --repo "$REPO_SLUG" --workflow "$WORKFLOW" \
+    --repo-root "$REPO_ROOT" --out-dir "$STATE_DIR" >> "$LOG" 2>&1
+PROBE_RC=$?
+set -e
+
+# The probe writes .last-run-pointer.json naming what it just produced — read
+# THAT instead of recomputing the same fact in shell (scar family #9: two
+# independent computations of one derived fact drift).
+POINTER_FILE="$STATE_DIR/.last-run-pointer.json"
+RECORD_PATH="(unknown — pointer file missing)"
+ERRORS_COUNT="-1"
+ALERTS_COUNT="-1"
+if [ -f "$POINTER_FILE" ]; then
+    RECORD_PATH="$("$SYSTEM_PY" -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d.get("record_path",""))' "$POINTER_FILE" 2>/dev/null)"
+    ERRORS_COUNT="$("$SYSTEM_PY" -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d.get("errors_count",-1))' "$POINTER_FILE" 2>/dev/null)"
+    ALERTS_COUNT="$("$SYSTEM_PY" -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d.get("alerts_sent_count",-1))' "$POINTER_FILE" 2>/dev/null)"
+fi
+
+# Wrapper's own execution receipt (distinct from the probe's DATA record
+# above) — same convention as queue-baseline.sh.
+RECEIPT_FILE="$RECEIPT_DIR/suite-growth-probe-last-receipt.json"
+"$SYSTEM_PY" - "$RECEIPT_FILE" "$PROBE_RC" "$RECORD_PATH" "$ERRORS_COUNT" "$ALERTS_COUNT" <<'PY'
+import json, os, sys, time
+receipt_path, rc, record_path, errors_count, alerts_count = sys.argv[1:6]
+json.dump({
+    "job": "suite-growth-probe",
+    "ran_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "probe_rc": int(rc),
+    "record_path": record_path,
+    "record_exists": bool(record_path) and os.path.exists(record_path),
+    "errors_count": int(errors_count) if errors_count not in ("", "-1") else None,
+    "alerts_sent_count": int(alerts_count) if alerts_count not in ("", "-1") else None,
+    "status": "ok" if int(rc) == 0 else "failed",
+}, open(receipt_path, "w"), indent=2)
+PY
+
+if [ "$PROBE_RC" -ne 0 ]; then
+    log "probe FAILED rc=$PROBE_RC record=$RECORD_PATH errors=$ERRORS_COUNT — see $LOG for detail, alerting"
+
+    MSG="suite-growth-probe FAILED to collect data (rc=$PROBE_RC) on $(hostname -s). errors=$ERRORS_COUNT record=$RECORD_PATH log=$LOG. NOTE: this is a data-collection failure, NOT a suite-growth finding — those alert directly from the probe itself."
+    # Same lookup convention as the neighboring wrappers (queue-baseline.sh,
+    # audit-launchd-daily.sh, cron-agent.sh): a live HOME deployment may keep
+    # tg_notify.py alongside the wrapper itself; the repo canon is the fallback.
+    GATEWAY="$(dirname "$0")/tg_notify.py"
+    [ -f "$GATEWAY" ] || GATEWAY="$REPO_ROOT/scripts/tg_notify.py"
+    if [ -f "$GATEWAY" ]; then
+        # W104: tg_notify.py always returns rc=0 (spool-best-effort) — judge its
+        # printed status line, never $?.
+        REPLY="$("$SYSTEM_PY" "$GATEWAY" --tier digest --source suite-growth-probe \
+            --dedup-key "suite-growth-probe:$(hostname -s):collection-failed" -- "$MSG" 2>&1)"
+        log "tg_notify reply: $(printf '%s' "$REPLY" | tr '\n' ' ' | head -c 200)"
+    else
+        log "ALERT NOT SENT: tg_notify.py gateway missing (looked in $(dirname "$0") and $REPO_ROOT/scripts)"
+    fi
+else
+    log "probe OK record=$RECORD_PATH errors=$ERRORS_COUNT alerts_sent=$ALERTS_COUNT"
+fi
+
+exit "$PROBE_RC"

--- a/scripts/suite_growth_probe.py
+++ b/scripts/suite_growth_probe.py
@@ -1,0 +1,777 @@
+#!/usr/bin/env python3
+"""suite_growth_probe.py — Merge-OS v3 build-order step 3 slice 1 (MEASUREMENT ONLY).
+
+Spec: research/operations/2026-08-14-merge-os-v3-research-council.md §6 step 3
+"Suite-growth governance (the dominant lever, C1): ... rolling p50/p95 + slot-minutes
++ top-N-by-duration telemetry per lane with weekly delta and owner". This script is
+the FIRST slice of that step: telemetry + an alarm on the derivative. It changes
+NOTHING about how tests.yml jobs are gated, retried, or timed out — it only RECORDS
+what already happened and, when the numbers cross a declared line, tells a human via
+Telegram. No test selection, no auto-deletion, no gate-semantics change (§6 step 3's
+own scope: "NO auto-deletion on slowness/flake alone").
+
+WHY THIS EXISTS (§8 meta-pattern, restated concretely): the backend test suite's
+median wall time grew from ~18 to ~29 minutes over five weeks (~+10%/week) while
+`backend-tests.timeout-minutes` in tests.yml has stayed 30. When the median crosses
+that ceiling, `Backend Tests (Python)` — a required check on `main` and `merge_group`
+— starts reporting `cancelled`, not `failure` (the exact scar family #9 trap
+`scripts/lint_workflow_timeout_floor.py` documents for `actions/checkout`, one layer
+up the same job). A cancelled required check never turns green by itself and the
+merge queue jams with nothing red to fix. Nothing in this repo measured or alarmed
+on that derivative before this script existed (scar family #2 "esiste != armato" —
+the growth was happening in full view of seven weeks of CI logs and no organ read
+them as a trend).
+
+Invoked nightly (Pro) by infra/launchagents/wrappers/suite-growth-probe.sh via the
+(NOT-YET-ARMED — W81, built != armed) com.nuzantara.suite-growth-probe.plist.template.
+Writes one record per invocation to `~/.nuzantara-mq/suite-growth/<date>.json`
+(`--out-dir` overridable).
+
+WHAT IS MEASURED, per job of `--workflow` (default tests.yml), over the last
+`--window-days` (default 7) days of *completed* runs whose event is `push` (with
+`head_branch == main`, so `develop` pushes and PR-triggered runs are excluded) or
+`merge_group` — the two events step 2's own council doc names as this repo's real
+gate load, distinct from the 2-hourly `schedule` run (§6 step 2's own subject: that
+schedule is a documented independent health probe, not gate load):
+
+  1. Per-job wall time (job `completed_at` - `started_at`, GitHub Actions Jobs API),
+     bucketed into a CURRENT window (`now - window_days .. now`) and a PREVIOUS
+     window (`now - 2*window_days .. now - window_days`) — p50/p95 each, computed by
+     the same dependency-free linear-interpolation percentile() this repo's
+     queue_baseline_probe.py already uses (numpy 'linear' method), duplicated here
+     rather than imported: scripts/ is a flat bag of standalone tools, not a package
+     (see that module's own docstring / scripts/tests/test_queue_baseline_probe.py
+     header for the same declared convention).
+  2. Weekly trend: `(current_p50 - previous_p50) / previous_p50 * 100`. `None` when
+     the previous window has no sample (first week this organ runs, or a job that
+     did not exist 7-14 days ago) — never coerced to 0.0, which would silently claim
+     "measured, and it was flat".
+  3. Distance from timeout: `current_p95 / timeout_minutes * 100`, where
+     `timeout_minutes` is read from `--workflow`'s own YAML (best-effort: this
+     script tries `import yaml`; if PyYAML is unavailable the timeout is left
+     `None` for every job and the gap is recorded in `errors[]`, never silently
+     treated as "no timeout configured" — see `read_job_timeouts()`).
+  4. Test file count: `find <repo-root>/apps/backend-rag/backend/tests -name
+     'test_*.py'` equivalent (`Path.rglob`, no subprocess) — a correlate for the
+     suite-growth trend, not itself alarmed on.
+
+DECLARED LIMITATION (early-exit bias): `backend-tests`' own "Run unit tests" step
+runs pytest with `-x` (stop at first failure). A run that fails early finishes
+FASTER than a full pass, which can pull a window's p50 DOWN exactly when the suite
+is least healthy. This script does not attempt to correct for that — it records
+wall time for every `status == "completed"` job regardless of `conclusion`,
+matching what the merge queue itself experiences (a cancelled-on-timeout job's
+duration lands at/near the timeout ceiling, which is precisely the signal
+`p95_pct_of_timeout` needs to see). A future slice could split by conclusion; this
+one does not, and says so rather than presenting a falsely-precise number.
+
+ALARM (env-overridable via SUITE_GROWTH_P95_TIMEOUT_PCT / SUITE_GROWTH_WEEKLY_GROWTH_PCT,
+defaults 85.0 / 8.0):
+  - `near_timeout`   := current window has a sample AND timeout_minutes is known AND
+                         p95_pct_of_timeout >= SUITE_GROWTH_P95_TIMEOUT_PCT   -> P1
+  - `weekly_growth`  := both windows have a sample AND previous_p50 > 0 AND
+                         trend_delta_pct > SUITE_GROWTH_WEEKLY_GROWTH_PCT     -> P1
+  - both true for the same job                                               -> P0
+Alerts go through `scripts/tg_notify.py` — the ONE gateway every Telegram message in
+this repo passes through (scar W104: judge the gateway's printed verdict line, never
+its exit code, which is always 0 by the gateway's own spool-best-effort contract).
+P0 -> `--tier p0` (actionable now). P1-only -> `--tier digest` (informative). A job
+whose alert already escalated to P0 does not also fire a separate P1 — one message
+per job per run, dedup-keyed `suite-growth:<job-id>` so the gateway's own repeat
+ladder (scripts/tg_notify.py docstring) quiets a persisting condition instead of
+re-alerting every night. NO alert originates from GitHub Actions itself — the
+TELEGRAM_BOT_TOKEN in this repo's Actions secrets is dead (cicatrix-superscar.md
+family #9, C8/W102) — this organ lives on Pro launchd, never in a workflow.
+
+FAIL-VISIBLE (scar family #2): every `gh` denial, timeout, or unparseable response is
+appended to the record's top-level `errors[]`. The record is ALWAYS written, even
+when data collection failed completely. `main()` returns 0 only when `errors` is
+empty; a non-empty `errors[]` exits 1 (independent of whether an alert fired — a
+growth/timeout finding is a legitimate result, not a probe failure, and must not be
+conflated with one).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import re
+import socket
+import subprocess
+import sys
+import traceback
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("suite_growth_probe")
+
+DEFAULT_REPO = "Bali-Zero/Teman2"
+DEFAULT_WORKFLOW = "tests.yml"
+DEFAULT_OUT_DIR = Path.home() / ".nuzantara-mq" / "suite-growth"
+DEFAULT_WINDOW_DAYS = 7
+DEFAULT_TEST_DIR = "apps/backend-rag/backend/tests"
+SCHEMA_VERSION = 1
+
+GH_TIMEOUT_LIST_RUNS = 120
+GH_TIMEOUT_SHORT = 30
+GH_TIMEOUT_TG = 30
+
+GATE_EVENTS = ("push", "merge_group")
+
+
+def _env_float(name: str, default: float) -> float:
+    """Garbage in an env knob must never crash a nightly cron (fail-open contract,
+    same shape as tg_notify.py's own `_env_num`)."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("ignoring unparseable %s=%r, using default %s", name, raw, default)
+        return default
+
+
+P95_TIMEOUT_PCT_THRESHOLD = _env_float("SUITE_GROWTH_P95_TIMEOUT_PCT", 85.0)
+WEEKLY_GROWTH_PCT_THRESHOLD = _env_float("SUITE_GROWTH_WEEKLY_GROWTH_PCT", 8.0)
+
+
+# ---------------------------------------------------------------------------
+# Pure functions (no I/O)
+# ---------------------------------------------------------------------------
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    """Linear-interpolation percentile (numpy 'linear' method), dependency-free.
+
+    Duplicated from scripts/queue_baseline_probe.py by declared convention — see
+    module docstring. Returns None for an empty sample, never coerced to 0.0.
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    k = (len(ordered) - 1) * (pct / 100.0)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return ordered[int(k)]
+    d0 = ordered[int(f)] * (c - k)
+    d1 = ordered[int(c)] * (k - f)
+    return d0 + d1
+
+
+def job_window(created_at: datetime, now: datetime, window_days: int) -> str | None:
+    """Classify a run's created_at into "current" / "previous" / None (out of range).
+
+    Pure — no I/O. `None` means the run is older than the two windows combined and
+    is simply not part of this record (not an error: the API query already bounds
+    the fetch, this is a defensive second check on the exact cutoff).
+    """
+    current_start = now - timedelta(days=window_days)
+    previous_start = now - timedelta(days=2 * window_days)
+    if current_start <= created_at <= now:
+        return "current"
+    if previous_start <= created_at < current_start:
+        return "previous"
+    return None
+
+
+def qualifies_as_gate_run(run: dict[str, Any]) -> bool:
+    """True when a workflow run counts as gate load (module docstring: push-to-main
+    or merge_group — NOT develop pushes, NOT PR runs, NOT the 2-hourly schedule
+    probe, which the council doc treats as an independent health check, not load).
+    """
+    event = run.get("event")
+    if event == "merge_group":
+        return True
+    if event == "push" and run.get("head_branch") == "main":
+        return True
+    return False
+
+
+def job_wall_minutes(job: dict[str, Any]) -> float | None:
+    """(completed_at - started_at) in minutes for one Jobs-API job dict.
+
+    None when the job never reached "completed" status or is missing a timestamp —
+    caller records that as a skip, not a zero (a zero would silently claim "ran
+    instantly").
+    """
+    if job.get("status") != "completed":
+        return None
+    started = job.get("started_at")
+    completed = job.get("completed_at")
+    if not started or not completed:
+        return None
+    try:
+        t0 = datetime.fromisoformat(str(started).replace("Z", "+00:00"))
+        t1 = datetime.fromisoformat(str(completed).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    delta = (t1 - t0).total_seconds() / 60.0
+    return delta if delta >= 0 else None
+
+
+def compute_job_verdict(
+    current_p50: float | None,
+    current_p95: float | None,
+    previous_p50: float | None,
+    timeout_minutes: int | None,
+) -> dict[str, Any]:
+    """The alarm logic (module docstring "ALARM"), pure and independently testable.
+
+    Never raises: every branch is guarded by an explicit None check so a job with a
+    thin sample degrades to "cannot evaluate that condition" rather than a crash or
+    a fabricated verdict.
+    """
+    p95_pct_of_timeout: float | None = None
+    near_timeout = False
+    if current_p95 is not None and timeout_minutes:
+        p95_pct_of_timeout = current_p95 / timeout_minutes * 100.0
+        near_timeout = p95_pct_of_timeout >= P95_TIMEOUT_PCT_THRESHOLD
+
+    trend_delta_pct: float | None = None
+    weekly_growth = False
+    if current_p50 is not None and previous_p50 is not None and previous_p50 > 0:
+        trend_delta_pct = (current_p50 - previous_p50) / previous_p50 * 100.0
+        weekly_growth = trend_delta_pct > WEEKLY_GROWTH_PCT_THRESHOLD
+
+    if near_timeout and weekly_growth:
+        severity = "P0"
+    elif near_timeout or weekly_growth:
+        severity = "P1"
+    else:
+        severity = None
+
+    return {
+        "p95_pct_of_timeout": p95_pct_of_timeout,
+        "near_timeout": near_timeout,
+        "trend_delta_pct": trend_delta_pct,
+        "weekly_growth": weekly_growth,
+        "severity": severity,
+    }
+
+
+def read_job_timeouts(workflow_path: Path) -> tuple[dict[str, dict[str, Any]], str | None]:
+    """job-id -> {"name": <API job name>, "timeout_minutes": int|None} from the
+    workflow's own YAML.
+
+    Best-effort: PyYAML is not a stdlib module and this repo's other workflow-YAML
+    reader (scripts/lint_workflow_timeout_floor.py) already depends on it, but
+    unlike scripts/queue_baseline_probe.py this script is therefore NOT
+    stdlib-only. A missing/broken PyYAML degrades to an empty map plus a declared
+    error string — every job's timeout_minutes is then None in the record, which
+    read_job_timeouts' caller must treat as "distance-from-timeout not computable
+    this run", never as "no timeout configured".
+    """
+    try:
+        import yaml  # noqa: PLC0415 — deliberately lazy, see docstring
+    except ImportError as exc:
+        return {}, f"PyYAML unavailable ({exc}); job timeout-minutes not populated this run"
+
+    try:
+        doc = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        return {}, f"could not parse {workflow_path}: {exc}"
+    if not isinstance(doc, dict):
+        return {}, f"{workflow_path} did not parse to a mapping"
+
+    out: dict[str, dict[str, Any]] = {}
+    for job_id, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        timeout = job.get("timeout-minutes")
+        if not isinstance(timeout, int) or isinstance(timeout, bool):
+            timeout = None
+        out[str(job_id)] = {
+            "name": job.get("name") or str(job_id),
+            "timeout_minutes": timeout,
+        }
+    return out, None
+
+
+def count_test_files(repo_root: Path, test_dir: str) -> tuple[int | None, str | None]:
+    """`test_*.py` count under `<repo_root>/<test_dir>` — a correlate, not itself
+    alarmed on. None + error string when the directory does not exist (never a
+    silent 0, which would read as "test suite is empty")."""
+    target = repo_root / test_dir
+    if not target.is_dir():
+        return None, f"test dir not found: {target}"
+    return sum(1 for _ in target.rglob("test_*.py")), None
+
+
+# ---------------------------------------------------------------------------
+# subprocess boundaries — one for gh, one for tg_notify, so tests intercept each
+# shape independently (mirrors queue_baseline_probe.py's single `_run_gh` boundary).
+# ---------------------------------------------------------------------------
+
+
+def _run_gh(cmd: list[str], timeout: int = GH_TIMEOUT_SHORT) -> subprocess.CompletedProcess[str]:
+    """The one subprocess boundary this module crosses for `gh` calls. Never raises
+    on a non-zero exit; may raise `subprocess.TimeoutExpired`, caught by callers."""
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def _run_tg_notify(cmd: list[str], timeout: int = GH_TIMEOUT_TG) -> subprocess.CompletedProcess[str]:
+    """The one subprocess boundary this module crosses to reach tg_notify.py. Kept
+    separate from `_run_gh` so a test can fake one without accidentally answering
+    for the other (scar W114: the fake belongs at the boundary the real code
+    crosses, matched one-for-one, not merged into a single do-everything stub)."""
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+
+def _parse_concatenated_json(text: str) -> list[dict[str, Any]]:
+    """Parse zero or more whitespace-separated JSON objects (`gh api --paginate`
+    output) — identical to queue_baseline_probe.py's own helper, duplicated by the
+    same flat-bag-of-scripts convention."""
+    decoder = json.JSONDecoder()
+    text = text.strip()
+    objs: list[dict[str, Any]] = []
+    idx = 0
+    n = len(text)
+    while idx < n:
+        while idx < n and text[idx].isspace():
+            idx += 1
+        if idx >= n:
+            break
+        obj, end = decoder.raw_decode(text, idx)
+        objs.append(obj)
+        idx = end
+    return objs
+
+
+# ---------------------------------------------------------------------------
+# I/O-fetching functions — each returns (data, errors), never raises for a normal
+# gh failure.
+# ---------------------------------------------------------------------------
+
+
+def list_workflow_runs(
+    repo: str,
+    workflow: str,
+    since: datetime,
+    now: datetime,
+) -> tuple[list[dict[str, Any]], int | None, list[str]]:
+    """Completed runs of `workflow` created in `[since, now]` (UTC), with a census
+    check exactly like queue_baseline_probe.list_workflow_runs — a pagination
+    shortfall against `total_count` is an error, not a quietly-partial success."""
+    created_query = f"{since.strftime('%Y-%m-%dT%H:%M:%S')}..{now.strftime('%Y-%m-%dT%H:%M:%S')}"
+    cmd = [
+        "gh", "api", f"repos/{repo}/actions/workflows/{workflow}/runs",
+        "-X", "GET",
+        "-f", "status=completed",
+        "-f", f"created={created_query}",
+        "-f", "per_page=100",
+        "--paginate",
+    ]
+    errors: list[str] = []
+    try:
+        proc = _run_gh(cmd, timeout=GH_TIMEOUT_LIST_RUNS)
+    except subprocess.TimeoutExpired as exc:
+        return [], None, [f"list_workflow_runs timeout: {exc}"]
+    except OSError as exc:
+        return [], None, [f"list_workflow_runs OSError: {exc}"]
+    if proc.returncode != 0:
+        return [], None, [
+            f"list_workflow_runs failed rc={proc.returncode} stderr={proc.stderr.strip()[:400]}"
+        ]
+    try:
+        pages = _parse_concatenated_json(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return [], None, [f"list_workflow_runs bad JSON: {exc}"]
+
+    reported_totals = {
+        int(page["total_count"]) for page in pages if isinstance(page.get("total_count"), int)
+    }
+    positive_totals = {t for t in reported_totals if t > 0}
+    reported_total = max(reported_totals) if reported_totals else None
+    if len(positive_totals) > 1:
+        errors.append(
+            "list_workflow_runs inconsistent positive total_count values across pages: "
+            f"{sorted(positive_totals)}"
+        )
+    if reported_total is None:
+        errors.append("list_workflow_runs response missing integer total_count")
+
+    runs_by_id: dict[int, dict[str, Any]] = {}
+    for page in pages:
+        for run in page.get("workflow_runs") or []:
+            run_id = run.get("id") if isinstance(run, dict) else None
+            if isinstance(run_id, int):
+                runs_by_id[run_id] = run
+    runs = list(runs_by_id.values())
+    if reported_total is not None and len(runs) < reported_total:
+        errors.append(
+            "list_workflow_runs pagination shortfall: "
+            f"fetched={len(runs)} reported_total={reported_total}; record is partial"
+        )
+    return runs, reported_total, errors
+
+
+def fetch_run_jobs(repo: str, run_id: int) -> tuple[list[dict[str, Any]], str | None]:
+    """GET .../actions/runs/{run_id}/jobs -> jobs list (name/status/started_at/completed_at).
+
+    `-X GET` is NOT optional here: `gh api` switches its default method to POST
+    the instant any `-f`/`-F` field is present, unless `-X`/`--method` says
+    otherwise (verified live against this endpoint during this script's own
+    dry-run — every job fetch 404'd until this flag was added; see the PR
+    description for the reproduction). `list_workflow_runs()` above already had
+    this right; this function did not, which is exactly the kind of drift a
+    single shared `_run_gh` boundary is supposed to prevent from mattering —
+    it didn't, because the argv is still assembled per call-site.
+    """
+    cmd = ["gh", "api", f"repos/{repo}/actions/runs/{run_id}/jobs", "-X", "GET", "-f", "per_page=100", "--paginate"]
+    try:
+        proc = _run_gh(cmd, timeout=GH_TIMEOUT_SHORT)
+    except subprocess.TimeoutExpired as exc:
+        return [], f"jobs fetch timeout run={run_id}: {exc}"
+    except OSError as exc:
+        return [], f"jobs fetch OSError run={run_id}: {exc}"
+    if proc.returncode != 0:
+        return [], f"jobs fetch failed run={run_id} rc={proc.returncode} stderr={proc.stderr.strip()[:300]}"
+    try:
+        pages = _parse_concatenated_json(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return [], f"jobs fetch bad JSON run={run_id}: {exc}"
+    jobs: list[dict[str, Any]] = []
+    for page in pages:
+        jobs.extend(page.get("jobs") or [])
+    return jobs, None
+
+
+def send_alert(
+    tier: str,
+    source: str,
+    dedup_key: str,
+    message: str,
+    tg_notify_path: Path,
+    python_executable: str | None = None,
+) -> tuple[bool, str]:
+    """Dispatch one message through scripts/tg_notify.py (job_health.py's own
+    subprocess-invocation pattern, --tier/--source/--dedup-key/-- <msg>).
+
+    Returns (dispatched, detail). `dispatched` is True whenever the subprocess call
+    itself completed (tg_notify.py's own contract is to always exit 0 — W104: a
+    caller judges the printed verdict line, never the exit code, so this function
+    surfaces stdout/stderr in `detail` for the caller to log, but does not treat a
+    non-zero rc as proof the alert failed to spool).
+    """
+    if not tg_notify_path.is_file():
+        return False, f"tg_notify.py not found at {tg_notify_path}"
+    python_executable = python_executable or sys.executable
+    cmd = [
+        python_executable, str(tg_notify_path),
+        "--tier", tier,
+        "--source", source,
+        "--dedup-key", dedup_key,
+        "--", message,
+    ]
+    try:
+        proc = _run_tg_notify(cmd)
+    except subprocess.TimeoutExpired as exc:
+        return False, f"tg_notify timeout: {exc}"
+    except OSError as exc:
+        return False, f"tg_notify OSError: {exc}"
+    detail = (proc.stdout + proc.stderr).strip()[:400]
+    return True, detail or f"rc={proc.returncode}"
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _empty_record(repo: str, workflow: str, now: datetime, window_days: int) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repo": repo,
+        "workflow": workflow,
+        "window_days": window_days,
+        "thresholds": {
+            "p95_timeout_pct": P95_TIMEOUT_PCT_THRESHOLD,
+            "weekly_growth_pct": WEEKLY_GROWTH_PCT_THRESHOLD,
+        },
+        "run_collection": {"reported_total": None, "fetched": 0, "complete": False},
+        "jobs": {},
+        "test_file_count": None,
+        "alerts_sent": [],
+        "errors": [],
+    }
+
+
+def build_record(
+    repo: str,
+    workflow: str,
+    repo_root: Path,
+    test_dir: str,
+    now: datetime,
+    window_days: int,
+    tg_notify_path: Path,
+    dispatch_alerts: bool = True,
+) -> dict[str, Any]:
+    """Build one record. Never raises — a crash mid-way is caught by main() and
+    turned into an emergency record carrying the traceback, same contract as
+    queue_baseline_probe.build_record / _emergency_record."""
+    record = _empty_record(repo, workflow, now, window_days)
+    errors: list[str] = record["errors"]
+
+    since = now - timedelta(days=2 * window_days)
+    runs, reported_total, run_errors = list_workflow_runs(repo, workflow, since, now)
+    errors.extend(run_errors)
+    record["run_collection"] = {
+        "reported_total": reported_total,
+        "fetched": len(runs),
+        "complete": reported_total == len(runs),
+    }
+
+    gate_runs = [r for r in runs if qualifies_as_gate_run(r)]
+
+    # job_id -> window -> list[minutes]; job_id -> observed API display name
+    samples: dict[str, dict[str, list[float]]] = {}
+    display_names: dict[str, str] = {}
+
+    for run in gate_runs:
+        run_id = run.get("id")
+        created_at_raw = run.get("created_at")
+        if run_id is None or not created_at_raw:
+            errors.append(f"gate run missing id/created_at, skipped: {run.get('name', '?')!r}")
+            continue
+        try:
+            created_at = datetime.fromisoformat(str(created_at_raw).replace("Z", "+00:00"))
+        except ValueError as exc:
+            errors.append(f"unparseable created_at run={run_id}: {exc}")
+            continue
+        window = job_window(created_at, now, window_days)
+        if window is None:
+            continue
+
+        jobs, jobs_error = fetch_run_jobs(repo, run_id)
+        if jobs_error:
+            errors.append(jobs_error)
+            continue
+        for job in jobs:
+            minutes = job_wall_minutes(job)
+            if minutes is None:
+                continue
+            job_name = str(job.get("name") or "unknown")
+            job_key = re.sub(r"\s*\(.*?\)\s*$", "", job_name).strip() or job_name
+            job_key = re.sub(r"[^a-zA-Z0-9]+", "-", job_key).strip("-").lower() or "unknown"
+            display_names.setdefault(job_key, job_name)
+            samples.setdefault(job_key, {"current": [], "previous": []})[window].append(minutes)
+
+    workflow_path = repo_root / ".github" / "workflows" / workflow
+    timeout_map, timeout_error = read_job_timeouts(workflow_path)
+    if timeout_error:
+        errors.append(timeout_error)
+    # name -> timeout_minutes, matched on the same normalized-name key as `samples`
+    timeout_by_key: dict[str, int | None] = {}
+    for meta in timeout_map.values():
+        key = re.sub(r"\s*\(.*?\)\s*$", "", str(meta["name"])).strip() or str(meta["name"])
+        key = re.sub(r"[^a-zA-Z0-9]+", "-", key).strip("-").lower() or "unknown"
+        timeout_by_key[key] = meta["timeout_minutes"]
+
+    jobs_out: dict[str, Any] = {}
+    alerts_sent: list[dict[str, Any]] = []
+    for job_key, windows in sorted(samples.items()):
+        current_samples = windows.get("current", [])
+        previous_samples = windows.get("previous", [])
+        current_p50 = percentile(current_samples, 50)
+        current_p95 = percentile(current_samples, 95)
+        previous_p50 = percentile(previous_samples, 50)
+        timeout_minutes = timeout_by_key.get(job_key)
+        if job_key not in timeout_by_key:
+            errors.append(f"no timeout-minutes entry found for job '{job_key}' in {workflow}")
+
+        verdict = compute_job_verdict(current_p50, current_p95, previous_p50, timeout_minutes)
+
+        jobs_out[job_key] = {
+            "api_job_name": display_names.get(job_key, job_key),
+            "timeout_minutes": timeout_minutes,
+            "current_window": {
+                "sample_size": len(current_samples),
+                "p50_minutes": current_p50,
+                "p95_minutes": current_p95,
+            },
+            "previous_window": {
+                "sample_size": len(previous_samples),
+                "p50_minutes": previous_p50,
+            },
+            **verdict,
+        }
+
+        if verdict["severity"] is not None:
+            reasons = []
+            if verdict["near_timeout"]:
+                pct = verdict["p95_pct_of_timeout"]
+                reasons.append(
+                    f"p95={current_p95:.1f}min is {pct:.0f}% of the {timeout_minutes}min timeout"
+                )
+            if verdict["weekly_growth"]:
+                reasons.append(f"p50 grew {verdict['trend_delta_pct']:.1f}% week-over-week")
+            message = (
+                f"suite-growth {verdict['severity']}: {display_names.get(job_key, job_key)} "
+                f"({workflow}) — {'; '.join(reasons)}."
+            )
+            tier = "p0" if verdict["severity"] == "P0" else "digest"
+            dedup_key = f"suite-growth:{job_key}"
+            alert_entry = {
+                "job": job_key,
+                "severity": verdict["severity"],
+                "tier": tier,
+                "dedup_key": dedup_key,
+                "message": message,
+                "dispatched": None,
+                "detail": None,
+            }
+            if dispatch_alerts:
+                dispatched, detail = send_alert(
+                    tier, "suite-growth-probe", dedup_key, message, tg_notify_path
+                )
+                alert_entry["dispatched"] = dispatched
+                alert_entry["detail"] = detail
+                if not dispatched:
+                    errors.append(f"alert dispatch failed for job={job_key}: {detail}")
+            alerts_sent.append(alert_entry)
+
+    record["jobs"] = jobs_out
+    record["alerts_sent"] = alerts_sent
+
+    count, count_error = count_test_files(repo_root, test_dir)
+    if count_error:
+        errors.append(count_error)
+    record["test_file_count"] = {"path": test_dir, "count": count}
+
+    return record
+
+
+def _emergency_record(
+    repo: str, workflow: str, now: datetime, window_days: int, exc: BaseException
+) -> dict[str, Any]:
+    record = _empty_record(repo, workflow, now, window_days)
+    record["errors"].append(
+        f"FATAL uncaught exception while building record: {exc!r}\n{traceback.format_exc()}"
+    )
+    return record
+
+
+def write_record(out_dir: Path, record: dict[str, Any]) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = record["generated_at_utc"].replace(":", "").replace("-", "")
+    out_path = out_dir / f"{stamp}.json"
+    tmp_path = out_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    tmp_path.replace(out_path)  # atomic on the same filesystem
+    return out_path
+
+
+def write_pointer(out_dir: Path, record: dict[str, Any], record_path: Path) -> Path:
+    """Same rationale as queue_baseline_probe.write_pointer: one computation of
+    "what did the last run produce", read by the wrapper, never recomputed twice."""
+    pointer_path = out_dir / ".last-run-pointer.json"
+    pointer = {
+        "generated_at_utc": record["generated_at_utc"],
+        "record_path": str(record_path),
+        "errors_count": len(record["errors"]),
+        "alerts_sent_count": len(record["alerts_sent"]),
+    }
+    tmp_path = pointer_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(pointer, indent=2, sort_keys=True) + "\n")
+    tmp_path.replace(pointer_path)
+    return pointer_path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/repo, default %(default)s")
+    parser.add_argument("--workflow", default=DEFAULT_WORKFLOW, help="workflow file, default %(default)s")
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parent.parent),
+        help="local checkout root, for reading the workflow YAML + counting test files",
+    )
+    parser.add_argument("--test-dir", default=DEFAULT_TEST_DIR, help="relative test dir, default %(default)s")
+    parser.add_argument("--out-dir", default=str(DEFAULT_OUT_DIR), help="directory for records, default %(default)s")
+    parser.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS, help="default %(default)s")
+    parser.add_argument(
+        "--now",
+        default=None,
+        help="UTC ISO-8601 instant to treat as 'now' (default: real now — for test determinism)",
+    )
+    parser.add_argument(
+        "--tg-notify-path",
+        default=None,
+        help="override path to tg_notify.py (default: <repo-root>/scripts/tg_notify.py)",
+    )
+    parser.add_argument(
+        "--no-alert",
+        action="store_true",
+        help="build the record and compute verdicts, but never dispatch to tg_notify.py "
+        "(dry-run / local inspection)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="DEBUG-level logging")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+    )
+
+    now = (
+        datetime.fromisoformat(args.now.replace("Z", "+00:00"))
+        if args.now
+        else datetime.now(timezone.utc)
+    )
+    repo_root = Path(args.repo_root)
+    tg_notify_path = Path(args.tg_notify_path) if args.tg_notify_path else repo_root / "scripts" / "tg_notify.py"
+    out_dir = Path(args.out_dir)
+
+    try:
+        record = build_record(
+            args.repo,
+            args.workflow,
+            repo_root,
+            args.test_dir,
+            now,
+            args.window_days,
+            tg_notify_path,
+            dispatch_alerts=not args.no_alert,
+        )
+    except Exception as exc:  # noqa: BLE001 — last-resort guard, see module docstring
+        logger.exception("uncaught exception building record")
+        record = _emergency_record(args.repo, args.workflow, now, args.window_days, exc)
+
+    out_path = write_record(out_dir, record)
+    write_pointer(out_dir, record, out_path)
+
+    n_errors = len(record["errors"])
+    n_alerts = len(record["alerts_sent"])
+    if n_errors:
+        logger.warning("wrote %s with %d error(s) — see errors[] in the record", out_path, n_errors)
+        for err in record["errors"]:
+            logger.warning("  - %s", err.splitlines()[0] if err else err)
+    else:
+        logger.info(
+            "wrote %s on %s — jobs=%d alerts=%d",
+            out_path,
+            socket.gethostname().split(".")[0],
+            len(record["jobs"]),
+            n_alerts,
+        )
+    if n_alerts:
+        for alert in record["alerts_sent"]:
+            logger.info("  alert %s job=%s dispatched=%s", alert["severity"], alert["job"], alert["dispatched"])
+
+    return 1 if n_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/suite_growth_probe.py
+++ b/scripts/suite_growth_probe.py
@@ -122,6 +122,12 @@ GH_TIMEOUT_TG = 30
 
 GATE_EVENTS = ("push", "merge_group")
 
+# tg_notify.py prints its real outcome as `tg_notify: <verdict>` on stderr — the
+# gateway's own exit code is always 0 (W104), so this is the only place a caller
+# can tell "sent" from "deduped"/"p0_overflow_spooled"/etc. Same convention as
+# scripts/job_health.py's _GATEWAY_VERDICT_RE.
+_GATEWAY_VERDICT_RE = re.compile(r"^tg_notify:\s*(\S+)", re.MULTILINE)
+
 
 def _env_float(name: str, default: float) -> float:
     """Garbage in an env knob must never crash a nightly cron (fail-open contract,
@@ -321,8 +327,23 @@ def _run_tg_notify(cmd: list[str], timeout: int = GH_TIMEOUT_TG) -> subprocess.C
     """The one subprocess boundary this module crosses to reach tg_notify.py. Kept
     separate from `_run_gh` so a test can fake one without accidentally answering
     for the other (scar W114: the fake belongs at the boundary the real code
-    crosses, matched one-for-one, not merged into a single do-everything stub)."""
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    crosses, matched one-for-one, not merged into a single do-everything stub).
+
+    tg_notify.py always exits 0 (W104) — sent/logged/spooled/deduped/
+    p0_overflow_spooled/p0_unsent_spooled are all rc=0. The gateway prints the
+    real outcome as `tg_notify: <verdict>` on its own stderr; a caller that never
+    parses that line reads a refusal as a delivery
+    (scripts/tests/test_gateway_callers_read_the_verdict.py). Parse and log it
+    here, at the one place this module crosses the subprocess boundary, so every
+    caller of this function inherits the reading for free instead of each one
+    re-deriving it (or forgetting to)."""
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    m = _GATEWAY_VERDICT_RE.search(proc.stderr or "")
+    print(
+        f"tg_notify: {m.group(1) if m else f'NESSUN verdetto rc={proc.returncode}'}",
+        file=sys.stderr,
+    )
+    return proc
 
 
 def _parse_concatenated_json(text: str) -> list[dict[str, Any]]:

--- a/scripts/tests/test_suite_growth_probe.py
+++ b/scripts/tests/test_suite_growth_probe.py
@@ -1,0 +1,522 @@
+"""Tests for scripts/suite_growth_probe.py — Merge-OS v3 step 3 slice 1 (measurement-only).
+
+Module is imported via importlib.util.spec_from_file_location (not a package import)
+because scripts/ is a flat bag of standalone tools — same convention as
+scripts/tests/test_queue_baseline_probe.py, whose header explains it.
+
+NO network anywhere in this file. Every `gh` invocation is intercepted at the real
+subprocess boundary the module crosses (`monkeypatch.setattr(sgp.subprocess, "run",
+fake_run)`, W114: the fake belongs at the boundary the real code crosses). The
+`tg_notify.py` dispatch is intercepted the same way, at its own separate boundary
+(`sgp._run_tg_notify`), so a test cannot accidentally make one fake answer for both.
+
+Scenarios required by the mandate (team-lead message, step 3 slice 1):
+  1. guilt: `gh api` denied for the run-listing call -> errors[] non-empty, main()
+     returns 1, the record is still written to disk (never a silent empty success).
+  2. guilt: current-window p95 crosses the timeout threshold alone -> P1, alert
+     dispatch path invoked (tg_notify called with --tier digest).
+  3. guilt: week-over-week growth crosses the threshold alone -> P1, alert
+     dispatch path invoked.
+  4. guilt: both conditions on the same job -> P0, --tier p0, exactly one alert
+     for that job (not two).
+  5. innocence: both windows comfortably under both thresholds -> severity None,
+     alerts_sent == [], tg_notify never invoked.
+  6. record is written even on total API failure (schema-shape parity with the
+     healthy-empty-day case).
+Plus pure-function unit tests for the sub-mechanisms above lean on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "suite_growth_probe.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("suite_growth_probe", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sgp = _load_module()
+
+NOW = datetime(2026, 8, 14, 0, 0, 0, tzinfo=timezone.utc)
+CURRENT_TS = "2026-08-10T00:00:00Z"  # 4 days before NOW -> current window
+PREVIOUS_TS = "2026-08-03T00:00:00Z"  # 11 days before NOW -> previous window
+
+
+# ---------------------------------------------------------------------------
+# Pure functions
+# ---------------------------------------------------------------------------
+
+
+def test_percentile_empty_is_none():
+    assert sgp.percentile([], 50) is None
+
+
+def test_percentile_single_value():
+    assert sgp.percentile([42.0], 95) == 42.0
+
+
+def test_percentile_p50_p95_known_sample():
+    values = [10.0, 20.0, 30.0, 40.0, 50.0]
+    assert sgp.percentile(values, 50) == 30.0
+    assert sgp.percentile(values, 95) == pytest.approx(48.0)
+
+
+def test_job_window_current_previous_and_out_of_range():
+    current = datetime.fromisoformat(CURRENT_TS.replace("Z", "+00:00"))
+    previous = datetime.fromisoformat(PREVIOUS_TS.replace("Z", "+00:00"))
+    ancient = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert sgp.job_window(current, NOW, 7) == "current"
+    assert sgp.job_window(previous, NOW, 7) == "previous"
+    assert sgp.job_window(ancient, NOW, 7) is None
+
+
+def test_qualifies_as_gate_run():
+    assert sgp.qualifies_as_gate_run({"event": "merge_group"}) is True
+    assert sgp.qualifies_as_gate_run({"event": "push", "head_branch": "main"}) is True
+    assert sgp.qualifies_as_gate_run({"event": "push", "head_branch": "develop"}) is False
+    assert sgp.qualifies_as_gate_run({"event": "pull_request", "head_branch": "main"}) is False
+    assert sgp.qualifies_as_gate_run({"event": "schedule"}) is False
+
+
+def test_job_wall_minutes_happy_path():
+    job = {
+        "status": "completed",
+        "started_at": "2026-08-10T00:00:00Z",
+        "completed_at": "2026-08-10T00:29:00Z",
+    }
+    assert sgp.job_wall_minutes(job) == pytest.approx(29.0)
+
+
+def test_job_wall_minutes_not_completed_is_none():
+    job = {"status": "in_progress", "started_at": "2026-08-10T00:00:00Z", "completed_at": None}
+    assert sgp.job_wall_minutes(job) is None
+
+
+def test_job_wall_minutes_missing_timestamp_is_none():
+    job = {"status": "completed", "started_at": None, "completed_at": "2026-08-10T00:29:00Z"}
+    assert sgp.job_wall_minutes(job) is None
+
+
+def test_job_wall_minutes_negative_delta_is_none():
+    job = {
+        "status": "completed",
+        "started_at": "2026-08-10T00:29:00Z",
+        "completed_at": "2026-08-10T00:00:00Z",
+    }
+    assert sgp.job_wall_minutes(job) is None
+
+
+class TestComputeJobVerdict:
+    """Guilt + innocence on the two named guards (mutation-checked by hand during
+    development: flipping `>=`/`>` to `<`/`<=` or the threshold constants makes
+    these red — see PR description)."""
+
+    def test_innocence_both_under_threshold(self):
+        # p95=25/30=83.3% < 85% ; growth (25-24)/24=4.2% < 8%
+        v = sgp.compute_job_verdict(24.0, 25.0, 24.0, 30)
+        assert v["near_timeout"] is False
+        assert v["weekly_growth"] is False
+        assert v["severity"] is None
+
+    def test_near_timeout_only_is_p1(self):
+        # p95=27/30=90% >= 85% ; growth (20-20)/20=0% < 8%
+        v = sgp.compute_job_verdict(20.0, 27.0, 20.0, 30)
+        assert v["near_timeout"] is True
+        assert v["weekly_growth"] is False
+        assert v["severity"] == "P1"
+
+    def test_weekly_growth_only_is_p1(self):
+        # p95=20/30=66.7% < 85% ; growth (28-19)/19=47.4% > 8%
+        v = sgp.compute_job_verdict(28.0, 20.0, 19.0, 30)
+        assert v["near_timeout"] is False
+        assert v["weekly_growth"] is True
+        assert v["severity"] == "P1"
+
+    def test_both_conditions_is_p0(self):
+        v = sgp.compute_job_verdict(28.0, 29.0, 19.0, 30)
+        assert v["near_timeout"] is True
+        assert v["weekly_growth"] is True
+        assert v["severity"] == "P0"
+
+    def test_missing_timeout_never_fabricates_near_timeout(self):
+        v = sgp.compute_job_verdict(28.0, 29.0, 19.0, None)
+        assert v["near_timeout"] is False
+        assert v["p95_pct_of_timeout"] is None
+
+    def test_missing_previous_window_never_fabricates_growth(self):
+        v = sgp.compute_job_verdict(28.0, 29.0, None, 30)
+        assert v["weekly_growth"] is False
+        assert v["trend_delta_pct"] is None
+
+    def test_exact_threshold_boundary_is_not_over(self):
+        # p95 exactly at threshold pct -> >= triggers (near_timeout uses >=).
+        v = sgp.compute_job_verdict(20.0, 25.5, 20.0, 30)  # 25.5/30 = 85.0% exactly
+        assert v["near_timeout"] is True
+        # growth strictly below the threshold -> does not trigger; strictly above
+        # -> does (weekly_growth uses a plain >, tested off the exact float
+        # boundary to avoid asserting on binary-float rounding of 8.0%).
+        below = sgp.compute_job_verdict(21.5, 20.0, 20.0, 30)  # (21.5-20)/20 = 7.5%
+        above = sgp.compute_job_verdict(21.7, 20.0, 20.0, 30)  # (21.7-20)/20 = 8.5%
+        assert below["weekly_growth"] is False
+        assert above["weekly_growth"] is True
+
+
+def test_read_job_timeouts_parses_declared_timeout(tmp_path):
+    workflow = tmp_path / "tests.yml"
+    workflow.write_text(
+        "jobs:\n"
+        "  backend-tests:\n"
+        "    name: Backend Tests (Python)\n"
+        "    timeout-minutes: 30\n"
+        "  no-timeout-job:\n"
+        "    name: No Timeout\n"
+    )
+    mapping, error = sgp.read_job_timeouts(workflow)
+    assert error is None
+    assert mapping["backend-tests"] == {"name": "Backend Tests (Python)", "timeout_minutes": 30}
+    assert mapping["no-timeout-job"]["timeout_minutes"] is None
+
+
+def test_read_job_timeouts_missing_pyyaml_degrades_to_declared_error(tmp_path, monkeypatch):
+    import builtins
+
+    workflow = tmp_path / "tests.yml"
+    workflow.write_text("jobs:\n  x:\n    timeout-minutes: 5\n")
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("simulated: no module named yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    mapping, error = sgp.read_job_timeouts(workflow)
+    assert mapping == {}
+    assert error is not None and "PyYAML unavailable" in error
+
+
+def test_count_test_files(tmp_path):
+    test_dir = tmp_path / "backend" / "tests"
+    (test_dir / "sub").mkdir(parents=True)
+    (test_dir / "test_a.py").write_text("")
+    (test_dir / "sub" / "test_b.py").write_text("")
+    (test_dir / "sub" / "not_a_test.py").write_text("")
+    count, error = sgp.count_test_files(tmp_path, "backend/tests")
+    assert error is None
+    assert count == 2
+
+
+def test_count_test_files_missing_dir_is_error_not_zero(tmp_path):
+    count, error = sgp.count_test_files(tmp_path, "does/not/exist")
+    assert count is None
+    assert error is not None
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders for the subprocess boundary
+# ---------------------------------------------------------------------------
+
+
+def _proc(cmd, rc: int, out: str, err: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(cmd, rc, out, err)
+
+
+def _mk_run(run_id: int, event: str, created_at: str, head_branch: str = "main") -> dict:
+    return {"id": run_id, "event": event, "head_branch": head_branch, "created_at": created_at}
+
+
+def _mk_job(name: str, minutes: float, status: str = "completed") -> dict:
+    started_dt = datetime(2026, 8, 10, 0, 0, 0, tzinfo=timezone.utc)
+    completed_dt = started_dt + timedelta(minutes=minutes)
+    return {
+        "name": name,
+        "status": status,
+        "started_at": started_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "completed_at": completed_dt.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def _assert_explicit_get(cmd: list[str]) -> None:
+    """`gh api` silently switches its default method to POST the instant any
+    `-f`/`-F` field is present, unless `-X`/`--method` overrides it — every
+    `-f`-bearing call this module makes MUST carry an explicit `-X GET`
+    (regression coverage for the real-API 404 this script's own first dry-run
+    hit on `fetch_run_jobs()` before this flag was added — see PR description).
+    A fake that stayed silent on a missing `-X GET` would never have caught
+    that; a real subprocess call did, and this assertion is what keeps it
+    caught without needing the network again.
+    """
+    has_f = "-f" in cmd or "-F" in cmd
+    if has_f:
+        assert "-X" in cmd, f"gh api call has -f but no explicit -X GET: {cmd}"
+        idx = cmd.index("-X")
+        assert cmd[idx + 1] == "GET", f"gh api call's -X is not GET: {cmd}"
+
+
+def _make_fake_gh(repo: str, workflow: str, runs: list[dict], jobs_by_run: dict[int, list[dict]], deny_list_runs: bool = False):
+    def fake_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        assert cmd[0] == "gh", f"unexpected non-gh subprocess call: {cmd}"
+        _assert_explicit_get(cmd)
+        if cmd[1] == "api" and cmd[2] == f"repos/{repo}/actions/workflows/{workflow}/runs":
+            if deny_list_runs:
+                return _proc(cmd, 1, "", "HTTP 403: denied")
+            return _proc(cmd, 0, json.dumps({"total_count": len(runs), "workflow_runs": runs}))
+        if cmd[1] == "api" and cmd[2].endswith("/jobs"):
+            run_id = int(cmd[2].split("/")[-2])
+            return _proc(cmd, 0, json.dumps({"jobs": jobs_by_run.get(run_id, [])}))
+        raise AssertionError(f"unexpected gh invocation: {cmd}")
+
+    return fake_run
+
+
+def _write_workflow(tmp_path: Path, timeout_minutes: int = 30) -> Path:
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    wf_path = wf_dir / "tests.yml"
+    wf_path.write_text(
+        "jobs:\n"
+        "  backend-tests:\n"
+        "    name: Backend Tests (Python)\n"
+        f"    timeout-minutes: {timeout_minutes}\n"
+    )
+    # count_test_files() must find a real directory — declared-error-not-zero
+    # discipline (module docstring) means an absent test dir lands in errors[],
+    # which every build_record() scenario below asserts is empty.
+    test_dir = tmp_path / "backend" / "tests"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_placeholder.py").write_text("")
+    # send_alert() fail-visibly refuses to dispatch through a gateway that does
+    # not exist on disk (mirrors the wrapper's own "ALERT NOT SENT: tg_notify.py
+    # gateway missing" branch) — every scenario that expects a dispatch needs a
+    # real (fake-content) file at the path it passes.
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    (scripts_dir / "tg_notify.py").write_text("# fake gateway for tests\n")
+    return wf_path
+
+
+# ---------------------------------------------------------------------------
+# build_record integration scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_build_record_p0_both_conditions_dispatches_one_p0_alert(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, timeout_minutes=30)
+    repo, workflow = "acme/repo", "tests.yml"
+
+    runs = [
+        _mk_run(1, "merge_group", CURRENT_TS),
+        _mk_run(2, "merge_group", PREVIOUS_TS),
+    ]
+    jobs_by_run = {
+        1: [_mk_job("Backend Tests (Python)", 29.0)],  # current: p50=p95=29 -> 96.7% of 30min
+        2: [_mk_job("Backend Tests (Python)", 19.0)],  # previous: p50=19 -> growth (29-19)/19=52.6%
+    }
+    monkeypatch.setattr(sgp.subprocess, "run", _make_fake_gh(repo, workflow, runs, jobs_by_run))
+
+    tg_calls: list[list[str]] = []
+
+    def fake_tg_run(cmd, **kwargs):  # noqa: ANN001, ANN003
+        tg_calls.append(cmd)
+        return _proc(cmd, 0, "tg_notify: sent\n", "")
+
+    monkeypatch.setattr(sgp, "_run_tg_notify", fake_tg_run)
+
+    record = sgp.build_record(
+        repo, workflow, tmp_path, "backend/tests", NOW, 7, tmp_path / "scripts" / "tg_notify.py"
+    )
+
+    job = record["jobs"]["backend-tests"]
+    assert job["severity"] == "P0"
+    assert job["near_timeout"] is True
+    assert job["weekly_growth"] is True
+    assert len(record["alerts_sent"]) == 1
+    assert record["alerts_sent"][0]["tier"] == "p0"
+    assert record["alerts_sent"][0]["dedup_key"] == "suite-growth:backend-tests"
+    assert len(tg_calls) == 1
+    assert "--tier" in tg_calls[0] and "p0" in tg_calls[0]
+    assert record["errors"] == []
+
+
+def test_build_record_near_timeout_only_is_p1_digest(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, timeout_minutes=30)
+    repo, workflow = "acme/repo", "tests.yml"
+    runs = [
+        _mk_run(1, "merge_group", CURRENT_TS),
+        _mk_run(2, "merge_group", PREVIOUS_TS),
+    ]
+    jobs_by_run = {
+        1: [_mk_job("Backend Tests (Python)", 27.0)],  # 90% of timeout -> near_timeout
+        2: [_mk_job("Backend Tests (Python)", 27.0)],  # flat growth -> not weekly_growth
+    }
+    monkeypatch.setattr(sgp.subprocess, "run", _make_fake_gh(repo, workflow, runs, jobs_by_run))
+    tg_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        sgp, "_run_tg_notify", lambda cmd, **kw: (tg_calls.append(cmd), _proc(cmd, 0, "sent", ""))[1]
+    )
+
+    record = sgp.build_record(
+        repo, workflow, tmp_path, "backend/tests", NOW, 7, tmp_path / "scripts" / "tg_notify.py"
+    )
+
+    job = record["jobs"]["backend-tests"]
+    assert job["severity"] == "P1"
+    assert job["near_timeout"] is True
+    assert job["weekly_growth"] is False
+    assert len(record["alerts_sent"]) == 1
+    assert record["alerts_sent"][0]["tier"] == "digest"
+    assert len(tg_calls) == 1
+
+
+def test_build_record_weekly_growth_only_is_p1_digest(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, timeout_minutes=30)
+    repo, workflow = "acme/repo", "tests.yml"
+    runs = [
+        _mk_run(1, "merge_group", CURRENT_TS),
+        _mk_run(2, "merge_group", PREVIOUS_TS),
+    ]
+    jobs_by_run = {
+        1: [_mk_job("Backend Tests (Python)", 15.0)],  # 50% of timeout -> not near_timeout
+        2: [_mk_job("Backend Tests (Python)", 10.0)],  # growth (15-10)/10=50% -> weekly_growth
+    }
+    monkeypatch.setattr(sgp.subprocess, "run", _make_fake_gh(repo, workflow, runs, jobs_by_run))
+    tg_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        sgp, "_run_tg_notify", lambda cmd, **kw: (tg_calls.append(cmd), _proc(cmd, 0, "sent", ""))[1]
+    )
+
+    record = sgp.build_record(
+        repo, workflow, tmp_path, "backend/tests", NOW, 7, tmp_path / "scripts" / "tg_notify.py"
+    )
+
+    job = record["jobs"]["backend-tests"]
+    assert job["severity"] == "P1"
+    assert job["near_timeout"] is False
+    assert job["weekly_growth"] is True
+    assert len(record["alerts_sent"]) == 1
+    assert record["alerts_sent"][0]["tier"] == "digest"
+
+
+def test_build_record_innocence_no_alert(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, timeout_minutes=30)
+    repo, workflow = "acme/repo", "tests.yml"
+    runs = [
+        _mk_run(1, "merge_group", CURRENT_TS),
+        _mk_run(2, "merge_group", PREVIOUS_TS),
+    ]
+    jobs_by_run = {
+        1: [_mk_job("Backend Tests (Python)", 18.0)],  # 60% of timeout
+        2: [_mk_job("Backend Tests (Python)", 17.5)],  # growth ~2.9% < 8%
+    }
+    monkeypatch.setattr(sgp.subprocess, "run", _make_fake_gh(repo, workflow, runs, jobs_by_run))
+
+    def fail_if_called(cmd, **kw):
+        raise AssertionError("tg_notify must never be invoked when nothing crosses a threshold")
+
+    monkeypatch.setattr(sgp, "_run_tg_notify", fail_if_called)
+
+    record = sgp.build_record(
+        repo, workflow, tmp_path, "backend/tests", NOW, 7, tmp_path / "scripts" / "tg_notify.py"
+    )
+
+    job = record["jobs"]["backend-tests"]
+    assert job["severity"] is None
+    assert record["alerts_sent"] == []
+    assert record["errors"] == []
+
+
+def test_build_record_excludes_develop_push_and_pull_request(tmp_path, monkeypatch):
+    """Only push:main + merge_group count as gate load (module docstring)."""
+    _write_workflow(tmp_path, timeout_minutes=30)
+    repo, workflow = "acme/repo", "tests.yml"
+    runs = [
+        _mk_run(1, "push", CURRENT_TS, head_branch="develop"),
+        _mk_run(2, "pull_request", CURRENT_TS, head_branch="main"),
+    ]
+    jobs_by_run = {
+        1: [_mk_job("Backend Tests (Python)", 99.0)],  # would blow every threshold if counted
+        2: [_mk_job("Backend Tests (Python)", 99.0)],
+    }
+    monkeypatch.setattr(sgp.subprocess, "run", _make_fake_gh(repo, workflow, runs, jobs_by_run))
+    monkeypatch.setattr(sgp, "_run_tg_notify", lambda cmd, **kw: (_ for _ in ()).throw(AssertionError("unreachable")))
+
+    record = sgp.build_record(
+        repo, workflow, tmp_path, "backend/tests", NOW, 7, tmp_path / "scripts" / "tg_notify.py"
+    )
+    assert record["jobs"] == {}
+    assert record["alerts_sent"] == []
+
+
+def test_main_writes_record_and_exits_nonzero_on_total_api_failure(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, timeout_minutes=30)
+    repo, workflow = "acme/repo", "tests.yml"
+    monkeypatch.setattr(
+        sgp.subprocess, "run", _make_fake_gh(repo, workflow, [], {}, deny_list_runs=True)
+    )
+    out_dir = tmp_path / "out"
+
+    rc = sgp.main(
+        [
+            "--repo", repo,
+            "--workflow", workflow,
+            "--repo-root", str(tmp_path),
+            "--out-dir", str(out_dir),
+            "--test-dir", "backend/tests",
+            "--now", "2026-08-14T00:00:00Z",
+            "--no-alert",
+        ]
+    )
+
+    assert rc == 1
+    written = [p for p in out_dir.glob("*.json") if p.name != ".last-run-pointer.json"]
+    assert written, "record must be written even when every gh call failed"
+    payload = json.loads((out_dir / ".last-run-pointer.json").read_text())
+    assert payload["errors_count"] >= 1
+    record = json.loads(written[0].read_text())
+    assert any("list_workflow_runs" in e for e in record["errors"])
+
+
+def test_main_healthy_day_exits_zero(tmp_path, monkeypatch):
+    _write_workflow(tmp_path, timeout_minutes=30)
+    repo, workflow = "acme/repo", "tests.yml"
+    runs = [
+        _mk_run(1, "merge_group", CURRENT_TS),
+        _mk_run(2, "merge_group", PREVIOUS_TS),
+    ]
+    jobs_by_run = {
+        1: [_mk_job("Backend Tests (Python)", 18.0)],
+        2: [_mk_job("Backend Tests (Python)", 17.5)],
+    }
+    monkeypatch.setattr(sgp.subprocess, "run", _make_fake_gh(repo, workflow, runs, jobs_by_run))
+    out_dir = tmp_path / "out"
+
+    rc = sgp.main(
+        [
+            "--repo", repo,
+            "--workflow", workflow,
+            "--repo-root", str(tmp_path),
+            "--out-dir", str(out_dir),
+            "--test-dir", "backend/tests",
+            "--now", "2026-08-14T00:00:00Z",
+            "--no-alert",
+        ]
+    )
+    assert rc == 0
+    written = [p for p in out_dir.glob("*.json") if p.name != ".last-run-pointer.json"]
+    assert len(written) == 1


### PR DESCRIPTION
## Summary
- Merge-OS v3 build order step 3 slice 1 (`research/operations/2026-08-14-merge-os-v3-research-council.md` §6 step 3, branch `agent/air-m5/ops/mergeos-v3-research`): the backend test suite's median wall time has grown ~18→29 min over five weeks (~+10%/week) against `backend-tests.timeout-minutes: 30` in `tests.yml`. Nothing in this repo measured or alarmed on that derivative before this PR. When the median crosses the ceiling, `Backend Tests (Python)` — a required check on `main`/`merge_group` — reports `cancelled`, not `failure`, and the merge queue jams with nothing red to fix.
- Adds `scripts/suite_growth_probe.py` (modeled on `scripts/queue_baseline_probe.py`'s fail-visible pattern): nightly, per-job wall-time p50/p95 over rolling 7-day windows for `tests.yml`'s `push:main` + `merge_group` runs, week-over-week trend, distance from each job's declared `timeout-minutes`, and a Telegram alarm via `scripts/tg_notify.py` — P1 at `p95 >= 85% of timeout` OR `p50 growth > +8%/week`, P0 when both fire on the same job.
- **This PR changes NOTHING about how `tests.yml` jobs are gated, retried, timed out, or selected.** Pure measurement + alarm.
- Wrapper (`infra/launchagents/wrappers/suite-growth-probe.sh`) + LaunchAgent template (`infra/launchagents/com.nuzantara.suite-growth-probe.plist.template`, 03:57 WITA, `KeepAlive=false`) are **NOT installed by this PR** — arming on Pro (`launchctl bootstrap` + verify first receipt) is a separate ALIGN-FLEET step (scar family #2 "esiste != armato" / built != armed), owned by the team-lead per the mandate.

## Real dry-run (live API, not a fixture)
Ran `scripts/suite_growth_probe.py --repo Bali-Zero/Teman2 --window-days 1 --no-alert` against the real repo before shipping. It caught a real bug: `fetch_run_jobs()` was missing `-X GET` — `gh api` silently switches its default method to POST once any `-f` flag is present, so every job fetch 404'd. Fixed, plus a regression test (`_assert_explicit_get`) that fails if the flag is dropped again (verified by reintroducing the bug manually → red → fix → green).

With the fix, the same dry-run measured, live, today:
```
backend-tests (Backend Tests (Python)):
  current window (7d... run used --window-days 1 for speed):  p50=27.13min  p95=28.59min  n=37
  previous window:                                            p50=26.73min             n=66
  timeout_minutes: 30  ->  p95_pct_of_timeout: 95.3%  ->  near_timeout: TRUE
  trend_delta_pct: +1.5%  ->  weekly_growth: FALSE (threshold +8%)
  severity: P1  (near_timeout alone)
run_collection: fetched=231/231 (complete, no pagination shortfall)
test_file_count: 1359 (apps/backend-rag/backend/tests)
errors: []
```
This independently confirms the incident this organ exists to catch — `backend-tests` is sitting at 95% of its own timeout budget *today*, on a single-day sample (the real nightly cron uses `--window-days 7`, which is what actually matters for the trend calculation — this smoke test used a 1-day window only to keep the interactive dry-run fast against the live API's per-run job-fetch cost).

## Test plan
- [x] `python3 -m pytest scripts/tests/test_suite_growth_probe.py -q` → **27 passed**
- [x] Mutation-check (manual, per mandate): flipped each of the two alarm guard operators (`near_timeout` `>=`→`<`, `weekly_growth` `>`→`<`) one at a time → 9 tests reliably went red each time → reverted, diff confirmed byte-identical to original, suite green again (27/27).
- [x] Real dry-run against the live GitHub API (`--no-alert`, see above) — found and fixed a real `-X GET` bug, now regression-tested.
- [x] `plutil -lint` on the plist template → OK. `bash -n` on the wrapper → OK. `shellcheck` → only an SC1091 info-level "not following sourced file" (expected, same as the reference `queue-baseline.sh`).
- [x] Independent adversarial review (spalla-review agent) on the full diff — no blockers found; confirmed both `gh api` call sites carry `-X GET`, window-boundary math is exactly complementary at the edges, threshold semantics (`>=` vs `>`) match the docstring and are pinned by an explicit boundary test, and the wrapper's `PROBE_RC` capture is genuinely errexit-immune. A few non-blocking follow-up notes it raised (job-key normalizer only strips one trailing parenthetical; pointer-file reads in the wrapper aren't `set +e`-guarded, inherited byte-for-byte from `queue-baseline.sh` — not a regression this PR introduces) are left for a future slice, out of this PR's narrow scope.

## Not in scope (per mandate)
- `tests.yml`, `security.yml`, `scripts/queue_baseline_probe.py` — untouched.
- Arming the LaunchAgent on Pro — separate ALIGN-FLEET step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)