### PR TITLE
fix(codex-spalla): grep -c empty-input pipefail bug (W104-class)

### DIFF
--- a/.claude/scripts/codex-spalla.sh
+++ b/.claude/scripts/codex-spalla.sh
@@ -94,7 +94,20 @@ FILES_CHANGED="$(git "${DIFF_ARGS[@]}" --stat 2>/dev/null | tail -1 | grep -oE '
 # Codex spalla BLOCKER #2 + #3: include uncommitted + untracked in the
 # "what's about to ship" tally; otherwise fresh `Write` files look empty.
 UNCOMMITTED_LINES="$(git diff HEAD 2>/dev/null | wc -l | tr -d ' ')"
-UNCOMMITTED_FILES="$(git diff HEAD --name-only 2>/dev/null | grep -c . 2>/dev/null || echo 0)"
+# W104-class bug fixed 2026-08-14 (found by spalla-review on an unrelated PR):
+# `grep -c .` ALWAYS prints a count to stdout (0 on no match) but STILL exits
+# 1 when that count is 0 — under this script's own `set -o pipefail` (line
+# 24), a zero-match pipeline is "failed", so the old `|| echo 0` fallback ran
+# TOO, appending a second "0" after the one grep had already printed. The
+# captured value on an empty diff was the two-line string "0\n0", which then
+# broke `$((...))` arithmetic at TOTAL_FILES below with a hard `syntax error
+# in expression` (reproduced verbatim: `printf '' | grep -c . 2>/dev/null ||
+# echo 0` -> "0\n0"). Fix: `|| true` instead of `|| echo 0` — grep's own
+# printed count is authoritative and the exit code carries no information
+# worth reacting to (same lesson as W104: judge the output, not the exit
+# code), so the fallback only needs to stop `set -e`/pipefail from treating
+# "zero matches" as an error, never to supply its own value.
+UNCOMMITTED_FILES="$(git diff HEAD --name-only 2>/dev/null | grep -c . 2>/dev/null || true)"
 UNTRACKED_FILES="$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')"
 TOTAL_DIFF_LINES=$((DIFF_LINES + UNCOMMITTED_LINES))
 
@@ -180,7 +193,9 @@ UNCOMMITTED_BODY="$(git diff HEAD 2>/dev/null | head -1000 || true)"
 # Cap: max 25 files × 200 lines/file ≈ 5000 lines budget, plus skip binary.
 UNTRACKED_FILES_FOR_DUMP="$(git ls-files --others --exclude-standard 2>/dev/null | head -25 || true)"
 UNTRACKED_LIST="$(git ls-files --others --exclude-standard 2>/dev/null | head -50 || true)"
-UNTRACKED_TOTAL_FOR_DUMP="$(printf '%s\n' "$UNTRACKED_FILES_FOR_DUMP" | grep -c . 2>/dev/null || echo 0)"
+# Same class of bug as UNCOMMITTED_FILES above (`|| echo 0` doubling grep -c's
+# own already-printed "0" under pipefail) — same fix, `|| true`.
+UNTRACKED_TOTAL_FOR_DUMP="$(printf '%s\n' "$UNTRACKED_FILES_FOR_DUMP" | grep -c . 2>/dev/null || true)"
 UNTRACKED_BODIES=""
 if [[ -n "$UNTRACKED_FILES_FOR_DUMP" ]]; then
     while IFS= read -r ufile; do

--- a/scripts/tests/test_codex_spalla_grep_c.sh
+++ b/scripts/tests/test_codex_spalla_grep_c.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# test_codex_spalla_grep_c.sh — pins the W104-class `grep -c .` fix in
+# .claude/scripts/codex-spalla.sh (2026-08-14, class-audit per W89): `grep -c .`
+# ALWAYS prints a valid count to stdout, including "0" on zero matches, but
+# STILL exits 1 on zero matches — under this script's own `set -o pipefail`
+# (codex-spalla.sh line 24), a zero-match pipeline counts as "failed", so the
+# old `|| echo 0` fallback fired TOO, appending a second "0" after the one
+# grep had already printed. On an empty diff the captured value was the
+# two-line string "0\n0", which then broke `$((...))` arithmetic downstream
+# (TOTAL_FILES=$((FILES_CHANGED + UNCOMMITTED_FILES + UNTRACKED_FILES))) with
+# a hard `syntax error in expression`. Found by an independent spalla-review
+# agent while reviewing an unrelated PR (attempting to invoke this script's
+# sibling codex-second-opinion tooling); fixed by swapping the fallback from
+# `|| echo 0` to `|| true` at BOTH call sites in the file (UNCOMMITTED_FILES
+# and UNTRACKED_TOTAL_FOR_DUMP — the second was dead code with no downstream
+# reader at fix time, but carried the identical defect shape).
+#
+# Section 1 (GUILT) proves the defect class is real and reproducible,
+# standalone, never against the real file (which is already fixed).
+# Section 2 (INNOCENCE) extracts and EXECUTES the actual assignment lines
+# from the real file — not a hand-copied lookalike that could drift from
+# what it's supposed to protect — against controlled empty/non-empty inputs,
+# so a future regression that reintroduces `|| echo 0` fails this test
+# directly.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+TARGET="$REPO_ROOT/.claude/scripts/codex-spalla.sh"
+[ -f "$TARGET" ] || { echo "FAIL: target not found at $TARGET"; exit 2; }
+
+FAILED=0
+ok()  { echo "  ok   — $1"; }
+bad() { echo "  FAIL — $1"; FAILED=1; }
+
+# ── 1. GUILT: the historical broken pattern really does double-print and
+#    really does break arithmetic on empty input — the bug class is not
+#    hypothetical. ────────────────────────────────────────────────────────
+broken_out="$(bash -euo pipefail -c 'printf "" | grep -c . 2>/dev/null || echo 0')"
+if [ "$broken_out" = "$(printf '0\n0')" ]; then
+    ok "historical '|| echo 0' pattern reproducibly double-prints '0\\n0' on empty input"
+else
+    bad "could not reproduce the historical double-print (got: $(printf '%q' "$broken_out")) — guilt fixture may be stale"
+fi
+
+broken_arith_rc=0
+bash -euo pipefail -c 'X="$(printf "" | grep -c . 2>/dev/null || echo 0)"; TOTAL=$((X + 0))' >/dev/null 2>&1 || broken_arith_rc=$?
+if [ "$broken_arith_rc" -ne 0 ]; then
+    ok "historical pattern reproducibly breaks \$(( )) arithmetic on empty input (rc=$broken_arith_rc)"
+else
+    bad "historical pattern unexpectedly did NOT break arithmetic (rc=0) — guilt fixture may be stale"
+fi
+
+# ── 2. INNOCENCE: extract the two REAL fixed lines from the file and run
+#    them against controlled empty/non-empty inputs — must be a clean single
+#    value each time. ───────────────────────────────────────────────────────
+extract_line() { grep -m1 "$1" "$TARGET"; }
+
+uncommitted_line="$(extract_line '^UNCOMMITTED_FILES=')"
+[ -n "$uncommitted_line" ] || { echo "FAIL: UNCOMMITTED_FILES assignment not found in $TARGET"; exit 2; }
+if printf '%s\n' "$uncommitted_line" | grep -qE '\|\|[[:space:]]*echo[[:space:]]+0'; then
+    bad "UNCOMMITTED_FILES line still contains the buggy '|| echo 0' fallback: $uncommitted_line"
+else
+    ok "UNCOMMITTED_FILES line no longer contains '|| echo 0'"
+fi
+
+untracked_line="$(extract_line '^UNTRACKED_TOTAL_FOR_DUMP=')"
+[ -n "$untracked_line" ] || { echo "FAIL: UNTRACKED_TOTAL_FOR_DUMP assignment not found in $TARGET"; exit 2; }
+if printf '%s\n' "$untracked_line" | grep -qE '\|\|[[:space:]]*echo[[:space:]]+0'; then
+    bad "UNTRACKED_TOTAL_FOR_DUMP line still contains the buggy '|| echo 0' fallback: $untracked_line"
+else
+    ok "UNTRACKED_TOTAL_FOR_DUMP line no longer contains '|| echo 0'"
+fi
+
+# Execute the ACTUAL extracted lines (not a hand-copy) against a real
+# throwaway git repo, so the assertion is against the file's own logic.
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/codexspalla-grepc.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+git -C "$SANDBOX" init -q
+git -C "$SANDBOX" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+run_uncommitted() {
+    ( cd "$SANDBOX" && eval "$uncommitted_line" && printf '%s' "$UNCOMMITTED_FILES" )
+}
+
+out_empty="$(run_uncommitted)"
+lines_empty="$(printf '%s' "$out_empty" | wc -l | tr -d ' ')"
+if [ "$out_empty" = "0" ] && [ "$lines_empty" -eq 0 ]; then
+    ok "UNCOMMITTED_FILES on a clean repo -> single clean '0'"
+else
+    bad "UNCOMMITTED_FILES on a clean repo -> expected single '0', got $(printf '%q' "$out_empty") ($lines_empty extra newline(s))"
+fi
+
+echo one >> "$SANDBOX/a.txt"; git -C "$SANDBOX" add a.txt >/dev/null; git -C "$SANDBOX" commit -q -m a
+echo two >> "$SANDBOX/b.txt"; git -C "$SANDBOX" add b.txt >/dev/null; git -C "$SANDBOX" commit -q -m b
+echo changed >> "$SANDBOX/a.txt"
+echo changed >> "$SANDBOX/b.txt"
+out_two="$(run_uncommitted)"
+if [ "$out_two" = "2" ]; then
+    ok "UNCOMMITTED_FILES with 2 modified files -> '2'"
+else
+    bad "UNCOMMITTED_FILES with 2 modified files -> expected '2', got $(printf '%q' "$out_two")"
+fi
+
+# UNTRACKED_TOTAL_FOR_DUMP reads from a shell variable, not a git command —
+# exercise it directly with an empty and a populated value, matching how the
+# real script populates UNTRACKED_FILES_FOR_DUMP just above it.
+run_untracked_total() {
+    ( UNTRACKED_FILES_FOR_DUMP="$1"; eval "$untracked_line"; printf '%s' "$UNTRACKED_TOTAL_FOR_DUMP" )
+}
+
+out_ut_empty="$(run_untracked_total "")"
+lines_ut_empty="$(printf '%s' "$out_ut_empty" | wc -l | tr -d ' ')"
+if [ "$out_ut_empty" = "0" ] && [ "$lines_ut_empty" -eq 0 ]; then
+    ok "UNTRACKED_TOTAL_FOR_DUMP on empty var -> single clean '0'"
+else
+    bad "UNTRACKED_TOTAL_FOR_DUMP on empty var -> expected single '0', got $(printf '%q' "$out_ut_empty") ($lines_ut_empty extra newline(s))"
+fi
+
+out_ut_three="$(run_untracked_total "$(printf 'x.txt\ny.txt\nz.txt')")"
+if [ "$out_ut_three" = "3" ]; then
+    ok "UNTRACKED_TOTAL_FOR_DUMP with 3 paths -> '3'"
+else
+    bad "UNTRACKED_TOTAL_FOR_DUMP with 3 paths -> expected '3', got $(printf '%q' "$out_ut_three")"
+fi
+
+echo
+[ "$FAILED" -eq 0 ] && { echo "PASS — codex-spalla.sh grep -c fix"; exit 0; } || { echo "FAIL — codex-spalla.sh grep -c fix"; exit 1; }


### PR DESCRIPTION
## Summary
- `.claude/scripts/codex-spalla.sh` used `grep -c . 2>/dev/null || echo 0` at two call sites (`UNCOMMITTED_FILES` line, `UNTRACKED_TOTAL_FOR_DUMP` line). `grep -c` always prints a valid count (including "0" on zero matches) but still exits 1 on zero matches — under this script's own `set -o pipefail`, that "failure" also triggered the `|| echo 0` fallback, which appended a SECOND "0" after the one grep had already printed. On an empty diff the captured value was the two-line string `"0\n0"`, which then broke `$((...))` arithmetic at `TOTAL_FILES` with a hard `syntax error in expression`.
- Found by an independent spalla-review agent as a side note while reviewing an unrelated PR (#4186); this PR is the standalone fix, per the team-lead's micro-mandate.
- Fix: `|| true` instead of `|| echo 0` at both instances (class-audit, W89 — same defect shape, same fix, both occurrences in this one file; confirmed via grep that no third instance exists). grep's own printed count is authoritative; the fallback only needs to stop `set -e`/pipefail from treating "zero matches" as an error — never to supply its own value (W104: judge the output, not the exit code).
- One file, one concern — only `.claude/scripts/codex-spalla.sh` and its new test are touched.

## Reproduction (verbatim)
```
$ bash -euo pipefail -c 'printf "" | grep -c . 2>/dev/null || echo 0'
0
0
$ bash -euo pipefail -c 'X="$(printf "" | grep -c . 2>/dev/null || echo 0)"; TOTAL=$((X + 0))'
bash: line 1: 0
0: syntax error in expression (error token is "0")
```

## Test plan
- [x] Adds `scripts/tests/test_codex_spalla_grep_c.sh` (bash, guilt+innocence, no existing test file for this script to extend):
  - GUILT: reproduces the historical double-print and the arithmetic break standalone (proves the defect class is real, not hypothetical).
  - INNOCENCE: extracts and EXECUTES the actual fixed assignment lines from the real file (not a hand-copy that could drift) against a throwaway git repo — empty-diff and 2-modified-files cases for `UNCOMMITTED_FILES`, empty-var and 3-path cases for `UNTRACKED_TOTAL_FOR_DUMP`.
- [x] `bash scripts/tests/test_codex_spalla_grep_c.sh` → **8/8 checks pass, exit 0**.
- [x] `bash -n .claude/scripts/codex-spalla.sh` → clean, no syntax errors.
- [x] Independent verification (separate subagent, fresh context): confirmed exactly 2 `grep -c` occurrences in the file (both fixed), confirmed no other `grep -c ... || echo <literal>` instance remains, ran the healthy suite (8/8 pass), then manually reverted just the `UNCOMMITTED_FILES` line back to `|| echo 0` and re-ran — **2/8 checks correctly flip to FAIL, exit 1** (proves the test catches the regression, not a rubber stamp) — then restored and confirmed `git diff` matched the intended fix exactly, re-ran → pass again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)