### PR TITLE
feat(ci): test-cost regression gate (built, not wired)

### DIFF
--- a/scripts/ci/test_cost_baseline.json
+++ b/scripts/ci/test_cost_baseline.json
@@ -1,0 +1,63 @@
+{
+  "_doc": "Committed reference baseline for scripts/ci/test_cost_gate.py. Snapshot of one scripts/suite_growth_probe.py record measured on Pro (this repo's suite-growth telemetry organ, research/operations/2026-08-14-merge-os-v3-research-council.md \u00a7C1/\u00a76 step 3) \u2014 committed here deliberately so the gate never makes a live call to Pro from CI (CI cannot see Pro; council contract point 3). p50_minutes is the comparison baseline (the gate's own docstring explains why not p95). Refresh this file periodically by re-running scripts/suite_growth_probe.py --no-alert on Pro and copying its jobs{}.current_window \u2014 there is no automation for that yet (deliberately out of this PR's scope, same as the tests.yml wiring itself).",
+  "jobs": {
+    "backend-tests": {
+      "p50_minutes": 26.5,
+      "p95_minutes": 28.188333333333333,
+      "sample_size": 459,
+      "timeout_minutes": 30
+    },
+    "change-map": {
+      "p50_minutes": 0.0,
+      "p95_minutes": 1.1666666666666667,
+      "sample_size": 312,
+      "timeout_minutes": 10
+    },
+    "e2e-tests": {
+      "p50_minutes": 7.066666666666666,
+      "p95_minutes": 7.784999999999999,
+      "sample_size": 459,
+      "timeout_minutes": 20
+    },
+    "evaluator-critical-tests": {
+      "p50_minutes": 0.5666666666666667,
+      "p95_minutes": 0.7333333333333333,
+      "sample_size": 456,
+      "timeout_minutes": null
+    },
+    "frontend-tests": {
+      "p50_minutes": 1.7666666666666666,
+      "p95_minutes": 5.683333333333334,
+      "sample_size": 913,
+      "timeout_minutes": 10
+    },
+    "mcp-server-tests": {
+      "p50_minutes": 0.8666666666666667,
+      "p95_minutes": 1.15,
+      "sample_size": 457,
+      "timeout_minutes": 10
+    },
+    "shared-core-package-tests": {
+      "p50_minutes": 1.4666666666666666,
+      "p95_minutes": 1.7899999999999996,
+      "sample_size": 457,
+      "timeout_minutes": null
+    },
+    "test-summary": {
+      "p50_minutes": 0.06666666666666667,
+      "p95_minutes": 0.1,
+      "sample_size": 460,
+      "timeout_minutes": 10
+    }
+  },
+  "schema_version": 1,
+  "source": {
+    "captured_by": "scripts/ci/test_cost_gate.py build session, 2026-08-15 (ssh pro cat)",
+    "generated_at_utc": "2026-08-14T21:18:00Z",
+    "machine": "pro",
+    "organ": "scripts/suite_growth_probe.py",
+    "record_path": "~/.nuzantara-mq/suite-growth/20260814T211800Z.json",
+    "window_days": 7,
+    "workflow": "tests.yml"
+  }
+}

--- a/scripts/ci/test_cost_gate.py
+++ b/scripts/ci/test_cost_gate.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""test_cost_gate.py — block only the test-cost REGRESSION a PR introduces.
+
+Spec: research/operations/2026-08-14-merge-os-v3-research-council.md §C1/§6
+step 3 ("test-cost regression gate that blocks only the regression a PR
+introduces (hard on PRs touching test infra/fixtures/timeouts, telemetry-only
+elsewhere)"). This is a slice of that step, same family as
+`scripts/suite_growth_probe.py` (the nightly telemetry organ this gate reads
+its baseline from) — that organ measures the TREND across the whole suite over
+time; this gate judges ONE PR's ONE job run against a committed reference.
+
+WHAT THIS DOES NOT DO (scope, matching the mandate that dispatched this build):
+  - It never calls Pro live from CI — CI cannot see Pro (council contract point
+    3). The comparison baseline is `scripts/ci/test_cost_baseline.json`, a
+    committed snapshot of one `suite_growth_probe.py` record. Refreshing that
+    snapshot is a manual, periodic, out-of-band step (see that file's `_doc`).
+  - It never selects, skips, or deletes a test. It answers exactly one
+    question: "is THIS job's measured duration on THIS PR run enough worse
+    than the committed baseline, on a PR that touched the surface where a
+    regression like that could be introduced on purpose or by accident, to
+    block?" Anything else (suite diet, ownership SLA) is a separate artifact
+    (research/operations/2026-08-15-suite-diet-round1.md).
+  - It is NOT wired into tests.yml yet (built != armed, scar family #2 —
+    declared, not hidden). Wiring a step to measure "this run's actual job
+    duration" and feed it to `--duration-minutes` is the next PR. This module
+    is complete and independently testable without that wiring: every
+    guilt/innocence case below drives it exactly the way a wired caller would
+    (synthetic `--duration-minutes` + a synthetic changed-file list), so the
+    logic is proven before a single CI minute is spent running it live.
+
+CONTRACT (research council §6 step 3, all four points):
+  1. HARD (blocking) only on a PR that touches test-infra: conftest.py,
+     pytest.ini/tox.ini, fixtures/ under a tests/ tree, .github/workflows/
+     tests.yml itself, or this gate's own files (self-reference, same
+     anti-self-approval shape as scripts/ci/change_map.py's EXACT_RULES entry
+     for itself — a PR that edits the gate must not be able to loosen the gate
+     and pass its own loosened check unexamined).
+  2. Telemetry-only (a notice, never a non-zero exit) on every other PR —
+     including one that DOES regress a job's duration, as long as it did not
+     touch test-infra. Ordinary feature PRs that happen to add slow tests are
+     not blocked by this gate; that is the suite-diet report's job, not this
+     one's (§6 step 3's own scope line: "NO auto-deletion on slowness/flake
+     alone").
+  3. Comparison = this run's measured duration for ONE job vs the COMMITTED
+     baseline's p50 for that job (never p95 — p95 already answers a different
+     question, "how close to the timeout ceiling", which is
+     `suite_growth_probe.py`'s job, not this gate's; p50 is the stable center
+     a single run's regression should be measured against).
+  4. Threshold: declared here, not implicit. `DEFAULT_REGRESSION_THRESHOLD_PCT
+     = 10.0` — the council doc's own worked example ("+10% sul job toccato").
+     A percent alone cannot judge jobs whose baseline p50 is near zero (this
+     repo's own committed baseline has `change-map` at `p50_minutes: 0.0` —
+     see test_cost_baseline.json) — ANY absolute increase above that baseline
+     would read as an "infinite" or triple-digit percent regression, which is
+     noise, not signal. `DEFAULT_ABS_FLOOR_MINUTES = 2.0` requires the
+     absolute delta to also clear a real floor before either threshold counts
+     as a regression — chosen as roughly the smallest delta this repo's own
+     suite-growth telemetry (P95_TIMEOUT_PCT/WEEKLY_GROWTH_PCT thresholds in
+     suite_growth_probe.py) treats as a signal rather than run-to-run jitter
+     on a shared GitHub Actions runner.
+
+MISSING DATA IS NEVER A BLOCK (scar family #9 "il proxy mente" / #2 "esiste
+!= armato" both apply here in mirror form): a job absent from the committed
+baseline, or a caller that never supplies `--duration-minutes`, degrades to
+verdict `cannot_verify` — exit 0, always, regardless of what the PR touched.
+Blocking on data this gate does not actually have would itself be the guard
+misbehaving on absence rather than on evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# --- declared thresholds (contract point 4) ---------------------------------
+
+DEFAULT_REGRESSION_THRESHOLD_PCT = 10.0
+DEFAULT_ABS_FLOOR_MINUTES = 2.0
+
+DEFAULT_BASELINE_PATH = Path(__file__).resolve().parent / "test_cost_baseline.json"
+
+# --- test-infra classification (contract point 1) ---------------------------
+#
+# Deliberately narrow (scar family #3 — over-match traps): this is NOT "any
+# file under tests/", which would hard-block every ordinary PR that adds a
+# test (exactly the outcome contract point 2 forbids). It is the specific,
+# structural surface where a change can silently inflate or hide suite cost:
+# the fixture/config machinery tests run UNDER, not the tests themselves.
+
+TEST_INFRA_EXACT = frozenset(
+    {
+        ".github/workflows/tests.yml",
+        "scripts/ci/test_cost_gate.py",
+        "scripts/ci/test_test_cost_gate.py",
+        "scripts/ci/test_cost_baseline.json",
+        "scripts/suite_growth_probe.py",
+        "apps/backend-rag/pytest.ini",
+    }
+)
+
+TEST_INFRA_BASENAMES = frozenset({"conftest.py", "pytest.ini", "tox.ini"})
+
+
+def _normalize(raw: str) -> str | None:
+    """Repo-relative POSIX path, or None for malformed input.
+
+    Deliberately the same shape as scripts/ci/change_map.py's own
+    `_normalize` (duplicated, not imported — scripts/ is a flat bag of
+    standalone tools per that module's and suite_growth_probe.py's own
+    declared convention).
+    """
+    if raw != raw.strip():
+        return None
+    path = raw
+    while path.startswith("./"):
+        path = path[2:]
+    if not path or "\x00" in path or "\n" in path or "\r" in path:
+        return None
+    if path.startswith("/") or any(part == ".." for part in path.split("/")):
+        return None
+    return path
+
+
+def _is_test_infra_path(path: str) -> bool:
+    """Guilt case: conftest.py / pytest.ini / tests.yml / this gate's own
+    files / a fixtures/ dir inside a tests/ tree. Innocence case: an ordinary
+    product file, or a new `test_*.py` file that is not itself fixture/config
+    machinery — see test_test_cost_gate.py for both, guilt AND innocence,
+    registered per infra/guard-conformance/registry.json's own convention
+    (cicatrix-superscar.md #3: no guard merges without both proofs)."""
+    if path in TEST_INFRA_EXACT:
+        return True
+    basename = path.rsplit("/", 1)[-1]
+    if basename in TEST_INFRA_BASENAMES:
+        return True
+    # "fixtures" must sit INSIDE a "tests" tree — a product directory that
+    # happens to be named fixtures/ (e.g. business seed data, unrelated to
+    # the test suite) must not trip this guard. Scoping to co-occurrence with
+    # a "tests" path segment is the innocence half of this exact rule.
+    parts = path.split("/")
+    if "fixtures" in parts and "tests" in parts:
+        return True
+    return False
+
+
+def touches_test_infra(paths: list[str]) -> bool:
+    """True when ANY normalized path in `paths` is test-infra (contract point 1)."""
+    for raw in paths:
+        path = _normalize(raw)
+        if path is not None and _is_test_infra_path(path):
+            return True
+    return False
+
+
+# --- regression math (contract points 3 and 4) -------------------------------
+
+
+def evaluate_regression(
+    measured_minutes: float,
+    baseline_p50_minutes: float | None,
+    threshold_pct: float = DEFAULT_REGRESSION_THRESHOLD_PCT,
+    abs_floor_minutes: float = DEFAULT_ABS_FLOOR_MINUTES,
+) -> dict[str, Any]:
+    """Pure comparison of one measured duration against one committed p50.
+
+    Never raises (no baseline, negative measurement, zero baseline are all
+    explicit branches, not exceptions a caller has to catch). A regression is
+    only `True` when BOTH the percent threshold AND the absolute floor are
+    cleared — see module docstring, contract point 4, for why the floor
+    exists (a near-zero baseline turns any real increase into a nonsensical
+    percent).
+    """
+    if baseline_p50_minutes is None:
+        return {
+            "baseline_available": False,
+            "baseline_p50_minutes": None,
+            "measured_minutes": measured_minutes,
+            "delta_minutes": None,
+            "delta_pct": None,
+            "threshold_pct": threshold_pct,
+            "abs_floor_minutes": abs_floor_minutes,
+            "regression_detected": False,
+        }
+
+    delta_minutes = measured_minutes - baseline_p50_minutes
+    delta_pct: float | None
+    if baseline_p50_minutes > 0:
+        delta_pct = delta_minutes / baseline_p50_minutes * 100.0
+        pct_exceeded = delta_pct > threshold_pct
+    else:
+        # No percent is defined off a zero baseline (division by zero) — fall
+        # back to the absolute floor alone rather than fabricating a percent
+        # or silently treating a zero baseline as "cannot regress".
+        delta_pct = None
+        pct_exceeded = delta_minutes > abs_floor_minutes
+
+    abs_exceeded = delta_minutes > abs_floor_minutes
+    regression_detected = pct_exceeded and abs_exceeded
+
+    return {
+        "baseline_available": True,
+        "baseline_p50_minutes": baseline_p50_minutes,
+        "measured_minutes": measured_minutes,
+        "delta_minutes": delta_minutes,
+        "delta_pct": delta_pct,
+        "threshold_pct": threshold_pct,
+        "abs_floor_minutes": abs_floor_minutes,
+        "regression_detected": regression_detected,
+    }
+
+
+def decide(is_test_infra_touch: bool, regression: dict[str, Any]) -> dict[str, Any]:
+    """Combine contract points 1+2+3+4 into one verdict.
+
+    `blocking=True` is the ONLY case that should ever produce a non-zero
+    exit — every other branch (no baseline, no regression, regression on a
+    PR that never touched test-infra) is a pass, by design (contract point
+    2: telemetry-only PRs are never failed by this gate)."""
+    if not regression.get("baseline_available"):
+        return {"verdict": "cannot_verify", "blocking": False}
+    if not regression["regression_detected"]:
+        return {"verdict": "clean", "blocking": False}
+    if is_test_infra_touch:
+        return {"verdict": "regression_blocking", "blocking": True}
+    return {"verdict": "regression_telemetry_only", "blocking": False}
+
+
+# --- I/O + CLI ---------------------------------------------------------------
+
+
+def load_baseline(path: Path) -> tuple[dict[str, Any], str | None]:
+    """(jobs_map, error). jobs_map is `{}` on any read/parse failure — the
+    caller (main) treats an empty map exactly like "job not found", which
+    routes through `cannot_verify`, never a fabricated block or pass."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return {}, f"could not read baseline {path}: {exc}"
+    except json.JSONDecodeError as exc:
+        return {}, f"could not parse baseline {path}: {exc}"
+    jobs = raw.get("jobs")
+    if not isinstance(jobs, dict):
+        return {}, f"baseline {path} has no 'jobs' mapping"
+    return jobs, None
+
+
+def _read_paths(argv_paths: list[str], stdin_text: str) -> list[str]:
+    if argv_paths:
+        return [line for arg in argv_paths for line in arg.splitlines()]
+    return [line for line in stdin_text.splitlines() if line.strip()]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument("--baseline", default=str(DEFAULT_BASELINE_PATH), help="path to test_cost_baseline.json")
+    parser.add_argument("--job", required=True, help="job key as it appears in the baseline (e.g. backend-tests)")
+    parser.add_argument("--duration-minutes", type=float, required=True, help="this run's measured job duration")
+    parser.add_argument("--threshold-pct", type=float, default=DEFAULT_REGRESSION_THRESHOLD_PCT)
+    parser.add_argument("--abs-floor-minutes", type=float, default=DEFAULT_ABS_FLOOR_MINUTES)
+    parser.add_argument(
+        "--changed-files-file",
+        default=None,
+        help="path to a file of changed paths, one per line (default: read stdin, or trailing argv)",
+    )
+    parser.add_argument(
+        "changed_files",
+        nargs="*",
+        help="changed paths as positional args (alternative to stdin/--changed-files-file)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.changed_files_file:
+        stdin_text = Path(args.changed_files_file).read_text(encoding="utf-8")
+        changed = _read_paths([], stdin_text)
+    elif args.changed_files:
+        changed = _read_paths(args.changed_files, "")
+    elif not sys.stdin.isatty():
+        changed = _read_paths([], sys.stdin.read())
+    else:
+        changed = []
+
+    is_test_infra_touch = touches_test_infra(changed)
+
+    jobs, baseline_error = load_baseline(Path(args.baseline))
+    job_entry = jobs.get(args.job) if isinstance(jobs, dict) else None
+    baseline_p50 = job_entry.get("p50_minutes") if isinstance(job_entry, dict) else None
+
+    regression = evaluate_regression(
+        args.duration_minutes,
+        baseline_p50,
+        threshold_pct=args.threshold_pct,
+        abs_floor_minutes=args.abs_floor_minutes,
+    )
+    verdict = decide(is_test_infra_touch, regression)
+
+    result: dict[str, Any] = {
+        "job": args.job,
+        "is_test_infra_touch": is_test_infra_touch,
+        "changed_file_count": len(changed),
+        "regression": regression,
+        "baseline_error": baseline_error,
+        **verdict,
+    }
+    print(json.dumps(result, sort_keys=True))
+
+    # delta_pct is None when baseline_p50_minutes == 0 (evaluate_regression's
+    # own explicit branch — no percent is defined off a zero baseline). The
+    # human-readable messages below must degrade gracefully on that, same as
+    # the JSON above already does via json.dumps: delta_minutes is always
+    # available even when delta_pct is not, so report that instead of
+    # crashing on `None.__format__`.
+    delta_pct_display = (
+        f"{regression['delta_pct']:.1f}%" if regression["delta_pct"] is not None else "n/a (baseline is 0)"
+    )
+
+    if verdict["blocking"]:
+        print(
+            f"test_cost_gate: BLOCKING — {args.job} measured {args.duration_minutes:.1f}min, "
+            f"{delta_pct_display} over baseline p50={baseline_p50:.1f}min "
+            f"(delta {regression['delta_minutes']:.1f}min) "
+            f"(threshold {args.threshold_pct:.0f}%, floor {args.abs_floor_minutes:.1f}min) "
+            "and this PR touches test-infra.",
+            file=sys.stderr,
+        )
+    elif verdict["verdict"] == "regression_telemetry_only":
+        print(
+            f"test_cost_gate: NOTICE (not blocking) — {args.job} measured "
+            f"{args.duration_minutes:.1f}min, {delta_pct_display} over baseline "
+            f"p50={baseline_p50:.1f}min (delta {regression['delta_minutes']:.1f}min), "
+            "but this PR does not touch test-infra.",
+            file=sys.stderr,
+        )
+    elif verdict["verdict"] == "cannot_verify":
+        detail = baseline_error or f"job '{args.job}' not in baseline"
+        print(f"test_cost_gate: cannot verify ({detail}) — not blocking.", file=sys.stderr)
+    else:
+        print(f"test_cost_gate: clean — {args.job} within threshold of baseline.", file=sys.stderr)
+
+    return 1 if verdict["blocking"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_test_cost_gate.py
+++ b/scripts/ci/test_test_cost_gate.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Guilt + innocence corpus for `test_cost_gate.py` (cicatrix-superscar.md #3:
+no guard merges without both proofs, plus mutation-guard cases pinning the
+exact comparison operators — `>` not `>=`, `and` not `or` — that a plausible
+one-character bug in this file would flip).
+
+Runs standalone (`python3 scripts/ci/test_test_cost_gate.py`) and under pytest.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from test_cost_gate import (  # noqa: E402
+    DEFAULT_ABS_FLOOR_MINUTES,
+    DEFAULT_REGRESSION_THRESHOLD_PCT,
+    decide,
+    evaluate_regression,
+    load_baseline,
+    touches_test_infra,
+)
+
+GATE_SCRIPT = Path(__file__).resolve().parent / "test_cost_gate.py"
+
+
+def _baseline_file(jobs: dict) -> str:
+    fh = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    json.dump({"jobs": jobs}, fh)
+    fh.close()
+    return fh.name
+
+
+def run_cli(argv: list[str]) -> tuple[int, dict]:
+    # `input=""` closes stdin immediately (EOF) — without it, a subprocess
+    # inheriting an open (non-tty, non-empty) parent stdin would block
+    # forever on main()'s `sys.stdin.read()` fallback when the test passes
+    # neither positional changed_files nor --changed-files-file. Verified
+    # live: this exact call hung the first version of this corpus.
+    proc = _run_cli_raw(argv)
+    payload = json.loads(proc.stdout.strip().splitlines()[-1]) if proc.stdout.strip() else {}
+    assert proc.returncode == (1 if payload.get("blocking") else 0), (
+        f"exit code {proc.returncode} does not match verdict.blocking={payload.get('blocking')}: "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    return proc.returncode, payload
+
+
+def _run_cli_raw(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Same subprocess invocation as run_cli(), minus the payload/exit-code
+    assertion — for tests that need the raw stderr (e.g. asserting no
+    traceback) without run_cli()'s own assertion getting in the way. Keeps
+    run_cli()'s contract untouched for its other callers."""
+    return subprocess.run(
+        [sys.executable, str(GATE_SCRIPT), *argv],
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# =============================================================================
+# touches_test_infra() — guilt + innocence
+# =============================================================================
+
+
+def test_a_guilt_conftest_edit_is_test_infra():
+    assert touches_test_infra(["apps/backend-rag/backend/tests/unit/conftest.py"]) is True
+
+
+def test_a_guilt_pytest_ini_edit_is_test_infra():
+    assert touches_test_infra(["apps/backend-rag/pytest.ini"]) is True
+
+
+def test_a_guilt_tests_workflow_edit_is_test_infra():
+    assert touches_test_infra([".github/workflows/tests.yml"]) is True
+
+
+def test_a_guilt_fixtures_dir_inside_a_tests_tree_is_test_infra():
+    assert (
+        touches_test_infra(["apps/backend-rag/backend/tests/services/fixtures/sample_akta.json"])
+        is True
+    )
+
+
+def test_a_guilt_the_gate_editing_itself_is_test_infra():
+    """Anti-self-approval (same shape as change_map.py's EXACT_RULES entry
+    for its own file): a PR that loosens this gate must not be able to slip
+    through as telemetry-only because it 'only touched the gate'."""
+    assert touches_test_infra(["scripts/ci/test_cost_gate.py"]) is True
+    assert touches_test_infra(["scripts/ci/test_cost_baseline.json"]) is True
+
+
+def test_a_guilt_one_test_infra_path_among_many_still_counts():
+    assert (
+        touches_test_infra(
+            [
+                "apps/backend-rag/backend/app/routers/crm.py",
+                "apps/backend-rag/backend/tests/unit/conftest.py",
+            ]
+        )
+        is True
+    )
+
+
+def test_b_innocence_an_ordinary_backend_file_is_not_test_infra():
+    assert touches_test_infra(["apps/backend-rag/backend/app/routers/crm.py"]) is False
+
+
+def test_b_innocence_a_brand_new_test_file_is_not_test_infra():
+    """Adding a slow test is exactly the case contract point 2 says must
+    stay telemetry-only, never blocking — this is the guard's core innocence
+    case, not an edge case."""
+    assert (
+        touches_test_infra(["apps/backend-rag/backend/tests/services/test_new_feature.py"])
+        is False
+    )
+
+
+def test_b_innocence_a_product_directory_literally_named_fixtures_is_not_test_infra():
+    """A 'fixtures' directory OUTSIDE any tests/ tree (e.g. business seed
+    data) must not trip the guard — co-occurrence with a 'tests' path
+    segment is required, not the bare word 'fixtures'."""
+    assert touches_test_infra(["apps/backend-rag/backend/data/fixtures/seed.json"]) is False
+
+
+def test_b_innocence_empty_changed_set_is_not_test_infra():
+    assert touches_test_infra([]) is False
+
+
+def test_b_innocence_malformed_path_is_ignored_not_test_infra():
+    assert touches_test_infra(["../../etc/passwd"]) is False
+
+
+# =============================================================================
+# evaluate_regression() — guilt + innocence + mutation-guard
+# =============================================================================
+
+
+def test_a_guilt_regression_over_threshold_and_floor_is_detected():
+    r = evaluate_regression(measured_minutes=30.0, baseline_p50_minutes=26.5)
+    assert r["baseline_available"] is True
+    assert r["regression_detected"] is True
+    assert round(r["delta_pct"], 2) == round((30.0 - 26.5) / 26.5 * 100, 2)
+
+
+def test_b_innocence_small_increase_under_threshold_is_not_a_regression():
+    # +5% is under the 10% default threshold.
+    r = evaluate_regression(measured_minutes=27.8, baseline_p50_minutes=26.5)
+    assert r["regression_detected"] is False
+
+
+def test_b_innocence_no_baseline_is_never_a_regression():
+    r = evaluate_regression(measured_minutes=999.0, baseline_p50_minutes=None)
+    assert r["baseline_available"] is False
+    assert r["regression_detected"] is False
+
+
+def test_b_innocence_faster_than_baseline_is_not_a_regression():
+    r = evaluate_regression(measured_minutes=10.0, baseline_p50_minutes=26.5)
+    assert r["regression_detected"] is False
+    assert r["delta_minutes"] < 0
+
+
+def test_mutation_guard_exact_threshold_boundary_does_not_block():
+    """Pins `>` not `>=` on the PERCENT comparison (suite_growth_probe.py
+    convention, same comparison shape as its own `trend_delta_pct >
+    WEEKLY_GROWTH_PCT_THRESHOLD`): a delta landing EXACTLY on the percent
+    threshold must not block. baseline=30.0 makes the abs delta at +10%
+    equal 3.0min — safely OVER the 2.0min floor — so this case isolates the
+    percent boundary alone; the boundary case in the abs-floor mutation
+    guard below is intentionally the mirror of this one, but at the floor
+    boundary instead."""
+    baseline = 30.0
+    measured = baseline * 1.10  # exactly +10.0%, delta=3.0min (over the 2.0min floor)
+    r = evaluate_regression(measured_minutes=measured, baseline_p50_minutes=baseline)
+    assert round(r["delta_pct"], 6) == 10.0
+    assert r["delta_minutes"] > DEFAULT_ABS_FLOOR_MINUTES
+    assert r["regression_detected"] is False, (
+        "a delta exactly AT the percent threshold must not block — mutating `>` to "
+        "`>=` on the percent comparison in evaluate_regression would flip this to True"
+    )
+
+
+def test_mutation_guard_exact_abs_floor_boundary_does_not_block():
+    """Mirror of the percent-boundary case above: the abs delta lands
+    EXACTLY on the 2.0min floor while the percent is safely over its own
+    threshold — isolates `>` not `>=` on the ABS-FLOOR comparison."""
+    baseline = 20.0
+    measured = baseline + DEFAULT_ABS_FLOOR_MINUTES  # +2.0min exactly, +10.0% exactly too
+    # Use a baseline where the percent clears its threshold with margin so
+    # only the abs-floor boundary is under test: baseline=100 -> +2.0min is +2%,
+    # well under the 10% threshold, so pct_exceeded is unambiguously False —
+    # not what we want either. Pick baseline=15.0: +2.0min = +13.3%, over the
+    # 10% threshold with margin, while the abs delta sits exactly at the floor.
+    baseline = 15.0
+    measured = baseline + DEFAULT_ABS_FLOOR_MINUTES
+    r = evaluate_regression(measured_minutes=measured, baseline_p50_minutes=baseline)
+    assert r["delta_minutes"] == DEFAULT_ABS_FLOOR_MINUTES
+    assert r["delta_pct"] > DEFAULT_REGRESSION_THRESHOLD_PCT
+    assert r["regression_detected"] is False, (
+        "a delta exactly AT the abs floor must not block — mutating `>` to `>=` "
+        "on the abs-floor comparison in evaluate_regression would flip this to True"
+    )
+
+
+def test_mutation_guard_just_over_threshold_and_floor_blocks():
+    baseline = 20.0
+    measured = 20.0 + 2.01  # +10.05% and +2.01min — both just over their lines
+    r = evaluate_regression(measured_minutes=measured, baseline_p50_minutes=baseline)
+    assert r["regression_detected"] is True
+
+
+def test_mutation_guard_zero_baseline_never_divides_by_zero():
+    """Pins the `baseline_p50_minutes > 0` guard: this repo's own committed
+    baseline has change-map at p50_minutes=0.0 (test_cost_baseline.json) —
+    a caller must never crash on it."""
+    r = evaluate_regression(measured_minutes=0.05, baseline_p50_minutes=0.0)
+    assert r["baseline_available"] is True
+    assert r["delta_pct"] is None
+    assert r["regression_detected"] is False, "0.05min over a zero baseline is under the abs floor"
+
+
+def test_mutation_guard_zero_baseline_with_real_increase_still_needs_the_floor():
+    r = evaluate_regression(measured_minutes=3.0, baseline_p50_minutes=0.0)
+    assert r["regression_detected"] is True, "3.0min over a zero baseline clears the 2.0min floor"
+
+
+def test_mutation_guard_percent_alone_without_abs_floor_does_not_block():
+    """A near-zero baseline job growing to 1.5min (still under the abs
+    floor) must not block even though the PERCENT increase is enormous —
+    pins the `and` (both conditions required), not `or`, in
+    evaluate_regression."""
+    r = evaluate_regression(measured_minutes=1.5, baseline_p50_minutes=0.5)
+    # +200% pct, but only +1.0min absolute — under the 2.0min floor.
+    assert r["delta_pct"] == 200.0
+    assert r["regression_detected"] is False, (
+        "mutating `pct_exceeded and abs_exceeded` to `or` in evaluate_regression "
+        "would flip this to True"
+    )
+
+
+def test_mutation_guard_abs_floor_alone_without_percent_does_not_block():
+    """A huge baseline job growing by a large absolute amount but a small
+    percent must not block either — the other half of the `and` pin."""
+    r = evaluate_regression(measured_minutes=105.0, baseline_p50_minutes=100.0)
+    # +5min absolute (over the 2.0min floor) but only +5% (under the 10% threshold).
+    assert r["delta_minutes"] == 5.0
+    assert r["regression_detected"] is False
+
+
+# =============================================================================
+# decide() — guilt + innocence
+# =============================================================================
+
+
+def test_a_guilt_regression_plus_test_infra_touch_blocks():
+    r = evaluate_regression(measured_minutes=30.0, baseline_p50_minutes=26.5)
+    v = decide(is_test_infra_touch=True, regression=r)
+    assert v == {"verdict": "regression_blocking", "blocking": True}
+
+
+def test_b_innocence_regression_without_test_infra_touch_is_telemetry_only():
+    """Contract point 2's core case: same regression magnitude as the guilt
+    case above, but the PR never touched test-infra — must NEVER block."""
+    r = evaluate_regression(measured_minutes=30.0, baseline_p50_minutes=26.5)
+    v = decide(is_test_infra_touch=False, regression=r)
+    assert v == {"verdict": "regression_telemetry_only", "blocking": False}
+
+
+def test_b_innocence_test_infra_touch_without_regression_is_clean():
+    r = evaluate_regression(measured_minutes=26.6, baseline_p50_minutes=26.5)
+    v = decide(is_test_infra_touch=True, regression=r)
+    assert v == {"verdict": "clean", "blocking": False}
+
+
+def test_b_innocence_missing_baseline_never_blocks_even_with_test_infra_touch():
+    r = evaluate_regression(measured_minutes=999.0, baseline_p50_minutes=None)
+    v = decide(is_test_infra_touch=True, regression=r)
+    assert v == {"verdict": "cannot_verify", "blocking": False}
+
+
+# =============================================================================
+# load_baseline() — I/O edges
+# =============================================================================
+
+
+def test_load_baseline_missing_file_returns_empty_map_and_error():
+    jobs, err = load_baseline(Path("/nonexistent/does-not-exist.json"))
+    assert jobs == {}
+    assert err is not None
+
+
+def test_load_baseline_valid_file_returns_jobs_map():
+    path = Path(_baseline_file({"backend-tests": {"p50_minutes": 26.5}}))
+    jobs, err = load_baseline(path)
+    assert err is None
+    assert jobs["backend-tests"]["p50_minutes"] == 26.5
+
+
+def test_load_baseline_shapeless_file_is_cannot_verify_not_crash():
+    fh = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    fh.write("{}")
+    fh.close()
+    jobs, err = load_baseline(Path(fh.name))
+    assert jobs == {}
+    assert err is not None
+
+
+# =============================================================================
+# CLI (main()) — end-to-end, exit codes
+# =============================================================================
+
+
+def test_cli_guilt_blocks_on_regression_with_test_infra_touch():
+    baseline_path = _baseline_file({"backend-tests": {"p50_minutes": 26.5}})
+    rc, payload = run_cli(
+        [
+            "--baseline",
+            baseline_path,
+            "--job",
+            "backend-tests",
+            "--duration-minutes",
+            "31.0",
+            "apps/backend-rag/backend/tests/unit/conftest.py",
+        ]
+    )
+    assert rc == 1
+    assert payload["blocking"] is True
+    assert payload["verdict"] == "regression_blocking"
+
+
+def test_cli_innocence_same_regression_without_test_infra_touch_exits_zero():
+    baseline_path = _baseline_file({"backend-tests": {"p50_minutes": 26.5}})
+    rc, payload = run_cli(
+        [
+            "--baseline",
+            baseline_path,
+            "--job",
+            "backend-tests",
+            "--duration-minutes",
+            "31.0",
+            "apps/backend-rag/backend/app/routers/crm.py",
+        ]
+    )
+    assert rc == 0
+    assert payload["blocking"] is False
+    assert payload["verdict"] == "regression_telemetry_only"
+
+
+def test_cli_innocence_unknown_job_is_cannot_verify_exits_zero():
+    baseline_path = _baseline_file({"backend-tests": {"p50_minutes": 26.5}})
+    rc, payload = run_cli(
+        [
+            "--baseline",
+            baseline_path,
+            "--job",
+            "some-new-job-not-in-baseline",
+            "--duration-minutes",
+            "999.0",
+            "apps/backend-rag/backend/tests/unit/conftest.py",
+        ]
+    )
+    assert rc == 0
+    assert payload["verdict"] == "cannot_verify"
+
+
+def test_cli_innocence_no_changed_files_argument_is_not_test_infra():
+    baseline_path = _baseline_file({"backend-tests": {"p50_minutes": 26.5}})
+    rc, payload = run_cli(
+        [
+            "--baseline",
+            baseline_path,
+            "--job",
+            "backend-tests",
+            "--duration-minutes",
+            "27.0",
+        ]
+    )
+    assert rc == 0
+    assert payload["is_test_infra_touch"] is False
+
+
+def test_cli_guilt_zero_baseline_regression_with_test_infra_touch_blocks_without_crashing():
+    """Pins the exact live crash this fix addresses: `change-map` in the real
+    committed baseline has p50_minutes=0.0, so evaluate_regression() sets
+    delta_pct=None (no percent is defined off a zero baseline) — main()'s
+    BLOCKING f-string used to format that None with `:.1f` unconditionally
+    and raise TypeError. Must exit 1 (blocking) with zero traceback."""
+    baseline_path = _baseline_file({"change-map": {"p50_minutes": 0.0}})
+    proc = _run_cli_raw(
+        [
+            "--baseline",
+            baseline_path,
+            "--job",
+            "change-map",
+            "--duration-minutes",
+            "3.0",
+            "apps/backend-rag/backend/tests/unit/conftest.py",
+        ]
+    )
+    assert "Traceback" not in proc.stderr, f"crashed: stderr={proc.stderr!r}"
+    assert proc.returncode == 1, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert payload["blocking"] is True
+    assert payload["verdict"] == "regression_blocking"
+    assert payload["regression"]["delta_pct"] is None
+    assert payload["regression"]["delta_minutes"] == 3.0
+
+
+def test_cli_innocence_zero_baseline_regression_without_test_infra_touch_exits_zero_without_crashing():
+    """Same zero-baseline regression as the guilt case above, but the changed
+    file never touches test-infra — must degrade to telemetry-only (exit 0)
+    without crashing, same fix, the NOTICE f-string side of main()."""
+    baseline_path = _baseline_file({"change-map": {"p50_minutes": 0.0}})
+    proc = _run_cli_raw(
+        [
+            "--baseline",
+            baseline_path,
+            "--job",
+            "change-map",
+            "--duration-minutes",
+            "3.0",
+            "apps/backend-rag/backend/app/routers/crm.py",
+        ]
+    )
+    assert "Traceback" not in proc.stderr, f"crashed: stderr={proc.stderr!r}"
+    assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert payload["blocking"] is False
+    assert payload["verdict"] == "regression_telemetry_only"
+    assert payload["regression"]["delta_pct"] is None
+
+
+def test_cli_uses_the_real_committed_baseline_by_default():
+    """The default --baseline path resolves to the actual committed
+    test_cost_baseline.json shipped in this PR — this test would fail if
+    that file went missing or lost the backend-tests key."""
+    rc, payload = run_cli(
+        [
+            "--job",
+            "backend-tests",
+            "--duration-minutes",
+            "1.0",
+        ]
+    )
+    assert rc == 0
+    assert payload["regression"]["baseline_available"] is True
+    assert payload["regression"]["baseline_p50_minutes"] == 26.5
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"  ok   {fn.__name__}")
+        except AssertionError as exc:
+            failed += 1
+            print(f"  FAIL {fn.__name__}: {exc}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Summary
- Adds `scripts/ci/test_cost_gate.py` — blocks only the test-cost REGRESSION a PR introduces, judged against a committed baseline snapshot (`scripts/ci/test_cost_baseline.json`), not a live call to Pro (CI cannot see Pro).
- Companion `scripts/ci/test_test_cost_gate.py` covers guilt/innocence for the gate logic.
- Per council spec `research/operations/2026-08-14-merge-os-v3-research-council.md` §C1/§6 step 3: hard-block on PRs touching test infra/fixtures/timeouts, telemetry-only elsewhere.
- **Built, not wired**: this PR only lands the organ. Wiring it into a workflow is a separate follow-up PR.

## Test plan
- [x] Pre-commit anti-reward-hacking lint: clean
- [x] Pre-push path-aware gate: full suite triggered (required CI check is the real gate)
- [ ] Follow-up PR wires the gate into the relevant workflow