### PR TITLE
fix(visa): align offline replay with public policy path

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
@@ -12,6 +12,9 @@ that can be compared with production:
   same deterministic, no-I/O policy adapter helper as the public evaluate path.
   This proves only what that repository artifact and those checked-out policy
   adapters do; it never claims that the artifact is the active production pack.
+  Offline mode runs inside the repository's backend environment and therefore
+  requires the serving stack's lock-pinned dependencies; it is not a standalone
+  stdlib utility.
 
 The JSON report keeps every divergence visible.  By default every divergent
 persona has ``"explanation": null`` and therefore makes the command exit 1.
@@ -324,7 +327,7 @@ def replay_offline_decisions(
                 decision,
                 facts,
                 compiled,
-                disclosed_review_flags=request.disclosed_review_flags,
+                disclosed_review_flags=request.effective_review_flags(),
             )
         )
     logger.info(
@@ -617,12 +620,7 @@ def build_offline_report(
             "decision_identity": (
                 "offline-only non-secret provider; not production integrity evidence"
             ),
-            "policy_adapters": [
-                "minor_privacy_hold",
-                "decisive_source_authority_and_freshness_hold",
-                "safety_critical_source_freshness_hold",
-                "disclosed_review_flags",
-            ],
+            "policy_adapters": list(evaluate_path.PUBLIC_POLICY_ADAPTER_NAMES),
             "runtime_operations_excluded": [
                 "active_database_binding",
                 "retention_gate",

--- a/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py
@@ -8,9 +8,10 @@ that can be compared with production:
   ``traffic_source=synthetic_gold``.  The driver token is read only from the
   operator-owned token file; it has no CLI option and is never logged.
 * ``--offline`` verifies, compiles, and evaluates the highest-sequence signed
-  PRODUCTION pack actually present in ``contracts/packs``.  This proves only
-  what that repository artifact does; it never claims that the artifact is the
-  active production pack.
+  PRODUCTION pack actually present in ``contracts/packs``.  It then calls the
+  same deterministic, no-I/O policy adapter helper as the public evaluate path.
+  This proves only what that repository artifact and those checked-out policy
+  adapters do; it never claims that the artifact is the active production pack.
 
 The JSON report keeps every divergence visible.  By default every divergent
 persona has ``"explanation": null`` and therefore makes the command exit 1.
@@ -48,7 +49,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from pydantic import ValidationError
 
 from backend.scripts.visa_engine.activate_pack import _load_strict_json
-from backend.services.visa_engine import evaluator
+from backend.services.visa_engine import evaluate_path, evaluator
 from backend.services.visa_engine.api_models import VisaOracleEvaluateRequest
 from backend.services.visa_engine.bundle import (
     StaticTrustStore,
@@ -58,7 +59,11 @@ from backend.services.visa_engine.bundle import (
 from backend.services.visa_engine.compiler import build_compiled_pack
 from backend.services.visa_engine.enums import Environment
 from backend.services.visa_engine.evaluator import DecisionIdentity, build_decision_identity
-from backend.services.visa_engine.models import ApplicantFacts, Decision, RulePackRef
+from backend.services.visa_engine.models import (
+    ApplicantFacts,
+    Decision,
+    RulePackRef,
+)
 from backend.tests.services.visa_engine import _gold_fixtures as gf
 from backend.tests.services.visa_engine.gold_replay import (
     _decision_actual,
@@ -303,16 +308,25 @@ def replay_offline_decisions(
     )
     compiled = build_compiled_pack(verified.pack)
 
-    decisions = tuple(
-        evaluator.evaluate(
-            build_persona_request(persona).applicant_facts(),
+    decisions: list[Decision] = []
+    for persona in PERSONAS:
+        request = build_persona_request(persona)
+        facts = request.applicant_facts()
+        decision = evaluator.evaluate(
+            facts,
             compiled,
             effective_at=evaluated_at,
             observed_at=evaluated_at,
             identity_provider=_offline_identity_provider,
         )
-        for persona in PERSONAS
-    )
+        decisions.append(
+            evaluate_path.apply_public_policy_adapters(
+                decision,
+                facts,
+                compiled,
+                disclosed_review_flags=request.disclosed_review_flags,
+            )
+        )
     logger.info(
         "offline replay used repository signed pack file=%s sequence=%d version=%s; "
         "active production status was not checked",
@@ -320,7 +334,7 @@ def replay_offline_decisions(
         compiled.sequence,
         compiled.version,
     )
-    return decisions, pack_path
+    return tuple(decisions), pack_path
 
 
 def _normalized_expected(persona: Persona) -> dict[str, Any]:
@@ -603,6 +617,19 @@ def build_offline_report(
             "decision_identity": (
                 "offline-only non-secret provider; not production integrity evidence"
             ),
+            "policy_adapters": [
+                "minor_privacy_hold",
+                "decisive_source_authority_and_freshness_hold",
+                "safety_critical_source_freshness_hold",
+                "disclosed_review_flags",
+            ],
+            "runtime_operations_excluded": [
+                "active_database_binding",
+                "retention_gate",
+                "pricing",
+                "sealing",
+                "persistence",
+            ],
         },
         explanations=explanations,
     )

--- a/apps/backend-rag/backend/services/visa_engine/evaluate_path.py
+++ b/apps/backend-rag/backend/services/visa_engine/evaluate_path.py
@@ -70,6 +70,7 @@ import logging
 import os
 import secrets
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timezone
 from types import MappingProxyType
 from typing import TypeAlias
@@ -1220,6 +1221,62 @@ def _apply_disclosed_review_flags(
     return Decision.model_validate(payload)
 
 
+_PublicPolicyAdapter: TypeAlias = Callable[
+    [Decision, ApplicantFacts, CompiledRulePack, tuple[DisclosedReviewFlag, ...]],
+    Decision,
+]
+
+
+def _minor_privacy_policy_adapter(
+    decision: Decision,
+    facts: ApplicantFacts,
+    _compiled: CompiledRulePack,
+    _disclosed_review_flags: tuple[DisclosedReviewFlag, ...],
+) -> Decision:
+    return _apply_minor_privacy_hold(decision, facts)
+
+
+def _decisive_source_policy_adapter(
+    decision: Decision,
+    _facts: ApplicantFacts,
+    compiled: CompiledRulePack,
+    _disclosed_review_flags: tuple[DisclosedReviewFlag, ...],
+) -> Decision:
+    return _apply_decisive_source_authority_hold(decision, compiled)
+
+
+def _safety_critical_source_policy_adapter(
+    decision: Decision,
+    _facts: ApplicantFacts,
+    compiled: CompiledRulePack,
+    _disclosed_review_flags: tuple[DisclosedReviewFlag, ...],
+) -> Decision:
+    return _apply_safety_critical_source_hold(decision, compiled)
+
+
+def _disclosed_review_policy_adapter(
+    decision: Decision,
+    _facts: ApplicantFacts,
+    _compiled: CompiledRulePack,
+    disclosed_review_flags: tuple[DisclosedReviewFlag, ...],
+) -> Decision:
+    return _apply_disclosed_review_flags(decision, disclosed_review_flags)
+
+
+# This ordered registry is both the executable chain and report provenance.
+# Adding, removing, or reordering a public adapter therefore changes behavior
+# and the offline evidence manifest in the same diff.
+_PUBLIC_POLICY_ADAPTERS: tuple[tuple[str, _PublicPolicyAdapter], ...] = (
+    ("_apply_minor_privacy_hold", _minor_privacy_policy_adapter),
+    ("_apply_decisive_source_authority_hold", _decisive_source_policy_adapter),
+    ("_apply_safety_critical_source_hold", _safety_critical_source_policy_adapter),
+    ("_apply_disclosed_review_flags", _disclosed_review_policy_adapter),
+)
+PUBLIC_POLICY_ADAPTER_NAMES: tuple[str, ...] = tuple(
+    name for name, _adapter in _PUBLIC_POLICY_ADAPTERS
+)
+
+
 def apply_public_policy_adapters(
     decision: Decision,
     facts: ApplicantFacts,
@@ -1235,10 +1292,9 @@ def apply_public_policy_adapters(
     remain outside this helper.
     """
 
-    decision = _apply_minor_privacy_hold(decision, facts)
-    decision = _apply_decisive_source_authority_hold(decision, compiled)
-    decision = _apply_safety_critical_source_hold(decision, compiled)
-    return _apply_disclosed_review_flags(decision, disclosed_review_flags)
+    for _name, adapter in _PUBLIC_POLICY_ADAPTERS:
+        decision = adapter(decision, facts, compiled, disclosed_review_flags)
+    return decision
 
 
 async def _save_evaluate_decision(
@@ -1796,6 +1852,8 @@ __all__ = [
     "DRIVER_TOKEN_ENV",
     "EVALUATE_ENVIRONMENT_ENV",
     "EVALUATE_MODE_ENV",
+    "PUBLIC_POLICY_ADAPTER_NAMES",
+    "apply_public_policy_adapters",
     "build_temp_unavailable_body",
     "derive_request_category",
     "resolve_allowed_synthetic_sources",

--- a/apps/backend-rag/backend/services/visa_engine/evaluate_path.py
+++ b/apps/backend-rag/backend/services/visa_engine/evaluate_path.py
@@ -1220,6 +1220,27 @@ def _apply_disclosed_review_flags(
     return Decision.model_validate(payload)
 
 
+def apply_public_policy_adapters(
+    decision: Decision,
+    facts: ApplicantFacts,
+    compiled: CompiledRulePack,
+    *,
+    disclosed_review_flags: tuple[DisclosedReviewFlag, ...] = (),
+) -> Decision:
+    """Apply every deterministic abstention adapter used by the public path.
+
+    Keeping the ordering in one pure helper prevents offline evidence tools
+    from silently drifting away from the endpoint. Runtime-only operations
+    such as binding resolution, retention, pricing, sealing, and persistence
+    remain outside this helper.
+    """
+
+    decision = _apply_minor_privacy_hold(decision, facts)
+    decision = _apply_decisive_source_authority_hold(decision, compiled)
+    decision = _apply_safety_critical_source_hold(decision, compiled)
+    return _apply_disclosed_review_flags(decision, disclosed_review_flags)
+
+
 async def _save_evaluate_decision(
     db_pool: asyncpg.Pool,
     *,
@@ -1438,7 +1459,7 @@ async def run_evaluation(
         pricing_catalog: ExactPricingCatalog = await asyncio.to_thread(get_pricing_service)
     except Exception as exc:
         # Pricing availability cannot overwrite a legal decision. Log only the
-        # type: adapter exceptions may include catalog payloads or paths.
+        # exception class; adapter exceptions may include catalog payloads or paths.
         logger.warning(
             "evaluate path: pricing catalog acquisition failed: %s (trace=%s)",
             type(exc).__name__,
@@ -1455,11 +1476,12 @@ async def run_evaluation(
             observed_at=now,
             identity_provider=identity_provider,
         )
-        decision = evaluation.decision
-        decision = _apply_minor_privacy_hold(decision, facts)
-        decision = _apply_decisive_source_authority_hold(decision, compiled)
-        decision = _apply_safety_critical_source_hold(decision, compiled)
-        decision = _apply_disclosed_review_flags(decision, disclosed_review_flags)
+        decision = apply_public_policy_adapters(
+            evaluation.decision,
+            facts,
+            compiled,
+            disclosed_review_flags=disclosed_review_flags,
+        )
         try:
             decision = _attach_price_quotes(
                 decision,

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_gold_replay_driver.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_gold_replay_driver.py
@@ -205,3 +205,69 @@ def test_offline_replay_uses_highest_signed_pack_without_claiming_it_is_active()
     assert report["pack_source"]["file"].endswith(selected_path.name)
     assert report["pack_source"]["selection"].startswith("highest signed PRODUCTION")
     assert report["pack_source"]["production_activation_status"].startswith("not checked")
+    assert report["pack_source"]["policy_adapters"] == [
+        "minor_privacy_hold",
+        "decisive_source_authority_and_freshness_hold",
+        "safety_critical_source_freshness_hold",
+        "disclosed_review_flags",
+    ]
+    assert "active_database_binding" in report["pack_source"]["runtime_operations_excluded"]
+
+
+def test_public_policy_helper_preserves_endpoint_adapter_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    decision = _fixture_decisions()[0]
+    facts = driver.build_persona_request(PERSONAS[0]).applicant_facts()
+    compiled = gf.build_gold_compiled_pack()
+    calls: list[str] = []
+
+    def minor(current, current_facts):
+        assert current_facts is facts
+        calls.append("minor")
+        return current
+
+    def decisive(current, current_compiled):
+        assert current_compiled is compiled
+        calls.append("decisive")
+        return current
+
+    def safety(current, current_compiled):
+        assert current_compiled is compiled
+        calls.append("safety")
+        return current
+
+    def disclosed(current, flags):
+        assert flags == ()
+        calls.append("disclosed")
+        return current
+
+    monkeypatch.setattr(driver.evaluate_path, "_apply_minor_privacy_hold", minor)
+    monkeypatch.setattr(driver.evaluate_path, "_apply_decisive_source_authority_hold", decisive)
+    monkeypatch.setattr(driver.evaluate_path, "_apply_safety_critical_source_hold", safety)
+    monkeypatch.setattr(driver.evaluate_path, "_apply_disclosed_review_flags", disclosed)
+
+    assert driver.evaluate_path.apply_public_policy_adapters(decision, facts, compiled) is decision
+    assert calls == ["minor", "decisive", "safety", "disclosed"]
+
+
+def test_offline_replay_applies_public_policy_adapter_to_every_persona(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original = driver.evaluate_path.apply_public_policy_adapters
+    persona_calls: list[str] = []
+
+    def recording_adapter(decision, facts, compiled, *, disclosed_review_flags=()):
+        persona_calls.append(facts.assessment_id)
+        return original(
+            decision,
+            facts,
+            compiled,
+            disclosed_review_flags=disclosed_review_flags,
+        )
+
+    monkeypatch.setattr(driver.evaluate_path, "apply_public_policy_adapters", recording_adapter)
+    decisions, _ = driver.replay_offline_decisions(evaluated_at=_OFFLINE_AT)
+
+    assert len(decisions) == len(PERSONAS)
+    assert persona_calls == [driver._persona_assessment_id(persona.id) for persona in PERSONAS]

--- a/apps/backend-rag/backend/tests/scripts/visa_engine/test_gold_replay_driver.py
+++ b/apps/backend-rag/backend/tests/scripts/visa_engine/test_gold_replay_driver.py
@@ -12,7 +12,10 @@ import pytest
 
 from backend.scripts.visa_engine import gold_replay_driver as driver
 from backend.services.visa_engine import evaluator
-from backend.services.visa_engine.api_models import VisaOracleEvaluateRequest
+from backend.services.visa_engine.api_models import (
+    DisclosedReviewFlag,
+    VisaOracleEvaluateRequest,
+)
 from backend.services.visa_engine.models import ApplicantFactsData, Decision
 from backend.tests.services.visa_engine import _gold_fixtures as gf
 from backend.tests.services.visa_engine.test_evaluator_gold import PERSONAS
@@ -205,13 +208,65 @@ def test_offline_replay_uses_highest_signed_pack_without_claiming_it_is_active()
     assert report["pack_source"]["file"].endswith(selected_path.name)
     assert report["pack_source"]["selection"].startswith("highest signed PRODUCTION")
     assert report["pack_source"]["production_activation_status"].startswith("not checked")
-    assert report["pack_source"]["policy_adapters"] == [
-        "minor_privacy_hold",
-        "decisive_source_authority_and_freshness_hold",
-        "safety_critical_source_freshness_hold",
-        "disclosed_review_flags",
-    ]
+    assert report["pack_source"]["policy_adapters"] == list(
+        driver.evaluate_path.PUBLIC_POLICY_ADAPTER_NAMES
+    )
     assert "active_database_binding" in report["pack_source"]["runtime_operations_excluded"]
+
+
+@pytest.mark.parametrize(
+    ("overstay_days", "expected_flags"),
+    [
+        (0, ()),
+        (2, (DisclosedReviewFlag.CONFLICTING_IMMIGRATION_STATUS,)),
+    ],
+)
+def test_offline_replay_passes_effective_review_flags_to_public_adapters(
+    monkeypatch: pytest.MonkeyPatch,
+    overstay_days: int,
+    expected_flags: tuple[DisclosedReviewFlag, ...],
+) -> None:
+    persona = PERSONAS[0]
+    wire = driver.build_persona_payload(persona)
+    wire["facts"]["immigration.currently_in_indonesia"] = {
+        "status": "KNOWN",
+        "value": False,
+    }
+    wire["facts"]["immigration.overstay_days"] = {
+        "status": "KNOWN",
+        "value": overstay_days,
+    }
+    request = VisaOracleEvaluateRequest.model_validate(wire)
+    flags_seen: list[tuple[DisclosedReviewFlag, ...]] = []
+
+    def recording_adapter(
+        decision,
+        facts,
+        compiled,
+        *,
+        disclosed_review_flags=(),
+    ):
+        flags_seen.append(disclosed_review_flags)
+        return decision
+
+    monkeypatch.setattr(driver, "PERSONAS", (persona,))
+    monkeypatch.setattr(driver, "build_persona_request", lambda _: request)
+    monkeypatch.setattr(
+        driver.evaluate_path,
+        "apply_public_policy_adapters",
+        recording_adapter,
+    )
+
+    driver.replay_offline_decisions(evaluated_at=_OFFLINE_AT)
+
+    assert flags_seen == [expected_flags]
+
+
+def test_public_policy_helper_and_manifest_are_explicit_exports() -> None:
+    assert {
+        "PUBLIC_POLICY_ADAPTER_NAMES",
+        "apply_public_policy_adapters",
+    } <= set(driver.evaluate_path.__all__)
 
 
 def test_public_policy_helper_preserves_endpoint_adapter_order(
@@ -224,22 +279,22 @@ def test_public_policy_helper_preserves_endpoint_adapter_order(
 
     def minor(current, current_facts):
         assert current_facts is facts
-        calls.append("minor")
+        calls.append("_apply_minor_privacy_hold")
         return current
 
     def decisive(current, current_compiled):
         assert current_compiled is compiled
-        calls.append("decisive")
+        calls.append("_apply_decisive_source_authority_hold")
         return current
 
     def safety(current, current_compiled):
         assert current_compiled is compiled
-        calls.append("safety")
+        calls.append("_apply_safety_critical_source_hold")
         return current
 
     def disclosed(current, flags):
         assert flags == ()
-        calls.append("disclosed")
+        calls.append("_apply_disclosed_review_flags")
         return current
 
     monkeypatch.setattr(driver.evaluate_path, "_apply_minor_privacy_hold", minor)
@@ -248,7 +303,7 @@ def test_public_policy_helper_preserves_endpoint_adapter_order(
     monkeypatch.setattr(driver.evaluate_path, "_apply_disclosed_review_flags", disclosed)
 
     assert driver.evaluate_path.apply_public_policy_adapters(decision, facts, compiled) is decision
-    assert calls == ["minor", "decisive", "safety", "disclosed"]
+    assert calls == list(driver.evaluate_path.PUBLIC_POLICY_ADAPTER_NAMES)
 
 
 def test_offline_replay_applies_public_policy_adapter_to_every_persona(

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_evaluate_endpoint.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_evaluate_endpoint.py
@@ -1083,6 +1083,56 @@ def _public_request() -> VisaOracleEvaluateRequest:
     )
 
 
+async def test_run_evaluation_delegates_to_public_policy_helper_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(evaluate_path.EVALUATE_MODE_ENV, "SHADOW")
+    monkeypatch.setenv(evaluate_path.EVALUATE_ENVIRONMENT_ENV, "TEST")
+    _, _, compiled = _patch_engine_chain(monkeypatch)
+    facts = _facts_with_purposes(["TOURISM"])
+    flags = (DisclosedReviewFlag.NOT_CERTAIN,)
+    evaluations = []
+    helper_calls = []
+    original_evaluate = evaluate_path.evaluate_with_trace
+    original_helper = evaluate_path.apply_public_policy_adapters
+
+    def recording_evaluate(*args: object, **kwargs: object):
+        evaluation = original_evaluate(*args, **kwargs)
+        evaluations.append(evaluation)
+        return evaluation
+
+    def recording_helper(
+        decision: Decision,
+        current_facts: ApplicantFacts,
+        current_compiled: object,
+        *,
+        disclosed_review_flags: tuple[DisclosedReviewFlag, ...] = (),
+    ) -> Decision:
+        helper_calls.append((decision, current_facts, current_compiled, disclosed_review_flags))
+        return original_helper(
+            decision,
+            current_facts,
+            current_compiled,
+            disclosed_review_flags=disclosed_review_flags,
+        )
+
+    monkeypatch.setattr(evaluate_path, "evaluate_with_trace", recording_evaluate)
+    monkeypatch.setattr(evaluate_path, "apply_public_policy_adapters", recording_helper)
+
+    await evaluate_path.run_evaluation(
+        object(),
+        facts=facts,
+        traffic_source="real",
+        request_category_hint=None,
+        request_trace="trace-public-policy-delegation",
+        disclosed_review_flags=flags,
+        evaluation_time=gold_loader.GOLD_EFFECTIVE_AT,
+    )
+
+    assert len(evaluations) == 1
+    assert helper_calls == [(evaluations[0].decision, facts, compiled, flags)]
+
+
 def _cached_reservation(response: VisaOracleEvaluateResponse | None) -> IdempotencyReservation:
     reserved_at = datetime(2026, 8, 4, 1, 0, tzinfo=timezone.utc)
     return IdempotencyReservation(


### PR DESCRIPTION
## Summary
- centralize deterministic public decision adapters so endpoint and offline G-b replay share one ordered helper
- include minor privacy, decisive source authority/freshness, safety-critical freshness, and effective disclosed-review holds in offline decisions
- pass `VisaOracleEvaluateRequest.effective_review_flags()` in offline replay, matching both HTTP endpoint call sites
- add guilt-and-innocence regression coverage for the derived offshore-positive-overstay conflict
- explicitly export the shared helper and provenance manifest through `evaluate_path.__all__`
- record policy adapters and excluded runtime-only operations in report provenance

## Evidence
- exact candidate SHA: `4367d2c7aa2739011a7bedadb46d374424b6041a`
- exact binary diff SHA-256: `77019d5daa5c1915a253aa78f3aacbea1885f0964f212a809a9a53398fcd48e0`
- replay driver + full evaluate endpoint test files: 240 passed
- Ruff: PASS
- mypy on driver and evaluate path: PASS
- ChangeMap: backend-tests + e2e-tests
- fresh signed seq-7 offline replay: 5/20 matches, 15 unexplained divergences, expected exit 1
- effective-flags regression observed red before fix and green after for guilty and innocent cases
- explicit-export regression observed red before fix and green after; addresses CodeQL alert #8539

## Review state
- all review evidence on pre-fix SHAs `ff05743d930d068ff57dc5b92478658c20854eb2` and `a0f85d88329fb8b3b920b2bbe5f987ecb6c00ba9` is invalidated
- PR intentionally remains draft pending required CI and independent exact-SHA Fable review

## Safety
- no DB writes, production calls, pack edits, signing, activation, deploy, auto-merge, or ENFORCE change