### PR TITLE
chore(army): seed first Jules queue task — spark-study BARRED wording fix

### DIFF
--- a/infra/army/jules-queue/2026-08-15-spark-study-barred-wording.md
+++ b/infra/army/jules-queue/2026-08-15-spark-study-barred-wording.md
@@ -1,0 +1,33 @@
+# Align the Spark study's BARRED wording with its own worktree scoping
+
+File: `research/operations/2026-08-15-gemini-spark-repo-lane-study.md`.
+
+The "Capability verdict for repo work" section ends with a paragraph that
+reads: «point Spark (Ultra, Mac) at a **non-code, document-shaped folder** —
+sorting/summarizing research PDFs, drafting doc prose — never at
+`.git`-tracked source, never unsupervised, never as a git-committing
+worker.»
+
+The "## Adversarial review" section of the same file records the one
+surviving objection: the "Standing mandate draft — GATED, NOT ARMED"
+section scopes Spark to a dedicated `.worktrees/spark-<task-id>/` worktree,
+whose contents ARE `.git`-tracked source — so "never at `.git`-tracked
+source" contradicts the mandate two sections below it.
+
+The precise change (one sentence, nothing else): in that Capability-verdict
+paragraph, replace the fragment
+
+`never at \`.git\`-tracked source, never unsupervised, never as a git-committing worker`
+
+with
+
+`never at repo source outside a dedicated task-scoped worktree (and inside one, only the document-shaped files the task names — per the standing-mandate scoping below), never unsupervised, never as a git-committing worker`
+
+Scope fence: do NOT change anything else — not the frontmatter, not the
+"## Adversarial review" section, not the standing-mandate section, no other
+file.
+
+Green looks like: `python3 scripts/check_adversarial_review.py --files
+research/operations/2026-08-15-gemini-spark-repo-lane-study.md` still
+passes, and `git diff` shows exactly one modified region in exactly one
+file.


### PR DESCRIPTION
## Summary
- First task seeded into the Jules lane queue (`infra/army/jules-queue/`), per the standing lane wired in #4180.
- Scopes a single-sentence fix in `research/operations/2026-08-15-gemini-spark-repo-lane-study.md`'s "Capability verdict for repo work" section, anchored with real file:line/quote per the queue README's task-authoring discipline (exact anchor · precise change · motivating rule · scope fence · acceptance check).
- The objection motivating this task is already recorded in that same study's own "## Adversarial review" section — the BARRED wording ("never at `.git`-tracked source") contradicts the standing-mandate section two below it, which scopes Spark to a `.worktrees/spark-<task-id>/` worktree (itself `.git`-tracked).

This PR only seeds the task file for the Jules dispatcher (`scripts/army/jules_lane.py --dispatch`) to pick up later — it does not touch the study file itself. Jules generates, an interactive session verifies and lands the resulting diff independently (per `docs/runbooks/jules-dispatch.md`).

## Test plan
- [x] New file only, no existing file touched (`git diff --stat` = 1 file, 33 insertions)
- [x] Pre-commit + pre-push hooks passed clean
- [x] Format matches `infra/army/jules-queue/README.md` task-authoring discipline (where/what/why/scope-fence/acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)