### PR TITLE
feat(visa-oracle): QW-6a HRR reason audit tooling

### DIFF
--- a/research/visa/doctrine-factory/tools/hrr_reason_audit.py
+++ b/research/visa/doctrine-factory/tools/hrr_reason_audit.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""QW-6a — HRR reason audit: repo-side scripts/queries.
+
+Re-measures the conclusive-rate and per-reason-code counts on the LIVE
+``visa_decisions`` ledger, post rule-pack seq-7 activation, the moment a
+read-only DSN is available (that execution step is QW-6b, gated on an
+operator credential — NOT run by this task).
+
+GROUNDING (verified on disk, this session — cite, do not re-derive; see
+``hrr_reason_audit.sql`` header for the migration-line citations):
+
+* ``visa_decisions.verdict`` is the 5-value ``DecisionState`` CHECK enum
+  (migration 252) — NOT a generic conclusive/inconclusive tri-state.
+* There is NO ``review_reason_codes`` column anywhere on ``visa_decisions``
+  (252 explicitly defers it). The reason codes live INSIDE the
+  ``grounding_summary`` JSONB array (migration 255) as claims shaped
+  ``{"claim_kind": "REVIEW_REASON", "claim_code": "<reason code>",
+  "source_record_ids": [...]}`` — built by
+  ``backend/services/visa_engine/shadow.py::_build_grounding_summary``.
+* ``traffic_source`` (migration 256) is nullable TEXT IN ('real',
+  'synthetic_gold', 'synthetic_driver'); NULL means "legacy/unknown
+  provenance" and must never be silently folded into 'real'. This module
+  buckets NULL as ``"legacy_unknown"`` everywhere, on purpose — the
+  contamination guard QW-6a exists to enforce.
+* ``visa_rule_packs.sequence`` (migration 250) is the pack-activation
+  sequence number the plan's "pack seq-7" baseline refers to. It is UNIQUE
+  only per ``(environment, jurisdiction, decision_domain)`` (250's own
+  constraint), NOT globally — a TEST-environment pack and a PRODUCTION
+  pack can both be "sequence 7". ``visa_decisions.jurisdiction`` and
+  ``.decision_domain`` are each single-valued CHECK enums today ('ID' /
+  'IMMIGRATION_VISA' only — 252), so fixing ``environment`` (below) is
+  sufficient to make "seq-7" mean one thing.
+* ``visa_decisions.environment`` (migration 252) is a CHECK enum IN
+  ('TEST', 'STAGING', 'PRODUCTION'). This module filters/reports on
+  PRODUCTION only by default (``--environment``) — kimi adversarial review
+  finding F1/F2 (2026-08-16): without this, TEST/STAGING rows pollute the
+  "live ledger" conclusive-rate this audit exists to measure, and combined
+  with the per-scope ``sequence`` above, a TEST pack "seq 7" and a
+  PRODUCTION pack "seq 7" would silently collapse into one bucket.
+
+CONTRACT: this module contains ONLY pure computation
+(``compute_reason_counts`` / ``compute_conclusive_rate`` /
+``compute_sequence_activation_split``) plus a thin, optional asyncpg fetch
+path (``fetch_decisions_pg``) used ONLY when a DSN is supplied. The pure
+functions are exercised by the fixture-driven pytest suite
+(``tests/test_hrr_reason_audit.py``) with ZERO network/prod access. QW-6b
+runs this same module against the live ledger once a read-only credential
+exists.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+logger = logging.getLogger("hrr_reason_audit")
+
+# migration 252's DecisionState CHECK enum, verbatim — closed vocabulary.
+VALID_VERDICTS = frozenset(
+    {
+        "NEEDS_INPUT",
+        "SUPPORTED_CANDIDATES",
+        "HUMAN_REVIEW_REQUIRED",
+        "NO_SUPPORTED_PATH",
+        "TEMPORARILY_UNAVAILABLE",
+    }
+)
+
+# migration 256's CHECK enum, verbatim.
+VALID_TRAFFIC_SOURCES = frozenset({"real", "synthetic_gold", "synthetic_driver"})
+
+LEGACY_UNKNOWN_BUCKET = "legacy_unknown"
+
+# Verdicts counted as "conclusive" for the conclusive-rate gate: anything
+# that is NOT HUMAN_REVIEW_REQUIRED / NEEDS_INPUT / TEMPORARILY_UNAVAILABLE.
+# NO_SUPPORTED_PATH is conclusive too (the engine reached a definite
+# negative answer) — only the three "we could not decide" states are not.
+INCONCLUSIVE_VERDICTS = frozenset(
+    {"HUMAN_REVIEW_REQUIRED", "NEEDS_INPUT", "TEMPORARILY_UNAVAILABLE"}
+)
+
+DEFAULT_MIN_SEQUENCE = 7
+
+
+def _traffic_bucket(raw: str | None) -> str:
+    """Map a raw traffic_source value to its reporting bucket.
+
+    NULL/legacy and any value outside the migration-256 CHECK enum both land
+    in ``legacy_unknown`` — fail-closed, matches shadow_evidence.py's own
+    "reported as legacy, counted toward NEITHER gate" precedent (256 header).
+    """
+
+    if raw in VALID_TRAFFIC_SOURCES:
+        return raw
+    return LEGACY_UNKNOWN_BUCKET
+
+
+@dataclass(frozen=True)
+class DecisionRow:
+    """One flattened ``visa_decisions`` row, as consumed by this module.
+
+    Field names mirror the SQL column names in ``hrr_reason_audit.sql``
+    Query 1-3 so a Postgres row (via ``fetch_decisions_pg``) and a JSON
+    fixture row need no field-renaming step.
+    """
+
+    decision_id: str
+    verdict: str
+    traffic_source: str | None
+    rule_pack_sequence: int | None
+    ruleset_activation_id: str | None
+    grounding_summary: tuple[Mapping[str, Any], ...] = field(default_factory=tuple)
+    # Optional (default None = "unknown scope"): fixtures that predate the
+    # F1/F2 fix may omit these. filter_rows() treats None as "does not match
+    # any concrete --environment/--engine-mode filter" (fail-closed, not
+    # fail-open) so an old fixture without these keys is simply excluded by
+    # a scoped filter rather than silently counted as PRODUCTION/SHADOW.
+    environment: str | None = None
+    engine_mode: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.verdict not in VALID_VERDICTS:
+            raise ValueError(
+                f"decision {self.decision_id!r} has unknown verdict {self.verdict!r} "
+                f"(not in migration 252's DecisionState enum)"
+            )
+
+    @property
+    def traffic_bucket(self) -> str:
+        return _traffic_bucket(self.traffic_source)
+
+    @property
+    def review_reason_codes(self) -> list[str]:
+        """claim_code of every REVIEW_REASON claim in grounding_summary."""
+
+        codes, _malformed = self._review_reason_codes_and_malformed_count()
+        return codes
+
+    def _review_reason_codes_and_malformed_count(self) -> tuple[list[str], int]:
+        codes: list[str] = []
+        malformed = 0
+        for claim in self.grounding_summary:
+            if not isinstance(claim, Mapping):
+                continue
+            if claim.get("claim_kind") != "REVIEW_REASON":
+                continue
+            code = claim.get("claim_code")
+            if isinstance(code, str) and code:
+                codes.append(code)
+            else:
+                # F9 (kimi adversarial review, QW-6a): a REVIEW_REASON claim
+                # with a missing/non-string claim_code is exactly the "dirty
+                # data" an audit must surface, not silently drop — counted
+                # so build_report can report it instead of hiding it.
+                malformed += 1
+        return codes, malformed
+
+
+def row_from_mapping(raw: Mapping[str, Any]) -> DecisionRow:
+    """Build a DecisionRow from a loosely-typed mapping (asyncpg Record or
+    a JSON fixture dict). Tolerates a JSON-encoded-string grounding_summary
+    (asyncpg returns jsonb columns as str by default unless a codec is set)
+    as well as an already-decoded list.
+    """
+
+    grounding_raw = raw.get("grounding_summary") or []
+    if isinstance(grounding_raw, str):
+        try:
+            grounding_raw = json.loads(grounding_raw)
+        except json.JSONDecodeError:
+            logger.warning(
+                "decision %s: grounding_summary is not valid JSON, treating as empty",
+                raw.get("decision_id"),
+            )
+            grounding_raw = []
+    if not isinstance(grounding_raw, list):
+        grounding_raw = []
+
+    rule_pack_sequence = raw.get("rule_pack_sequence")
+    if rule_pack_sequence is not None:
+        rule_pack_sequence = int(rule_pack_sequence)
+
+    return DecisionRow(
+        decision_id=str(raw["decision_id"]),
+        verdict=str(raw["verdict"]),
+        traffic_source=raw.get("traffic_source"),
+        rule_pack_sequence=rule_pack_sequence,
+        ruleset_activation_id=(
+            str(raw["ruleset_activation_id"])
+            if raw.get("ruleset_activation_id") is not None
+            else None
+        ),
+        grounding_summary=tuple(grounding_raw),
+        environment=raw.get("environment"),
+        engine_mode=raw.get("engine_mode"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure computation — fixture-tested, zero I/O.
+# ---------------------------------------------------------------------------
+
+DEFAULT_ENVIRONMENT = "PRODUCTION"
+DEFAULT_ENGINE_MODE = "SHADOW"
+SCOPE_FILTER_ALL = "ALL"
+
+
+def filter_rows(
+    rows: Iterable[DecisionRow],
+    *,
+    environment: str | None = DEFAULT_ENVIRONMENT,
+    engine_mode: str | None = DEFAULT_ENGINE_MODE,
+) -> list[DecisionRow]:
+    """Scope the ledger to one (environment, engine_mode) pair before any
+    other computation runs (kimi review F1/F2/F8, 2026-08-16).
+
+    ``environment``/``engine_mode`` of ``None`` (or the sentinel
+    ``SCOPE_FILTER_ALL``) disables that filter — use only for an explicit
+    cross-scope debugging pass, never as the audit's default, because
+    ``visa_rule_packs.sequence`` is unique only within one (environment,
+    jurisdiction, decision_domain) triple (migration 250): mixing
+    environments makes "pack seq-7" mean two different packs at once.
+    """
+
+    want_env = None if environment in (None, SCOPE_FILTER_ALL) else environment
+    want_mode = None if engine_mode in (None, SCOPE_FILTER_ALL) else engine_mode
+
+    out: list[DecisionRow] = []
+    for row in rows:
+        if want_env is not None and row.environment != want_env:
+            continue
+        if want_mode is not None and row.engine_mode != want_mode:
+            continue
+        out.append(row)
+    return out
+
+
+def compute_reason_counts(
+    rows: Iterable[DecisionRow], *, min_sequence: int = DEFAULT_MIN_SEQUENCE
+) -> dict[str, dict[str, dict[str, int]]]:
+    """(a) count per reason-code across HUMAN_REVIEW_REQUIRED decisions,
+    split by traffic_source bucket (mandatory) and gated to
+    rule_pack_sequence >= min_sequence ("post-seq-7").
+
+    Returns {traffic_bucket: {reason_code: {"reason_count": N,
+    "decisions_with_this_reason": M}}}.
+    """
+
+    counts: dict[str, dict[str, dict[str, int]]] = defaultdict(
+        lambda: defaultdict(lambda: {"reason_count": 0, "decisions_with_this_reason": 0})
+    )
+    for row in rows:
+        if row.verdict != "HUMAN_REVIEW_REQUIRED":
+            continue
+        if row.rule_pack_sequence is None or row.rule_pack_sequence < min_sequence:
+            continue
+        codes = row.review_reason_codes
+        seen_this_decision: set[str] = set()
+        for code in codes:
+            bucket = counts[row.traffic_bucket][code]
+            bucket["reason_count"] += 1
+            if code not in seen_this_decision:
+                bucket["decisions_with_this_reason"] += 1
+                seen_this_decision.add(code)
+    return {bucket: dict(reasons) for bucket, reasons in counts.items()}
+
+
+def compute_malformed_review_reason_claims(
+    rows: Iterable[DecisionRow], *, min_sequence: int = DEFAULT_MIN_SEQUENCE
+) -> dict[str, int]:
+    """Count REVIEW_REASON claims with a missing/non-string claim_code, per
+    traffic_source bucket, on HUMAN_REVIEW_REQUIRED rows in scope (kimi
+    review F9, 2026-08-16). Dirty data an audit must surface, not hide."""
+
+    malformed: dict[str, int] = defaultdict(int)
+    for row in rows:
+        if row.verdict != "HUMAN_REVIEW_REQUIRED":
+            continue
+        if row.rule_pack_sequence is None or row.rule_pack_sequence < min_sequence:
+            continue
+        _codes, count = row._review_reason_codes_and_malformed_count()
+        if count:
+            malformed[row.traffic_bucket] += count
+    return dict(malformed)
+
+
+def compute_conclusive_rate(
+    rows: Iterable[DecisionRow], *, min_sequence: int = DEFAULT_MIN_SEQUENCE
+) -> dict[str, dict[str, Any]]:
+    """(b) conclusive-rate split: verdict counts + share per traffic_source
+    bucket, gated to rule_pack_sequence >= min_sequence ("post-seq-7").
+
+    Returns {traffic_bucket: {"total": N, "conclusive": C, "inconclusive": I,
+    "conclusive_rate_pct": pct, "by_verdict": {verdict: count}}}.
+    """
+
+    by_bucket: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for row in rows:
+        if row.rule_pack_sequence is None or row.rule_pack_sequence < min_sequence:
+            continue
+        by_bucket[row.traffic_bucket][row.verdict] += 1
+
+    report: dict[str, dict[str, Any]] = {}
+    for bucket, verdict_counts in by_bucket.items():
+        total = sum(verdict_counts.values())
+        inconclusive = sum(
+            n for v, n in verdict_counts.items() if v in INCONCLUSIVE_VERDICTS
+        )
+        conclusive = total - inconclusive
+        report[bucket] = {
+            "total": total,
+            "conclusive": conclusive,
+            "inconclusive": inconclusive,
+            "conclusive_rate_pct": round(100.0 * conclusive / total, 2) if total else None,
+            "by_verdict": dict(verdict_counts),
+        }
+    return report
+
+
+def compute_sequence_activation_split(
+    rows: Iterable[DecisionRow],
+) -> dict[str, dict[str, dict[str, dict[str, int]]]]:
+    """(d) optional split by rule_pack sequence / ruleset_activation_id,
+    still carrying traffic_source (mandatory contamination guard).
+
+    Returns {sequence_key: {activation_key: {traffic_bucket: {verdict: count}}}}
+    where sequence_key/activation_key are strings ("unknown" for NULL).
+    """
+
+    report: dict[str, dict[str, dict[str, dict[str, int]]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    )
+    for row in rows:
+        seq_key = str(row.rule_pack_sequence) if row.rule_pack_sequence is not None else "unknown"
+        act_key = row.ruleset_activation_id or "unknown"
+        report[seq_key][act_key][row.traffic_bucket][row.verdict] += 1
+
+    return {
+        seq: {
+            act: {bucket: dict(verdicts) for bucket, verdicts in buckets.items()}
+            for act, buckets in acts.items()
+        }
+        for seq, acts in report.items()
+    }
+
+
+def build_report(
+    rows: Sequence[DecisionRow],
+    *,
+    min_sequence: int = DEFAULT_MIN_SEQUENCE,
+    environment: str | None = DEFAULT_ENVIRONMENT,
+    engine_mode: str | None = DEFAULT_ENGINE_MODE,
+) -> dict[str, Any]:
+    """Filter rows to (environment, engine_mode) FIRST (F1/F2/F8), then run
+    every other computation only on that scoped set — including the
+    un-gated sequence_activation_split, which would otherwise mix scopes
+    that happen to share a rule_pack.sequence number.
+    """
+
+    scoped = filter_rows(rows, environment=environment, engine_mode=engine_mode)
+    return {
+        "min_sequence": min_sequence,
+        "environment_filter": environment,
+        "engine_mode_filter": engine_mode,
+        "total_rows_fetched": len(rows),
+        "total_rows_in_scope": len(scoped),
+        "reason_counts": compute_reason_counts(scoped, min_sequence=min_sequence),
+        "malformed_review_reason_claims": compute_malformed_review_reason_claims(
+            scoped, min_sequence=min_sequence
+        ),
+        "conclusive_rate": compute_conclusive_rate(scoped, min_sequence=min_sequence),
+        "sequence_activation_split": compute_sequence_activation_split(scoped),
+    }
+
+
+# ---------------------------------------------------------------------------
+# I/O boundary — fixture loader (tests) + Postgres fetch (QW-6b, live only).
+# ---------------------------------------------------------------------------
+
+
+def load_fixture(path: Path) -> list[DecisionRow]:
+    """Load a JSON fixture: a list of decision-row dicts, same shape as
+    ``hrr_reason_audit.sql`` Query 3's flattened columns. No network access.
+    """
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"fixture {path} must contain a JSON array of decision rows")
+    return [row_from_mapping(item) for item in data]
+
+
+async def fetch_decisions_pg(dsn: str) -> list[DecisionRow]:
+    """Fetch the flattened decision rows straight from the live ledger via a
+    READ-ONLY DSN (QW-6b execution only — never called by this task or its
+    tests). Async per CLAUDE.md golden rule #4/#10; a one-shot audit script,
+    not a persistent-server hot path, so a fresh connection is correct here.
+    """
+
+    import asyncpg  # local import: keeps this module importable without
+
+    # asyncpg installed when only the pure computation path is exercised.
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        await conn.execute("SET default_transaction_read_only = on")
+        rows = await conn.fetch(
+            """
+            SELECT
+                d.decision_id::text                  AS decision_id,
+                d.verdict                            AS verdict,
+                d.traffic_source                     AS traffic_source,
+                d.environment                        AS environment,
+                d.engine_mode                        AS engine_mode,
+                rp.sequence                          AS rule_pack_sequence,
+                d.ruleset_activation_id::text        AS ruleset_activation_id,
+                d.grounding_summary::text            AS grounding_summary
+            FROM public.visa_decisions d
+            LEFT JOIN public.visa_rule_packs rp ON rp.id = d.rule_pack_id
+            WHERE d.engine_surface = 'MATCH'
+            """
+            # No environment/engine_mode WHERE clause here on purpose: this
+            # fetch stays scope-agnostic (mirrors hrr_reason_audit.sql Query
+            # 3), and filter_rows() applies the (environment, engine_mode)
+            # scope in build_report() — one place decides the scope, not two
+            # (kimi review F1/F2/F8: d.decision_id, not the surrogate d.id).
+        )
+    finally:
+        await conn.close()
+    return [row_from_mapping(dict(record)) for record in rows]
+
+
+def _write_output(report: Mapping[str, Any], out: Path | None) -> None:
+    text = json.dumps(report, indent=2, sort_keys=True)
+    if out is None:
+        print(text)
+    else:
+        out.write_text(text + "\n", encoding="utf-8")
+        logger.info("wrote report to %s", out)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        help="Path to a JSON fixture (list of decision-row dicts). No network access.",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help=(
+            "Read-only Postgres DSN. Falls back to $VISA_DECISIONS_RO_DSN "
+            "ONLY when --fixture is not given (kimi review F3, 2026-08-16: "
+            "an operator with VISA_DECISIONS_RO_DSN exported must still be "
+            "able to run --fixture for a dry run). QW-6b execution only — "
+            "never pass this in a test."
+        ),
+    )
+    parser.add_argument(
+        "--min-sequence",
+        type=int,
+        default=DEFAULT_MIN_SEQUENCE,
+        help=f"rule_pack.sequence cutoff for the 'post-seq-N' gate (default {DEFAULT_MIN_SEQUENCE}).",
+    )
+    parser.add_argument(
+        "--environment",
+        default=DEFAULT_ENVIRONMENT,
+        help=(
+            f"visa_decisions.environment to scope to (default {DEFAULT_ENVIRONMENT}). "
+            f"Pass {SCOPE_FILTER_ALL} to disable this filter — debugging only, "
+            "never for a reported figure (see filter_rows() docstring)."
+        ),
+    )
+    parser.add_argument(
+        "--engine-mode",
+        default=DEFAULT_ENGINE_MODE,
+        help=(
+            f"visa_decisions.engine_mode to scope to (default {DEFAULT_ENGINE_MODE}). "
+            f"Pass {SCOPE_FILTER_ALL} to disable this filter."
+        ),
+    )
+    parser.add_argument("--out", type=Path, help="Write JSON report here instead of stdout.")
+    args = parser.parse_args(argv)
+
+    if args.fixture and args.dsn:
+        parser.error("pass either --fixture or --dsn, not both")
+    if not args.fixture and not args.dsn:
+        args.dsn = os.environ.get("VISA_DECISIONS_RO_DSN")
+    if not args.fixture and not args.dsn:
+        parser.error("pass --fixture (offline) or --dsn/VISA_DECISIONS_RO_DSN (live ledger)")
+
+    if args.fixture:
+        rows = load_fixture(args.fixture)
+    else:
+        import asyncio
+
+        rows = asyncio.run(fetch_decisions_pg(args.dsn))
+
+    report = build_report(
+        rows,
+        min_sequence=args.min_sequence,
+        environment=args.environment,
+        engine_mode=args.engine_mode,
+    )
+    _write_output(report, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/visa/doctrine-factory/tools/hrr_reason_audit.sql
+++ b/research/visa/doctrine-factory/tools/hrr_reason_audit.sql
@@ -1,0 +1,162 @@
+-- QW-6a — HRR reason audit: repo-side read-only queries
+--
+-- GROUNDING (verified on disk, this session — cite, do not re-derive):
+--   apps/backend-rag/backend/db/migrations_v2/252_visa_engine_write_substrate.sql
+--     visa_decisions.verdict is the 5-value DecisionState CHECK enum:
+--     'NEEDS_INPUT' | 'SUPPORTED_CANDIDATES' | 'HUMAN_REVIEW_REQUIRED' |
+--     'NO_SUPPORTED_PATH' | 'TEMPORARILY_UNAVAILABLE'. There is NO
+--     review_reason_codes/no_path_reason_codes column on this table — 252's
+--     own header explicitly defers them ("rich per-candidate detail SHADOW
+--     comparison does not need"). Also: visa_decisions.environment is a
+--     CHECK enum IN ('TEST','STAGING','PRODUCTION'); visa_decisions.id is
+--     the surrogate PK, distinct from visa_decisions.decision_id (the
+--     engine's own domain UUID — the one to report/correlate against).
+--   apps/backend-rag/backend/db/migrations_v2/255_visa_shadow_evidence.sql
+--     adds grounding_summary JSONB NOT NULL DEFAULT '[]' ("candidate_summary
+--     and grounding_summary contain only engine identifiers, reason codes,
+--     and source-record UUIDs") and request_category/candidate_summary.
+--   apps/backend-rag/backend/db/migrations_v2/256_visa_traffic_source.sql
+--     adds traffic_source TEXT NULLable CHECK IN ('real','synthetic_gold',
+--     'synthetic_driver'); NULL = legacy/unknown provenance, must NEVER be
+--     folded into 'real' silently (fail-closed, per 256's own header).
+--   apps/backend-rag/backend/services/visa_engine/shadow.py::_build_grounding_summary
+--     the ACTUAL reason-code carrier: grounding_summary is a JSON array of
+--     claims {"claim_kind": "VERDICT"|"CANDIDATE"|"REVIEW_REASON"|
+--     "NO_PATH_REASON"|"NOTICE", "claim_code": <str>, "source_record_ids":
+--     [...]}. For a HUMAN_REVIEW_REQUIRED verdict the reason codes are the
+--     claim_code values of every claim with claim_kind='REVIEW_REASON'.
+--   apps/backend-rag/backend/db/migrations_v2/250_visa_engine_core.sql
+--     visa_rule_packs.sequence BIGINT — the pack-activation sequence number
+--     ("pack seq-7") referenced by the plan's pre/post-seq-7 baseline. It is
+--     UNIQUE only per (environment, jurisdiction, decision_domain) — NOT
+--     globally. visa_decisions.jurisdiction/.decision_domain are each
+--     single-valued CHECK enums today ('ID' / 'IMMIGRATION_VISA' only), so
+--     pinning environment (below) is what makes "seq-7" mean one pack.
+--
+-- SCOPE (kimi adversarial review F1/F2/F5/F8, 2026-08-16 — hardened after
+-- the first draft): every query below is pinned to
+-- ``d.environment = 'PRODUCTION' AND d.engine_mode = 'SHADOW'``. Without
+-- this, TEST/STAGING rows and a future ENFORCE-mode row would silently mix
+-- into the "live ledger" figures this audit exists to measure, and — given
+-- sequence's per-scope uniqueness above — a TEST pack "seq 7" and a
+-- PRODUCTION pack "seq 7" would collapse into one bucket. To audit a
+-- different scope, edit the WHERE clause explicitly; never drop it.
+--
+-- USAGE: run against the LIVE ledger with a READ-ONLY role only (QW-6b), via
+--   psql -v min_sequence=7 -f hrr_reason_audit.sql "$VISA_DECISIONS_RO_DSN"
+-- (psql :min_sequence has NO in-file default — psql errors on an unset
+-- variable reference, so -v is mandatory, not optional; the Python module's
+-- own --min-sequence default of 7 mirrors the plan's "post-seq-7" baseline).
+-- Every query below also carries traffic_source explicitly in its GROUP
+-- BY/SELECT list so a probe/synthetic row can never silently pollute a
+-- "real" figure — this is QW-6a's mandatory contamination guard, not
+-- optional polish.
+
+-- =============================================================================
+-- Query 1 — per-reason-code counts for HUMAN_REVIEW_REQUIRED decisions,
+--           split by traffic_source (mandatory) and by min rule_pack sequence
+--           (mandatory cutoff — pass -v min_sequence=7 for "post-seq-7").
+--           A REVIEW_REASON claim with a NULL/malformed claim_code is kept
+--           as its own NULL-reason_code row rather than dropped (F9) — an
+--           auditor must see dirty data, not have it silently vanish.
+-- =============================================================================
+WITH hrr_claims AS (
+    SELECT
+        d.decision_id,
+        d.traffic_source,
+        rp.sequence                                      AS rule_pack_sequence,
+        claim.value ->> 'claim_code'                     AS reason_code
+    FROM public.visa_decisions d
+    LEFT JOIN public.visa_rule_packs rp ON rp.id = d.rule_pack_id
+    CROSS JOIN LATERAL jsonb_array_elements(d.grounding_summary) AS claim(value)
+    WHERE d.verdict = 'HUMAN_REVIEW_REQUIRED'
+      AND d.engine_surface = 'MATCH'
+      AND d.environment = 'PRODUCTION'
+      AND d.engine_mode = 'SHADOW'
+      AND claim.value ->> 'claim_kind' = 'REVIEW_REASON'
+)
+SELECT
+    COALESCE(traffic_source, 'legacy_unknown')  AS traffic_source_bucket,
+    reason_code,
+    COUNT(*)                                    AS reason_count,
+    COUNT(DISTINCT decision_id)                 AS decisions_with_this_reason
+FROM hrr_claims
+WHERE rule_pack_sequence IS NOT NULL AND rule_pack_sequence >= :min_sequence
+GROUP BY 1, 2
+ORDER BY 1, reason_count DESC;
+
+-- =============================================================================
+-- Query 2 — conclusive-rate split: SUPPORTED_CANDIDATES / NEEDS_INPUT /
+--           HUMAN_REVIEW_REQUIRED / NO_SUPPORTED_PATH / TEMPORARILY_UNAVAILABLE
+--           counts + share, split by traffic_source (mandatory), post-seq-7.
+--           "Conclusive" mirrors hrr_reason_audit.py::INCONCLUSIVE_VERDICTS
+--           EXACTLY (kimi review F6): inconclusive = HUMAN_REVIEW_REQUIRED
+--           + NEEDS_INPUT + TEMPORARILY_UNAVAILABLE; conclusive = everything
+--           else (SUPPORTED_CANDIDATES and NO_SUPPORTED_PATH both count as
+--           conclusive — the engine reached a definite answer either way).
+--           This query computes conclusive_rate_pct DIRECTLY so a QW-6b
+--           auditor never has to hand-sum verdicts to reproduce the Python
+--           module's own headline number.
+-- =============================================================================
+WITH scoped AS (
+    SELECT
+        d.verdict,
+        d.traffic_source,
+        rp.sequence AS rule_pack_sequence
+    FROM public.visa_decisions d
+    LEFT JOIN public.visa_rule_packs rp ON rp.id = d.rule_pack_id
+    WHERE d.engine_surface = 'MATCH'
+      AND d.environment = 'PRODUCTION'
+      AND d.engine_mode = 'SHADOW'
+      AND rp.sequence IS NOT NULL
+      AND rp.sequence >= :min_sequence
+),
+by_verdict AS (
+    SELECT
+        COALESCE(traffic_source, 'legacy_unknown') AS traffic_source_bucket,
+        verdict,
+        COUNT(*)                                    AS decision_count
+    FROM scoped
+    GROUP BY 1, 2
+)
+SELECT
+    traffic_source_bucket,
+    verdict,
+    decision_count,
+    SUM(decision_count) OVER (PARTITION BY traffic_source_bucket)             AS bucket_total,
+    SUM(CASE WHEN verdict NOT IN
+            ('HUMAN_REVIEW_REQUIRED', 'NEEDS_INPUT', 'TEMPORARILY_UNAVAILABLE')
+        THEN decision_count ELSE 0 END)
+        OVER (PARTITION BY traffic_source_bucket)                             AS bucket_conclusive,
+    ROUND(
+        100.0
+        * SUM(CASE WHEN verdict NOT IN
+                ('HUMAN_REVIEW_REQUIRED', 'NEEDS_INPUT', 'TEMPORARILY_UNAVAILABLE')
+              THEN decision_count ELSE 0 END)
+              OVER (PARTITION BY traffic_source_bucket)
+        / NULLIF(SUM(decision_count) OVER (PARTITION BY traffic_source_bucket), 0),
+        2
+    )                                                                          AS bucket_conclusive_rate_pct
+FROM by_verdict
+ORDER BY 1, 2;
+
+-- =============================================================================
+-- Query 3 — optional split by rule_pack sequence / ruleset_activation_id.
+--           Use to locate exactly which activation flipped the conclusive
+--           rate. Deliberately NOT gated by :min_sequence (it IS the tool
+--           for finding the sequence boundary) — still pinned to
+--           environment/engine_mode (F1/F2/F8) so it never mixes scopes.
+-- =============================================================================
+SELECT
+    rp.sequence                                 AS rule_pack_sequence,
+    d.ruleset_activation_id,
+    COALESCE(d.traffic_source, 'legacy_unknown') AS traffic_source_bucket,
+    d.verdict,
+    COUNT(*)                                     AS decision_count
+FROM public.visa_decisions d
+LEFT JOIN public.visa_rule_packs rp ON rp.id = d.rule_pack_id
+WHERE d.engine_surface = 'MATCH'
+  AND d.environment = 'PRODUCTION'
+  AND d.engine_mode = 'SHADOW'
+GROUP BY 1, 2, 3, 4
+ORDER BY 1 NULLS FIRST, 2, 3, 4;

--- a/research/visa/doctrine-factory/tools/tests/fixtures/hrr_reason_audit_sample.json
+++ b/research/visa/doctrine-factory/tools/tests/fixtures/hrr_reason_audit_sample.json
@@ -1,0 +1,166 @@
+[
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000001",
+    "verdict": "HUMAN_REVIEW_REQUIRED",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-a",
+    "grounding_summary": [
+      {
+        "claim_kind": "VERDICT",
+        "claim_code": "HUMAN_REVIEW_REQUIRED",
+        "source_record_ids": []
+      },
+      {
+        "claim_kind": "REVIEW_REASON",
+        "claim_code": "SPONSOR_WITNESS_MISSING",
+        "source_record_ids": [
+          "r1"
+        ]
+      },
+      {
+        "claim_kind": "REVIEW_REASON",
+        "claim_code": "AMBIGUOUS_PURPOSE",
+        "source_record_ids": [
+          "r2"
+        ]
+      }
+    ],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000002",
+    "verdict": "HUMAN_REVIEW_REQUIRED",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-a",
+    "grounding_summary": [
+      {
+        "claim_kind": "VERDICT",
+        "claim_code": "HUMAN_REVIEW_REQUIRED",
+        "source_record_ids": []
+      },
+      {
+        "claim_kind": "REVIEW_REASON",
+        "claim_code": "SPONSOR_WITNESS_MISSING",
+        "source_record_ids": [
+          "r1"
+        ]
+      }
+    ],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000003",
+    "verdict": "SUPPORTED_CANDIDATES",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-a",
+    "grounding_summary": [
+      {
+        "claim_kind": "VERDICT",
+        "claim_code": "SUPPORTED_CANDIDATES",
+        "source_record_ids": [
+          "r3"
+        ]
+      },
+      {
+        "claim_kind": "CANDIDATE",
+        "claim_code": "E33G",
+        "source_record_ids": [
+          "r3"
+        ]
+      }
+    ],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000004",
+    "verdict": "HUMAN_REVIEW_REQUIRED",
+    "traffic_source": "synthetic_driver",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-a",
+    "grounding_summary": [
+      {
+        "claim_kind": "VERDICT",
+        "claim_code": "HUMAN_REVIEW_REQUIRED",
+        "source_record_ids": []
+      },
+      {
+        "claim_kind": "REVIEW_REASON",
+        "claim_code": "PROBE_TOKEN_UNRESOLVED",
+        "source_record_ids": []
+      }
+    ],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000005",
+    "verdict": "HUMAN_REVIEW_REQUIRED",
+    "traffic_source": null,
+    "rule_pack_sequence": 6,
+    "ruleset_activation_id": "act-6-legacy",
+    "grounding_summary": [
+      {
+        "claim_kind": "VERDICT",
+        "claim_code": "HUMAN_REVIEW_REQUIRED",
+        "source_record_ids": []
+      },
+      {
+        "claim_kind": "REVIEW_REASON",
+        "claim_code": "PRE_SEQ7_LEGACY_REASON",
+        "source_record_ids": []
+      }
+    ],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000006",
+    "verdict": "NEEDS_INPUT",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-a",
+    "grounding_summary": [
+      {
+        "claim_kind": "VERDICT",
+        "claim_code": "NEEDS_INPUT",
+        "source_record_ids": []
+      }
+    ],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000007",
+    "verdict": "NO_SUPPORTED_PATH",
+    "traffic_source": "real",
+    "rule_pack_sequence": 8,
+    "ruleset_activation_id": "act-8-a",
+    "grounding_summary": [
+      {
+        "claim_kind": "VERDICT",
+        "claim_code": "NO_SUPPORTED_PATH",
+        "source_record_ids": [
+          "r4"
+        ]
+      }
+    ],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-000000000008",
+    "verdict": "TEMPORARILY_UNAVAILABLE",
+    "traffic_source": "real",
+    "rule_pack_sequence": null,
+    "ruleset_activation_id": null,
+    "grounding_summary": [],
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW"
+  }
+]

--- a/research/visa/doctrine-factory/tools/tests/fixtures/hrr_reason_audit_scope_sample.json
+++ b/research/visa/doctrine-factory/tools/tests/fixtures/hrr_reason_audit_scope_sample.json
@@ -1,0 +1,53 @@
+[
+  {
+    "decision_id": "00000000-0000-0000-0000-0000000000a1",
+    "verdict": "HUMAN_REVIEW_REQUIRED",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-prod",
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW",
+    "grounding_summary": [
+      {"claim_kind": "VERDICT", "claim_code": "HUMAN_REVIEW_REQUIRED", "source_record_ids": []},
+      {"claim_kind": "REVIEW_REASON", "claim_code": "VALID_REASON_X", "source_record_ids": ["r1"]},
+      {"claim_kind": "REVIEW_REASON", "claim_code": null, "source_record_ids": ["r2"]}
+    ]
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-0000000000a2",
+    "verdict": "HUMAN_REVIEW_REQUIRED",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-test",
+    "environment": "TEST",
+    "engine_mode": "SHADOW",
+    "grounding_summary": [
+      {"claim_kind": "VERDICT", "claim_code": "HUMAN_REVIEW_REQUIRED", "source_record_ids": []},
+      {"claim_kind": "REVIEW_REASON", "claim_code": "SHOULD_NOT_APPEAR_IN_PRODUCTION_AUDIT", "source_record_ids": []}
+    ]
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-0000000000a3",
+    "verdict": "SUPPORTED_CANDIDATES",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-prod",
+    "environment": "PRODUCTION",
+    "engine_mode": "ENFORCE",
+    "grounding_summary": [
+      {"claim_kind": "VERDICT", "claim_code": "SUPPORTED_CANDIDATES", "source_record_ids": ["r3"]}
+    ]
+  },
+  {
+    "decision_id": "00000000-0000-0000-0000-0000000000a4",
+    "verdict": "SUPPORTED_CANDIDATES",
+    "traffic_source": "real",
+    "rule_pack_sequence": 7,
+    "ruleset_activation_id": "act-7-prod",
+    "environment": "PRODUCTION",
+    "engine_mode": "SHADOW",
+    "grounding_summary": [
+      {"claim_kind": "VERDICT", "claim_code": "SUPPORTED_CANDIDATES", "source_record_ids": ["r4"]}
+    ]
+  }
+]

--- a/research/visa/doctrine-factory/tools/tests/test_hrr_reason_audit.py
+++ b/research/visa/doctrine-factory/tools/tests/test_hrr_reason_audit.py
@@ -1,0 +1,303 @@
+"""Fixture-driven tests for QW-6a's HRR reason audit tooling.
+
+Zero network/prod access: every test loads the local JSON fixture
+(``fixtures/hrr_reason_audit_sample.json``) via ``load_fixture`` and drives
+the pure computation functions only. ``fetch_decisions_pg`` (the live-ledger
+path, QW-6b) is never invoked here.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hrr_reason_audit import (
+    DecisionRow,
+    build_report,
+    compute_conclusive_rate,
+    compute_malformed_review_reason_claims,
+    compute_reason_counts,
+    compute_sequence_activation_split,
+    filter_rows,
+    load_fixture,
+    main as hrr_main,
+    row_from_mapping,
+)
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "hrr_reason_audit_sample.json"
+SCOPE_FIXTURE_PATH = Path(__file__).parent / "fixtures" / "hrr_reason_audit_scope_sample.json"
+
+
+@pytest.fixture()
+def rows() -> list[DecisionRow]:
+    return load_fixture(FIXTURE_PATH)
+
+
+@pytest.fixture()
+def scope_rows() -> list[DecisionRow]:
+    return load_fixture(SCOPE_FIXTURE_PATH)
+
+
+def test_load_fixture_row_count(rows: list[DecisionRow]) -> None:
+    assert len(rows) == 8
+
+
+def test_reason_counts_split_by_traffic_source_post_seq7(rows: list[DecisionRow]) -> None:
+    report = compute_reason_counts(rows, min_sequence=7)
+
+    assert report["real"]["SPONSOR_WITNESS_MISSING"] == {
+        "reason_count": 2,
+        "decisions_with_this_reason": 2,
+    }
+    assert report["real"]["AMBIGUOUS_PURPOSE"] == {
+        "reason_count": 1,
+        "decisions_with_this_reason": 1,
+    }
+    assert report["synthetic_driver"]["PROBE_TOKEN_UNRESOLVED"] == {
+        "reason_count": 1,
+        "decisions_with_this_reason": 1,
+    }
+    # The pre-seq-7 legacy row must NEVER surface here (min_sequence gate).
+    assert "PRE_SEQ7_LEGACY_REASON" not in json.dumps(report)
+    # No legacy_unknown bucket should appear once the seq-7 gate excludes it.
+    assert "legacy_unknown" not in report
+
+
+def test_reason_counts_never_pool_synthetic_into_real(rows: list[DecisionRow]) -> None:
+    """Contamination guard: a synthetic_driver reason code must never land
+    under the 'real' bucket, and vice versa — this is QW-6a's mandatory
+    split, not a nice-to-have."""
+
+    report = compute_reason_counts(rows, min_sequence=7)
+    assert "PROBE_TOKEN_UNRESOLVED" not in report.get("real", {})
+    assert "SPONSOR_WITNESS_MISSING" not in report.get("synthetic_driver", {})
+
+
+def test_conclusive_rate_split_post_seq7(rows: list[DecisionRow]) -> None:
+    report = compute_conclusive_rate(rows, min_sequence=7)
+
+    real = report["real"]
+    assert real["total"] == 5
+    assert real["inconclusive"] == 3  # 2x HRR + 1x NEEDS_INPUT
+    assert real["conclusive"] == 2  # SUPPORTED_CANDIDATES + NO_SUPPORTED_PATH
+    assert real["conclusive_rate_pct"] == 40.0
+    assert real["by_verdict"] == {
+        "HUMAN_REVIEW_REQUIRED": 2,
+        "SUPPORTED_CANDIDATES": 1,
+        "NEEDS_INPUT": 1,
+        "NO_SUPPORTED_PATH": 1,
+    }
+
+    synth = report["synthetic_driver"]
+    assert synth["total"] == 1
+    assert synth["conclusive"] == 0
+    assert synth["conclusive_rate_pct"] == 0.0
+
+    # Pre-seq-7 legacy row (rule_pack_sequence=6) must be excluded entirely.
+    assert "legacy_unknown" not in report
+
+
+def test_conclusive_rate_gate_pre_seq7_reproduces_zero_percent(rows: list[DecisionRow]) -> None:
+    """Sanity-anchor to the plan's stated baseline: with the gate lowered to
+    include the pre-seq-7 legacy row (min_sequence=6), that row's own bucket
+    reads 0% conclusive — same shape as the documented "6,610/6,610 HRR,
+    0% conclusive" pre-seq-7 contamination baseline."""
+
+    report = compute_conclusive_rate(rows, min_sequence=6)
+    legacy = report["legacy_unknown"]
+    assert legacy["total"] == 1
+    assert legacy["conclusive_rate_pct"] == 0.0
+    assert legacy["by_verdict"] == {"HUMAN_REVIEW_REQUIRED": 1}
+
+
+def test_sequence_activation_split_has_no_min_sequence_gate(rows: list[DecisionRow]) -> None:
+    """(d) is the optional un-gated breakdown — it must show every sequence,
+    including the pre-seq-7 legacy row and the NULL-sequence
+    TEMPORARILY_UNAVAILABLE row, so an auditor can see exactly where the
+    conclusive rate flips."""
+
+    report = compute_sequence_activation_split(rows)
+
+    assert report["7"]["act-7-a"]["real"] == {
+        "HUMAN_REVIEW_REQUIRED": 2,
+        "SUPPORTED_CANDIDATES": 1,
+        "NEEDS_INPUT": 1,
+    }
+    assert report["7"]["act-7-a"]["synthetic_driver"] == {"HUMAN_REVIEW_REQUIRED": 1}
+    assert report["6"]["act-6-legacy"]["legacy_unknown"] == {"HUMAN_REVIEW_REQUIRED": 1}
+    assert report["8"]["act-8-a"]["real"] == {"NO_SUPPORTED_PATH": 1}
+    assert report["unknown"]["unknown"]["real"] == {"TEMPORARILY_UNAVAILABLE": 1}
+
+
+def test_build_report_is_json_serializable(rows: list[DecisionRow]) -> None:
+    report = build_report(rows, min_sequence=7)
+    # Round-trips clean — this is exactly what --out writes for QW-6b.
+    json.dumps(report)
+    assert report["total_rows_fetched"] == 8
+    assert report["total_rows_in_scope"] == 8  # all 8 fixture rows are PRODUCTION/SHADOW
+    assert report["min_sequence"] == 7
+
+
+def test_row_from_mapping_tolerates_json_string_grounding_summary() -> None:
+    raw = {
+        "decision_id": "x",
+        "verdict": "HUMAN_REVIEW_REQUIRED",
+        "traffic_source": "real",
+        "rule_pack_sequence": 7,
+        "ruleset_activation_id": "a",
+        "grounding_summary": json.dumps(
+            [{"claim_kind": "REVIEW_REASON", "claim_code": "FOO", "source_record_ids": []}]
+        ),
+    }
+    row = row_from_mapping(raw)
+    assert row.review_reason_codes == ["FOO"]
+
+
+def test_row_from_mapping_rejects_unknown_verdict() -> None:
+    with pytest.raises(ValueError):
+        row_from_mapping(
+            {
+                "decision_id": "x",
+                "verdict": "TOTALLY_MADE_UP",
+                "traffic_source": None,
+                "rule_pack_sequence": None,
+                "ruleset_activation_id": None,
+                "grounding_summary": [],
+            }
+        )
+
+
+def test_row_from_mapping_malformed_grounding_summary_is_empty_not_a_crash() -> None:
+    row = row_from_mapping(
+        {
+            "decision_id": "x",
+            "verdict": "HUMAN_REVIEW_REQUIRED",
+            "traffic_source": "real",
+            "rule_pack_sequence": 7,
+            "ruleset_activation_id": None,
+            "grounding_summary": "{not valid json",
+        }
+    )
+    assert row.review_reason_codes == []
+
+
+def test_filter_rows_defaults_to_production_shadow_only(scope_rows: list[DecisionRow]) -> None:
+    """kimi adversarial review F1/F2/F8 (2026-08-16): TEST-environment and
+    ENFORCE-mode rows must never silently pollute the default PRODUCTION/
+    SHADOW audit scope."""
+
+    scoped = filter_rows(scope_rows)
+    scoped_ids = {row.decision_id for row in scoped}
+
+    assert scoped_ids == {
+        "00000000-0000-0000-0000-0000000000a1",
+        "00000000-0000-0000-0000-0000000000a4",
+    }
+
+
+def test_filter_rows_all_sentinel_disables_scope(scope_rows: list[DecisionRow]) -> None:
+    assert len(filter_rows(scope_rows, environment="ALL", engine_mode="ALL")) == len(scope_rows)
+
+
+def test_filter_rows_can_target_a_different_environment(scope_rows: list[DecisionRow]) -> None:
+    scoped = filter_rows(scope_rows, environment="TEST")
+    assert {row.decision_id for row in scoped} == {"00000000-0000-0000-0000-0000000000a2"}
+
+
+def test_build_report_defaults_exclude_test_and_enforce_rows(
+    scope_rows: list[DecisionRow],
+) -> None:
+    """build_report scopes BEFORE computing anything else — a TEST row's
+    reason code must never reach reason_counts, and an ENFORCE row's verdict
+    must never reach conclusive_rate, under the default call."""
+
+    report = build_report(scope_rows, min_sequence=7)
+
+    assert report["environment_filter"] == "PRODUCTION"
+    assert report["engine_mode_filter"] == "SHADOW"
+    assert report["total_rows_fetched"] == 4
+    assert report["total_rows_in_scope"] == 2
+
+    assert "SHOULD_NOT_APPEAR_IN_PRODUCTION_AUDIT" not in json.dumps(report)
+
+    real = report["conclusive_rate"]["real"]
+    assert real["total"] == 2  # a1 (HRR) + a4 (SUPPORTED_CANDIDATES) only
+    assert real["conclusive_rate_pct"] == 50.0
+
+    split = report["sequence_activation_split"]["7"]["act-7-prod"]["real"]
+    assert split == {"HUMAN_REVIEW_REQUIRED": 1, "SUPPORTED_CANDIDATES": 1}
+
+
+def test_malformed_review_reason_claims_are_counted_not_dropped(
+    scope_rows: list[DecisionRow],
+) -> None:
+    """kimi adversarial review F9 (2026-08-16): a REVIEW_REASON claim with a
+    NULL claim_code must surface as dirty data, not vanish silently."""
+
+    scoped = filter_rows(scope_rows)
+    malformed = compute_malformed_review_reason_claims(scoped, min_sequence=7)
+    assert malformed == {"real": 1}
+
+    # And the well-formed sibling claim on the same row is still counted.
+    reasons = compute_reason_counts(scoped, min_sequence=7)
+    assert reasons["real"]["VALID_REASON_X"] == {
+        "reason_count": 1,
+        "decisions_with_this_reason": 1,
+    }
+
+
+def test_row_from_mapping_uses_engine_decision_id_not_surrogate_pk() -> None:
+    """kimi adversarial review F5 (2026-08-16): fetch_decisions_pg selects
+    ``d.decision_id`` (the engine's domain UUID), never the surrogate
+    ``d.id`` PK — this test pins the DecisionRow field/fixture contract so a
+    future regression back to ``d.id`` cannot land unnoticed. The live SQL
+    column name itself is exercised only by QW-6b (no DSN here)."""
+
+    row = row_from_mapping(
+        {
+            "decision_id": "engine-domain-uuid",
+            "verdict": "NEEDS_INPUT",
+            "traffic_source": "real",
+            "rule_pack_sequence": 7,
+            "ruleset_activation_id": None,
+            "grounding_summary": [],
+            "environment": "PRODUCTION",
+            "engine_mode": "SHADOW",
+        }
+    )
+    assert row.decision_id == "engine-domain-uuid"
+
+
+def test_unknown_traffic_source_value_buckets_as_legacy_unknown() -> None:
+    """A value outside migration 256's CHECK enum (should be impossible at
+    the DB layer, but defense-in-depth) must never masquerade as a known
+    bucket — it fails closed into legacy_unknown, same as NULL."""
+
+    row = row_from_mapping(
+        {
+            "decision_id": "x",
+            "verdict": "SUPPORTED_CANDIDATES",
+            "traffic_source": "not_a_real_enum_value",
+            "rule_pack_sequence": 7,
+            "ruleset_activation_id": None,
+            "grounding_summary": [],
+        }
+    )
+    assert row.traffic_bucket == "legacy_unknown"
+
+
+def test_cli_fixture_mode_works_even_if_dsn_env_var_is_exported(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """kimi adversarial review F3 (2026-08-16): before this fix, an operator
+    with VISA_DECISIONS_RO_DSN exported (exactly QW-6b's own environment)
+    could not run ``--fixture`` for a dry run — argparse's env-var default
+    made ``--fixture`` + the ambient env var look like ``--fixture --dsn``
+    together and hard-error. This must now succeed."""
+
+    monkeypatch.setenv("VISA_DECISIONS_RO_DSN", "postgresql://irrelevant/should-not-be-used")
+    rc = hrr_main(["--fixture", str(FIXTURE_PATH)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["total_rows_fetched"] == 8


### PR DESCRIPTION
## Summary
Repo-side tooling for QW-6a — the mechanical half of the HRR (HUMAN_REVIEW_REQUIRED) reason audit for the Visa Oracle doctrine-factory execution plan. QW-6b (running this against the live `visa_decisions` ledger) is separately gated on an operator read-only DB credential and is out of scope here — this PR only produces ready-to-run tooling.

- `research/visa/doctrine-factory/tools/hrr_reason_audit.py` — pure-Python computation (fixture-tested, zero I/O) + a thin optional `asyncpg` fetch path used only when a DSN is supplied.
- `research/visa/doctrine-factory/tools/hrr_reason_audit.sql` — standalone SQL equivalent for QW-6b to run directly via `psql`.
- `research/visa/doctrine-factory/tools/tests/test_hrr_reason_audit.py` + 2 JSON fixtures — 18 fixture-driven pytest tests, no network/prod access.

Produces: (a) per-reason-code counts for HRR decisions, (b) conclusive-rate split (SUPPORTED_CANDIDATES / NEEDS_INPUT / HUMAN_REVIEW_REQUIRED / NO_SUPPORTED_PATH / TEMPORARILY_UNAVAILABLE), (c) mandatory split by `traffic_source` (real / synthetic_gold / synthetic_driver / legacy_unknown — so probe contamination can never silently pollute real numbers), (d) optional split by rule_pack sequence / activation id.

## Grounding
Verified on disk this session (not re-derived from the mandate prompt):
- `apps/backend-rag/backend/db/migrations_v2/{250,252,255,256}_*.sql` — `visa_decisions.verdict` is the 5-value `DecisionState` CHECK enum; there is **no** `review_reason_codes` column (252 explicitly defers it); `traffic_source` (256) is nullable, NULL = legacy; `visa_rule_packs.sequence` (250) is unique only per `(environment, jurisdiction, decision_domain)`, not globally.
- `apps/backend-rag/backend/services/visa_engine/shadow.py::_build_grounding_summary` — the actual reason-code carrier: `grounding_summary` JSONB claims shaped `{"claim_kind": "REVIEW_REASON", "claim_code": "<reason>", "source_record_ids": [...]}`.

## Adversarial review (generator≠grader)
Kimi K3 (`kimi -m kimi-code/k3`), full diff pasted, ~9 min wall. 10 findings, all dispositioned:

| # | Finding | Disposition |
|---|---|---|
| F1 | No `environment` filter — TEST/STAGING rows pollute the "live ledger" audit | **Fixed** — default scope pinned to `environment=PRODUCTION` via `filter_rows()` |
| F2 | `rule_pack.sequence` is per-scope, not global — "seq-7" gate mixes scopes | **Fixed** — same scope pin resolves it (jurisdiction/decision_domain are single-valued today) |
| F3 | `--fixture` breaks if `VISA_DECISIONS_RO_DSN` is exported | **Fixed** — env var now only read on the live-DSN path |
| F5 | Fetch selected surrogate `d.id`, mislabeled as `decision_id` | **Fixed** — selects `d.decision_id` (engine's domain UUID) |
| F6 | SQL never computed `conclusive_rate_pct` directly, cross-check impossible | **Fixed** — Query 2 rewritten to match `INCONCLUSIVE_VERDICTS` exactly |
| F7 | `:min_sequence` has no psql default, `psql -f` errors | **Fixed** — header documents mandatory `psql -v min_sequence=7` |
| F8 | No `engine_mode='SHADOW'` filter, latent ENFORCE-mode mixing risk | **Fixed** — covered by the same `filter_rows()` scope |
| F9 | Malformed `REVIEW_REASON` claim (`claim_code=NULL`) silently dropped | **Fixed** — counted via `compute_malformed_review_reason_claims()`, surfaced in report |
| F4 | Missing `conftest.py` breaks test imports | **REFUTED** — `conftest.py` already exists in `tools/tests/` from prior QW-1 work; 18/18 tests pass live |
| F10 | Streaming cursor / DSN-in-`ps`-args / minor edges | Accepted as documented trade-offs for a one-shot audit script |

## Test plan
- [x] `python3 -m pytest research/visa/doctrine-factory/tools/tests/test_hrr_reason_audit.py -v` — 18/18 passed
- [x] `python3 -m py_compile` on both new `.py` files
- [x] CLI smoke test (`--fixture`, `--dsn`+`--fixture` mutual exclusion, missing-both error)
- [x] Pre-commit + pre-push hooks passed locally (full path-aware suite triggered, clean)

QW-6b (execution against the live ledger) picks this up once a read-only DSN credential exists — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>