### PR TITLE
fix(visa-oracle): label organic shadow traffic explicitly

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.test.ts
@@ -30,7 +30,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 }
 
 describe("Visa Oracle evaluation HTTP client", () => {
-  it("uses the generated endpoint contract without semantic query data", async () => {
+  it("labels organic browser evaluations explicitly and sends no other query data", async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () =>
       jsonResponse(makeVisaOracleResponse()),
     );
@@ -44,7 +44,12 @@ describe("Visa Oracle evaluation HTTP client", () => {
     expect(result.mode).toBe("ENGINE");
     expect(fetchImpl).toHaveBeenCalledOnce();
     const [url, init] = fetchImpl.mock.calls[0];
-    expect(url).toBe("/api/visa-oracle/evaluate");
+    expect(url).toBe("/api/visa-oracle/evaluate?traffic_source=real");
+    const parsedUrl = new URL(String(url), "http://localhost");
+    expect(parsedUrl.pathname).toBe("/api/visa-oracle/evaluate");
+    expect([...parsedUrl.searchParams.entries()]).toEqual([
+      ["traffic_source", "real"],
+    ]);
     expect(init).toMatchObject({
       method: "POST",
       body: JSON.stringify(REQUEST),

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/evaluation-client.ts
@@ -12,7 +12,8 @@ import type {
   VisaOracleEvaluateResponse,
 } from "./visa-oracle-contract";
 
-export const VISA_ORACLE_EVALUATE_URL = "/api/visa-oracle/evaluate";
+export const VISA_ORACLE_EVALUATE_URL =
+  "/api/visa-oracle/evaluate?traffic_source=real";
 export const VISA_ORACLE_MAX_REQUEST_BYTES = 32 * 1_024;
 export const VISA_ORACLE_DEFAULT_TIMEOUT_MS = 12_000;
 

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-client.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-client.test.ts
@@ -34,7 +34,7 @@ describe("sendShadowEvaluation — the ONE network call site for SHADOW mode", (
     expect(result).toBeUndefined();
   });
 
-  it("POSTs to the exact anonymous evaluate endpoint, no query params, keepalive + JSON headers", () => {
+  it("POSTs to the anonymous evaluate endpoint with an explicit organic label, keepalive + JSON headers", () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(new Response("{}", { status: 200 }));
@@ -48,11 +48,11 @@ describe("sendShadowEvaluation — the ONE network call site for SHADOW mode", (
       RequestInit & { keepalive?: boolean },
     ];
     expect(url).toBe(SHADOW_EVALUATE_URL);
-    expect(url.endsWith("/api/visa-oracle/evaluate")).toBe(true);
-    // No traffic_source / request_category query params (grounded contract:
-    // the server default traffic_source="real" is exactly what organic
-    // browser SHADOW traffic should be labelled as).
-    expect(url).not.toContain("?");
+    const parsedUrl = new URL(url);
+    expect(parsedUrl.pathname).toBe("/api/visa-oracle/evaluate");
+    expect([...parsedUrl.searchParams.entries()]).toEqual([
+      ["traffic_source", "real"],
+    ]);
     expect(init.method).toBe("POST");
     expect(init.keepalive).toBe(true);
     expect(init.headers).toMatchObject({ "Content-Type": "application/json" });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-client.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-client.ts
@@ -22,11 +22,11 @@
  * fully anonymous, exact-match public endpoint (no token, no auth
  * header), rate-limited 30 req/60s per IP, and returns HTTP 200 for every
  * well-formed body (including its own fail-closed
- * TEMPORARILY_UNAVAILABLE shape). No query params are sent from here:
- * `traffic_source` defaults server-side to `"real"` — exactly the right
- * label for organic browser SHADOW traffic — and the `synthetic_*`
- * classes are gated behind an `X-Visa-Driver-Token` header this UI has no
- * business sending.
+ * TEMPORARILY_UNAVAILABLE shape). Organic browser SHADOW traffic is
+ * labelled explicitly with `traffic_source=real`; this client does not
+ * rely on a server default that could silently misclassify an unlabeled
+ * caller. The `synthetic_*` classes are gated behind an
+ * `X-Visa-Driver-Token` header this UI has no business sending.
  *
  * `API_BASE` mirrors `lib/visa-oracle/api.ts`'s existing pattern verbatim
  * — same env var, same fallback host, so this module resolves to the
@@ -38,7 +38,7 @@ import { mapOracleFactsToApplicantFacts } from "./fact-mapper";
 const API_BASE =
   process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://nuzantara-rag.fly.dev";
 
-export const SHADOW_EVALUATE_URL = `${API_BASE}/api/visa-oracle/evaluate`;
+export const SHADOW_EVALUATE_URL = `${API_BASE}/api/visa-oracle/evaluate?traffic_source=real`;
 
 /**
  * Fire the SHADOW evaluate POST for one completed interview. `today` MUST


### PR DESCRIPTION
## What changed
- add `traffic_source=real` explicitly to the live Visa Oracle evaluation client used by `OracleShell`
- apply the same explicit label to the dormant fire-and-forget SHADOW client so it cannot reintroduce unlabeled traffic if reused
- pin both URL contracts to the exact path and single allowed query parameter

## Why
The evaluate endpoint currently defaults an omitted `traffic_source` to `real`. That makes unlabeled callers indistinguishable from organic browser traffic and can contaminate G-a evidence. This is phase A of the safe migration: publish the explicit frontend label before making the backend fail closed on an omitted label.

## Impact
The live request remains same-origin, anonymous, and body-compatible. Only its evidence provenance becomes explicit. The proxy already forwards the query string while suppressing Visa semantic query values from logs.

## Validation
- focused Vitest: 2 files, 16 tests passed
- `npm run typecheck`
- ESLint on both changed source files with `--max-warnings=0`
- repository pre-commit and pre-push gates

The repository-wide ESLint run reports 175 pre-existing warnings outside this change; the changed source files report zero warnings.
