### PR TITLE
refactor(docs-sync): stop committing volume counts — serve them live (Merge-OS v3 step 4)

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -79,9 +79,23 @@ jobs:
             echo "::error::could not determine the changed set (rc=$ENUM_RC) — failing rather than skipping"
             exit 1
           fi
+          # The backend-volume paths (router_registration.py, backend/services/,
+          # backend/tests/, backend/channels/, package.json) were dropped from this
+          # list on 2026-08-16 by Merge-OS v3 step 4: they fed ONLY the volume counts
+          # this repo no longer commits (RETIRED_COUNT_KEYS in scripts/docs_sync.py).
+          # They were also ~97% of this gate's traffic — 189 of 195 commits touching
+          # docs/AI_ONBOARDING.md and 61 of 63 touching README.md in the 60 days
+          # before that date changed nothing but those numbers, and each one of them
+          # could hand the NEXT innocent backend PR a red required check (W86).
+          #
+          # README.md and docs/AI_ONBOARDING.md deliberately STAY on this list even
+          # though they no longer contain any marker: they are still docs_sync
+          # TARGET_FILES, and the anti-regrowth corpus that forbids a retired count
+          # from coming back only runs when this job runs. Dropping them would leave
+          # that guard present but unarmed (superscar #2, esiste ≠ armato).
           RELEVANT=false
           if printf '%s\n' "$CHANGED" | grep -qE \
-            '^apps/backend-rag/backend/app/setup/router_registration\.py$|^apps/backend-rag/backend/services/|^apps/backend-rag/backend/tests/|^apps/backend-rag/backend/channels/|^apps/[^/]+/README\.md$|^package\.json$|^scripts/docs_sync\.py$|^scripts/tests/test_docs_sync_atlas\.py$|^scripts/ci/docs_sync_gate\.sh$|^scripts/tests/test_docs_sync_gate_failclosed\.sh$|^scripts/automation_catalog\.json$|^README\.md$|^INDEX\.md$|^docs/AI_ONBOARDING\.md$|^docs/AUTOMATIONS_REFERENCE\.md$|^docs/runbooks/|^infra/workflows/|^infra/launchagents/|^\.claude/skills/|^\.github/workflows/docs-sync\.yml$'; then
+            '^apps/[^/]+/README\.md$|^scripts/docs_sync\.py$|^scripts/tests/test_docs_sync_atlas\.py$|^scripts/ci/docs_sync_gate\.sh$|^scripts/tests/test_docs_sync_gate_failclosed\.sh$|^scripts/automation_catalog\.json$|^README\.md$|^INDEX\.md$|^docs/AI_ONBOARDING\.md$|^docs/AUTOMATIONS_REFERENCE\.md$|^docs/runbooks/|^infra/workflows/|^infra/launchagents/|^\.claude/skills/|^\.github/workflows/docs-sync\.yml$'; then
             RELEVANT=true
           fi
           echo "relevant=$RELEVANT" >> "$GITHUB_OUTPUT"
@@ -108,6 +122,22 @@ jobs:
         run: |
           python -m pip install --quiet pytest
           bash scripts/ci/docs_sync_gate.sh test
+
+      # The plists-vs-docs coverage ratio used to live as a committed number in
+      # INDEX.md (DOCSYNC:AUTOMATION_COVERAGE). Step 4 removed it with the other
+      # counts, but its purpose was to keep a documentation GAP visible (W81
+      # signaler), so it is reported here instead of being dropped: recomputed on
+      # every run, shown to the author whose diff can move it. Reporting only — it
+      # must never gate, and `|| true` keeps a signaler from becoming a blocker.
+      - name: Automation-coverage signal (report only, never gates)
+        if: steps.relevant.outputs.relevant == 'true'
+        run: |
+          COVERAGE="$(python scripts/docs_sync.py --coverage)" || true
+          if [ -n "$COVERAGE" ]; then
+            echo "::notice::automation coverage — $COVERAGE"
+          else
+            echo "::notice::automation coverage unavailable (docs_sync --coverage produced no output)"
+          fi
 
       - name: Not docs-sync-relevant
         if: steps.relevant.outputs.relevant != 'true'

--- a/INDEX.md
+++ b/INDEX.md
@@ -12,7 +12,7 @@
 | Perché fare X?                                | [SYMBIOSIS.md](SYMBIOSIS.md)                                                        | Filosofia, "prima di toccare"                                            |
 | Come fare X?                                  | [VADEMECUM.md](VADEMECUM.md)                                                        | Checklist operativa per ogni tipo di elemento                            |
 | Dove vive X?                                  | Questa pagina, sezione "Organi" sotto                                               | Mappa statica top-level                                                  |
-| Metriche live (count routers/servizi/vector)? | [README.md](README.md) §Tech Stack + [docs/AI_ONBOARDING.md](docs/AI_ONBOARDING.md) | Auto-sincronizzate via `docs_sync.py` (marker rimossi da CLAUDE.md, F44) |
+| Metriche live (count routers/servizi/vector)? | `python scripts/docs_sync.py --json`                                                | NON committate in nessuna pagina dal 2026-08-16 (Merge-OS v3 §C2)        |
 | Dettagli tecnici di un'app?                   | `apps/<nome>/README.md` o `apps/<nome>/CLAUDE.md`                                   | File locali all'app                                                      |
 | Quando X è stato fatto?                       | `git log` + MOS (`~/.claude/scripts/mem query "X"`)                                 | Git + memoria persistente                                                |
 | Policy AI dispatch / federazione?             | [docs/AI_DISPATCH_REFERENCE.md](docs/AI_DISPATCH_REFERENCE.md)                      | Dispatch, fallback, timeout                                              |
@@ -29,7 +29,7 @@
 
 ### Production workloads
 
-- **`apps/backend-rag/`** — RAG backend (FastAPI, deploy Fly.io; count routers/services in README.md §Tech Stack auto-sync). Prompt SSOT: `backend/prompts/zantara_core.py`. Include WR2 pipeline (`backend/services/{war_room,council,visual,canva_renderer,review,publisher}/`).
+- **`apps/backend-rag/`** — RAG backend (FastAPI, deploy Fly.io; count routers/services via `python scripts/docs_sync.py --json`, non committati). Prompt SSOT: `backend/prompts/zantara_core.py`. Include WR2 pipeline (`backend/services/{war_room,council,visual,canva_renderer,review,publisher}/`).
 - **`apps/mouth/`** — Next.js frontend (Vercel). kita/my/prime.balizero.com.
 - **`apps/bali-intel-scraper/`** — Intel pipeline daily 03:00 WITA (solo Pro, NOT Fly). Articoli MDX → GitHub → Vercel.
 - **`apps/zantara-media/`** — Curator Agent GARUDA (Sprint 5.1 LIVE). Drive indexer + Qdrant `garuda_assets` + Postgres `garuda_index`.
@@ -169,9 +169,15 @@ Tabelle core: `articles`, `kg_nodes`/`kg_edges` (108K/242K), `publication_histor
 
 ### LaunchAgents — copertura documentale
 
-<!-- DOCSYNC:AUTOMATION_COVERAGE_START -->
-`141 plist tracked in infra/launchagents/ · 106 documented in automation_catalog.json + AUTOMATIONS_REFERENCE.md (75% coverage)`
-<!-- DOCSYNC:AUTOMATION_COVERAGE_END -->
+La copertura (quanti plist di `infra/launchagents/` sono documentati in
+`automation_catalog.json` + `AUTOMATIONS_REFERENCE.md`) **non è più committata qui**: era
+un numero che si muoveva a ogni plist aggiunto e restava stantio su `main`. Ora il gate
+`docs-sync.yml` la stampa come `::notice::` su ogni PR che tocca quei path — cioè a chi la
+può muovere, nel momento in cui la muove. Misurala anche a mano:
+
+```bash
+python scripts/docs_sync.py --coverage
+```
 
 Runbook operativi: indice auto-generato in [docs/runbooks/README.md](docs/runbooks/README.md).
 
@@ -203,4 +209,4 @@ Questo file è **mantenuto manualmente**. Si aggiorna quando:
 - Un nuovo pattern di riferimento emerge
 - Una sezione diventa obsoleta
 
-Le metriche quantitative (router count, vector count, etc.) vivono tra marker `<!-- DOCSYNC:* -->` in `README.md` (più `docs/AI_ONBOARDING.md`, `docs/DOCS_INVENTORY.md`, ecc.) — NON più in CLAUDE.md, da cui i marker sono stati rimossi (F44) — e sono auto-sincronizzate da `scripts/docs_sync.py`.
+Le metriche quantitative (router count, vector count, test count, ecc.) **non vivono più in nessuna pagina committata**: dal 2026-08-16 (Merge-OS v3 step 4, §C2) `scripts/docs_sync.py` le serve solo live via `--json`/`--coverage`. Restano committati, tra marker `<!-- DOCSYNC:* -->`, soltanto gli **elenchi** (app, runbook, skill, workflow) — contenuto di navigazione, non numeri. `docs/DOCS_INVENTORY.md` resta generato e committato per una ragione precisa: la colonna `orphan_flipped_on` è l'unico canale con cui `docs_audit.py` ricorda i flip precedenti, quindi è un vero input di programma, non prosa derivata.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Production AI-powered business intelligence platform for **Bali Zero** — Indon
 
 ## Architecture
 
-Monorepo powered by agentic RAG with Knowledge Graph (live app/router/service counts in **Tech Stack** below — auto-synced by `scripts/docs_sync.py`).
+Monorepo powered by agentic RAG with Knowledge Graph. App/router/service counts are not
+committed in this file — get them live with `python scripts/docs_sync.py --json`.
 
 ```
 nuzantara/
@@ -33,13 +34,18 @@ nuzantara/
 
 ## Tech Stack
 
-<!-- DOCSYNC:TECH_STATS_START -->
-- Backend: FastAPI · 330 routers · 697 services
-- Vector DB: Qdrant · 12 collections · 104,154 documents
-- Knowledge Graph: 108,068 nodes · 242,827 edges
-- Apps: 32 · Packages: 6
-- Version: 5.2.0
-<!-- DOCSYNC:TECH_STATS_END -->
+- Backend: Python 3.11+ · FastAPI · Postgres 17 (Fly.io) · Redis
+- Vector DB: Qdrant · embeddings `text-embedding-3-small`, 1536 dims (FROZEN)
+- Knowledge Graph + agentic RAG · LangGraph
+- Frontend: Next.js on Vercel · macOS/SwiftUI control surfaces
+
+Counts (routers, services, tests, collections, vectors, KG nodes) are **not committed
+here** on purpose: they moved on nearly every backend PR, so the committed line was
+stale on `main` more often than it was right. Read them live instead:
+
+```bash
+python scripts/docs_sync.py --json
+```
 
 ## Search Pipeline (enabled 2026-03-24)
 

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -3,9 +3,14 @@
 **Last Updated:** 2026-07-02
 **Purpose:** Technical reference for AI assistants. For behavioral rules, see `CLAUDE.md`. For the founding principles of the organism, see `SYMBIOSIS.md` (monorepo root).
 
-<!-- DOCSYNC:QUICK_NUMBERS_START -->
-`330 routers · 697 services · 1366 tests · 12 Qdrant collections · 104,154 vectors · 108,068 KG nodes`
-<!-- DOCSYNC:QUICK_NUMBERS_END -->
+**Quick numbers** (routers · services · tests · Qdrant collections · vectors · KG nodes) are
+**deliberately not committed to this file**: they changed on nearly every backend PR, which made
+this line stale on `main` most of the time and turned it into a merge conflict on every parallel
+backend PR. Get them live — the generator is the source of truth, not this page:
+
+```bash
+python scripts/docs_sync.py --json
+```
 
 > **Role split:** `CLAUDE.md` = how to act (rules, delegation, language, deploy QA). This file = how to build (architecture, code patterns, debugging, workflows).
 

--- a/docs/DOCSYNC_SENTINEL.md
+++ b/docs/DOCSYNC_SENTINEL.md
@@ -6,7 +6,7 @@
 
 ## What It Does
 
-Extracts live metrics from the codebase and injects them into markdown files between `<!-- DOCSYNC:KEY_START -->` / `<!-- DOCSYNC:KEY_END -->` markers. Numbers like router count, service count, vector document count stay always in sync with the actual code.
+Extracts live metrics from the codebase. **Enumerations** (which app, which runbook, which skill, which workflow) are injected into markdown between `<!-- DOCSYNC:KEY_START -->` / `<!-- DOCSYNC:KEY_END -->` markers, so the atlas tables stay in sync with the tree. **Volume counts** (router count, service count, vector document count, …) are still computed but deliberately NOT written to any tracked page — they are served live by `--json` / `--coverage`. See the retirement note under "Markers in Docs".
 
 ## How It Works
 
@@ -31,11 +31,26 @@ Code Change → docs_sync.py extracts stats → Injects into marker regions → 
 
 ### Markers in Docs
 
-| File                    | Markers                                             | Content                                        |
-| ----------------------- | --------------------------------------------------- | ---------------------------------------------- |
-| `README.md`             | `TECH_STATS`, `FEATURE_FLAGS`                       | Tech stack table, feature flags table          |
-| `CLAUDE.md`             | `BACKEND_STATS`, `VECTOR_STATS`, `EMBEDDING_FROZEN` | Backend metrics, vector counts, frozen warning |
-| `docs/AI_ONBOARDING.md` | `QUICK_NUMBERS`                                     | One-line stats summary                         |
+| File                      | Markers                                            | Content                                   |
+| ------------------------- | -------------------------------------------------- | ----------------------------------------- |
+| `INDEX.md`                | `LIVING_ORGANS`, `WORKFLOWS_INDEX`, `SKILLS_INDEX` | Apps table, workflows table, skills table |
+| `docs/runbooks/README.md` | `RUNBOOKS_INDEX`                                   | Runbooks table                            |
+
+**Only enumerations are injected. Volume counts are not, and this is enforced.**
+`TECH_STATS`, `QUICK_NUMBERS`, `AUTOMATION_COVERAGE`, `BACKEND_STATS`, `VECTOR_STATS`
+and `EMBEDDING_FROZEN` were retired on 2026-08-16 (Merge-OS v3 step 4 / §C2,
+`research/operations/2026-08-14-merge-os-v3-research-council.md`): a committed count
+went stale on `main` on nearly every backend PR and handed the next innocent PR a red
+required check (W86). They live in `RETIRED_COUNT_KEYS` in `scripts/docs_sync.py` and
+`scripts/tests/test_docs_sync_atlas.py` fails if one comes back as a template or as a
+marker in a tracked page. Read the numbers with `--json` (or `--coverage` for the
+plists-vs-docs ratio) instead.
+
+`README.md` and `docs/AI_ONBOARDING.md` stay in `TARGET_FILES` with zero markers, on
+purpose: that is what keeps `--check` and the anti-regrowth corpus watching them.
+(`FEATURE_FLAGS` in README.md was never a docs_sync marker — that table is
+hand-maintained; its source of truth is `fly secrets list -a nuzantara-rag`.)
+`CLAUDE.md` lost its markers in F44 and is deliberately not a target.
 
 ### Marker Format
 
@@ -61,8 +76,11 @@ python scripts/docs_sync.py --check
 # Show what would change without writing
 python scripts/docs_sync.py --diff
 
-# Output raw stats as JSON
+# Output raw stats as JSON — the channel for every volume count
 python scripts/docs_sync.py --json
+
+# Plists-vs-docs coverage, one line (also printed as a CI ::notice::)
+python scripts/docs_sync.py --coverage
 
 # Quiet mode (for hooks)
 python scripts/docs_sync.py --quiet
@@ -70,12 +88,12 @@ python scripts/docs_sync.py --quiet
 
 ## Triggers
 
-| Trigger         | File                              | When                   | Blocking             |
-| --------------- | --------------------------------- | ---------------------- | -------------------- |
-| **Manual**      | `python scripts/docs_sync.py`     | On demand              | —                    |
-| **Post-commit** | `.husky/post-commit`              | After every git commit | No (background)      |
-| **CI/CD**       | `.github/workflows/docs-sync.yml` | PRs touching `apps/`   | Yes (fails if stale) |
-| **Cron**        | `scripts/docs_sync_cron.sh`       | Daily at 03:17         | No (auto-commits)    |
+| Trigger         | File                              | When                                                                                | Blocking             |
+| --------------- | --------------------------------- | ----------------------------------------------------------------------------------- | -------------------- |
+| **Manual**      | `python scripts/docs_sync.py`     | On demand                                                                           | —                    |
+| **Post-commit** | `.husky/post-commit`              | After every git commit                                                              | No (background)      |
+| **CI/CD**       | `.github/workflows/docs-sync.yml` | PRs touching a marker input (job-level relevance check; see the regex in that file) | Yes (fails if stale) |
+| **Cron**        | `scripts/docs_sync_cron.sh`       | Daily at 03:17                                                                      | No (auto-commits)    |
 
 ### Setting Up Cron
 
@@ -100,20 +118,25 @@ crontab -e
 
 ## Adding New Markers
 
+First: **is it an enumeration or a count?** If the block would carry a number that moves
+with code volume, stop — it does not belong in a marker at all, it belongs in `--json`
+(see the retirement note above; `scripts/tests/test_docs_sync_atlas.py` fails the PR that
+tries). Markers are for lists of organs a reader navigates by.
+
 1. Add a template to `TEMPLATES` dict in `docs_sync.py`:
 
 ```python
-TEMPLATES["MY_NEW_STAT"] = lambda s: f"My stat: {s['routers']} routers"
+TEMPLATES["MY_NEW_INDEX"] = lambda s: _render_rows(s["my_organs"])
 ```
 
 2. Add markers to target .md file:
 
 ```markdown
-<!-- DOCSYNC:MY_NEW_STAT_START -->
+<!-- DOCSYNC:MY_NEW_INDEX_START -->
 
 placeholder
 
-<!-- DOCSYNC:MY_NEW_STAT_END -->
+<!-- DOCSYNC:MY_NEW_INDEX_END -->
 ```
 
 3. Add target file to `TARGET_FILES` list if not already there.
@@ -135,7 +158,7 @@ scripts/docs_sync.py
 │   └── get_kg_stats()       → cached hardcoded values
 ├── Templates (string formatters per marker key)
 ├── inject_markers()         → regex replace between marker pairs
-└── main()                   → CLI: --check, --diff, --json, --quiet
+└── main()                   → CLI: --check, --diff, --json, --coverage, --quiet
 ```
 
 No external dependencies. Uses only Python stdlib (`json`, `re`, `pathlib`, `urllib`).

--- a/scripts/docs_sync.py
+++ b/scripts/docs_sync.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python3
 """DocSentinel — Automated Documentation Stats Synchronizer.
 
-Extracts live metrics from the Nuzantara codebase and injects them into
-markdown files between <!-- DOCSYNC:KEY_START --> / <!-- DOCSYNC:KEY_END -->
-markers. Keeps README.md, INDEX.md, docs/AI_ONBOARDING.md and
-docs/runbooks/README.md in sync with actual code state.
+Extracts live metrics from the Nuzantara codebase. Two channels, and which one a
+number goes to is now a rule, not a habit (Merge-OS v3 step 4 / §C2, 2026-08-16):
+
+  ENUMERATIONS (which app, which runbook, which skill, which workflow) are injected
+  into markdown between <!-- DOCSYNC:KEY_START --> / <!-- DOCSYNC:KEY_END --> markers
+  in INDEX.md and docs/runbooks/README.md — they are navigational content, and they
+  only move when an organ is added or renamed.
+
+  VOLUME COUNTS (routers, services, tests, collections, vectors, KG nodes, version,
+  coverage ratio) are NOT committed anywhere. They are served live by `--json` /
+  `--coverage`. See RETIRED_COUNT_KEYS for why, and for the two tracked derived
+  files that are deliberately exempt because a program reads them back as input.
+
+README.md and docs/AI_ONBOARDING.md stay listed in TARGET_FILES although they now
+carry no marker: that is what keeps `--check` (and the anti-regrowth corpus) watching
+them for a retired count sneaking back in.
 (CLAUDE.md was a target until F44 removed its markers — kept out on purpose.)
 
 Spec: docs/DOCSYNC_SENTINEL.md
@@ -15,6 +27,7 @@ Usage:
     python scripts/docs_sync.py --check    # CI mode: exit 1 if stale
     python scripts/docs_sync.py --diff     # show what would change
     python scripts/docs_sync.py --json     # raw stats as JSON
+    python scripts/docs_sync.py --coverage # plists-vs-docs coverage line
     python scripts/docs_sync.py --quiet    # hook mode (no output on success)
 
 No external dependencies. Python stdlib only.
@@ -487,49 +500,75 @@ def _render_skills_index(stats: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _render_automation_coverage(stats: dict[str, Any]) -> str:
-    """Render AUTOMATION_COVERAGE marker: plists vs documentation coverage."""
+def format_automation_coverage(stats: dict[str, Any]) -> str:
+    """One-line plists-vs-docs coverage, for a LIVE surface — never for tracked prose.
+
+    This used to be the AUTOMATION_COVERAGE marker body written into INDEX.md. The
+    docstring on `automation_coverage()` calls it "a signaler, not a gate (W81): the
+    coverage gap stays visible instead of hiding in no diff" — and that purpose is
+    exactly why it could not simply be deleted with the other counts (superscar #2:
+    a signal nobody reads is not armed, and a signal that is stale most of the time
+    is worse than none).
+
+    So the signal moved rather than died: the docs-sync workflow prints it as a
+    `::notice::` on every PR that touches `infra/launchagents/`,
+    `scripts/automation_catalog.json` or `docs/AUTOMATIONS_REFERENCE.md` — it fires
+    at the moment the ratio can change, at the author who changed it, always
+    recomputed. Also available any time via `--coverage` / `--json`.
+    """
     cov = stats["automation_coverage"]
     pct = round(100 * cov["documented"] / cov["plists"]) if cov["plists"] else 0
     return (
-        f"\n`{cov['plists']} plist tracked in infra/launchagents/ · "
+        f"{cov['plists']} plist tracked in infra/launchagents/ · "
         f"{cov['documented']} documented in automation_catalog.json + "
-        f"AUTOMATIONS_REFERENCE.md ({pct}% coverage)`\n"
+        f"AUTOMATIONS_REFERENCE.md ({pct}% coverage)"
     )
 
 
+# Keys this tool used to render into tracked prose and must never render again
+# (Merge-OS v3 step 4 / §C2, 2026-08-16 — verify-don't-store). Each was a VOLUME
+# COUNT: routers, services, tests, vectors, KG nodes, package version, or the
+# plist-vs-docs coverage ratio. They moved on nearly every backend PR — measured on
+# 60 days of origin/main, 189 of 195 commits touching docs/AI_ONBOARDING.md and 61
+# of 63 touching README.md changed nothing but these numbers — so the committed
+# value was stale on main more often than it was right, every parallel backend PR
+# collided on the same derived line, and an innocent PR inherited the drift as a red
+# required check (W86; PRs #4101/#4066).
+#
+# The sweep that authorised the deletion found ZERO programmatic consumers of the
+# VALUES: every reader was this writer, the docs-sync gate/auditor, a test, or human
+# prose — nothing under apps/ or packages/ opens README.md, INDEX.md or
+# AI_ONBOARDING.md at all. The numbers are still computed and still available; they
+# are served live by `--json` / `--coverage` instead of being frozen into a page.
+#
+# Two tracked derived files were deliberately NOT touched, because a program reads
+# them back as INPUT: `.docs_sync_cache.json` (the qdrant/kg fallback this script
+# loads) and `docs/DOCS_INVENTORY.md` (docs_audit.py::parse_prev_flipped reads its
+# `orphan_flipped_on` column as the sole channel carrying prior-flip provenance).
+# That is the red-team seat's own exception clause: "derived documentation non
+# versionata, salvo eccezioni che siano veri input runtime/client".
+#
+# Enforced by scripts/tests/test_docs_sync_atlas.py (guilt + innocence). Putting a
+# key back here means re-committing a number no program reads — read §C2 first.
+RETIRED_COUNT_KEYS = frozenset(
+    {
+        "TECH_STATS",
+        "QUICK_NUMBERS",
+        "AUTOMATION_COVERAGE",
+        "BACKEND_STATS",
+        "VECTOR_STATS",
+        "EMBEDDING_FROZEN",
+    }
+)
+
+# What survives is the ENUMERATIONS — navigational tables whose rows are the organs
+# themselves (which app, which runbook, which skill, which workflow). They are
+# content a reader navigates by, not a number, and they move only when an organ is
+# added or renamed: the PR that moves the input is the PR that regenerates them.
 TEMPLATES: dict[str, Any] = {
     "RUNBOOKS_INDEX": _render_runbooks_index,
     "WORKFLOWS_INDEX": _render_workflows_index,
     "SKILLS_INDEX": _render_skills_index,
-    "AUTOMATION_COVERAGE": _render_automation_coverage,
-    "BACKEND_STATS": lambda s: (
-        f"\n- **Backend:** Python 3.11+, FastAPI, "
-        f"{s['routers']} routers, {s['services']} services, "
-        f"{s['test_files']} test files\n"
-    ),
-    "VECTOR_STATS": lambda s: (
-        f"\n- **Vector Collections:** {s['qdrant']['collections']} live on Fly.io "
-        f"({s['qdrant']['documents']:,} documents), "
-        f"{s['qdrant']['collections']} defined in code\n"
-    ),
-    "EMBEDDING_FROZEN": lambda s: (
-        f"\n### Embedding — `{s['qdrant']['embedding_model']}` "
-        f"(1536 dims) FROZEN. Never change without re-indexing plan.\n"
-    ),
-    "TECH_STATS": lambda s: (
-        f"\n- Backend: FastAPI · {s['routers']} routers · {s['services']} services\n"
-        f"- Vector DB: Qdrant · {s['qdrant']['collections']} collections · "
-        f"{s['qdrant']['documents']:,} documents\n"
-        f"- Knowledge Graph: {s['kg']['nodes']:,} nodes · {s['kg']['edges']:,} edges\n"
-        f"- Apps: {s['app_count']} · Packages: {s['package_count']}\n"
-        f"- Version: {s['version']}\n"
-    ),
-    "QUICK_NUMBERS": lambda s: (
-        f"\n`{s['routers']} routers · {s['services']} services · "
-        f"{s['test_files']} tests · {s['qdrant']['collections']} Qdrant collections · "
-        f"{s['qdrant']['documents']:,} vectors · {s['kg']['nodes']:,} KG nodes`\n"
-    ),
     "LIVING_ORGANS": _render_living_organs,
 }
 
@@ -541,16 +580,30 @@ TEMPLATES: dict[str, Any] = {
 def gather_stats(*, read_only: bool = False) -> dict[str, Any]:
     """Collect all stats from codebase.
 
-    read_only=True skips the cache refresh below. Used by --check/--diff/--json:
-    those modes are documented (and, for --check, relied on by CI) as
+    read_only=True skips the cache refresh below. Used by --check/--diff/--json/
+    --coverage: those modes are documented (and, for --check, relied on by CI) as
     non-mutating, but this function used to call `_save_cache` unconditionally
     — every "read-only" invocation quietly dirtied `.docs_sync_cache.json` on
-    disk. The tracked cache itself must stay committed: CI's docs-sync.yml
-    workflow has no QDRANT_URL/QDRANT_API_KEY, so `get_qdrant_stats()` falls
-    back to this committed snapshot rather than the older hardcoded
-    `_QDRANT_FALLBACK` — untracking it would make --check fail on every
-    triggering PR (verified empirically: removing the file flips
-    `--check` from OK to STALE). This flag only stops the SIDE-EFFECT write,
+    disk.
+
+    The tracked cache must still stay committed, but the REASON changed on
+    2026-08-16 and the old one is now false. It used to read: "untracking it would
+    make --check fail on every triggering PR (verified empirically: removing the
+    file flips --check from OK to STALE)". True while TECH_STATS / QUICK_NUMBERS /
+    VECTOR_STATS rendered qdrant numbers into tracked prose. Merge-OS v3 step 4
+    retired every one of those templates (see RETIRED_COUNT_KEYS), so no surviving
+    template touches `stats["qdrant"]` or `stats["kg"]` at all — and the claim was
+    RE-MEASURED here rather than inherited (W106, a cure anchored to a frozen
+    measurement of the world): with `.docs_sync_cache.json` deleted, `--check` still
+    prints `DOCSYNC OK (no changes)` and exits 0.
+
+    What the cache is load-bearing for NOW is `--json`, which since step 4 is the
+    only channel serving these numbers to a reader. CI, and any machine without
+    QDRANT_URL/QDRANT_API_KEY exported, falls back to this committed snapshot;
+    untrack it and `--json` silently degrades to the much older hardcoded
+    `_QDRANT_FALLBACK` (93,283 documents against the 104,154 the snapshot carries)
+    — wrong numbers rather than a red check, which is the quieter failure of the
+    two. This flag only stops the SIDE-EFFECT write,
     never the read.
     """
     qdrant = get_qdrant_stats()
@@ -656,16 +709,28 @@ def main() -> int:
         "--json", action="store_true", help="Output raw stats as JSON (no writes)"
     )
     parser.add_argument(
+        "--coverage",
+        action="store_true",
+        help="Print the plists-vs-docs coverage line (no writes) — see "
+        "format_automation_coverage()",
+    )
+    parser.add_argument(
         "--quiet", action="store_true", help="Suppress output on success (hook mode)"
     )
     args = parser.parse_args()
 
     # --check/--diff/--json are all documented as non-mutating; none of them
     # may leave .docs_sync_cache.json touched on disk.
-    stats = gather_stats(read_only=args.check or args.diff or args.json)
+    stats = gather_stats(
+        read_only=args.check or args.diff or args.json or args.coverage
+    )
 
     if args.json:
         print(json.dumps(stats, indent=2, default=str))
+        return 0
+
+    if args.coverage:
+        print(format_automation_coverage(stats))
         return 0
 
     any_changed = False

--- a/scripts/tests/test_docs_sync_atlas.py
+++ b/scripts/tests/test_docs_sync_atlas.py
@@ -100,7 +100,6 @@ def test_templates_registered_and_render():
         "RUNBOOKS_INDEX",
         "WORKFLOWS_INDEX",
         "SKILLS_INDEX",
-        "AUTOMATION_COVERAGE",
     ):
         assert key in docs_sync.TEMPLATES
         body = docs_sync.TEMPLATES[key](_stats())
@@ -115,15 +114,98 @@ def test_table_cells_escape_pipes():
 
 
 def test_automation_coverage_render_pct():
-    body = docs_sync.TEMPLATES["AUTOMATION_COVERAGE"](_stats())
+    body = docs_sync.format_automation_coverage(_stats())
     assert "4 plist" in body and "(25% coverage)" in body
 
 
 def test_coverage_zero_plists_no_division_error():
-    body = docs_sync.TEMPLATES["AUTOMATION_COVERAGE"](
+    body = docs_sync.format_automation_coverage(
         {"automation_coverage": {"plists": 0, "documented": 0}}
     )
     assert "(0% coverage)" in body
+
+
+# ---------------------------------------------------------------------------
+# Retired volume counts must not come back (Merge-OS v3 step 4 / §C2)
+#
+# Guilt AND innocence on both halves of the rule (superscar #3): the retired keys
+# must be refused wherever they could return — as a TEMPLATES entry, or as a marker
+# re-pasted into a tracked page — and the surviving enumeration markers, which look
+# identical in shape, must NOT be caught by the same check.
+# ---------------------------------------------------------------------------
+
+# Every file that could plausibly regain one, whether or not it is a TARGET_FILE
+# today — a guard scoped to TARGET_FILES would go blind the moment someone trims
+# that list, which is the exact shape of the thing being prevented.
+_PAGES_WATCHED_FOR_REGROWTH = (
+    "README.md",
+    "INDEX.md",
+    "docs/AI_ONBOARDING.md",
+    "docs/runbooks/README.md",
+)
+
+
+def _markers_in(rel: str) -> set[str]:
+    """DOCSYNC keys present in a tracked page (entity, not substring)."""
+    text = (REPO_ROOT / rel).read_text(encoding="utf-8", errors="ignore")
+    return {m.group("key") for m in docs_sync.MARKER_RE.finditer(text)}
+
+
+def test_retired_count_keys_have_no_template():
+    """GUILT: re-registering a retired key as a renderer must fail here."""
+    overlap = docs_sync.RETIRED_COUNT_KEYS & set(docs_sync.TEMPLATES)
+    assert not overlap, (
+        f"{sorted(overlap)} back in TEMPLATES — these are volume counts with no "
+        "programmatic consumer; they were removed from tracked prose by Merge-OS v3 "
+        "step 4 (§C2). Serve them from --json/--coverage instead."
+    )
+
+
+def test_retired_count_markers_absent_from_tracked_pages():
+    """GUILT: pasting a retired marker back into a tracked page must fail here."""
+    for rel in _PAGES_WATCHED_FOR_REGROWTH:
+        found = _markers_in(rel) & docs_sync.RETIRED_COUNT_KEYS
+        assert not found, (
+            f"{rel} regained retired DOCSYNC marker(s) {sorted(found)} — a committed "
+            "volume count goes stale on main and hands the next innocent PR a red "
+            "check (W86). Link to `python scripts/docs_sync.py --json` instead."
+        )
+
+
+def test_surviving_enumeration_markers_are_not_flagged():
+    """INNOCENCE: the enumerations that legitimately stay are not caught.
+
+    Without this, a guard that simply banned every DOCSYNC marker would pass the
+    two tests above while quietly deleting the atlas.
+    """
+    index_markers = _markers_in("INDEX.md")
+    assert {"LIVING_ORGANS", "WORKFLOWS_INDEX", "SKILLS_INDEX"} <= index_markers, (
+        f"INDEX.md lost enumeration markers — found {sorted(index_markers)}"
+    )
+    assert "RUNBOOKS_INDEX" in _markers_in("docs/runbooks/README.md")
+    assert not (index_markers & docs_sync.RETIRED_COUNT_KEYS)
+
+
+def test_coverage_flag_is_read_only_and_reports():
+    """The signal that replaced the INDEX.md coverage block must actually run.
+
+    A `::notice::` step in docs-sync.yml is only a signal if the command behind it
+    exits 0 and prints something (superscar #2 — a signaler nobody can read is not
+    armed). Also pins that --coverage does not dirty the tracked cache.
+    """
+    cache = docs_sync.CACHE_PATH
+    before = cache.read_bytes() if cache.exists() else None
+    proc = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "docs_sync.py"), "--coverage"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    after = cache.read_bytes() if cache.exists() else None
+    assert proc.returncode == 0, f"--coverage exited {proc.returncode}: {proc.stderr}"
+    assert "coverage)" in proc.stdout, f"--coverage printed nothing usable: {proc.stdout!r}"
+    assert before == after, "--coverage modified .docs_sync_cache.json"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Executes **Merge-OS v3 step 4 — derived-state deletion** (`research/operations/2026-08-14-merge-os-v3-research-council.md` §C2 + §6 step 4). Zero's GO for the step was given in the mandate that opened this work.

## The assumption-check came first, and it changed the scope

§6 makes one thing a hard precondition: *"Requires the ASSUMPTION check: grep-verified no programmatic consumer — one dependency sweep before deletion."* That sweep ran before a line was edited.

**Result: zero programmatic consumers of the VALUES.** Every reader of the DOCSYNC blocks classifies as (a) the writer, (b) the docs-sync gate/auditor, (c) a test, or (e) human prose. Nothing under `apps/` or `packages/` opens `README.md`, `INDEX.md` or `docs/AI_ONBOARDING.md` at all.

**But it also found where the council's own wording would have overreached.** §6 step 4 says "counts/**inventories**". Two tracked derived files are read back as INPUT by a program, and they are deliberately untouched here:

| File | Who reads it back | Consequence of untracking |
|---|---|---|
| `docs/DOCS_INVENTORY.md` | `docs_audit.py::parse_prev_flipped` / `read_trusted_prev_flipped` — its `orphan_flipped_on` column is *"the sole channel through which a PRIOR organ-flip survives into the next run"* | not deleting prose, deleting **state**: every organ-archived doc silently resurrects |
| `.docs_sync_cache.json` | `docs_sync.py::get_qdrant_stats` when no `QDRANT_URL` is exported (i.e. CI) | `--json` degrades to the older hardcoded fallback — **93,283** documents against the snapshot's **104,154** |

That is the red-team seat's own exception clause, quoted in the council doc: *"derived documentation non versionata, **salvo eccezioni che siano veri input runtime/client**"*. It is not decorative.

## Why the counts had to go — measured, not assumed

On 60 days of `origin/main`:

| page | commits | of which changed **only** the derived count |
|---|---:|---:|
| `docs/AI_ONBOARDING.md` | 195 | **189** |
| `README.md` | 63 | **61** |

So the committed value was stale on `main` more often than it was right; every parallel backend PR collided on the same derived line (ledger entry 2026-08-11: `mergeStateStatus: DIRTY` on that one line, six times in a row); and the drift was handed to the **next innocent PR** as a red required check — W86, PRs #4101/#4066.

## What changed

- **`scripts/docs_sync.py`** — `RETIRED_COUNT_KEYS` (`TECH_STATS`, `QUICK_NUMBERS`, `AUTOMATION_COVERAGE`, `BACKEND_STATS`, `VECTOR_STATS`, `EMBEDDING_FROZEN`) with the evidence inline; those six templates removed. Extractors and `--json` stay — the numbers are still computed, they are just no longer frozen into a page.
- **Pages** — blocks replaced by a pointer to `python scripts/docs_sync.py --json`, plus the three prose lines elsewhere in `INDEX.md` that still told a reader those counts lived in a committed page, and the stale table in `docs/DOCSYNC_SENTINEL.md`.
- **The four ENUMERATIONS stay generated** (`LIVING_ORGANS`, `WORKFLOWS_INDEX`, `SKILLS_INDEX`, `RUNBOOKS_INDEX`). They are navigational content, not a number, and they move only when an organ is added or renamed — the PR that moves the input is the PR that regenerates them, which is guilt-by-delta rather than by proximity.
- **The W81 coverage signaler moved rather than died.** Deleting it outright would have traded a stale signal for no signal (superscar #2). It is now `--coverage` plus a report-only `::notice::` in `docs-sync.yml`: recomputed every run, shown to the author whose diff can move it.
- **Relevance regex** — dropped **only** the paths that fed the deleted counts (`router_registration.py`, `backend/services/`, `backend/tests/`, `backend/channels/`, `package.json`). `README.md` and `docs/AI_ONBOARDING.md` stay listed although they now hold no marker: dropping them would leave the anti-regrowth corpus present but **unarmed**, which is the exact shape of what this diff exists to prevent.
- **A frozen measurement was re-measured, not inherited (W106).** `gather_stats`' docstring claimed deleting `.docs_sync_cache.json` flips `--check` to STALE. True while the qdrant templates existed; **false now** — verified by deleting the file: `--check` still prints `DOCSYNC OK` and exits 0. The docstring now states the real, current reason the file must stay committed.

## Verification

`test_docs_sync_atlas.py` gains guilt **and** innocence guards, **mutation-verified 5/5** — each mutation kills exactly one test and nothing else:

1. re-register a retired key as a template → `test_retired_count_keys_have_no_template`
2. paste a retired marker back into `README.md` → `test_retired_count_markers_absent_from_tracked_pages`
3. paste one into the runbooks page (proves the guard is **not** scoped to `TARGET_FILES`) → same test
4. delete a surviving enumeration marker → `test_surviving_enumeration_markers_are_not_flagged` (the innocence half: a guard that simply banned every marker would pass the others while quietly deleting the atlas)
5. break the `--coverage` signal → `test_coverage_flag_is_read_only_and_reports`

Green locally: `pytest` 16/16 · `docs_sync.py --check` · `--coverage` · `docs_sync_gate.sh check` · `test_docs_sync_gate_failclosed.sh` 7/7 · `ruff` · `prettier` · `actionlint`.

## Declared, not hidden

- **Legge 5.** Council §9 lists "removing counts from README/INDEX/AI_ONBOARDING" as needing doctrine sign-off because it touches the public face of the repo and the AI-onboarding contract. Zero gave that GO in the mandate.
- **Pre-existing gap, unchanged by this PR, not closed by it:** a brand-new app directory containing no `README.md` can move `LIVING_ORGANS` without matching the relevance regex, so the enumeration can go stale unnoticed. That was already true before this diff (the dropped backend paths never covered it either); a path filter cannot express "first file in a new directory" cheaply. Named here rather than left for someone to discover.
- Depends on #4227 for the council doc it cites to exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)