### PR TITLE
docs(visa): reconcile the ENFORCE gate ruling

### DIFF
--- a/.agents/skills/visaoracle/CURRENT_STATE.md
+++ b/.agents/skills/visaoracle/CURRENT_STATE.md
@@ -8,6 +8,14 @@ Purpose: canonical restart and Claude-review handoff for `/visaoracle`
 
 ## Read this first
 
+> **BUSINESS-VALIDATION RULING (Zero, 2026-08-08):** there is no automated
+> traffic-volume gate for ENFORCE — the former 1,000/7d proposal, 100/14d
+> fallback and Wilson-threshold approach are superseded. The Bali Zero team
+> validates through heavy manual testing in SHADOW. This ruling does not close
+> the DPIA, analytics-TTL or explicit ENFORCE-authorization blockers below.
+> Canonical rationale:
+> `research/visa/2026-08-08-decision-tree-v2-full-index-design.md` §4.
+
 Visa Oracle V2 is **ONLINE IN SHADOW with every operational gate proven
 against real production** — roles provisioned, migrations 262–267 applied,
 Privacy Policy V1 registered, a corrected signed RulePack activated

--- a/.agents/skills/visaoracle/SKILL.md
+++ b/.agents/skills/visaoracle/SKILL.md
@@ -20,77 +20,44 @@ Mandate: Zero, 2026-07-17. Working mode: multi-LLM deep-research ↔ brainstorm 
 rounds), all work in worktree `mouth-visa-oracle` until final draft for operator analysis. This is
 Subhi's surface (`apps/mouth`) — verification per CLAUDE.md §13 (CI + AI review, generator≠grader).
 
-## ENFORCE-GATE (Zero pre-authorized the flip, Legge 5 exercised 2026-07-19 — OBJECTIVE gate, never early)
+## ENFORCE-GATE (canonical ruling as of 2026-08-08 — NO-GO / SHADOW)
 
-**Firebreak change (durable).** The ENFORCE flip on the public Visa Oracle surface was previously
-"Zero's decision only" (Legge 5). Zero has now PRE-EXERCISED that decision (2026-07-19, genuine message):
-the SESSION may execute the ENFORCE flip itself **without returning to ask** — but ONLY when the objective
-gate below is ALL-GREEN, and NEVER a flip in anticipation. If any criterion is red/unmeasured, ENFORCE stays
-OFF; the session keeps the engine in SHADOW and keeps collecting evidence. This authorization is conditional
-on the gate, not a blanket unlock. (Any change to the engine's legal _content/logic_ still re-opens the
-gate — a green gate certifies the engine as it was measured, not future edits.)
+**The 2026-08-08 Zero ruling supersedes the 2026-07-19 gate proposal.** There
+is no automated traffic-volume threshold for ENFORCE: no 1,000 sessions/7d,
+no 100 real sessions/14d fallback and no Wilson lower-bound test. Organic
+traffic measurements remain useful diagnostic evidence, but they neither
+authorize nor mechanically block the mode change. The business-validation
+gate is Bali Zero team heavy-testing and verification against the engine in
+SHADOW. See
+`research/visa/2026-08-08-decision-tree-v2-full-index-design.md` §4.
 
-**Prerequisites (both must hold before the gate can even be evaluated):**
+ENFORCE remains a distinct, explicit Zero-gated action. A session must not
+infer pre-authorization from operational checks, a RulePack activation,
+traffic counts or this skill. It must keep `VISA_ENGINE_EVALUATE_MODE=SHADOW`
+until all of the following are true:
 
-- PR4 #2804 merged to main ✅ (2026-07-19, squash `4f8f40ee48` — bitemporal substrate live on main).
-- SHADOW wiring LIVE on the real surface (STEP-6c): engine runs on real end-user requests, output written to
-  the audit log / `visa_decisions` ONLY, never rendered to the client. Until this is live there is no
-  evidence to measure, so the gate is trivially red.
+- the Bali Zero team has completed heavy manual SHADOW testing and signed off
+  the observed outcomes;
+- the current gold-persona replay has zero unexplained divergences;
+- current decisions carry valid, in-force citations and no ungrounded claims;
+- the kill switch has a current, independently reproducible rollback proof;
+- the DPIA is complete, signed and its residual privacy risks are accepted;
+- the real analytics destination/provider is identified and a fresh,
+  closed-schema 90-day TTL proof has been independently reproduced; and
+- Zero explicitly authorizes the ENFORCE flip after the preceding blockers
+  close.
 
-**The four criteria (ALL must be objectively green, measured from the SHADOW audit log):**
+**Current status: 🔴 NO-GO / SHADOW.** `CURRENT_STATE.md` records the DPIA,
+analytics-TTL proof and explicit ENFORCE authorization as open. Gold-persona
+divergences must also be resolved or accepted in writing against the active
+pack. No agent may deploy, activate a RulePack or change evaluation mode merely
+because this list appears green; each is a separate controlled action.
 
-- **G-a — VOLUME (threshold proposed + set by the session, per Zero's instruction).** ≥ **1,000** distinct
-  real end-user requests processed end-to-end by the engine in SHADOW (each producing a tri-state verdict +
-  an audit record), accumulated over a window of **≥ 7 consecutive days** (not a single-day burst — catches
-  day-boundary / regulatory-delta edges), AND with breadth ≥ **all 7 interview categories** exercised and
-  **≥ 30 distinct visa codes** hit (so the volume is not concentrated on 2–3 popular paths). Rationale: 1k
-  real requests over a week across ≥30 codes exercises the decision tree's live branches well beyond the 20
-  gold personas' designed cases, surfacing the long tail before any client sees an ENFORCE verdict.
-- **G-b — GOLD PERSONAS.** 20/20 gold personas replay through the engine with **zero unexplained
-  divergences** (any divergence from the expected verdict must have a written, accepted explanation — a
-  regulation change, a deliberate design correction — never an unexplained mismatch).
-- **G-c — GROUNDING.** Every SHADOW verdict in the window carries **valid citations** and **zero ungrounded
-  claims** (no verdict asserts a rule/number/eligibility without a resolvable, in-force source; abstention
-  where evidence is thin is a PASS, not a divergence).
-- **G-d — ROLLBACK PROVEN.** The ENFORCE→OFF rollback flag is **drilled and proven instantaneous** (a
-  recorded drill: flip ENFORCE, then flip back to OFF, confirm the public surface stops consulting the
-  engine immediately — no redeploy, no cache lag). ENFORCE is never armed without a proven kill-switch.
-
-**GATE STATUS: 🔴 RED (2026-07-28 — collection is LIVE and MEASURED; NEITHER of the two counted lanes can
-currently mature G-a, for two different reasons).** Receipt: `research/visa/2026-07-28-shadow-gate-measurement.md`
-(re-runnable SQL inline). Measured on prod `visa_decisions`: **1,483 rows / 14 distinct fingerprints /
-4 days / 3 categories / 0 distinct visa codes**, every row `HUMAN_REVIEW_REQUIRED` with an EMPTY
-`candidate_summary` — G-a red on every component.
-**The finding is a LANE ASYMMETRY, not a dead end.** On **RECOMMEND** (the `noindex` `/visa-oracle`, source
-of all 1,483 rows) `fact-mapper.ts:360` sends `person.nationalities: NOT_ASKED`, and the pack's GLOBAL rule
-`review.calling-visa` carries `on_unknown: HUMAN_REVIEW` (`rulepack-prod-001.source.json:1826-1845`) — a
-correct fail-safe meeting an interview that never asks. So that lane abstains by construction and its rows
-are worthless as breadth evidence. On **MATCH** (STEP-6c, the `/visa` funnel that HAS organic traffic) all
-three blockers are absent: it sets nationality from the 4-field submission (`shadow.py:242-268`), its
-fingerprint is `SHA-256` of a per-submission RANDOM token (`shadow.py:399`, `repository.py:115` — so its
-1,000-distinct threshold is traffic-bounded, NOT interview-bounded), and the collector counts it
-(`EVIDENCE_ENGINE_SURFACES={"MATCH","RECOMMEND"}`). It has ZERO rows because it is off: `fly secrets list`
-(run 07-28) shows TRUST_STORE / DRIVER_TOKEN / EVALUATE_MODE / FINGERPRINT_KEYS deployed and **no
-`VISA_ENGINE_MATCH_MODE`**, which defaults OFF (`shadow.py:207`). **⇒ BUT DO NOT JUST ARM IT — see the
-07-28 correction below: the MATCH writer does not label its rows, so they would land `traffic_source
-IS NULL` = legacy = counted toward NEITHER G-a gate. Arming alone is a **G-a** no-op (those rows DO
-still feed G-c, which is deliberately not split by provenance).** Also: 1,464 rows are THREE byte-identical payloads at 3-4s cadence, all labelled
-`traffic_source='real'` (the 07-27 contamination defect, 3 orders of magnitude larger) — G-a-vol is not
-measuring adoption until that label is split. **On ENFORCE, correcting a wrong first reading:** the
-authoritative render IS unbuilt (`resolve_response_mode()` returns literal `CURATED`,
-`evaluate_path.py:197`) and that is an unnamed prerequisite of the flip — but the **kill-switch is NOT
-inert** (OFF short-circuits before engine/pack/DB, `evaluate_path.py:554-556`; ENFORCE evaluates and
-persists), so **G-d is drillable TODAY**. G-b's replay still targets the gold FIXTURE pack
-(`gold_replay.py:160-170`), not the ACTIVE `446ee4ee`. The session updates
-this line as criteria go green,
-with the evidence pointer (audit-log query + gold-persona replay report + rollback-drill capture) for each.
-Evidence is collected from the SHADOW audit substrate; nothing here is self-attested — each green needs a
-re-runnable measurement (generator≠grader on G-b/G-c: the grader is not the engine).
-
-**Flip procedure (when GATE STATUS goes 🟢 all-green):** the session executes the flip itself, captures the
-before/after (flag state, a live ENFORCE verdict on a real request, the audit record), and reports the
-outcome to Zero — flip done + evidence, not a request for permission. Then it stands ready to execute the
-G-d rollback on any anomaly.
+Traffic provenance must stay explicit while evidence is collected. Only
+requests deliberately labelled `traffic_source=real` are organic evidence;
+synthetic lanes stay separate and legacy/NULL rows are not silently promoted
+to real traffic. This classification is diagnostic under the current ruling,
+not an automated ENFORCE threshold.
 
 ## Established truths (GROUND 2026-07-17, scout-verified file:line)
 


### PR DESCRIPTION
## Summary
- make the 2026-08-08 Zero ruling canonical in the Visa Oracle skill and current state
- remove the superseded automated volume gate and stale self-flip authorization
- preserve manual SHADOW validation, gold/citation/rollback evidence, DPIA, analytics TTL, and explicit Zero authorization as fail-closed blockers

## Independent review
- Fable 5 grader: SHIP
- verified the ruling at the canonical 2026-08-08 research record and checked later Visa documents for supersession
- verified stale pre-authorization text is removed and the current DPIA, TTL, and approval blockers remain intact

## Safety
- documentation-only; no runtime, RulePack, ENFORCE, data, secret, or deployment changes
- kept draft for exact-SHA CI and a fresh independent merge decision