### PR TITLE
fix(intake): sweeper — wider transient set, CRM poison keeps the document, poison breaker, PII-safe logs (post-refuter)

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
@@ -107,8 +107,16 @@ def _row(rid: int, *, blob_path: str, bmid: str | None = None) -> dict[str, Any]
     }
 
 
-def _wire(monkeypatch, wms, *, rows, watermark_seed, upsert=None, enqueue=None):
-    """Monkeypatch everything run_one_tick() needs, none of it real I/O."""
+def _wire(
+    monkeypatch, wms, *, rows, watermark_seed, upsert=None, enqueue=None, tg_notify=None
+):
+    """Monkeypatch everything run_one_tick() needs, none of it real I/O.
+
+    ``_tg_notify`` defaults to a no-op stub: without it, the poison-breaker
+    (verbale #3) would spawn a REAL subprocess against scripts/tg_notify.py
+    on every test that hits ANY poison row, writing to the live
+    ``~/.organism/tg_spool`` outside tmp_path (W96 — test-writes-prod).
+    """
     monkeypatch.setattr(wms.asyncpg, "create_pool", _fake_create_pool(rows))
     monkeypatch.setattr(wms, "_sweep_text_clients", _noop_text_sweep)
     monkeypatch.setattr(wms, "_load_watermark", lambda: watermark_seed)
@@ -118,7 +126,12 @@ def _wire(monkeypatch, wms, *, rows, watermark_seed, upsert=None, enqueue=None):
         wms, "_upsert_client_by_phone", upsert or _default_upsert
     )
     monkeypatch.setattr(wms, "enqueue", enqueue or _default_enqueue)
+    monkeypatch.setattr(wms, "_tg_notify", tg_notify or _default_tg_notify)
     return saved
+
+
+def _default_tg_notify(_tier: str, _dedup_key: str, _text: str) -> bool:
+    return True
 
 
 def _fake_create_pool(rows: list[dict[str, Any]]):
@@ -388,3 +401,102 @@ async def test_blob_path_is_a_directory_counts_as_missing_and_advances(
     assert enqueue_calls == []
     assert saved.get("wm") == 500
     assert any("blob_missing=1" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# Poison breaker (verbale #3, post-refuter Qwen 3.8 Max, P1). The tick used to
+# `return 0` unconditionally regardless of how many rows were poisoned.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_poison_breaker_no_call_when_zero_poison(monkeypatch, tmp_path) -> None:
+    """Zero poison rows this tick -> the breaker stays completely silent."""
+    row_n = _row(600, blob_path=_write_blob(tmp_path, "n.pdf"))
+    tg_calls: list[tuple[str, str, str]] = []
+
+    def recording_tg_notify(tier: str, dedup_key: str, text: str) -> bool:
+        tg_calls.append((tier, dedup_key, text))
+        return True
+
+    wms = _load_sweeper()
+    _wire(
+        monkeypatch, wms, rows=[row_n], watermark_seed=599, tg_notify=recording_tg_notify
+    )
+
+    rc = await wms.run_one_tick()
+
+    assert rc == 0
+    assert tg_calls == []
+
+
+@pytest.mark.asyncio
+async def test_poison_breaker_digest_only_below_storm_threshold(
+    monkeypatch, tmp_path
+) -> None:
+    """One poison row, well below the storm threshold (max(5, ceil(0.2*2))=5):
+    exactly one digest-tier line, no P0, tick still returns 0."""
+    row_n = _row(700, blob_path=_write_blob(tmp_path, "n.pdf"))
+    row_n1 = _row(701, blob_path=_write_blob(tmp_path, "n1.pdf"))
+    tg_calls: list[tuple[str, str, str]] = []
+
+    def recording_tg_notify(tier: str, dedup_key: str, text: str) -> bool:
+        tg_calls.append((tier, dedup_key, text))
+        return True
+
+    async def flaky_enqueue(_pool, *, source_ref, **_kw):
+        if source_ref == f"wa-mirror:{row_n['baileys_message_id']}":
+            raise ValueError("malformed payload — permanent")
+        return SimpleNamespace(was_new=True)
+
+    wms = _load_sweeper()
+    _wire(
+        monkeypatch,
+        wms,
+        rows=[row_n, row_n1],
+        watermark_seed=699,
+        enqueue=flaky_enqueue,
+        tg_notify=recording_tg_notify,
+    )
+
+    rc = await wms.run_one_tick()
+
+    assert rc == 0
+    assert [c[0] for c in tg_calls] == ["digest"]
+    assert tg_calls[0][1].startswith("wa-mirror-sweeper:poison:")
+    assert re.search(r"(?<!crm_)\bpoison=1\b", tg_calls[0][2])
+    # Counts only — no row id or phone in the Telegram text (Law 2 / UU-PDP).
+    assert str(row_n["id"]) not in tg_calls[0][2]
+    assert row_n["sender_phone"] not in tg_calls[0][2]
+
+
+@pytest.mark.asyncio
+async def test_poison_breaker_p0_and_rc2_on_storm(monkeypatch, tmp_path) -> None:
+    """poison >= max(5, ceil(0.2*scanned)) is a STORM: a P0 fires (in addition
+    to the digest line) and the tick returns 2 so launchd marks the run
+    FAILED instead of green — the failure mode this breaker exists to catch.
+    """
+    rows = [_row(800 + i, blob_path=_write_blob(tmp_path, f"n{i}.pdf")) for i in range(5)]
+    tg_calls: list[tuple[str, str, str]] = []
+
+    def recording_tg_notify(tier: str, dedup_key: str, text: str) -> bool:
+        tg_calls.append((tier, dedup_key, text))
+        return True
+
+    async def always_poison_enqueue(_pool, *, source_ref, **_kw):
+        raise ValueError("malformed payload — permanent")
+
+    wms = _load_sweeper()
+    _wire(
+        monkeypatch,
+        wms,
+        rows=rows,
+        watermark_seed=799,
+        enqueue=always_poison_enqueue,
+        tg_notify=recording_tg_notify,
+    )
+
+    rc = await wms.run_one_tick()
+
+    assert rc == 2
+    assert [c[0] for c in tg_calls] == ["digest", "p0"]
+    assert tg_calls[1][1] == "wa-mirror-sweeper:poison-storm"
+    assert "poison=5/5" in tg_calls[1][2]

--- a/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
@@ -500,3 +500,40 @@ async def test_poison_breaker_p0_and_rc2_on_storm(monkeypatch, tmp_path) -> None
     assert [c[0] for c in tg_calls] == ["digest", "p0"]
     assert tg_calls[1][1] == "wa-mirror-sweeper:poison-storm"
     assert "poison=5/5" in tg_calls[1][2]
+
+
+# --------------------------------------------------------------------------- #
+# PII-safe error logs (verbale #6, post-refuter Qwen 3.8 Max, P2).
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_postgres_error_detail_never_reaches_the_log(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    """``asyncpg.PostgresError.__str__()`` appends DETAIL/HINT when the server
+    supplies them, and a constraint violation on a phone-keyed table (e.g.
+    ``clients.phone_normalized`` UNIQUE) can embed the raw offending phone in
+    DETAIL. A poison-row error log must summarize a Postgres exception as
+    type+sqlstate ONLY — the phone-shaped DETAIL must never reach the log
+    text (message OR any attached traceback rendering).
+    """
+    row_n = _row(1000, blob_path=_write_blob(tmp_path, "n.pdf"))
+    phone_in_detail = "6281234567890"
+
+    async def poison_enqueue(_pool, *, source_ref, **_kw):
+        exc = asyncpg.UniqueViolationError(
+            "duplicate key value violates unique constraint"
+        )
+        exc.detail = f"Key (phone_normalized)=({phone_in_detail}) already exists."
+        raise exc
+
+    wms = _load_sweeper()
+    _wire(monkeypatch, wms, rows=[row_n], watermark_seed=999, enqueue=poison_enqueue)
+
+    with caplog.at_level(logging.INFO, logger="wa_mirror_sweeper"):
+        rc = await wms.run_one_tick()
+
+    assert rc == 0
+    # Neither the formatted message nor any attached traceback text (the
+    # reason exc_info is False for a PostgresError) carries the phone.
+    assert phone_in_detail not in caplog.text
+    assert any("UniqueViolationError[23505]" in r.message for r in caplog.records)

--- a/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
@@ -163,6 +163,31 @@ def test_is_transient_rejects_everything_else_as_permanent() -> None:
     assert wms._is_transient(asyncpg.DataError("bad data")) is False
     assert wms._is_transient(KeyError("missing")) is False
     assert wms._is_transient(RuntimeError("assertion")) is False
+    assert wms._is_transient(asyncpg.UndefinedTableError("no such table")) is False
+    assert wms._is_transient(asyncpg.UniqueViolationError("dup key")) is False
+
+
+# --------------------------------------------------------------------------- #
+# Widened transient set (verbale #1, post-refuter Qwen 3.8 Max, 2026-08-17):
+# retryable Postgres classes the original connectivity-only tuple missed.
+# --------------------------------------------------------------------------- #
+def test_is_transient_classifies_widened_retryable_postgres_errors() -> None:
+    wms = _load_sweeper()
+    assert wms._is_transient(asyncpg.QueryCanceledError("canceled")) is True
+    assert wms._is_transient(asyncpg.DeadlockDetectedError("deadlock")) is True
+    assert wms._is_transient(asyncpg.SerializationError("serialization")) is True
+    # OperatorInterventionError family (admin shutdown / crash / maintenance).
+    assert wms._is_transient(asyncpg.OperatorInterventionError("intervention")) is True
+    assert wms._is_transient(asyncpg.AdminShutdownError("admin shutdown")) is True
+    assert wms._is_transient(asyncpg.CrashShutdownError("crash shutdown")) is True
+    assert wms._is_transient(asyncpg.CannotConnectNowError("cannot connect now")) is True
+    assert wms._is_transient(asyncpg.IdleSessionTimeoutError("idle timeout")) is True
+    # InsufficientResourcesError family (OOM / too many conns / disk full).
+    assert wms._is_transient(asyncpg.InsufficientResourcesError("resources")) is True
+    assert wms._is_transient(asyncpg.OutOfMemoryError("oom")) is True
+    assert wms._is_transient(asyncpg.TooManyConnectionsError("too many conns")) is True
+    assert wms._is_transient(asyncpg.DiskFullError("disk full")) is True
+    assert wms._is_transient(asyncpg.PostgresSystemError("system error")) is True
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
@@ -537,3 +537,46 @@ async def test_postgres_error_detail_never_reaches_the_log(
     # reason exc_info is False for a PostgresError) carries the phone.
     assert phone_in_detail not in caplog.text
     assert any("UniqueViolationError[23505]" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# Partial progress (verbale #7, post-refuter Qwen 3.8 Max — test-suite gap):
+# rows before a transient break must still advance the watermark and still
+# get enqueued — the break stops the tick, it must not discard progress
+# already made this tick.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_partial_progress_before_transient_break(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    row_a = _row(1100, blob_path=_write_blob(tmp_path, "a.pdf"))
+    row_b = _row(1101, blob_path=_write_blob(tmp_path, "b.pdf"))
+    row_c = _row(1102, blob_path=_write_blob(tmp_path, "c.pdf"))
+    enqueue_calls: list[str] = []
+
+    async def flaky_enqueue(_pool, *, source_ref, **_kw):
+        if source_ref == f"wa-mirror:{row_c['baileys_message_id']}":
+            raise asyncpg.PostgresConnectionError("connection reset")
+        enqueue_calls.append(source_ref)
+        return SimpleNamespace(was_new=True)
+
+    wms = _load_sweeper()
+    saved = _wire(
+        monkeypatch,
+        wms,
+        rows=[row_a, row_b, row_c],
+        watermark_seed=1099,
+        enqueue=flaky_enqueue,
+    )
+
+    with caplog.at_level(logging.INFO, logger="wa_mirror_sweeper"):
+        rc = await wms.run_one_tick()
+
+    assert rc == 0
+    # A and B were enqueued and the watermark advanced to B — the transient
+    # break on C stops the tick, it does not discard A/B's progress.
+    assert enqueue_calls == [
+        f"wa-mirror:{row_a['baileys_message_id']}",
+        f"wa-mirror:{row_b['baileys_message_id']}",
+    ]
+    assert saved.get("wm") == row_b["id"]

--- a/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
@@ -349,3 +349,42 @@ async def test_transient_crm_upsert_error_does_not_advance_watermark(
     assert enqueue_calls == []
     assert "wm" not in saved
     assert any("poison=0" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# Blob pre-check (verbale #4, post-refuter Qwen 3.8 Max, P2).
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_blob_path_is_a_directory_counts_as_missing_and_advances(
+    monkeypatch, tmp_path, caplog
+) -> None:
+    """A directory (or unreadable file) at ``media_stored_path`` must be
+    counted as a missing blob and advanced past — NOT treated as a transient
+    OSError. ``os.path.exists()`` passes for a directory too, and
+    ``compute_blob_hash()``'s bare ``open(blob_path, "rb")`` would then raise
+    ``IsADirectoryError`` (an ``OSError`` subclass), which ``_is_transient()``
+    misclassifies as retryable — freezing the watermark on that row forever.
+    ``os.path.isfile()`` + ``os.access(..., os.R_OK)`` catch it HERE, before
+    enqueue()/compute_blob_hash() ever opens the path.
+    """
+    bad_dir = tmp_path / "not_a_file"
+    bad_dir.mkdir()
+    row_n = _row(500, blob_path=str(bad_dir))
+    enqueue_calls: list[str] = []
+
+    async def recording_enqueue(_pool, *, source_ref, **_kw):
+        enqueue_calls.append(source_ref)
+        return SimpleNamespace(was_new=True)
+
+    wms = _load_sweeper()
+    saved = _wire(
+        monkeypatch, wms, rows=[row_n], watermark_seed=499, enqueue=recording_enqueue
+    )
+
+    with caplog.at_level(logging.INFO, logger="wa_mirror_sweeper"):
+        rc = await wms.run_one_tick()
+
+    assert rc == 0
+    assert enqueue_calls == []
+    assert saved.get("wm") == 500
+    assert any("blob_missing=1" in r.message for r in caplog.records)

--- a/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
+++ b/apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 import logging
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -230,19 +231,27 @@ async def test_permanent_enqueue_error_advances_watermark_past_poison_row(
 async def test_permanent_crm_upsert_error_advances_watermark_and_still_enqueues_next(
     monkeypatch, tmp_path, caplog
 ) -> None:
+    """Verbale #2 (post-refuter Qwen 3.8 Max, P1): a PERMANENT CRM-upsert
+    failure must NOT drop the media document. Only the CRM identity hint is
+    lost — row N still reaches ``enqueue()`` with ``client_id_hint=None``
+    (review/OCR still happens, it just isn't pre-linked to a client), and
+    row N+1 gets its own fresh CRM upsert attempt and its own hint.
+    """
     row_n = _row(200, blob_path=_write_blob(tmp_path, "n.pdf"))
     row_n1 = _row(201, blob_path=_write_blob(tmp_path, "n1.pdf"))
     upsert_calls: list[int] = []
     enqueue_calls: list[str] = []
+    enqueue_hints: dict[str, int | None] = {}
 
     async def flaky_upsert(_conn, *, raw_phone, **_kw):
         upsert_calls.append(1)
         if raw_phone == row_n["sender_phone"]:
             raise RuntimeError("constraint violation — permanent")
-        return 1
+        return 42
 
-    async def recording_enqueue(_pool, *, source_ref, **_kw):
+    async def recording_enqueue(_pool, *, source_ref, client_id_hint, **_kw):
         enqueue_calls.append(source_ref)
+        enqueue_hints[source_ref] = client_id_hint
         return SimpleNamespace(was_new=True)
 
     wms = _load_sweeper()
@@ -259,11 +268,20 @@ async def test_permanent_crm_upsert_error_advances_watermark_and_still_enqueues_
         rc = await wms.run_one_tick()
 
     assert rc == 0
-    # Row N's CRM upsert died -> row N is SKIPPED (never reaches enqueue), but
-    # row N+1 still gets a fresh CRM upsert attempt and IS enqueued.
-    assert enqueue_calls == [f"wa-mirror:{row_n1['baileys_message_id']}"]
+    ref_n = f"wa-mirror:{row_n['baileys_message_id']}"
+    ref_n1 = f"wa-mirror:{row_n1['baileys_message_id']}"
+    # Both rows reach enqueue() — row N's document is KEPT despite the CRM
+    # failure, just with no client-identity hint; row N+1 gets its real hint.
+    assert enqueue_calls == [ref_n, ref_n1]
+    assert enqueue_hints[ref_n] is None
+    assert enqueue_hints[ref_n1] == 42
     assert saved.get("wm") == 201
-    assert any("poison=1" in r.message for r in caplog.records)
+    # crm_poison counts the CRM-identity loss; the enqueue-level `poison`
+    # counter stays 0 (word-boundary match so `crm_poison=1` in the same
+    # message can't make a bare "poison=0" assertion pass by substring —
+    # `_` is a word char, so `\bpoison=` never matches inside `crm_poison=`).
+    assert any(re.search(r"\bcrm_poison=1\b", r.message) for r in caplog.records)
+    assert any(re.search(r"(?<!crm_)\bpoison=0\b", r.message) for r in caplog.records)
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/wa_mirror_intake_sweeper.py
+++ b/scripts/wa_mirror_intake_sweeper.py
@@ -41,6 +41,17 @@ Environment:
 - WA_MIRROR_MEDIA_TYPES              (default "document,image" — comma list)
 - WA_MIRROR_TEXT_SWEEP_BATCH          (default 100 — direct text rows promoted per tick)
 - WA_MIRROR_TEXT_START_ID             (optional — same seed semantics for text rows)
+
+Exit codes (poison breaker, verbale #3, post-refuter Qwen 3.8 Max, 2026-08-17):
+  0  normal tick, including a tick with SOME poison rows (< storm threshold)
+     — a digest-tier Telegram line is still sent so poison is never silent.
+  2  a POISON STORM this tick: `poison >= max(5, ceil(0.2 * scanned))`. A P0
+     Telegram alert fires and the tick returns non-zero ON PURPOSE so launchd
+     records the run as FAILED — the old unconditional `return 0` meant a
+     systemic misclassification (e.g. a broken migration) could silently
+     drain the entire backlog at full rate with launchd showing green every
+     time. `crm_poison` (CRM-identity-only failures, verbale #2) never counts
+     toward the storm threshold — those never drop a document.
 """
 from __future__ import annotations
 
@@ -48,8 +59,11 @@ import asyncio
 import fcntl
 import hashlib
 import logging
+import math
 import os
+import subprocess
 import sys
+import time
 from pathlib import Path
 
 import asyncpg
@@ -59,7 +73,24 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "apps" / "backen
 from backend.services.intake.enqueue import enqueue
 from backend.services.intake.routing import normalize_sender_phone
 
+# The tg_notify gateway parser (scripts/tg_gateway_verdict.py) — repo root on
+# sys.path so this resolves whether the module is run directly or loaded via
+# importlib (tests), same pattern as scripts/intake_health_report.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.tg_gateway_verdict import extract_gateway_verdict  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
 logger = logging.getLogger("wa_mirror_sweeper")
+
+# The absolute python3 candidates tg_notify.py is spawned with (W108 — the
+# alarm must not share the failure mode of a possibly-broken venv PATH
+# resolution). tg_notify.py is stdlib-only by design for exactly this reason.
+_PY3_CANDIDATES: tuple[str, ...] = (
+    "/usr/bin/python3",
+    "/opt/homebrew/bin/python3",
+    "/usr/local/bin/python3",
+)
 
 STATE_DIR = Path.home() / ".cell-bridge-state"
 LAST_ID_FILE = STATE_DIR / "wa_mirror_sweep_last_id.txt"
@@ -551,6 +582,40 @@ async def _sweep_text_clients(pool: asyncpg.Pool, batch: int) -> dict[str, int]:
     return counters
 
 
+def _resolve_py3() -> str:
+    for candidate in _PY3_CANDIDATES:
+        if Path(candidate).is_file():
+            return candidate
+    return sys.executable  # last resort — never crash over interpreter resolution
+
+
+def _tg_notify(tier: str, dedup_key: str, text: str) -> bool:
+    """Route the poison breaker's alert through the tg_notify gateway.
+
+    Module-level side effect, monkeypatchable (same pattern as
+    scripts/intake_health_report.py::_tg_notify) — never raises, so a
+    Telegram/gateway hiccup never turns a completed sweep tick into a crash.
+    `text` MUST carry counts only (poison/crm_poison/scanned/watermark) —
+    never a row id, phone, or exception body (Law 2 / UU-PDP).
+    """
+    try:
+        gateway = _REPO_ROOT / "scripts" / "tg_notify.py"
+        if not gateway.is_file():
+            logger.warning("[wa_mirror_sweep] tg_notify.py missing at %s", gateway)
+            return False
+        res = subprocess.run(
+            [_resolve_py3(), str(gateway), "--tier", tier,
+             "--source", "wa-mirror-sweeper", "--dedup-key", dedup_key, "--", text],
+            capture_output=True, text=True, timeout=30,
+        )
+        verdict = extract_gateway_verdict(res.stderr)
+        logger.info("[wa_mirror_sweep] tg_notify: %s", verdict or f"NESSUN verdetto rc={res.returncode}")
+        return res.returncode == 0 and verdict is not None
+    except Exception as exc:  # never raises
+        logger.warning("[wa_mirror_sweep] tg_notify failed: %s", exc)
+        return False
+
+
 async def run_one_tick() -> int:
     db_url = os.getenv(
         "INTAKE_DATABASE_URL",
@@ -729,6 +794,38 @@ async def run_one_tick() -> int:
             crm_poison,
             max_done,
         )
+
+        # Poison breaker (verbale #3, post-refuter Qwen 3.8 Max, P1). The tick
+        # used to `return 0` unconditionally no matter how many rows were
+        # poisoned — a systemic misclassification (e.g. a broken migration)
+        # could silently drain the entire backlog at full rate with launchd
+        # recording a clean success every tick. Any poison at all is worth a
+        # digest line (never silent); a STORM — a large fraction of the batch
+        # poisoned in one tick — is worth a P0 and a non-zero exit so launchd
+        # marks the run FAILED. crm_poison never counts toward the storm
+        # threshold: a CRM-identity-only failure (verbale #2) never drops a
+        # document, so it is not the "backlog silently draining" failure mode
+        # this breaker exists to catch.
+        scanned = len(rows)
+        today = time.strftime("%Y-%m-%d")
+        if poison + crm_poison > 0:
+            _tg_notify(
+                "digest",
+                f"wa-mirror-sweeper:poison:{today}",
+                f"wa-mirror sweeper poison this tick: poison={poison} "
+                f"crm_poison={crm_poison} scanned={scanned} watermark={max_done}",
+            )
+        storm_threshold = max(5, math.ceil(0.2 * scanned))
+        if poison >= storm_threshold:
+            _tg_notify(
+                "p0",
+                "wa-mirror-sweeper:poison-storm",
+                f"wa-mirror sweeper POISON STORM: poison={poison}/{scanned} "
+                f"(>= threshold {storm_threshold}); watermark={max_done}. "
+                "Likely a systemic misclassification, not per-row bad data — "
+                "check recent enqueue()/schema changes before requeuing.",
+            )
+            return 2
         return 0
     finally:
         await pool.close()

--- a/scripts/wa_mirror_intake_sweeper.py
+++ b/scripts/wa_mirror_intake_sweeper.py
@@ -607,6 +607,7 @@ async def run_one_tick() -> int:
         direct_media = 0
         group_media = 0
         poison = 0
+        crm_poison = 0
         max_done = watermark
 
         for r in rows:
@@ -644,16 +645,23 @@ async def run_one_tick() -> int:
                             exc_info=True,
                         )
                         break
-                    poison += 1
+                    # PERMANENT CRM-identity failure (verbale #2, post-refuter
+                    # Qwen 3.8 Max): the CRM upsert is a phone->client_id HINT,
+                    # not the document itself. Dropping the row here (the old
+                    # `continue`) skipped enqueue() entirely and lost the media
+                    # document — a constraint violation on the CRM side is not
+                    # a reason to lose a client's passport/document. Record the
+                    # loss of the identity hint, keep client_id_hint=None, and
+                    # FALL THROUGH so the row still reaches enqueue() below.
+                    crm_poison += 1
                     logger.error(
                         "[wa_mirror_sweep] CRM phone upsert failed for media row %d "
-                        "(poison row, advancing past it): %s",
+                        "(permanent, CRM identity hint dropped — document still enqueued): %s",
                         rid,
                         exc,
                         exc_info=True,
                     )
-                    max_done = max(max_done, rid)
-                    continue
+                    client_id_hint = None
             else:
                 group_media += 1
             try:
@@ -699,7 +707,7 @@ async def run_one_tick() -> int:
             _save_watermark(max_done)
         logger.info(
             "[wa_mirror_sweep] done: scanned=%d direct=%d group=%d new=%d dup=%d "
-            "blob_missing=%d poison=%d watermark=%d",
+            "blob_missing=%d poison=%d crm_poison=%d watermark=%d",
             len(rows),
             direct_media,
             group_media,
@@ -707,6 +715,7 @@ async def run_one_tick() -> int:
             already,
             blob_missing,
             poison,
+            crm_poison,
             max_done,
         )
         return 0

--- a/scripts/wa_mirror_intake_sweeper.py
+++ b/scripts/wa_mirror_intake_sweeper.py
@@ -618,7 +618,18 @@ async def run_one_tick() -> int:
                 logger.warning("[wa_mirror_sweep] row %d missing id/path, skipping", rid)
                 max_done = max(max_done, rid)  # don't re-scan a structurally-bad row
                 continue
-            if not os.path.exists(blob_path):
+            # verbale #4 (post-refuter Qwen 3.8 Max, P2): `os.path.exists()`
+            # passes for a DIRECTORY or an unreadable file too. compute_blob_hash()
+            # then does a bare `open(blob_path, "rb")`, which raises
+            # IsADirectoryError/PermissionError — both OSError subclasses, so
+            # `_is_transient()` (OSError is transient) classified them as
+            # retry-worthy and `break`-froze the watermark on that row forever
+            # (the exact pre-fix pathology, reproduced for this input shape).
+            # `os.path.isfile()` + `os.access(..., os.R_OK)` catch both shapes
+            # HERE, before enqueue()/compute_blob_hash() ever opens the path,
+            # so a bad blob is counted and advanced past like any other
+            # missing blob instead of freezing the tick.
+            if not (os.path.isfile(blob_path) and os.access(blob_path, os.R_OK)):
                 blob_missing += 1
                 logger.warning("[wa_mirror_sweep] row %d blob missing on disk, skipping", rid)
                 max_done = max(max_done, rid)  # blob gone; never coming back, advance past it

--- a/scripts/wa_mirror_intake_sweeper.py
+++ b/scripts/wa_mirror_intake_sweeper.py
@@ -157,6 +157,24 @@ def _is_transient(exc: BaseException) -> bool:
     return isinstance(exc, _TRANSIENT_EXCEPTIONS)
 
 
+def _exc_summary(exc: BaseException) -> str:
+    """PII-safe one-line exception summary for the media-loop error logs
+    (verbale #6, post-refuter Qwen 3.8 Max, P2).
+
+    ``asyncpg.PostgresError.__str__()`` appends ``DETAIL``/``HINT`` when the
+    server supplies them, and a constraint-violation DETAIL on a phone-keyed
+    table (``clients.phone_normalized`` UNIQUE) can embed the raw offending
+    phone value — doubling the poison-row ERROR call sites that could leak
+    PII into ``wa-mirror-intake-sweeper.log``. A Postgres exception is
+    therefore summarized as its type + sqlstate ONLY, never its message.
+    Anything else (OSError, ValueError, ...) is not DB-error-shaped and does
+    not carry that DETAIL/HINT risk, so it keeps its message.
+    """
+    if isinstance(exc, asyncpg.PostgresError):
+        return f"{type(exc).__name__}[{getattr(exc, 'sqlstate', '-')}]"
+    return f"{type(exc).__name__}: {exc}"
+
+
 # --------------------------------------------------------------------------- #
 # Internal-sender guard (2026-06-29).
 #
@@ -717,8 +735,8 @@ async def run_one_tick() -> int:
                             "[wa_mirror_sweep] CRM phone upsert failed for media row %d "
                             "(transient, retrying next tick): %s",
                             rid,
-                            exc,
-                            exc_info=True,
+                            _exc_summary(exc),
+                            exc_info=not isinstance(exc, asyncpg.PostgresError),
                         )
                         break
                     # PERMANENT CRM-identity failure (verbale #2, post-refuter
@@ -734,8 +752,8 @@ async def run_one_tick() -> int:
                         "[wa_mirror_sweep] CRM phone upsert failed for media row %d "
                         "(permanent, CRM identity hint dropped — document still enqueued): %s",
                         rid,
-                        exc,
-                        exc_info=True,
+                        _exc_summary(exc),
+                        exc_info=not isinstance(exc, asyncpg.PostgresError),
                     )
                     client_id_hint = None
             else:
@@ -758,8 +776,8 @@ async def run_one_tick() -> int:
                         "[wa_mirror_sweep] enqueue failed for row %d "
                         "(transient, retrying next tick): %s",
                         rid,
-                        exc,
-                        exc_info=True,
+                        _exc_summary(exc),
+                        exc_info=not isinstance(exc, asyncpg.PostgresError),
                     )
                     # Do NOT advance past a transient failure — retry next tick.
                     break
@@ -768,8 +786,8 @@ async def run_one_tick() -> int:
                     "[wa_mirror_sweep] enqueue failed for row %d "
                     "(poison row, advancing past it): %s",
                     rid,
-                    exc,
-                    exc_info=True,
+                    _exc_summary(exc),
+                    exc_info=not isinstance(exc, asyncpg.PostgresError),
                 )
                 max_done = max(max_done, rid)
                 continue

--- a/scripts/wa_mirror_intake_sweeper.py
+++ b/scripts/wa_mirror_intake_sweeper.py
@@ -73,7 +73,8 @@ _CRM_ACTOR = "wa-mirror-crm-writer@balizero.com"
 _LEAD_SOURCE = "whatsapp_auto"
 
 # --------------------------------------------------------------------------- #
-# Transient-vs-permanent exception classification (dossier C-31, 2026-08-15).
+# Transient-vs-permanent exception classification (dossier C-31, 2026-08-15;
+# widened post-refuter Qwen 3.8 Max finding #1, 2026-08-17).
 #
 # The media loop's per-row `except Exception: ... break` is correct for a
 # TRANSIENT failure (DB/connection hiccup — retry the SAME row next tick) but
@@ -86,6 +87,24 @@ _LEAD_SOURCE = "whatsapp_auto"
 # `asyncio.TimeoutError` and the builtin `TimeoutError` are the same class on
 # Python 3.11+ but were distinct before — both listed so this stays correct
 # regardless of interpreter version.
+#
+# The original tuple only caught connection-shaped failures. It missed the
+# retryable Postgres error classes below — all confirmed live (asyncpg 0.31.0,
+# apps/backend-rag/.venv) NOT to be subclasses of any pre-existing entry, so
+# each was silently misclassified as permanent poison and the row it hit was
+# dropped forever instead of being retried next tick:
+#   - QueryCanceledError    — a statement_timeout cancel mid-CRM-upsert
+#   - DeadlockDetectedError / SerializationError — lock/serialization conflict
+#     (the CRM upsert takes pg_advisory_xact_lock + SELECT...FOR UPDATE)
+#   - OperatorInterventionError — covers AdminShutdownError, CrashShutdownError,
+#     CannotConnectNowError, IdleSessionTimeoutError (a DB restart/maintenance
+#     window, not a data defect)
+#   - InsufficientResourcesError — covers OutOfMemoryError,
+#     TooManyConnectionsError, DiskFullError (resource pressure, not poison)
+#   - PostgresSystemError — server-side I/O/system failure
+# Deliberately conservative: constraint/data errors (UniqueViolationError,
+# UndefinedTableError, DataError, ValueError, ...) stay OUTSIDE this tuple and
+# permanent, per the existing classify-by-exclusion contract.
 # --------------------------------------------------------------------------- #
 _TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     asyncpg.PostgresConnectionError,
@@ -93,6 +112,12 @@ _TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     OSError,
     TimeoutError,
     asyncio.TimeoutError,
+    asyncpg.QueryCanceledError,
+    asyncpg.DeadlockDetectedError,
+    asyncpg.SerializationError,
+    asyncpg.OperatorInterventionError,
+    asyncpg.InsufficientResourcesError,
+    asyncpg.PostgresSystemError,
 )
 
 


### PR DESCRIPTION
## Context

Follow-up to #4221 (merged `ec2ca6753`) — a cross-family refuter (Qwen 3.8 Max) re-verified
that merge against `scripts/wa_mirror_intake_sweeper.py` and found 7 real defects, each
re-verified on disk before this PR was written. Verbale: `refuter-qwen-pr4221.md`
(`CONFERMATE=7 RESPINTE=0 NON_VERIFICABILI=0`).

## Adversarial review

**Seat**: Qwen 3.8 Max (`qwen3.8-max-preview`, ModelStudio Token Plan, via `qwen --safe-mode`) —
a different model family than the author of #4221 (Claude), satisfying generator≠grader.

All 7 findings addressed in this PR, one atomic commit each:

| # | Sev | Finding | Fix |
|---|-----|---------|-----|
| 1 | P1 | `_TRANSIENT_EXCEPTIONS` only covered connectivity-shaped failures — `QueryCanceledError`, `DeadlockDetectedError`, `SerializationError`, `AdminShutdownError`/`CrashShutdownError`/`CannotConnectNowError`/`IdleSessionTimeoutError`, `OutOfMemoryError`/`TooManyConnectionsError`/`DiskFullError`, `PostgresSystemError` were misclassified as permanent poison | Widened the tuple with the 6 retryable classes (`QueryCanceledError`, `DeadlockDetectedError`, `SerializationError`, `OperatorInterventionError`, `InsufficientResourcesError`, `PostgresSystemError`) — verified live in `apps/backend-rag/.venv` (asyncpg 0.31.0) that each name exists and is not already covered; permanent classes stay outside the tuple |
| 2 | P1 | A **permanent** CRM-upsert failure did `poison += 1; continue` **before** `enqueue()` — the media document itself was dropped, not just the CRM identity hint. The merged test codified this as correct | `crm_poison += 1`, log, `client_id_hint = None`, **fall through** to `enqueue()` — the document is kept, just without a pre-linked client |
| 3 | P1 | `run_one_tick()` `return 0` unconditionally, no matter how many rows were poisoned — a systemic misclassification could silently drain the whole backlog with launchd green every tick | **Poison breaker**: any poison → one digest-tier Telegram line (counts only); `poison >= max(5, ceil(0.2*scanned))` → P0 Telegram alert + `return 2` so launchd records the run FAILED |
| 4 | P2 | `os.path.exists(blob_path)` passes for a directory/unreadable file; `compute_blob_hash()`'s bare `open()` then raises an `OSError` subclass, misclassified transient → freezes the watermark forever (the exact pre-fix pathology, reproduced) | `os.path.isfile(blob_path) and os.access(blob_path, os.R_OK)` — caught before `enqueue()`/`compute_blob_hash()` ever opens the path |
| 5 | P2 | PR body "Touches only" 2 files undisclosed the mechanical `docs/AI_ONBOARDING.md` test-counter delta | N/A for this PR — see Scope below, no `docs/AI_ONBOARDING.md` delta this time (no new test *file*, only new tests inside the existing file) |
| 6 | P2 | `asyncpg.PostgresError.__str__()` appends `DETAIL`/`HINT`, which can embed a raw client phone on a constraint violation (`clients.phone_normalized` UNIQUE); the 4 poison-row ERROR logs interpolated the raw exception via `%s` | `_exc_summary(exc)` → `"{type}[{sqlstate}]"` for a `PostgresError` (never the message body), `"{type}: {exc}"` otherwise; `exc_info=True` only when NOT a `PostgresError` (no traceback smuggling the DETAIL back in) |
| 7 | P2 | Test-suite gap: no test exercised mid-batch **partial progress** (rows before a transient break should still have advanced the watermark) | New test: rows A, B succeed, C is transient → watermark advances to B, exactly A and B enqueued |

## Fix detail

Same media loop in `scripts/wa_mirror_intake_sweeper.py`, six atomic commits:

1. `fix(intake): widen sweeper transient-exception set (post-refuter #1)`
2. `fix(intake): sweeper keeps the document on permanent CRM-upsert failure`
3. `fix(intake): sweeper blob pre-check rejects directories/unreadable files`
4. `feat(intake): sweeper poison breaker — Telegram alert + non-zero exit on storm`
5. `fix(intake): sweeper poison-row error logs never carry Postgres DETAIL/HINT`
6. `test(intake): sweeper — cover mid-batch partial progress before a transient break`

The poison breaker's `_tg_notify()` follows the same module-level, monkeypatchable,
never-raises pattern as `scripts/intake_health_report.py::_tg_notify` (absolute python3
candidates per W108 — the alarm must not share the failure mode of a possibly-broken venv
PATH resolution). New exit-code contract (0 normal / 2 poison storm) documented in the
module docstring.

## Tests

`apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py` — pure,
**no real DB** (W96): `asyncpg.create_pool`, `_upsert_client_by_phone`, `enqueue`, and now
`_tg_notify` are all monkeypatched (`_wire()`'s new `tg_notify` param defaults to a no-op
stub — without it, any poison-row test would spawn a REAL subprocess against
`scripts/tg_notify.py`, writing to the live `~/.organism/tg_spool` outside `tmp_path`, the
exact W96 class of bug).

```
$ apps/backend-rag/.venv/bin/python -m pytest apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py -q
..............                                                          [100%]
14 passed in 0.2s
```

- 2 classifier unit tests (transient set, widened set)
- CRM-permanent test rewritten: row N IS enqueued with `client_id_hint=None`, row N+1 gets its
  own real hint, watermark advances past both
- 1 blob pre-check test (directory path → advanced, `enqueue()` not called)
- 3 poison-breaker tests (0 poison → no Telegram call; 1 poison → digest only, rc 0; storm →
  P0 + rc 2)
- 1 PII-safe-log test (`UniqueViolationError` with a phone-shaped `DETAIL` → phone never
  appears anywhere in `caplog.text`, summary still names the failure)
- 1 partial-progress test (A, B succeed; C transient → watermark == B, exactly A/B enqueued)
- existing guilt/innocence tests from #4221 all still pass, updated where finding #2 changed
  their asserted behavior

Existing `test_wa_mirror_intake_sweeper_helpers.py` (11 tests) and
`test_wa_mirror_intake_sweeper.py` (25 passed / 6 skipped — `whatsapp_message_context` runtime
schema absent locally, unaffected by this change) — both green, `ruff check` clean on both
changed files, `python -c "from backend.app.dependencies import get_current_user"`
import-chain smoke passes (pre-commit ran it).

## Not installed/deployed by this PR

Repo-only change, same as #4221. The live cron-invoked copy on Pro still runs the pre-#4221
script until an operator pulls this after merge — no runtime/cron change ships with this PR.

## Scope

Touches only:
- `scripts/wa_mirror_intake_sweeper.py`
- `apps/backend-rag/backend/tests/scripts/test_wa_mirror_intake_sweeper_watermark.py`

No launchd, no DB, no other files (no `docs/AI_ONBOARDING.md` delta this time — no new test
*file*, only new tests appended to the existing one). Text-sweep loop (`_sweep_text_clients`)
untouched — same out-of-scope call as #4221; its similar `break`-without-advancing pattern
and single unguarded CRM-upsert error log were not in the refuter's findings for this PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
