### PR TITLE
feat(visa-oracle): QW-2 real SHADOW parity baseline

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_components/OracleShell.tsx
@@ -46,8 +46,10 @@ import {
 import {
   emitVisaOracleTelemetry,
   nonReversibleHash,
+  resolveFrontendVersion,
   type VisaOracleTelemetryState,
 } from "../_lib/telemetry";
+import { GOLD_ORACLE_PACK_HASH } from "../_lib/gold-oracle-baseline";
 import {
   resolveVisaOracleMode,
   type VisaOracleMode,
@@ -584,6 +586,8 @@ function OracleShellRuntime({
                     : "visa_oracle_v2_parity_mismatch",
                   state: response.decision.state,
                   correlationHash: telemetryCorrelationHash,
+                  packHash: GOLD_ORACLE_PACK_HASH,
+                  frontendVersion: resolveFrontendVersion(),
                 });
                 return buildShadowOutcome({
                   code: "SHADOW_VERIFICATION_ONLY",

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -36,7 +36,15 @@ const KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_COPY = text(
   "Pasal 60 ayat (2) UU 6/2011 mensyaratkan usia perkawinan mencapai dua tahun dan Pernyataan Integrasi yang ditandatangani untuk KITAP perkawinan campur. Penilaian ini belum memverifikasi kedua prasyarat tersebut.",
 );
 
-const NEXT_STEPS: OutcomeNextSteps = [
+/**
+ * Exported so the gold-oracle SHADOW baseline (`preview-adapter.ts`'s
+ * `buildGoldOraclePreviewOutcome`) reproduces the SAME public next-steps
+ * copy a real `NEEDS_INPUT` engine outcome carries — `shadow-parity.ts`'s
+ * `semanticProjection` compares `nextSteps` verbatim (id/title/body), so an
+ * independently-worded preview copy would read as a permanent mismatch on
+ * this axis alone, even when state and missing facts agree exactly.
+ */
+export const NEXT_STEPS: OutcomeNextSteps = [
   {
     id: "review-decision",
     title: text(

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/gold-oracle-baseline.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/gold-oracle-baseline.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  findGoldOraclePersona,
+  GOLD_ORACLE_PACK_HASH,
+  goldOracleReviewReasonCode,
+} from "./gold-oracle-baseline";
+
+describe("gold oracle baseline (QW-2 independent SHADOW-parity oracle)", () => {
+  it("pins a stable, non-empty source identifier", () => {
+    expect(GOLD_ORACLE_PACK_HASH).toBe(
+      "evaluate_path.py@8ee131a989fc786f1fc54ad531ddefaa9614756361f284b6412ee8a23120e569",
+    );
+  });
+
+  it("predicts the disclosed-uncertainty review reason", () => {
+    expect(goldOracleReviewReasonCode()).toBe("DISCLOSED_UNCERTAINTY_REVIEW");
+  });
+
+  it("matches the remote-worker persona (unsure whether employer is Indonesian)", () => {
+    const persona = findGoldOraclePersona({
+      category: "remote",
+      work_payer: "unsure",
+      remote_compensation: "no",
+      remote_clients: "foreign",
+      review_gate: "none",
+    });
+    expect(persona?.personaId).toBe("remote-worker-payer-unsure");
+  });
+
+  it("matches the family-spouse persona (unsure whether marriage is registered)", () => {
+    const persona = findGoldOraclePersona({
+      category: "family",
+      family_relation: "SPOUSE",
+      family_sponsor_nationalities: "ID",
+      family_sponsor_confirmed: "yes",
+      family_marriage_registered: "unsure",
+      review_gate: "none",
+    });
+    expect(persona?.personaId).toBe("family-spouse-marriage-registered-unsure");
+  });
+
+  it("does not match once the unsure answer is actually resolved", () => {
+    expect(
+      findGoldOraclePersona({
+        category: "remote",
+        work_payer: "no",
+        remote_compensation: "no",
+        remote_clients: "foreign",
+        review_gate: "none",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not match a DIFFERENT unsure answer than the pinned one", () => {
+    expect(
+      findGoldOraclePersona({
+        category: "remote",
+        work_payer: "no",
+        remote_compensation: "unsure",
+        remote_clients: "foreign",
+        review_gate: "none",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for interviews outside the pinned subset", () => {
+    expect(
+      findGoldOraclePersona({
+        category: "work",
+        work_payer: "yes",
+        review_gate: "none",
+      }),
+    ).toBeUndefined();
+    expect(findGoldOraclePersona({})).toBeUndefined();
+  });
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/gold-oracle-baseline.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/gold-oracle-baseline.ts
@@ -1,0 +1,159 @@
+import type { OracleFacts } from "./tree";
+
+/**
+ * Independent SHADOW-parity baseline (QW-2, 2026-08).
+ *
+ * REDESIGN NOTE (why this is not "3 NEEDS_INPUT gold personas copied
+ * verbatim", the first draft of this file): the obvious approach — pin the
+ * frontend's `OracleFacts` for a `NEEDS_INPUT` gold persona from
+ * `apps/backend-rag/backend/tests/services/visa_engine/test_evaluator_gold.py`
+ * (e.g. persona 13, "remote worker, local-clients fact unprovided") — turned
+ * out to be UNREACHABLE from real browser traffic, reproducing the exact
+ * "parity_match dead by construction" defect this file exists to fix,
+ * one layer down:
+ *
+ *   1. `flow.ts`'s reducer NEVER leaves an in-path question's fact key
+ *      absent at verdict time. `ANSWER` sets `facts[questionId] = value`;
+ *      `SKIP` (the only user-facing way to leave a question "not really
+ *      answered") sets `facts[questionId] = "unsure"` — a DEFINED sentinel,
+ *      never `undefined` (flow.ts's reducer, verified by reading the ANSWER/
+ *      SKIP cases and `FIXED_CATEGORY_QUESTIONS`/`computeNextNode`'s
+ *      unconditional walk over every in-path question).
+ *   2. `fact-mapper.ts::mapDisclosedReviewFlags` adds `"NOT_CERTAIN"` to the
+ *      request's `disclosed_review_flags` whenever ANY answer in the whole
+ *      interview is `"unsure"` (`Object.values(facts).includes("unsure")`).
+ *   3. `evaluate_path.py::_apply_disclosed_review_flags` is a MONOTONE
+ *      adapter: whenever `disclosed_review_flags` is non-empty, it
+ *      unconditionally overrides the decision to `HUMAN_REVIEW_REQUIRED`
+ *      with `candidates=()` and `missing_facts=()` — "This adapter cannot
+ *      create or retain candidates" (its own docstring). It runs on every
+ *      public evaluation (`apply_public_policy_adapters`'s ordered chain).
+ *
+ * So the ONE real, user-reachable way to make a fact "missing" from this
+ * frontend (the SKIP/NotSure affordance) NEVER reaches the engine as a
+ * `NEEDS_INPUT` — it is always overridden to `HUMAN_REVIEW_REQUIRED` before
+ * the response leaves the backend. A `NEEDS_INPUT`-shaped baseline built on
+ * a SKIP path would therefore never see a genuine `parity_match` in live
+ * SHADOW traffic either — the SAME defect, moved.
+ *
+ * WHAT THIS BASELINE PINS INSTEAD: the two personas below both use the
+ * SKIP/NotSure affordance on exactly one otherwise-inconsequential question,
+ * and predict the `HUMAN_REVIEW_REQUIRED` state the disclosed-flags override
+ * ALWAYS produces for that shape of interview. This is MORE robust than a
+ * NEEDS_INPUT baseline, not a downgrade: `_DISCLOSED_REVIEW_REASON_CODES`
+ * (evaluate_path.py, module-level constant) is PACK-INDEPENDENT — unlike a
+ * rule-derived `NEEDS_INPUT`/`SUPPORTED_CANDIDATES` outcome, it does not
+ * depend on which RulePack (the synthetic TEST gold pack vs. whatever pack
+ * SHADOW production actually runs) is loaded, so this baseline cannot go
+ * stale on a pack rotation the way a rule-derived one silently could.
+ *
+ * EMPIRICAL VERIFICATION (not inferred from reading — RUN, this turn,
+ * 2026-08-16): both personas were built as `ApplicantFacts` overrides on the
+ * gold suite's own `_gold_fixtures.applicant_facts()` / rule pack, pushed
+ * through the REAL `evaluator.evaluate()` AND the REAL
+ * `evaluate_path.apply_public_policy_adapters(..., disclosed_review_flags=
+ * (NOT_CERTAIN,))` — the exact function `apply_public_policy_adapters`'s own
+ * docstring calls "every deterministic abstention adapter used by the
+ * public path" (minus runtime-only DB/pricing/persistence steps that do not
+ * touch `state`/`review_reasons` on this path). Both personas: underlying
+ * (pre-disclosure) state `NEEDS_INPUT` (never itself `HUMAN_REVIEW_REQUIRED`
+ * — this matters because `_apply_disclosed_review_flags` MERGES in any
+ * pre-existing review reasons, `existing_reasons`, only when the underlying
+ * decision was already `HUMAN_REVIEW_REQUIRED`; here it wasn't, so the final
+ * `review_reasons` is EXACTLY the disclosed reason, nothing merged in).
+ * Final, for both: `state=HUMAN_REVIEW_REQUIRED`,
+ * `review_reasons=[("DISCLOSED_UNCERTAINTY_REVIEW", source_refs=())]`,
+ * `candidates=()`. Pin: `evaluate_path.py` sha256
+ * `8ee131a989fc786f1fc54ad531ddefaa9614756361f284b6412ee8a23120e569`
+ * (`_apply_disclosed_review_flags`/`_DISCLOSED_REVIEW_REASON_CODES`/
+ * `apply_public_policy_adapters`).
+ *
+ * This file is a NON-TAUTOLOGICAL baseline by construction: every function
+ * here takes only `OracleFacts` (what the applicant answered in THIS
+ * browser tab) and returns a fixed, pre-authored expectation. It never
+ * receives, inspects, or derives anything from a `VisaOracleEvaluateResponse`
+ * — the thing SHADOW parity is checking. `shadow-parity.test.ts` and
+ * `preview-adapter.test.ts` pin this with an explicit non-tautology test:
+ * the SAME baseline instance is checked against several DIFFERENT mocked
+ * responses, some agreeing and some not.
+ *
+ * SCOPE (documented, not silent): only these 2 "exactly one SKIP answer, no
+ * other disclosed-flag trigger" personas are pinned — deliberately narrow
+ * predicates (`matches` below checks every other answer is a SPECIFIC known
+ * value, not "anything"), because `mapDisclosedReviewFlags` can add several
+ * OTHER flags from unrelated answers (`ACTIVITY_BOUNDARY`,
+ * `AMBIGUOUS_SPONSOR`, `MULTI_PURPOSE_TRIP`, …) that this baseline has not
+ * verified the ordering/merge behaviour for. A wider "any SKIP anywhere"
+ * matcher would be a false-precision trap, not a bigger baseline. This
+ * baseline also predicts an EMPTY `sources` array (the disclosed-flag
+ * adapter emits `source_refs=()` for its own reason, verified above; a real
+ * response attaching unrelated sources elsewhere would still read as a
+ * mismatch on that axis). Extending coverage is future work — not silently
+ * absorbed into this subset.
+ */
+
+/** Identifies the pinned evaluator source this baseline was verified
+ * against — the disclosed-review-flags policy is pack-independent (see file
+ * doc comment), so this is a source digest, not a RulePack id. */
+export const GOLD_ORACLE_PACK_HASH =
+  "evaluate_path.py@8ee131a989fc786f1fc54ad531ddefaa9614756361f284b6412ee8a23120e569";
+
+/** The one review reason `_apply_disclosed_review_flags` attaches for a
+ * lone `NOT_CERTAIN` disclosure — `DisclosedReviewFlag.NOT_CERTAIN` ->
+ * `_DISCLOSED_REVIEW_REASON_CODES` in `evaluate_path.py`. Empty `sourceIds`
+ * is not a simplification: the adapter emits `source_refs=()` verbatim,
+ * "these codes describe an applicant disclosure requiring a human workflow,
+ * not a legal eligibility claim" (its own docstring). */
+const DISCLOSED_UNCERTAINTY_REVIEW_CODE = "DISCLOSED_UNCERTAINTY_REVIEW";
+
+export interface GoldOraclePersona {
+  readonly personaId: string;
+  readonly label: string;
+  /** True when `facts` (this browser tab's interview answers, keyed by
+   * question id — see `tree.ts`'s `OracleFacts` doc) matches this persona's
+   * exact, narrow fact pattern. */
+  matches(facts: OracleFacts): boolean;
+}
+
+const HUMAN_REVIEW_PERSONAS: readonly GoldOraclePersona[] = [
+  {
+    // Empirically verified via evaluator.evaluate + apply_public_policy_adapters
+    // (see file doc comment) — remote worker, uncertain whether the employer
+    // is an Indonesian entity; every other REMOTE_WORK-relevant fact known.
+    personaId: "remote-worker-payer-unsure",
+    label: "remote worker, unsure whether employer is an Indonesian entity",
+    matches: (facts) =>
+      facts.category === "remote" &&
+      facts.work_payer === "unsure" &&
+      facts.remote_compensation === "no" &&
+      facts.remote_clients === "foreign" &&
+      facts.review_gate === "none",
+  },
+  {
+    // Empirically verified the same way — spouse-sponsored family route,
+    // uncertain whether the marriage is registered; every other FAMILY-
+    // relevant fact known.
+    personaId: "family-spouse-marriage-registered-unsure",
+    label: "family spouse route, unsure whether marriage is registered",
+    matches: (facts) =>
+      facts.category === "family" &&
+      facts.family_relation === "SPOUSE" &&
+      facts.family_sponsor_nationalities === "ID" &&
+      facts.family_sponsor_confirmed === "yes" &&
+      facts.family_marriage_registered === "unsure" &&
+      facts.review_gate === "none",
+  },
+];
+
+/** First matching pinned persona, or `undefined` when this interview's
+ * answers were not curated into the subset (documented SCOPE above). */
+export function findGoldOraclePersona(
+  facts: OracleFacts,
+): GoldOraclePersona | undefined {
+  return HUMAN_REVIEW_PERSONAS.find((persona) => persona.matches(facts));
+}
+
+/** The `HUMAN_REVIEW_REQUIRED` reason every matched persona predicts. */
+export function goldOracleReviewReasonCode(): string {
+  return DISCLOSED_UNCERTAINTY_REVIEW_CODE;
+}

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/preview-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/preview-adapter.test.ts
@@ -22,4 +22,34 @@ describe("preview adapter", () => {
     });
     expect(JSON.stringify(outcome)).not.toContain("C1");
   });
+
+  it("renders the pinned gold-oracle HUMAN_REVIEW_REQUIRED baseline for a matched persona", () => {
+    const outcome = buildPreviewOutcome(
+      {
+        category: "remote",
+        work_payer: "unsure",
+        remote_compensation: "no",
+        remote_clients: "foreign",
+        review_gate: "none",
+      },
+      new Date("2026-08-03T00:00:00.000Z"),
+    );
+
+    expect(outcome).toMatchObject({
+      state: "HUMAN_REVIEW_REQUIRED",
+      provenance: "PREVIEW",
+      assessment: null,
+      candidates: [],
+      sources: [],
+      reviewReasons: [{ code: "DISCLOSED_UNCERTAINTY_REVIEW" }],
+    });
+  });
+
+  it("still falls back to the honest zero-candidate hold outside the pinned subset", () => {
+    const outcome = buildPreviewOutcome(
+      { category: "remote" },
+      new Date("2026-08-03T00:00:00.000Z"),
+    );
+    expect(outcome.state).toBe("TEMPORARILY_UNAVAILABLE");
+  });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/preview-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/preview-adapter.ts
@@ -1,5 +1,13 @@
+import { NEXT_STEPS as ENGINE_NEXT_STEPS } from "./engine-adapter";
+import {
+  findGoldOraclePersona,
+  goldOracleReviewReasonCode,
+  type GoldOraclePersona,
+} from "./gold-oracle-baseline";
 import type {
+  HumanReviewOutcome,
   OutcomeNextSteps,
+  OutcomeReason,
   TemporarilyUnavailableOutcome,
 } from "./outcome-view-model";
 import type { OracleFacts } from "./tree";
@@ -25,15 +33,7 @@ const NEXT_STEPS: OutcomeNextSteps = [
   },
 ];
 
-/**
- * Developer/test-only display boundary. The retired fixture evaluator cannot
- * select even a preview candidate, so PREVIEW is an explicit zero-candidate
- * hold. Production coerces this mode to ENGINE in `runtime-mode.ts`.
- */
-export function buildPreviewOutcome(
-  _facts: OracleFacts,
-  _assessmentClock: Date,
-): TemporarilyUnavailableOutcome {
+function unavailablePreviewOutcome(): TemporarilyUnavailableOutcome {
   return {
     state: "TEMPORARILY_UNAVAILABLE",
     provenance: "PREVIEW",
@@ -52,4 +52,76 @@ export function buildPreviewOutcome(
       retryable: false,
     },
   };
+}
+
+const GOLD_ORACLE_REVIEW_REASON: OutcomeReason = {
+  code: goldOracleReviewReasonCode(),
+  // `semanticProjection` never looks at `message` (only `code`/`sourceIds`),
+  // so this copy is honest display text, not a parity input. It is NOT the
+  // frontend's own `REVIEW_REASON_COPY` (engine-adapter.ts) fallback string:
+  // that map has no entry for `DISCLOSED_UNCERTAINTY_REVIEW` yet, so a real
+  // ENGINE render of this same reason currently falls back to
+  // engine-adapter.ts's `GENERIC_REVIEW_REASON` — unrelated to parity, this
+  // baseline's own copy is free to be specific.
+  message: {
+    en: "You marked one answer as “not sure”, so a person will review this case by hand.",
+    id: "Anda menandai satu jawaban sebagai “tidak yakin”, sehingga kasus ini akan ditinjau langsung oleh seseorang.",
+  },
+  sourceIds: [],
+};
+
+/**
+ * The gold-oracle baseline's rendering for a matched persona (see
+ * `gold-oracle-baseline.ts`): every pinned persona predicts
+ * `HUMAN_REVIEW_REQUIRED` with exactly one review reason,
+ * `DISCLOSED_UNCERTAINTY_REVIEW` — the disclosed-review-flags policy's own
+ * verbatim, pack-independent outcome for "exactly one SKIP answer, no other
+ * disclosed-flag trigger" (empirically verified, see that file's doc
+ * comment).
+ */
+function buildGoldOraclePreviewOutcome(
+  _persona: GoldOraclePersona,
+): HumanReviewOutcome {
+  return {
+    state: "HUMAN_REVIEW_REQUIRED",
+    provenance: "PREVIEW",
+    assessment: null,
+    candidates: [],
+    pathsRemaining: 1,
+    assumptions: [],
+    sources: [],
+    // Real engine copy, not the developer-preview NEXT_STEPS above — see the
+    // export site's doc comment in engine-adapter.ts for why this must match.
+    nextSteps: ENGINE_NEXT_STEPS,
+    reviewReasons: [GOLD_ORACLE_REVIEW_REASON],
+  };
+}
+
+/**
+ * Developer/test-only display boundary. `assessmentClock` is accepted for
+ * interface parity with the engine adapters (a caller may need it for a
+ * future dated persona) but is never read: this baseline is a documented,
+ * pinned snapshot (see `gold-oracle-baseline.ts`), never a live clock read.
+ *
+ * QW-2 (2026-08): when `facts` matches one of the pinned gold-oracle
+ * personas, this returns that persona's independently-verified
+ * `HUMAN_REVIEW_REQUIRED` expectation — the real SHADOW-parity baseline. For
+ * every other interview (not yet curated into the pinned subset), it falls
+ * back to the original zero-candidate `TEMPORARILY_UNAVAILABLE` hold: an
+ * honest "no independent baseline available" signal, never a fabricated
+ * match.
+ *
+ * Non-tautology invariant (pinned by `preview-adapter.test.ts` and
+ * `shadow-parity.test.ts`): this function's ENTIRE input is `(facts, clock)`
+ * — it has no `VisaOracleEvaluateResponse` parameter to read from, so it is
+ * structurally incapable of deriving its answer from the response under
+ * test.
+ */
+export function buildPreviewOutcome(
+  facts: OracleFacts,
+  _assessmentClock: Date,
+): TemporarilyUnavailableOutcome | HumanReviewOutcome {
+  const persona = findGoldOraclePersona(facts);
+  if (persona) return buildGoldOraclePreviewOutcome(persona);
+  return unavailablePreviewOutcome();
 }

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/shadow-parity.test.ts
@@ -79,3 +79,90 @@ describe("shadow public-contract parity", () => {
     expect(shadowParityMatches(noPath, noPathBaseline)).toBe(false);
   });
 });
+
+describe("QW-2 gold-oracle SHADOW baseline (independent, non-tautological)", () => {
+  // Empirically verified against the real evaluator + policy-adapter chain
+  // (see gold-oracle-baseline.ts's doc comment): a real SHADOW response for
+  // this exact interview is HUMAN_REVIEW_REQUIRED with exactly one review
+  // reason, DISCLOSED_UNCERTAINTY_REVIEW, empty source_refs.
+  const REMOTE_WORKER_UNSURE_FACTS = {
+    category: "remote",
+    work_payer: "unsure",
+    remote_compensation: "no",
+    remote_clients: "foreign",
+    review_gate: "none",
+  };
+
+  function humanReviewResponseMatchingBaseline() {
+    const response = makeVisaOracleResponse("HUMAN_REVIEW_REQUIRED");
+    response.decision.review_reasons = [
+      {
+        code: "DISCLOSED_UNCERTAINTY_REVIEW",
+        rule_ids: ["system.disclosed-review.not-certain"],
+        source_refs: [],
+      },
+    ];
+    response.sources = [];
+    return response;
+  }
+
+  it("parity_match is reachable against the independent gold-oracle baseline", () => {
+    const baseline = buildPreviewOutcome(
+      REMOTE_WORKER_UNSURE_FACTS,
+      new Date("2026-08-03T04:00:00Z"),
+    );
+    expect(baseline.state).toBe("HUMAN_REVIEW_REQUIRED");
+
+    const response = humanReviewResponseMatchingBaseline();
+
+    expect(shadowParityMatches(response, baseline)).toBe(true);
+  });
+
+  it("parity_mismatch is reachable against the same independent baseline", () => {
+    const baseline = buildPreviewOutcome(
+      REMOTE_WORKER_UNSURE_FACTS,
+      new Date("2026-08-03T04:00:00Z"),
+    );
+
+    const response = humanReviewResponseMatchingBaseline();
+    response.decision.review_reasons = [
+      {
+        code: "DISCLOSED_ACTIVITY_BOUNDARY_REVIEW",
+        rule_ids: ["system.disclosed-review.activity-boundary"],
+        source_refs: [],
+      },
+    ];
+
+    expect(shadowParityMatches(response, baseline)).toBe(false);
+  });
+
+  it(
+    "non-tautology: one baseline instance, built ONLY from facts before " +
+      "either response exists, agrees with one response and disagrees " +
+      "with another — proving the verdict is not read back off the " +
+      "response under test",
+    () => {
+      // `buildPreviewOutcome` has no `VisaOracleEvaluateResponse` parameter
+      // at all — this call happens before either response object below is
+      // constructed, so it cannot have read either of them.
+      const baseline = buildPreviewOutcome(
+        REMOTE_WORKER_UNSURE_FACTS,
+        new Date("2026-08-03T04:00:00Z"),
+      );
+
+      const agreeing = humanReviewResponseMatchingBaseline();
+
+      const disagreeing = humanReviewResponseMatchingBaseline();
+      disagreeing.decision.review_reasons = [
+        {
+          code: "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW",
+          rule_ids: ["system.disclosed-review.ambiguous-sponsor"],
+          source_refs: [],
+        },
+      ];
+
+      expect(shadowParityMatches(agreeing, baseline)).toBe(true);
+      expect(shadowParityMatches(disagreeing, baseline)).toBe(false);
+    },
+  );
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/telemetry.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/telemetry.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const trackPiiFreeEvent = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/analytics", () => ({ trackPiiFreeEvent }));
 
-import { emitVisaOracleTelemetry, nonReversibleHash } from "./telemetry";
+import {
+  emitVisaOracleTelemetry,
+  nonReversibleHash,
+  resolveFrontendVersion,
+} from "./telemetry";
 
 describe("Visa Oracle PII-free telemetry boundary", () => {
   beforeEach(() => trackPiiFreeEvent.mockReset());
@@ -47,5 +51,29 @@ describe("Visa Oracle PII-free telemetry boundary", () => {
         state: "TEMPORARILY_UNAVAILABLE",
       },
     );
+  });
+
+  it("carries the pinned pack hash and frontend version on a parity event", () => {
+    emitVisaOracleTelemetry({
+      event: "visa_oracle_v2_parity_match",
+      state: "NEEDS_INPUT",
+      packHash: "7fba37bd-be23-5be8-ae46-21004a42f4d5@1.0.0#1",
+      frontendVersion: "abc1234",
+    });
+    expect(trackPiiFreeEvent).toHaveBeenCalledWith(
+      "visa_oracle_v2_parity_match",
+      {
+        state: "NEEDS_INPUT",
+        pack_hash: "7fba37bd-be23-5be8-ae46-21004a42f4d5@1.0.0#1",
+        frontend_version: "abc1234",
+      },
+    );
+  });
+
+  it("resolveFrontendVersion falls back to 'unknown' when unset", () => {
+    expect(resolveFrontendVersion(undefined)).toBe("unknown");
+    expect(resolveFrontendVersion("")).toBe("unknown");
+    expect(resolveFrontendVersion("  ")).toBe("unknown");
+    expect(resolveFrontendVersion("deadbeef")).toBe("deadbeef");
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/telemetry.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/telemetry.ts
@@ -25,6 +25,22 @@ export interface VisaOracleTelemetry {
   state?: VisaOracleTelemetryState;
   /** SHA-256 only. Raw facts, category, nationality, or payload are forbidden. */
   correlationHash?: string;
+  /**
+   * SHADOW-parity events only (QW-2). Identifies the independent gold-oracle
+   * baseline's PINNED rule-pack (`gold-oracle-baseline.ts`'s
+   * `GOLD_ORACLE_PACK_HASH`) that produced this match/mismatch verdict —
+   * never a live server value, so a rotation of the pinned pack is visible
+   * in the event stream without a schema change. PII-free by construction:
+   * it is a build-time constant, not a value read from applicant data.
+   */
+  packHash?: string;
+  /**
+   * SHADOW-parity events only (QW-2). Build identifier for the frontend
+   * that emitted the verdict, so a parity_mismatch spike can be correlated
+   * to a specific deploy. PII-free (a commit SHA / build id, never a
+   * request-derived value).
+   */
+  frontendVersion?: string;
 }
 
 const SHA256_HEX = /^[a-f0-9]{64}$/;
@@ -37,12 +53,31 @@ export async function nonReversibleHash(value: string): Promise<string> {
   ).join("");
 }
 
-/** Closed telemetry boundary: only event, terminal state, and SHA-256 leave. */
+/**
+ * Build identifier for this frontend deploy. Vercel does not auto-expose its
+ * system `VERCEL_GIT_COMMIT_SHA` to client bundles (only `NEXT_PUBLIC_`-
+ * prefixed vars are inlined) — `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` must be
+ * added to the Vercel project's environment variables for this to carry a
+ * real commit; until then it deliberately falls back to `"unknown"` rather
+ * than fabricating a value. The repository is public, so the SHA is not a
+ * secret (same posture as `app/api/health/route.ts`'s server-side `COMMIT`).
+ */
+export function resolveFrontendVersion(
+  value: string | undefined = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+): string {
+  return value && value.trim().length > 0 ? value : "unknown";
+}
+
+/** Closed telemetry boundary: only event, terminal state, SHA-256, and (for
+ * SHADOW-parity events) the pinned pack/build identifiers leave. */
 export function emitVisaOracleTelemetry(input: VisaOracleTelemetry): void {
   const properties: Record<string, string> = {};
   if (input.state) properties.state = input.state;
   if (input.correlationHash && SHA256_HEX.test(input.correlationHash)) {
     properties.correlation_hash = input.correlationHash;
   }
+  if (input.packHash) properties.pack_hash = input.packHash;
+  if (input.frontendVersion)
+    properties.frontend_version = input.frontendVersion;
   trackPiiFreeEvent(input.event, properties);
 }


### PR DESCRIPTION
## What

Replaces the stub-driven SHADOW-parity baseline (`buildPreviewOutcome` always
returned `TEMPORARILY_UNAVAILABLE`, so `parity_match` telemetry was
unreachable by construction) with an **independent, empirically-verified
baseline**.

**Design changed mid-task** — the obvious approach (pin 3 `NEEDS_INPUT` gold
personas from `test_evaluator_gold.py`, matched on `facts[q] === undefined`)
turned out to reproduce the exact same "unreachable by construction" defect
one layer down:

1. `flow.ts`'s reducer never leaves an in-path question's fact key absent at
   verdict time — `SKIP` writes the sentinel `"unsure"`, not `undefined`
   (verified by reading `ANSWER`/`SKIP` cases + `FIXED_CATEGORY_QUESTIONS`'s
   unconditional walk).
2. `fact-mapper.ts::mapDisclosedReviewFlags` adds `NOT_CERTAIN` to the
   request whenever ANY answer is `"unsure"`.
3. `evaluate_path.py::_apply_disclosed_review_flags` is a **monotone**
   adapter: whenever `disclosed_review_flags` is non-empty, it *always*
   overrides the decision to `HUMAN_REVIEW_REQUIRED` (`candidates=()`,
   `missing_facts=()`) — on every public evaluation.

So the one real, user-reachable way to leave a fact "missing" (the SKIP/
NotSure affordance) never reaches the engine as `NEEDS_INPUT` — always
`HUMAN_REVIEW_REQUIRED`. A `NEEDS_INPUT` baseline built on that path would
never see a genuine `parity_match` in live SHADOW traffic either.

**Redesigned baseline** (`gold-oracle-baseline.ts`): 2 personas, each "exactly
one SKIP/unsure answer, no other disclosed-flag trigger", predicting
`HUMAN_REVIEW_REQUIRED` + `DISCLOSED_UNCERTAINTY_REVIEW`. This is *more*
robust than a rule-derived baseline, not a downgrade: the disclosed-review-
flags policy (`_DISCLOSED_REVIEW_REASON_CODES`, `evaluate_path.py`) is a
module-level constant, **pack-independent** — it can't go stale on a
rule-pack rotation the way a `NEEDS_INPUT`/`SUPPORTED_CANDIDATES` baseline
tied to the synthetic TEST gold pack could.

**Empirically verified, not inferred**: ran the real `evaluator.evaluate()` +
the real `evaluate_path.apply_public_policy_adapters(..., disclosed_review_flags=(NOT_CERTAIN,))`
(its own docstring: "every deterministic abstention adapter used by the
public path") against both persona fact patterns on the gold rule pack.
Both: underlying (pre-disclosure) state `NEEDS_INPUT` (so no pre-existing
`HUMAN_REVIEW_REQUIRED` reasons bleed into the final `review_reasons`),
final `state=HUMAN_REVIEW_REQUIRED`, `review_reasons=[("DISCLOSED_UNCERTAINTY_REVIEW", source_refs=())]`,
`candidates=()`. Pin: `evaluate_path.py` sha256
`8ee131a989fc786f1fc54ad531ddefaa9614756361f284b6412ee8a23120e569`.

**Telemetry**: `packHash` + `frontendVersion` added to `VisaOracleTelemetry`
and wired on the parity-match/mismatch emit in `OracleShell.tsx`.
`frontendVersion` reads `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` (falls back to
`"unknown"` — that env var isn't yet exposed to the client bundle on
Vercel, documented in `telemetry.ts`; no new network call).

## Non-tautology

`buildPreviewOutcome(facts, clock)` has **no** `VisaOracleEvaluateResponse`
parameter — structurally incapable of reading the response under test.
Pinned by an explicit test in `shadow-parity.test.ts`: one baseline
instance, built once from facts before either response object exists,
agrees with one mocked response and disagrees with another.

## Gate evidence

- `parity_match` reachable: `shadow-parity.test.ts` — asserted `true`.
- `parity_mismatch` reachable: same file — asserted `false` on a different
  review reason.
- Non-tautology: explicit test, see above.
- `npx tsc --noEmit`: 0 errors.
- `npx vitest run "src/app/(visa-oracle)"`: **376/376 tests, 33/33 files
  passing** (full existing OracleShell dedupe/internal-preview/fail-closed
  suite intact — no facts pattern used by any existing test collides with
  the 2 new pinned personas).
- `npx eslint`: 0 errors (2 pre-existing, unrelated `<a>` vs `<Link>`
  warnings in `OracleShell.tsx:929`).
- `npx prettier --check`: clean.

No client-facing UI copy changed (measurement plumbing only). No price
logic. No new live network calls. Shadow POST dedupe contract in
`OracleShell.tsx` untouched — only the parity-telemetry emit call gained
2 extra fields.

## Review dispositions (generator≠grader)

1. **Codex (`gpt-5.6-terra`, read-only sandbox)**: killed after ~8 min with
   zero usable verdict (only echoed the diff back, no synthesis) —
   unproductive, disposition: abandoned, fell back to Kimi per
   orchestrator instruction.
2. **Kimi K3** (diff pasted inline, ordered to refute): surfaced the
   central real finding above — the 3 original `NEEDS_INPUT` personas were
   permanently unreachable, both via the reducer (`undefined` never
   produced) and, once that was fixed, via the disclosed-review-flags
   monotone override. This finding drove the full redesign described
   above. Disposition: **fixed** (not a patch — the baseline's target
   state, personas, and provenance pin all changed).
3. Independent verification (this session, not the reviewer): confirmed
   the redesigned baseline by directly running the real backend evaluator
   + policy-adapter chain against both persona fact patterns, rather than
   trusting inference from reading code.

## What's NOT done (documented scope, not silently absorbed)

Only 2 personas pinned (`HUMAN_REVIEW_REQUIRED` via disclosed uncertainty).
`SUPPORTED_CANDIDATES`/`NO_SUPPORTED_PATH`/other `HUMAN_REVIEW_REQUIRED`
shapes are out of scope for this PR — see `gold-oracle-baseline.ts`'s doc
comment for exactly what's covered and why the predicates are deliberately
narrow (not "any unsure answer anywhere").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>