### PR TITLE
docs(visa): disposition live gold divergences

### DIFF
--- a/research/visa/2026-08-15-gold-divergence-disposition.md
+++ b/research/visa/2026-08-15-gold-divergence-disposition.md
@@ -8,6 +8,8 @@ sources:
   - research/visa/2026-08-15-gold-family-refuter.md
   - apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
   - apps/backend-rag/backend/tests/services/visa_engine/_gold_fixtures.py
+  - https://github.com/Bali-Zero/Teman2/pull/4195
+  - https://github.com/Bali-Zero/Teman2/actions/runs/31828149383
 adversarial_review: kimi-k3
 status: DRAFT — proposed dispositions; no divergence accepted without owner or legal approval
 ---
@@ -26,6 +28,24 @@ The six matching personas (3, 4, 11, 12, 13 and 14) are enumerated in the
 2026-08-12 live report and are out of scope here except as stability witnesses
 under the replay contract.
 
+## Notice-dedupe deployment evidence
+
+PR #4195 merged at `2026-08-14T18:20:09Z` as exact merge commit
+`35494716abcfdb4bf7e104382cc2fef81ff3b2d7`. GitHub deploy workflow
+`31828149383` completed successfully for that same head SHA, and Fly release
+`4125` completed at `2026-08-14T18:27:38Z` with image
+`registry.fly.io/nuzantara-rag:deployment-01M00RA6VF7H915NWC055DTHPJ`.
+The read-only `fly image show --app nuzantara-rag --json` inspection on
+2026-08-15 resolved that tag on every listed machine to immutable digest
+`sha256:e075926299c082587fab4022f64127e5c3f3c8685e0389708931d3c81b1851fc`;
+the same image metadata carries OCI label
+`GH_SHA=35494716abcfdb4bf7e104382cc2fef81ff3b2d7`. This binds the deployed
+artifact, rather than only its release time, to the merge commit.
+
+This closes the merge/deployment prerequisite only. No fresh active-pack replay
+after that deployment is recorded here, so the affected rows remain unexplained
+and G-b remains RED.
+
 ## Correction to the first-read narrative
 
 The companion Markdown report said most divergences were “expected by
@@ -41,9 +61,9 @@ observation; this document narrows the interpretation.
 
 - **BLOCK — defect:** evidence identifies a fail-open rule defect; the row
   cannot be accepted as a catalogue change.
-- **CODE FIX PENDING MERGE:** a bounded implementation fix exists, but the row
-  stays unexplained until its exact merge SHA is deployed and a fresh replay
-  proves the effect.
+- **CODE FIX DEPLOYED; REPLAY PENDING:** the bounded implementation fix is
+  merged and deployed at a pinned revision, but the row stays unexplained until
+  a fresh active-pack replay proves the effect.
 - **OWNER/LEGAL DECISION:** the engine is behaving deterministically, but the
   repository does not contain authority to decide whether the live behavior or
   the fixture expectation is normative.
@@ -78,8 +98,8 @@ observation; this document narrows the interpretation.
 | 15 — tourism plus employment | Fixture supports only `E23`; seq-7 needs input because E23 does not cover the entire purpose set. | **SAFE-DIRECTION REVIEW + OWNER PRODUCT DECISION** | Choose whole-intent coverage or partial-candidate semantics for multi-purpose requests. If partial candidates are allowed, specify how unsupported purposes remain visible and non-authoritative. |
 | 16 — below investment threshold | Fixture rejects at one rupiah below its E28A minimum; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — NEGATIVE CONTROL, SUPPORT DIRECTION** | Legal approval is required because accepting D12 here changes route meaning. Do not describe this as a threshold bypass until route semantics are settled: D12 may be a different pre-investment visit route. Decide whether that substitution is allowed for an investment-intent request and prove it cannot be presented as investor-status eligibility. |
 | 17 — investor at fixture minimum | Fixture supports `E28A`; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — SUPPORT DIRECTION** | Reconcile the fixture's investment-capital model with the active pack's E28A facts and decide whether missing paid-up/role facts should yield input instead of a D12 substitution. Require positive E28A and D12 sibling-negative controls. |
-| 18 — obsolete code, incomplete purpose | Both sides need input; seq-7 emits three duplicate `OBSOLETE_PRODUCT_CODE` notices instead of one. | **CODE FIX PENDING MERGE** | PR #4195 aggregates successor source references into one notice. Keep the row unexplained until the exact merge/deploy is replayed and proves one notice with the complete reference union. |
-| 19 — obsolete code, complete tourism facts | Fixture supports `C1`; seq-7 supports `B1,C1`, and emits three duplicate notices. | **SPLIT: CODE FIX PENDING MERGE + OWNER PRODUCT DECISION** | PR #4195 addresses only notice multiplicity. Separately accept or reject B1 as a legitimate catalogue expansion for this persona; prove eligibility and a B1 sibling-negative control. |
+| 18 — obsolete code, incomplete purpose | Both sides need input; seq-7 emits three duplicate `OBSOLETE_PRODUCT_CODE` notices instead of one. | **CODE FIX DEPLOYED; REPLAY PENDING** | PR #4195 is merged and deployed at the pinned revision above and aggregates successor source references into one notice. Keep the row unexplained until a fresh replay proves one notice with the complete reference union. |
+| 19 — obsolete code, complete tourism facts | Fixture supports `C1`; seq-7 supports `B1,C1`, and emits three duplicate notices. | **SPLIT: CODE FIX DEPLOYED; REPLAY PENDING + OWNER PRODUCT DECISION** | PR #4195 addresses only notice multiplicity and is deployed at the pinned revision above. A fresh replay must prove that component; separately accept or reject B1 as a legitimate catalogue expansion for this persona and prove eligibility plus a B1 sibling-negative control. |
 | 20 — onshore conversion, status unknown | Fixture needs status/overstay input; seq-7 requires review for visit-to-ITK and bridging-to-bridging prohibitions. | **SAFE-DIRECTION REVIEW + OWNER/LEGAL DECISION** | Choose whether unknown current status must first request input or conservatively escalate. Bind the choice to a closed null/unknown policy and prove known-safe, known-prohibited and unknown witnesses. |
 
 ## Decision package and replay contract
@@ -119,26 +139,34 @@ The fresh active-pack replay must then:
 ## What can close without owner judgment
 
 Only the notice aggregation for persona 18 and the notice portion of persona
-19 currently have a bounded code fix. Even those are not closed by a green PR:
-they close only after merge, deployment and replay. Personas 7 and 8 are
-blocked defects. The remaining ten rows require explicit owner, legal, privacy
-or product semantics before an agent may edit expected outcomes or author the
-corresponding RulePack behavior.
+19 currently have a bounded code fix. Its exact merge and deployment are now
+proven above, but those components close only after a fresh active-pack replay
+proves the corrected notice union. Personas 7 and 8 are blocked defects. The
+remaining ten rows, plus the B1 component of persona 19, require explicit owner,
+legal, privacy or product semantics before an agent may edit expected outcomes
+or author the corresponding RulePack behavior.
 
 Until those conditions are met, the operationally correct state is **SHADOW / G-b
 RED / ENFORCE NO-GO**.
 
 ## Adversarial review
 
-Kimi K3 reviewed the complete non-PII draft through the repository's pinned
-no-tools wrapper and returned **SHIP-WITH-FIXES**. Both major findings were
-adopted: the status vocabulary now defines product, split and directional
-qualifiers without lowering legal approval for route meaning, and the replay
-stability floor no longer silently exempts E31 outcomes. The revision also
-adopts the review's exact generator/grader separation, enumerates the six
-matching stability witnesses and records the still-unassigned owner seats.
-Kimi's bounded second pass returned **SHIP** with no surviving findings.
+Kimi K3 reviewed the original non-PII draft, before the deployment-evidence
+section existed, through the repository's pinned no-tools wrapper and returned
+**SHIP-WITH-FIXES**. Both major findings were adopted: the status vocabulary now
+defines product, split and directional qualifiers without lowering legal
+approval for route meaning, and the replay stability floor no longer silently
+exempts E31 outcomes. That bounded second pass returned **SHIP** for the
+pre-deployment-evidence revision.
 
-The canonical pack hash was retained in this file and independently checked
-against the machine-readable report. It was masked only in the review transport
-because the wrapper's fail-closed PII filter rejects long numeric shapes.
+A fresh Kimi K3 delta review on 2026-08-15 covered the deployment-evidence
+section, the persona 18/19 status changes and the updated closure statement. It
+returned **SHIP-WITH-FIXES**. This revision adopts all four findings by scoping
+the older review, binding the Fly artifact with its immutable digest and
+`GH_SHA` label, reconciling the persona-19 B1 owner seat and downgrading the
+unattributed hash-check claim below. The bounded second pass returned **SHIP**
+with no surviving findings.
+
+The canonical pack hash in this file is copied from the cited machine-readable
+report. That provenance assertion is not a substitute for the named independent
+grader and deployed-revision checks required by the replay contract.

--- a/research/visa/2026-08-15-gold-divergence-disposition.md
+++ b/research/visa/2026-08-15-gold-divergence-disposition.md
@@ -5,7 +5,9 @@ client_case: none — Visa Oracle v2 G-b divergence disposition matrix
 sources:
   - research/visa/2026-08-12-gold-replay-live-report.json
   - research/visa/2026-08-12-gold-replay-live.md
+  - research/visa/2026-08-15-gold-replay-live-post-notice-report.json
   - research/visa/2026-08-15-gold-family-refuter.md
+  - apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
   - apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
   - apps/backend-rag/backend/tests/services/visa_engine/_gold_fixtures.py
   - https://github.com/Bali-Zero/Teman2/pull/4195
@@ -28,7 +30,7 @@ The six matching personas (3, 4, 11, 12, 13 and 14) are enumerated in the
 2026-08-12 live report and are out of scope here except as stability witnesses
 under the replay contract.
 
-## Notice-dedupe deployment evidence
+## Notice-dedupe deployment and live replay evidence
 
 PR #4195 merged at `2026-08-14T18:20:09Z` as exact merge commit
 `35494716abcfdb4bf7e104382cc2fef81ff3b2d7`. GitHub deploy workflow
@@ -42,9 +44,42 @@ the same image metadata carries OCI label
 `GH_SHA=35494716abcfdb4bf7e104382cc2fef81ff3b2d7`. This binds the deployed
 artifact, rather than only its release time, to the merge commit.
 
-This closes the merge/deployment prerequisite only. No fresh active-pack replay
-after that deployment is recorded here, so the affected rows remain unexplained
-and G-b remains RED.
+One live replay ran at `2026-08-14T19:09:23Z` against the deployment bound to
+merge commit `35494716abcfdb4bf7e104382cc2fef81ff3b2d7` by the digest and
+`GH_SHA` evidence above. At that exact revision, the cited runner implements a
+single sequential loop over the 20 personas, supplies
+`traffic_source=synthetic_gold`, has no retry loop, requires HTTP 200 before
+appending each decision, and aborts on any other status. The artifact records
+one completed invocation: the presence of all 20 persona
+decisions therefore supports a completed 20-response HTTP-200 batch with no
+intentionally organic request. These transport attributes derive from the
+pinned runner plus the complete report; they are not fields in the preserved
+JSON, and the artifact does not by itself prove whether a separate invocation
+was attempted. The byte-preserved report is
+`2026-08-15-gold-replay-live-post-notice-report.json`, SHA-256
+`24b9f1d5ca23a80981a268a4a58d16916fc8fa1af7fff9ecc5d54dcbf13eb80b`
+(the filename reflects its 2026-08-15 preservation date; the report's
+`generated_at` timestamp is authoritative). Every response named the same
+active sequence-7 pack and payload hash recorded above.
+
+The bounded notice component is now verified live: persona 18 has exactly one
+`OBSOLETE_PRODUCT_CODE` notice and matches its fixture in full; persona 19 also
+has exactly one such notice. The notice-dedupe component is therefore closed.
+
+G-b as a whole remains RED. The fresh report has only 5/20 matches and 15
+unexplained divergences: six personas now carry `DECISIVE_SOURCE_STALE`, and
+three carry `SAFETY_CRITICAL_SOURCE_STALE`. This replay does not erase the
+immutable 2026-08-12 observation or prove the underlying family/product rules
+safe. In particular, the stale-source holds currently mask the persona-7/8
+family candidates; they do not repair the fail-open sequence-7 predicates.
+
+Personas 11 and 14 were 2026-08-12 stability witnesses but moved from match to
+divergence in this fresh observation solely because each now carries
+`SAFETY_CRITICAL_SOURCE_STALE`. They are not added retroactively to the anchored
+14-row matrix. Their current disposition is source refresh followed by an
+independent replay: each must return to its fixture match or receive its own
+written disposition before a future G-b-green grading attempt. This observation
+does not imply an owner or product-semantics change for either persona.
 
 ## Correction to the first-read narrative
 
@@ -61,9 +96,9 @@ observation; this document narrows the interpretation.
 
 - **BLOCK — defect:** evidence identifies a fail-open rule defect; the row
   cannot be accepted as a catalogue change.
-- **CODE FIX DEPLOYED; REPLAY PENDING:** the bounded implementation fix is
-  merged and deployed at a pinned revision, but the row stays unexplained until
-  a fresh active-pack replay proves the effect.
+- **CODE FIX VERIFIED LIVE — CLOSED COMPONENT:** the bounded implementation fix
+  is merged, deployed at a pinned revision and proven by a fresh active-pack
+  replay. This closes only the named component, never unrelated row deltas.
 - **OWNER/LEGAL DECISION:** the engine is behaving deterministically, but the
   repository does not contain authority to decide whether the live behavior or
   the fixture expectation is normative.
@@ -98,8 +133,8 @@ observation; this document narrows the interpretation.
 | 15 — tourism plus employment | Fixture supports only `E23`; seq-7 needs input because E23 does not cover the entire purpose set. | **SAFE-DIRECTION REVIEW + OWNER PRODUCT DECISION** | Choose whole-intent coverage or partial-candidate semantics for multi-purpose requests. If partial candidates are allowed, specify how unsupported purposes remain visible and non-authoritative. |
 | 16 — below investment threshold | Fixture rejects at one rupiah below its E28A minimum; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — NEGATIVE CONTROL, SUPPORT DIRECTION** | Legal approval is required because accepting D12 here changes route meaning. Do not describe this as a threshold bypass until route semantics are settled: D12 may be a different pre-investment visit route. Decide whether that substitution is allowed for an investment-intent request and prove it cannot be presented as investor-status eligibility. |
 | 17 — investor at fixture minimum | Fixture supports `E28A`; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — SUPPORT DIRECTION** | Reconcile the fixture's investment-capital model with the active pack's E28A facts and decide whether missing paid-up/role facts should yield input instead of a D12 substitution. Require positive E28A and D12 sibling-negative controls. |
-| 18 — obsolete code, incomplete purpose | Both sides need input; seq-7 emits three duplicate `OBSOLETE_PRODUCT_CODE` notices instead of one. | **CODE FIX DEPLOYED; REPLAY PENDING** | PR #4195 is merged and deployed at the pinned revision above and aggregates successor source references into one notice. Keep the row unexplained until a fresh replay proves one notice with the complete reference union. |
-| 19 — obsolete code, complete tourism facts | Fixture supports `C1`; seq-7 supports `B1,C1`, and emits three duplicate notices. | **SPLIT: CODE FIX DEPLOYED; REPLAY PENDING + OWNER PRODUCT DECISION** | PR #4195 addresses only notice multiplicity and is deployed at the pinned revision above. A fresh replay must prove that component; separately accept or reject B1 as a legitimate catalogue expansion for this persona and prove eligibility plus a B1 sibling-negative control. |
+| 18 — obsolete code, incomplete purpose | Both sides need input; seq-7 emits three duplicate `OBSOLETE_PRODUCT_CODE` notices instead of one. | **CODE FIX VERIFIED LIVE — CLOSED COMPONENT** | PR #4195 is merged and deployed at the pinned revision above. The 2026-08-15 live replay proves exactly one `OBSOLETE_PRODUCT_CODE` notice and a full fixture match, including the notice-code set, for persona 18. |
+| 19 — obsolete code, complete tourism facts | Fixture supports `C1`; seq-7 supports `B1,C1`, and emits three duplicate notices. | **SPLIT: NOTICE FIX VERIFIED LIVE — CLOSED COMPONENT + OWNER PRODUCT DECISION** | The 2026-08-15 live replay proves exactly one notice, closing only notice multiplicity. Its stale-source hold masks the former candidate set, so it neither accepts nor rejects B1 as a catalogue expansion; that decision still needs eligibility evidence and a B1 sibling-negative control after source freshness is restored. |
 | 20 — onshore conversion, status unknown | Fixture needs status/overstay input; seq-7 requires review for visit-to-ITK and bridging-to-bridging prohibitions. | **SAFE-DIRECTION REVIEW + OWNER/LEGAL DECISION** | Choose whether unknown current status must first request input or conservatively escalate. Bind the choice to a closed null/unknown policy and prove known-safe, known-prohibited and unknown witnesses. |
 
 ## Decision package and replay contract
@@ -121,7 +156,7 @@ Owner seats remain pending assignment for personas 1, 2, 5, 6, 9, 10, 15,
 repository records a named accountable owner, plus legal or privacy approval
 where applicable.
 
-The fresh active-pack replay must then:
+A replay that could eventually turn G-b green must:
 
 - regenerate all 20 rows without mutating the 2026-08-12 observation;
 - contain zero unexplained divergences and no duplicated obsolete-code notice;
@@ -139,12 +174,14 @@ The fresh active-pack replay must then:
 ## What can close without owner judgment
 
 Only the notice aggregation for persona 18 and the notice portion of persona
-19 currently have a bounded code fix. Its exact merge and deployment are now
-proven above, but those components close only after a fresh active-pack replay
-proves the corrected notice union. Personas 7 and 8 are blocked defects. The
-remaining ten rows, plus the B1 component of persona 19, require explicit owner,
-legal, privacy or product semantics before an agent may edit expected outcomes
-or author the corresponding RulePack behavior.
+19 currently have a bounded code fix. Exact merge, deployment and fresh live
+replay now close those notice components. They do not close persona 19's product
+semantics or G-b. Personas 7 and 8 remain blocked defects even though current
+stale-source holds mask their unsafe candidates. The remaining ten rows, plus
+the B1 component of persona 19, require explicit owner, legal, privacy or product
+semantics before an agent may edit expected outcomes or author the corresponding
+RulePack behavior. The new stale-source divergences are operational evidence to
+refresh and re-verify sources, not permission to accept new fixture outcomes.
 
 Until those conditions are met, the operationally correct state is **SHADOW / G-b
 RED / ENFORCE NO-GO**.
@@ -166,6 +203,20 @@ the older review, binding the Fly artifact with its immutable digest and
 `GH_SHA` label, reconciling the persona-19 B1 owner seat and downgrading the
 unattributed hash-check claim below. The bounded second pass returned **SHIP**
 with no surviving findings.
+
+A further Kimi K3 delta review covered the post-deployment live replay, its
+preserved JSON artifact and the resulting closure wording. It returned
+**SHIP-WITH-FIXES**. This revision adopts all four findings: transport
+attributes are now derived explicitly from the pinned runner plus the complete
+report rather than attributed to absent JSON fields; personas 11 and 14 receive
+explicit fresh-observation dispositions; deployed-revision linkage is stated in
+the correct direction; and the report filename date is distinguished from its
+authoritative run timestamp.
+The bounded second pass confirmed those four closures and returned
+**SHIP-WITH-FIXES** for one residual phrase that attributed the notice reference
+union to a report schema containing only notice codes. Row 18 now claims only
+what the JSON carries. The final bounded pass returned **SHIP** with no
+surviving findings.
 
 The canonical pack hash in this file is copied from the cited machine-readable
 report. That provenance assertion is not a substitute for the named independent

--- a/research/visa/2026-08-15-gold-divergence-disposition.md
+++ b/research/visa/2026-08-15-gold-divergence-disposition.md
@@ -6,6 +6,7 @@ sources:
   - research/visa/2026-08-12-gold-replay-live-report.json
   - research/visa/2026-08-12-gold-replay-live.md
   - research/visa/2026-08-15-gold-replay-live-post-notice-report.json
+  - research/visa/2026-08-15-shadow-evidence-post-notice.json
   - research/visa/2026-08-15-gold-family-refuter.md
   - apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
   - apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
@@ -61,6 +62,26 @@ was attempted. The byte-preserved report is
 (the filename reflects its 2026-08-15 preservation date; the report's
 `generated_at` timestamp is authoritative). Every response named the same
 active sequence-7 pack and payload hash recorded above.
+
+The production collector was then run read-only for the bounded window
+`[2026-08-14T18:27:38Z, 2026-08-14T19:20:30Z)`. Its byte-preserved,
+aggregate-only report is `2026-08-15-shadow-evidence-post-notice.json`,
+SHA-256
+`5fc1659fe4e20f05a0826623433352108a2fa50399cfdf61f2528f8df27f041c`.
+It reports exactly 20 audit rows and — per its G-a-breadth counters
+(`distinct_requests=20`, `missing_request_fingerprints=0`) — 20 distinct request
+fingerprints, all on the `RECOMMEND` surface with
+`traffic_source=synthetic_gold`; `real`, `synthetic_driver` and legacy counts are
+zero, and duplicate evaluations are zero. This independently confirms
+bounded-window traffic attribution and the absence of any extra persisted replay
+row; it does not claim visibility into a transport attempt that produced no
+audit row.
+
+The same aggregate report remains fail-closed: `enforce_ready=false`, overall
+gate status RED, G-a-volume/G-a-breadth/G-c RED, and G-b/G-d UNMEASURED. In
+particular, its G-c counters retain one decision without citations, two malformed
+grounding summaries and three ungrounded claims. Those are blockers, not a
+reason to reinterpret an HTTP-200 response as grounded or legally verified.
 
 The bounded notice component is now verified live: persona 18 has exactly one
 `OBSOLETE_PRODUCT_CODE` notice and matches its fixture in full; persona 19 also
@@ -217,6 +238,17 @@ The bounded second pass confirmed those four closures and returned
 union to a report schema containing only notice codes. Row 18 now claims only
 what the JSON carries. The final bounded pass returned **SHIP** with no
 surviving findings.
+
+The later aggregate-only collector artifact and its bounded interpretation are
+a separate evidence delta. Kimi K3 reviewed a PII-gate-safe projection that
+omitted only the two long-decimal `window_duration_hours` values and the artifact
+SHA-256 string; it returned **SHIP-WITH-FIXES**. This revision adopts both
+findings by tracing the distinct-fingerprint derivation and making the review
+boundary explicit. The bounded Kimi re-review returned **SHIP** with no
+surviving findings. The byte-exact artifact and its SHA-256 binding remain
+subject to a separate Fable review; the projection-based Kimi pass cannot
+discharge it. This delta does not change the earlier SHIP verdict or any gate
+state.
 
 The canonical pack hash in this file is copied from the cited machine-readable
 report. That provenance assertion is not a substitute for the named independent

--- a/research/visa/2026-08-15-gold-divergence-disposition.md
+++ b/research/visa/2026-08-15-gold-divergence-disposition.md
@@ -1,0 +1,144 @@
+---
+date: 2026-08-15
+domain: visa
+client_case: none — Visa Oracle v2 G-b divergence disposition matrix
+sources:
+  - research/visa/2026-08-12-gold-replay-live-report.json
+  - research/visa/2026-08-12-gold-replay-live.md
+  - research/visa/2026-08-15-gold-family-refuter.md
+  - apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
+  - apps/backend-rag/backend/tests/services/visa_engine/_gold_fixtures.py
+adversarial_review: kimi-k3
+status: DRAFT — proposed dispositions; no divergence accepted without owner or legal approval
+---
+
+# Visa Oracle G-b divergence disposition matrix
+
+**Evidence scope:** the first live replay of the 20 canonical personas against
+active RulePack sequence 7 (`2026.8.11`, payload SHA-256
+`3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82`).
+
+**Measured result:** 6/20 matches and 14 unexplained divergences. **G-b remains
+RED.** This document classifies the work needed to dispose of each divergence;
+it does not retroactively edit the immutable live report, approve a legal
+interpretation, change a RulePack, authorize activation, or make ENFORCE ready.
+The six matching personas (3, 4, 11, 12, 13 and 14) are enumerated in the
+2026-08-12 live report and are out of scope here except as stability witnesses
+under the replay contract.
+
+## Correction to the first-read narrative
+
+The companion Markdown report said most divergences were “expected by
+construction” before the active rules had been inspected. That is too broad.
+Catalogue differences can explain a changed candidate set only after the new
+candidate's predicates, legal basis and product semantics are independently
+accepted. The sequence-7 inspection has already refuted that presumption for
+personas 7 and 8, and the D12 substitutions in personas 9, 10, 16 and 17 still
+need an owner/legal decision. The machine-readable replay remains the canonical
+observation; this document narrows the interpretation.
+
+## Status vocabulary
+
+- **BLOCK — defect:** evidence identifies a fail-open rule defect; the row
+  cannot be accepted as a catalogue change.
+- **CODE FIX PENDING MERGE:** a bounded implementation fix exists, but the row
+  stays unexplained until its exact merge SHA is deployed and a fresh replay
+  proves the effect.
+- **OWNER/LEGAL DECISION:** the engine is behaving deterministically, but the
+  repository does not contain authority to decide whether the live behavior or
+  the fixture expectation is normative.
+- **OWNER PRODUCT DECISION:** a subtype of OWNER/LEGAL DECISION used only where
+  the open question is catalogue or product semantics and no legal
+  discriminator, guardian handling, bridging behavior or route meaning
+  changes. If route meaning is affected, legal approval is also required.
+- **SAFE-DIRECTION REVIEW:** the live result abstains more than the fixture.
+  This lowers immediate automation risk, but it is not an automatic G-b pass;
+  owner/legal must still accept the semantics and user experience.
+- **SPLIT:** a row with independently disposable components. Each component
+  carries its own status and closes only under its own criteria; the row stays
+  unexplained until every component is closed.
+- **SUPPORT DIRECTION:** a qualifier marking that the live engine supports a
+  candidate the fixture did not. It is never a standalone status or evidence
+  of correctness.
+- **NEGATIVE CONTROL:** a qualifier requiring a witness that proves the
+  deciding fact's absence changes the result. It is never a standalone status.
+
+## Complete 14-row matrix
+
+| Persona | Observed divergence | Proposed status | Evidence and decision required |
+|---|---|---|---|
+| 1 — Indonesian citizen | Fixture `NO_SUPPORTED_PATH / APPLICANT_IS_INDONESIAN_CITIZEN`; seq-7 `HUMAN_REVIEW_REQUIRED / CITIZENSHIP_LIST_DIVERGENCE`. | **SAFE-DIRECTION REVIEW + OWNER/LEGAL DECISION** | Confirm whether conflicting citizenship-list evidence must outrank the citizen hard filter. If accepted, update the expected state and reason vocabulary explicitly; otherwise add precedence proof that the hard filter wins. |
+| 2 — conflicting nationality | Both sides require review, but fixture says `CITIZENSHIP_EVIDENCE_CONFLICT`; seq-7 says `CALLING_VISA_REVIEW` plus `CITIZENSHIP_LIST_DIVERGENCE`. | **OWNER/LEGAL DECISION** | Approve the canonical review reasons and their precedence. A same-state result is not a match when the legal escalation reason changes. |
+| 5 — minor, guardian unconfirmed | Both sides require review; seq-7 adds `MINOR_GUARDIAN_PRIVACY_REVIEW`. | **SAFE-DIRECTION REVIEW + OWNER/LEGAL DECISION** | Decide whether the privacy hold is always additive or only applies under a narrower guardian/data condition. Preserve the existing missing-guardian protection. |
+| 6 — minor, guardian confirmed | Fixture supports `E31`; seq-7 requires `MINOR_GUARDIAN_PRIVACY_REVIEW`. | **SAFE-DIRECTION REVIEW + OWNER/LEGAL DECISION** | Decide whether a confirmed guardian can ever clear the privacy hold and which affirmative consent/evidence facts are required. Do not remove the hold from a rule-pack edit without an approved privacy interpretation and positive/negative controls. |
+| 7 — adult spouse, marriage registered | Fixture supports `E31`; seq-7 supports `C1,E31A,E31B,E31D`. | **BLOCK — DEFECT** | The E31B predicate accepts sponsor status `NONE`, and the E31D family supports on FAMILY intent without the named relationship evidence. The authoritative diagnosis and repair criteria are in `2026-08-15-gold-family-refuter.md`. |
+| 8 — adult spouse, marriage unverified | Fixture needs input; seq-7 supports `C1,E31D`. | **BLOCK — DEFECT** | Same E31D fail-open family as persona 7. No explanation may accept this row until approved family facts, a signed successor pack and an independent active-pack replay prove the repair. |
+| 9 — investor, direct onshore | Fixture rejects direct onshore conversion; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — SUPPORT DIRECTION** | Decide whether D12 is a legitimate alternative visit route or must be excluded when the requested process is direct onshore conversion. Reconcile `process.application_channel` with `process.wants_onshore_conversion`; prove the chosen signal changes the outcome. |
+| 10 — investor, status bridging | Fixture requires `STATUS_BRIDGING_REVIEW`; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — SUPPORT DIRECTION** | Decide whether a visit route may be proposed when the requested workflow is status bridging. Define the authoritative process fact and unknown/null behavior; add a sibling-negative witness. |
+| 15 — tourism plus employment | Fixture supports only `E23`; seq-7 needs input because E23 does not cover the entire purpose set. | **SAFE-DIRECTION REVIEW + OWNER PRODUCT DECISION** | Choose whole-intent coverage or partial-candidate semantics for multi-purpose requests. If partial candidates are allowed, specify how unsupported purposes remain visible and non-authoritative. |
+| 16 — below investment threshold | Fixture rejects at one rupiah below its E28A minimum; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — NEGATIVE CONTROL, SUPPORT DIRECTION** | Legal approval is required because accepting D12 here changes route meaning. Do not describe this as a threshold bypass until route semantics are settled: D12 may be a different pre-investment visit route. Decide whether that substitution is allowed for an investment-intent request and prove it cannot be presented as investor-status eligibility. |
+| 17 — investor at fixture minimum | Fixture supports `E28A`; seq-7 supports `D12`. | **OWNER/LEGAL DECISION — SUPPORT DIRECTION** | Reconcile the fixture's investment-capital model with the active pack's E28A facts and decide whether missing paid-up/role facts should yield input instead of a D12 substitution. Require positive E28A and D12 sibling-negative controls. |
+| 18 — obsolete code, incomplete purpose | Both sides need input; seq-7 emits three duplicate `OBSOLETE_PRODUCT_CODE` notices instead of one. | **CODE FIX PENDING MERGE** | PR #4195 aggregates successor source references into one notice. Keep the row unexplained until the exact merge/deploy is replayed and proves one notice with the complete reference union. |
+| 19 — obsolete code, complete tourism facts | Fixture supports `C1`; seq-7 supports `B1,C1`, and emits three duplicate notices. | **SPLIT: CODE FIX PENDING MERGE + OWNER PRODUCT DECISION** | PR #4195 addresses only notice multiplicity. Separately accept or reject B1 as a legitimate catalogue expansion for this persona; prove eligibility and a B1 sibling-negative control. |
+| 20 — onshore conversion, status unknown | Fixture needs status/overstay input; seq-7 requires review for visit-to-ITK and bridging-to-bridging prohibitions. | **SAFE-DIRECTION REVIEW + OWNER/LEGAL DECISION** | Choose whether unknown current status must first request input or conservatively escalate. Bind the choice to a closed null/unknown policy and prove known-safe, known-prohibited and unknown witnesses. |
+
+## Decision package and replay contract
+
+For any row to move from “unexplained” to “accepted explanation,” its linked
+decision must record:
+
+1. the exact persona, active pack identity and observed delta;
+2. the accountable owner, plus legal/privacy approval where the row changes a
+   legal discriminator, guardian handling, bridging behavior or route meaning;
+3. whether the fixture expectation changes or code/RulePack behavior changes,
+   with the approved reason and product semantics;
+4. at least one positive witness and one sibling-negative or metamorphic
+   witness showing that the deciding fact actually controls the result; and
+5. the exact code/pack SHA, CI evidence and independent grader identity.
+
+Owner seats remain pending assignment for personas 1, 2, 5, 6, 9, 10, 15,
+16, 17, the B1 component of 19, and 20. No decision is valid until the
+repository records a named accountable owner, plus legal or privacy approval
+where applicable.
+
+The fresh active-pack replay must then:
+
+- regenerate all 20 rows without mutating the 2026-08-12 observation;
+- contain zero unexplained divergences and no duplicated obsolete-code notice;
+- prove personas 7 and 8 no longer manufacture E31B/E31D from unrelated or
+  missing family facts;
+- prove the approved D12/onshore and multi-purpose semantics explicitly;
+- keep every previously matching outcome stable unless it has its own written
+  disposition. Any E31-specific stability exemption must itself name its
+  scope, accountable owner and expiry before the replay is graded; and
+- be graded by an agent that is neither the author of the code, RulePack or
+  fixture changes nor the generator of the replay artifact, and belongs to a
+  different model family from both where cross-family grading is required. The
+  grading must pin the exact signed payload hash and deployed revision.
+
+## What can close without owner judgment
+
+Only the notice aggregation for persona 18 and the notice portion of persona
+19 currently have a bounded code fix. Even those are not closed by a green PR:
+they close only after merge, deployment and replay. Personas 7 and 8 are
+blocked defects. The remaining ten rows require explicit owner, legal, privacy
+or product semantics before an agent may edit expected outcomes or author the
+corresponding RulePack behavior.
+
+Until those conditions are met, the operationally correct state is **SHADOW / G-b
+RED / ENFORCE NO-GO**.
+
+## Adversarial review
+
+Kimi K3 reviewed the complete non-PII draft through the repository's pinned
+no-tools wrapper and returned **SHIP-WITH-FIXES**. Both major findings were
+adopted: the status vocabulary now defines product, split and directional
+qualifiers without lowering legal approval for route meaning, and the replay
+stability floor no longer silently exempts E31 outcomes. The revision also
+adopts the review's exact generator/grader separation, enumerates the six
+matching stability witnesses and records the still-unassigned owner seats.
+Kimi's bounded second pass returned **SHIP** with no surviving findings.
+
+The canonical pack hash was retained in this file and independently checked
+against the machine-readable report. It was masked only in the review transport
+because the wrapper's fail-closed PII filter rejects long numeric shapes.

--- a/research/visa/2026-08-15-gold-replay-live-post-notice-report.json
+++ b/research/visa/2026-08-15-gold-replay-live-post-notice-report.json
@@ -1,0 +1,1022 @@
+{
+  "gate": "G-b",
+  "generated_at": "2026-08-14T19:09:23.009037+00:00",
+  "mode": "live",
+  "overall_pass": false,
+  "pack": {
+    "consistent_across_personas": true,
+    "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+    "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+    "sequence": 7,
+    "version": "2026.8.11"
+  },
+  "pack_source": {
+    "endpoint": "https://nuzantara-rag.fly.dev/api/visa-oracle/evaluate",
+    "kind": "live_endpoint",
+    "pack_metadata_source": "each endpoint response decision.rule_pack"
+  },
+  "packs_observed": [
+    {
+      "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+      "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+      "sequence": 7,
+      "version": "2026.8.11"
+    }
+  ],
+  "persona_count": 20,
+  "personas": [
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "CITIZENSHIP_LIST_DIVERGENCE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "APPLICANT_IS_INDONESIAN_CITIZEN"
+          ],
+          "field": "no_path_reason_codes",
+          "persona_id": 1
+        },
+        {
+          "actual": [
+            "CITIZENSHIP_LIST_DIVERGENCE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 1
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "NO_SUPPORTED_PATH",
+          "field": "state",
+          "persona_id": 1
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [
+          "APPLICANT_IS_INDONESIAN_CITIZEN"
+        ],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NO_SUPPORTED_PATH"
+      },
+      "explanation": null,
+      "label": "ID citizen excluded outright",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 1
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "CALLING_VISA_REVIEW",
+          "CITIZENSHIP_LIST_DIVERGENCE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [
+            "CALLING_VISA_REVIEW",
+            "CITIZENSHIP_LIST_DIVERGENCE"
+          ],
+          "expected": [
+            "CITIZENSHIP_EVIDENCE_CONFLICT"
+          ],
+          "field": "review_reason_codes",
+          "persona_id": 2
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "CITIZENSHIP_EVIDENCE_CONFLICT"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "explanation": null,
+      "label": "conflicting nationality evidence -> human review",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 2
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "CALLING_VISA_REVIEW"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [],
+      "divergence": false,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "CALLING_VISA_REVIEW"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "explanation": null,
+      "label": "calling-visa nationality -> human review",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 3
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "ACTIVE_OVERSTAY"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [],
+      "divergence": false,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "ACTIVE_OVERSTAY"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "explanation": null,
+      "label": "active overstay -> human review",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 4
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "MINOR_WITHOUT_CONFIRMED_GUARDIAN",
+          "MINOR_GUARDIAN_PRIVACY_REVIEW"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [
+            "MINOR_WITHOUT_CONFIRMED_GUARDIAN",
+            "MINOR_GUARDIAN_PRIVACY_REVIEW"
+          ],
+          "expected": [
+            "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+          ],
+          "field": "review_reason_codes",
+          "persona_id": 5
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "explanation": null,
+      "label": "minor without confirmed guardian -> human review",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 5
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "MINOR_GUARDIAN_PRIVACY_REVIEW"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "E31"
+          ],
+          "field": "candidate_products",
+          "persona_id": 6
+        },
+        {
+          "actual": [
+            "MINOR_GUARDIAN_PRIVACY_REVIEW"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 6
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "SUPPORTED_CANDIDATES",
+          "field": "state",
+          "persona_id": 6
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [
+          "E31"
+        ],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "SUPPORTED_CANDIDATES"
+      },
+      "explanation": null,
+      "label": "minor child with confirmed family sponsor -> E31",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 6
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "DECISIVE_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "E31"
+          ],
+          "field": "candidate_products",
+          "persona_id": 7
+        },
+        {
+          "actual": [
+            "DECISIVE_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 7
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "SUPPORTED_CANDIDATES",
+          "field": "state",
+          "persona_id": 7
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [
+          "E31"
+        ],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "SUPPORTED_CANDIDATES"
+      },
+      "explanation": null,
+      "label": "adult spouse, registered marriage, confirmed sponsor -> E31",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 7
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "DECISIVE_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "family.marriage_registered"
+          ],
+          "field": "missing_facts",
+          "persona_id": 8
+        },
+        {
+          "actual": [
+            "DECISIVE_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 8
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "NEEDS_INPUT",
+          "field": "state",
+          "persona_id": 8
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [
+          "family.marriage_registered"
+        ],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NEEDS_INPUT"
+      },
+      "explanation": null,
+      "label": "same as #7 but marriage_registered unverified -> needs input",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 8
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "DECISIVE_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "DIRECT_ONSHORE_CONVERSION_UNSUPPORTED"
+          ],
+          "field": "no_path_reason_codes",
+          "persona_id": 9
+        },
+        {
+          "actual": [
+            "DECISIVE_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 9
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "NO_SUPPORTED_PATH",
+          "field": "state",
+          "persona_id": 9
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [
+          "DIRECT_ONSHORE_CONVERSION_UNSUPPORTED"
+        ],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NO_SUPPORTED_PATH"
+      },
+      "explanation": null,
+      "label": "investor direct onshore conversion -> unsupported",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 9
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "DECISIVE_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [
+            "DECISIVE_SOURCE_STALE"
+          ],
+          "expected": [
+            "STATUS_BRIDGING_REVIEW"
+          ],
+          "field": "review_reason_codes",
+          "persona_id": 10
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "STATUS_BRIDGING_REVIEW"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "explanation": null,
+      "label": "same investor facts via status bridging -> human review",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 10
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "SAFETY_CRITICAL_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "E33G"
+          ],
+          "field": "candidate_products",
+          "persona_id": 11
+        },
+        {
+          "actual": [
+            "SAFETY_CRITICAL_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 11
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "SUPPORTED_CANDIDATES",
+          "field": "state",
+          "persona_id": 11
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [
+          "E33G"
+        ],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "SUPPORTED_CANDIDATES"
+      },
+      "explanation": null,
+      "label": "clean remote worker, no local footprint -> E33G",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 11
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "LOCAL_MARKET_ACTIVITY_REVIEW"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [],
+      "divergence": false,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "LOCAL_MARKET_ACTIVITY_REVIEW"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "explanation": null,
+      "label": "remote worker serving Indonesian clients -> human review",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 12
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [
+          "work.serves_indonesian_clients"
+        ],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NEEDS_INPUT"
+      },
+      "differences": [],
+      "divergence": false,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [
+          "work.serves_indonesian_clients"
+        ],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NEEDS_INPUT"
+      },
+      "explanation": null,
+      "label": "remote worker, local-clients fact unprovided -> needs input",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 13
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "SAFETY_CRITICAL_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "E33G"
+          ],
+          "field": "candidate_products",
+          "persona_id": 14
+        },
+        {
+          "actual": [
+            "SAFETY_CRITICAL_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 14
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "SUPPORTED_CANDIDATES",
+          "field": "state",
+          "persona_id": 14
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [
+          "E33G"
+        ],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "SUPPORTED_CANDIDATES"
+      },
+      "explanation": null,
+      "label": "tourism + remote-work purposes -> E33G only, never C1",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 14
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [
+          "intent.requested_product_code"
+        ],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NEEDS_INPUT"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "E23"
+          ],
+          "field": "candidate_products",
+          "persona_id": 15
+        },
+        {
+          "actual": [
+            "intent.requested_product_code"
+          ],
+          "expected": [],
+          "field": "missing_facts",
+          "persona_id": 15
+        },
+        {
+          "actual": "NEEDS_INPUT",
+          "expected": "SUPPORTED_CANDIDATES",
+          "field": "state",
+          "persona_id": 15
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [
+          "E23"
+        ],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "SUPPORTED_CANDIDATES"
+      },
+      "explanation": null,
+      "label": "tourism + employment purposes -> E23 only, never C1",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 15
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "DECISIVE_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "INVESTMENT_CAPITAL_BELOW_FIXTURE_MINIMUM"
+          ],
+          "field": "no_path_reason_codes",
+          "persona_id": 16
+        },
+        {
+          "actual": [
+            "DECISIVE_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 16
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "NO_SUPPORTED_PATH",
+          "field": "state",
+          "persona_id": 16
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [
+          "INVESTMENT_CAPITAL_BELOW_FIXTURE_MINIMUM"
+        ],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NO_SUPPORTED_PATH"
+      },
+      "explanation": null,
+      "label": "investor capital 1 IDR below minimum -> no supported path",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 16
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "DECISIVE_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "E28A"
+          ],
+          "field": "candidate_products",
+          "persona_id": 17
+        },
+        {
+          "actual": [
+            "DECISIVE_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 17
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "SUPPORTED_CANDIDATES",
+          "field": "state",
+          "persona_id": 17
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [
+          "E28A"
+        ],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "SUPPORTED_CANDIDATES"
+      },
+      "explanation": null,
+      "label": "investor at fixture minimum, low budget never filters -> E28A",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 17
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [
+          "intent.purposes"
+        ],
+        "no_path_reason_codes": [],
+        "notice_codes": [
+          "OBSOLETE_PRODUCT_CODE"
+        ],
+        "review_reason_codes": [],
+        "state": "NEEDS_INPUT"
+      },
+      "differences": [],
+      "divergence": false,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [
+          "intent.purposes"
+        ],
+        "no_path_reason_codes": [],
+        "notice_codes": [
+          "OBSOLETE_PRODUCT_CODE"
+        ],
+        "review_reason_codes": [],
+        "state": "NEEDS_INPUT"
+      },
+      "explanation": null,
+      "label": "obsolete code requested, purposes not provided -> needs input + notice",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 18
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [
+          "OBSOLETE_PRODUCT_CODE"
+        ],
+        "review_reason_codes": [
+          "SAFETY_CRITICAL_SOURCE_STALE"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "C1"
+          ],
+          "field": "candidate_products",
+          "persona_id": 19
+        },
+        {
+          "actual": [
+            "SAFETY_CRITICAL_SOURCE_STALE"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 19
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "SUPPORTED_CANDIDATES",
+          "field": "state",
+          "persona_id": 19
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [
+          "C1"
+        ],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [
+          "OBSOLETE_PRODUCT_CODE"
+        ],
+        "review_reason_codes": [],
+        "state": "SUPPORTED_CANDIDATES"
+      },
+      "explanation": null,
+      "label": "obsolete code requested, complete tourism facts -> C1 + notice",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 19
+    },
+    {
+      "actual": {
+        "candidate_products": [],
+        "missing_facts": [],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [
+          "BRIDGING_FROM_VISIT_ITK_PROHIBITED",
+          "BRIDGING_TO_BRIDGING_PROHIBITED"
+        ],
+        "state": "HUMAN_REVIEW_REQUIRED"
+      },
+      "differences": [
+        {
+          "actual": [],
+          "expected": [
+            "immigration.current_status_code",
+            "immigration.overstay_days"
+          ],
+          "field": "missing_facts",
+          "persona_id": 20
+        },
+        {
+          "actual": [
+            "BRIDGING_FROM_VISIT_ITK_PROHIBITED",
+            "BRIDGING_TO_BRIDGING_PROHIBITED"
+          ],
+          "expected": [],
+          "field": "review_reason_codes",
+          "persona_id": 20
+        },
+        {
+          "actual": "HUMAN_REVIEW_REQUIRED",
+          "expected": "NEEDS_INPUT",
+          "field": "state",
+          "persona_id": 20
+        }
+      ],
+      "divergence": true,
+      "expected": {
+        "candidate_products": [],
+        "missing_facts": [
+          "immigration.current_status_code",
+          "immigration.overstay_days"
+        ],
+        "no_path_reason_codes": [],
+        "notice_codes": [],
+        "review_reason_codes": [],
+        "state": "NEEDS_INPUT"
+      },
+      "explanation": null,
+      "label": "onshore conversion wanted, status+overstay both unprovided",
+      "pack": {
+        "payload_sha256": "3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82",
+        "rule_pack_id": "453ee842-7f35-5d77-b460-31d67e2784c2",
+        "sequence": 7,
+        "version": "2026.8.11"
+      },
+      "persona_id": 20
+    }
+  ],
+  "report_schema_version": "1.0.0",
+  "summary": {
+    "explained_divergences": 0,
+    "personas_match": 5,
+    "personas_total": 20,
+    "personas_with_divergence": 15,
+    "unexplained_divergences": 15
+  }
+}

--- a/research/visa/2026-08-15-shadow-evidence-post-notice.json
+++ b/research/visa/2026-08-15-shadow-evidence-post-notice.json
@@ -1,0 +1,155 @@
+{
+  "blockers": [
+    "G-a-vol",
+    "G-a-breadth",
+    "G-c",
+    "G-b",
+    "G-d"
+  ],
+  "enforce_ready": false,
+  "gate_status": "RED",
+  "gates": {
+    "G-a-breadth": {
+      "active_utc_days": 1,
+      "category_counts": {
+        "family": 3,
+        "investor": 4,
+        "long_tourism": 7,
+        "other": 3,
+        "work_remote": 3
+      },
+      "distinct_requests": 20,
+      "distinct_visa_codes": 0,
+      "duplicate_evaluations": 0,
+      "green": false,
+      "invalid_candidate_bindings": 0,
+      "longest_consecutive_utc_day_streak": 1,
+      "malformed_candidate_summaries": 0,
+      "minimum_consecutive_days": 7,
+      "minimum_distinct_requests": 1000,
+      "minimum_distinct_visa_codes": 30,
+      "minimum_window_duration_hours": 168,
+      "missing_or_invalid_categories": 0,
+      "missing_request_fingerprints": 0,
+      "missing_required_categories": [
+        "retirement",
+        "student",
+        "work_employee"
+      ],
+      "reported_only_categories": [
+        "business",
+        "diaspora"
+      ],
+      "required_categories": [
+        "family",
+        "investor",
+        "long_tourism",
+        "retirement",
+        "student",
+        "work_employee",
+        "work_remote"
+      ],
+      "status": "RED",
+      "total_audit_rows": 20,
+      "traffic_source_counts": {
+        "synthetic_driver": 0,
+        "synthetic_gold": 20
+      },
+      "traffic_sources": [
+        "synthetic_driver",
+        "synthetic_gold"
+      ],
+      "visa_codes": [],
+      "window_duration_hours": 0.8811111111111111
+    },
+    "G-a-vol": {
+      "active_utc_days": 0,
+      "category_counts": {},
+      "distinct_requests": 0,
+      "distinct_visa_codes": 0,
+      "duplicate_evaluations": 0,
+      "green": false,
+      "invalid_candidate_bindings": 0,
+      "longest_consecutive_utc_day_streak": 0,
+      "malformed_candidate_summaries": 0,
+      "minimum_consecutive_days": 7,
+      "minimum_distinct_requests": 1000,
+      "minimum_distinct_visa_codes": 30,
+      "minimum_window_duration_hours": 168,
+      "missing_or_invalid_categories": 0,
+      "missing_request_fingerprints": 0,
+      "missing_required_categories": [
+        "family",
+        "investor",
+        "long_tourism",
+        "retirement",
+        "student",
+        "work_employee",
+        "work_remote"
+      ],
+      "reported_only_categories": [
+        "business",
+        "diaspora"
+      ],
+      "required_categories": [
+        "family",
+        "investor",
+        "long_tourism",
+        "retirement",
+        "student",
+        "work_employee",
+        "work_remote"
+      ],
+      "status": "RED",
+      "total_audit_rows": 0,
+      "traffic_source_counts": {
+        "real": 0
+      },
+      "traffic_sources": [
+        "real"
+      ],
+      "visa_codes": [],
+      "window_duration_hours": 0.8811111111111111
+    },
+    "G-b": {
+      "green": false,
+      "reason": "requires independent canonical 20-persona replay evidence",
+      "status": "UNMEASURED"
+    },
+    "G-c": {
+      "citations_not_claimed": 0,
+      "claimed_sources_not_cited": 0,
+      "decisions_without_citations": 1,
+      "green": false,
+      "invalid_rule_pack_payloads": 0,
+      "malformed_citations": 0,
+      "malformed_grounding_summaries": 2,
+      "missing_rule_pack_digests": 0,
+      "missing_ruleset_activations": 0,
+      "status": "RED",
+      "ungrounded_claims": 3,
+      "unresolved_or_invalid_sources": 0
+    },
+    "G-d": {
+      "green": false,
+      "reason": "requires a recorded live ENFORCE-to-OFF rollback drill",
+      "status": "UNMEASURED"
+    }
+  },
+  "schema_version": "visa-shadow-evidence/1.3.0",
+  "skipped_non_evidence_surfaces": 0,
+  "surfaces": {
+    "RECOMMEND": 20
+  },
+  "traffic_source": {
+    "legacy": 0,
+    "real": 0,
+    "synthetic_driver": 0,
+    "synthetic_gold": 20,
+    "total_audit_rows": 20
+  },
+  "window": {
+    "end_exclusive": "2026-08-14T19:20:30+00:00",
+    "start": "2026-08-14T18:27:38+00:00"
+  }
+}

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -220,21 +220,23 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
         "docs/runbooks/visa-engine-key-ceremony.md — a trust root read at "
         "replay time, never a credential (private key is off-repo)",
     ),
-    # research/visa/2026-08-12-gold-replay-live-report.json: the G-b gold
-    # replay driver's live-run report. `payload_sha256` (repeated once per
-    # persona/pack observation, 23x in this file, all the same value) is the
-    # content-derived sha256 of a PUBLIC signed RulePack payload — the same
-    # class of value as the AUTO_APPROVE_RULES `contracts/packs/rulepack-*.json`
-    # rule above (content/payload hashes of public legal documents), just
-    # embedded in a research/ run report rather than the pack artifact itself.
+    # research/visa/2026-08-12-gold-replay-live-report.json and the exact
+    # post-notice follow-up report from 2026-08-15: G-b gold replay driver
+    # live-run reports. `payload_sha256` is the content-derived sha256 of a
+    # PUBLIC signed RulePack payload — the same class of value as the
+    # AUTO_APPROVE_RULES `contracts/packs/rulepack-*.json` rule above
+    # (content/payload hashes of public legal documents), just embedded in a
+    # research/ run report rather than the pack artifact itself.
     # Not covered by the existing `research/.*\.md$` path rule because this is
     # a `.json` report, not markdown. Content-keyed rather than a path-only
     # research/*.json rule because this file's directory (research/visa/) can
     # carry other ad-hoc JSON in the future with different content; narrowed
-    # to a `"payload_sha256": "<64-hex>"` line, end-anchored.
+    # to the two exact reviewed report paths and a
+    # `"payload_sha256": "<64-hex>"` line, end-anchored.
     (
         re.compile(
-            r"(^|/)research/visa/2026-08-12-gold-replay-live-report\.json$"
+            r"(^|/)research/visa/(?:2026-08-12-gold-replay-live-report|"
+            r"2026-08-15-gold-replay-live-post-notice-report)\.json$"
         ),
         re.compile(r'^\s*"payload_sha256"\s*:\s*"[0-9a-f]{64}"\s*,?\s*$'),
         "gold replay driver live-run report: payload_sha256 is the "

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -620,17 +620,25 @@ def test_innocence_gold_replay_driver_ride_along_statement_not_approved() -> Non
 # moved to CONTENT_KEYED_RULES[6].
 
 GOLD_REPLAY_LIVE_REPORT = "research/visa/2026-08-12-gold-replay-live-report.json"
+GOLD_REPLAY_POST_NOTICE_REPORT = (
+    "research/visa/2026-08-15-gold-replay-live-post-notice-report.json"
+)
 
 
-def test_gold_replay_live_report_rule_registered_and_scoped_to_exactly_one_file() -> (
+def test_gold_replay_live_report_rule_registered_and_scoped_to_reviewed_files() -> (
     None
 ):
     path_pat, _content_pat, reason = CONTENT_KEYED_RULES[6]
     assert path_pat.search(GOLD_REPLAY_LIVE_REPORT)
+    assert path_pat.search(GOLD_REPLAY_POST_NOTICE_REPORT)
     assert not path_pat.search(
         "research/visa/2026-08-12-gold-replay-live-report.json.bak"
     )
+    assert not path_pat.search(
+        "research/visa/2026-08-15-gold-replay-live-post-notice-report.json.bak"
+    )
     assert not path_pat.search("research/visa/2026-08-13-some-other-report.json")
+    assert not path_pat.search("research/visa/2026-08-16-gold-replay-live-report.json")
     assert "never a credential" in reason
 
 
@@ -641,6 +649,15 @@ def test_guilt_gold_replay_live_report_real_line_is_approved() -> None:
     merely if someone edits a string literal in this test."""
     auto, reason = classify(GOLD_REPLAY_LIVE_REPORT, 8)
     assert auto, f"the real payload_sha256 finding must be approved (got {reason!r})"
+    assert "never a credential" in reason
+
+
+def test_guilt_gold_replay_post_notice_real_line_is_approved() -> None:
+    """The exact line 8 finding from Detect Secrets job 94874089047 is the
+    public RulePack payload digest and must be approved by the same narrow
+    content-keyed rule."""
+    auto, reason = classify(GOLD_REPLAY_POST_NOTICE_REPORT, 8)
+    assert auto, f"the post-notice payload_sha256 must be approved (got {reason!r})"
     assert "never a credential" in reason
 
 
@@ -723,6 +740,16 @@ def test_innocence_gold_replay_live_report_same_shape_in_another_file_not_approv
     """Path-scoped: the identical line shape in a different file gets no
     pass from this rule."""
     auto, reason = classify("research/visa/some_other_report.json", 8)
+    assert not (auto and "never a credential" in reason)
+
+
+def test_innocence_gold_replay_post_notice_same_shape_in_similar_file_not_approved() -> (
+    None
+):
+    """A future or renamed report receives no implicit approval."""
+    auto, reason = classify(
+        "research/visa/2026-08-16-gold-replay-live-post-notice-report.json", 8
+    )
     assert not (auto and "never a credential" in reason)
 
 


### PR DESCRIPTION
## Summary

- classify all 14 divergences in the immutable 2026-08-12 sequence-7 gold observation without accepting them prematurely
- keep personas 7/8 blocked on the family predicate defect and split the deployed #4195 notice-dedupe component from the remaining persona-19 product decision
- pin #4195 merge SHA, successful deploy workflow, Fly release, immutable image digest, and matching `GH_SHA` label
- preserve the byte-exact post-notice live replay: 5/20 matches, 15 unexplained divergences, consistent active sequence-7 pack; notice multiplicity is closed live while G-b stays RED
- preserve the read-only aggregate window: exactly 20 `synthetic_gold` rows, 20 distinct requests, 0 duplicate/real/driver/legacy rows, with G-a/G-c RED and G-b/G-d UNMEASURED
- give the new stale-source regressions for personas 11/14 an explicit non-retroactive disposition
- teach Detect Secrets to recognize only the public RulePack `payload_sha256` line in the two exact reviewed replay reports; no baseline or blanket research-path exception

## Verification

- Kimi K3 original adversarial review: SHIP after both major findings were adopted
- Kimi K3 deployment-evidence delta review: SHIP after all four findings were adopted
- Kimi K3 post-notice replay review: final bounded pass SHIP with no surviving findings
- Kimi K3 aggregate projection review: bounded re-review SHIP with no surviving findings; byte-exact aggregate/hash review remains assigned to Fable because the fail-closed numeric-shape gate rejected two duration decimals and a hash segment
- Kimi K3 security-rule review: SHIP after verifying the public digest against `rulepack-prod-007.signed.json`, exact path/content anchors, and guilt/innocence coverage
- `python3 scripts/check_adversarial_review.py --files research/visa/2026-08-15-gold-divergence-disposition.md`
- `python3 scripts/check_adversarial_review.py --selftest`
- `/Users/nuzantara/nuzantara/.venv/bin/python -m pytest scripts/tests/test_check_worker_plane_review.py scripts/tests/test_launch_worker_plane_review_panel.py scripts/tests/test_worker_plane_review_packet.py scripts/tests/test_v3_final_gate_parity.py scripts/tests/test_detect_secrets_auto_triage.py -q` — 226 passed, 2 skipped
- targeted Detect Secrets reproduction: exactly one finding at the new report line 8; content-keyed triage marks it `is_secret: false`
- Prettier, Ruff lint, pre-commit, pre-push, `git diff --check`, exact JSON assertions, reproducibility diff, and numeric-shape accounting
- replay report SHA-256 `24b9f1d5ca23a80981a268a4a58d16916fc8fa1af7fff9ecc5d54dcbf13eb80b`
- aggregate report SHA-256 `5fc1659fe4e20f05a0826623433352108a2fa50399cfdf61f2528f8df27f041c`
- active payload SHA-256 `3d068aef2dca40f1efb74bdd3f8859e767c000282ab8299ac7f277b0b9719f82`
- Fly digest `sha256:e075926299c082587fab4022f64127e5c3f3c8685e0389708931d3c81b1851fc` carries `GH_SHA=35494716abcfdb4bf7e104382cc2fef81ff3b2d7`

## Safety

Evidence-only apart from the narrowly content-keyed Detect Secrets false-positive rule. No RulePack, activation, deployment, baseline, secret, data, or ENFORCE change. The notice component alone is closed; G-b remains RED, SHADOW remains active, and ENFORCE remains NO-GO.