### PR TITLE
fix(docs-audit): name the severed orphan-flip provenance channel instead of reading it as bootstrap

### DIFF
--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -1303,7 +1303,43 @@ def read_trusted_prev_flipped(repo: Path, trusted_ref: str = "origin/main") -> D
         # Ref resolves fine; the FILE just doesn't exist on it (yet). Legit
         # {} — matches parse_prev_flipped()'s own bootstrap contract.
         return {}
-    return parse_prev_flipped(show.stdout)
+    prev = parse_prev_flipped(show.stdout)
+    if not prev:
+        # THIRD STATE — the docstring above knows only two ("ref unresolvable"
+        # -> raise, "file absent" -> bootstrap {}) and this is neither: the
+        # file EXISTS on the trusted ref and carries no parseable provenance
+        # table at all. PR #4233 ("delete tracked derived state", 2026-08-16)
+        # replaced docs/DOCS_INVENTORY.md with a pointer document, so from
+        # that commit on this branch is reached on EVERY invocation and the
+        # channel is severed permanently, not bootstrapping toward anything.
+        #
+        # The harm is the one the fail-closed paragraph above already spells
+        # out in full — "would incorrectly tell every already-organ-ARCHIVED
+        # doc 'no prior flip on record', letting Rule 2 fall through and
+        # silently resurrect it" — reached through infrastructure instead of
+        # malice, which is the route that paragraph did not anticipate.
+        # Measured 2026-08-17: 148 documents carried a flip at b626e01f6^ and
+        # 0 do on the pointer; under --gate-consistent all 148 now read LIVE.
+        # See .claude/skills/modus/PENDING-ARMS.md.
+        #
+        # DELIBERATELY a signaler, not a gate: the return contract is
+        # unchanged ({} exactly as before) so no caller's behaviour moves on
+        # this commit. Whether the mechanism should be re-armed against a
+        # declared input or retired outright is an open ledger decision, and
+        # a warning may not pre-empt it. What this DOES buy is that the break
+        # stops being invisible (superscar #2, "esiste != armato"): it is now
+        # named, with its cause, in the log of every run that reaches here.
+        print(
+            "docs_audit: WARNING - orphan-flip provenance channel is SEVERED. "
+            f"{trusted_ref}:docs/DOCS_INVENTORY.md exists but contains no "
+            "parseable provenance table, so every prior orphan flip reads as "
+            "'never flipped'. This is NOT the bootstrap case (that one is a "
+            "MISSING file). Docs previously archived by the organ can fall "
+            "through Rule 2 and silently resurrect. See PENDING-ARMS.md, row "
+            "'orphan-flip anti-forgery gate'.",
+            file=sys.stderr,
+        )
+    return prev
 
 
 def _flip_is_still_valid(carried: str, last_touched: date) -> bool:

--- a/scripts/docs_audit.py
+++ b/scripts/docs_audit.py
@@ -1329,9 +1329,17 @@ def read_trusted_prev_flipped(repo: Path, trusted_ref: str = "origin/main") -> D
         # a warning may not pre-empt it. What this DOES buy is that the break
         # stops being invisible (superscar #2, "esiste != armato"): it is now
         # named, with its cause, in the log of every run that reaches here.
+        # The trusted ref's NAME is deliberately not interpolated here.
+        # CodeQL's py/clear-text-logging-sensitive-data taints the value of
+        # this argument and rates the resulting log a HIGH alert (measured on
+        # PR #4248, scripts/docs_audit.py:1333). The name buys nothing a
+        # reader does not already have — the caller chose the ref, the path is
+        # a constant, and this file documents the default — so the cheap and
+        # honest move is to stop logging the argument rather than to suppress
+        # the rule.
         print(
             "docs_audit: WARNING - orphan-flip provenance channel is SEVERED. "
-            f"{trusted_ref}:docs/DOCS_INVENTORY.md exists but contains no "
+            "docs/DOCS_INVENTORY.md exists on the trusted ref but contains no "
             "parseable provenance table, so every prior orphan flip reads as "
             "'never flipped'. This is NOT the bootstrap case (that one is a "
             "MISSING file). Docs previously archived by the organ can fall "

--- a/scripts/tests/test_docs_audit.py
+++ b/scripts/tests/test_docs_audit.py
@@ -2272,6 +2272,95 @@ def test_trusted_ref_tip_date_succeeds_when_fetch_succeeds(tmp_path):
     assert result == date.today() - timedelta(days=200)
 
 
+# ---------------------------------------------------------------------------
+# Severed provenance channel (2026-08-17). read_trusted_prev_flipped()'s
+# docstring knows exactly two ways to reach {}: the ref will not resolve
+# (raise) or the file is absent on it (legitimate bootstrap). PR #4233 created
+# a THIRD: the file is present and is a pointer document with no table, so {}
+# is returned forever while reading exactly like a first-ever run.
+#
+# The signal is a WARNING, never a behaviour change — these tests pin the
+# signal AND pin that the two legitimate {}-producing states stay silent, so
+# an unconditional "always warn" (which would pass guilt alone) fails here.
+# ---------------------------------------------------------------------------
+
+_SEVERED = "SEVERED"
+
+
+def _trusted_prev_flipped_stderr(repo, capsys):
+    """Call the real function; return (result, stderr) with stderr captured."""
+    sys.path.insert(0, str(AUDIT_SCRIPT.parent))
+    import docs_audit  # noqa: E402
+
+    capsys.readouterr()  # drop anything buffered by fixture setup
+    result = docs_audit.read_trusted_prev_flipped(repo, "origin/main")
+    return result, capsys.readouterr().err
+
+
+def test_severed_channel_tableless_trusted_inventory_warns(tmp_path, capsys):
+    """GUILT: a trusted inventory that EXISTS but carries no parseable table
+    must name itself as a severed channel. This is the post-#4233 state of
+    origin/main: an 11-line pointer document. Without this, the break is
+    indistinguishable from a first-ever run in every log the organism keeps.
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=200)
+    (repo / "docs" / "DOCS_INVENTORY.md").write_text(
+        "# Documentation Inventory\n\n"
+        "Derived state now lives in `.artifacts/docs-derived-state/`.\n",
+        encoding="utf-8",
+    )
+    _commit_and_push(repo, "replace inventory with a pointer")
+
+    result, err = _trusted_prev_flipped_stderr(repo, capsys)
+
+    assert result == {}, "contract unchanged: a tableless trusted inventory still yields {}"
+    assert _SEVERED in err, (
+        "a present-but-tableless trusted inventory is NOT the bootstrap case and "
+        f"must say so; stderr was: {err!r}"
+    )
+
+
+def test_real_trusted_table_does_not_warn(tmp_path, capsys):
+    """INNOCENCE 1: a healthy trusted inventory with real provenance must
+    return it and stay silent. An unconditional warning would fail here.
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=200)
+    (repo / "docs" / "DOCS_INVENTORY.md").write_text(
+        "# Documentation Inventory\n\n"
+        "## Files\n\n"
+        "| File | Status | orphan_flipped_on |\n"
+        "|------|--------|--------------------|\n"
+        "| docs/OLD_DOC.md | ARCHIVED | 2026-07-19 |\n",
+        encoding="utf-8",
+    )
+    _commit_and_push(repo, "inventory with a real flip")
+
+    result, err = _trusted_prev_flipped_stderr(repo, capsys)
+
+    assert result == {"docs/OLD_DOC.md": "2026-07-19"}, (
+        f"a real trusted table must still be read verbatim: got {result}"
+    )
+    assert _SEVERED not in err, f"a healthy table must not be called severed; stderr: {err!r}"
+
+
+def test_absent_trusted_inventory_stays_a_silent_bootstrap(tmp_path, capsys):
+    """INNOCENCE 2: the ORIGINAL {}-producing state — no docs/DOCS_INVENTORY.md
+    on the trusted ref at all — is a legitimate bootstrap and must remain
+    silent. Warning here would cry severed-channel at every genuinely fresh
+    repo, which is how a real signal gets trained into noise.
+    """
+    repo = _make_git_repo_with_old_doc(tmp_path, backdate_days=200)
+    assert not (repo / "docs" / "DOCS_INVENTORY.md").exists(), "fixture: file must be absent"
+
+    result, err = _trusted_prev_flipped_stderr(repo, capsys)
+
+    assert result == {}, "bootstrap still yields {}"
+    assert _SEVERED not in err, (
+        f"an ABSENT trusted inventory is the bootstrap case, not a severed "
+        f"channel; stderr: {err!r}"
+    )
+
+
 def test_redteam_major5_doc_touched_after_flip_resurrects_to_live(tmp_path):
     """INNOCENCE (red-team 2026-07-18 MAJOR-5, exact prescribed shape: "doc
     toccato post-flip -> LIVE"). A doc archived via a genuine organ flip,


### PR DESCRIPTION
Closes the actionable half of the PENDING-ARMS row opened in #4240 and measured in #4242, without pre-empting the part that is still a design decision.

## The defect

`read_trusted_prev_flipped()` documents exactly two ways to return an empty map:

- the trusted ref will not resolve → **raises** (fail-closed, BLOCKER-2)
- the file does not exist on that ref yet → **legitimate bootstrap** `{}`

#4233 created a third the docstring never anticipated: `docs/DOCS_INVENTORY.md` **exists** on the trusted ref and is a pointer document with no table. `git show` succeeds, `parse_prev_flipped` finds no rows, and the function returns `{}` on every invocation — reading exactly like a first-ever run, forever.

The harm is the one the function's own fail-closed paragraph already spells out verbatim: every already-organ-archived doc is told *"no prior flip on record"*, Rule 2 falls through, and the doc silently resurrects. It is reached through infrastructure rather than malice, which is the route that paragraph did not cover.

Measured: **148** documents carried a flip at `b626e01f6^`, **0** do on the pointer; under `--gate-consistent` all 148 now read `LIVE`.

## What this change is, and what it deliberately is not

A **signaler, not a gate**. The return contract is unchanged (`{}` exactly as before), so no caller's behaviour moves on this commit — the organ, the CI generator-correctness job and every write mode behave identically.

Whether the mechanism should be re-armed against a declared program input or retired outright is an open ledger decision, and a warning must not pre-empt it. What this buys is that the break stops being invisible (superscar #2, *esiste ≠ armato*): it is now named, with its cause, in the log of every run that reaches it.

Proved live against the real `origin/main` from a clean worktree:

```
docs_audit: WARNING - orphan-flip provenance channel is SEVERED.
origin/main:docs/DOCS_INVENTORY.md exists but contains no parseable
provenance table, so every prior orphan flip reads as 'never flipped'.
This is NOT the bootstrap case (that one is a MISSING file). ...
returned entries: 0
```

## Corpus

Guilt **and both** innocences — the two legitimate `{}`-producing states have to stay silent, or the signal trains into noise and the next real one goes unread.

Mutation-verified; each test is killed by a distinct, plausible mutation:

| mutation | kills |
|---|---|
| guard can never fire (`if False and not prev`) | guilt (tableless → warns) |
| warn unconditionally (`if True`) | innocence 1 (real table → silent) |
| warn on the file-absent path too | innocence 2 (bootstrap → silent) |

The bootstrap innocence survives mutation 2 by construction — that path early-returns before the guard — so mutation 3 exists specifically to prove it is not decorative (W116: a surviving mutant can mean an unreachable guard rather than a missing test).

## Pre-existing failure, NOT from this diff

`test_trusted_ref_tip_date_succeeds_when_fetch_succeeds` fails on this machine: the fixture backdates in UTC while the assertion compares against a **local** `date.today()`, so it breaks whenever local and UTC straddle midnight (`date -u` → 2026-08-16, `date` → 2026-08-17 at the time of the run). Proved pre-existing by re-running it against `origin/main`'s untouched `docs_audit.py` — identical failure — and this diff has exactly one hunk, inside `read_trusted_prev_flipped`. CI runners are UTC, so it does not reproduce there. Left out of scope (one PR, one concern); worth its own one-line fix.

Rest of the file: **90 passed**.