### PR TITLE
chore(ci): raise backend-tests timeout 30->40 (p95=28.59min at 95.3% of cap)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -355,7 +355,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     services:
       postgres:


### PR DESCRIPTION
## Summary
- Measured p95 wall-clock for the `backend-tests` job (Backend Tests, Python) = 28.59 min = 95.3% of its `timeout-minutes: 30` cap.
- After #4181 (change-map promoted shadow→enforcing), a run landing in the canary window that hits a spurious `cancelled` timeout would be misread as a selection failure rather than a timeout margin problem.
- Raises `timeout-minutes: 30` → `40` on the `backend-tests` job only (`.github/workflows/tests.yml`). No other job/line touched.

This PR doubles as a change-map guilt-test datapoint: a workflow-file change must classify run_all (no job skips).

## Test plan
- [x] `actionlint .github/workflows/tests.yml` — exit 0
- [x] Diff limited to exactly one line (`timeout-minutes: 30` → `40` on the `backend-tests` job)
- [ ] Observe `gh pr checks` on this PR: confirm `changes` (change-map) classifies this workflow-file diff as run_all with no job skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)