### PR TITLE
fix(visa): dedupe obsolete product notices

### DIFF
--- a/apps/backend-rag/backend/services/visa_engine/evaluator.py
+++ b/apps/backend-rag/backend/services/visa_engine/evaluator.py
@@ -865,17 +865,23 @@ def _build_notices(facts: FactSnapshot, compiled_pack: CompiledRulePack) -> tupl
     if requested is None or isinstance(requested, UnknownFact):
         return ()
     requested_code = str(requested.value)
-    notices: list[Reason] = []
+    # One retired code may map to several current products (for example,
+    # B211A maps to C1/C2/C6 in the production catalogue).  That is one
+    # applicant-facing event, not one event per successor product.  Aggregate
+    # every successor citation into a single deterministic notice.
+    source_refs: set[uuid.UUID] = set()
     for compiled_product in compiled_pack.products:
         if requested_code in compiled_product.product.legacy_codes:
-            notices.append(
-                Reason(
-                    code="OBSOLETE_PRODUCT_CODE",
-                    rule_ids=(),
-                    source_refs=_sorted_uuids(compiled_product.product.source_refs),
-                )
-            )
-    return tuple(notices)
+            source_refs.update(compiled_product.product.source_refs)
+    if not source_refs:
+        return ()
+    return (
+        Reason(
+            code="OBSOLETE_PRODUCT_CODE",
+            rule_ids=(),
+            source_refs=_sorted_uuids(source_refs),
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq7_sponsor_witnesses.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq7_sponsor_witnesses.py
@@ -477,3 +477,31 @@ def test_broad_sponsor_only_eligibility_rule_manufactures_an_offer(
         "pins no longer reproduces and the module docstring's claim needs "
         "re-checking"
     )
+
+
+def test_obsolete_code_emits_one_notice_with_all_successor_sources(seq7):
+    """B211A maps to multiple current products but is one legacy-code event.
+
+    The active sequence-7 catalogue maps B211A to C1, C2 and C6.  The
+    decision must therefore carry one deduplicated notice whose citations
+    cover every matching successor, rather than three identical notices.
+    """
+    decision = _decide(
+        seq7,
+        {
+            "intent.purposes": _known(["TOURISM"]),
+            "intent.stay_days": _known(30),
+            "intent.requested_product_code": _known("B211A"),
+        },
+    )
+
+    assert len(decision.notices) == 1
+    notice = decision.notices[0]
+    assert notice.code == "OBSOLETE_PRODUCT_CODE"
+    expected_sources = {
+        source_ref
+        for compiled_product in seq7.products
+        if "B211A" in compiled_product.product.legacy_codes
+        for source_ref in compiled_product.product.source_refs
+    }
+    assert set(notice.source_refs) == expected_sources


### PR DESCRIPTION
## Summary
- emit one OBSOLETE_PRODUCT_CODE notice when a retired code maps to multiple successors
- union and deterministically sort all successor source references
- add a sequence-7 regression witness for B211A mapping to C1, C2, and C6

## Verification
- independent Fable 5 grader reproduced old behavior: 3 byte-identical notices
- fixed behavior: 1 notice, unchanged decision state and candidates, exact source-ref union
- focused Visa engine checks: 41 passed
- full Visa engine suite: 1,660 passed, 1 expected skip, exit 0
- ruff, mypy, diff check: pass

## Safety
- notice-only change; no rulepack, activation, ENFORCE, or deployment changes
- kept draft for exact-SHA CI and independent merge decision