### PR TITLE
fix(army): spark lane first-tick defects — README dispatched as task, quota over-match on model output

### DIFF
--- a/scripts/army/spark_lane.sh
+++ b/scripts/army/spark_lane.sh
@@ -266,6 +266,16 @@ candidates = []
 for name in names:
     if not name.endswith(".md"):
         continue
+    # The queue dir carries a README.md alongside real task files (it
+    # documents the queue format, quota/backoff/429 behavior, etc.) — it
+    # matches the *.md glob but is not a task. Case-insensitive so
+    # README.md/readme.md/Readme.MD are all excluded the same way. This is
+    # the ONLY place that enumerates queue files for dispatch, so this
+    # exclusion is automatically the single source of truth (nothing else
+    # reads QUEUE_DIR directly — the daily digest counts attempts.jsonl,
+    # not the queue dir).
+    if name.lower().startswith("readme"):
+        continue
     path = os.path.join(queue_dir, name)
     if not os.path.isfile(path):
         continue
@@ -520,7 +530,25 @@ if [ "$SHOULD_WORK" = "1" ]; then
             run_count=$((run_count + 1))
             echo "$run_count" > "$COUNT_FILE"
 
-            if grep -qiE 'out of extra usage|usage limit|quota exceeded|rate.limit|429|weekly limit' "$OUT_TMP" 2>/dev/null; then
+            # Quota markers are classified ONLY when the invocation actually
+            # FAILED (CODEX_RC != 0) — cicatrix family #3 (guard-over-match):
+            # the classifier used to grep the model's OUTPUT unconditionally,
+            # even on a successful (rc=0) run. Measured live 2026-08-15: the
+            # dispatched task was infra/army/spark-queue/README.md (defect 1,
+            # now excluded above), which *documents* this lane's own
+            # quota/backoff/429 behavior — codex's legitimate analysis of
+            # that doc contained those substrings, producing a false
+            # status=quota, a false 12h backoff, and a false P0-class alert,
+            # while a manual codex probe on the same bucket 3 minutes later
+            # answered fine (the bucket was never actually in quota). A
+            # successful run whose TEXT happens to mention quota is
+            # innocent; only a failed run whose text names the reason is
+            # guilty. The pattern itself is kept unchanged for the failure
+            # branch — codex exec (unlike some CLIs) fails non-zero on a
+            # genuine quota exhaustion (see the stub's `quota` mode, exit 1),
+            # so gating on rc!=0 does not blind this branch to a real quota
+            # hit.
+            if [ "$CODEX_RC" -ne 0 ] && grep -qiE 'out of extra usage|usage limit|quota exceeded|rate.limit|429|weekly limit' "$OUT_TMP" 2>/dev/null; then
                 new_backoff=$((now_epoch + BACKOFF_HOURS * 3600))
                 echo "$new_backoff" > "$BACKOFF_FILE"
                 echo 0 > "$CONSEC_FAIL_FILE"   # quota is a distinct, correctly-classified state

--- a/scripts/tests/test_army_spark_lane.sh
+++ b/scripts/tests/test_army_spark_lane.sh
@@ -68,6 +68,23 @@ PY
     mkdir -p "$WORK/world/home/.codex-o2"
     echo '{}' > "$WORK/world/home/.codex-o2/auth.json"
 
+    # The real queue dir carries a README.md alongside real tasks (documents
+    # the queue format, incl. quota/backoff/429 behavior) — every fake world
+    # must reproduce that shape so the README-exclusion fix (defect 1,
+    # 2026-08-15) is exercised by every case, not just a dedicated one.
+    # Written BEFORE task-one.md on purpose: select_task() without the
+    # exclusion picks the earliest-mtime never-attempted candidate, so if
+    # README.md were still eligible it would win the race by CREATION ORDER
+    # alone — the guilt assertion in Case 13 below must not depend on
+    # alphabetical/mtime luck to catch the defect.
+    cat > "$WORK/world/queue/README.md" <<'MD'
+# Spark queue README
+
+This queue feeds army.spark_lane. If the bucket returns "out of extra usage",
+"usage limit", "quota exceeded", or HTTP 429, the lane backs off for 12h.
+Rate-limit and weekly limit markers are treated the same way.
+MD
+
     cat > "$WORK/world/queue/task-one.md" <<'MD'
 # Test task one
 
@@ -96,6 +113,7 @@ write_codex_stub() {
 echo "invoked \$*" >> "$WORK/world/codex-invocations.log"
 case "\$STUB_CODEX_MODE" in
     success) echo "STUB REPORT BODY"; exit 0 ;;
+    success_quota_text) echo "Analysis: this queue documents a usage limit and 429 backoff policy."; exit 0 ;;
     quota) echo "error: out of extra usage on this weekly bucket"; exit 1 ;;
     fail) echo "boom: synthetic codex crash"; exit 3 ;;
     *) echo "unset STUB_CODEX_MODE"; exit 9 ;;
@@ -462,6 +480,81 @@ if grep -q "army-spark:codex-failed" "$WORK/world/tg.log" 2>/dev/null; then
     note_pass "no codex seat anywhere: P0 alert fired"
 else
     note_fail "no codex seat anywhere: no P0 alert found in stub log"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 13 (guilt+innocence, defect 1 — 2026-08-15 live evidence): the queue
+# README must never be dispatched as a task, while a real task file
+# alongside it IS. Live symptom on Pro 17:09-17:10 WITA: run.log showed
+# "dispatching task=README.md" (select_task()'s *.md glob matched it).
+# setup_world's fake queue always has README.md next to task-one.md, so
+# every case above already exercises this — this case asserts it directly.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rc="$(run_wrapper STUB_CODEX_MODE=success)"
+if [ "$rc" = "0" ] && [ "$(report_count)" = "1" ] \
+    && grep -q "dispatching task=task-one.md" "$WORK/world/logs/run.log" 2>/dev/null; then
+    note_pass "README exclusion innocence: the real task alongside README.md IS dispatched"
+else
+    note_fail "README exclusion innocence: rc=$rc report_count=$(report_count)"
+fi
+if ! grep -q "dispatching task=README.md" "$WORK/world/logs/run.log" 2>/dev/null; then
+    note_pass "README exclusion guilt: README.md is never selected as a dispatch target"
+else
+    note_fail "README exclusion guilt: README.md was dispatched as a task"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 13b (guilt, defect 1): a queue containing ONLY README.md (no real
+# task) reads as EMPTY, not as "one task named README.md" — no dispatch, no
+# report, heartbeat=ok.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success
+rm -f "$WORK/world/queue/task-one.md"
+rc="$(run_wrapper STUB_CODEX_MODE=success)"
+status="$(sidecar_status)"
+if [ "$rc" = "0" ] && [ "$(report_count)" = "0" ] && [ "$status" = "ok" ] \
+    && ! grep -q "dispatching task=README.md" "$WORK/world/logs/run.log" 2>/dev/null; then
+    note_pass "README exclusion guilt (queue-only-README): treated as empty queue, never dispatched"
+else
+    note_fail "README exclusion guilt (queue-only-README): rc=$rc report_count=$(report_count) status=$status"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 14 (guilt+innocence, defect 2 — 2026-08-15 live evidence): a
+# SUCCESSFUL codex run (rc=0) whose output text happens to mention
+# quota/usage-limit/429 language must be classified as a normal successful
+# report, NOT quota. This is the exact false-positive measured live: the
+# dispatched README documents quota/backoff/429 behavior, so codex's
+# legitimate analysis of it contained those substrings -> false
+# status=quota, false 12h backoff, false P0-class alert; a manual codex
+# probe on the same bucket 3 minutes later answered fine (bucket was never
+# actually in quota). The pre-existing quota-on-FAILURE case (Case 5) must
+# stay green — this case only closes the rc=0 false-positive gap.
+# ---------------------------------------------------------------------------
+setup_world
+write_codex_stub success_quota_text
+rc="$(run_wrapper STUB_CODEX_MODE=success_quota_text)"
+status="$(sidecar_status)"
+report_file="$(find "$WORK/world/reports" -maxdepth 1 -name '*.md' 2>/dev/null | head -1)"
+if [ "$rc" = "0" ] && [ "$status" = "ok" ] && [ "$(report_count)" = "1" ] \
+    && [ -n "$report_file" ] && grep -q "usage limit" "$report_file"; then
+    note_pass "quota over-match fix: rc=0 output mentioning 'usage limit' classified as a normal report, not quota"
+else
+    note_fail "quota over-match fix: rc=$rc status=$status report_count=$(report_count)"
+fi
+if [ ! -f "$WORK/world/state/backoff-until.txt" ]; then
+    note_pass "quota over-match fix innocence: no backoff file written on a successful run"
+else
+    note_fail "quota over-match fix innocence: a backoff file was written despite rc=0 success"
+fi
+if grep -q '"status":"ok"' "$WORK/world/state/attempts.jsonl" 2>/dev/null \
+    && ! grep -q '"status":"quota"' "$WORK/world/state/attempts.jsonl" 2>/dev/null; then
+    note_pass "quota over-match fix: attempt recorded as ok, not quota"
+else
+    note_fail "quota over-match fix: attempts.jsonl did not record ok-not-quota"
 fi
 
 echo


### PR DESCRIPTION
## Summary

Two real defects observed on the **first live tick** of the merged army-spark lane (PR #4179, on main) — measured on Pro at 17:09-17:10 WITA, 2026-08-15.

**Defect 1 — README dispatched as a task.** `~/logs/army-spark/run.log` on Pro showed `dispatching task=README.md`. `select_task()`'s `*.md` glob over `infra/army/spark-queue/` matched the queue's own `README.md`. Fixed by excluding `readme*` case-insensitively inside `select_task()` — the *only* place that enumerates `QUEUE_DIR` for dispatch, so the exclusion is automatically the single source of truth (the daily digest never reads the queue dir; it counts `attempts.jsonl`).

**Defect 2 — quota classifier over-matches the model's OUTPUT** (cicatrix-superscar.md family #3, guard-over-match). The quota-marker `grep` ran unconditionally on `$OUT_TMP`, *before* checking `CODEX_RC`. The dispatched task was the README itself, which *documents* this lane's quota/backoff/429 behavior — codex's legitimate analysis of that doc contained those substrings, producing a false `status=quota`, a false 12h backoff, and a false P0-class Telegram alert. A manual `codex exec -m gpt-5.3-codex-spark` probe on the same bucket 3 minutes later answered fine — the bucket was never actually in quota.

Cure: gate classification on `[ "$CODEX_RC" -ne 0 ] && grep -qiE '...'` — only a run that actually **failed** can be classified as quota; a successful (rc=0) run whose text merely mentions quota is innocent. Kept the simple `rc!=0` gate (not a "short output near the start" heuristic) because `codex exec` fails non-zero on a genuine quota exhaustion (see the test stub's `quota` mode: `exit 1`), so this gate doesn't blind the failure branch to a real quota hit.

## Evidence the tests catch the real bugs

`scripts/tests/test_army_spark_lane.sh`: **27 → 33 cases, 0 failed.**
- Case 13/13b: README.md is added to `setup_world`'s fake queue (with quota-marker text, created *before* the real task so guilt doesn't depend on mtime/alpha ordering) — asserts README is never dispatched while the real task alongside it IS, and a README-only queue reads as EMPTY.
- Case 14: stub codex **succeeds** (rc 0) with output containing `"usage limit"` — asserts it is classified as a normal successful report, NOT quota (the exact false-positive shape observed live). The pre-existing quota-on-*failure* case (Case 5) stays green.

Mutation-verified: ran the new corpus against the **pre-fix** script — all 9 new-defect assertions fail (plus 3 pre-existing dedup/quarantine cases that now also catch the exposure via the README's quota-marker text); against the fixed script, all 33 pass.

`scripts/tests/test_codex_seat_lib.py`: 14/14 green (untouched).

## Test plan
- [x] `sh scripts/tests/test_army_spark_lane.sh` → 33 passed, 0 failed
- [x] `python3 -m pytest scripts/tests/test_codex_seat_lib.py -q` → 14 passed
- [x] `bash -n` / `sh -n` syntax check on both changed files
- [x] `shellcheck -x scripts/army/spark_lane.sh` → only pre-existing SC2329 info notices, unrelated to this diff
- [x] Mutation check: new assertions fail against pre-fix `spark_lane.sh`, pass against fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>