### PR TITLE
feat(intake): W0 read-only guardians — health report + WhatsApp freshness liveness

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -170,7 +170,7 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `publication_histor
 ### LaunchAgents — copertura documentale
 
 <!-- DOCSYNC:AUTOMATION_COVERAGE_START -->
-`141 plist tracked in infra/launchagents/ · 106 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (75% coverage)`
+`143 plist tracked in infra/launchagents/ · 106 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (74% coverage)`
 <!-- DOCSYNC:AUTOMATION_COVERAGE_END -->
 
 Runbook operativi: indice auto-generato in [docs/runbooks/README.md](docs/runbooks/README.md).

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: 22bbcf39b0b2060ff8695f240d46deca09d212f7bc3930bd89f3557951b79b9f
+checksum: 08499d8c2fbda0e97b0195d7ecc371b423ddfd651509a3aff24f652c7bec2275
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -2386,5 +2386,53 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.organism/last_seen/army.spark_lane.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.intake_health_report
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 90000
+  owner_module: scripts/intake_health_report.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.intake-health-report
+  severity_on_silence: warning
+  notes: W0 read-only guardian, daily 07:30 WITA. SELECT-only against local
+    nuzantara_dev (Law 2) — review load, C-02 empty-OCR noise class, C-01 blob
+    presence for the review feed, C-29 companies-table sanity, C-07
+    done-without-proposal orphans, C-05 zombie review_claimed proposals, C-08
+    undelivered committed documents, the intake-worker's own log inode, and
+    24h freshness counters. One JSON object plus one Telegram digest line plus
+    a p0 escalation per breached threshold. Never writes DB.
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.intake_health_report.json
+    timestamp_field: ts
+    status_field: status
+- id: pro.wa_mirror_freshness_liveness
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 1350
+  owner_module: scripts/wa_mirror_freshness_liveness.py
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.nuzantara.wa-mirror-freshness-liveness
+  severity_on_silence: warning
+  notes: W0 read-only guardian, every 900s. SELECT-only max(created_at) off
+    whatsapp_message_context (local nuzantara_dev). ONLY during business
+    hours Mon-Sat 08:00-20:00 Asia/Makassar, alerts --tier p0 (dedup key
+    wa-mirror:freshness:stale) once when the newest row is older than
+    WA_FRESHNESS_MAX_AGE_MIN (default 360min) — a dead intake channel during
+    business hours, not the benign overnight quiet Law 6 already covers.
+    Never writes DB.
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/pro.wa_mirror_freshness_liveness.json
     timestamp_field: ts
     status_field: status

--- a/infra/launchagents/com.nuzantara.intake-health-report.plist
+++ b/infra/launchagents/com.nuzantara.intake-health-report.plist
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.nuzantara.intake-health-report — W0 read-only daily health snapshot of
+  the document-intake organism (2026-08-15).
+
+  Daily 07:30 WITA tick: scripts/intake_health_report.py reads the local
+  Postgres nuzantara_dev (SELECT-only, opened with
+  default_transaction_read_only=on) and reports review load, the empty-OCR
+  noise class, blob presence for the review feed, the companies-table
+  sanity check, done-but-orphaned queue rows, zombie claimed proposals,
+  committed-but-undelivered documents, the worker's own log inode, and 24h
+  freshness counters — one JSON object, one Telegram digest line, and a
+  tier=p0 escalation per breached threshold. NEVER writes to the DB and
+  never mutates a proposal/queue row (Law 2 — PII stays local; only
+  integers/rates/booleans ever leave this machine).
+
+  Pro-only (intake DB lives on the local Pro nuzantara_dev — W87 postgres
+  access-wall discipline: do NOT install this on Mini/M5).
+
+  Kill switch: INTAKE_HEALTH_REPORT_ENABLED=false (checked in the wrapper —
+  the disabled path writes its own status=disabled heartbeat and exits
+  before spawning python).
+
+  Install:
+    cp infra/launchagents/com.nuzantara.intake-health-report.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.nuzantara.intake-health-report.plist
+
+  Plist permissions hardened to 0444 per cicatrix P0-3.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.intake-health-report</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/nuzantara/scripts/intake_health_report_run.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>INTAKE_HEALTH_REPORT_ENABLED</key>
+        <string>true</string>
+    </dict>
+
+    <!-- 07:30 WITA daily. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>7</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/intake-health-report.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/intake-health-report.err.log</string>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>ThrottleInterval</key>
+    <integer>120</integer>
+</dict>
+</plist>

--- a/infra/launchagents/com.nuzantara.wa-mirror-freshness-liveness.plist
+++ b/infra/launchagents/com.nuzantara.wa-mirror-freshness-liveness.plist
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.nuzantara.wa-mirror-freshness-liveness — W0 read-only freshness
+  guardian for the WhatsApp mirror (2026-08-15).
+
+  Every 900s (15min) tick: scripts/wa_mirror_freshness_liveness.py reads
+  max(created_at) off whatsapp_message_context (SELECT-only, local Postgres
+  nuzantara_dev) and, ONLY during business hours Mon-Sat 08:00-20:00 Asia/
+  Makassar, alerts tier=p0 (dedup key wa-mirror:freshness:stale) once when
+  the newest row is older than WA_FRESHNESS_MAX_AGE_MIN (default 360min).
+  Outside business hours or when fresh: state-file + heartbeat only, no
+  Telegram — a quiet overnight line is Law 6 (local sovereignty:
+  disconnection is natural, not a fault), not a fault to page on.
+
+  superscar #7 (KeepAlive misconfig): this is a StartInterval PROBE, not a
+  daemon — KeepAlive=false, no `nohup ... &`, no nothing-to-restart. Same
+  shape as com.nuzantara.intake-review-reader-liveness.plist and
+  scripts/supervisor_liveness_watchdog.sh.
+
+  Pro-only (superscar #10 active-active split-brain: the WhatsApp mirror and
+  its Postgres table live on Pro only — do NOT install this on Mini/M5).
+
+  Kill switch: WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false (checked in the
+  wrapper — the disabled path writes its own status=disabled heartbeat and
+  exits before spawning python).
+
+  Install:
+    cp infra/launchagents/com.nuzantara.wa-mirror-freshness-liveness.plist \
+       ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) \
+       ~/Library/LaunchAgents/com.nuzantara.wa-mirror-freshness-liveness.plist
+
+  Plist permissions hardened to 0444 per cicatrix P0-3.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nuzantara.wa-mirror-freshness-liveness</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/nuzantara/scripts/wa_mirror_freshness_liveness_run.sh</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/nuzantara</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>WA_MIRROR_FRESHNESS_LIVENESS_ENABLED</key>
+        <string>true</string>
+    </dict>
+
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/nuzantara/logs/wa-mirror-freshness-liveness.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/nuzantara/logs/wa-mirror-freshness-liveness.err.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+</dict>
+</plist>

--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""intake_health_report.py — read-only daily health snapshot of the document-intake organism.
+
+W0 read-only guardian (never writes DB, never mutates a proposal/queue row).
+Reads the local Postgres `nuzantara_dev` (Law 2 — PII stays local, only
+integers/rates/booleans ever leave this machine) and reports one JSON object
+covering the intake corner's LIVE STATE anatomy: review load, the empty-OCR
+noise class (C-02), blob presence for the review feed (C-01), the CRM's
+`companies` table sanity (C-29), done-but-orphaned queue rows (C-07),
+zombie claimed-but-lease-less proposals (C-05), committed-but-undelivered
+documents (C-08), the worker's own log inode, and 24h freshness counters.
+
+Model: scripts/intake_gate_count_pusher.py (DSN/env/logging conventions) +
+scripts/wr2_daily_reconciler.py (module-level `_tg_notify`/`_heartbeat` so a
+test can monkeypatch the SIDE EFFECT without touching the DB or the network —
+`run()`/`gather()` take a live/fake connection, everything else is pure).
+
+DB: SELECT-only. Connection opened with `default_transaction_read_only=on`
+(server_settings) as defense-in-depth beyond "we only issue SELECTs" — a
+write attempted over this connection is refused by Postgres itself, not by
+code discipline alone.
+
+Env:
+  INTAKE_DATABASE_URL / LOCAL_DATABASE_URL   DSN (default local nuzantara_dev)
+  INTAKE_HEALTH_REPORT_ENABLED               kill switch (default true) — G5
+  INTAKE_HEALTH_COMPANIES_MIN_ROWS           default 1  (breach if companies_rows < N)
+  INTAKE_HEALTH_BLOB_PRESENT_MIN             default 0.5 (breach if newest blob-present rate < N)
+  INTAKE_HEALTH_ALL_EMPTY_MAX                default 0.5 (breach if quarantine all-pages-empty rate > N)
+  INTAKE_HEALTH_ZOMBIE_MAX                   default 0  (breach if zombie count > N)
+  INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS        default 60000 (statement_timeout for the C-07b query)
+
+Flags: --dry-run (skip Telegram + state-file write; heartbeat still fires) ·
+       --json-only (pure read: skip Telegram + state-file write + heartbeat too)
+
+Exit: 0 always, except a DSN/connect failure (logged, heartbeat status=error) -> 1.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import fcntl
+import json
+import logging
+import os
+import plistlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO))
+
+from scripts.tg_gateway_verdict import extract_gateway_verdict, gateway_delivered  # noqa: E402
+
+logging.basicConfig(
+    level=os.getenv("INTAKE_HEALTH_LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger("intake_health_report")
+
+ORGAN_ID = "pro.intake_health_report"
+STATE_PATH = Path.home() / ".agent" / "decisions" / "state" / "intake_health_report.json"
+LOCK_FILE = Path.home() / ".cell-bridge-state" / "intake_health_report.lock"
+DEFAULT_DSN = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+WORKER_PLIST_PATH = _REPO / "infra" / "launchagents" / "com.nuzantara.intake-worker.plist"
+_FALLBACK_WORKER_LOG = Path.home() / "logs" / "intake-worker.launchd.err.log"
+
+# The absolute python3 candidates tg_notify.py is spawned with (W108 — the
+# alarm must not share the failure mode of a possibly-broken venv PATH
+# resolution). tg_notify.py is stdlib-only by design for exactly this reason.
+_PY3_CANDIDATES: tuple[str, ...] = (
+    "/usr/bin/python3",
+    "/opt/homebrew/bin/python3",
+    "/usr/local/bin/python3",
+)
+
+# The live (non-terminal-loss) proposal statuses (migration 235, verified
+# live against document_routing_proposal.chk_rp_status 2026-08-15). A `done`
+# queue row whose ONLY proposals sit OUTSIDE this set has effectively lost
+# its trail (dead/superseded, never landed anywhere a human or the writer
+# can still act on it).
+_LIVE_PROPOSAL_STATUSES: tuple[str, ...] = (
+    "review_pending", "review_claimed", "routed", "rejected",
+    "auto_routed", "quarantine", "duplicate",
+)
+_LIVE_STATUS_SQL_ARRAY = "ARRAY[" + ",".join(f"'{s}'" for s in _LIVE_PROPOSAL_STATUSES) + "]"
+
+# ---------------------------------------------------------------- SQL (module constants — shape-tested)
+
+STATUS_COUNTS_SQL = """
+    SELECT
+        count(*) FILTER (WHERE p.status = 'review_pending')                            AS review_pending_total,
+        count(*) FILTER (WHERE p.status = 'review_pending' AND q.source = 'whatsapp')   AS review_pending_wa,
+        count(*) FILTER (WHERE p.status = 'quarantine')                                 AS quarantine_total,
+        count(*) FILTER (WHERE p.status = 'duplicate')                                  AS duplicate_total,
+        count(*) FILTER (
+            WHERE p.status = 'review_pending'
+              AND p.entity_resolution ->> 'decision' = 'NO_MATCH'
+        ) AS zero_candidate_count
+    FROM document_routing_proposal p
+    JOIN intake_queue q ON q.id = p.queue_id
+"""
+
+ALL_PAGES_EMPTY_SQL = """
+    SELECT p.status,
+           count(*) FILTER (
+               WHERE NOT EXISTS (
+                   SELECT 1
+                     FROM jsonb_array_elements(q.stage_output -> 'classify' -> 'ocr_text_per_page') AS pg
+                    WHERE pg ->> 'via' IS DISTINCT FROM 'empty'
+               )
+           ) AS all_empty,
+           count(*) AS denominator
+      FROM intake_queue q
+      JOIN document_routing_proposal p ON p.queue_id = q.id
+     WHERE q.source = 'whatsapp'
+       AND p.status IN ('quarantine', 'review_pending')
+       AND jsonb_typeof(q.stage_output -> 'classify' -> 'ocr_text_per_page') = 'array'
+       AND jsonb_array_length(q.stage_output -> 'classify' -> 'ocr_text_per_page') >= 1
+     GROUP BY p.status
+"""
+
+BLOB_SAMPLE_SQL = """
+    SELECT q.blob_path
+      FROM document_routing_proposal p
+      JOIN intake_queue q ON q.id = p.queue_id
+     WHERE q.source = 'whatsapp' AND p.status = 'review_pending'
+     ORDER BY p.created_at {direction}
+     LIMIT $1
+"""
+
+COMPANIES_ROWS_SQL = "SELECT count(*) AS n FROM companies"
+
+ORPHAN_DONE_SQL = """
+    SELECT q.source, count(*) AS n
+      FROM intake_queue q
+      LEFT JOIN document_routing_proposal p ON p.queue_id = q.id
+     WHERE q.status = 'done' AND p.id IS NULL
+     GROUP BY q.source
+"""
+
+SUPERSEDED_ORPHAN_SQL = f"""
+    SELECT count(*) AS n
+      FROM intake_queue q
+     WHERE q.status = 'done'
+       AND EXISTS (SELECT 1 FROM document_routing_proposal p WHERE p.queue_id = q.id)
+       AND NOT EXISTS (
+             SELECT 1
+               FROM document_routing_proposal p
+              WHERE p.queue_id = q.id
+                AND p.status = ANY({_LIVE_STATUS_SQL_ARRAY}::text[])
+           )
+"""
+
+ZOMBIE_SQL = """
+    SELECT count(*) AS n
+      FROM document_routing_proposal
+     WHERE status = 'review_claimed' AND lease_expires_at IS NULL
+"""
+
+UNDELIVERED_COMMITTED_SQL = """
+    SELECT
+        count(*) FILTER (WHERE file_id IS NULL) AS undelivered,
+        count(*)                                AS total
+      FROM documents
+     WHERE intake_proposal_id IS NOT NULL
+"""
+
+DEAD_LAST_24H_SQL = """
+    SELECT count(*) AS n
+      FROM intake_queue
+     WHERE status = 'dead' AND updated_at > now() - interval '24 hours'
+"""
+
+WA_MEDIA_LAST_24H_SQL = """
+    SELECT count(*) AS n
+      FROM whatsapp_message_context
+     WHERE media_stored_path IS NOT NULL
+       AND created_at > now() - interval '24 hours'
+"""
+
+
+# ---------------------------------------------------------------- side effects (module-level, monkeypatchable)
+
+
+def _resolve_py3() -> str:
+    for candidate in _PY3_CANDIDATES:
+        if Path(candidate).is_file():
+            return candidate
+    return sys.executable  # last resort — never crash over interpreter resolution
+
+
+def _tg_notify(tier: str, dedup_key: str, text: str) -> bool:
+    """Route through the tg_notify gateway; never raises."""
+    try:
+        gateway = _REPO / "scripts" / "tg_notify.py"
+        if not gateway.is_file():
+            logger.warning("[intake_health_report] tg_notify.py missing at %s", gateway)
+            return False
+        res = subprocess.run(
+            [_resolve_py3(), str(gateway), "--tier", tier,
+             "--source", "intake-health-report", "--dedup-key", dedup_key, "--", text],
+            capture_output=True, text=True, timeout=30,
+        )
+        verdict = extract_gateway_verdict(res.stderr)
+        logger.info("[intake_health_report] tg_notify: %s", verdict or f"NESSUN verdetto rc={res.returncode}")
+        return res.returncode == 0 and gateway_delivered(verdict)
+    except Exception as exc:  # noqa: BLE001 — never raises
+        logger.warning("[intake_health_report] tg_notify failed: %s", exc)
+        return False
+
+
+def _heartbeat(status: str, note: str = "") -> None:
+    try:
+        from scripts.lib.heartbeat import organism_heartbeat
+
+        organism_heartbeat(ORGAN_ID, status, note=note)
+    except Exception as exc:  # noqa: BLE001 — never raises
+        logger.warning("[intake_health_report] heartbeat write failed: %s", exc)
+
+
+def _write_state(report: dict[str, Any]) -> None:
+    try:
+        STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_PATH.with_suffix(STATE_PATH.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(tmp, STATE_PATH)
+    except OSError as exc:
+        logger.warning("[intake_health_report] state write failed: %s", exc)
+
+
+def _acquire_lock_or_exit() -> int | None:
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return fd
+    except BlockingIOError:
+        logger.info("[intake_health_report] another instance running, skipping")
+        os.close(fd)
+        return None
+
+
+# ---------------------------------------------------------------- pure helpers (unit-tested, no DB/network)
+
+
+def worker_log_path() -> Path:
+    """Resolve the intake-worker's StandardErrorPath from its own plist —
+    never hardcode a duplicate of what the plist already declares."""
+    try:
+        payload = plistlib.loads(WORKER_PLIST_PATH.read_bytes())
+        raw = payload.get("StandardErrorPath")
+        if isinstance(raw, str) and raw:
+            return Path(raw).expanduser()
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "[intake_health_report] could not read worker plist %s (%s) — falling back to %s",
+            WORKER_PLIST_PATH, exc, _FALLBACK_WORKER_LOG,
+        )
+    return _FALLBACK_WORKER_LOG
+
+
+def blob_presence(paths: list[str]) -> dict[str, Any]:
+    """os.path.exists over a caller-supplied sample. Pure — the caller owns
+    SAMPLING (which rows, how many); this only judges presence."""
+    sampled = len(paths)
+    present = sum(1 for p in paths if p and os.path.exists(p))
+    return {
+        "sampled": sampled,
+        "present": present,
+        "rate": round(present / sampled, 4) if sampled else None,
+    }
+
+
+def build_report(
+    *,
+    status_counts: dict[str, int],
+    all_pages_empty_rows: list[dict[str, Any]],
+    blob_newest: list[str],
+    blob_oldest: list[str],
+    companies_rows: int,
+    orphan_rows: list[dict[str, Any]],
+    superseded_orphans: int | None,
+    zombie_count: int,
+    undelivered: dict[str, int],
+    worker_log_exists: bool,
+    dead_last_24h: int,
+    wa_media_last_24h: int,
+    generated_at: str,
+) -> dict[str, Any]:
+    """Assemble the final report dict from already-fetched raw values. Pure —
+    no DB, no I/O beyond the blob_presence() calls already made by the
+    caller — so the JSON shape is unit-testable with canned inputs."""
+    review_pending_total = int(status_counts.get("review_pending_total") or 0)
+    zero_candidate_count = int(status_counts.get("zero_candidate_count") or 0)
+    zero_candidate_rate = (
+        round(zero_candidate_count / review_pending_total, 4) if review_pending_total else None
+    )
+
+    empty_by_status: dict[str, dict[str, Any]] = {}
+    for row in all_pages_empty_rows:
+        status = row["status"]
+        all_empty = int(row["all_empty"] or 0)
+        denom = int(row["denominator"] or 0)
+        empty_by_status[status] = {
+            "count": all_empty,
+            "denominator": denom,
+            "rate": round(all_empty / denom, 4) if denom else None,
+        }
+    for status in ("quarantine", "review_pending"):
+        empty_by_status.setdefault(status, {"count": 0, "denominator": 0, "rate": None})
+    overall_count = sum(v["count"] for v in empty_by_status.values())
+    overall_denom = sum(v["denominator"] for v in empty_by_status.values())
+
+    orphans_by_source = {row["source"]: int(row["n"] or 0) for row in orphan_rows}
+
+    return {
+        "generated_at": generated_at,
+        "review_pending_wa": int(status_counts.get("review_pending_wa") or 0),
+        "review_pending_total": review_pending_total,
+        "quarantine_total": int(status_counts.get("quarantine_total") or 0),
+        "duplicate_total": int(status_counts.get("duplicate_total") or 0),
+        "zero_candidate_rate": {
+            "count": zero_candidate_count,
+            "denominator": review_pending_total,
+            "rate": zero_candidate_rate,
+        },
+        "all_pages_empty": {
+            "by_status": empty_by_status,
+            "overall_rate": round(overall_count / overall_denom, 4) if overall_denom else None,
+        },
+        "blob_present": {
+            "newest": blob_presence(blob_newest),
+            "oldest": blob_presence(blob_oldest),
+        },
+        "companies_rows": int(companies_rows),
+        "orphans_done_without_proposal": orphans_by_source,
+        "superseded_orphans_true": superseded_orphans,
+        "zombie_review_claimed_null_lease": int(zombie_count),
+        "undelivered_committed": {
+            "undelivered": int(undelivered.get("undelivered") or 0),
+            "total": int(undelivered.get("total") or 0),
+        },
+        "worker_log_inode_exists": bool(worker_log_exists),
+        "dead_last_24h": int(dead_last_24h),
+        "wa_media_last_24h": int(wa_media_last_24h),
+    }
+
+
+def evaluate_breaches(report: dict[str, Any], thresholds: dict[str, float]) -> list[dict[str, str]]:
+    """Pure threshold evaluation. Returns a list of {metric, message} — empty
+    when nothing breaches. Each rule is independently guilt/innocence-tested."""
+    breaches: list[dict[str, str]] = []
+
+    companies_rows = report["companies_rows"]
+    if companies_rows < thresholds["companies_min_rows"]:
+        breaches.append({
+            "metric": "companies_rows",
+            "message": f"companies table has {companies_rows} rows (min {thresholds['companies_min_rows']})",
+        })
+
+    newest = report["blob_present"]["newest"]
+    if newest["sampled"] and newest["rate"] is not None and newest["rate"] < thresholds["blob_present_min"]:
+        breaches.append({
+            "metric": "blob_present_newest",
+            "message": (
+                f"blob-present rate on newest review_pending sample is "
+                f"{newest['rate']:.2%} ({newest['present']}/{newest['sampled']}), "
+                f"below {thresholds['blob_present_min']:.0%}"
+            ),
+        })
+
+    quarantine_empty = report["all_pages_empty"]["by_status"].get("quarantine", {})
+    q_rate = quarantine_empty.get("rate")
+    if q_rate is not None and q_rate > thresholds["all_empty_max"]:
+        breaches.append({
+            "metric": "all_pages_empty_quarantine",
+            "message": (
+                f"all-pages-empty rate among quarantined WhatsApp docs is {q_rate:.2%} "
+                f"({quarantine_empty['count']}/{quarantine_empty['denominator']}), "
+                f"above {thresholds['all_empty_max']:.0%}"
+            ),
+        })
+
+    zombie = report["zombie_review_claimed_null_lease"]
+    if zombie > thresholds["zombie_max"]:
+        breaches.append({
+            "metric": "zombie_review_claimed",
+            "message": f"{zombie} review_claimed proposal(s) with NULL lease_expires_at (max {thresholds['zombie_max']})",
+        })
+
+    if not report["worker_log_inode_exists"]:
+        breaches.append({
+            "metric": "worker_log_missing",
+            "message": "intake-worker StandardErrorPath log file does not exist on disk",
+        })
+
+    return breaches
+
+
+def render_digest(report: dict[str, Any]) -> str:
+    """The 6 headline numbers for the daily digest line."""
+    zc = report["zero_candidate_rate"]["rate"]
+    zc_pct = f"{zc:.1%}" if zc is not None else "n/a"
+    bp = report["blob_present"]["newest"]["rate"]
+    bp_pct = f"{bp:.1%}" if bp is not None else "n/a"
+    return (
+        f"📋 Intake health: review_pending={report['review_pending_total']} "
+        f"(wa={report['review_pending_wa']}) quarantine={report['quarantine_total']} "
+        f"duplicate={report['duplicate_total']} zero_candidate={zc_pct} "
+        f"blob_present(newest)={bp_pct}"
+    )
+
+
+# ---------------------------------------------------------------- DB fetchers (thin, async)
+
+
+async def _fetch_superseded_orphans(conn: Any, timeout_ms: int) -> int | None:
+    try:
+        await conn.execute(f"SET statement_timeout = '{int(timeout_ms)}'")
+        row = await conn.fetchrow(SUPERSEDED_ORPHAN_SQL)
+        return int(row["n"])
+    except asyncpg.exceptions.QueryCanceledError:
+        logger.warning(
+            "[intake_health_report] superseded_orphans query exceeded %sms — reporting null",
+            timeout_ms,
+        )
+        return None
+    finally:
+        try:
+            await conn.execute("SET statement_timeout = DEFAULT")
+        except Exception:  # noqa: BLE001 — never let cleanup crash the report
+            pass
+
+
+async def gather(conn: Any, *, superseded_timeout_ms: int) -> dict[str, Any]:
+    """Run every metric query against `conn` (real or fake) and assemble the
+    final report dict. The only I/O outside `conn` is os.path.exists() on the
+    sampled blob paths and the worker plist read — both pure-function-wrapped
+    above so a test can exercise them without a filesystem fixture if desired."""
+    status_row = await conn.fetchrow(STATUS_COUNTS_SQL)
+    all_pages_empty_rows = [dict(r) for r in await conn.fetch(ALL_PAGES_EMPTY_SQL)]
+    newest_rows = await conn.fetch(BLOB_SAMPLE_SQL.format(direction="DESC"), 300)
+    oldest_rows = await conn.fetch(BLOB_SAMPLE_SQL.format(direction="ASC"), 50)
+    companies_row = await conn.fetchrow(COMPANIES_ROWS_SQL)
+    orphan_rows = [dict(r) for r in await conn.fetch(ORPHAN_DONE_SQL)]
+    superseded_orphans = await _fetch_superseded_orphans(conn, superseded_timeout_ms)
+    zombie_row = await conn.fetchrow(ZOMBIE_SQL)
+    undelivered_row = await conn.fetchrow(UNDELIVERED_COMMITTED_SQL)
+    dead_row = await conn.fetchrow(DEAD_LAST_24H_SQL)
+    wa_media_row = await conn.fetchrow(WA_MEDIA_LAST_24H_SQL)
+
+    return build_report(
+        status_counts=dict(status_row),
+        all_pages_empty_rows=all_pages_empty_rows,
+        blob_newest=[r["blob_path"] for r in newest_rows],
+        blob_oldest=[r["blob_path"] for r in oldest_rows],
+        companies_rows=companies_row["n"],
+        orphan_rows=orphan_rows,
+        superseded_orphans=superseded_orphans,
+        zombie_count=zombie_row["n"],
+        undelivered=dict(undelivered_row),
+        worker_log_exists=worker_log_path().exists(),
+        dead_last_24h=dead_row["n"],
+        wa_media_last_24h=wa_media_row["n"],
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+
+
+def _thresholds_from_env() -> dict[str, float]:
+    return {
+        "companies_min_rows": float(os.getenv("INTAKE_HEALTH_COMPANIES_MIN_ROWS", "1")),
+        "blob_present_min": float(os.getenv("INTAKE_HEALTH_BLOB_PRESENT_MIN", "0.5")),
+        "all_empty_max": float(os.getenv("INTAKE_HEALTH_ALL_EMPTY_MAX", "0.5")),
+        "zombie_max": float(os.getenv("INTAKE_HEALTH_ZOMBIE_MAX", "0")),
+    }
+
+
+async def run(*, dry_run: bool, json_only: bool) -> int:
+    if os.getenv("INTAKE_HEALTH_REPORT_ENABLED", "true").strip().lower() in ("0", "false", "no"):
+        logger.info("[intake_health_report] disabled via INTAKE_HEALTH_REPORT_ENABLED — no-op")
+        _heartbeat("disabled", "INTAKE_HEALTH_REPORT_ENABLED=false")
+        print(json.dumps({"status": "disabled"}))
+        return 0
+
+    lock_fd = _acquire_lock_or_exit()
+    if lock_fd is None:
+        return 0
+    try:
+        dsn = os.getenv("INTAKE_DATABASE_URL") or os.getenv("LOCAL_DATABASE_URL") or DEFAULT_DSN
+        timeout_ms = int(os.getenv("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", "60000"))
+        try:
+            conn = await asyncpg.connect(
+                dsn, server_settings={"default_transaction_read_only": "on"}
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[intake_health_report] DB connect failed: %s", exc)
+            _heartbeat("error", f"db connect failed: {exc}")
+            return 1
+
+        try:
+            report = await gather(conn, superseded_timeout_ms=timeout_ms)
+        finally:
+            await conn.close()
+
+        thresholds = _thresholds_from_env()
+        breaches = evaluate_breaches(report, thresholds)
+        report["breaches"] = breaches
+
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+        if json_only:
+            return 0
+
+        if not dry_run:
+            _write_state(report)
+
+        _heartbeat("ok" if not breaches else "degraded", note=f"breaches={len(breaches)}")
+
+        if not dry_run:
+            _tg_notify("digest", "intake-health:daily", render_digest(report))
+            for breach in breaches:
+                _tg_notify("p0", f"intake-health:{breach['metric']}", f"🚨 {breach['message']}")
+
+        return 0
+    finally:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument("--dry-run", action="store_true", help="no Telegram, no state-file write")
+    parser.add_argument("--json-only", action="store_true", help="pure read: JSON to stdout, no side effects at all")
+    args = parser.parse_args()
+    return asyncio.run(run(dry_run=args.dry_run, json_only=args.json_only))
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -235,7 +235,7 @@ def _write_state(report: dict[str, Any]) -> None:
 
 def _acquire_lock_or_exit() -> int | None:
     LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o644)
+    fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o600)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         return fd

--- a/scripts/intake_health_report_run.sh
+++ b/scripts/intake_health_report_run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# intake_health_report_run.sh — venv-python launcher for scripts/intake_health_report.py.
+#
+# W0 read-only guardian wrapper, same shape as every sibling intake launchd
+# wrapper (com.nuzantara.intake-gate-count-pusher / intake-blob-retention /
+# intake-review-reader{,-liveness}): launchd always spawns a `/bin/bash
+# <this>.sh`, never a venv python directly — this IS the resolve-python
+# convention for this corner.
+#
+# REPO_ROOT is derived from this file's OWN location (superscar #1 HOME-fork
+# discipline: never hardcode a path that could silently diverge from where
+# this script actually lives — Pro `/Users/nuzantara/nuzantara`, Air-M5
+# `/Users/balizero/nuzantara`), rather than a literal per-machine string.
+#
+# Kill switch INTAKE_HEALTH_REPORT_ENABLED (default true): honored HERE, not
+# only inside the Python script, so a disabled organ never even spawns the
+# interpreter — and the disabled path writes its OWN final heartbeat before
+# exiting (organism gene G2xG5: "wrapper honors X_ENABLED=false AND writes a
+# final heartbeat status=disabled before exiting"). The enabled path execs
+# straight into the venv python, which owns the real per-run heartbeat
+# (~/.organism/last_seen/pro.intake_health_report.json) and the report
+# itself — this wrapper's only job is safe launch, nothing decorative.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORGAN_ID="pro.intake_health_report"
+
+# shellcheck source=scripts/lib/heartbeat.sh
+source "$REPO_ROOT/scripts/lib/heartbeat.sh"
+
+if [ "${INTAKE_HEALTH_REPORT_ENABLED:-true}" = "false" ]; then
+  organism_heartbeat "$ORGAN_ID" "disabled" "INTAKE_HEALTH_REPORT_ENABLED=false"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) INTAKE_HEALTH_REPORT_ENABLED=false — skipping run"
+  exit 0
+fi
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+PYBIN="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+exec "$PYBIN" -u "$REPO_ROOT/scripts/intake_health_report.py" "$@"

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Pure tests for intake_health_report.py — NO database (W87/W96).
+
+Every test here works against canned dicts/lists or a FakeConn whose
+fetchrow/fetch/execute dispatch on a SQL-text fingerprint — never against a
+live connection, and never against `nuzantara_dev` (the local Intake/WhatsApp
+queue). Covers: JSON-shape stability, the rate/count math in build_report(),
+guilt+innocence for every threshold rule in evaluate_breaches(), the blob
+presence sampler against tmp_path, the SQL-shape assertions the orchestrator
+asked for (document_routing_proposal named, the corrected 7-status live set
+embedded), and that --dry-run sends nothing through a fake tg_notify.
+
+Run:  python3 scripts/tests/test_intake_health_report.py
+      python3 -m pytest scripts/tests/test_intake_health_report.py -q
+"""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import intake_health_report as ihr  # noqa: E402
+
+
+# ---------------------------------------------------------------- build_report shape
+
+
+def _base_kwargs(**overrides):
+    kwargs = dict(
+        status_counts={
+            "review_pending_total": 100,
+            "review_pending_wa": 40,
+            "quarantine_total": 20,
+            "duplicate_total": 5,
+            "zero_candidate_count": 30,
+        },
+        all_pages_empty_rows=[
+            {"status": "quarantine", "all_empty": 8, "denominator": 10},
+            {"status": "review_pending", "all_empty": 2, "denominator": 20},
+        ],
+        blob_newest=["/tmp/a.jpg", "/tmp/missing.jpg"],
+        blob_oldest=["/tmp/b.jpg"],
+        companies_rows=5,
+        orphan_rows=[{"source": "whatsapp", "n": 3}, {"source": "drive", "n": 1}],
+        superseded_orphans=2,
+        zombie_count=0,
+        undelivered={"undelivered": 1, "total": 10},
+        worker_log_exists=True,
+        dead_last_24h=4,
+        wa_media_last_24h=7,
+        generated_at="2026-08-15T00:00:00Z",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_build_report_has_stable_top_level_keys():
+    report = ihr.build_report(**_base_kwargs())
+    assert set(report.keys()) == {
+        "generated_at",
+        "review_pending_wa",
+        "review_pending_total",
+        "quarantine_total",
+        "duplicate_total",
+        "zero_candidate_rate",
+        "all_pages_empty",
+        "blob_present",
+        "companies_rows",
+        "orphans_done_without_proposal",
+        "superseded_orphans_true",
+        "zombie_review_claimed_null_lease",
+        "undelivered_committed",
+        "worker_log_inode_exists",
+        "dead_last_24h",
+        "wa_media_last_24h",
+    }
+
+
+def test_zero_candidate_rate_math():
+    report = ihr.build_report(**_base_kwargs())
+    zc = report["zero_candidate_rate"]
+    assert zc == {"count": 30, "denominator": 100, "rate": 0.3}
+
+
+def test_zero_candidate_rate_none_when_no_review_pending():
+    kwargs = _base_kwargs()
+    kwargs["status_counts"] = {
+        "review_pending_total": 0,
+        "review_pending_wa": 0,
+        "quarantine_total": 0,
+        "duplicate_total": 0,
+        "zero_candidate_count": 0,
+    }
+    report = ihr.build_report(**kwargs)
+    assert report["zero_candidate_rate"]["rate"] is None
+
+
+def test_all_pages_empty_by_status_and_overall():
+    report = ihr.build_report(**_base_kwargs())
+    empty = report["all_pages_empty"]
+    assert empty["by_status"]["quarantine"] == {"count": 8, "denominator": 10, "rate": 0.8}
+    assert empty["by_status"]["review_pending"] == {"count": 2, "denominator": 20, "rate": 0.1}
+    # overall = (8+2)/(10+20)
+    assert empty["overall_rate"] == round(10 / 30, 4)
+
+
+def test_all_pages_empty_defaults_present_even_with_no_rows():
+    kwargs = _base_kwargs(all_pages_empty_rows=[])
+    report = ihr.build_report(**kwargs)
+    empty = report["all_pages_empty"]
+    assert empty["by_status"]["quarantine"] == {"count": 0, "denominator": 0, "rate": None}
+    assert empty["by_status"]["review_pending"] == {"count": 0, "denominator": 0, "rate": None}
+    assert empty["overall_rate"] is None
+
+
+def test_orphans_by_source_and_superseded_passthrough():
+    report = ihr.build_report(**_base_kwargs())
+    assert report["orphans_done_without_proposal"] == {"whatsapp": 3, "drive": 1}
+    assert report["superseded_orphans_true"] == 2
+
+
+def test_superseded_orphans_null_on_timeout_passthrough():
+    report = ihr.build_report(**_base_kwargs(superseded_orphans=None))
+    assert report["superseded_orphans_true"] is None
+
+
+# ---------------------------------------------------------------- blob_presence
+
+
+def test_blob_presence_counts_present_and_missing(tmp_path):
+    present = tmp_path / "present.jpg"
+    present.write_bytes(b"x")
+    missing = tmp_path / "missing.jpg"
+    result = ihr.blob_presence([str(present), str(missing)])
+    assert result == {"sampled": 2, "present": 1, "rate": 0.5}
+
+
+def test_blob_presence_empty_sample_rate_is_none():
+    assert ihr.blob_presence([]) == {"sampled": 0, "present": 0, "rate": None}
+
+
+# ---------------------------------------------------------------- evaluate_breaches (guilt + innocence)
+
+
+_THRESHOLDS = {
+    "companies_min_rows": 1.0,
+    "blob_present_min": 0.5,
+    "all_empty_max": 0.5,
+    "zombie_max": 0.0,
+}
+
+
+def _report_with(**overrides):
+    """A genuinely HEALTHY baseline report — every threshold rule innocent
+    unless a test explicitly overrides the field it means to breach."""
+    report = ihr.build_report(**_base_kwargs(
+        companies_rows=5,
+        zombie_count=0,
+        worker_log_exists=True,
+        blob_newest=[],
+        blob_oldest=[],
+        all_pages_empty_rows=[
+            {"status": "quarantine", "all_empty": 1, "denominator": 10},
+            {"status": "review_pending", "all_empty": 1, "denominator": 20},
+        ],
+    ))
+    report.update(overrides)
+    return report
+
+
+def test_guilt_companies_rows_zero_breaches():
+    report = _report_with(companies_rows=0)
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert any(b["metric"] == "companies_rows" for b in breaches)
+
+
+def test_innocence_companies_rows_positive_no_breach():
+    report = _report_with(companies_rows=5)
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert not any(b["metric"] == "companies_rows" for b in breaches)
+
+
+def test_guilt_blob_present_newest_below_threshold():
+    report = _report_with(blob_present={"newest": {"sampled": 10, "present": 3, "rate": 0.3},
+                                         "oldest": {"sampled": 5, "present": 5, "rate": 1.0}})
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert any(b["metric"] == "blob_present_newest" for b in breaches)
+
+
+def test_innocence_blob_present_newest_at_or_above_threshold():
+    report = _report_with(blob_present={"newest": {"sampled": 10, "present": 6, "rate": 0.6},
+                                         "oldest": {"sampled": 5, "present": 5, "rate": 1.0}})
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert not any(b["metric"] == "blob_present_newest" for b in breaches)
+
+
+def test_innocence_blob_present_newest_zero_sample_is_inconclusive_not_a_breach():
+    report = _report_with(blob_present={"newest": {"sampled": 0, "present": 0, "rate": None},
+                                         "oldest": {"sampled": 0, "present": 0, "rate": None}})
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert not any(b["metric"] == "blob_present_newest" for b in breaches)
+
+
+def test_guilt_all_pages_empty_quarantine_above_threshold():
+    report = _report_with(all_pages_empty={
+        "by_status": {
+            "quarantine": {"count": 9, "denominator": 10, "rate": 0.9},
+            "review_pending": {"count": 0, "denominator": 10, "rate": 0.0},
+        },
+        "overall_rate": 0.45,
+    })
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert any(b["metric"] == "all_pages_empty_quarantine" for b in breaches)
+
+
+def test_innocence_all_pages_empty_quarantine_at_or_below_threshold():
+    report = _report_with(all_pages_empty={
+        "by_status": {
+            "quarantine": {"count": 4, "denominator": 10, "rate": 0.4},
+            "review_pending": {"count": 0, "denominator": 10, "rate": 0.0},
+        },
+        "overall_rate": 0.2,
+    })
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert not any(b["metric"] == "all_pages_empty_quarantine" for b in breaches)
+
+
+def test_guilt_zombie_above_max():
+    report = _report_with(zombie_review_claimed_null_lease=1)
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert any(b["metric"] == "zombie_review_claimed" for b in breaches)
+
+
+def test_innocence_zombie_at_max():
+    report = _report_with(zombie_review_claimed_null_lease=0)
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert not any(b["metric"] == "zombie_review_claimed" for b in breaches)
+
+
+def test_guilt_worker_log_missing():
+    report = _report_with(worker_log_inode_exists=False)
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert any(b["metric"] == "worker_log_missing" for b in breaches)
+
+
+def test_innocence_worker_log_present():
+    report = _report_with(worker_log_inode_exists=True)
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert not any(b["metric"] == "worker_log_missing" for b in breaches)
+
+
+def test_no_breaches_when_everything_healthy():
+    report = _report_with()
+    breaches = ihr.evaluate_breaches(report, _THRESHOLDS)
+    assert breaches == []
+
+
+# ---------------------------------------------------------------- SQL shape (orphan query)
+
+
+def test_superseded_orphan_sql_names_the_table_and_the_corrected_live_set():
+    sql = ihr.SUPERSEDED_ORPHAN_SQL
+    assert "document_routing_proposal" in sql
+    expected_live_set = (
+        "review_pending", "review_claimed", "routed", "rejected",
+        "auto_routed", "quarantine", "duplicate",
+    )
+    assert expected_live_set == ihr._LIVE_PROPOSAL_STATUSES
+    for status in expected_live_set:
+        assert f"'{status}'" in sql, f"{status!r} missing from SUPERSEDED_ORPHAN_SQL"
+    # 'dead' and 'superseded' are deliberately OUT of the live set (terminal-loss).
+    assert "'dead'" not in sql
+    assert "'superseded'" not in sql
+
+
+def test_orphan_done_sql_left_joins_proposal_and_groups_by_source():
+    sql = ihr.ORPHAN_DONE_SQL
+    assert "document_routing_proposal" in sql
+    assert "LEFT JOIN" in sql
+    assert "q.source" in sql
+
+
+# ---------------------------------------------------------------- --dry-run sends nothing (fake tg + fake conn)
+
+
+class _FakeConn:
+    """Dispatches fetchrow/fetch/execute on a SQL-text fingerprint — no DB."""
+
+    async def fetchrow(self, query, *args):
+        if "review_pending_total" in query:
+            return {
+                "review_pending_total": 10, "review_pending_wa": 4,
+                "quarantine_total": 2, "duplicate_total": 1, "zero_candidate_count": 3,
+            }
+        if "FROM companies" in query:
+            return {"n": 5}
+        if "review_claimed' AND lease_expires_at IS NULL" in query:
+            return {"n": 0}
+        if "FROM documents" in query:
+            return {"undelivered": 0, "total": 2}
+        if "'dead'" in query and "intake_queue" in query:
+            return {"n": 0}
+        if "whatsapp_message_context" in query:
+            return {"n": 1}
+        if "NOT EXISTS" in query and "document_routing_proposal" in query:
+            return {"n": 0}
+        raise AssertionError(f"FakeConn.fetchrow: unrecognized query fingerprint: {query[:80]!r}")
+
+    async def fetch(self, query, *args):
+        if "jsonb_array_elements" in query:
+            return []
+        if "blob_path" in query:
+            return []
+        if "LEFT JOIN document_routing_proposal" in query:
+            return [{"source": "whatsapp", "n": 0}]
+        raise AssertionError(f"FakeConn.fetch: unrecognized query fingerprint: {query[:80]!r}")
+
+    async def execute(self, query, *args):
+        return "SET"
+
+    async def close(self):
+        return None
+
+
+def test_dry_run_sends_no_telegram_and_writes_no_state(tmp_path, monkeypatch):
+    sent = []
+    monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: sent.append((tier, key)) or True)
+    monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+
+    async def _fake_connect(*_args, **_kwargs):
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _fake_connect)
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=False))
+
+    assert rc == 0
+    assert sent == []
+    assert not (tmp_path / "state.json").exists()
+
+
+def test_non_dry_run_writes_state_and_sends_digest(tmp_path, monkeypatch):
+    sent = []
+    monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: sent.append((tier, key)) or True)
+    monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+
+    async def _fake_connect(*_args, **_kwargs):
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _fake_connect)
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
+
+    assert rc == 0
+    assert (tmp_path / "state.json").exists()
+    # digest always sent + at least the worker_log_missing breach (file doesn't exist)
+    tiers = {t for t, _k in sent}
+    assert "digest" in tiers
+    assert ("p0", "intake-health:worker_log_missing") in sent
+
+
+def test_json_only_skips_all_side_effects(tmp_path, monkeypatch, capsys):
+    sent = []
+    monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: sent.append((tier, key)) or True)
+    monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: sent.append(("heartbeat", a)))
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+
+    async def _fake_connect(*_args, **_kwargs):
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _fake_connect)
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=False, json_only=True))
+
+    assert rc == 0
+    assert sent == []
+    assert not (tmp_path / "state.json").exists()
+    out = capsys.readouterr().out
+    assert '"review_pending_total"' in out
+
+
+def test_kill_switch_disabled_short_circuits(monkeypatch, capsys):
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "false")
+    called = []
+    monkeypatch.setattr(ihr, "_heartbeat", lambda status, note="": called.append(status))
+
+    rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
+
+    assert rc == 0
+    assert called == ["disabled"]
+    assert '"status": "disabled"' in capsys.readouterr().out
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/tests/test_wa_mirror_freshness_liveness.py
+++ b/scripts/tests/test_wa_mirror_freshness_liveness.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Pure tests for wa_mirror_freshness_liveness.py — NO database (W87/W96).
+
+Guilt: stale + business hours -> exactly one p0 through a fake tg_notify.
+Innocence: stale outside business hours -> no p0; fresh -> no p0 either way.
+Plus: dedup-key stability (a literal constant, never embeds the variable
+age), DEAD-count parsing off a CANNED status table using fake numbers
+(+6200000000000-style — never real staff numbers), and the business-hours /
+staleness pure-function math in isolation.
+
+Run:  python3 scripts/tests/test_wa_mirror_freshness_liveness.py
+      python3 -m pytest scripts/tests/test_wa_mirror_freshness_liveness.py -q
+"""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+from datetime import datetime, timedelta
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import wa_mirror_freshness_liveness as wmfl  # noqa: E402
+
+
+# ---------------------------------------------------------------- pure math
+
+
+def test_age_minutes_computes_delta():
+    now = datetime(2026, 8, 15, 10, 0, tzinfo=wmfl.timezone.utc)
+    newest = now - timedelta(minutes=90)
+    assert wmfl.age_minutes(newest, now) == 90.0
+
+
+def test_age_minutes_none_when_table_empty():
+    now = datetime(2026, 8, 15, 10, 0, tzinfo=wmfl.timezone.utc)
+    assert wmfl.age_minutes(None, now) is None
+
+
+def test_is_stale_true_beyond_max_age():
+    assert wmfl.is_stale(400.0, max_age_min=360.0) is True
+
+
+def test_is_stale_false_within_max_age():
+    assert wmfl.is_stale(100.0, max_age_min=360.0) is False
+
+
+def test_is_stale_true_when_age_is_none():
+    assert wmfl.is_stale(None, max_age_min=360.0) is True
+
+
+def test_in_business_hours_true_weekday_daytime():
+    now_wita = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)  # Monday noon
+    assert wmfl.in_business_hours(now_wita, start_hour=8, end_hour=20, business_days={0, 1, 2, 3, 4, 5}) is True
+
+
+def test_in_business_hours_false_at_night():
+    now_wita = datetime(2026, 8, 17, 3, 0, tzinfo=wmfl.WITA)  # Monday 03:00
+    assert wmfl.in_business_hours(now_wita, start_hour=8, end_hour=20, business_days={0, 1, 2, 3, 4, 5}) is False
+
+
+def test_in_business_hours_false_on_sunday():
+    now_wita = datetime(2026, 8, 16, 12, 0, tzinfo=wmfl.WITA)  # Sunday noon
+    assert wmfl.in_business_hours(now_wita, start_hour=8, end_hour=20, business_days={0, 1, 2, 3, 4, 5}) is False
+
+
+def test_in_business_hours_boundary_end_hour_exclusive():
+    now_wita = datetime(2026, 8, 17, 20, 0, tzinfo=wmfl.WITA)  # exactly 20:00
+    assert wmfl.in_business_hours(now_wita, start_hour=8, end_hour=20, business_days={0, 1, 2, 3, 4, 5}) is False
+
+
+# ---------------------------------------------------------------- DEAD-count parsing (canned, fake numbers)
+
+# Fake wa-mirror-launcher status.sh table — masked per repo convention: fake
+# E.164 numbers (+6200000000000-style), never real staff numbers.
+_CANNED_STATUS_TABLE_ALL_DEAD = """NAME       E164                 STATUS     PID        LAST LOG
+─────────────────────────────────────────────────────────────────────────────
+alice      +6200000000001 (linked) 🔴 DEAD    -          {"level":50}
+bob        +6200000000002 (linked) 🔴 DEAD    -          {"level":50}
+carol      +6200000000003 (no-link) ⚪ STOPPED -
+"""
+
+_CANNED_STATUS_TABLE_ALL_HEALTHY = """NAME       E164                 STATUS     PID        LAST LOG
+─────────────────────────────────────────────────────────────────────────────
+alice      +6200000000001 (linked) 🟢 RUNNING 11111      {"level":30}
+bob        +6200000000002 (linked) 🟢 RUNNING 22222      {"level":30}
+"""
+
+
+def test_count_dead_lines_on_canned_table_with_dead_entries():
+    assert wmfl.count_dead_lines(_CANNED_STATUS_TABLE_ALL_DEAD) == 2
+
+
+def test_count_dead_lines_on_canned_table_all_healthy():
+    assert wmfl.count_dead_lines(_CANNED_STATUS_TABLE_ALL_HEALTHY) == 0
+
+
+def test_count_dead_lines_none_when_script_output_unavailable():
+    assert wmfl.count_dead_lines(None) is None
+
+
+# ---------------------------------------------------------------- dedup key stability
+
+
+def test_dedup_key_is_a_fixed_literal_not_derived_from_variable_state():
+    assert wmfl.DEDUP_KEY == "wa-mirror:freshness:stale"
+    # build_alert_text embeds the variable age in the TEXT, never in the key.
+    text_a = wmfl.build_alert_text(90.0, 2)
+    text_b = wmfl.build_alert_text(9000.0, 5)
+    assert text_a != text_b
+    assert wmfl.DEDUP_KEY not in text_a and wmfl.DEDUP_KEY not in text_b
+
+
+# ---------------------------------------------------------------- _tick guilt + innocence (FakeConn, no DB)
+
+
+class _FakeConn:
+    def __init__(self, newest):
+        self._newest = newest
+
+    async def fetchrow(self, query, *args):
+        assert "whatsapp_message_context" in query
+        return {"newest": self._newest}
+
+
+def _run_tick(newest, now_wita, *, dry_run, monkeypatch, tmp_path, status_output=None):
+    sent = []
+    monkeypatch.setattr(wmfl, "_tg_notify", lambda tier, key, text: sent.append((tier, key, text)) or True)
+    monkeypatch.setattr(wmfl, "_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(wmfl, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(wmfl, "_run_status_script", lambda: status_output)
+    monkeypatch.setenv("WA_FRESHNESS_MAX_AGE_MIN", "360")
+    monkeypatch.setenv("WA_FRESHNESS_BUSINESS_START", "8")
+    monkeypatch.setenv("WA_FRESHNESS_BUSINESS_END", "20")
+    monkeypatch.setenv("WA_FRESHNESS_BUSINESS_DAYS", "0,1,2,3,4,5")
+
+    conn = _FakeConn(newest)
+    rc = asyncio.run(wmfl._tick(conn, now_wita, dry_run=dry_run))
+    return rc, sent
+
+
+def test_guilt_stale_in_business_hours_sends_exactly_one_p0(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)  # Monday noon
+    newest = now - timedelta(hours=7)  # 420min > 360min threshold
+    rc, sent = _run_tick(
+        newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path,
+        status_output=_CANNED_STATUS_TABLE_ALL_DEAD,
+    )
+    assert rc == 0
+    p0_sends = [s for s in sent if s[0] == "p0"]
+    assert len(p0_sends) == 1
+    assert p0_sends[0][1] == wmfl.DEDUP_KEY
+
+
+def test_innocence_stale_outside_business_hours_sends_nothing(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 3, 0, tzinfo=wmfl.WITA)  # Monday 03:00 — night
+    newest = now - timedelta(hours=7)
+    rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    assert sent == []
+
+
+def test_innocence_fresh_in_business_hours_sends_nothing(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = now - timedelta(minutes=5)  # well within the freshness window
+    rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    assert sent == []
+
+
+def test_dry_run_never_sends_even_when_stale_in_business_hours(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = now - timedelta(hours=7)
+    rc, sent = _run_tick(newest, now, dry_run=True, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    assert sent == []
+    assert not (tmp_path / "state.json").exists()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/wa_mirror_freshness_liveness.py
+++ b/scripts/wa_mirror_freshness_liveness.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""wa_mirror_freshness_liveness.py — read-only freshness guardian for the WhatsApp mirror.
+
+W0 read-only guardian (SELECT-only; never mutates whatsapp_message_context or
+any wa-mirror state). The intake mouth's blind spot (Mythos M4, 2026-06-14):
+"no new media arriving" is silently indistinguishable from "the bridge is
+paralyzed" unless something watches the clock. This organ is the clock-watch:
+it reads the newest whatsapp_message_context row and, ONLY during business
+hours (so an overnight quiet line — Law 6, disconnection is natural — never
+pages anyone), alerts once when that row is older than the freshness window.
+
+Secondary signal (best-effort, tolerates absence): counts "DEAD" lines out of
+`bash ~/scripts/wa-mirror-launcher/status.sh` — the per-employee bridge
+process table — and folds the count into the alert text. Absence of that
+script (a different machine, a moved path) never blocks the primary
+freshness check; it degrades to "n/a", logged, not silent.
+
+Model: scripts/wa_mirror_bridge_liveness_alarm.py (business-hours + cooldown
++ tg_notify gateway shape) and scripts/wr2_daily_reconciler.py (module-level
+`_tg_notify`/`_heartbeat`, `run()`/`_tick()` split so tests inject a fake
+clock + fake rows + fake tg without touching the DB or network).
+
+Env:
+  INTAKE_DATABASE_URL / LOCAL_DATABASE_URL   DSN (default local nuzantara_dev)
+  WA_MIRROR_FRESHNESS_LIVENESS_ENABLED       kill switch (default true) — G5
+  WA_FRESHNESS_MAX_AGE_MIN                   default 360 (6h) — staleness threshold
+  WA_FRESHNESS_BUSINESS_START                default 8  (WITA hour, inclusive)
+  WA_FRESHNESS_BUSINESS_END                  default 20 (WITA hour, exclusive)
+  WA_FRESHNESS_BUSINESS_DAYS                 default "0,1,2,3,4,5" (Mon=0..Sun=6; Mon-Sat)
+  WA_MIRROR_STATUS_SCRIPT                    default ~/scripts/wa-mirror-launcher/status.sh
+  WA_FRESHNESS_DRY_RUN=1                     same as --dry-run
+
+Exit: 0 always, except a DSN/connect failure (logged, heartbeat status=error) -> 2.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import fcntl
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import asyncpg
+
+_REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO))
+
+from scripts.tg_gateway_verdict import extract_gateway_verdict, gateway_delivered  # noqa: E402
+
+logging.basicConfig(
+    level=os.getenv("WA_FRESHNESS_LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+)
+logger = logging.getLogger("wa_mirror_freshness_liveness")
+
+ORGAN_ID = "pro.wa_mirror_freshness_liveness"
+STATE_PATH = Path.home() / ".agent" / "decisions" / "state" / "wa_mirror_freshness.json"
+LOCK_FILE = Path.home() / ".cell-bridge-state" / "wa_mirror_freshness_liveness.lock"
+DEFAULT_DSN = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+DEFAULT_STATUS_SCRIPT = Path.home() / "scripts" / "wa-mirror-launcher" / "status.sh"
+WITA = ZoneInfo("Asia/Makassar")
+DEDUP_KEY = "wa-mirror:freshness:stale"
+
+_PY3_CANDIDATES: tuple[str, ...] = (
+    "/usr/bin/python3",
+    "/opt/homebrew/bin/python3",
+    "/usr/local/bin/python3",
+)
+
+FRESHNESS_SQL = "SELECT max(created_at) AS newest FROM whatsapp_message_context"
+
+
+# ---------------------------------------------------------------- side effects (module-level, monkeypatchable)
+
+
+def _resolve_py3() -> str:
+    for candidate in _PY3_CANDIDATES:
+        if Path(candidate).is_file():
+            return candidate
+    return sys.executable
+
+
+def _tg_notify(tier: str, dedup_key: str, text: str) -> bool:
+    """Route through the tg_notify gateway; never raises."""
+    try:
+        gateway = _REPO / "scripts" / "tg_notify.py"
+        if not gateway.is_file():
+            logger.warning("[wa_freshness] tg_notify.py missing at %s", gateway)
+            return False
+        res = subprocess.run(
+            [_resolve_py3(), str(gateway), "--tier", tier,
+             "--source", "wa-mirror-freshness-liveness", "--dedup-key", dedup_key, "--", text],
+            capture_output=True, text=True, timeout=30,
+        )
+        verdict = extract_gateway_verdict(res.stderr)
+        logger.info("[wa_freshness] tg_notify: %s", verdict or f"NESSUN verdetto rc={res.returncode}")
+        return res.returncode == 0 and gateway_delivered(verdict)
+    except Exception as exc:  # noqa: BLE001 — never raises
+        logger.warning("[wa_freshness] tg_notify failed: %s", exc)
+        return False
+
+
+def _heartbeat(status: str, note: str = "") -> None:
+    try:
+        from scripts.lib.heartbeat import organism_heartbeat
+
+        organism_heartbeat(ORGAN_ID, status, note=note)
+    except Exception as exc:  # noqa: BLE001 — never raises
+        logger.warning("[wa_freshness] heartbeat write failed: %s", exc)
+
+
+def _write_state(state: dict[str, Any]) -> None:
+    try:
+        STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_PATH.with_suffix(STATE_PATH.suffix + f".tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(tmp, STATE_PATH)
+    except OSError as exc:
+        logger.warning("[wa_freshness] state write failed: %s", exc)
+
+
+def _acquire_lock_or_exit() -> int | None:
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return fd
+    except BlockingIOError:
+        logger.info("[wa_freshness] another instance running, skipping tick")
+        os.close(fd)
+        return None
+
+
+def _run_status_script() -> str | None:
+    """Best-effort: run the wa-mirror status table. None (not '') when the
+    script is absent/unreadable/times out — the caller must tell "n/a" apart
+    from "zero DEAD lines"."""
+    script = Path(os.getenv("WA_MIRROR_STATUS_SCRIPT", "") or DEFAULT_STATUS_SCRIPT)
+    if not script.is_file():
+        logger.info("[wa_freshness] status script absent at %s — DEAD count n/a", script)
+        return None
+    try:
+        res = subprocess.run(
+            ["bash", str(script)], capture_output=True, text=True, timeout=30,
+        )
+        return res.stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("[wa_freshness] status script run failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------- pure helpers (unit-tested, no DB/network)
+
+
+def count_dead_lines(status_output: str | None) -> int | None:
+    """Count table rows whose STATUS column reads DEAD (e.g. '🔴 DEAD').
+    None when the script output itself is unavailable — never conflated with
+    a genuine zero."""
+    if status_output is None:
+        return None
+    return sum(1 for line in status_output.splitlines() if "DEAD" in line)
+
+
+def age_minutes(newest: datetime | None, now: datetime) -> float | None:
+    """Minutes since the newest row, or None when the table has no rows at
+    all (treated as maximally stale by is_stale — an empty mirror table
+    during business hours is itself a genuine paralysis signal)."""
+    if newest is None:
+        return None
+    if newest.tzinfo is None:
+        newest = newest.replace(tzinfo=timezone.utc)
+    return (now.astimezone(timezone.utc) - newest.astimezone(timezone.utc)).total_seconds() / 60.0
+
+
+def is_stale(age_min: float | None, max_age_min: float) -> bool:
+    return age_min is None or age_min > max_age_min
+
+
+def in_business_hours(
+    now_wita: datetime,
+    *,
+    start_hour: int,
+    end_hour: int,
+    business_days: set[int],
+) -> bool:
+    """Mon–Sat (default) 08:00–20:00 Asia/Makassar, both bounds env-overridable."""
+    return now_wita.weekday() in business_days and start_hour <= now_wita.hour < end_hour
+
+
+def build_alert_text(age_min: float | None, dead_count: int | None) -> str:
+    age_txt = "never (table empty)" if age_min is None else f"{age_min:.0f} min"
+    dead_txt = "n/a" if dead_count is None else str(dead_count)
+    return (
+        f"🔴 WA mirror FRESHNESS stale — newest message context row is {age_txt} old "
+        f"(bridge DEAD lines: {dead_txt}). During business hours this reads as intake "
+        f"CIECO on WhatsApp, not quiet. Check: bash ~/scripts/wa-mirror-launcher/status.sh"
+    )
+
+
+def _business_days_from_env() -> set[int]:
+    raw = os.getenv("WA_FRESHNESS_BUSINESS_DAYS", "0,1,2,3,4,5")
+    return {int(x) for x in raw.split(",") if x.strip() != ""}
+
+
+# ---------------------------------------------------------------- core tick (async, DB-only I/O via `conn`)
+
+
+async def _tick(conn: Any, now_wita: datetime, *, dry_run: bool) -> int:
+    max_age_min = float(os.getenv("WA_FRESHNESS_MAX_AGE_MIN", "360"))
+    start_hour = int(os.getenv("WA_FRESHNESS_BUSINESS_START", "8"))
+    end_hour = int(os.getenv("WA_FRESHNESS_BUSINESS_END", "20"))
+    business_days = _business_days_from_env()
+
+    row = await conn.fetchrow(FRESHNESS_SQL)
+    newest = row["newest"]
+    age_min = age_minutes(newest, now_wita)
+    stale = is_stale(age_min, max_age_min)
+    business = in_business_hours(
+        now_wita, start_hour=start_hour, end_hour=end_hour, business_days=business_days
+    )
+    dead_count = count_dead_lines(_run_status_script())
+
+    state = {
+        "generated_at": now_wita.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "newest_created_at": newest.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if newest else None,
+        "age_minutes": round(age_min, 1) if age_min is not None else None,
+        "stale": stale,
+        "business_hours": business,
+        "dead_bridge_count": dead_count,
+        "max_age_minutes": max_age_min,
+    }
+
+    logger.info(
+        "[wa_freshness] age=%s stale=%s business_hours=%s dead=%s",
+        state["age_minutes"], stale, business, dead_count,
+    )
+
+    if not dry_run:
+        _write_state(state)
+
+    _heartbeat("degraded" if stale else "ok", note=f"age_min={state['age_minutes']} business_hours={business}")
+
+    alerted = False
+    if stale and business and not dry_run:
+        alerted = _tg_notify("p0", DEDUP_KEY, build_alert_text(age_min, dead_count))
+    state["alerted"] = alerted
+    return 0
+
+
+async def run(*, dry_run: bool) -> int:
+    if os.getenv("WA_MIRROR_FRESHNESS_LIVENESS_ENABLED", "true").strip().lower() in ("0", "false", "no"):
+        logger.info("[wa_freshness] disabled via WA_MIRROR_FRESHNESS_LIVENESS_ENABLED — no-op")
+        _heartbeat("disabled", "WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false")
+        return 0
+
+    dry_run = dry_run or os.getenv("WA_FRESHNESS_DRY_RUN", "") == "1"
+
+    lock_fd = _acquire_lock_or_exit()
+    if lock_fd is None:
+        return 0
+    try:
+        dsn = os.getenv("INTAKE_DATABASE_URL") or os.getenv("LOCAL_DATABASE_URL") or DEFAULT_DSN
+        try:
+            conn = await asyncpg.connect(
+                dsn, server_settings={"default_transaction_read_only": "on"}
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[wa_freshness] DB connect failed: %s", exc)
+            _heartbeat("error", f"db connect failed: {exc}")
+            return 2
+
+        try:
+            now_wita = datetime.now(WITA)
+            return await _tick(conn, now_wita, dry_run=dry_run)
+        finally:
+            await conn.close()
+    finally:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument("--dry-run", action="store_true", help="no Telegram, no state-file write")
+    args = parser.parse_args()
+    return asyncio.run(run(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scripts/wa_mirror_freshness_liveness.py
+++ b/scripts/wa_mirror_freshness_liveness.py
@@ -128,7 +128,7 @@ def _write_state(state: dict[str, Any]) -> None:
 
 def _acquire_lock_or_exit() -> int | None:
     LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o644)
+    fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o600)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         return fd

--- a/scripts/wa_mirror_freshness_liveness_run.sh
+++ b/scripts/wa_mirror_freshness_liveness_run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# wa_mirror_freshness_liveness_run.sh — venv-python launcher for
+# scripts/wa_mirror_freshness_liveness.py.
+#
+# Same shape and rationale as scripts/intake_health_report_run.sh (see that
+# file's header for the full HOME-fork / kill-switch / heartbeat design
+# note) — REPO_ROOT derived from this file's own location, kill switch
+# honored here with its OWN disabled-heartbeat before exiting, enabled path
+# execs straight into the venv python which owns the real per-run heartbeat
+# and the freshness/liveness check itself.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ORGAN_ID="pro.wa_mirror_freshness_liveness"
+
+# shellcheck source=scripts/lib/heartbeat.sh
+source "$REPO_ROOT/scripts/lib/heartbeat.sh"
+
+if [ "${WA_MIRROR_FRESHNESS_LIVENESS_ENABLED:-true}" = "false" ]; then
+  organism_heartbeat "$ORGAN_ID" "disabled" "WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false — skipping run"
+  exit 0
+fi
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+PYBIN="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+exec "$PYBIN" -u "$REPO_ROOT/scripts/wa_mirror_freshness_liveness.py" "$@"


### PR DESCRIPTION
## What

Two new SELECT-only launchd organs for the document-intake pipeline (W0 wave, read-only-only):

1. **`scripts/intake_health_report.py`** (planned daily 07:30 WITA) — one JSON health snapshot in a single run:
   - `review_pending_wa` / `review_pending_total` / `quarantine_total` / `duplicate_total`
   - `zero_candidate_rate` — share of `review_pending` with `entity_resolution->>'decision'='NO_MATCH'`
   - `all_pages_empty_rate` (C-02) — among WhatsApp proposals in quarantine/review_pending, share whose `ocr_text_per_page` has ≥1 page and ALL pages `via='empty'`, reported per-status
   - `blob_present_rate` (C-01) — `os.path.exists` sample of newest 300 + oldest 50 `blob_path`s
   - `companies_rows` (C-29) — sanity floor, must be >0
   - `orphans_done_without_proposal` (C-07) + `superseded_orphans_true` (60s statement_timeout, reports `null` on timeout rather than crashing)
   - `zombie_review_claimed_null_lease` (C-05)
   - `undelivered_committed` (C-08)
   - `worker_log_inode_exists` (C-03) — reads `StandardErrorPath` from `infra/launchagents/com.nuzantara.intake-worker.plist` at runtime, never hardcoded
   - `dead_last_24h` / `wa_media_last_24h`

   One Telegram `digest` line per run + a `p0` escalation (dedup key `intake-health:<metric>`) **only** on breach: `companies_rows==0`, `blob_present_rate(newest)<0.5`, `all_pages_empty_rate>0.5` (quarantine bucket), `zombie>0`, `worker_log_inode_exists==False`. All thresholds env-overridable. `--dry-run` / `--json-only` flags.

2. **`scripts/wa_mirror_freshness_liveness.py`** (planned every 900s) — reads `max(created_at)` off `whatsapp_message_context`, cross-checks `~/scripts/wa-mirror-launcher/status.sh` DEAD-line count. Pages `p0` (dedup key `wa-mirror:freshness:stale`) **only** when the newest row is older than `WA_FRESHNESS_MAX_AGE_MIN` (default 360min) **and** it's inside business hours (Mon–Sat 08:00–20:00 Asia/Makassar, env-overridable) — a quiet overnight gap is Law 6, not a page.

Both scripts open their DB connection with `default_transaction_read_only=on` (defense-in-depth on top of never issuing a write statement), write per-run state to `~/.agent/decisions/state/*.json` (atomic tmp+rename) and a heartbeat via `scripts/lib/heartbeat.py`, and honor a real kill switch (`INTAKE_HEALTH_REPORT_ENABLED` / `WA_MIRROR_FRESHNESS_LIVENESS_ENABLED`) implemented in their bash wrappers, not just the Python.

## Why

Read-only visibility into the intake backlog's health (review load, orphan/zombie rows, blob presence, worker log liveness) and into WhatsApp-mirror freshness during business hours, without any DB mutation and without installing anything yet.

## No DB writes, not installed by this PR

- Every SQL statement in both scripts is `SELECT`. Connections are opened with `default_transaction_read_only=on`.
- `infra/launchagents/*.plist` ship as **source only** — this PR does **not** `launchctl bootstrap` either plist. Installation is a separate, explicit step for later.
- `organs_registry.yaml` gets both organs registered (id, runtime, heartbeat expectations, recovery action) so the fleet-wide conformance/heartbeat tooling knows about them ahead of install; the top-level checksum was recomputed.

## Tests

- `scripts/tests/test_intake_health_report.py` — 24 pure cases (fake asyncpg connection, no real DB — W96 discipline): guilt/innocence per breach threshold, blob-sampling math, JSON-shape stability, `--dry-run`/`--json-only` side-effect suppression, kill-switch short-circuit, SQL-shape assertions (orphan query names `document_routing_proposal` + the corrected 7-status live set).
- `scripts/tests/test_wa_mirror_freshness_liveness.py` — 20 pure cases (fake clock/connection/tg): guilt (stale + business hours → exactly one p0), innocence (stale at night / fresh → no p0), dedup-key stability, DEAD-count parsing off a canned status table with masked fake numbers.

```
44 passed in 0.20s
```

`ruff check` clean on both scripts + both test files. `python3 scripts/lint_plist_keepalive.py` → 0 findings for the new plists. `check_organ_conformance.py` → `170 plists scanned, 121 grandfathered, 0 regressions, 0 non-conformant births`.

## Honest uncertainties

- The "C-01/C-02/.../C-29" codes referenced in the task spec weren't found anywhere on disk (`research/`, `docs/`) — implemented literally from the spec text handed down, not from a dossier I could cross-check.
- Interpreted "`all_pages_empty_rate>0.5` for the day's quarantines" as the `quarantine`-status bucket's rate specifically (not a time-windowed "today") — both quarantine and review_pending rates are reported in the JSON regardless.
- While manually verifying the wrapper scripts I hit a real bug (missing `"$@"` forwarding, since fixed) that caused one live run to write real state + send real Telegram messages before the fix — I did not attempt to reverse those, since the data reflected genuinely true current backlog state, not fabricated data.
- Two real findings surfaced by that same manual run: `companies_rows=0` and the intake-worker's `StandardErrorPath` log file doesn't currently exist on disk — both will show as real `p0` breaches once/if this cron is installed and run live.

Not arming auto-merge — leaving that to the orchestrator after an external refuter pass, per the mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)