### PR TITLE
fix(intake): W0 guardians — business-time staleness, organ-not-finding heartbeat, source filter, timeouts (post-refuter)

### DIFF
--- a/infra/launchagents/com.nuzantara.intake-health-report.plist
+++ b/infra/launchagents/com.nuzantara.intake-health-report.plist
@@ -29,6 +29,15 @@
        ~/Library/LaunchAgents/com.nuzantara.intake-health-report.plist
 
   Plist permissions hardened to 0444 per cicatrix P0-3.
+
+  TZ NOTE (verbale #11): launchd's StartCalendarInterval has NO timezone
+  field — "07:30 daily = WITA" holds ONLY while the host's system TZ is set
+  to Asia/Makassar. A TZ drift on the host silently shifts this cron's wall-
+  clock time with no error anywhere. The freshness organ (wa-mirror-
+  freshness-liveness, StartInterval-based) is unaffected by this class of
+  drift since it computes business hours via ZoneInfo("Asia/Makassar") in
+  code, not off the host's system TZ — that asymmetry between the two W0
+  guardians is easy to miss if you assume they share a TZ dependency.
 -->
 <plist version="1.0">
 <dict>

--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -489,6 +489,18 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
 
     lock_fd = _acquire_lock_or_exit()
     if lock_fd is None:
+        # Previously exited silently: a hung run (verbale #7 — every gather()
+        # query but one ran unbounded) could hold this flock past the next
+        # scheduled 07:30 tick, and that tick's own return-0-without-a-word
+        # meant the organ went fully dark (no digest, no P0, no heartbeat)
+        # until a human found the hung process by hand. Now it says so.
+        date_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        _heartbeat("error", "lock held")
+        _tg_notify(
+            "digest",
+            f"intake-health:lock-held:{date_key}",
+            "🔒 intake-health-report: previous instance still running — this tick skipped",
+        )
         return 0
     try:
         dsn = os.getenv("INTAKE_DATABASE_URL") or os.getenv("LOCAL_DATABASE_URL") or DEFAULT_DSN
@@ -519,7 +531,12 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
         if not dry_run:
             _write_state(report)
 
-        _heartbeat("ok" if not breaches else "degraded", note=f"breaches={len(breaches)}")
+        # Heartbeat reflects the ORGAN (did the report complete?), never the
+        # FINDING (are there breaches?) — same rule as wa_mirror_freshness_
+        # liveness.py (verbale #2): a breach is real information, but it does
+        # not mean this organ is unhealthy, and "degraded" made the healer
+        # sentinel treat a completed report carrying findings as a dead organ.
+        _heartbeat("ok", note=f"breaches={len(breaches)}")
 
         if not dry_run:
             _tg_notify("digest", "intake-health:daily", render_digest(report))

--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -236,6 +236,15 @@ def _write_state(report: dict[str, Any]) -> None:
 def _acquire_lock_or_exit() -> int | None:
     LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o600)
+    # O_CREAT's mode argument only applies when the file is CREATED (verbale
+    # #9) — it does not retroactively chmod a lock file that already exists
+    # on disk from an earlier pre-hardening run. Mirrors tg_notify.py's
+    # harden() rationale (same repo, same PR family, and the exact lesson
+    # tg_notify.py already documents in its own docstring).
+    try:
+        os.chmod(LOCK_FILE, 0o600)
+    except OSError as exc:  # noqa: BLE001 — never let a chmod failure block the lock
+        logger.warning("[intake_health_report] lock chmod failed: %s", exc)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         return fd
@@ -539,7 +548,14 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
         _heartbeat("ok", note=f"breaches={len(breaches)}")
 
         if not dry_run:
-            _tg_notify("digest", "intake-health:daily", render_digest(report))
+            # Date-stamped, not a bare constant (verbale #4): a fixed daily
+            # dedup key can knife-edge-collide with tg_notify's own escalating
+            # mute window — once a condition's streak reaches 2, its mute
+            # window is exactly 24h, the same as this cron's own cadence, so
+            # ordinary cron jitter of a few seconds could silently drop that
+            # day's digest line into the existing dedup entry.
+            date_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            _tg_notify("digest", f"intake-health:daily:{date_key}", render_digest(report))
             for breach in breaches:
                 _tg_notify("p0", f"intake-health:{breach['metric']}", f"🚨 {breach['message']}")
 

--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -66,7 +66,16 @@ ORGAN_ID = "pro.intake_health_report"
 STATE_PATH = Path.home() / ".agent" / "decisions" / "state" / "intake_health_report.json"
 LOCK_FILE = Path.home() / ".cell-bridge-state" / "intake_health_report.lock"
 DEFAULT_DSN = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
-WORKER_PLIST_PATH = _REPO / "infra" / "launchagents" / "com.nuzantara.intake-worker.plist"
+REPO_WORKER_PLIST_PATH = _REPO / "infra" / "launchagents" / "com.nuzantara.intake-worker.plist"
+# The INSTALLED launchd plist — the one actually driving the running worker —
+# takes precedence over the repo copy (verbale #8, superscar #1 HOME-fork):
+# this script's own _REPO is derived from whichever checkout happened to
+# invoke it (main / a worktree / a stale deploy copy), which is not
+# necessarily the checkout the worker was installed from. Reading the repo
+# copy when the two diverge is a false-clean or a false-breach on
+# worker_log_inode_exists, decided by an accident of which checkout ran this
+# report today rather than by what launchd is actually running.
+INSTALLED_WORKER_PLIST_PATH = Path.home() / "Library" / "LaunchAgents" / "com.nuzantara.intake-worker.plist"
 _FALLBACK_WORKER_LOG = Path.home() / "logs" / "intake-worker.launchd.err.log"
 
 # The absolute python3 candidates tg_notify.py is spawned with (W108 — the
@@ -257,20 +266,30 @@ def _acquire_lock_or_exit() -> int | None:
 # ---------------------------------------------------------------- pure helpers (unit-tested, no DB/network)
 
 
-def worker_log_path() -> Path:
+def resolve_worker_plist_path() -> tuple[Path, str]:
+    """Prefer the INSTALLED launchd plist over the repo copy (verbale #8) —
+    returns (path, "installed"|"repo")."""
+    if INSTALLED_WORKER_PLIST_PATH.is_file():
+        return INSTALLED_WORKER_PLIST_PATH, "installed"
+    return REPO_WORKER_PLIST_PATH, "repo"
+
+
+def worker_log_path() -> tuple[Path, str]:
     """Resolve the intake-worker's StandardErrorPath from its own plist —
-    never hardcode a duplicate of what the plist already declares."""
+    never hardcode a duplicate of what the plist already declares. Returns
+    (log_path, plist_source) so the caller can report which plist was read."""
+    plist_path, source = resolve_worker_plist_path()
     try:
-        payload = plistlib.loads(WORKER_PLIST_PATH.read_bytes())
+        payload = plistlib.loads(plist_path.read_bytes())
         raw = payload.get("StandardErrorPath")
         if isinstance(raw, str) and raw:
-            return Path(raw).expanduser()
+            return Path(raw).expanduser(), source
     except (OSError, ValueError) as exc:
         logger.warning(
             "[intake_health_report] could not read worker plist %s (%s) — falling back to %s",
-            WORKER_PLIST_PATH, exc, _FALLBACK_WORKER_LOG,
+            plist_path, exc, _FALLBACK_WORKER_LOG,
         )
-    return _FALLBACK_WORKER_LOG
+    return _FALLBACK_WORKER_LOG, source
 
 
 def blob_presence(paths: list[str]) -> dict[str, Any]:
@@ -297,6 +316,7 @@ def build_report(
     zombie_count: int,
     undelivered: dict[str, int],
     worker_log_exists: bool,
+    worker_plist_source: str,
     dead_last_24h: int,
     wa_media_last_24h: int,
     generated_at: str,
@@ -355,6 +375,7 @@ def build_report(
             "total": int(undelivered.get("total") or 0),
         },
         "worker_log_inode_exists": bool(worker_log_exists),
+        "worker_plist_source": worker_plist_source,
         "dead_last_24h": int(dead_last_24h),
         "wa_media_last_24h": int(wa_media_last_24h),
     }
@@ -462,6 +483,7 @@ async def gather(conn: Any, *, superseded_timeout_ms: int) -> dict[str, Any]:
     undelivered_row = await conn.fetchrow(UNDELIVERED_COMMITTED_SQL)
     dead_row = await conn.fetchrow(DEAD_LAST_24H_SQL)
     wa_media_row = await conn.fetchrow(WA_MEDIA_LAST_24H_SQL)
+    worker_log_p, worker_plist_source = worker_log_path()
 
     return build_report(
         status_counts=dict(status_row),
@@ -473,7 +495,8 @@ async def gather(conn: Any, *, superseded_timeout_ms: int) -> dict[str, Any]:
         superseded_orphans=superseded_orphans,
         zombie_count=zombie_row["n"],
         undelivered=dict(undelivered_row),
-        worker_log_exists=worker_log_path().exists(),
+        worker_log_exists=worker_log_p.exists(),
+        worker_plist_source=worker_plist_source,
         dead_last_24h=dead_row["n"],
         wa_media_last_24h=wa_media_row["n"],
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -515,8 +538,21 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
         dsn = os.getenv("INTAKE_DATABASE_URL") or os.getenv("LOCAL_DATABASE_URL") or DEFAULT_DSN
         timeout_ms = int(os.getenv("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", "60000"))
         try:
+            # statement_timeout at the SESSION level (verbale #7): every
+            # gather() query except _fetch_superseded_orphans ran unbounded —
+            # a hung jsonb-heavy join could hold the single-instance flock
+            # indefinitely, and the NEXT scheduled tick would then hit the
+            # lock-held branch above. _fetch_superseded_orphans still gets
+            # its own tighter override (default 60000ms) via `SET
+            # statement_timeout` and resets to this session default (not
+            # Postgres's true default) afterward — same 60s guard as before.
             conn = await asyncpg.connect(
-                dsn, server_settings={"default_transaction_read_only": "on"}
+                dsn,
+                server_settings={
+                    "default_transaction_read_only": "on",
+                    "statement_timeout": "120000",
+                },
+                timeout=20,
             )
         except Exception as exc:  # noqa: BLE001
             logger.error("[intake_health_report] DB connect failed: %s", exc)

--- a/scripts/intake_health_report_run.sh
+++ b/scripts/intake_health_report_run.sh
@@ -28,11 +28,16 @@ ORGAN_ID="pro.intake_health_report"
 # shellcheck source=scripts/lib/heartbeat.sh
 source "$REPO_ROOT/scripts/lib/heartbeat.sh"
 
-if [ "${INTAKE_HEALTH_REPORT_ENABLED:-true}" = "false" ]; then
-  organism_heartbeat "$ORGAN_ID" "disabled" "INTAKE_HEALTH_REPORT_ENABLED=false"
-  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) INTAKE_HEALTH_REPORT_ENABLED=false — skipping run"
-  exit 0
-fi
+# Case-insensitive, and matching the Python side's superset (0|false|no) —
+# verbale #10a: see wa_mirror_freshness_liveness_run.sh's twin comment.
+_intake_health_enabled_lc="$(printf '%s' "${INTAKE_HEALTH_REPORT_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')"
+case "$_intake_health_enabled_lc" in
+  false|0|no)
+    organism_heartbeat "$ORGAN_ID" "disabled" "INTAKE_HEALTH_REPORT_ENABLED=$INTAKE_HEALTH_REPORT_ENABLED"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) INTAKE_HEALTH_REPORT_ENABLED=$INTAKE_HEALTH_REPORT_ENABLED — skipping run"
+    exit 0
+    ;;
+esac
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 PYBIN="$REPO_ROOT/apps/backend-rag/.venv/bin/python"

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -393,6 +393,49 @@ def test_json_only_skips_all_side_effects(tmp_path, monkeypatch, capsys):
     assert '"review_pending_total"' in out
 
 
+def test_heartbeat_is_ok_even_with_breaches_organ_not_finding(tmp_path, monkeypatch):
+    hb = []
+    monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: True)
+    monkeypatch.setattr(ihr, "_heartbeat", lambda status, note="": hb.append((status, note)))
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+
+    async def _fake_connect(*_args, **_kwargs):
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _fake_connect)
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
+
+    assert rc == 0
+    # worker_log_missing breach fires (file doesn't exist) — heartbeat must
+    # still read "ok", never "degraded" (verbale #2's twin, this organ).
+    assert hb
+    status, note = hb[-1]
+    assert status == "ok"
+    assert "breaches=" in note
+
+
+def test_lock_held_writes_error_heartbeat_and_digest_instead_of_exiting_silently(monkeypatch):
+    hb = []
+    sent = []
+    monkeypatch.setattr(ihr, "_heartbeat", lambda status, note="": hb.append((status, note)))
+    monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: sent.append((tier, key, text)) or True)
+    monkeypatch.setattr(ihr, "_acquire_lock_or_exit", lambda: None)
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
+
+    assert rc == 0
+    assert hb == [("error", "lock held")]
+    assert len(sent) == 1
+    tier, key, _text = sent[0]
+    assert tier == "digest"
+    assert key.startswith("intake-health:lock-held:")
+
+
 def test_kill_switch_disabled_short_circuits(monkeypatch, capsys):
     monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "false")
     called = []

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -16,6 +16,7 @@ Run:  python3 scripts/tests/test_intake_health_report.py
 from __future__ import annotations
 
 import asyncio
+import os
 import pathlib
 import sys
 
@@ -393,6 +394,29 @@ def test_json_only_skips_all_side_effects(tmp_path, monkeypatch, capsys):
     assert '"review_pending_total"' in out
 
 
+def test_digest_dedup_key_is_date_stamped_not_a_bare_constant(tmp_path, monkeypatch):
+    sent = []
+    monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: sent.append((tier, key)) or True)
+    monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+
+    async def _fake_connect(*_args, **_kwargs):
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _fake_connect)
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
+
+    assert rc == 0
+    digest_keys = [k for t, k in sent if t == "digest"]
+    assert len(digest_keys) == 1
+    assert digest_keys[0].startswith("intake-health:daily:")
+    assert digest_keys[0] != "intake-health:daily"
+
+
 def test_heartbeat_is_ok_even_with_breaches_organ_not_finding(tmp_path, monkeypatch):
     hb = []
     monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: True)
@@ -434,6 +458,22 @@ def test_lock_held_writes_error_heartbeat_and_digest_instead_of_exiting_silently
     tier, key, _text = sent[0]
     assert tier == "digest"
     assert key.startswith("intake-health:lock-held:")
+
+
+def test_acquire_lock_hardens_a_pre_existing_loose_lock_file(tmp_path, monkeypatch):
+    lock = tmp_path / "state" / "intake_health_report.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("")
+    lock.chmod(0o644)  # simulate a pre-hardening-era lock file already on disk
+    monkeypatch.setattr(ihr, "LOCK_FILE", lock)
+
+    fd = ihr._acquire_lock_or_exit()
+    try:
+        assert fd is not None
+        assert (lock.stat().st_mode & 0o777) == 0o600
+    finally:
+        if fd is not None:
+            os.close(fd)
 
 
 def test_kill_switch_disabled_short_circuits(monkeypatch, capsys):

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -50,6 +50,7 @@ def _base_kwargs(**overrides):
         zombie_count=0,
         undelivered={"undelivered": 1, "total": 10},
         worker_log_exists=True,
+        worker_plist_source="repo",
         dead_last_24h=4,
         wa_media_last_24h=7,
         generated_at="2026-08-15T00:00:00Z",
@@ -75,6 +76,7 @@ def test_build_report_has_stable_top_level_keys():
         "zombie_review_claimed_null_lease",
         "undelivered_committed",
         "worker_log_inode_exists",
+        "worker_plist_source",
         "dead_last_24h",
         "wa_media_last_24h",
     }
@@ -326,13 +328,100 @@ class _FakeConn:
         return None
 
 
+# ---------------------------------------------------------------- connect timeouts (verbale #7)
+
+
+def test_connect_sets_session_statement_timeout_and_connect_timeout(tmp_path, monkeypatch):
+    # Records the actual args/kwargs asyncpg.connect() was called with — a
+    # fake connection object at the connect boundary, not just a canned
+    # return value, so a regression to the un-timed-out connect call is
+    # caught even though every individual query still "succeeds" in the fake.
+    recorded = {}
+
+    async def _recording_connect(dsn, **kwargs):
+        recorded["dsn"] = dsn
+        recorded["kwargs"] = kwargs
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _recording_connect)
+    monkeypatch.setattr(ihr, "_tg_notify", lambda *a, **k: True)
+    monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: (tmp_path / "does-not-exist.log", "repo"))
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+
+    assert rc == 0
+    assert recorded["kwargs"].get("timeout") is not None and recorded["kwargs"]["timeout"] <= 20
+    assert recorded["kwargs"]["server_settings"]["statement_timeout"] == "120000"
+    assert recorded["kwargs"]["server_settings"]["default_transaction_read_only"] == "on"
+
+
+# ---------------------------------------------------------------- worker plist resolution (verbale #8)
+
+
+def test_resolve_worker_plist_path_prefers_installed_over_repo(tmp_path, monkeypatch):
+    installed = tmp_path / "installed.plist"
+    installed.write_text("<plist></plist>")
+    monkeypatch.setattr(ihr, "INSTALLED_WORKER_PLIST_PATH", installed)
+
+    path, source = ihr.resolve_worker_plist_path()
+
+    assert path == installed
+    assert source == "installed"
+
+
+def test_resolve_worker_plist_path_falls_back_to_repo_when_installed_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(ihr, "INSTALLED_WORKER_PLIST_PATH", tmp_path / "does-not-exist.plist")
+
+    path, source = ihr.resolve_worker_plist_path()
+
+    assert path == ihr.REPO_WORKER_PLIST_PATH
+    assert source == "repo"
+
+
+def test_worker_log_path_reads_installed_plist_when_present(tmp_path, monkeypatch):
+    import plistlib
+
+    installed = tmp_path / "installed.plist"
+    installed.write_bytes(plistlib.dumps({"StandardErrorPath": str(tmp_path / "worker.err.log")}))
+    monkeypatch.setattr(ihr, "INSTALLED_WORKER_PLIST_PATH", installed)
+
+    log_path, source = ihr.worker_log_path()
+
+    assert log_path == tmp_path / "worker.err.log"
+    assert source == "installed"
+
+
+def test_report_records_worker_plist_source(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(ihr, "_tg_notify", lambda *a, **k: True)
+    monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: (tmp_path / "does-not-exist.log", "installed"))
+
+    async def _fake_connect(*_args, **_kwargs):
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _fake_connect)
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"worker_plist_source": "installed"' in out
+
+
 def test_dry_run_sends_no_telegram_and_writes_no_state(tmp_path, monkeypatch):
     sent = []
     monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: sent.append((tier, key)) or True)
     monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
     monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
     monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
-    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: (tmp_path / "does-not-exist.log", "repo"))
 
     async def _fake_connect(*_args, **_kwargs):
         return _FakeConn()
@@ -353,7 +442,7 @@ def test_non_dry_run_writes_state_and_sends_digest(tmp_path, monkeypatch):
     monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
     monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
     monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
-    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: (tmp_path / "does-not-exist.log", "repo"))
 
     async def _fake_connect(*_args, **_kwargs):
         return _FakeConn()
@@ -377,7 +466,7 @@ def test_json_only_skips_all_side_effects(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: sent.append(("heartbeat", a)))
     monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
     monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
-    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: (tmp_path / "does-not-exist.log", "repo"))
 
     async def _fake_connect(*_args, **_kwargs):
         return _FakeConn()
@@ -400,7 +489,7 @@ def test_digest_dedup_key_is_date_stamped_not_a_bare_constant(tmp_path, monkeypa
     monkeypatch.setattr(ihr, "_heartbeat", lambda *a, **k: None)
     monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
     monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
-    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: (tmp_path / "does-not-exist.log", "repo"))
 
     async def _fake_connect(*_args, **_kwargs):
         return _FakeConn()
@@ -423,7 +512,7 @@ def test_heartbeat_is_ok_even_with_breaches_organ_not_finding(tmp_path, monkeypa
     monkeypatch.setattr(ihr, "_heartbeat", lambda status, note="": hb.append((status, note)))
     monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
     monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
-    monkeypatch.setattr(ihr, "worker_log_path", lambda: tmp_path / "does-not-exist.log")
+    monkeypatch.setattr(ihr, "worker_log_path", lambda: (tmp_path / "does-not-exist.log", "repo"))
 
     async def _fake_connect(*_args, **_kwargs):
         return _FakeConn()

--- a/scripts/tests/test_wa_mirror_freshness_liveness.py
+++ b/scripts/tests/test_wa_mirror_freshness_liveness.py
@@ -136,6 +136,17 @@ def test_count_dead_lines_none_when_script_output_unavailable():
     assert wmfl.count_dead_lines(None) is None
 
 
+# ---------------------------------------------------------------- SQL shape (bridge-writer filter, verbale #3)
+
+
+def test_freshness_sql_filters_to_the_wa_mirror_bridge_writer():
+    # whatsapp_message_context is shared with the legacy meta_cloud_api
+    # writer (migration 173) — without this filter a dead wa-mirror bridge
+    # is masked by the other writer still inserting rows.
+    assert "whatsapp_message_context" in wmfl.FRESHNESS_SQL
+    assert "source = 'wa_mirror'" in wmfl.FRESHNESS_SQL
+
+
 # ---------------------------------------------------------------- dedup key stability
 
 

--- a/scripts/tests/test_wa_mirror_freshness_liveness.py
+++ b/scripts/tests/test_wa_mirror_freshness_liveness.py
@@ -14,6 +14,7 @@ Run:  python3 scripts/tests/test_wa_mirror_freshness_liveness.py
 from __future__ import annotations
 
 import asyncio
+import json
 import pathlib
 import sys
 from datetime import datetime, timedelta
@@ -70,6 +71,41 @@ def test_in_business_hours_boundary_end_hour_exclusive():
     assert wmfl.in_business_hours(now_wita, start_hour=8, end_hour=20, business_days={0, 1, 2, 3, 4, 5}) is False
 
 
+# ---------------------------------------------------------------- business-time reference (verbale #1)
+
+
+def test_business_hours_open_wita_floors_to_start_hour():
+    now_wita = datetime(2026, 8, 17, 14, 37, tzinfo=wmfl.WITA)  # Monday afternoon
+    opened = wmfl.business_hours_open_wita(now_wita, start_hour=8)
+    assert opened == datetime(2026, 8, 17, 8, 0, tzinfo=wmfl.WITA)
+
+
+def test_business_reference_uses_newest_when_newer_than_open():
+    now_wita = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)  # Monday noon
+    newest = datetime(2026, 8, 17, 11, 30, tzinfo=wmfl.WITA)  # 11:30 today
+    ref = wmfl.business_reference(newest, now_wita, start_hour=8)
+    assert ref == newest
+
+
+def test_business_reference_floors_at_today_open_for_overnight_message():
+    now_wita = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)  # Monday noon
+    newest = datetime(2026, 8, 17, 5, 0, tzinfo=wmfl.WITA)  # overnight, before open
+    ref = wmfl.business_reference(newest, now_wita, start_hour=8)
+    assert ref == datetime(2026, 8, 17, 8, 0, tzinfo=wmfl.WITA)
+
+
+def test_business_reference_floors_at_today_open_when_table_empty():
+    now_wita = datetime(2026, 8, 17, 11, 1, tzinfo=wmfl.WITA)  # Monday
+    ref = wmfl.business_reference(None, now_wita, start_hour=8)
+    assert ref == datetime(2026, 8, 17, 8, 0, tzinfo=wmfl.WITA)
+
+
+def test_business_age_minutes_computes_delta_from_reference():
+    ref = datetime(2026, 8, 17, 8, 0, tzinfo=wmfl.WITA)
+    now_wita = datetime(2026, 8, 17, 11, 1, tzinfo=wmfl.WITA)
+    assert wmfl.business_age_minutes(ref, now_wita) == 181.0
+
+
 # ---------------------------------------------------------------- DEAD-count parsing (canned, fake numbers)
 
 # Fake wa-mirror-launcher status.sh table — masked per repo convention: fake
@@ -119,18 +155,22 @@ class _FakeConn:
     def __init__(self, newest):
         self._newest = newest
 
-    async def fetchrow(self, query, *args):
+    async def fetchrow(self, query, *args, **kwargs):
         assert "whatsapp_message_context" in query
         return {"newest": self._newest}
 
 
-def _run_tick(newest, now_wita, *, dry_run, monkeypatch, tmp_path, status_output=None):
+def _run_tick(newest, now_wita, *, dry_run, monkeypatch, tmp_path, status_output=None,
+              max_age_min="180", prior_state=None):
     sent = []
+    state_path = tmp_path / "state.json"
+    if prior_state is not None:
+        state_path.write_text(json.dumps(prior_state), encoding="utf-8")
     monkeypatch.setattr(wmfl, "_tg_notify", lambda tier, key, text: sent.append((tier, key, text)) or True)
     monkeypatch.setattr(wmfl, "_heartbeat", lambda *a, **k: None)
-    monkeypatch.setattr(wmfl, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(wmfl, "STATE_PATH", state_path)
     monkeypatch.setattr(wmfl, "_run_status_script", lambda: status_output)
-    monkeypatch.setenv("WA_FRESHNESS_MAX_AGE_MIN", "360")
+    monkeypatch.setenv("WA_FRESHNESS_MAX_AGE_MIN", max_age_min)
     monkeypatch.setenv("WA_FRESHNESS_BUSINESS_START", "8")
     monkeypatch.setenv("WA_FRESHNESS_BUSINESS_END", "20")
     monkeypatch.setenv("WA_FRESHNESS_BUSINESS_DAYS", "0,1,2,3,4,5")
@@ -140,9 +180,14 @@ def _run_tick(newest, now_wita, *, dry_run, monkeypatch, tmp_path, status_output
     return rc, sent
 
 
-def test_guilt_stale_in_business_hours_sends_exactly_one_p0(tmp_path, monkeypatch):
+# New default (verbale #1): WA_FRESHNESS_MAX_AGE_MIN=180 (3h), evaluated
+# against a business-hours-adjusted reference — max(newest, today's 08:00).
+
+
+def test_guilt_overnight_message_ages_past_threshold_into_the_morning(tmp_path, monkeypatch):
+    # newest=Mon 05:00, now=Mon 12:00 -> ref=Mon 08:00, business_age=240 > 180.
     now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)  # Monday noon
-    newest = now - timedelta(hours=7)  # 420min > 360min threshold
+    newest = datetime(2026, 8, 17, 5, 0, tzinfo=wmfl.WITA)
     rc, sent = _run_tick(
         newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path,
         status_output=_CANNED_STATUS_TABLE_ALL_DEAD,
@@ -153,12 +198,50 @@ def test_guilt_stale_in_business_hours_sends_exactly_one_p0(tmp_path, monkeypatc
     assert p0_sends[0][1] == wmfl.DEDUP_KEY
 
 
-def test_innocence_stale_outside_business_hours_sends_nothing(tmp_path, monkeypatch):
-    now = datetime(2026, 8, 17, 3, 0, tzinfo=wmfl.WITA)  # Monday 03:00 — night
-    newest = now - timedelta(hours=7)
+def test_innocence_quiet_overnight_gap_never_pages_at_next_morning_open(tmp_path, monkeypatch):
+    # newest=Mon 19:55, now=Tue 09:00 -> ref=Tue 08:00, business_age=60 <= 180.
+    # This is exactly the false-P0 shape the refuter caught pre-fix.
+    now = datetime(2026, 8, 18, 9, 0, tzinfo=wmfl.WITA)  # Tuesday
+    newest = datetime(2026, 8, 17, 19, 55, tzinfo=wmfl.WITA)  # Monday 19:55
     rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
     assert rc == 0
     assert sent == []
+
+
+def test_innocence_weekend_gap_never_pages_monday_mid_morning(tmp_path, monkeypatch):
+    # newest=Sat 19:00, now=Mon 10:30 -> ref=Mon 08:00, business_age=150 <= 180.
+    now = datetime(2026, 8, 17, 10, 30, tzinfo=wmfl.WITA)  # Monday
+    newest = datetime(2026, 8, 15, 19, 0, tzinfo=wmfl.WITA)  # Saturday 19:00
+    rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    assert sent == []
+
+
+def test_guilt_weekend_gap_pages_once_past_threshold_monday(tmp_path, monkeypatch):
+    # newest=Sat 19:00, now=Mon 11:01 -> ref=Mon 08:00, business_age=181 > 180.
+    now = datetime(2026, 8, 17, 11, 1, tzinfo=wmfl.WITA)  # Monday
+    newest = datetime(2026, 8, 15, 19, 0, tzinfo=wmfl.WITA)  # Saturday 19:00
+    rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    p0_sends = [s for s in sent if s[0] == "p0"]
+    assert len(p0_sends) == 1
+
+
+def test_innocence_sunday_never_pages_regardless_of_age(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 16, 15, 0, tzinfo=wmfl.WITA)  # Sunday afternoon
+    newest = datetime(2026, 8, 10, 0, 0, tzinfo=wmfl.WITA)  # a week stale
+    rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    assert sent == []
+
+
+def test_guilt_null_newest_pages_past_threshold_in_business_hours(tmp_path, monkeypatch):
+    # table has never had a row -> ref floors at today_open regardless.
+    now = datetime(2026, 8, 17, 11, 1, tzinfo=wmfl.WITA)  # Monday
+    rc, sent = _run_tick(None, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    p0_sends = [s for s in sent if s[0] == "p0"]
+    assert len(p0_sends) == 1
 
 
 def test_innocence_fresh_in_business_hours_sends_nothing(tmp_path, monkeypatch):
@@ -171,11 +254,78 @@ def test_innocence_fresh_in_business_hours_sends_nothing(tmp_path, monkeypatch):
 
 def test_dry_run_never_sends_even_when_stale_in_business_hours(tmp_path, monkeypatch):
     now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
-    newest = now - timedelta(hours=7)
+    newest = datetime(2026, 8, 17, 5, 0, tzinfo=wmfl.WITA)
     rc, sent = _run_tick(newest, now, dry_run=True, monkeypatch=monkeypatch, tmp_path=tmp_path)
     assert rc == 0
     assert sent == []
     assert not (tmp_path / "state.json").exists()
+
+
+# ---------------------------------------------------------------- alerted persisted BEFORE write (verbale #5)
+
+
+def test_alerted_flag_is_persisted_in_the_written_state_file(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = datetime(2026, 8, 17, 5, 0, tzinfo=wmfl.WITA)  # guilty -> pages
+    rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    written = json.loads((tmp_path / "state.json").read_text())
+    assert written["alerted"] is True
+
+
+def test_innocent_tick_persists_alerted_false(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = now - timedelta(minutes=5)
+    rc, sent = _run_tick(newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path)
+    assert rc == 0
+    written = json.loads((tmp_path / "state.json").read_text())
+    assert written["alerted"] is False
+
+
+# ---------------------------------------------------------------- recovered digest (verbale #1 follow-on)
+
+
+def test_recovered_digest_sent_when_previous_alerted_and_now_fresh(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = now - timedelta(minutes=5)  # fresh now
+    rc, sent = _run_tick(
+        newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path,
+        prior_state={"alerted": True},
+    )
+    assert rc == 0
+    digests = [s for s in sent if s[0] == "digest"]
+    assert len(digests) == 1
+    assert digests[0][1] == f"wa-mirror:freshness:recovered:{now.strftime('%Y-%m-%d')}"
+
+
+def test_no_recovered_digest_when_previous_was_not_alerted(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = now - timedelta(minutes=5)
+    rc, sent = _run_tick(
+        newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path,
+        prior_state={"alerted": False},
+    )
+    assert rc == 0
+    assert sent == []
+
+
+def test_no_recovered_digest_when_still_stale(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = datetime(2026, 8, 17, 5, 0, tzinfo=wmfl.WITA)  # still stale
+    rc, sent = _run_tick(
+        newest, now, dry_run=False, monkeypatch=monkeypatch, tmp_path=tmp_path,
+        prior_state={"alerted": True},
+    )
+    assert rc == 0
+    digests = [s for s in sent if s[0] == "digest"]
+    assert digests == []
+    p0_sends = [s for s in sent if s[0] == "p0"]
+    assert len(p0_sends) == 1
+
+
+def test_dedup_key_recovered_is_date_stamped():
+    now_wita = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    assert wmfl.recovered_dedup_key(now_wita) == "wa-mirror:freshness:recovered:2026-08-17"
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_wa_mirror_freshness_liveness.py
+++ b/scripts/tests/test_wa_mirror_freshness_liveness.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import pathlib
 import sys
 from datetime import datetime, timedelta
@@ -376,6 +377,48 @@ class _StubConn:
         return None
 
 
+def test_run_level_kill_switch_never_reaches_the_dsn(monkeypatch):
+    # verbale #10c: the freshness test suite never called run() at all — the
+    # kill switch, lock/flock logic and DB-connect gating were entirely
+    # untested. A fake DSN that raises if asyncpg.connect is ever invoked
+    # proves the disabled path short-circuits BEFORE touching the network,
+    # not merely that it returns 0.
+    hb = []
+    monkeypatch.setattr(wmfl, "_heartbeat", lambda status, note="": hb.append((status, note)))
+    monkeypatch.setenv("WA_MIRROR_FRESHNESS_LIVENESS_ENABLED", "false")
+    monkeypatch.setenv("INTAKE_DATABASE_URL", "postgresql://unreachable-host-must-not-be-dialed/db")
+
+    async def _must_not_be_called(*_args, **_kwargs):
+        raise AssertionError("asyncpg.connect must not be reached when the kill switch is off")
+
+    monkeypatch.setattr(wmfl.asyncpg, "connect", _must_not_be_called)
+
+    rc = asyncio.run(wmfl.run(dry_run=False))
+
+    assert rc == 0
+    assert hb == [("disabled", "WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false")]
+
+
+def test_run_level_kill_switch_accepts_case_insensitive_0(monkeypatch):
+    hb = []
+    monkeypatch.setattr(wmfl, "_heartbeat", lambda status, note="": hb.append((status, note)))
+    monkeypatch.setenv("WA_MIRROR_FRESHNESS_LIVENESS_ENABLED", "0")
+    monkeypatch.setenv("INTAKE_DATABASE_URL", "postgresql://unreachable-host-must-not-be-dialed/db")
+
+    async def _must_not_be_called(*_args, **_kwargs):
+        raise AssertionError("asyncpg.connect must not be reached when the kill switch is off")
+
+    monkeypatch.setattr(wmfl.asyncpg, "connect", _must_not_be_called)
+
+    rc = asyncio.run(wmfl.run(dry_run=False))
+
+    assert rc == 0
+    # note text is a fixed literal regardless of which accepted spelling
+    # ("0"/"false"/"no") the caller used — only the short-circuit itself
+    # (never dialing the DSN) is what this test exists to prove.
+    assert hb == [("disabled", "WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false")]
+
+
 def test_run_heartbeats_error_and_exits_2_on_uncaught_tick_exception(tmp_path, monkeypatch):
     hb = []
     monkeypatch.setattr(wmfl, "_heartbeat", lambda status, note="": hb.append((status, note)))
@@ -396,6 +439,25 @@ def test_run_heartbeats_error_and_exits_2_on_uncaught_tick_exception(tmp_path, m
 
     assert rc == 2
     assert hb and hb[-1][0] == "error"
+
+
+# ---------------------------------------------------------------- lock file chmod hardening (verbale #9)
+
+
+def test_acquire_lock_hardens_a_pre_existing_loose_lock_file(tmp_path, monkeypatch):
+    lock = tmp_path / "state" / "wa_mirror_freshness_liveness.lock"
+    lock.parent.mkdir(parents=True)
+    lock.write_text("")
+    lock.chmod(0o644)  # simulate a pre-hardening-era lock file already on disk
+    monkeypatch.setattr(wmfl, "LOCK_FILE", lock)
+
+    fd = wmfl._acquire_lock_or_exit()
+    try:
+        assert fd is not None
+        assert (lock.stat().st_mode & 0o777) == 0o600
+    finally:
+        if fd is not None:
+            os.close(fd)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_wa_mirror_freshness_liveness.py
+++ b/scripts/tests/test_wa_mirror_freshness_liveness.py
@@ -328,6 +328,65 @@ def test_dedup_key_recovered_is_date_stamped():
     assert wmfl.recovered_dedup_key(now_wita) == "wa-mirror:freshness:recovered:2026-08-17"
 
 
+# ---------------------------------------------------------------- heartbeat reflects the ORGAN, not the finding (verbale #2)
+
+
+def test_heartbeat_is_ok_even_when_stale_organ_not_finding(tmp_path, monkeypatch):
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=wmfl.WITA)
+    newest = datetime(2026, 8, 17, 5, 0, tzinfo=wmfl.WITA)  # stale -> would have been "degraded" pre-fix
+    hb = []
+    monkeypatch.setattr(wmfl, "_tg_notify", lambda *a, **k: True)
+    monkeypatch.setattr(wmfl, "_heartbeat", lambda status, note="": hb.append((status, note)))
+    monkeypatch.setattr(wmfl, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(wmfl, "_run_status_script", lambda: None)
+    monkeypatch.setenv("WA_FRESHNESS_MAX_AGE_MIN", "180")
+    monkeypatch.setenv("WA_FRESHNESS_BUSINESS_START", "8")
+    monkeypatch.setenv("WA_FRESHNESS_BUSINESS_END", "20")
+    monkeypatch.setenv("WA_FRESHNESS_BUSINESS_DAYS", "0,1,2,3,4,5")
+
+    conn = _FakeConn(newest)
+    rc = asyncio.run(wmfl._tick(conn, now, dry_run=False))
+
+    assert rc == 0
+    assert len(hb) == 1
+    status, note = hb[0]
+    assert status == "ok"
+    assert "stale=True" in note
+
+
+# ---------------------------------------------------------------- run() wraps the whole tick, never exits uncaught (verbale #6)
+
+
+class _StubConn:
+    async def fetchrow(self, query, *args, **kwargs):
+        return {"newest": None}
+
+    async def close(self):
+        return None
+
+
+def test_run_heartbeats_error_and_exits_2_on_uncaught_tick_exception(tmp_path, monkeypatch):
+    hb = []
+    monkeypatch.setattr(wmfl, "_heartbeat", lambda status, note="": hb.append((status, note)))
+    monkeypatch.setattr(wmfl, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(wmfl, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setenv("WA_MIRROR_FRESHNESS_LIVENESS_ENABLED", "true")
+    # A garbage env value is parsed OUTSIDE the connect-phase try/except (it
+    # lives inside _tick), so pre-fix this propagated to Python's default
+    # exit 1 with a bare traceback and no heartbeat at all.
+    monkeypatch.setenv("WA_FRESHNESS_MAX_AGE_MIN", "not-a-number")
+
+    async def _fake_connect(*_args, **_kwargs):
+        return _StubConn()
+
+    monkeypatch.setattr(wmfl.asyncpg, "connect", _fake_connect)
+
+    rc = asyncio.run(wmfl.run(dry_run=True))
+
+    assert rc == 2
+    assert hb and hb[-1][0] == "error"
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/scripts/wa_mirror_freshness_liveness.py
+++ b/scripts/wa_mirror_freshness_liveness.py
@@ -292,7 +292,7 @@ async def _tick(conn: Any, now_wita: datetime, *, dry_run: bool) -> int:
     end_hour = int(os.getenv("WA_FRESHNESS_BUSINESS_END", "20"))
     business_days = _business_days_from_env()
 
-    row = await conn.fetchrow(FRESHNESS_SQL)
+    row = await conn.fetchrow(FRESHNESS_SQL, timeout=30)
     newest = row["newest"]
     business = in_business_hours(
         now_wita, start_hour=start_hour, end_hour=end_hour, business_days=business_days
@@ -342,9 +342,16 @@ async def _tick(conn: Any, now_wita: datetime, *, dry_run: bool) -> int:
     if not dry_run:
         _write_state(state)
 
+    # The heartbeat reflects the ORGAN (did the tick complete?), never the
+    # FINDING (is the mirror stale?) — verbale #2: an unconditional
+    # "degraded" heartbeat on every stale tick made healer_receptor_registry
+    # classify this healthy organ as dead (HEALTHY_STATUSES has no
+    # "degraded") and spawn an auto-remediation session against it, on
+    # ordinary quiet nights. "error" is reserved for the outer try/except in
+    # run() — an exception, never a clean tick with an unwelcome result.
     _heartbeat(
-        "degraded" if stale else "ok",
-        note=f"business_age_min={round(business_age_min, 1)} business_hours={business}",
+        "ok",
+        note=f"stale={stale} business={business} business_age_min={round(business_age_min, 1)} alerted={alerted}",
     )
 
     return 0
@@ -365,7 +372,7 @@ async def run(*, dry_run: bool) -> int:
         dsn = os.getenv("INTAKE_DATABASE_URL") or os.getenv("LOCAL_DATABASE_URL") or DEFAULT_DSN
         try:
             conn = await asyncpg.connect(
-                dsn, server_settings={"default_transaction_read_only": "on"}
+                dsn, server_settings={"default_transaction_read_only": "on"}, timeout=20
             )
         except Exception as exc:  # noqa: BLE001
             logger.error("[wa_freshness] DB connect failed: %s", exc)
@@ -375,6 +382,16 @@ async def run(*, dry_run: bool) -> int:
         try:
             now_wita = datetime.now(WITA)
             return await _tick(conn, now_wita, dry_run=dry_run)
+        except Exception as exc:  # noqa: BLE001 — the whole tick (env parsing
+            # included, verbale #6) must never exit uncaught: a mid-tick
+            # failure (garbage env value, a non-connect-phase DB error) used
+            # to propagate to Python's default exit 1 with a bare traceback
+            # and no _heartbeat("error", ...) at all, contradicting this
+            # module's own documented exit contract and leaving the healer
+            # sentinel to misdiagnose a config/error fault as staleness.
+            logger.error("[wa_freshness] tick failed: %s", exc)
+            _heartbeat("error", f"tick failed: {exc}")
+            return 2
         finally:
             await conn.close()
     finally:

--- a/scripts/wa_mirror_freshness_liveness.py
+++ b/scripts/wa_mirror_freshness_liveness.py
@@ -9,6 +9,24 @@ it reads the newest whatsapp_message_context row and, ONLY during business
 hours (so an overnight quiet line — Law 6, disconnection is natural — never
 pages anyone), alerts once when that row is older than the freshness window.
 
+BUSINESS-TIME STALENESS (post-refuter fix, verbale #1, 2026-08-17): staleness
+is measured against a business-hours-adjusted REFERENCE, not the raw age of
+the newest row. The 12h overnight gap (20:00 close -> 08:00 reopen, Asia/
+Makassar) is longer than any sane intraday freshness window, so comparing raw
+age against a flat threshold guaranteed a false P0 on the FIRST in-business-
+hours tick after every ordinary quiet night (proven live: the PR's own
+"guilt" test used a 7h overnight gap and asserted a P0 — indistinguishable
+from a real outage). The fix: `ref = max(newest, today_open)` where
+`today_open` is today's business-start instant in WITA. A message from last
+night floors at today's open, so the clock effectively starts fresh at
+08:00 — staleness now measures "how long INTO the business day has this been
+quiet", never "how long since the office closed". WA_FRESHNESS_MAX_AGE_MIN's
+default therefore drops from 360 (6h — sized to survive the false-positive
+overnight gap) to 180 (3h — sized to the actual intraday risk, now that the
+overnight gap no longer inflates the age). Outside business hours the organ
+never evaluates staleness at all (business=False short-circuits before the
+threshold comparison) — a quiet night is Law 6, not a fault.
+
 Secondary signal (best-effort, tolerates absence): counts "DEAD" lines out of
 `bash ~/scripts/wa-mirror-launcher/status.sh` — the per-employee bridge
 process table — and folds the count into the alert text. Absence of that
@@ -23,14 +41,15 @@ clock + fake rows + fake tg without touching the DB or network).
 Env:
   INTAKE_DATABASE_URL / LOCAL_DATABASE_URL   DSN (default local nuzantara_dev)
   WA_MIRROR_FRESHNESS_LIVENESS_ENABLED       kill switch (default true) — G5
-  WA_FRESHNESS_MAX_AGE_MIN                   default 360 (6h) — staleness threshold
+  WA_FRESHNESS_MAX_AGE_MIN                   default 180 (3h) — business-hours-adjusted staleness threshold (see above)
   WA_FRESHNESS_BUSINESS_START                default 8  (WITA hour, inclusive)
   WA_FRESHNESS_BUSINESS_END                  default 20 (WITA hour, exclusive)
   WA_FRESHNESS_BUSINESS_DAYS                 default "0,1,2,3,4,5" (Mon=0..Sun=6; Mon-Sat)
   WA_MIRROR_STATUS_SCRIPT                    default ~/scripts/wa-mirror-launcher/status.sh
   WA_FRESHNESS_DRY_RUN=1                     same as --dry-run
 
-Exit: 0 always, except a DSN/connect failure (logged, heartbeat status=error) -> 2.
+Exit: 0 always, except a DSN/connect failure or an uncaught tick error
+(logged, heartbeat status=error) -> 2.
 """
 from __future__ import annotations
 
@@ -126,6 +145,19 @@ def _write_state(state: dict[str, Any]) -> None:
         logger.warning("[wa_freshness] state write failed: %s", exc)
 
 
+def _read_state() -> dict[str, Any] | None:
+    """Best-effort read of the previous tick's state file — used only to
+    detect a stale->fresh transition for the recovered digest. Never raises;
+    a missing/corrupt file just means "no prior state to compare against"."""
+    try:
+        if not STATE_PATH.is_file():
+            return None
+        return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        logger.warning("[wa_freshness] state read failed: %s", exc)
+        return None
+
+
 def _acquire_lock_or_exit() -> int | None:
     LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o600)
@@ -194,14 +226,56 @@ def in_business_hours(
     return now_wita.weekday() in business_days and start_hour <= now_wita.hour < end_hour
 
 
+def business_hours_open_wita(now_wita: datetime, *, start_hour: int) -> datetime:
+    """Today's business-open instant in WITA — the staleness reference floor
+    (verbale #1): a message received before this instant never counts as
+    "old" beyond how long the business day has been open."""
+    return now_wita.replace(hour=start_hour, minute=0, second=0, microsecond=0)
+
+
+def business_reference(
+    newest: datetime | None, now_wita: datetime, *, start_hour: int
+) -> datetime:
+    """max(newest, today_open) in WITA. A NULL table (never a row) also
+    floors at today_open — never "since epoch", which would report a
+    meaningless multi-year age instead of the intended maximally-stale-for-
+    today signal."""
+    today_open = business_hours_open_wita(now_wita, start_hour=start_hour)
+    if newest is None:
+        return today_open
+    newest_wita = (
+        newest.astimezone(WITA)
+        if newest.tzinfo is not None
+        else newest.replace(tzinfo=timezone.utc).astimezone(WITA)
+    )
+    return max(newest_wita, today_open)
+
+
+def business_age_minutes(ref: datetime, now_wita: datetime) -> float:
+    return (now_wita - ref).total_seconds() / 60.0
+
+
 def build_alert_text(age_min: float | None, dead_count: int | None) -> str:
     age_txt = "never (table empty)" if age_min is None else f"{age_min:.0f} min"
     dead_txt = "n/a" if dead_count is None else str(dead_count)
     return (
         f"🔴 WA mirror FRESHNESS stale — newest message context row is {age_txt} old "
-        f"(bridge DEAD lines: {dead_txt}). During business hours this reads as intake "
-        f"CIECO on WhatsApp, not quiet. Check: bash ~/scripts/wa-mirror-launcher/status.sh"
+        f"(business-hours reference; bridge DEAD lines: {dead_txt}). During business "
+        f"hours this reads as intake CIECO on WhatsApp, not quiet. "
+        f"Check: bash ~/scripts/wa-mirror-launcher/status.sh"
     )
+
+
+def build_recovered_text(business_age_min: float) -> str:
+    return (
+        f"✅ WA mirror FRESHNESS recovered — newest message context row is now "
+        f"{business_age_min:.0f} min old (business-hours reference), back under the "
+        f"threshold after a prior P0."
+    )
+
+
+def recovered_dedup_key(now_wita: datetime) -> str:
+    return f"wa-mirror:freshness:recovered:{now_wita.strftime('%Y-%m-%d')}"
 
 
 def _business_days_from_env() -> set[int]:
@@ -213,45 +287,66 @@ def _business_days_from_env() -> set[int]:
 
 
 async def _tick(conn: Any, now_wita: datetime, *, dry_run: bool) -> int:
-    max_age_min = float(os.getenv("WA_FRESHNESS_MAX_AGE_MIN", "360"))
+    max_age_min = float(os.getenv("WA_FRESHNESS_MAX_AGE_MIN", "180"))
     start_hour = int(os.getenv("WA_FRESHNESS_BUSINESS_START", "8"))
     end_hour = int(os.getenv("WA_FRESHNESS_BUSINESS_END", "20"))
     business_days = _business_days_from_env()
 
     row = await conn.fetchrow(FRESHNESS_SQL)
     newest = row["newest"]
-    age_min = age_minutes(newest, now_wita)
-    stale = is_stale(age_min, max_age_min)
     business = in_business_hours(
         now_wita, start_hour=start_hour, end_hour=end_hour, business_days=business_days
     )
+    ref = business_reference(newest, now_wita, start_hour=start_hour)
+    business_age_min = business_age_minutes(ref, now_wita)
+    # Outside business hours the organ never evaluates staleness at all —
+    # an overnight/Sunday quiet line is Law 6, not a fault (verbale #1).
+    stale = business and is_stale(business_age_min, max_age_min)
+    raw_age_min = age_minutes(newest, now_wita)
     dead_count = count_dead_lines(_run_status_script())
+
+    previous_state = _read_state()
+    previously_alerted = bool(previous_state.get("alerted")) if previous_state else False
+
+    logger.info(
+        "[wa_freshness] business_age_min=%s stale=%s business_hours=%s dead=%s",
+        round(business_age_min, 1), stale, business, dead_count,
+    )
+
+    # `alerted` is computed BEFORE _write_state (verbale #5) so the persisted
+    # state file — which the NEXT tick reads back for recovered-detection —
+    # actually carries whether this tick paged.
+    alerted = False
+    recovered_sent = False
+    if stale and business and not dry_run:
+        alerted = _tg_notify("p0", DEDUP_KEY, build_alert_text(raw_age_min, dead_count))
+    elif previously_alerted and not stale and not dry_run:
+        recovered_sent = _tg_notify(
+            "digest", recovered_dedup_key(now_wita), build_recovered_text(business_age_min)
+        )
 
     state = {
         "generated_at": now_wita.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "newest_created_at": newest.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         if newest else None,
-        "age_minutes": round(age_min, 1) if age_min is not None else None,
+        "age_minutes": round(raw_age_min, 1) if raw_age_min is not None else None,
+        "business_age_minutes": round(business_age_min, 1),
         "stale": stale,
         "business_hours": business,
         "dead_bridge_count": dead_count,
         "max_age_minutes": max_age_min,
+        "alerted": alerted,
+        "recovered_sent": recovered_sent,
     }
-
-    logger.info(
-        "[wa_freshness] age=%s stale=%s business_hours=%s dead=%s",
-        state["age_minutes"], stale, business, dead_count,
-    )
 
     if not dry_run:
         _write_state(state)
 
-    _heartbeat("degraded" if stale else "ok", note=f"age_min={state['age_minutes']} business_hours={business}")
+    _heartbeat(
+        "degraded" if stale else "ok",
+        note=f"business_age_min={round(business_age_min, 1)} business_hours={business}",
+    )
 
-    alerted = False
-    if stale and business and not dry_run:
-        alerted = _tg_notify("p0", DEDUP_KEY, build_alert_text(age_min, dead_count))
-    state["alerted"] = alerted
     return 0
 
 

--- a/scripts/wa_mirror_freshness_liveness.py
+++ b/scripts/wa_mirror_freshness_liveness.py
@@ -169,6 +169,15 @@ def _read_state() -> dict[str, Any] | None:
 def _acquire_lock_or_exit() -> int | None:
     LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_RDWR, 0o600)
+    # O_CREAT's mode argument only applies when the file is CREATED (verbale
+    # #9) — it does not retroactively chmod a lock file that already exists
+    # on disk from an earlier pre-hardening run. Mirrors tg_notify.py's
+    # harden() rationale (same repo, same PR family, and the exact lesson
+    # tg_notify.py already documents in its own docstring).
+    try:
+        os.chmod(LOCK_FILE, 0o600)
+    except OSError as exc:  # noqa: BLE001 — never let a chmod failure block the lock
+        logger.warning("[wa_freshness] lock chmod failed: %s", exc)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         return fd

--- a/scripts/wa_mirror_freshness_liveness.py
+++ b/scripts/wa_mirror_freshness_liveness.py
@@ -93,7 +93,15 @@ _PY3_CANDIDATES: tuple[str, ...] = (
     "/usr/local/bin/python3",
 )
 
-FRESHNESS_SQL = "SELECT max(created_at) AS newest FROM whatsapp_message_context"
+# whatsapp_message_context is shared by two writers (migration 173 adds
+# `source VARCHAR(32) NOT NULL DEFAULT 'meta_cloud_api'`) — verbale #3.
+# Verified live 2026-08-17 (READ-ONLY psql, no PII beyond aggregate counts):
+# source='wa_mirror' 94,487 rows / source='meta_cloud_api' 14,049 rows — the
+# legacy path is NOT dormant. Without this filter a completely dead wa-mirror
+# bridge would never trip this check: max(created_at) stays fresh off the
+# other writer, and this organ would report healthy while the bridge it
+# exists to watch is down.
+FRESHNESS_SQL = "SELECT max(created_at) AS newest FROM whatsapp_message_context WHERE source = 'wa_mirror'"
 
 
 # ---------------------------------------------------------------- side effects (module-level, monkeypatchable)

--- a/scripts/wa_mirror_freshness_liveness_run.sh
+++ b/scripts/wa_mirror_freshness_liveness_run.sh
@@ -16,11 +16,21 @@ ORGAN_ID="pro.wa_mirror_freshness_liveness"
 # shellcheck source=scripts/lib/heartbeat.sh
 source "$REPO_ROOT/scripts/lib/heartbeat.sh"
 
-if [ "${WA_MIRROR_FRESHNESS_LIVENESS_ENABLED:-true}" = "false" ]; then
-  organism_heartbeat "$ORGAN_ID" "disabled" "WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false"
-  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=false — skipping run"
-  exit 0
-fi
+# Case-insensitive, and matching the Python side's superset (0|false|no) —
+# verbale #10a: the literal-"false"-only match let WA_MIRROR_FRESHNESS_
+# LIVENESS_ENABLED=0 / =No slip past the wrapper into an interpreter spawn
+# that the Python script itself then correctly no-oped on (Python does
+# `.strip().lower() in ("0", "false", "no")`), so this was a wasted spawn
+# rather than a real bypass — but a wrapper that disagrees with the script
+# it launches about what "disabled" means is worth closing regardless.
+_wa_freshness_enabled_lc="$(printf '%s' "${WA_MIRROR_FRESHNESS_LIVENESS_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')"
+case "$_wa_freshness_enabled_lc" in
+  false|0|no)
+    organism_heartbeat "$ORGAN_ID" "disabled" "WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=$WA_MIRROR_FRESHNESS_LIVENESS_ENABLED"
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) WA_MIRROR_FRESHNESS_LIVENESS_ENABLED=$WA_MIRROR_FRESHNESS_LIVENESS_ENABLED — skipping run"
+    exit 0
+    ;;
+esac
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 PYBIN="$REPO_ROOT/apps/backend-rag/.venv/bin/python"


### PR DESCRIPTION
## What

Follow-up to #4223 (merged `656880c70`): fixes 11 real defects found by an
independent cross-family refuter review of that PR's two W0 read-only
guardians (`scripts/intake_health_report.py`,
`scripts/wa_mirror_freshness_liveness.py`). Six commits, in order:

1. **Business-hours-adjusted staleness** (`wa_mirror_freshness_liveness.py`) —
   staleness now measures against `ref = max(newest, today_open)` instead of
   raw age, so an ordinary overnight gap no longer inflates across the closed
   hours. `WA_FRESHNESS_MAX_AGE_MIN` default drops **360 → 180** (env-tunable
   either way). Also adds a "recovered" digest fired when a prior tick had
   paged and the current tick reads fresh.
2. **Heartbeat reflects the organ, not the finding** (both scripts) — was
   `_heartbeat("degraded", ...)` on every stale tick / every breach,
   unconditional on business hours in the freshness script. Now always `ok`
   when the tick/report completed; `error` only on an actual exception. Also
   wraps the whole freshness tick (env parsing included) in try/except so a
   mid-tick failure heartbeats `error` + exits 2 instead of an uncaught
   traceback and exit 1. `intake_health_report.py`'s lock-held branch now
   writes `heartbeat(error, "lock held")` + a digest line instead of exiting
   silently.
3. **Filter the freshness SQL to the bridge writer** — `whatsapp_message_context`
   is shared with the legacy `meta_cloud_api` path (migration 173). Verified
   live (read-only, aggregate counts only): `wa_mirror` 94,487 rows /
   `meta_cloud_api` 14,049 rows — the legacy writer is **not** dormant, so an
   unfiltered query really could mask a dead bridge.
4. **State/lock/dedup hygiene** — `alerted` computed before `_write_state`
   (needed by #1's recovered-digest to have anything real to read back);
   health-report digest dedup key date-stamped; lock files `os.chmod(0o600)`
   after `os.open` (mirrors `tg_notify.py`'s `harden()`); both `_run.sh`
   wrappers accept `0|false|no` case-insensitively, matching the Python side.
5. **Installed-plist preference + bounded queries** (`intake_health_report.py`) —
   prefers `~/Library/LaunchAgents/com.nuzantara.intake-worker.plist` over the
   repo copy when it exists (superscar #1 HOME-fork: the invoking checkout is
   not necessarily the one the worker was installed from), and records which
   one it read (`worker_plist_source`). Session-level `statement_timeout=120000`
   on the connection so every `gather()` query is bounded (previously only
   `_fetch_superseded_orphans` had a timeout).
6. **Doc**: TZ dependency note on `StartCalendarInterval` in the health-report
   plist (no TZ field in the launchd schema; holds only while host TZ is
   Asia/Makassar).

## Adversarial review

Seat: **qwen-3.8-max** (Qwen 3.8 Max, ModelStudio Token Plan, `qwen --safe-mode`),
cross-family refuter against merge SHA `656880c70`. All 11 findings
re-verified on disk in this branch before fixing (file:line, or a fresh
read-only DB check where the refuter itself flagged NON VERIFICABILE).

| # | Sev | Fixed in |
|---|-----|----------|
| 1 | P1 | commit 1 — business-hours-adjusted staleness reference |
| 2 | P1 | commit 2 — heartbeat `ok` unconditional on the finding |
| 3 | P1 (structural) | commit 3 — `WHERE source = 'wa_mirror'`, verified live-relevant |
| 4 | P2 | commit 4 — digest dedup key date-stamped |
| 5 | P2 | commit 1 — `alerted` computed before `_write_state` |
| 6 | P2 | commit 2 — whole tick wrapped in try/except, exit 2 |
| 7 | P2 | commit 2 (lock-held branch) + commit 5 (query timeouts) |
| 8 | P2 (structural) | commit 5 — installed-plist preference + `worker_plist_source` |
| 9 | P2 | commit 4 — `os.chmod(LOCK_FILE, 0o600)` both scripts |
| 10 | P2 | commit 4 — wrapper kill-switch case-insensitivity + new `run()`-level tests |
| 11 | P2 | commit 6 — TZ-dependency doc note |

`CONFERMATE=11 RESPINTE=0` per the refuter's own verbale.

## Policy decision for Zero

`WA_FRESHNESS_MAX_AGE_MIN` default changes **360min (6h) → 180min (3h)**.
This is safe *because* of the business-hours-reference fix landing in the
same commit (the old 360 was sized to survive the false-positive overnight
gap; the new reference no longer inflates across closed hours, so 180 is
sized to the actual intraday risk) — but it is still a threshold a human
should confirm, not something to wave through silently. Env-overridable
either way if 180 turns out too tight in practice.

## Scope discipline

- READ-ONLY toward DB/prod/launchd for the whole session: no `launchctl`
  calls, no writes against `nuzantara_dev` beyond the plain `SELECT`s used to
  verify finding #3 (reported as aggregate counts only, no PII).
- Never armed `INTAKE_WRITER_ENABLED` / `*_AUTO_ATTACH_ENABLED` /
  `IDENTITY_BACKFILL_WRITE_ENABLED` — untouched by this PR.
- Did not read `docs/mandates/2026-08-15-intake-answer-key-INTERNAL.md`.
- Auto-merge **not** armed — leaving that decision to the orchestrator per
  the mandate for this follow-up.

## Tests

- `apps/backend-rag/.venv/bin/python -m pytest scripts/tests/test_wa_mirror_freshness_liveness.py scripts/tests/test_intake_health_report.py -q`
  → **74 passed** (was 44/44 on #4223 — 37 + 37, up from 20 + 24; the
  freshness suite in particular went from never calling `run()` at all to
  covering the kill switch, lock chmod, and uncaught-exception paths).
- `ruff check` clean on both scripts + both test files.
- `bash -n` + `shellcheck` clean on both `_run.sh` wrappers (only pre-existing
  informational SC1091 on the `source` line, unrelated to this diff).
- `plutil -lint` clean on the touched plist; `scripts/lint_plist_keepalive.py --root infra/launchagents`
  → 0 findings against either touched plist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
