### PR TITLE
chore(army): seed two Spark queue tasks — step-4 consumer sweep + orphan-scripts audit

### DIFF
--- a/infra/army/spark-queue/mergeos-step4-derived-state-consumer-sweep.md
+++ b/infra/army/spark-queue/mergeos-step4-derived-state-consumer-sweep.md
@@ -1,0 +1,37 @@
+# mergeos-step4: derived-state consumer sweep — who actually READS the volatile counts
+
+Read-only analysis. No plan to edit/commit/push anything — output is a report only.
+
+Context: Merge-OS v3 step 4 (council doc
+`research/operations/2026-08-14-merge-os-v3-research-council.md` §C2 + §6 step 4)
+mandates removing volatile counts/inventories from tracked docs (linking to
+`docs_sync.py --json` / CI artifacts instead). §6 makes one check a hard
+precondition: "Requires the ASSUMPTION check: grep-verified no programmatic
+consumer — one dependency sweep before deletion." This task IS that sweep,
+done exhaustively so the implementing session inherits evidence, not a guess.
+
+Scope — enumerate every tracked file carrying an auto-regenerated volatile
+block or count, starting from (but not limited to):
+
+- every `<!-- DOCSYNC:*_START/END -->` block (grep the markers repo-wide):
+  `docs/AI_ONBOARDING.md` QUICK_NUMBERS, `INDEX.md` AUTOMATION_COVERAGE, any others
+- `docs/DOCS_INVENTORY.md` (the scheduled-refresh target)
+- anything `scripts/docs_sync.py` and `.github/workflows/docs-inventory-refresh.yml` write
+- any other tracked file a generator script rewrites on a schedule (search
+  `infra/launchagents/`, `.github/workflows/`, `scripts/` for writers whose
+  target is a tracked `.md`/`.json`)
+
+For EACH such file/block, answer: who reads it? Classify every reader found
+by grep into: (a) the writer itself, (b) the docs-sync auditor/gate
+(`scripts/ci/docs_sync_gate.sh`, `check-docs-sync`), (c) tests, (d) a REAL
+programmatic consumer (code whose runtime behavior depends on the value),
+(e) prose/human reference only. Class (d) is the finding that would block
+step 4 — quote the exact file:line for any candidate and say whether the
+dependency is on the VALUE or merely on the block's existence.
+
+Output: one markdown table per derived file — reader file:line | class
+(a-e) | what it does with the value — followed by a verdict line per file:
+"safe to untrack per C2" or "has a class-(d) consumer: <which>". If any
+generator or block is found beyond the starting list, include it and say
+how it was found. Do not cap the sweep; if output length forces a cut, say
+exactly what was dropped.

--- a/infra/army/spark-queue/orphan-scripts-audit.md
+++ b/infra/army/spark-queue/orphan-scripts-audit.md
@@ -1,0 +1,39 @@
+# orphan-scripts audit: root scripts/ files nothing invokes, retirement-ranked
+
+Read-only analysis. No plan to edit/commit/push anything — output is a report only.
+
+Why: superscar #2 (esiste ≠ armato) has a mirror image — scripts that exist
+and are armed NOWHERE. They cost audit attention on every sweep (W107's
+producer census had to reason about files that turned out to be dead), they
+rot silently, and some carry copies of logic whose live twin has since been
+fixed (family #1 risk if anyone ever re-arms the stale copy).
+
+Scope: every `*.py` and `*.sh` directly under `scripts/` (not recursive into
+`scripts/tests/`, `scripts/ci/`, `scripts/lib/`, `scripts/army/` — those have
+their own executors). For each file, search for references across:
+
+- `infra/launchagents/*.plist` and `infra/launchagents/wrappers/*`
+- `.github/workflows/*.yml`
+- every other script under `scripts/` (including tests — a script whose ONLY
+  reference is its own test corpus counts as "test-only", a distinct class)
+- `docs/runbooks/`, `CLAUDE.md`, `INDEX.md`, skill files under `.claude/skills/`
+- `package.json` / `Makefile` / `.husky/` hooks if present
+
+Classify each unreferenced or weakly-referenced file:
+
+- ORPHAN: zero references anywhere outside itself
+- TEST-ONLY: referenced only by its own test corpus
+- DOC-ONLY: referenced only in prose (runbook/skill/memory), no executor
+- LIVE: referenced by an executor (plist/workflow/cron wrapper/another live script)
+
+Output: a markdown table — file | class | references found (file:line, or
+"none") | last commit date (git log -1) | one-line retirement recommendation
+(retire / keep-as-doc-tool / needs-a-session-decision). Sort ORPHAN first,
+then TEST-ONLY, then DOC-ONLY; omit LIVE from the table but report the
+total counts per class so coverage is checkable. Do not silently cap — if
+you must truncate, state exactly how many rows were dropped and from which
+class. Caveat to carry in the report header: absence of a repo reference is
+NOT proof nothing invokes the file — HOME crontabs and unc committed plists
+on Pro/Mini can invoke repo scripts (family #1); the recommendation column
+must say "retire" only for files whose name also fails a case-insensitive
+grep against infra/home-fork/declared-pairs.json.


### PR DESCRIPTION
## Summary

The spark lane queue is empty since the 16/8 09:10 tick (every 2h tick since logs "queue empty" — verified live on Pro). Seeds two read-only analysis tasks per the queue README format:

1. **mergeos-step4-derived-state-consumer-sweep** — runs the ASSUMPTION check that Merge-OS v3 §6 step 4 (council doc restored in #4227) declares a hard precondition: grep-verified sweep of every programmatic consumer of the volatile DOCSYNC counts/inventories, classed (writer / gate / test / real consumer / prose). The step-4 implementing session inherits evidence instead of re-deriving it.
2. **orphan-scripts-audit** — retirement-ranked census of root `scripts/` files with no executor anywhere, with the family-#1 caveat wired into the recommendation rule (repo-unreferenced ≠ uninvoked; "retire" only clears against `declared-pairs.json`).

## Test plan

- [x] Both files follow the queue README contract (one question per task, explicit read-only statement, acceptance shape, no-silent-cap)
- [x] Queue-dir-only diff — the lane picks them up by mtime on its next 2h tick after the Pro checkout syncs

🤖 Generated with [Claude Code](https://claude.com/claude-code)