### PR TITLE
feat(merge-os): quarantine-as-allowlist + positive critical floor (F6)

### DIFF
--- a/infra/merge-os/critical-floor.d/SCHEMA.md
+++ b/infra/merge-os/critical-floor.d/SCHEMA.md
@@ -1,0 +1,42 @@
+# critical-floor.d/ — the POSITIVE never-quarantine manifest (Merge-OS v3, step 6 slice 1)
+
+Spec: same disposition as `infra/merge-os/quarantine.d/SCHEMA.md` (Codex F6,
+`research/operations/2026-08-14-merge-os-v3-research-council.md` §5/§6 step
+6). The critical floor is **never the complement of an unused marker** — it
+is its own positive, populated, verified manifest. A test category earns a
+place here by being enumerated and pattern-matched against the REAL tree in
+this PR, not by inheriting from whatever the `critical` pytest marker would
+have covered (it covers nothing — that is the defect this replaces).
+
+## One YAML file per category
+
+`infra/merge-os/critical-floor.d/<slug>.yaml`, one category per file, same
+W109b rationale as the quarantine directory: independent categories should
+be independently addable/editable without two unrelated PRs colliding on
+one shared file.
+
+## Fields
+
+| field                  | type            | meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ---------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`                   | string          | Slug matching the filename (without `.yaml`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `category`             | string          | Human-readable name.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `description`          | string          | What this category protects and why it can never be quarantined.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `patterns`             | list of strings | Each entry is either (a) a `pathlib.Path.glob()`-syntax pattern relative to the repo root (supports `**` for recursive matching), or (b) a literal file path relative to the repo root (no wildcard characters). `scripts/ci/quarantine_lint.py` verifies every pattern/path matches **at least one real file on disk** — a pattern matching zero files is an ORPHAN and FAILs the lint (anti-decorative: a floor category that protects nothing is exactly the same defect as the unused `critical` marker it replaces, just wearing a YAML file instead of a pytest marker). |
+| `rationale`            | string          | Why this category is load-bearing enough to never quarantine — usually a one-line pointer to the invariant it guards (CLAUDE.md golden rule, data invariant, etc).                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `verified_match_count` | integer         | The number of real files this category's patterns matched **at the time this file was written**, recorded so a future reader can tell "did this shrink to zero without anyone noticing" from the file's own history (`git blame`/`git log` on the count), independent of re-running the linter. This is a snapshot, not re-validated automatically to stay in sync — the linter re-derives the live count on every run and is the actual source of truth; this field is a breadcrumb, not a cache someone should trust over the linter's own verdict.                          |
+
+## Cross-check against quarantine.d/
+
+`scripts/ci/quarantine_lint.py` rejects any quarantine entry (see
+`infra/merge-os/quarantine.d/SCHEMA.md`) whose `node_id` file-path matches
+any pattern here. The floor always wins.
+
+## Not wired into CI yet
+
+Same declared scope as the quarantine directory: this PR ships the
+manifests + the validator + its test corpus. Nothing in `tests.yml` reads
+either directory yet — that wiring is a follow-up PR, after the sibling
+push:main-removal PR (#4181) lands and one full cycle is observed (Merge-OS
+v3 build order step 2's own ordering discipline, applied here too: don't
+stack a new dependency on a hot file mid-flight).

--- a/infra/merge-os/critical-floor.d/auth-authorization.yaml
+++ b/infra/merge-os/critical-floor.d/auth-authorization.yaml
@@ -1,0 +1,15 @@
+id: auth-authorization
+category: Auth / authorization
+description: >
+  Authentication (session, API key, OAuth) and authorization (RBAC,
+  route-level authz) tests. A regression here is a live security incident,
+  not a flaky-test triage item — CLAUDE.md §13's CRM RBAC rule and the
+  route-authz coverage gate both depend on these staying green on every run.
+patterns:
+  - apps/backend-rag/**/test_*auth*.py
+rationale: >
+  CLAUDE.md §13 "CRM RBAC: Admin ... = all access. Team = only assigned_to
+  matches" + apps/backend-rag/backend/tests/security/test_route_authz_coverage.py
+  (route-level authz coverage census). Never quarantinable: a passing suite
+  is the only evidence this boundary holds.
+verified_match_count: 24

--- a/infra/merge-os/critical-floor.d/deploy-health.yaml
+++ b/infra/merge-os/critical-floor.d/deploy-health.yaml
@@ -1,0 +1,18 @@
+id: deploy-health
+category: Deploy health
+description: >
+  Health-endpoint/monitor tests (service health, channel health, drive
+  watchdog health, collection/KG health) plus the backend stability gate
+  test — the pytest counterpart of scripts/backend_stability_gate.py, which
+  CLAUDE.md §11 runs as a required step of the "Run backend stability gate"
+  CI job before deploy. A quarantined health test is a blind spot in
+  exactly the signal CLAUDE.md §11's mandatory post-deploy QA depends on.
+patterns:
+  - apps/backend-rag/**/test_*health*.py
+  - apps/backend-rag/backend/tests/db/test_backend_stability_gate.py
+rationale: >
+  CLAUDE.md §11 Deploy Lifecycle "Post-deploy QA OBBLIGATORIO: wait curl
+  200/307 -> screenshot ... verify colors/logo/no broken -> fix/redeploy"
+  and the tests.yml "Run backend stability gate" step this floor's second
+  pattern targets directly.
+verified_match_count: 18

--- a/infra/merge-os/critical-floor.d/embedding-model-dims.yaml
+++ b/infra/merge-os/critical-floor.d/embedding-model-dims.yaml
@@ -1,0 +1,21 @@
+id: embedding-model-dims
+category: Embedding model / dimensions
+description: >
+  Tests asserting the frozen embedding model identity and vector dimension.
+  Deliberately narrow: a broad grep for the literal "1536" or
+  "text-embedding-3-small" across the suite returns ~70 files, but that
+  string also matches unrelated numeric literals (token limits, ports,
+  etc.) in most of them — including only the files whose actual SUBJECT is
+  the embedding model/dimension itself keeps this floor a precise
+  allowlist rather than noise (see PR description for the full grep output
+  and the declared exclusion). Widening this category to the full grep
+  result is left to a future slice, deliberately, rather than gold-plated
+  into this one.
+patterns:
+  - apps/backend-rag/**/test_embedding*.py
+rationale: >
+  CLAUDE.md §9 Data Invariant "Embedding model FROZEN: text-embedding-3-small
+  (1536 dims). Changing invalidates 93,283 vectors. NEVER change without a
+  re-indexing plan." — the single most expensive-to-violate invariant in
+  this repo's data layer.
+verified_match_count: 3

--- a/infra/merge-os/critical-floor.d/gate-verifiers.yaml
+++ b/infra/merge-os/critical-floor.d/gate-verifiers.yaml
@@ -1,0 +1,29 @@
+id: gate-verifiers
+category: Verifiers of other gates
+description: >
+  Tests that verify OTHER gates/guards are themselves correct — the
+  data-invariant tripwires, and every corpus file registered as a
+  guilt+innocence proof in infra/guard-conformance/registry.json. These are
+  meta-level: quarantining one doesn't just lose coverage of a feature, it
+  silently disarms this repo's own guilt+innocence discipline
+  (cicatrix-superscar.md family #3's own antidote) for whatever guard that
+  corpus protects. Listed as explicit paths rather than a glob pattern —
+  this is a small, curated, cross-cutting set rather than a directory/name
+  convention.
+patterns:
+  - apps/backend-rag/backend/tests/test_data_invariant_tripwires.py
+  - apps/backend-rag/backend/tests/unit/scripts/test_openclaw_whatsapp_bridge_script.py
+  - scripts/tests/test_tg_gateway.py
+  - scripts/tests/test_evidence_pack_lint.py
+  - scripts/tests/test_wr2_editorial_pregate.py
+  - apps/wa-mirror/scripts/test_api_server_path_confinement.py
+  - scripts/tests/test_check_required_workflow_conformance.py
+  - apps/backend-rag/backend/tests/unit/services/rag/agentic/test_casual_gate_overmatch.py
+rationale: >
+  CLAUDE.md §9 "Evidence scoring thresholds ... tripwire tests" +
+  infra/guard-conformance/registry.json's own mandate ("nessuna guardia
+  mergiata senza un test di innocenza E di colpevolezza",
+  cicatrix-superscar.md #3) + infra/guard-conformance/check_guard_conformance.py's
+  CI enforcement of exactly this corpus. A gate whose own verifier can be
+  quarantined is a gate that can silently regress.
+verified_match_count: 8

--- a/infra/merge-os/critical-floor.d/migration-schema-integrity.yaml
+++ b/infra/merge-os/critical-floor.d/migration-schema-integrity.yaml
@@ -1,0 +1,19 @@
+id: migration-schema-integrity
+category: Migration / schema integrity
+description: >
+  Tests exercising individual Alembic-style migration files (apply/rollback,
+  advisory-lock behavior, runtime-grants, DDL validity) plus the migration
+  runner/contract/uniqueness tests. A broken migration test means the schema
+  this codebase depends on cannot be proven to apply or roll back cleanly —
+  CLAUDE.md §11 requires migration PRs to pass Squawk lint AND these tests;
+  quarantining one is quarantining the proof that a specific schema change
+  is safe.
+patterns:
+  - apps/backend-rag/**/test_migration_*.py
+  - apps/backend-rag/**/test_*migrations.py
+rationale: >
+  CLAUDE.md §11 "Migration PRs touching migrations_v2/*.sql auto-run Squawk
+  lint" — the pytest side of that same safety net. Migration correctness is
+  the textbook example of a defect class that costs orders of magnitude more
+  to catch in production than in CI.
+verified_match_count: 44

--- a/infra/merge-os/critical-floor.d/pricing-billing.yaml
+++ b/infra/merge-os/critical-floor.d/pricing-billing.yaml
@@ -1,0 +1,17 @@
+id: pricing-billing
+category: Pricing / billing
+description: >
+  Every test touching PricingTool, dynamic pricing, billing endpoints, or
+  the hardcoded-pricing-detector. CLAUDE.md Golden Rule #11 is absolute
+  ("All prices from PricingTool. Never hardcode.") and this is a
+  client-facing agency — a pricing regression is a direct financial-harm
+  surface, not an internal-quality one.
+patterns:
+  - apps/backend-rag/**/test_*pricing*.py
+  - apps/backend-rag/**/test_*billing*.py
+rationale: >
+  CLAUDE.md §8 Golden Rule #11 "PricingTool Only — All prices from
+  PricingTool. Never hardcode." + §13 "Client-facing: single price
+  all-inclusive from PricingTool". A quarantined pricing test is an
+  unverified price shown to a real client.
+verified_match_count: 20

--- a/infra/merge-os/critical-floor.d/rag-abstention-confidence.yaml
+++ b/infra/merge-os/critical-floor.d/rag-abstention-confidence.yaml
@@ -1,0 +1,21 @@
+id: rag-abstention-confidence
+category: RAG abstention / confidence
+description: >
+  The evidence-scoring abstain-policy suite (generation gate, per-domain
+  label gate, confidence-zone edges, WhatsApp abstain-reaches-a-human/
+  content-is-sent behavior) plus the confidence-computation suite that feeds
+  those thresholds. This is the mechanism that decides whether the RAG
+  system answers a legal/tax/visa question at all or defers to a human —
+  the single highest-consequence decision point in the whole pipeline.
+patterns:
+  - apps/backend-rag/**/test_*abstain*.py
+  - apps/backend-rag/**/test_*confidence*.py
+rationale: >
+  CLAUDE.md §9 "Evidence scoring thresholds ... 5 NAMED gates, one SSOT" —
+  the same section explicitly names test_abstain_threshold_convergence.py
+  and test_abstain_policy_hardening.py as the tripwire/golden-matrix tests
+  enforcing the intentional generation<>label divergence. Quarantining
+  either would let that divergence silently collapse or drift, which
+  CLAUDE.md records as a panel-ruled SAFETY decision (2026-06-14: per-domain
+  in generation = tax advice at 0.11 evidence = safety regression).
+verified_match_count: 10

--- a/infra/merge-os/critical-floor.d/security-boundaries.yaml
+++ b/infra/merge-os/critical-floor.d/security-boundaries.yaml
@@ -1,0 +1,20 @@
+id: security-boundaries
+category: Security boundaries
+description: >
+  Tests under a dedicated security/ test directory (dashboard-map exposure,
+  mutating-route gating, webhook signature verification, brute-force
+  protection, token revocation, audit logging) plus filename-tagged security
+  tests scattered elsewhere (security-definer binding, advanced/error-path
+  security scenarios, LLM-gateway security). Distinct from auth-authorization
+  (session/RBAC identity) — this category is about the boundary controls
+  AROUND authenticated actions: what a request is allowed to DO, not just
+  who it claims to be.
+patterns:
+  - apps/backend-rag/**/security/test_*.py
+  - apps/backend-rag/**/test_*security*.py
+rationale: >
+  CLAUDE.md §14 PII/OSINT output boundary + §2 Golden Rule #6 "No Hardcoded
+  Secrets" + the repo's own cicatrix-superscar.md family #3 (guard
+  over/under-match) — this suite is the enforcement layer for exactly the
+  class of defect that family documents ~15 scars for. Never quarantinable.
+verified_match_count: 13

--- a/infra/merge-os/critical-floor.d/startup-import-chain.yaml
+++ b/infra/merge-os/critical-floor.d/startup-import-chain.yaml
@@ -1,0 +1,22 @@
+id: startup-import-chain
+category: Startup / import chain
+description: >
+  Tests that specifically exercise dependency-injection wiring and the
+  application's own import chain (backend.app.dependencies and friends) —
+  distinct from the much larger set of router tests that merely IMPORT
+  dependencies.py incidentally for DI overrides (that broader set is not
+  included here; it would make this floor a near-total-suite allowlist
+  instead of a targeted one). This is the single point of failure CLAUDE.md
+  §11's pre-deploy "Import chain gate" step exists to catch:
+  `python -c "from backend.app.dependencies import get_current_user; ..."`.
+patterns:
+  - apps/backend-rag/**/test_dependenc*.py
+  - apps/backend-rag/tests/test_import_time.py
+  - apps/backend-rag/**/test_light_router_startup_imports.py
+rationale: >
+  CLAUDE.md §11 pre-deploy sequence names the import-chain check explicitly,
+  and the "Fix dependencies.py / service_initializer" row of the Federation
+  Orchestrator trigger table (CLAUDE.md §2) calls this out as an "Import
+  chain SPOF" — a broken import here does not fail one feature, it fails
+  the whole app's boot.
+verified_match_count: 6

--- a/infra/merge-os/quarantine.d/SCHEMA.md
+++ b/infra/merge-os/quarantine.d/SCHEMA.md
@@ -1,0 +1,79 @@
+# quarantine.d/ — the quarantine ALLOWLIST (Merge-OS v3, step 6 slice 1)
+
+Spec: `research/operations/2026-08-14-merge-os-v3-research-council.md` §5 row
+"Codex F6 (vacuous critical marker)" + §6 step 6. Disposition: **invert the
+polarity**. Today nothing quarantines a test from blocking CI — a test either
+passes or it hard-fails the required check. The pytest `critical` marker
+registered in `apps/backend-rag/pytest.ini` was meant to be the complement
+("everything NOT critical can be quarantined") but is applied to **zero**
+tests (verified: `grep -rn "pytest.mark.critical" apps/backend-rag/` → no
+hits) — an unused marker is not a barrier, it is the appearance of one
+(cicatrix-superscar.md family #2, "esiste != armato").
+
+This directory is the fix: **default-deny**. A flaky/broken test is
+blocking-by-default; it is excused from blocking ONLY by an explicit,
+time-boxed, owned entry in here — never by the absence of a marker on it.
+`scripts/ci/quarantine_lint.py` is the judge (see that file's own docstring
+for the full validation contract); this file is the schema it enforces.
+
+**This directory starts EMPTY at this PR** (aside from this schema file) —
+no test is quarantined today. Wiring `quarantine_lint.py`'s verdict into
+`tests.yml` (i.e. actually skipping/soft-failing a quarantined node_id in
+CI) is a declared follow-up PR, not this one (`tests.yml` is a hot file with
+a sibling PR #4181 already in the merge queue — built here, armed later;
+scar family #2, declared not silently assumed).
+
+## One YAML file per entry — never a monolithic list
+
+Each quarantine grant is its own file, `infra/merge-os/quarantine.d/<slug>.yaml`,
+where `<slug>` is a short kebab-case identifier for the quarantined node
+(e.g. `backend-tests-flaky-redis-timeout.yaml`). This is deliberate, not
+incidental: a single shared file that many unrelated PRs each shrink or grow
+independently is exactly the shape of cicatrix-superscar.md's W109b
+("two PRs that shrink the same monotone registry are coupled even with zero
+shared lines") — two quarantine grants opened the same week, from different
+bases, would silently fight each other in a merge. A directory of one-entry
+files makes every grant/removal a genuinely independent diff.
+
+## Required fields (every one mandatory — `quarantine_lint.py` FAILs on any entry missing a field, per the mandate: "an exemption wants its own justification, not a free pass")
+
+| field                 | type                | meaning                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `node_id`             | string              | The quarantined unit — either a bare file path (`apps/backend-rag/backend/tests/foo/test_bar.py`) or a pytest node id (`...test_bar.py::test_baz`). The validator matches the file-path portion (everything before the first `::`) against the critical floor.                                                                                                                                                                                   |
+| `owner`               | string              | Who is accountable for triaging this — a GitHub login or team handle, never a bare "TBD".                                                                                                                                                                                                                                                                                                                                                        |
+| `issue`               | string              | A tracking reference (issue URL, or this repo's own tracking convention) — where the actual fix/triage work is recorded.                                                                                                                                                                                                                                                                                                                         |
+| `failure_fingerprint` | string              | A short, stable string identifying THIS failure signature (e.g. a truncated stack-trace hash, or `"asyncpg.InterfaceError: connection was closed"`) — distinguishes "same known flake, still happening" from "a NEW failure landed on an already-quarantined test", which must not hide silently behind an old grant.                                                                                                                            |
+| `first_seen`          | date (`YYYY-MM-DD`) | When this quarantine was granted. Must not be in the future.                                                                                                                                                                                                                                                                                                                                                                                     |
+| `expires_at`          | date (`YYYY-MM-DD`) | Hard cap: **at most 14 days after `first_seen`**. `quarantine_lint.py` FAILs the entry both if the 14-day cap is violated at grant time AND if `expires_at` has already passed as of the lint run ("expired quarantine = test goes back to blocking" — an expired grant is not read as "still excused", it is read as a violation, because the alternative is a quarantine that renews itself by nobody ever running the linter on a quiet day). |
+| `sample_size`         | integer ≥ 1         | How many observed runs the flake-rate estimate below is based on.                                                                                                                                                                                                                                                                                                                                                                                |
+| `observed_flake_rate` | number, `0.0`–`1.0` | Measured failure rate over `sample_size` runs — never a guess; if you don't have the number yet, you don't have grounds for a quarantine yet.                                                                                                                                                                                                                                                                                                    |
+| `reason`              | string              | Free-text: what's actually going on, in enough detail that the next reader doesn't have to reconstruct it from the fingerprint alone.                                                                                                                                                                                                                                                                                                            |
+
+## The other half of the contract: the critical floor
+
+A `node_id` may **never** be quarantined if it (or the file it belongs to)
+matches any pattern in `infra/merge-os/critical-floor.d/` — see that
+directory's own `SCHEMA.md`. `quarantine_lint.py` cross-checks every
+quarantine entry against every floor pattern and FAILs the entry if it
+collides — the floor wins even if someone opens a technically well-formed
+quarantine grant against it.
+
+## Example entry (illustrative only — not a real grant; this repo has none at this PR)
+
+```yaml
+# infra/merge-os/quarantine.d/example-backend-tests-redis-timeout.yaml
+node_id: apps/backend-rag/backend/tests/services/cache/test_semantic_cache_ttl.py::test_ttl_expiry_under_load
+owner: subhi
+issue: https://github.com/Bali-Zero/Teman2/issues/9999
+failure_fingerprint: "redis.exceptions.TimeoutError: Timeout reading from socket"
+first_seen: "2026-08-14"
+expires_at: "2026-08-21"
+sample_size: 12
+observed_flake_rate: 0.25
+reason: >
+  Fails ~1-in-4 on the shared CI Redis service container under load;
+  reproduces locally only under artificial network latency injection.
+  Root cause not yet isolated — tracked in the linked issue. Quarantined
+  for one week while a dedicated container health-check is added; NOT
+  quarantined indefinitely.
+```

--- a/scripts/ci/quarantine_lint.py
+++ b/scripts/ci/quarantine_lint.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""quarantine_lint.py — Merge-OS v3 step 6 slice 1 judge (Codex F6 disposition).
+
+Spec: research/operations/2026-08-14-merge-os-v3-research-council.md §5 row
+"Codex F6 (vacuous critical marker)" + §6 step 6. Today the pytest `critical`
+marker registered in apps/backend-rag/pytest.ini is used by ZERO tests
+(verified: `grep -rn "pytest.mark.critical" apps/backend-rag/` -> no hits) —
+an unused marker that a quarantine mechanism would have excluded FROM is not
+a barrier, it is the appearance of one (cicatrix-superscar.md family #2,
+"esiste != armato"). The fix inverts the polarity to default-deny:
+
+  - infra/merge-os/quarantine.d/*.yaml  — a protected ALLOWLIST. A test is
+    excused from blocking CI ONLY by an explicit, owned, time-boxed entry
+    here. Absence of an entry = blocking (the correct default).
+  - infra/merge-os/critical-floor.d/*.yaml — a POSITIVE, populated manifest
+    of test categories that can NEVER be quarantined, regardless of any
+    grant. Never the complement of the (unused, now-irrelevant) `critical`
+    marker.
+
+This script is the judge over both. See infra/merge-os/quarantine.d/SCHEMA.md
+and infra/merge-os/critical-floor.d/SCHEMA.md for the full field contract —
+this docstring covers what gets CHECKED, not what the fields mean.
+
+WHAT IT CHECKS:
+
+  1. Every quarantine entry has all 9 required fields (node_id, owner,
+     issue, failure_fingerprint, first_seen, expires_at, sample_size,
+     observed_flake_rate, reason), non-empty, correctly typed. Missing/
+     malformed field(s) -> FAIL, naming the file and the field(s).
+  2. `first_seen` is a valid ISO date and not in the future (relative to
+     `--now`, default today).
+  3. `expires_at` is a valid ISO date, and `expires_at - first_seen <= 14
+     days` — the structural grant-length cap declared in the schema.
+  4. `expires_at < now` -> FAIL ("expired quarantine = test goes back to
+     blocking" — an expired grant is a VIOLATION, not a silently-renewing
+     excuse; this is the check that makes the 14-day cap actually bite).
+  5. No quarantined `node_id` (file-path portion, before the first `::`)
+     matches ANY critical-floor pattern -> FAIL if it does. The floor wins
+     even against an otherwise well-formed quarantine grant.
+  6. Every critical-floor entry has its required fields (id, category,
+     patterns non-empty).
+  7. Every critical-floor pattern/path matches >= 1 real file under
+     `--repo-root` -> FAIL if a pattern is ORPHANED (anti-decorative: a
+     floor category protecting zero real files is the exact same defect,
+     `critical` marker included, dressed in YAML instead of a pytest mark).
+
+Patterns/paths (both directories) are resolved relative to `--repo-root`.
+A `patterns` entry containing `*` is treated as a `pathlib.Path.glob()`
+pattern (supports `**`); an entry with no `*` is treated as a literal file
+path that must exist.
+
+FAIL-VISIBLE, stdlib + PyYAML only (no repo imports — this must be runnable
+standalone, e.g. from a hot workflow or a pre-commit hook, without pulling
+in the backend's own dependency tree).
+
+Exit codes:
+  0  clean — every entry (both directories) valid, no floor collisions, no
+     orphan patterns. An EMPTY quarantine.d/ (no grants at all) is the
+     normal, valid, zero-entry case — not an error.
+  1  a violation was found (any of checks 1-7 above failed for at least one
+     entry).
+  2  cannot verify — a YAML file failed to parse, PyYAML is unavailable, or
+     `--repo-root`/one of the two manifest directories does not exist as a
+     directory at all (an empty SWEEP is not a clean pass, W84 — a swept-zero
+     result from a directory that never existed is indistinguishable from a
+     genuinely empty, valid manifest unless this is a distinct exit code).
+
+This PR ships ONLY this validator + the manifests + its own test corpus.
+Nothing in tests.yml invokes this script yet — wiring the verdict into CI
+(actually skipping/soft-failing a quarantined node_id, and hard-failing a
+build when this script exits 1) is a declared follow-up PR (tests.yml is a
+hot file with a sibling PR already in the merge queue; built here, armed
+later — scar family #2, declared not silently assumed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # handled explicitly in main() -> exit 2, never a silent skip
+
+
+QUARANTINE_REQUIRED_FIELDS = (
+    "node_id",
+    "owner",
+    "issue",
+    "failure_fingerprint",
+    "first_seen",
+    "expires_at",
+    "sample_size",
+    "observed_flake_rate",
+    "reason",
+)
+FLOOR_REQUIRED_FIELDS = ("id", "category", "patterns")
+MAX_QUARANTINE_DAYS = 14
+
+
+@dataclass
+class Violation:
+    file: str
+    message: str
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.file}: {self.message}"
+
+
+@dataclass
+class LintResult:
+    violations: list[Violation] = field(default_factory=list)
+    cannot_verify: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations and not self.cannot_verify
+
+
+# ---------------------------------------------------------------------------
+# Pure functions (no I/O) — the judgment logic, independently testable.
+# ---------------------------------------------------------------------------
+
+
+def node_id_path(node_id: str) -> str:
+    """The file-path portion of a node_id — everything before the first
+    `::` (pytest nodeid separator). A bare file path is returned unchanged."""
+    return node_id.split("::", 1)[0]
+
+
+def path_matches_any_pattern(path: str, patterns: list[str], repo_root: Path) -> bool:
+    """True if `path` (relative to repo_root) is matched by any entry in
+    `patterns` — glob (contains `*`) matched via Path.glob() against
+    repo_root, literal (no `*`) matched by exact relative-path equality."""
+    target = (repo_root / path).resolve()
+    for pattern in patterns:
+        if "*" in pattern:
+            for hit in repo_root.glob(pattern):
+                if hit.resolve() == target:
+                    return True
+        else:
+            if (repo_root / pattern).resolve() == target:
+                return True
+    return False
+
+
+def validate_quarantine_entry(
+    entry: dict[str, Any], filename: str, now: date
+) -> list[Violation]:
+    """All structural checks for one quarantine entry (checks 1-4 in the
+    module docstring). Does NOT check the floor collision (check 5) — that
+    needs the floor manifest, checked separately by the caller."""
+    violations: list[Violation] = []
+
+    missing = [f for f in QUARANTINE_REQUIRED_FIELDS if not entry.get(f) and entry.get(f) != 0]
+    if missing:
+        violations.append(
+            Violation(filename, f"missing/empty required field(s): {', '.join(missing)}")
+        )
+        return violations  # further checks need the fields to exist
+
+    first_seen_raw = entry["first_seen"]
+    expires_at_raw = entry["expires_at"]
+    try:
+        first_seen = _coerce_date(first_seen_raw)
+    except (TypeError, ValueError) as exc:
+        violations.append(Violation(filename, f"unparseable first_seen {first_seen_raw!r}: {exc}"))
+        return violations
+    try:
+        expires_at = _coerce_date(expires_at_raw)
+    except (TypeError, ValueError) as exc:
+        violations.append(Violation(filename, f"unparseable expires_at {expires_at_raw!r}: {exc}"))
+        return violations
+
+    if first_seen > now:
+        violations.append(
+            Violation(filename, f"first_seen {first_seen.isoformat()} is in the future (now={now.isoformat()})")
+        )
+
+    if (expires_at - first_seen).days > MAX_QUARANTINE_DAYS:
+        violations.append(
+            Violation(
+                filename,
+                f"expires_at {expires_at.isoformat()} is more than {MAX_QUARANTINE_DAYS} days "
+                f"after first_seen {first_seen.isoformat()} — quarantine grants are capped",
+            )
+        )
+
+    if expires_at < now:
+        violations.append(
+            Violation(
+                filename,
+                f"quarantine EXPIRED (expires_at={expires_at.isoformat()}, now={now.isoformat()}) "
+                "— the test is blocking again; renew with a fresh entry or fix it",
+            )
+        )
+
+    sample_size = entry["sample_size"]
+    if not isinstance(sample_size, int) or isinstance(sample_size, bool) or sample_size < 1:
+        violations.append(Violation(filename, f"sample_size must be an integer >= 1, got {sample_size!r}"))
+
+    flake_rate = entry["observed_flake_rate"]
+    if not isinstance(flake_rate, (int, float)) or isinstance(flake_rate, bool) or not (0.0 <= float(flake_rate) <= 1.0):
+        violations.append(Violation(filename, f"observed_flake_rate must be a number in [0.0, 1.0], got {flake_rate!r}"))
+
+    return violations
+
+
+def validate_floor_entry(entry: dict[str, Any], filename: str, repo_root: Path) -> list[Violation]:
+    """Checks 6-7: required fields present, and every pattern matches >= 1
+    real file under repo_root (anti-decorative — no orphan patterns)."""
+    violations: list[Violation] = []
+
+    missing = [f for f in FLOOR_REQUIRED_FIELDS if not entry.get(f)]
+    if missing:
+        violations.append(
+            Violation(filename, f"missing/empty required field(s): {', '.join(missing)}")
+        )
+        return violations
+
+    patterns = entry["patterns"]
+    if not isinstance(patterns, list) or not patterns:
+        violations.append(Violation(filename, "patterns must be a non-empty list"))
+        return violations
+
+    for pattern in patterns:
+        if not isinstance(pattern, str):
+            violations.append(
+                Violation(filename, f"non-string pattern entry (must be a path/glob string): {pattern!r}")
+            )
+            continue
+        if "*" in pattern:
+            hits = list(repo_root.glob(pattern))
+        else:
+            hits = [repo_root / pattern] if (repo_root / pattern).is_file() else []
+        if not hits:
+            violations.append(
+                Violation(filename, f"orphan pattern (matches 0 real files): {pattern!r}")
+            )
+
+    return violations
+
+
+def _coerce_date(value: Any) -> date:
+    """YAML's safe_load already turns `YYYY-MM-DD` scalars into `date`
+    objects by default — accept that AND a plain string, so a quoted date
+    in the manifest (`"2026-08-14"`) still works, never silently coerced
+    from something else (e.g. an int)."""
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+    raise TypeError(f"expected a date, got {type(value).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# I/O — loading + orchestration.
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml_dir(dir_path: Path) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    """Loads every *.yaml file in dir_path (SCHEMA.md is markdown, skipped
+    naturally by extension) as {filename: parsed_dict}. Returns
+    (entries, cannot_verify_errors). A missing directory is NOT an error —
+    the caller decides whether that's valid-empty or CANNOT VERIFY based on
+    which directory it is."""
+    entries: dict[str, dict[str, Any]] = {}
+    errors: list[str] = []
+    if not dir_path.is_dir():
+        return entries, errors
+    for path in sorted(dir_path.glob("*.yaml")):
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            errors.append(f"{path}: YAML parse error: {exc}")
+            continue
+        if doc is None:
+            continue  # an empty *.yaml file is not an entry, not an error
+        if not isinstance(doc, dict):
+            errors.append(f"{path}: expected a mapping at the top level, got {type(doc).__name__}")
+            continue
+        entries[str(path)] = doc
+    return entries, errors
+
+
+def run_lint(repo_root: Path, quarantine_dir: Path, floor_dir: Path, now: date) -> LintResult:
+    result = LintResult()
+
+    if not floor_dir.is_dir():
+        result.cannot_verify.append(
+            f"critical-floor directory does not exist: {floor_dir} "
+            "(an empty sweep from a directory that was never there is not a clean pass)"
+        )
+        return result
+
+    quarantine_entries, q_errors = _load_yaml_dir(quarantine_dir)
+    floor_entries, f_errors = _load_yaml_dir(floor_dir)
+    result.cannot_verify.extend(q_errors)
+    result.cannot_verify.extend(f_errors)
+    if result.cannot_verify:
+        return result
+
+    if not floor_entries:
+        result.cannot_verify.append(
+            f"critical-floor directory has zero valid *.yaml entries: {floor_dir} "
+            "(a floor that protects nothing is not a clean pass)"
+        )
+        return result
+
+    # Floor entries: structural + orphan-pattern checks.
+    all_floor_patterns: list[str] = []
+    for filename, entry in floor_entries.items():
+        result.violations.extend(validate_floor_entry(entry, filename, repo_root))
+        patterns = entry.get("patterns")
+        if isinstance(patterns, list):
+            all_floor_patterns.extend(p for p in patterns if isinstance(p, str))
+
+    # Quarantine entries: structural checks + floor-collision check.
+    for filename, entry in quarantine_entries.items():
+        entry_violations = validate_quarantine_entry(entry, filename, now)
+        result.violations.extend(entry_violations)
+        # Floor-collision check only makes sense if node_id itself parsed —
+        # i.e. the entry didn't already fail on missing/malformed fields.
+        if not entry_violations and "node_id" in entry:
+            path = node_id_path(str(entry["node_id"]))
+            if path_matches_any_pattern(path, all_floor_patterns, repo_root):
+                result.violations.append(
+                    Violation(
+                        filename,
+                        f"node_id {entry['node_id']!r} matches the critical floor — "
+                        "this test can never be quarantined",
+                    )
+                )
+
+    return result
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    default_root = Path(__file__).resolve().parent.parent.parent
+    parser.add_argument("--repo-root", default=str(default_root), help="default %(default)s")
+    parser.add_argument(
+        "--quarantine-dir",
+        default=None,
+        help="default <repo-root>/infra/merge-os/quarantine.d",
+    )
+    parser.add_argument(
+        "--floor-dir",
+        default=None,
+        help="default <repo-root>/infra/merge-os/critical-floor.d",
+    )
+    parser.add_argument(
+        "--now",
+        default=None,
+        help="ISO date (YYYY-MM-DD) to treat as 'now' — default: real today (UTC)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if yaml is None:
+        print("CANNOT VERIFY: PyYAML is not importable in this environment", file=sys.stderr)
+        return 2
+
+    repo_root = Path(args.repo_root).resolve()
+    quarantine_dir = Path(args.quarantine_dir) if args.quarantine_dir else repo_root / "infra" / "merge-os" / "quarantine.d"
+    floor_dir = Path(args.floor_dir) if args.floor_dir else repo_root / "infra" / "merge-os" / "critical-floor.d"
+    if args.now:
+        try:
+            now = date.fromisoformat(args.now)
+        except ValueError as exc:
+            print(f"CANNOT VERIFY: --now {args.now!r} is not a valid ISO date: {exc}", file=sys.stderr)
+            return 2
+    else:
+        now = datetime.now(timezone.utc).date()
+
+    result = run_lint(repo_root, quarantine_dir, floor_dir, now)
+
+    if result.cannot_verify:
+        for msg in result.cannot_verify:
+            print(f"CANNOT VERIFY: {msg}", file=sys.stderr)
+        return 2
+
+    if result.violations:
+        print(f"{len(result.violations)} quarantine-lint violation(s):", file=sys.stderr)
+        for v in result.violations:
+            print(f"  {v}", file=sys.stderr)
+        return 1
+
+    print(
+        f"quarantine-lint: clean "
+        f"(quarantine.d valid, critical-floor.d valid, no collisions, no orphan patterns)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_quarantine_lint.py
+++ b/scripts/ci/test_quarantine_lint.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Guilt + innocence corpus for `quarantine_lint.py`.
+
+Runs standalone (`python3 scripts/ci/test_quarantine_lint.py`) and under
+pytest. Covers: (1) the pure judgment functions directly (no I/O), and
+(2) `run_lint`/`main` end-to-end against real temp directories on disk, so
+the YAML-loading + glob-matching + exit-code contract are exercised for
+real, not mocked.
+
+Team-lead's mandate (Merge-OS v3 step 6 slice 1) named these guilt cases
+explicitly: entry without owner -> red; expiry passed -> red; quarantine of
+a floor-protected test -> red; orphan floor pattern -> red; empty
+quarantine + populated floor -> green. All five are here, plus the
+additional structural checks the validator implements (14-day cap,
+future first_seen, malformed sample_size/flake_rate, unparseable dates,
+missing floor fields, malformed YAML, missing/empty floor dir).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from quarantine_lint import (  # noqa: E402
+    main,
+    node_id_path,
+    path_matches_any_pattern,
+    run_lint,
+    validate_floor_entry,
+    validate_quarantine_entry,
+)
+
+NOW = date(2026, 8, 15)
+
+
+def _valid_quarantine_entry(**overrides):
+    entry = {
+        "node_id": "apps/backend-rag/backend/tests/unit/test_something_flaky.py::test_flaky_thing",
+        "owner": "lane-c-security",
+        "issue": "https://github.com/balizero/nuzantara/issues/9999",
+        "failure_fingerprint": "AssertionError: timing race in test_flaky_thing",
+        "first_seen": date(2026, 8, 10),
+        "expires_at": date(2026, 8, 20),  # 10 days, within the 14-day cap
+        "sample_size": 12,
+        "observed_flake_rate": 0.25,
+        "reason": "known timing race, ticket filed, fix in progress",
+    }
+    entry.update(overrides)
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests — no filesystem.
+# ---------------------------------------------------------------------------
+
+# --- node_id_path -------------------------------------------------------
+
+
+def test_a_node_id_path_strips_the_pytest_nodeid_suffix():
+    assert node_id_path("apps/x/test_y.py::TestClass::test_method") == "apps/x/test_y.py"
+
+
+def test_a_node_id_path_bare_file_path_is_unchanged():
+    assert node_id_path("apps/x/test_y.py") == "apps/x/test_y.py"
+
+
+# --- path_matches_any_pattern -------------------------------------------
+
+
+def test_a_glob_pattern_matches_a_real_nested_file(tmp_repo):
+    assert path_matches_any_pattern(
+        "apps/backend-rag/backend/tests/test_auth_flow.py",
+        ["apps/backend-rag/**/test_*auth*.py"],
+        tmp_repo,
+    )
+
+
+def test_b_glob_pattern_does_not_match_an_unrelated_lookalike_file(tmp_repo):
+    """Innocence twin of the above: a file that merely lives in a sibling
+    directory, and does not match the glob's own name-shape, must not be
+    swept in by accident."""
+    assert not path_matches_any_pattern(
+        "apps/backend-rag/backend/tests/test_pricing_flow.py",
+        ["apps/backend-rag/**/test_*auth*.py"],
+        tmp_repo,
+    )
+
+
+def test_c_literal_pattern_matches_only_the_exact_path(tmp_repo):
+    literal = "apps/backend-rag/backend/tests/db/test_backend_stability_gate.py"
+    assert path_matches_any_pattern(literal, [literal], tmp_repo)
+    assert not path_matches_any_pattern(
+        "apps/backend-rag/backend/tests/db/test_backend_stability_gate_v2.py",
+        [literal],
+        tmp_repo,
+    )
+
+
+# --- validate_quarantine_entry (guilt) -----------------------------------
+
+
+def test_guilt_missing_owner_is_a_violation():
+    entry = _valid_quarantine_entry()
+    del entry["owner"]
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("owner" in v.message for v in violations), violations
+
+
+def test_guilt_expired_entry_is_a_violation():
+    entry = _valid_quarantine_entry(
+        first_seen=date(2026, 7, 20), expires_at=date(2026, 8, 1)
+    )
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("EXPIRED" in v.message for v in violations), violations
+
+
+def test_guilt_grant_longer_than_14_days_is_a_violation():
+    entry = _valid_quarantine_entry(
+        first_seen=date(2026, 8, 1), expires_at=date(2026, 8, 20)  # 19 days
+    )
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("capped" in v.message for v in violations), violations
+
+
+def test_guilt_first_seen_in_the_future_is_a_violation():
+    entry = _valid_quarantine_entry(
+        first_seen=date(2026, 8, 16), expires_at=date(2026, 8, 26)
+    )
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("future" in v.message for v in violations), violations
+
+
+def test_guilt_negative_sample_size_is_a_violation():
+    entry = _valid_quarantine_entry(sample_size=0)
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("sample_size" in v.message for v in violations), violations
+
+
+def test_guilt_out_of_range_flake_rate_is_a_violation():
+    entry = _valid_quarantine_entry(observed_flake_rate=1.4)
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("observed_flake_rate" in v.message for v in violations), violations
+
+
+def test_guilt_unparseable_first_seen_is_a_violation():
+    entry = _valid_quarantine_entry(first_seen="not-a-date")
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("unparseable" in v.message for v in violations), violations
+
+
+# --- validate_quarantine_entry (innocence) --------------------------------
+
+
+def test_innocence_a_well_formed_entry_within_the_cap_and_not_expired_is_clean():
+    entry = _valid_quarantine_entry()
+    assert validate_quarantine_entry(entry, "f.yaml", NOW) == []
+
+
+def test_innocence_expiry_exactly_equal_to_now_is_not_yet_expired():
+    """Boundary the spalla-review flagged as untested: a grant expiring
+    ON `now` is still valid THROUGH that day (strict `<` in the expired
+    check) — pin the inequality direction so a future refactor that flips
+    it goes red here first."""
+    entry = _valid_quarantine_entry(
+        first_seen=date(2026, 8, 5), expires_at=NOW
+    )
+    assert validate_quarantine_entry(entry, "f.yaml", NOW) == []
+
+
+def test_innocence_expiry_exactly_14_days_out_is_not_capped():
+    """Boundary: exactly 14 days is allowed, 15 is not (strictly-below and
+    strictly-above tested, not the exact float/int edge alone — pinning
+    W97's 'exactly-N-round' suspicion by testing both sides)."""
+    entry = _valid_quarantine_entry(
+        first_seen=date(2026, 8, 1), expires_at=date(2026, 8, 15)
+    )
+    assert validate_quarantine_entry(entry, "f.yaml", NOW) == []
+
+
+def test_innocence_expiry_15_days_out_is_capped():
+    entry = _valid_quarantine_entry(
+        first_seen=date(2026, 8, 1), expires_at=date(2026, 8, 16)
+    )
+    violations = validate_quarantine_entry(entry, "f.yaml", NOW)
+    assert any("capped" in v.message for v in violations), violations
+
+
+# --- validate_floor_entry (guilt + innocence) -----------------------------
+
+
+def test_guilt_floor_entry_missing_category_is_a_violation():
+    entry = {"id": "x", "patterns": ["apps/**/test_x.py"]}
+    violations = validate_floor_entry(entry, "f.yaml", Path("/nonexistent"))
+    assert any("category" in v.message for v in violations), violations
+
+
+def test_guilt_floor_entry_empty_patterns_list_is_a_violation():
+    """An empty list is falsy, so it is caught by the missing/empty
+    required-field guard (checked first) rather than the type guard below
+    it — still a violation naming 'patterns', just via the earlier check."""
+    entry = {"id": "x", "category": "X", "patterns": []}
+    violations = validate_floor_entry(entry, "f.yaml", Path("/nonexistent"))
+    assert any("patterns" in v.message for v in violations), violations
+
+
+def test_guilt_floor_entry_non_list_patterns_is_a_violation():
+    """Twin of the above for the type guard itself: a truthy `patterns`
+    that isn't a list (e.g. a bare string) must still be rejected — this
+    is the only way to reach the 'must be a non-empty list' branch, since
+    an empty list is intercepted earlier by the missing-field guard."""
+    entry = {"id": "x", "category": "X", "patterns": "apps/**/test_x.py"}
+    violations = validate_floor_entry(entry, "f.yaml", Path("/nonexistent"))
+    assert any("non-empty list" in v.message for v in violations), violations
+
+
+def test_guilt_floor_orphan_pattern_is_a_violation(tmp_repo):
+    entry = {
+        "id": "x",
+        "category": "X",
+        "patterns": ["apps/backend-rag/**/test_*nonexistent_shape*.py"],
+    }
+    violations = validate_floor_entry(entry, "f.yaml", tmp_repo)
+    assert any("orphan pattern" in v.message for v in violations), violations
+
+
+def test_guilt_floor_non_string_pattern_element_is_a_violation_not_a_crash(tmp_repo):
+    """spalla-review 2026-08-15: an unquoted non-string element in a
+    `patterns` list (e.g. `patterns: [123]`) used to raise an unguarded
+    TypeError from `"*" in pattern`. Must degrade to a Violation, never
+    crash the linter itself."""
+    entry = {"id": "x", "category": "X", "patterns": [123, "apps/backend-rag/**/test_*auth*.py"]}
+    violations = validate_floor_entry(entry, "f.yaml", tmp_repo)
+    assert any("non-string pattern" in v.message for v in violations), violations
+
+
+def test_innocence_floor_pattern_matching_real_files_is_clean(tmp_repo):
+    entry = {
+        "id": "x",
+        "category": "X",
+        "patterns": ["apps/backend-rag/**/test_*auth*.py"],
+    }
+    assert validate_floor_entry(entry, "f.yaml", tmp_repo) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end tests against real temp directories (run_lint / main).
+# ---------------------------------------------------------------------------
+
+
+class _TmpRepo:
+    """Builds a throwaway repo tree with a handful of real test files so
+    glob patterns have something genuine to match — never a mocked
+    filesystem, per W65 (no phantom paths, verified against a real tree)."""
+
+    def __init__(self, base: Path):
+        self.root = base
+        files = [
+            "apps/backend-rag/backend/tests/test_auth_flow.py",
+            "apps/backend-rag/backend/tests/test_pricing_flow.py",
+            "apps/backend-rag/backend/tests/unit/test_something_flaky.py",
+            "apps/backend-rag/backend/tests/db/test_backend_stability_gate.py",
+        ]
+        for rel in files:
+            p = self.root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("def test_x():\n    assert True\n", encoding="utf-8")
+
+
+def _write_floor(root: Path, filename: str, body: str) -> None:
+    d = root / "infra" / "merge-os" / "critical-floor.d"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / filename).write_text(body, encoding="utf-8")
+
+
+def _write_quarantine(root: Path, filename: str, body: str) -> None:
+    d = root / "infra" / "merge-os" / "quarantine.d"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / filename).write_text(body, encoding="utf-8")
+
+
+_DEFAULT_FLOOR_YAML = """\
+id: auth-authorization
+category: Auth
+patterns:
+  - apps/backend-rag/**/test_*auth*.py
+"""
+
+
+def _e2e(tmp_path_factory_dir, floor_yaml=_DEFAULT_FLOOR_YAML, quarantine_files=None):
+    root = tmp_path_factory_dir
+    _TmpRepo(root)
+    if floor_yaml is not None:
+        _write_floor(root, "auth-authorization.yaml", floor_yaml)
+    for filename, body in (quarantine_files or {}).items():
+        _write_quarantine(root, filename, body)
+    return run_lint(
+        root,
+        root / "infra" / "merge-os" / "quarantine.d",
+        root / "infra" / "merge-os" / "critical-floor.d",
+        NOW,
+    )
+
+
+def test_innocence_empty_quarantine_plus_populated_floor_is_clean():
+    with tempfile.TemporaryDirectory() as td:
+        result = _e2e(Path(td))
+        assert result.ok, (result.violations, result.cannot_verify)
+
+
+def test_innocence_a_well_formed_non_colliding_quarantine_entry_is_clean():
+    with tempfile.TemporaryDirectory() as td:
+        body = """\
+node_id: "apps/backend-rag/backend/tests/unit/test_something_flaky.py::test_flaky_thing"
+owner: lane-c-security
+issue: "https://github.com/balizero/nuzantara/issues/9999"
+failure_fingerprint: "AssertionError: timing race"
+first_seen: 2026-08-10
+expires_at: 2026-08-20
+sample_size: 12
+observed_flake_rate: 0.25
+reason: "known timing race, ticket filed"
+"""
+        result = _e2e(Path(td), quarantine_files={"flaky-thing.yaml": body})
+        assert result.ok, (result.violations, result.cannot_verify)
+
+
+def test_guilt_quarantine_of_a_floor_protected_test_is_a_violation():
+    with tempfile.TemporaryDirectory() as td:
+        body = """\
+node_id: "apps/backend-rag/backend/tests/test_auth_flow.py::test_login"
+owner: lane-c-security
+issue: "https://github.com/balizero/nuzantara/issues/9999"
+failure_fingerprint: "AssertionError: flaky auth timing"
+first_seen: 2026-08-10
+expires_at: 2026-08-20
+sample_size: 12
+observed_flake_rate: 0.25
+reason: "flaky, ticket filed"
+"""
+        result = _e2e(Path(td), quarantine_files={"auth-flake.yaml": body})
+        assert not result.ok
+        assert any("critical floor" in str(v) for v in result.violations), result.violations
+
+
+def test_guilt_orphan_floor_pattern_is_cannot_verify_via_run_lint():
+    orphan_floor = """\
+id: auth-authorization
+category: Auth
+patterns:
+  - apps/backend-rag/**/test_*totally_made_up_shape*.py
+"""
+    with tempfile.TemporaryDirectory() as td:
+        result = _e2e(Path(td), floor_yaml=orphan_floor)
+        assert not result.ok
+        assert any("orphan pattern" in str(v) for v in result.violations), result.violations
+
+
+def test_guilt_missing_floor_dir_is_cannot_verify():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _TmpRepo(root)
+        # no critical-floor.d at all
+        result = run_lint(
+            root,
+            root / "infra" / "merge-os" / "quarantine.d",
+            root / "infra" / "merge-os" / "critical-floor.d",
+            NOW,
+        )
+        assert not result.ok
+        assert result.cannot_verify, "missing floor dir must be CANNOT VERIFY, not a silent clean pass"
+
+
+def test_guilt_malformed_yaml_is_cannot_verify():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _TmpRepo(root)
+        _write_floor(root, "auth-authorization.yaml", _DEFAULT_FLOOR_YAML)
+        _write_quarantine(root, "broken.yaml", "node_id: [unclosed\n  owner: x")
+        result = run_lint(
+            root,
+            root / "infra" / "merge-os" / "quarantine.d",
+            root / "infra" / "merge-os" / "critical-floor.d",
+            NOW,
+        )
+        assert not result.ok
+        assert result.cannot_verify, result.violations
+
+
+def test_innocence_main_cli_exits_zero_on_a_clean_real_tree():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _TmpRepo(root)
+        _write_floor(root, "auth-authorization.yaml", _DEFAULT_FLOOR_YAML)
+        rc = main(
+            [
+                "--repo-root", str(root),
+                "--quarantine-dir", str(root / "infra" / "merge-os" / "quarantine.d"),
+                "--floor-dir", str(root / "infra" / "merge-os" / "critical-floor.d"),
+                "--now", NOW.isoformat(),
+            ]
+        )
+        assert rc == 0
+
+
+def test_guilt_main_cli_exits_one_on_a_floor_collision():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _TmpRepo(root)
+        _write_floor(root, "auth-authorization.yaml", _DEFAULT_FLOOR_YAML)
+        body = """\
+node_id: "apps/backend-rag/backend/tests/test_auth_flow.py::test_login"
+owner: lane-c-security
+issue: "https://github.com/balizero/nuzantara/issues/9999"
+failure_fingerprint: "x"
+first_seen: 2026-08-10
+expires_at: 2026-08-20
+sample_size: 12
+observed_flake_rate: 0.25
+reason: "x"
+"""
+        _write_quarantine(root, "collide.yaml", body)
+        rc = main(
+            [
+                "--repo-root", str(root),
+                "--quarantine-dir", str(root / "infra" / "merge-os" / "quarantine.d"),
+                "--floor-dir", str(root / "infra" / "merge-os" / "critical-floor.d"),
+                "--now", NOW.isoformat(),
+            ]
+        )
+        assert rc == 1
+
+
+def test_guilt_main_cli_exits_two_on_malformed_now_flag_not_a_crash():
+    """spalla-review 2026-08-15: `date.fromisoformat(args.now)` used to be
+    unguarded — an operator typo in `--now` raised an unhandled ValueError
+    traceback instead of routing through the documented exit-2 path."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _TmpRepo(root)
+        _write_floor(root, "auth-authorization.yaml", _DEFAULT_FLOOR_YAML)
+        rc = main(
+            [
+                "--repo-root", str(root),
+                "--quarantine-dir", str(root / "infra" / "merge-os" / "quarantine.d"),
+                "--floor-dir", str(root / "infra" / "merge-os" / "critical-floor.d"),
+                "--now", "not-a-date",
+            ]
+        )
+        assert rc == 2
+
+
+def test_guilt_main_cli_exits_two_on_missing_floor_dir():
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _TmpRepo(root)
+        rc = main(
+            [
+                "--repo-root", str(root),
+                "--quarantine-dir", str(root / "infra" / "merge-os" / "quarantine.d"),
+                "--floor-dir", str(root / "infra" / "merge-os" / "critical-floor.d"),
+                "--now", NOW.isoformat(),
+            ]
+        )
+        assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# The shipped manifests, exercised against the REAL repo tree — pins that
+# the actual infra/merge-os/critical-floor.d/*.yaml files shipped in this
+# PR are themselves clean under this same validator (dogfooding).
+# ---------------------------------------------------------------------------
+
+
+def test_the_shipped_manifests_are_clean_against_the_real_repo():
+    """Uses `date.today()`, NOT a frozen NOW: this is dogfooding against the
+    LIVE quarantine.d, which today is empty but won't stay that way forever.
+    A frozen date here would judge a future real grant against a stale
+    'now' and could silently keep reporting clean past that grant's actual
+    expiry (spalla-review finding, 2026-08-15) — the synthetic-entry tests
+    above are correctly frozen (deterministic fixtures), this one must not
+    be, because its subject is whatever is actually checked in."""
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    result = run_lint(
+        repo_root,
+        repo_root / "infra" / "merge-os" / "quarantine.d",
+        repo_root / "infra" / "merge-os" / "critical-floor.d",
+        date.today(),
+    )
+    assert result.ok, (result.violations, result.cannot_verify)
+
+
+# ---------------------------------------------------------------------------
+# pytest fixture (also usable as a plain callable by the standalone runner
+# below, via the _tmp_repo_dir shim).
+# ---------------------------------------------------------------------------
+
+try:
+    import pytest
+
+    @pytest.fixture
+    def tmp_repo(tmp_path):
+        _TmpRepo(tmp_path)
+        return tmp_path
+
+except ImportError:  # pragma: no cover - standalone runner path
+    pytest = None
+
+
+if __name__ == "__main__":
+    # Standalone runner: fixture-dependent tests (tmp_repo) are skipped here
+    # since there is no pytest fixture machinery outside pytest itself — run
+    # `pytest scripts/ci/test_quarantine_lint.py` for the full corpus. This
+    # runner still covers every fixture-free test, which is the majority.
+    fns = []
+    for k, v in sorted(globals().items()):
+        if not k.startswith("test_"):
+            continue
+        code = v.__code__
+        if "tmp_repo" in code.co_varnames[: code.co_argcount]:
+            continue
+        fns.append(v)
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  ok   {fn.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL {fn.__name__}: {exc}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed ({len(fns)} fixture-free of {sum(1 for k in globals() if k.startswith('test_'))} total — run under pytest for full corpus)")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary

Merge-OS v3 step 6 slice 1 — `research/operations/2026-08-14-merge-os-v3-research-council.md` §5 row **"Codex F6 (vacuous critical marker)"** + §6 step 6.

Today `apps/backend-rag/pytest.ini` registers a `critical` pytest marker used by **zero** tests (`grep -rn "pytest.mark.critical" apps/backend-rag/` → no hits). A quarantine mechanism that excludes tests FROM based on that marker would be a fake barrier — the appearance of a floor, not a floor (cicatrix-superscar.md family #2, "esiste ≠ armato"). This PR inverts the polarity to **default-deny**:

- `infra/merge-os/quarantine.d/*.yaml` — a protected allowlist. A test is excused from blocking CI **only** via an explicit, owned, time-boxed (≤14d) entry. Starts **empty** — no grants exist yet.
- `infra/merge-os/critical-floor.d/*.yaml` — a **positive**, populated manifest of 9 test categories that can never be quarantined regardless of any grant, never the complement of the unused `critical` marker.
- `scripts/ci/quarantine_lint.py` — stdlib+PyYAML validator implementing all 5 checks from the mandate: all required fields present + valid dates + 14-day grant cap + not-expired; no quarantined `node_id` matches the critical floor; every floor pattern matches ≥1 real file (anti-decorative/orphan check); exit 0/1/2 contract (clean/violation/cannot-verify).
- `scripts/ci/test_quarantine_lint.py` — 33 guilt+innocence tests.

Per-key directories (not one monolithic YAML) per W109b: new registries that grow/shrink under independent PRs mutually block each other with zero shared lines if they're a single file — per-entry files avoid the class entirely.

## Critical-floor categories — verified match counts (re-measured independently against the real tree, not copied from the YAML)

| Category | Pattern(s) | Real files matched |
|---|---|---|
| auth-authorization | `test_*auth*.py` | 24 |
| migration-schema-integrity | `test_migration_*.py`, `test_*migrations.py` | 44 |
| startup-import-chain | `test_dependenc*.py`, `test_import_time.py`, `test_light_router_startup_imports.py` | 6 |
| pricing-billing | `test_*pricing*.py`, `test_*billing*.py` | 20 |
| security-boundaries | `security/test_*.py`, `test_*security*.py` | 13 |
| rag-abstention-confidence | `test_*abstain*.py`, `test_*confidence*.py` | 10 |
| embedding-model-dims | `test_embedding*.py` (deliberately narrow, see YAML `description`) | 3 |
| gate-verifiers | 8 explicit paths (data-invariant tripwire + guard-conformance corpus) | 8 |
| deploy-health | `test_*health*.py`, `test_backend_stability_gate.py` | 18 |

Zero orphan patterns anywhere in either directory.

## Verification

- `python3 -m pytest scripts/ci/test_quarantine_lint.py -q` → **33 passed**.
- Manual mutation-check on the 2 main guards (floor-collision matcher, orphan-pattern check): each disabled one at a time via `if False and ...`, confirmed it kills exactly the tests that pin it (2 each) and nothing else, restored byte-identical (`shasum` match), 33/33 green again.
- Live CLI run against the real repo tree: `python3 scripts/ci/quarantine_lint.py --repo-root .` → `quarantine-lint: clean`, exit 0.
- Independent spalla-review pass (fresh context) found 3 real robustness gaps (non-string floor-pattern element crashing instead of degrading to a Violation; malformed `--now` crashing instead of routing to exit-2; a dogfooding test frozen to a fixed date instead of `date.today()`) — all 3 fixed, 3 new tests added pinning them, re-verified 33/33 green + mutation-check re-run clean after the fixes.

## Scope (built, not armed)

This PR ships **only** the manifests + validator + its own test corpus. `.github/workflows/tests.yml` is **not** touched — confirmed zero references to `quarantine_lint.py` anywhere in the workflow. That file is currently hot (sibling PR #4181 just landed, restructuring it); actually wiring the verdict into CI (skip/soft-fail a quarantined node_id, hard-fail the build on a non-zero exit) is a declared follow-up PR.

## Test plan

- [x] `python3 -m pytest scripts/ci/test_quarantine_lint.py -q` — 33/33 passed
- [x] Manual mutation-check on both main guards, restored byte-identical
- [x] Live CLI dry-run against the real repo tree — clean, exit 0
- [x] All 9 critical-floor `verified_match_count` values independently re-measured against the real tree in this PR's own commit — exact match
- [x] Independent spalla-review pass — 3 findings, all fixed and pinned
- [x] Pre-commit + pre-push hooks green (anti-reward-hacking lint, secrets scan, Python lint, prettier)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>