### PR TITLE
fix(visa-oracle): QW-4a reason-code copy — stale key rename + exhaustiveness test

### DIFF
--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.test.ts
@@ -2,7 +2,11 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
-import { SUPPORT_REASON_COPY, buildEngineOutcome } from "./engine-adapter";
+import {
+  REVIEW_REASON_COPY,
+  SUPPORT_REASON_COPY,
+  buildEngineOutcome,
+} from "./engine-adapter";
 import { TEST_NOW, makeVisaOracleResponse } from "./visa-oracle-test-fixture";
 
 describe("Visa Oracle authoritative outcome adapter", () => {
@@ -391,5 +395,202 @@ describe("support reasons are sentences, not machine codes", () => {
     // rules stopped parsing, would make the assertion below vacuously true.
     expect(codes.length).toBeGreaterThanOrEqual(13);
     expect(codes.filter((code) => !(code in SUPPORT_REASON_COPY))).toEqual([]);
+  });
+});
+
+describe("review reasons cover every code the current pack can emit", () => {
+  const HERE = path.dirname(fileURLToPath(import.meta.url));
+  const PACKS_DIR = path.resolve(
+    HERE,
+    "../../../../../../..",
+    "apps/backend-rag/backend/services/visa_engine/contracts/packs",
+  );
+
+  /**
+   * Unlike SUPPORT reason codes (grown purely additively, seq-1 through
+   * seq-8, `supportReasonCodesInPack` above safely globs every file), the
+   * HUMAN_REVIEW taxonomy was CONSOLIDATED at seq-6: rulepack-prod-001/002/
+   * 004/005 carried 51-53 granular review codes that were renamed/merged
+   * down to a stable 14 in seq-6/7/8 (verified identical across those
+   * three). Globbing every pack file for review codes would resurrect that
+   * dead pre-seq-6 taxonomy as a permanent "known gap" that can never
+   * actually fire again — so this reads only the pack with the HIGHEST
+   * `sequence` field on disk (the one closest to going live, same
+   * "not-yet-activated" blind-spot concern `supportReasonCodesInPack`
+   * documents, without the false positives a full-file glob would add).
+   */
+  function latestProductionPackFile(): string {
+    const files = fs
+      .readdirSync(PACKS_DIR)
+      .filter((name) => /^rulepack-prod-\d+\.source\.json$/.test(name));
+    if (files.length === 0) {
+      throw new Error(`no production packs found under ${PACKS_DIR}`);
+    }
+    let best: { file: string; sequence: number } | null = null;
+    for (const name of files) {
+      const full = path.join(PACKS_DIR, name);
+      const payload = JSON.parse(fs.readFileSync(full, "utf-8")) as {
+        sequence?: unknown;
+      };
+      // A pack without a numeric `sequence` cannot be compared — skip it
+      // rather than let it silently win via a sentinel default (a pack
+      // missing this field is malformed, not "oldest").
+      if (typeof payload.sequence !== "number") continue;
+      if (best === null || payload.sequence > best.sequence) {
+        best = { file: full, sequence: payload.sequence };
+      }
+    }
+    if (best === null) {
+      throw new Error(`no pack under ${PACKS_DIR} had a numeric sequence`);
+    }
+    return best.file;
+  }
+
+  function reviewReasonCodesInPack(): string[] {
+    const payload = JSON.parse(
+      fs.readFileSync(latestProductionPackFile(), "utf-8"),
+    ) as { rules?: Array<Record<string, unknown>> };
+    const codes = new Set<string>();
+    for (const rule of payload.rules ?? []) {
+      const effect = rule.effect as Record<string, unknown> | undefined;
+      if (
+        rule.stage === "HUMAN_REVIEW" &&
+        effect &&
+        typeof effect.reason_code === "string"
+      ) {
+        codes.add(effect.reason_code);
+      }
+    }
+    return [...codes].sort();
+  }
+
+  // Codes the backend emits itself, independent of any rule pack. These
+  // never appear in a pack's `rules[]`, so no glob over pack JSON can
+  // discover them — they have to be named here, from three sources in
+  // evaluate_path.py:
+  //   - `_DISCLOSED_REVIEW_REASON_CODES` (11 `DisclosedReviewFlag` entries)
+  //   - `_apply_minor_privacy_hold`'s `MINOR_GUARDIAN_PRIVACY_REVIEW`
+  //   - the decisive-source gate (`_apply_decisive_source_gate` family,
+  //     ~line 1030) and the safety-critical source hold
+  //     (`_apply_safety_critical_source_hold`, ~line 1136): each forces
+  //     `state: HUMAN_REVIEW_REQUIRED` with its own review reasons when a
+  //     legally decisive/safety-critical source isn't CURRENT. Missed in
+  //     the first cut of this test — `DECISIVE_SOURCE_STALE` is proven
+  //     live-emitted in research/visa/2026-08-15-gold-replay-live-post-
+  //     notice-report.json (persona 9/10, "actual").
+  const PACK_INDEPENDENT_REVIEW_REASON_CODES = [
+    "CONFLICTING_IMMIGRATION_STATUS_REVIEW",
+    "DECISIVE_PRIMARY_SOURCE_NOT_APPLICABLE",
+    "DECISIVE_SOURCE_FRESHNESS_UNKNOWN",
+    "DECISIVE_SOURCE_STALE",
+    "DISCLOSED_ACTIVITY_BOUNDARY_REVIEW",
+    "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW",
+    "DISCLOSED_CRIMINAL_RECORD_REVIEW",
+    "DISCLOSED_DIPLOMATIC_PASSPORT_REVIEW",
+    "DISCLOSED_HEALTH_CONCERN_REVIEW",
+    "DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW",
+    "DISCLOSED_PEP_OR_SANCTIONS_REVIEW",
+    "DISCLOSED_PRIOR_VISA_REFUSAL_REVIEW",
+    "DISCLOSED_SOURCE_OF_FUNDS_REVIEW",
+    "DISCLOSED_UNCERTAINTY_REVIEW",
+    "MINOR_GUARDIAN_PRIVACY_REVIEW",
+    "SAFETY_CRITICAL_PRIMARY_SOURCE_NOT_APPLICABLE",
+    "SAFETY_CRITICAL_SOURCE_FRESHNESS_UNKNOWN",
+    "SAFETY_CRITICAL_SOURCE_STALE",
+  ];
+
+  // Real, currently-emittable review reason codes with no copy yet (QW-4a
+  // scope: rename the stale keys + prove exhaustiveness; QW-4b, separately
+  // gated on copy-deck approval, writes the actual sentences). Every entry
+  // here must shrink out as QW-4b lands copy for it — the test below fails
+  // if a code that already has copy is still listed, and fails if a REAL
+  // unmapped code appears that isn't listed. A THIRD test below fails if an
+  // entry here stops naming a real code (renamed/retired upstream) — this
+  // list is not exempt from going stale the same way REVIEW_REASON_COPY's
+  // keys were.
+  const KNOWN_UNMAPPED_REVIEW_REASON_CODES = [
+    // From rulepack-prod-007+ (HUMAN_REVIEW stage):
+    "E28B_USD_THRESHOLD_MANUAL_CHECK",
+    "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK",
+    "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK",
+    "E28F_IKN_THRESHOLD_MANUAL_CHECK",
+    "E33B_EXPERTISE_QUALIFICATION_CHECK",
+    "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP",
+    "E33_WORK_RANGKAP_KEGIATAN_GATED",
+    "GOVT_INVITATION_REQUIRED",
+    // Pack-independent (evaluate_path.py):
+    "CONFLICTING_IMMIGRATION_STATUS_REVIEW",
+    "DECISIVE_PRIMARY_SOURCE_NOT_APPLICABLE",
+    "DECISIVE_SOURCE_FRESHNESS_UNKNOWN",
+    "DECISIVE_SOURCE_STALE",
+    "DISCLOSED_AMBIGUOUS_SPONSOR_REVIEW",
+    "DISCLOSED_CRIMINAL_RECORD_REVIEW",
+    "DISCLOSED_DIPLOMATIC_PASSPORT_REVIEW",
+    "DISCLOSED_HEALTH_CONCERN_REVIEW",
+    "DISCLOSED_MULTI_PURPOSE_TRIP_REVIEW",
+    "DISCLOSED_PEP_OR_SANCTIONS_REVIEW",
+    "DISCLOSED_PRIOR_VISA_REFUSAL_REVIEW",
+    "DISCLOSED_SOURCE_OF_FUNDS_REVIEW",
+    "DISCLOSED_UNCERTAINTY_REVIEW",
+    "MINOR_GUARDIAN_PRIVACY_REVIEW",
+    "SAFETY_CRITICAL_PRIMARY_SOURCE_NOT_APPLICABLE",
+    "SAFETY_CRITICAL_SOURCE_FRESHNESS_UNKNOWN",
+    "SAFETY_CRITICAL_SOURCE_STALE",
+  ];
+
+  it("names every code the current pack + backend can emit, mapped or in the known gap", () => {
+    const allRealCodes = [
+      ...reviewReasonCodesInPack(),
+      ...PACK_INDEPENDENT_REVIEW_REASON_CODES,
+    ].sort();
+    // Guard the guard: a glob/parse that silently found nothing would make
+    // every assertion below vacuously true. 14 pack + 18 pack-independent.
+    expect(allRealCodes.length).toBeGreaterThanOrEqual(32);
+
+    const unaccounted = allRealCodes.filter(
+      (code) =>
+        !(code in REVIEW_REASON_COPY) &&
+        !KNOWN_UNMAPPED_REVIEW_REASON_CODES.includes(code),
+    );
+    expect(unaccounted).toEqual([]);
+  });
+
+  it("never lets a stale key sit in the copy map", () => {
+    const allRealCodes = new Set([
+      ...reviewReasonCodesInPack(),
+      ...PACK_INDEPENDENT_REVIEW_REASON_CODES,
+    ]);
+    const staleKeys = Object.keys(REVIEW_REASON_COPY).filter(
+      (code) => !allRealCodes.has(code),
+    );
+    expect(staleKeys).toEqual([]);
+  });
+
+  it("keeps the known-gap list honest: no entry there already has copy", () => {
+    // If QW-4b lands copy for a code, that code must be removed from
+    // KNOWN_UNMAPPED_REVIEW_REASON_CODES in the same change — otherwise the
+    // gap list silently stops shrinking and stops meaning anything.
+    const alreadyMapped = KNOWN_UNMAPPED_REVIEW_REASON_CODES.filter(
+      (code) => code in REVIEW_REASON_COPY,
+    );
+    expect(alreadyMapped).toEqual([]);
+  });
+
+  it("keeps the known-gap list honest: no entry there names a code that stopped being real", () => {
+    // Mirror image of the stale-key test above, but for
+    // KNOWN_UNMAPPED_REVIEW_REASON_CODES instead of REVIEW_REASON_COPY: if
+    // an upstream rename/retirement drops a code this list still names, that
+    // entry becomes a dead placeholder no other assertion here would catch
+    // (it isn't a REVIEW_REASON_COPY key, so the stale-key test can't see
+    // it; it has no copy, so the "already has copy" test can't see it
+    // either).
+    const allRealCodes = new Set([
+      ...reviewReasonCodesInPack(),
+      ...PACK_INDEPENDENT_REVIEW_REASON_CODES,
+    ]);
+    const phantomEntries = KNOWN_UNMAPPED_REVIEW_REASON_CODES.filter(
+      (code) => !allRealCodes.has(code),
+    );
+    expect(phantomEntries).toEqual([]);
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/_lib/engine-adapter.ts
@@ -359,13 +359,22 @@ function reason(
   };
 }
 
-// Curated, human-readable copy for the rule pack's HUMAN_REVIEW reason
-// codes (source: services/visa_engine/contracts/packs/rulepack-prod-*.json
-// `effect.reason_code` on REQUIRE_REVIEW rules). A code missing from this
-// map falls back to an honest generic sentence — never a raw code dump —
-// so a new rule can ship without breaking this UI, and this map can grow
-// independently of a rule pack release.
-const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
+// Curated, human-readable copy for HUMAN_REVIEW reason codes: the rule
+// pack's own `effect.reason_code` on REQUIRE_REVIEW rules (source:
+// services/visa_engine/contracts/packs/rulepack-prod-*.json), plus a
+// pack-independent set the backend emits itself (disclosed-review flags +
+// the minor-guardian privacy hold — see evaluate_path.py
+// `_DISCLOSED_REVIEW_REASON_CODES` and `_apply_minor_privacy_hold`). A code
+// missing from this map falls back to an honest generic sentence — never a
+// raw code dump — so a new rule can ship without breaking this UI, and this
+// map can grow independently of a rule pack release.
+//
+// engine-adapter.test.ts's exhaustiveness test enforces two things: every
+// key here must name a code that still exists (no stale renames — see
+// KNOWN_UNMAPPED_REVIEW_REASON_CODES there for the ones this map doesn't
+// cover yet), and every code the current pack can emit is accounted for,
+// either here or in that known-gap list.
+export const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
   CALLING_VISA_REVIEW: text(
     "Your nationality is on the Calling Visa list, which always requires manual review before a visa can be confirmed.",
     "Kewarganegaraan Anda termasuk dalam daftar Calling Visa, yang selalu memerlukan peninjauan manual sebelum visa dapat dikonfirmasi.",
@@ -374,7 +383,11 @@ const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
     "An active overstay on record needs a person to review before any path can be confirmed.",
     "Overstay aktif yang tercatat memerlukan peninjauan oleh seseorang sebelum jalur apa pun dapat dikonfirmasi.",
   ),
-  CITIZENSHIP_EVIDENCE_CONFLICT: text(
+  // Renamed from CITIZENSHIP_EVIDENCE_CONFLICT (QW-4a, 2026-08-17): that key
+  // named no code in any pack from seq-6 onward. CITIZENSHIP_LIST_DIVERGENCE
+  // is its current name (services/visa_engine/contracts/packs/
+  // rulepack-prod-007.source.json). Copy text unchanged — only the key moved.
+  CITIZENSHIP_LIST_DIVERGENCE: text(
     "Your answers about citizenship do not fully agree with each other and need a person to confirm.",
     "Jawaban Anda tentang kewarganegaraan tidak sepenuhnya cocok satu sama lain dan memerlukan konfirmasi dari seseorang.",
   ),
@@ -382,7 +395,10 @@ const REVIEW_REASON_COPY: Record<string, LocalizedText> = {
     "This case involves a minor without a confirmed guardian on file and needs a person to review it.",
     "Kasus ini melibatkan anak di bawah umur tanpa wali yang terkonfirmasi dan memerlukan peninjauan oleh seseorang.",
   ),
-  STATUS_BRIDGING_REVIEW: text(
+  // Renamed from STATUS_BRIDGING_REVIEW (QW-4a, 2026-08-17): same stale
+  // situation — BRIDGING_ADVERSE_HISTORY is the current name for this rule
+  // in rulepack-prod-007+. Copy text unchanged.
+  BRIDGING_ADVERSE_HISTORY: text(
     "Bridging between immigration statuses needs a person to check the timing and conditions involved.",
     "Peralihan antar status keimigrasian memerlukan pemeriksaan oleh seseorang atas waktu dan ketentuan yang berlaku.",
   ),


### PR DESCRIPTION
## Summary

- Renames 2 stale keys in `REVIEW_REASON_COPY` (engine-adapter.ts) that named codes retired at the seq-6 review-taxonomy consolidation:
  - `CITIZENSHIP_EVIDENCE_CONFLICT` → `CITIZENSHIP_LIST_DIVERGENCE`
  - `STATUS_BRIDGING_REVIEW` → `BRIDGING_ADVERSE_HISTORY`
  - Copy text (EN/ID) unchanged — only the map keys moved.
- Adds an exhaustiveness test suite (`engine-adapter.test.ts`) proving `REVIEW_REASON_COPY`'s keys stay in sync with every review reason code the live system can actually emit.
- No new client-facing copy written — codes with no copy yet are recorded in an explicit `KNOWN_UNMAPPED_REVIEW_REASON_CODES` list. Writing that copy is QW-4b, separately gated on copy-deck approval.

## Measured facts (ground-truthed on disk, not assumed)

- The active pack (`rulepack-prod-007.source.json`) has **14** `HUMAN_REVIEW` reason codes — confirmed byte-identical across seq-6/7/8 (the current, stable taxonomy generation).
- `REVIEW_REASON_COPY` had **7** keys: only **2** were stale (not 3, as an earlier estimate guessed) — `CITIZENSHIP_EVIDENCE_CONFLICT` and `STATUS_BRIDGING_REVIEW` name no code in any pack; both are exact renames (backend gold-fixture tests still reference the old names: `test_evaluator_gold.py:57,167`, `_gold_fixtures.py:346,409`).
- Backend also emits **18** pack-independent review codes on its own (`evaluate_path.py`): 11 `DisclosedReviewFlag` codes + `MINOR_GUARDIAN_PRIVACY_REVIEW` + **6 more found only during adversarial review** (`DECISIVE_*`/`SAFETY_CRITICAL_*` source-gate codes, ~lines 1030/1136) — see Review section below.
- Result: **32** total real review codes (14 pack + 18 backend-independent). 6 keys now have copy (5 direct + the 2 renamed ones already had copy). **19 codes remain in `KNOWN_UNMAPPED_REVIEW_REASON_CODES`** for QW-4b.

## Design note: why the exhaustiveness test doesn't glob every pack file

The sibling `SUPPORT_REASON_COPY` test globs *all* `rulepack-prod-*.source.json` files, because SUPPORT codes grew purely additively (13 → 41, never renamed — verified: old-pack codes are a strict subset of the current 41). REVIEW codes are different: they were **consolidated** at seq-6 (51-53 granular codes in packs 001/002/004/005 → a stable 14 from seq-6 onward). Globbing every file for REVIEW codes would resurrect ~39 dead pre-seq-6 codes as permanent "known gaps" that can never fire again. Instead the test reads only the pack with the **highest `sequence` field on disk** (self-updating, no hardcoded pack number — mirrors the backend's own sequence-monotonic activation model in `repository.py`), which also naturally covers the "pack authored before activation" blind spot the SUPPORT test's own comment warns about.

## Checks

```
npx tsc --noEmit                                    # clean
npx vitest run "src/app/(visa-oracle)"               # 380/380 passed
npx prettier --check <touched files>                 # clean
pre-commit hooks (incl. tsc)                          # passed
```

Mutation-verified the new exhaustiveness test: removing `DECISIVE_SOURCE_STALE` from the pack-independent list makes the test fail (`expected 31 to be >= 32`) — confirmed it catches a real regression, then restored.

## Adversarial review (generator≠grader)

Ran via Kimi K3 (`kimi -m kimi-code/k3`), ~8 min. Findings and dispositions:

| # | Finding | Disposition |
|---|---|---|
| 1 | **CONFIRMED, cured.** `PACK_INDEPENDENT_REVIEW_REASON_CODES` was missing 6 real, live-emittable codes: `DECISIVE_PRIMARY_SOURCE_NOT_APPLICABLE`, `DECISIVE_SOURCE_FRESHNESS_UNKNOWN`, `DECISIVE_SOURCE_STALE`, `SAFETY_CRITICAL_PRIMARY_SOURCE_NOT_APPLICABLE`, `SAFETY_CRITICAL_SOURCE_FRESHNESS_UNKNOWN`, `SAFETY_CRITICAL_SOURCE_STALE` — set by `_apply_decisive_source_gate`/`_apply_safety_critical_source_hold` in `evaluate_path.py` (~lines 1030, 1136), forcing `HUMAN_REVIEW_REQUIRED`. `DECISIVE_SOURCE_STALE` is proven live-emitted in `research/visa/2026-08-15-gold-replay-live-post-notice-report.json` (persona 9/10, "actual"). Independently verified by reading `evaluate_path.py` directly and confirming no other `Reason(code=...)` sites feed `review_reasons` (the other two candidates, `OBSOLETE_PRODUCT_CODE` and `OPERATIONAL_NO_PRODUCT_MATCHES_DECLARED_PURPOSES`, feed `notices`/`no_path_reasons` instead, not review). Added all 6 to `PACK_INDEPENDENT_REVIEW_REASON_CODES` + `KNOWN_UNMAPPED_REVIEW_REASON_CODES`, bumped the guard-the-guard count 26→32. |
| 2 | **CONFIRMED, cured.** No test caught a dead/phantom entry in `KNOWN_UNMAPPED_REVIEW_REASON_CODES` (a code renamed/retired upstream while still listed there) — the mirror-image gap of the stale-key test. Added a 4th test asserting every `KNOWN_UNMAPPED` entry still names a real code. |
| 3 | **CONFIRMED, cured (minor).** `latestProductionPackFile()`'s second `throw` was dead code — `best` was always set on the first file regardless of whether it had a numeric `sequence`. Fixed to skip files without a numeric `sequence` instead of defaulting to `-Infinity`, so the "no pack had a numeric sequence" error path is now reachable. |
| — | Governance note (not code): `research/visa/2026-08-15-gold-divergence-disposition.md` parks the fixture-vs-engine vocabulary question for these two renamed codes as a pending "OWNER/LEGAL DECISION." This PR's rename assumes the pack/engine vocabulary wins (it's what the live engine actually emits) — flagged for awareness, not blocking. |

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx vitest run "src/app/(visa-oracle)"` — 380/380 passed
- [x] Prettier clean on touched files
- [x] Mutation-verified the exhaustiveness test actually fails on a real regression
- [x] Adversarial review findings cured and re-verified green

🤖 Generated with [Claude Code](https://claude.com/claude-code)