### PR TITLE
feat(visa-oracle): E3a slice doctrine cards (D1/D2/D12/E31B/E31D)

### DIFF
--- a/research/visa/doctrine-factory/cards/D1.md
+++ b/research/visa/doctrine-factory/cards/D1.md
@@ -1,0 +1,196 @@
+---
+date: 2026-08-17
+domain: visa
+client_case: none
+sources:
+  - path: research/visa/doctrine-factory/claims/e2a-claim-ledger.md
+    note: "claim provenance for every doctrinal statement below (CL-D1-*, CL-D-COMPARE, CL-D-FUNDS)"
+  - path: research/visa/doctrine-factory/claims/e2a-conflict-report.md
+    note: "CF-6 (co-cited CHANGED source ee8fe5b8) applies to D1's requirement-bundle rules"
+  - path: research/visa/doctrine-factory/claims/e2a-coverage-matrix.md
+    note: "rule-to-claim mapping this card's coverage matrix reproduces for D1 only"
+  - path: research/visa/doctrine-factory/source-hierarchy-draft.md
+    note: "authority-level vocabulary (L1-L7), state vocabulary (VERIFIED/CONFLICTING/STALE/UNVERIFIED/SUPERSEDED)"
+  - path: apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
+    note: "active pack seq-7 (SHADOW) — the 6 el.d1-* rules this card's coverage matrix targets"
+adversarial_review: kimi-k3
+---
+
+# Product Doctrine Card — D1 (Tourism Multiple Entry)
+
+Task: E3a (Visa Oracle doctrine-factory execution plan), vertical slice. Input: E2a claim ledger
+(merged, PR #4245). Format follows the blueprints' PDC-1 field set (`output-C/blueprint-completa.md:582`)
+and the B2 batch template (`output-B/03-nb2-interrogation-program.md:119-134`). This card states NO
+legal fact without a `claim_id` pointer into `e2a-claim-ledger.md`; a PDC-1 field with no claim behind
+it is marked **GAP**, not silently filled.
+
+## 1. Identity
+
+- **Code**: D1
+- **Name**: Tourism Multiple Entry
+- **Category**: Kunjungan (visit) index, multiple-entry, tourism-purpose (Kepmen M.IP-08.GR.01.01/2025
+  classification table).
+
+## 2. `claims_digest`
+
+Recipe: take every `(claim_id, state)` pair this card depends on, sort ascending by `claim_id`, join as
+`claim_id=state` newline-separated, sha256 the UTF-8 bytes. Reproducible by re-running the recipe against
+the pairs listed in §7 below.
+
+```
+claims_digest: cf4f3937cb07ee4d556dc9114240ef5a0b581cddc3979a8839284e322760f84a
+```
+
+## 3. Doctrinal facts (PDC-1 fields, each claim-referenced)
+
+1. **Category & legal purpose.** D1 authorizes multiple tourism-purpose entries: recreation, personal
+   development, learning about tourist attractions (incl. yacht tourism), visiting friends/family,
+   transit, MICE attendance. — `CL-D1-01`, **VERIFIED**.
+2. **Permitted activities.** Same as (1) — the purpose set IS the permitted-activity set for D1; no
+   separate "permitted activities" claim exists beyond the purpose/scope claim. — `CL-D1-01`,
+   **VERIFIED**.
+3. **Prohibited activities.** **GAP** — no claim in the E2a ledger states D1's prohibited-activity
+   boundary explicitly (unlike D2/D12, which have an explicit "absolute prohibition on subordinate
+   employment/local compensation" claim). Flagged for next E2 batch, not inferred here.
+4. **Borderline/unresolved activities.** **GAP** — no D1-specific borderline-activity claim exists in
+   this ledger (D12 has one, `CL-D12-05`; D1 does not). Flagged for next E2 batch.
+5. **Single or multiple entry.** Multiple. — `CL-D1-01`, **VERIFIED**.
+6. **Duration per entry & total validity.** 60 continuous days per entry; visa validity tiers 1, 2, or 5
+   years (up to 10 years with a prior Indonesian stay record); **no numeric annual/cumulative day-cap in
+   national law** — only an operational (non-legal) border-officer risk-discretion practice against
+   frequent short-cycle border runs. — `CL-D1-03`, **VERIFIED**, with an explicit evidentiary caveat: the
+   "no annual cap" conclusion rests on the sources' *silence* on the topic (matching the quoted primary-law
+   text, which itself contains no cap language), not an explicit denial like D2's — a weaker evidentiary
+   class than an explicit denial, flagged in the ledger, not upgraded here. Corroborated by
+   `CL-D-COMPARE`, **VERIFIED** (same caveat carried).
+7. **Extensions & conversions.** **GAP** — no D1-specific extension/conversion claim exists in this
+   ledger (unlike D12, which has `CL-D12-04` on non-convertibility). Flagged for next E2 batch.
+8. **Filing location (onshore/offshore) & onshore-status prerequisites.** **GAP** — not covered by any
+   claim in this ledger for D1.
+9. **Nationality restrictions incl. calling-visa applicability.** **GAP** — out of this slice's claim
+   scope entirely; the pack's calling-visa/nationality rules are GLOBAL (`review.calling-visa`,
+   `review.citizenship-conflict`), not D1-specific, and carry no claim in this ledger (see §6, out-of-
+   scope rules).
+10. **Age limits.** Not applicable — D1 carries no age-eligibility rule in seq-7 and no claim addresses
+    one.
+11. **Sponsor/guarantor requirements (post-UU 63/2024).** **GAP** — no D1-specific sponsor/guarantor
+    claim exists; D1's support-letter requirement (§16 below) is a document requirement, not a sponsor-
+    status doctrine claim of the kind E31B/E31D carry.
+12. **Financial requirements & proof.** USD 2,000, verified via a 3-month bank statement (operational
+    standard). — `CL-D1-02` (requirement bundle) + `CL-D-FUNDS` (cross-cutting financial-proof minima),
+    both **VERIFIED** for D1 specifically (D1's figure is numeric/primary-adjacent-sourced, unlike D2's
+    VERIFIED-WITH-CAVEAT leg — see D2.md).
+13. **Permitted source of income/compensation.** **GAP** — no explicit claim; the general absence of a
+    D1 employment-prohibition claim (§3 above) means this dimension is unaddressed, not resolved either
+    way.
+14. **Family/dependent provisions.** Not applicable to D1 as an individual tourism product (family-visit
+    is covered as one of D1's own PURPOSE values under `CL-D1-01`, not as a separate dependent-visa
+    mechanism).
+15. **Investment requirements.** Not applicable to D1.
+16. **Mandatory documents.** 6-month passport validity, CV, itinerary, support/statement letter (plus the
+    USD 2,000 funds proof at §12). — `CL-D1-02`, **VERIFIED**, sourced against the live D1
+    OFFICIAL_PORTAL page (QW-5 record #15, CURRENT, "verbatim confirms all 6"). **Caveat carried
+    forward from the ledger**: the pack's `el.d1-*` requirement-bundle rules also co-cite
+    `ee8fe5b8-...`, a general izin-tinggal-keimigrasian portal page flagged **CHANGED** in
+    `freshness-recheck-2026-08-16.md` record #4 (its own "Persyaratan Dokumen" section does not carry
+    the specific 6-month/USD 2000/CV/itinerary/support-letter items it is co-cited for). QW-5's own
+    D1-specific record (#15) backing `CL-D1-02` is unaffected (still CURRENT) — this claim's own
+    sourcing is sound — but the CHANGED co-citation is carried here per Conflict Report **CF-6**, not
+    silently dropped, so whoever authors seq-9 doesn't re-inherit the CHANGED leg unexamined.
+17. **Declarative vs. documentary-proof requirements.** **GAP** — no claim in this ledger classifies
+    which of D1's requirement-bundle items are self-declared vs. require documentary verification at the
+    fact level (the requirement-bundle claim, `CL-D1-02`, states the items exist, not their
+    declaration/verification class).
+
+## 4. Full-card query note
+
+The widest "full doctrine card" query for D1 (`E2A-D1-DOCTRINE`) **timed out** (150s `QueryTimeoutError`)
+during E2a's execution — logged honestly in `e2a-claim-ledger.md`'s Query execution summary, not
+backfilled by inference. Every fact the pack's current 6 `el.d1-*` rules actually require IS covered by
+the narrower successful queries above (§3 items 1, 5, 6, 12, 16); the timeout is a **documentation-
+completeness loss for PDC-1 fields not yet consumed by any rule** (§3 items 3, 4, 7-11, 13-15, 17), not a
+compilable-claim loss for the current pack. Those GAP items are exactly the next-E2-batch candidates
+listed in §8.
+
+## 5. Open conflicts
+
+None for D1. D1 carries no CF entry in `e2a-conflict-report.md` (CF-1/CF-2 are D2/D12-specific; CF-6's
+CHANGED co-source applies but is a sourcing-hygiene note, not a doctrinal disagreement — see §3.16).
+
+## 6. Rule coverage matrix (seq-7, verified live against `rulepack-prod-007.source.json`)
+
+D1 has 6 ELIGIBILITY rules, all gated on
+`intent.purposes intersects [TOURISM,FAMILY,TRANSIT,BUSINESS_MEETINGS] AND stay_days<=60 AND
+entry_pattern=MULTIPLE`.
+
+| rule_id | reason_code | required claim(s) | claim state | rule status |
+|---|---|---|---|---|
+| `el.d1-multi-entry-support` | `PURPOSE_PRODUCT_MATCH` | `CL-D1-01` | VERIFIED | SUPPORTED |
+| `el.d1-passport-validity` | `PASSPORT_VALIDITY_6_MONTHS_REQUIRED` | `CL-D1-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat, §3.16) |
+| `el.d1-funds-usd-2000` | `PROOF_OF_FUNDS_D1` | `CL-D1-02`, `CL-D-FUNDS` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d1-cv-required` | `CV_REQUIRED` | `CL-D1-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d1-itinerary-required` | `ITINERARY_REQUIRED` | `CL-D1-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d1-support-letter` | `SUPPORT_LETTER_REQUIRED` | `CL-D1-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+
+The `stay_days<=60`/`entry_pattern=MULTIPLE` gating condition itself (not a named `reason_code`, but
+load-bearing for every D1 rule firing at all) is backed by `CL-D1-03` (VERIFIED, evidentiary caveat per
+§3.6) and cross-checked by `CL-D-COMPARE` (VERIFIED, same caveat).
+
+**Rules WITHOUT backing in this ledger**: none — all 6 current `el.d1-*` rules have a VERIFIED claim.
+No pack rule currently encodes the PDC-1 dimensions marked GAP in §3 (prohibited/borderline activities,
+extensions/conversions, filing location, sponsor requirements, income-source permission,
+declarative-vs-documentary classification) because the pack has no fact/rule for them yet — that is an
+E4/E5 fact-vocabulary extension question, not a gap in this card's claim-backing of the rules that DO
+exist today.
+
+## 7. Disposition
+
+**REACHABLE_AND_SUPPORTED-candidate.** All 6 current `el.d1-*` rules have every required claim at state
+VERIFIED (5-way classification per the blueprints' terminology: this product is not
+`BLOCKED_BY_MISSING_DOCTRINE`, `HR-only`, nor `0 rules`). No CONFLICTING/STALE/UNVERIFIED claim gates any
+current D1 rule. The 7 GAP items in §3 do not block the slice gate (per `e2a-coverage-matrix.md`'s
+criterion: "nessun prodotto classificato REACHABLE_AND_SUPPORTED con claims richiesti non-VERIFIED" — D1
+has no *required* claim left non-VERIFIED) — they are E4/E5 fact-vocabulary candidates for a future,
+richer D1 rule set, not blockers on today's 6 rules.
+
+`claims_digest` pairs (sorted, `claim_id=state`):
+
+```
+CL-D-COMPARE=VERIFIED
+CL-D-FUNDS=VERIFIED
+CL-D1-01=VERIFIED
+CL-D1-02=VERIFIED
+CL-D1-03=VERIFIED
+```
+
+## 8. Claim gaps discovered (input for next E2 batch — not queried in this task per brief)
+
+1. D1 prohibited-activity boundary (mirror of D2/D12's explicit prohibition claim).
+2. D1 borderline-activity boundary (mirror of `CL-D12-05`).
+3. D1 extension/conversion mechanics (mirror of `CL-D12-04`).
+4. D1 filing location / onshore-status prerequisites.
+5. D1 declarative-vs-documentary classification of its 6 requirement-bundle items.
+6. The full-card query `E2A-D1-DOCTRINE` itself, re-run without the 150s timeout budget that killed it
+   in E2a (widest single-query documentation-completeness gap; every fact it would answer is otherwise
+   covered per §4, but the narrative synthesis itself is missing).
+
+## Adversarial review
+
+Cross-family review run via `kimi -p "REFUTA questa doctrine card: cerca fatti senza claim_id, claim
+citati con stato sbagliato, digest non riproducibile" -m kimi-code/k3` (generator≠grader, 8-minute
+timebox per task brief). Findings, re-verified independently against `e2a-claim-ledger.md` and
+`rulepack-prod-007.source.json` before dispositioning:
+
+1. **[P1, CONFIRMED, cured]** §3.6 originally stated the "no annual cap" conclusion as a flat VERIFIED
+   fact without carrying the ledger's own evidentiary-caveat language (silence-based, not explicit
+   denial) — risked reading as a stronger claim than the ledger itself supports. Reworded to state the
+   caveat explicitly, matching `CL-D1-03`'s own wording in `e2a-claim-ledger.md`.
+2. **[P2, CONFIRMED, cured]** The coverage matrix (§6) did not originally carry the CF-6 CHANGED-co-source
+   caveat on the 5 requirement-bundle rules (only `CL-D1-02` mentioned it in §3.16) — a reader consulting
+   only §6 would miss it. Added "(CF-6 co-source caveat)" to each affected row.
+3. **[P2, NOT-AN-ISSUE]** Reviewer asked whether `claims_digest` should include `CL-D1-STRUCT`-style
+   mechanical findings — D1 has none (structural findings only exist for E31B/E31D in this slice); no
+   change.
+
+Net: 2/3 raised findings were real and are cured above; 1/3 was reviewed and confirmed not applicable to
+this card.

--- a/research/visa/doctrine-factory/cards/D12.md
+++ b/research/visa/doctrine-factory/cards/D12.md
@@ -1,0 +1,191 @@
+---
+date: 2026-08-17
+domain: visa
+client_case: none
+sources:
+  - path: research/visa/doctrine-factory/claims/e2a-claim-ledger.md
+    note: "claim provenance for every doctrinal statement below (CL-D12-*, CL-D-COMPARE, CL-D-FUNDS)"
+  - path: research/visa/doctrine-factory/claims/e2a-conflict-report.md
+    note: "CF-2 (D12 total-validity conflict) RESOLVED as category error + CF-6 co-cited CHANGED source"
+  - path: research/visa/doctrine-factory/claims/e2a-coverage-matrix.md
+    note: "rule-to-claim mapping this card's coverage matrix reproduces for D12 only"
+  - path: research/visa/doctrine-factory/source-hierarchy-draft.md
+    note: "authority-level and claim-state vocabulary"
+  - path: apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
+    note: "active pack seq-7 (SHADOW) — the 6 el.d12-* + 1 hard-filter rules this card's coverage matrix targets"
+adversarial_review: kimi-k3
+---
+
+# Product Doctrine Card — D12 (Pre-Investment Multiple Entry)
+
+Task: E3a (Visa Oracle doctrine-factory execution plan), vertical slice. Input: E2a claim ledger
+(merged, PR #4245). Format follows the blueprints' PDC-1 field set and the B2 batch template. This card
+states NO legal fact without a `claim_id` pointer into `e2a-claim-ledger.md`; a PDC-1 field with no claim
+behind it is marked **GAP**.
+
+## 1. Identity
+
+- **Code**: D12
+- **Name**: Pre-Investment Multiple Entry
+- **Category**: Kunjungan (visit) index, multiple-entry, pre-investment-purpose (Kepmen
+  M.IP-08.GR.01.01/2025 classification table).
+
+## 2. `claims_digest`
+
+Recipe: take every `(claim_id, state)` pair this card depends on, sort ascending by `claim_id`, join as
+`claim_id=state` newline-separated, sha256 the UTF-8 bytes.
+
+```
+claims_digest: 50f98501e73dab73131d9a09f8a5acfdb1d625f295ea7f4e995fb212376ce7f6
+```
+
+## 3. Doctrinal facts (PDC-1 fields, each claim-referenced)
+
+1. **Category & legal purpose.** D12 authorizes activities aimed at starting a business — field surveys
+   (*survei lapangan*) and/or feasibility studies (*studi kelayakan*) — an exploratory
+   pre-PT-PMA-incorporation instrument. — `CL-D12-01`, **VERIFIED**.
+2. **Permitted activities.** Field surveys, feasibility studies, market research, land/site scouting,
+   legal/notarial consultation preliminary to incorporation. — `CL-D12-01` + `CL-D12-05`, both
+   **VERIFIED**.
+3. **Prohibited activities.** No subordinate work or local compensation. — `CL-D12-01`, **VERIFIED**.
+4. **Borderline/unresolved activities.** Hands-on operational work, installation, audit/QC of an existing
+   business, or supervision — these exit the pre-investment scope entirely and are NOT covered by D12. —
+   `CL-D12-05`, **VERIFIED**, corroborated by `E2A-D12-VS-D2`'s comparison table.
+5. **Single or multiple entry.** Multiple. — `CL-D12-01`, **VERIFIED**.
+6. **Duration per entry & total validity — CF-2, RESOLVED (category error, not a numeric conflict).**
+   180-day extension per request; **total continuous stay per entry capped at 12 months (360 days)**;
+   this is distinct from and does not modify the **visa validity tier** (1/2/5 years, up to 10 with prior
+   Indonesian stay record) — see §5. — `CL-D12-03`, **VERIFIED**.
+7. **Extensions & conversions.** Extendable onshore up to 12 months total per entry; **cannot be
+   converted to an ITAS onshore** — conversion (*alih status*) to E28A/E23-class stay permits requires
+   exiting Indonesia and applying offshore. — `CL-D12-04`, **VERIFIED** (two independent channels agree:
+   `E2A-D12-CONVERSION` structured citations + QW-5 OFFICIAL_PORTAL record #17, CURRENT).
+8. **Filing location (onshore/offshore) & onshore-status prerequisites.** Extension: onshore. Conversion
+   to a stay permit (ITAS-class): **offshore only** — see (7). — `CL-D12-04`, **VERIFIED**.
+9. **Nationality restrictions incl. calling-visa applicability.** **GAP** — out of this slice's claim
+   scope (GLOBAL rules, not D12-specific — see D1.md §3.9 for the identical note).
+10. **Age limits.** Not applicable — no age-eligibility rule/claim for D12.
+11. **Sponsor/guarantor requirements (post-UU 63/2024).** **GAP** — no D12-specific sponsor/guarantor
+    doctrine claim (D12 is an individual pre-investment product, not a sponsor-based family/employment
+    product like E31B/E31D).
+12. **Financial requirements & proof.** USD 5,000. — `CL-D12-02` (requirement bundle) + `CL-D-FUNDS`
+    (cross-cutting), both **VERIFIED** for D12 (numeric, primary-adjacent sourcing; independently
+    confirmed both in QW-5 record #17 and the E2a query).
+13. **Permitted source of income/compensation.** None — see (3), no subordinate work or local
+    compensation.
+14. **Family/dependent provisions.** Not applicable to D12.
+15. **Investment requirements.** None as an eligibility precondition — D12 is itself the
+    pre-investment-exploration instrument (no capital-commitment fact gates it); its
+    HARD_FILTER (`hf.d12-onshore-conversion-excluded`) applies only to the conversion pathway, not entry
+    eligibility. — `CL-D12-01`, **VERIFIED**.
+16. **Mandatory documents.** 6-month passport validity, CV, itinerary, support letter (plus USD 5,000
+    funds proof at §12). — `CL-D12-02`, **VERIFIED**, sourced against the live D12 OFFICIAL_PORTAL page
+    (QW-5 record #17, CURRENT). **CF-6 caveat carried forward**: the pack's `el.d12-*` requirement-bundle
+    rules also co-cite `ee8fe5b8-...`, flagged **CHANGED** in `freshness-recheck-2026-08-16.md` record
+    #4 — QW-5's own D12-specific record (#17) is unaffected (still CURRENT), but the co-citation is
+    logged so seq-9 authoring doesn't carry the CHANGED leg forward unexamined (see D1.md §3.16 for the
+    identical pattern).
+17. **Declarative vs. documentary-proof requirements.** **GAP** — same as D1/D2.
+
+## 4. Full-card query note
+
+D12's full-card and comparison queries (`E2A-D12-DURATION`, `E2A-D12-CONVERSION`, `E2A-D12-SITEVISIT`,
+`E2A-D12-VS-D2`) all completed **without timeout** — D12 is the one product in this slice whose doctrine
+card is backed by a complete, non-degraded query set. No completeness gap analogous to D1/D2's timed-out
+full-card queries applies here; the 2 GAP items in §3 (nationality/calling-visa, sponsor/guarantor) are
+genuine scope absences (out-of-slice / not-applicable), not timeout artifacts.
+
+## 5. Open conflicts — CF-2 (RESOLVED, carried for completeness)
+
+The blueprints flagged this as `[bench]` (unresolved) before E2a: `QB2-08` in output-B
+(`180/entry, ext 180, total 360 (Pasal 95(4) derogation)`) and `VO-NB2-088` in output-C. **`E2A-D12-
+DURATION` resolves it** with a verbatim primary-law pinpoint (Pasal 95(4), Permenkumham 11/2024, equivalent
+provision already present in 22/2023): the "1/2 years" and "1/2/5 years" figures the blueprints flagged as
+conflicting answer **two different questions**, not one: (a) the **visa validity tier** (the multi-year
+window during which entries are permitted, a property of the VISA — Pasal 5C(4)-(5)) vs. (b) the
+**per-entry stay-plus-extension ceiling** (180 days base + extension, capped at 12 months/360 days total
+per single entry — Pasal 95(4), a property of each individual STAY). The extension is confirmed strictly
+per-entry, never extending the visa's own multi-year validity — `E2A-D12-DURATION`: "L'estensione del
+visto D12 è strettamente per-entry... non modifica né prolunga la validità del visto madre." **This is a
+CLOSED conflict** — unlike D2's CF-1, no dissenting reading exists in this ledger for D12's duration
+figures. Carried here per the task brief's instruction to carry open conflicts visibly; D12 has none open.
+
+## 6. Rule coverage matrix (seq-7, verified live against `rulepack-prod-007.source.json`)
+
+D12 has 6 ELIGIBILITY rules + 1 HARD_FILTER, gated on `intent.purposes intersects [INVESTMENT] AND
+stay_days<=180` (eligibility rules) / `investment.pt_pma_committed != true` (conversion-exclusion filter).
+
+| rule_id | reason_code | required claim(s) | claim state | rule status |
+|---|---|---|---|---|
+| `el.d12-multi-entry-support` | `PURPOSE_PRODUCT_MATCH` | `CL-D12-01` | VERIFIED | SUPPORTED |
+| `el.d12-passport-validity` | `PASSPORT_VALIDITY_6_MONTHS_REQUIRED` | `CL-D12-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d12-funds-usd-5000` | `PROOF_OF_FUNDS_D12` | `CL-D12-02`, `CL-D-FUNDS` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d12-cv-required` | `CV_REQUIRED` | `CL-D12-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d12-itinerary-required` | `ITINERARY_REQUIRED` | `CL-D12-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d12-support-letter` | `SUPPORT_LETTER_REQUIRED` | `CL-D12-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `hf.d12-onshore-conversion-excluded` | `D12_NOT_CONVERTIBLE` | `CL-D12-04` | VERIFIED | SUPPORTED |
+
+The `stay_days<=180` gating condition (pre-extension figure) is backed by `CL-D12-03` (VERIFIED, CF-2
+resolved) and `CL-D-COMPARE` (VERIFIED). **No pack rule currently encodes the 360-day per-entry
+post-extension ceiling** — only the pre-extension `intent.stay_days<=180` gate exists in seq-7 — flagged
+for E4/E5 fact-vocabulary extension, not compiled here. The site-visit boundary claim (`CL-D12-05`)
+likewise has no `activity.*`-scoped fact/rule in seq-7 today — same E4 candidate status.
+
+**Rules WITHOUT backing in this ledger**: none — all 7 current `el.d12-*`/`hf.d12-*` rules have a
+VERIFIED claim.
+
+## 7. Disposition
+
+**REACHABLE_AND_SUPPORTED-candidate.** All 7 current D12 rules have every required claim at state
+VERIFIED. No CONFLICTING/STALE/UNVERIFIED claim gates any current D12 rule; CF-2, the one conflict the
+blueprints flagged for this product, is RESOLVED (not merely deferred) as a category error. The GAP items
+in §3 (nationality/calling-visa scope, sponsor/guarantor, declarative-vs-documentary classification, plus
+the 360-day post-extension ceiling and site-visit boundary at the rule level) are E4/E5 fact-vocabulary
+candidates for a future, richer D12 rule set — not blockers on today's 7 rules.
+
+`claims_digest` pairs (sorted, `claim_id=state`):
+
+```
+CL-D-COMPARE=VERIFIED
+CL-D-FUNDS=VERIFIED
+CL-D12-01=VERIFIED
+CL-D12-02=VERIFIED
+CL-D12-03=VERIFIED
+CL-D12-04=VERIFIED
+CL-D12-05=VERIFIED
+```
+
+## 8. Claim gaps discovered (input for next E2 batch — not queried in this task per brief)
+
+1. D12 nationality restrictions / calling-visa applicability (mirror of D1/D2's identical gap — likely
+   resolvable by the same GLOBAL-rule query across all three products at once, not per-product).
+2. D12 sponsor/guarantor requirements, if any exist at the individual-applicant level (currently assumed
+   not applicable, per §3.11 — worth a confirming query rather than leaving as an assumption).
+3. D12 declarative-vs-documentary classification of its 6 requirement-bundle items (mirror of D1/D2).
+4. A `activity.*`-scoped fact for D12's site-visit boundary (`CL-D12-05`) and a duration fact for the
+   360-day post-extension ceiling (`CL-D12-03`) — these are E4 fact-vocabulary decisions, not E2 claim
+   gaps (the claims backing them are already VERIFIED); listed here because E4 will need to consult this
+   card when scoping the new facts.
+
+## Adversarial review
+
+Cross-family review run via `kimi -p "REFUTA questa doctrine card: cerca fatti senza claim_id, claim
+citati con stato sbagliato, CF-2 trattato come ancora aperto quando è chiuso, digest non riproducibile"
+-m kimi-code/k3` (generator≠grader, 8-minute timebox). Findings, re-verified against
+`e2a-claim-ledger.md` and `e2a-conflict-report.md` before dispositioning:
+
+1. **[P1, CONFIRMED, cured]** §3.15 ("Investment requirements: Not applicable") initially read as a bare
+   assertion with no claim pointer — risked looking like an unbacked doctrinal statement rather than a
+   scope observation. Reworded to explicitly cite `CL-D12-01` (the purpose/scope claim that establishes
+   D12 has no capital-commitment eligibility gate) and clarify this is a scope reading of an existing
+   claim, not a new unbacked fact.
+2. **[P2, CONFIRMED, cured]** §6's coverage matrix listed `CL-D12-05` (site-visit boundary) nowhere,
+   even though it backs a doctrinal PDC-1 field (§3.4) — a reader relying only on §6 would not learn this
+   claim exists or that it has no corresponding pack rule yet. Added an explicit sentence after the table
+   noting the E4 gap for `CL-D12-05`.
+3. **[P2, NOT-AN-ISSUE]** Reviewer asked whether CF-2's resolution should be re-litigated given D2's CF-1
+   remains open on an adjacent fact (extension count) — checked: D12's Pasal 95(4) citation is verbatim
+   and undisputed by any second NB-2 answer in this ledger (unlike D2's Pasal 95(3), which has a
+   dissenting comparison-table cell). No structural reason to reopen CF-2. No change.
+
+Net: 2/3 raised findings were real and are cured above; 1/3 reviewed and confirmed the resolution stands.

--- a/research/visa/doctrine-factory/cards/D2.md
+++ b/research/visa/doctrine-factory/cards/D2.md
@@ -1,0 +1,228 @@
+---
+date: 2026-08-17
+domain: visa
+client_case: none
+sources:
+  - path: research/visa/doctrine-factory/claims/e2a-claim-ledger.md
+    note: "claim provenance for every doctrinal statement below (CL-D2-*, CL-D-COMPARE, CL-D-FUNDS)"
+  - path: research/visa/doctrine-factory/claims/e2a-conflict-report.md
+    note: "CF-1 (D2 duration citation disagreement, ESCALATED not resolved) + CF-6 (co-cited CHANGED source)"
+  - path: research/visa/doctrine-factory/claims/e2a-coverage-matrix.md
+    note: "rule-to-claim mapping this card's coverage matrix reproduces for D2 only"
+  - path: research/visa/doctrine-factory/source-hierarchy-draft.md
+    note: "authority-level vocabulary; §3.1.3 same-level-disagreement escalation rule this card's CF-1 section applies"
+  - path: apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
+    note: "active pack seq-7 (SHADOW) — the 6 el.d2-* rules this card's coverage matrix targets"
+adversarial_review: kimi-k3
+---
+
+# Product Doctrine Card — D2 (Business Multiple Entry)
+
+Task: E3a (Visa Oracle doctrine-factory execution plan), vertical slice. Input: E2a claim ledger
+(merged, PR #4245). Format follows the blueprints' PDC-1 field set (`output-C/blueprint-completa.md:582`)
+and the B2 batch template. This card states NO legal fact without a `claim_id` pointer into
+`e2a-claim-ledger.md`; a PDC-1 field with no claim behind it is marked **GAP**. **CF-1 is carried here
+as OPEN/ESCALATED — it is NOT resolved by this card, per the task brief.**
+
+## 1. Identity
+
+- **Code**: D2
+- **Name**: Business Multiple Entry
+- **Category**: Kunjungan (visit) index, multiple-entry, business-purpose (Kepmen
+  M.IP-08.GR.01.01/2025 classification table).
+
+## 2. `claims_digest`
+
+Recipe: take every `(claim_id, state)` pair this card depends on, sort ascending by `claim_id`, join as
+`claim_id=state` newline-separated, sha256 the UTF-8 bytes.
+
+```
+claims_digest: 3dbca20f8b864071fdf84f1e5541d7e13b227d9c78ef0e287eb1441d3639da9c
+```
+
+## 3. Doctrinal facts (PDC-1 fields, each claim-referenced)
+
+1. **Category & legal purpose.** D2 authorizes multiple business-purpose entries: meetings/negotiations,
+   market research, visits to partners/suppliers, trade fairs, preliminary contract signing — **absolute
+   prohibition on subordinate employment or local compensation**. — `CL-D2-01`,
+   **VERIFIED-WITH-CAVEAT**: the sole NB-2 citation is an internal guide (`0c22e859-...`, `type:
+   generated_text`) — upgraded to VERIFIED status only via the independently-verified OFFICIAL_PORTAL
+   corroboration channel (QW-5 record #16, CURRENT), never on the internal guide's authority alone (per
+   source-hierarchy-draft.md §3, an internal guide cannot outrank/self-certify a primary-level claim —
+   see `e2a-conflict-report.md` CF-3).
+2. **Permitted activities.** Same set as (1). — `CL-D2-01`, **VERIFIED-WITH-CAVEAT** (same sourcing note).
+3. **Prohibited activities.** Subordinate employment, local compensation — explicit prohibition, stated
+   directly in (1)'s source. — `CL-D2-01`, **VERIFIED-WITH-CAVEAT**.
+4. **Borderline/unresolved activities.** **GAP** — no D2-specific borderline-activity claim exists in
+   this ledger (D12 has one, `CL-D12-05`; D2 does not).
+5. **Single or multiple entry.** Multiple. — `CL-D2-01`, **VERIFIED-WITH-CAVEAT**.
+6. **Duration per entry & total validity — SEE §5 (OPEN CONFLICT CF-1).** 60 days per entry, up to 2
+   extensions of 60 days each, **180-day ceiling per single continuous stay** (60 base + up to 2×60
+   extensions) — this is a **per-stay ceiling, NOT a calendar-year cumulative cap**; no numeric
+   annual/calendar-year aggregate cap exists in primary law. — `CL-D2-03`, **VERIFIED-WITH-CAVEAT**.
+   **This field carries an open, human-escalated conflict — read §5 before treating any part of this
+   figure as fully closed.**
+7. **Extensions & conversions.** Up to 2 extensions of 60 days each (per `E2A-D2-DURATION`'s reading —
+   **disputed**, see §5: the dissenting `E2A-D12-VS-D2` comparison-table cell states only 1 extension of
+   60 days). — `CL-D2-03`, **VERIFIED-WITH-CAVEAT**, extension-count sub-question **OPEN** (part of CF-1).
+8. **Filing location (onshore/offshore) & onshore-status prerequisites.** **GAP** — no claim in this
+   ledger.
+9. **Nationality restrictions incl. calling-visa applicability.** **GAP** — out of this slice's claim
+   scope (GLOBAL rules, not D2-specific — see D1.md §3.9 for the identical note).
+10. **Age limits.** Not applicable — no age-eligibility rule/claim for D2.
+11. **Sponsor/guarantor requirements (post-UU 63/2024).** **GAP** — no D2-specific sponsor/guarantor
+    doctrine claim.
+12. **Financial requirements & proof.** "Sufficient living costs" — **no hardcoded national figure in the
+    parent statute** (Permenkumham 11/2024 Pasal 38(3) delegates the exact figure to the DG rather than
+    hardcoding it); operationally treated as USD 2,000 at the OFFICIAL_PORTAL layer, same tier as D1. —
+    `CL-D2-02` (requirement bundle, OFFICIAL_PORTAL-sourced, **VERIFIED**) + `CL-D-FUNDS` (cross-cutting,
+    **VERIFIED-WITH-CAVEAT** for D2 specifically — the caveat is precisely the statute-delegates-vs-
+    portal-hardcodes distinction; this is a **reconciled**, not-conflicting pair — `CL-D2-02`'s VERIFIED
+    status and `CL-D-FUNDS`'s VERIFIED-WITH-CAVEAT status describe two different layers of the same fact,
+    per the ledger's own cross-reference note).
+13. **Permitted source of income/compensation.** None — see (3), explicit absolute prohibition. —
+    `CL-D2-01`, **VERIFIED-WITH-CAVEAT**.
+14. **Family/dependent provisions.** Not applicable to D2.
+15. **Investment requirements.** Not applicable to D2 (D2 is business-visit, not pre-investment — D12
+    is the pre-investment product).
+16. **Mandatory documents.** 6-month passport validity, CV, itinerary, support letter (plus USD 2,000
+    funds proof at §12). — `CL-D2-02`, **VERIFIED**, sourced against the live D2 OFFICIAL_PORTAL page
+    (QW-5 record #16, CURRENT, "verbatim confirms all 6, identical structure to D1 page"). **CF-6 caveat
+    carried forward**: the pack's `el.d2-*` requirement-bundle rules also co-cite `ee8fe5b8-...`, flagged
+    **CHANGED** in `freshness-recheck-2026-08-16.md` record #4 — QW-5's own D2-specific record (#16) is
+    unaffected (still CURRENT), but the co-citation is logged so seq-9 authoring doesn't carry the
+    CHANGED leg forward unexamined (see D1.md §3.16 for the identical pattern).
+17. **Declarative vs. documentary-proof requirements.** **GAP** — same as D1.
+
+## 4. Full-card query note
+
+`E2A-D2-COMPARE` (the widest D2 comparison/full-card query) **timed out** during E2a's execution — logged
+in the ledger's execution summary, not backfilled by inference. `CL-D2-01`/`CL-D2-02`/`CL-D2-03` above
+were each backed by narrower successful queries; the 5 GAP items in §3 remain genuinely uncovered (not a
+timeout artifact — narrower queries never targeted them).
+
+## 5. OPEN CONFLICT — CF-1: D2 duration citation disagreement (ESCALATED, NOT resolved by this card)
+
+Per the task brief's explicit instruction, this section states **both readings and what evidence would
+resolve them** — it does not pick a winner.
+
+**What is settled** (both readings agree): 180 days is a **per-continuous-stay ceiling**
+(60-day base entry + extension mechanics), **never a calendar-year cumulative aggregate**. This
+category-error correction is confirmed and closed — do not port "calendar-year cumulative cap" language
+into seq-9 (per `e2a-conflict-report.md` CF-1's resolution).
+
+**What is NOT settled** — two same-tier NB-2 answers disagree on the extension mechanics behind that
+180-day figure:
+
+| | Reading A — `E2A-D2-DURATION` | Reading B — `E2A-D12-VS-D2` (dissenting cell) |
+|---|---|---|
+| Extensions | Up to **2×60-day** extensions | **1×60-day** extension only |
+| Arithmetic | 60 base + 2×60 = 180 | Implied: 60 base + 1×60 + (unstated remainder) = 180, OR a different base assumption — the dissenting cell states the conclusion, not the arithmetic |
+| Citation quality | **Verbatim primary-law pinpoint**: Permenkumham 11/2024 (amending 22/2023), Pasal 95(3), quoted in full | No verbatim citation — a comparison-table cell with no article/paragraph pinpoint |
+| Ledger's working assumption | Treated as the **operative doctrine** for `CL-D2-03` because it carries a checkable citation the dissenting cell lacks | Logged, not adopted, not discarded |
+
+**Why this is escalated, not hierarchy-resolved**: `source-hierarchy-draft.md` §3.1.3 governs
+disagreement **between sources** at different authority levels (an internal guide vs. a primary-law
+citation, resolved by rank) — it does **not** authorize a pinpoint-citation tiebreaker for two **same-tier
+NB-2 answers** referencing the same underlying instrument with differing citation completeness. An earlier
+draft of the E2a conflict report invoked such a tiebreaker; that framing was retracted by the adversarial
+review (kimi-k3) and corrected in `e2a-conflict-report.md`. This ledger/card treats Reading A as the
+*working* doctrine (it has the checkable citation) but the disagreement itself is **NOT closed** — flagged
+here for human/E3a review exactly as `e2a-claim-ledger.md`/`e2a-conflict-report.md` leave it.
+
+**What evidence would resolve it**: a direct re-query of NB-2 targeting Pasal 95(3)'s implementing
+guidance (or Ditjen Imigrasi's own operational SOP, if one exists as a Surat Edaran — see
+`source-hierarchy-draft.md` §2's noted L4 gap) specifically on the extension-count mechanics, phrased to
+force a verbatim quote rather than a comparison-table summary; alternatively, a direct read of the
+statute's own extension-procedure article (if distinct from Pasal 95(3)) rather than relying on NB-2's
+synthesis of it.
+
+**Disposition for this card**: `CL-D2-03` is `VERIFIED-WITH-CAVEAT`, not `CONFLICTING` — per
+`e2a-conflict-report.md`'s Status section, the per-stay-vs-annual category question IS resolved (that part
+of the claim is solid); only the citation-disagreement/extension-count sub-question is escalated. No pack
+rule currently encodes D2's duration fact at all (`intent.stay_days<=60` is the only D2 duration check in
+seq-7 — pre-extension, undisputed), so this open conflict does **not** block the slice gate today; it must
+be resolved (not silently picked) before any seq-9 rule attempts to encode the extension-count mechanics.
+
+## 6. Rule coverage matrix (seq-7, verified live against `rulepack-prod-007.source.json`)
+
+D2 has 6 ELIGIBILITY rules, all gated on `intent.purposes intersects [BUSINESS_MEETINGS] AND
+stay_days<=60`.
+
+| rule_id | reason_code | required claim(s) | claim state | rule status |
+|---|---|---|---|---|
+| `el.d2-multi-entry-support` | `PURPOSE_PRODUCT_MATCH` | `CL-D2-01` | VERIFIED-WITH-CAVEAT | SUPPORTED |
+| `el.d2-passport-validity` | `PASSPORT_VALIDITY_6_MONTHS_REQUIRED` | `CL-D2-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d2-funds-usd-2000` | `PROOF_OF_FUNDS_D2` | `CL-D2-02`, `CL-D-FUNDS` | VERIFIED / VERIFIED-WITH-CAVEAT | SUPPORTED (CF-6 co-source caveat; reconciled statute-vs-portal layering, §3.12) |
+| `el.d2-cv-required` | `CV_REQUIRED` | `CL-D2-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d2-itinerary-required` | `ITINERARY_REQUIRED` | `CL-D2-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+| `el.d2-support-letter` | `SUPPORT_LETTER_REQUIRED` | `CL-D2-02` | VERIFIED | SUPPORTED (CF-6 co-source caveat) |
+
+The `stay_days<=60` gating condition is backed by `CL-D2-03` (VERIFIED-WITH-CAVEAT, §5 open conflict) and
+`CL-D-COMPARE` (VERIFIED). **No pack rule currently encodes CL-D2-03's 180-day/extension mechanics at
+all** — flagged for E4/E5 fact-vocabulary extension; the open conflict in §5 must be resolved before that
+extension is authored, not carried forward silently.
+
+**Rules WITHOUT backing in this ledger**: none of the 6 current `el.d2-*` rules is unbacked — all 6 have
+at minimum a VERIFIED-WITH-CAVEAT claim. No current rule is blocked by CF-1 because no current rule
+consumes the disputed extension-count fact yet.
+
+## 7. Disposition
+
+**REACHABLE_AND_SUPPORTED-candidate, WITH the CF-1 open item flagged.** All 6 current `el.d2-*` rules
+have every required claim at state VERIFIED or VERIFIED-WITH-CAVEAT (none CONFLICTING/STALE/UNVERIFIED).
+Per the slice gate criterion ("nessun prodotto classificato REACHABLE_AND_SUPPORTED con claims richiesti
+non-VERIFIED"), D2 passes the gate for its CURRENT 6 rules — but this disposition is explicitly
+conditional: **CF-1 must not be silently closed when D2's duration/extension fact is eventually compiled
+into seq-9.** The 3 VERIFIED-WITH-CAVEAT claims on this card (`CL-D2-01`, `CL-D2-03`, `CL-D-FUNDS`) are
+carried visibly, not resolved to plain VERIFIED, per the task brief's gate requirement.
+
+`claims_digest` pairs (sorted, `claim_id=state`):
+
+```
+CL-D-COMPARE=VERIFIED
+CL-D-FUNDS=VERIFIED-WITH-CAVEAT
+CL-D2-01=VERIFIED-WITH-CAVEAT
+CL-D2-02=VERIFIED
+CL-D2-03=VERIFIED-WITH-CAVEAT
+```
+
+## 8. Claim gaps discovered (input for next E2 batch — not queried in this task per brief)
+
+1. **CF-1's extension-count resolution** (§5) — the single highest-priority gap in this card: a targeted
+   re-query or primary-source read to settle 1-vs-2 extensions before seq-9 encodes D2 duration.
+   Note: this is a CONFLICT to resolve, not a claim gap to fill blind — flagged distinctly from the items
+   below.
+2. D2 borderline-activity boundary (mirror of `CL-D12-05`).
+3. D2 filing location / onshore-status prerequisites.
+4. D2 declarative-vs-documentary classification of its 6 requirement-bundle items.
+5. `E2A-D2-COMPARE` full-card query, re-run without the timeout budget that killed it.
+
+## Adversarial review
+
+Cross-family review run via `kimi -p "REFUTA questa doctrine card: cerca fatti senza claim_id, claim
+citati con stato sbagliato, CF-1 trattato come risolto, digest non riproducibile" -m kimi-code/k3`
+(generator≠grader, 8-minute timebox). Findings, re-verified against `e2a-claim-ledger.md` and
+`e2a-conflict-report.md` before dispositioning:
+
+1. **[P0, CONFIRMED, cured]** An earlier draft of §5's table framed Reading A's 2-extension figure as the
+   settled answer with only a footnote acknowledging Reading B — functionally treating CF-1 as resolved
+   by pinpoint strength, exactly the framing the E2a adversarial review already retracted in
+   `e2a-conflict-report.md`. Rewritten: both readings are now presented symmetrically in the comparison
+   table, with the "working assumption vs. NOT closed" distinction stated explicitly and the retraction
+   history cited.
+2. **[P1, CONFIRMED, cured]** §3.6/§3.7 originally stated "60 base + up to 2×60 extensions" as a flat fact
+   without a pointer into §5's open-conflict section — a reader stopping at §3 would miss that the
+   extension count is disputed. Added explicit "SEE §5" cross-references and inline caveats.
+3. **[P2, CONFIRMED, cured]** §6's coverage-matrix row for `el.d2-funds-usd-2000` originally listed only
+   `CL-D2-02` at VERIFIED, omitting that `CL-D-FUNDS` (also required per the coverage-matrix source) is
+   VERIFIED-WITH-CAVEAT for D2 — could read as fully clean when one of its two backing claims carries a
+   caveat. Added both claim IDs and both states.
+4. **[P2, NOT-AN-ISSUE]** Reviewer asked whether `CL-D2-01`'s VERIFIED-WITH-CAVEAT status should propagate
+   to a "the whole card is caveated" banner — declined: the ledger's own convention (source-hierarchy
+   §3.2, five discrete states) is per-claim, not per-card: some D2 claims are plain VERIFIED
+   (`CL-D2-02`); collapsing to one card-wide caveat would lose that granularity. No change.
+
+Net: 3/4 raised findings were real and are cured above (1 at P0 — the CF-1 framing risk, the most
+consequential class of error this card could make per the task brief); 1/4 reviewed and confirmed
+correct as designed.

--- a/research/visa/doctrine-factory/cards/E31B.md
+++ b/research/visa/doctrine-factory/cards/E31B.md
@@ -1,0 +1,200 @@
+---
+date: 2026-08-17
+domain: visa
+client_case: none
+sources:
+  - path: research/visa/doctrine-factory/claims/e2a-claim-ledger.md
+    note: "claim provenance for every doctrinal statement below (CL-E31B-*)"
+  - path: research/visa/doctrine-factory/claims/e2a-conflict-report.md
+    note: "CF-4 (structural fail-open, cross-referenced not new) + CF-5 (index-swap claim, REFUTED for production)"
+  - path: research/visa/doctrine-factory/claims/e2a-coverage-matrix.md
+    note: "rule-to-claim mapping this card's coverage matrix reproduces for E31B only"
+  - path: apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
+    note: "active pack seq-7 (SHADOW) — the 2 el.e31b-* rules this card's coverage matrix targets, and the sponsor_status_code fact gate re-verified live this session"
+adversarial_review: kimi-k3
+---
+
+# Product Doctrine Card — E31B (Spouse of ITAS/ITAP Holder) — refuter product
+
+Task: E3a (Visa Oracle doctrine-factory execution plan), vertical slice. Input: E2a claim ledger
+(merged, PR #4245). E31B is one of the slice's two **fail-open refuter targets**
+(`adjudication-report.md` finding #5) — this card records both the mechanical structural finding AND
+the doctrinal P0 fix as E5-compiler input, per the task brief.
+
+## 1. Identity
+
+- **Code**: E31B
+- **Name**: Family Visa — Spouse of ITAS/ITAP Holder
+- **Category**: Family-reunion (Kunjungan/Izin Tinggal family class), single-entry-adjacent, sponsor-
+  based (Kepmen M.IP-08.GR.01.01/2025).
+
+## 2. `claims_digest`
+
+Recipe: take every `(claim_id, state)` pair this card depends on, sort ascending by `claim_id`, join as
+`claim_id=state` newline-separated, sha256 the UTF-8 bytes.
+
+```
+claims_digest: 511ef2a4d43594c691212604be3b5c7847f17f2e7c937a1e64365096b66a4b12
+```
+
+## 3. Doctrinal facts (PDC-1 fields, each claim-referenced)
+
+1. **Category & legal purpose.** Family-reunion visa for the foreign spouse of an ITAS/ITAP holder,
+   defined by Kepmen M.IP-08.GR.01.01/2025: *"Orang asing yang menggabungkan diri dengan suami atau
+   istri pemegang Izin Tinggal Terbatas atau Izin Tinggal Tetap."* — `CL-E31B-01`, **VERIFIED**.
+2. **Permitted activities.** Residence for the duration aligned to the sponsor's permit. — `CL-E31B-01`,
+   **VERIFIED**.
+3. **Prohibited activities.** Absolute prohibition on local income-generating work (Pasal 122, UU
+   6/2011). — `CL-E31B-01`, **VERIFIED**, verbatim primary-law pinpoint.
+4. **Borderline/unresolved activities.** **GAP** — no E31B-specific borderline-activity claim exists in
+   this ledger.
+5. **Single or multiple entry.** Aligned to the sponsor's own permit type/duration (implicit in (2));
+   no separate entry-pattern claim exists. — `CL-E31B-01`, **VERIFIED** (as scope of (1)-(2)).
+6. **Duration per entry & total validity.** Aligned to the sponsor's ITAS/ITAP duration — not an
+   independent figure. — `CL-E31B-01`, **VERIFIED** (as scope).
+7. **Extensions & conversions.** **GAP** — no explicit E31B extension/conversion claim exists in this
+   ledger.
+8. **Filing location (onshore/offshore) & onshore-status prerequisites.** **GAP** — not covered.
+9. **Nationality restrictions incl. calling-visa applicability.** **GAP** — out of slice scope
+   (GLOBAL rules).
+10. **Age limits.** Not applicable (spousal, not age-gated).
+11. **Sponsor/guarantor requirements — THE P0 DOCTRINE FIX.** Per **Permenkumham No. 22/2023 Pasal
+    44(2)(b)** (as amended by Permenkumham 11/2024), the sponsoring spouse **must hold a currently-valid,
+    non-expired ITAS or ITAP.** The **sole legal exception** (Pasal 44(3)) is where the sponsor's
+    ITAS/ITAP is not yet issued but has been **replaced by an approved VITAS** (Visa Tinggal Terbatas)
+    for the spouse. Per **Pasal 119**, if the sponsor's status is unverifiable, expired, absent, or
+    "pending"/"in process", the officer issues an incompleteness notice with **2 working days** to cure
+    before **automatic, definitive rejection**. — `CL-E31B-REFUTER`, **VERIFIED**, verbatim
+    primary-law pinpoint (Pasal 44(2)(b)/44(3)/119). **This is the field the structural fail-open finding
+    (§4) targets — see §5.**
+12. **Financial requirements & proof.** **GAP** — no explicit E31B-specific financial-proof claim exists
+    in this ledger (E31B is sponsor-dependent, not independently means-tested per the claims gathered).
+13. **Permitted source of income/compensation.** None — see (3).
+14. **Family/dependent provisions.** E31B itself IS the family-dependent instrument (spouse of an
+    ITAS/ITAP holder). **Principal-status eligibility**: both foreign workers holding E23/E25-family work
+    permits AND investors holding E28/E28A/E28B/E28G are eligible sponsors — both categories have an
+    explicit, legally guaranteed right to bring a spouse/minor unmarried children; the ITAS/ITAP status
+    check (§3.11) is category-agnostic (does not differentiate by which principal category the sponsor
+    falls under). — `CL-E31B-PRINCIPAL`, **VERIFIED-WITH-CAVEAT** (query_id provenance resolves against
+    the frozen NB-2 snapshot, but no verbatim article/paragraph pinpoint was captured for this specific
+    claim, unlike the REFUTER claim above — downgraded from plain VERIFIED per the E2a adversarial
+    review).
+15. **Investment requirements.** Not applicable to E31B directly (relevant only insofar as an E28-class
+    investor may be the sponsoring principal — see (14)).
+16. **Mandatory documents.** Authenticated, sworn-translated marriage certificate (*Akta Nikah/Buku
+    Nikah*). — `CL-E31B-01`, **VERIFIED**.
+17. **Declarative vs. documentary-proof requirements.** The marriage certificate is a **documentary**
+    requirement (authenticated + sworn-translated, not self-declared) — `CL-E31B-01`, **VERIFIED**. The
+    sponsor-status check (§3.11) is likewise **documentary/systemic** (verified against ITAS/ITAP
+    records, not self-declared) — `CL-E31B-REFUTER`, **VERIFIED**. No claim addresses whether every OTHER
+    requirement-bundle item is declarative or documentary — partial coverage, not a full GAP.
+
+## 4. Structural fail-open finding (mechanical, independent of NB-2 doctrine)
+
+**`CL-E31B-STRUCT`, VERIFIED as a mechanical/structural finding** (re-derived live against
+`rulepack-prod-007.source.json` this session, matches `adjudication-report.md` finding #5): both
+`el.e31b-spouse-itas-support` and `el.e31b-sponsor-itas-itap` gate on
+`{"fact":"family.sponsor_status_code","op":"known"}`. **`known` is value-blind** — any non-null value
+satisfies it, including a sentinel like `"NONE"`. The frontend mitigation
+(`mapFamilySponsorStatus()` never emits `KNOWN`) is a **UI workaround, not a doctrine fix** — it does not
+change what the rule itself would do if a KNOWN sentinel ever reached it through any other path (API
+call, future frontend change, direct evaluator invocation). This is exactly why this product is scoped as
+a refuter target: the doctrine question is "what does primary law say verified sponsor status actually
+requires" (§3.11/§5), independent of the current frontend workaround.
+
+## 5. The compilable doctrine fix (E5 compiler input)
+
+Per `CL-E31B-REFUTER` (§3.11): the compilable enum for `family.sponsor_status_code` is
+**`{ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED}`, nothing else** — the answer states explicitly:
+*"Uno sponsor il cui ITAS/ITAP risulti scaduto, non verificato, non registrato, assente o semplicemente
+dichiarato 'in corso di lavorazione' [...] non è mai sufficiente ad attivare la pratica."*
+
+**Recommended seq-9 change** (E4/E5 decision on exact fact-vocabulary naming, not authored here): narrow
+both `el.e31b-spouse-itas-support` and `el.e31b-sponsor-itas-itap` from
+`{"fact":"family.sponsor_status_code","op":"known"}` to
+`{"fact":"family.sponsor_status_code","op":"in","values":["ITAS_ACTIVE","ITAP_ACTIVE","VITAS_APPROVED"]}`.
+This directly closes the value-blind gate (§4) at the rule level rather than relying on a frontend
+mitigation.
+
+## 6. Open conflicts
+
+None specific to E31B. `CF-5` (E31B/E31D "index swap" claim) is cross-referenced for context, not a
+doctrinal conflict about E31B itself: two NB-2 answers cited an internal source
+(`nb2_visa_types_final.txt`) claiming a "Nuzantara dev / visa_types table" mislabels E31D as "Spouse
+KITAS" and E31B as "Dependent KITAS (Child)" — the opposite of the primary-law mapping this card and the
+ledger otherwise confirm. **Checked directly against the live production system** this session
+(`seed_visa_types_complete_2026.py:1172,1200` + `rulepack-prod-007.source.json`'s `products[].names`):
+both show the CORRECT mapping (E31B = spouse, E31D = stepchild). **Disposition: REFUTED for the live
+production system** — no swap exists in the code path that serves users. Recorded here per CF-5's own
+instruction so this claim is never re-raised as new without this disposition.
+
+## 7. Rule coverage matrix (seq-7, verified live against `rulepack-prod-007.source.json`)
+
+E31B has 2 ELIGIBILITY rules.
+
+| rule_id | reason_code | required claim(s) | claim state | rule status |
+|---|---|---|---|---|
+| `el.e31b-spouse-itas-support` | `PURPOSE_PRODUCT_MATCH` | `CL-E31B-01`, `CL-E31B-STRUCT` | VERIFIED | SUPPORTED-BUT-FAIL-OPEN — see §4/§5 |
+| `el.e31b-sponsor-itas-itap` | `REQ_SPONSOR_ITAS_ITAP` | `CL-E31B-REFUTER`, `CL-E31B-STRUCT` | VERIFIED | SUPPORTED-BUT-FAIL-OPEN — see §4/§5 |
+
+`CL-E31B-PRINCIPAL` (VERIFIED-WITH-CAVEAT, §3.14) informs the sponsor-eligibility doctrine generally but
+does not gate either current rule directly (neither rule discriminates by principal category).
+
+**Rules WITHOUT backing in this ledger**: none of the 2 current rules is unbacked — both have VERIFIED
+claims. **Both rules are, however, structurally fail-open** (§4) despite being claim-backed: the claim
+that gates them today (`known`, value-blind) is doctrinally correct in what it's SUPPOSED to check but
+mechanically wrong in HOW it checks it — the compilable fix in §5 is what closes this, not a new claim.
+
+## 8. Disposition
+
+**REACHABLE_AND_SUPPORTED-candidate for the slice gate; FAIL-OPEN at the rule-implementation level,
+flagged for E5.** Both current E31B rules have every required claim at state VERIFIED — the slice gate
+criterion is met (no product classified `REACHABLE_AND_SUPPORTED` with a required claim non-VERIFIED).
+But "claim-backed" and "safe" are not the same thing here: the claims are VERIFIED, and what they verify
+IS that the current rule implementation (`known`, value-blind) is a fail-open gap relative to what
+primary law actually requires. This is the entire point of scoping E31B as a refuter product — the E5
+compiler must consume `CL-E31B-REFUTER`'s enum (§5), not just confirm `CL-E31B-STRUCT`'s existence, to
+close the gap.
+
+`claims_digest` pairs (sorted, `claim_id=state`):
+
+```
+CL-E31B-01=VERIFIED
+CL-E31B-PRINCIPAL=VERIFIED-WITH-CAVEAT
+CL-E31B-REFUTER=VERIFIED
+CL-E31B-STRUCT=VERIFIED
+```
+
+## 9. Claim gaps discovered (input for next E2 batch — not queried in this task per brief)
+
+1. E31B borderline-activity boundary.
+2. E31B filing location / onshore-status prerequisites.
+3. E31B independent financial-proof requirement, if any exists beyond sponsor-dependency.
+4. E31B declarative-vs-documentary classification for requirement-bundle items other than the marriage
+   certificate and sponsor-status check.
+5. A verbatim primary-law pinpoint for `CL-E31B-PRINCIPAL` (currently VERIFIED-WITH-CAVEAT on query_id
+   provenance alone) — would upgrade it to plain VERIFIED.
+
+## Adversarial review
+
+Cross-family review run via `kimi -p "REFUTA questa doctrine card: cerca fatti senza claim_id, claim
+citati con stato sbagliato, il fail-open trattato come già risolto quando non lo è, digest non
+riproducibile" -m kimi-code/k3` (generator≠grader, 8-minute timebox). Findings, re-verified against
+`e2a-claim-ledger.md`, `e2a-conflict-report.md` and `rulepack-prod-007.source.json` before
+dispositioning:
+
+1. **[P0, CONFIRMED, cured]** §7's original rule-status column read "SUPPORTED" without qualification —
+   this risked a downstream reader (E5 compiler author) treating the current rule as already safe because
+   its claim is VERIFIED, missing that the *rule itself* is still fail-open until §5's enum change ships.
+   Reworded both rows to "SUPPORTED-BUT-FAIL-OPEN — see §4/§5" and added the explicit distinction
+   paragraph after the table.
+2. **[P1, CONFIRMED, cured]** §8's disposition originally stated only "REACHABLE_AND_SUPPORTED-candidate"
+   without flagging the fail-open status at the same altitude — could be read by a downstream gate as "E31B
+   is done." Rewrote the disposition heading and body to name both the gate-passing status AND the
+   still-open fail-open flag in the same sentence.
+3. **[P2, CONFIRMED, cured]** §14/§3.14 (`CL-E31B-PRINCIPAL`) originally did not explain WHY it is
+   VERIFIED-WITH-CAVEAT rather than plain VERIFIED, unlike every other caveat in this card. Added the
+   explicit reason (query_id-only provenance, no verbatim pinpoint) matching the ledger's own wording.
+
+Net: all 3 raised findings were real and are cured above (1 at P0 — the fail-open-vs-safe distinction is
+the single most important thing this card must not blur, given the product's role as a refuter target).

--- a/research/visa/doctrine-factory/cards/E31D.md
+++ b/research/visa/doctrine-factory/cards/E31D.md
@@ -1,0 +1,226 @@
+---
+date: 2026-08-17
+domain: visa
+client_case: none
+sources:
+  - path: research/visa/doctrine-factory/claims/e2a-claim-ledger.md
+    note: "claim provenance for every doctrinal statement below (CL-E31D-*)"
+  - path: research/visa/doctrine-factory/claims/e2a-conflict-report.md
+    note: "CF-4 (structural over-breadth, cross-referenced not new) + CF-5 (index-swap claim, REFUTED for production)"
+  - path: research/visa/doctrine-factory/claims/e2a-coverage-matrix.md
+    note: "rule-to-claim mapping this card's coverage matrix reproduces for E31D only"
+  - path: research/visa/doctrine-factory/sources/freshness-recheck-2026-08-16.md
+    note: "record #9 (E31D OFFICIAL_PORTAL page) CURRENT — confirms this card's document-list claim is not riding a CHANGED co-source, unlike D1/D2/D12"
+  - path: apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
+    note: "active pack seq-7 (SHADOW) — the 3 el.e31d-* rules this card's coverage matrix targets, and the intersects[FAMILY] reduction re-verified live this session"
+adversarial_review: kimi-k3
+---
+
+# Product Doctrine Card — E31D (Stepchild of Foreigner in Mixed Marriage) — refuter product
+
+Task: E3a (Visa Oracle doctrine-factory execution plan), vertical slice. Input: E2a claim ledger
+(merged, PR #4245). E31D is the slice's second **fail-open refuter target**
+(`adjudication-report.md` finding #5) — this card records both the mechanical structural finding AND
+the doctrinal P0 fix as E5-compiler input, per the task brief.
+
+## 1. Identity
+
+- **Code**: E31D
+- **Name**: Family Visa — Stepchild of Foreigner in Legal Mixed Marriage
+- **Category**: Family-reunion child visa, sponsor-based, age/marital-status-gated (Kepmen
+  M.IP-08.GR.01.01/2025).
+
+## 2. `claims_digest`
+
+Recipe: take every `(claim_id, state)` pair this card depends on, sort ascending by `claim_id`, join as
+`claim_id=state` newline-separated, sha256 the UTF-8 bytes.
+
+```
+claims_digest: 9aed9611653a2a384f167697706952d268894d14945cfd680696f4b004a43af1
+```
+
+## 3. Doctrinal facts (PDC-1 fields, each claim-referenced)
+
+1. **Category & legal purpose.** E31D is reserved exclusively for the foreign biological child of a
+   foreign parent legally, registeredly married to an Indonesian citizen (mixed marriage) — the child's
+   step-parent is Indonesian. Per Kepmen 2025: *"Menggabungkan diri bagi anak dari orang asing yang
+   kawin secara sah dengan warga negara Indonesia."* — `CL-E31D-01`, **VERIFIED**.
+2. **Permitted activities.** E31D holders are (uniquely among the E31 child-visa family, shared only with
+   E31A) permitted **informal/independent/self-employed work**. — `CL-E31D-01`, **VERIFIED**.
+3. **Prohibited activities.** By contrast, E31B/E31C/E31E/E31F/E31J strictly prohibit any work — this is
+   a comparative fact establishing what E31D is *not* prohibited from, not an E31D prohibition itself. —
+   `CL-E31D-01`, **VERIFIED** (comparative framing carried from the ledger's own wording).
+4. **Borderline/unresolved activities.** **GAP** — no E31D-specific borderline-activity claim exists in
+   this ledger (self-employed work permission at §2 is stated as a category fact, not bounded by a
+   scope-limit claim).
+5. **Single or multiple entry.** **GAP** — no explicit entry-pattern claim; implicit in the
+   family-reunion category but not separately verified.
+6. **Duration per entry & total validity.** Aligned to eligibility duration — **age/marital eligibility:
+   under 18 and unmarried** (loses eligibility on turning 18 or marrying); no separate entry/stay-duration
+   figure beyond that eligibility window. — `CL-E31D-REFUTER`, **VERIFIED**, verbatim primary-law
+   pinpoint (Permenkumham 22/2023 Pasal 46(2)).
+7. **Extensions & conversions.** **GAP** — no explicit E31D extension/conversion claim exists in this
+   ledger.
+8. **Filing location (onshore/offshore) & onshore-status prerequisites.** **GAP** — not covered, beyond
+   the mandatory **on-site field check within 4 working days** triggered by any mixed-marriage-based
+   application (§3.17 below) — `CL-E31D-REFUTER`, **VERIFIED**.
+9. **Nationality restrictions incl. calling-visa applicability.** **GAP** — out of slice scope (GLOBAL
+   rules).
+10. **Age limits — THE P0 DOCTRINE FIX (part 1).** **Under 18 and unmarried**; eligibility is lost on
+    turning 18 or on marriage. — `CL-E31D-REFUTER`, **VERIFIED**, verbatim primary-law pinpoint
+    (Permenkumham 22/2023 Pasal 46(2)).
+11. **Sponsor/guarantor requirements — THE P0 DOCTRINE FIX (part 2).** Declaring general `FAMILY` purpose
+    alone is **never sufficient**. Independent, certified, authenticated proof is required of: (a) the
+    specific child-to-foreign-parent relationship (birth certificate, sworn-translated), (b) the foreign
+    parent's legal, registered marriage to the Indonesian step-parent (Buku Nikah/Akta Perkawinan if
+    married in Indonesia; foreign certificate + Bukti Pelaporan if married abroad), (c) the Indonesian
+    step-parent's own identity/status as sponsor (Kartu Keluarga). All three document classes are
+    mandatory, verified/legalized/apostilled (Pasal 46(2)); a mixed-marriage-based application triggers a
+    mandatory on-site field check within 4 working days (Permenkumham 29/2021 Pasal 183-184). The answer
+    states explicitly: *"There is no administrative mechanism where a simple unilateral declaration of
+    intent or general family purpose bypasses these document-verification gates."* — `CL-E31D-REFUTER`,
+    **VERIFIED**, verbatim primary-law pinpoints (Pasal 46(2), Pasal 183-184). **This is the field the
+    structural over-breadth finding (§4) targets — see §5.**
+12. **Financial requirements & proof.** **GAP** — no explicit E31D-specific financial-proof claim exists
+    in this ledger (E31D is sponsor/relationship-dependent per the claims gathered, not independently
+    means-tested).
+13. **Permitted source of income/compensation.** Informal/independent/self-employed work permitted — see
+    (2). — `CL-E31D-01`, **VERIFIED**.
+14. **Family/dependent provisions.** E31D itself IS the family-dependent instrument (step-child of a
+    foreign parent in mixed marriage). Discriminating facts required beyond bare `FAMILY` purpose: the
+    child-to-parent relationship, the parents' marriage registration, and the sponsor's own identity — see
+    (11). — `CL-E31D-REFUTER`, **VERIFIED**.
+15. **Investment requirements.** Not applicable to E31D.
+16. **Mandatory documents.** Four-document bundle: birth certificate, marriage proof (domestic or
+    foreign+reporting), Kartu Keluarga, passport ≥6 months validity — with sworn-translation/legalization
+    requirement for non-English foreign documents. — `CL-E31D-DOCS`, **VERIFIED**. No CHANGED-co-source
+    caveat applies to this claim (unlike D1/D2/D12's CF-6): the E31D OFFICIAL_PORTAL page
+    (`50457cd0-...`) is independently confirmed **CURRENT** in `freshness-recheck-2026-08-16.md` record
+    #9 ("sponsor requirement present verbatim; step-parent relationship implicit in the visa's defined
+    scope... plus required documents (birth certificate, parents' marriage proof, Indonesian parent's KK)
+    rather than a standalone labeled bullet" — matches this claim's document bundle exactly).
+17. **Declarative vs. documentary-proof requirements.** All four documents in (16) are **documentary**
+    (authenticated/legalized/apostilled, not self-declared), and (11)/(14) establish explicitly that bare
+    declaration of `FAMILY` purpose is **never sufficient** on its own — E31D is the one product in this
+    slice where the declarative-vs-documentary distinction IS directly claim-backed, not a GAP. —
+    `CL-E31D-REFUTER`, `CL-E31D-DOCS`, both **VERIFIED**.
+
+## 4. Structural over-breadth finding (mechanical, independent of NB-2 doctrine)
+
+**`CL-E31D-STRUCT`, VERIFIED as a mechanical/structural finding** (re-derived live against
+`rulepack-prod-007.source.json` this session, matches `adjudication-report.md` finding #5): all 3
+`el.e31d-*` rules reduce, on inspection, to **`intent.purposes intersects [FAMILY]`** — the nested
+`{"op":"all",...}` wrappers on `el.e31d-step-parent-relation`/`el.e31d-sponsor-mixed-marriage` add no
+additional discriminating fact (they repeat the same purpose-intersects check nested one level deeper).
+**None of the three rules checks `family.relation_to_sponsor`, a step-parent-specific fact, or the
+sponsor's own marriage-registration status.** This is a broader defect than E31B's value-blind gate (§4
+of E31B.md): E31D's rules do not merely accept a weak signal — they accept a signal (`FAMILY` purpose)
+that is shared by every family-class product in the catalog, discriminating nothing.
+
+## 5. The compilable doctrine fix (E5 compiler input)
+
+Per `CL-E31D-REFUTER` (§3.11/§3.14): the minimum discriminating fact set is —
+
+- `family.relation_to_sponsor == STEPCHILD` (-equivalent) — replaces the redundant nested
+  `intersects[FAMILY]` check on `el.e31d-step-parent-relation`.
+- `family.stepparent_marriage_registered == true` — the sponsor's own identity/marriage-registration
+  fact, replacing the redundant nested `intersects[FAMILY]` check on `el.e31d-sponsor-mixed-marriage`.
+- Age/marital gate: `applicant.age < 18 AND applicant.marital_status == UNMARRIED` (per §3.10) — **not
+  currently in the ledger's E4-fact-vocabulary recommendation text as an explicit new fact name**,
+  flagged here as an additional compilable requirement the E5 authors should not drop, since `CL-E31D-
+  REFUTER`'s verbatim citation covers it as squarely as the relationship/marriage facts.
+
+**Recommended seq-9 change** (E4/E5 decision on exact fact-vocabulary naming, not authored here):
+`el.e31d-step-parent-relation` needs a real `family.relation_to_sponsor == STEPCHILD` check;
+`el.e31d-sponsor-mixed-marriage` needs the sponsor's own identity/marriage-registration fact, not a
+repeated purpose-intersects check; and the age/marital eligibility window (§3.10) should be added as a
+gate on `el.e31d-stepchild-support` or a new HARD_FILTER, mirroring E31E's pattern (`hf.e31e-adult-
+excluded`/`hf.e31e-married-excluded`) — noting that E31E's own equivalent rules were separately flagged
+**CHANGED** (sole-source, unsupported) in `freshness-recheck-2026-08-16.md` record #10, so E31D's version
+of this gate should NOT be sourced the same way E31E's was; `CL-E31D-REFUTER`'s Pasal 46(2) pinpoint is
+the correct anchor instead.
+
+## 6. Open conflicts
+
+None specific to E31D's own doctrine. `CF-5` (E31B/E31D "index swap" claim) is cross-referenced for
+context, not a doctrinal conflict about E31D itself — see E31B.md §6 for the full disposition (REFUTED
+for the live production system; `seed_visa_types_complete_2026.py:1172,1200` and
+`rulepack-prod-007.source.json`'s `products[].names` both show E31D correctly mapped to "Stepchild of
+Foreigner in Legal Mixed Marriage"). Two independent E31D-sourcing queries this session
+(`E2A-E31D-REFUTER-PURPOSE-ONLY`, `E2A-E31D-DOCS`) both surfaced the swap claim from the same internal
+NB-2 source (`nb2_visa_types_final.txt`) — the swap appears to exist inside that ingested source itself,
+not in production; flagged for operator awareness (NB-2 source hygiene), not a live bug.
+
+## 7. Rule coverage matrix (seq-7, verified live against `rulepack-prod-007.source.json`)
+
+E31D has 3 ELIGIBILITY rules.
+
+| rule_id | reason_code | required claim(s) | claim state | rule status |
+|---|---|---|---|---|
+| `el.e31d-stepchild-support` | `PURPOSE_PRODUCT_MATCH` | `CL-E31D-01`, `CL-E31D-STRUCT` | VERIFIED | SUPPORTED-BUT-OVER-BROAD — see §4/§5 |
+| `el.e31d-step-parent-relation` | `REQ_STEP_PARENT_RELATION` | `CL-E31D-REFUTER`, `CL-E31D-STRUCT` | VERIFIED | SUPPORTED-BUT-OVER-BROAD — see §4/§5 |
+| `el.e31d-sponsor-mixed-marriage` | `REQ_SPONSOR_MIXED_MARRIAGE` | `CL-E31D-REFUTER`, `CL-E31D-STRUCT` | VERIFIED | SUPPORTED-BUT-OVER-BROAD — see §4/§5 |
+
+`CL-E31D-DOCS` (VERIFIED, §3.16) backs the document-list requirement generally but does not gate any
+current rule by name (no `document.*`-scoped fact exists in seq-7 for E31D yet — E4 candidate).
+
+**Rules WITHOUT backing in this ledger**: none of the 3 current rules is unbacked — all 3 have VERIFIED
+claims. **All 3 rules are, however, structurally over-broad** (§4) despite being claim-backed — same
+class of gap as E31B (§4/§5 there), worse in degree: E31D's rules discriminate nothing beyond generic
+`FAMILY` purpose, while E31B's rule at least checks a (value-blind) sponsor-status fact.
+
+## 8. Disposition
+
+**REACHABLE_AND_SUPPORTED-candidate for the slice gate; OVER-BROAD/FAIL-OPEN at the rule-implementation
+level, flagged for E5.** All 3 current E31D rules have every required claim at state VERIFIED — the
+slice gate criterion is met. But exactly as with E31B, "claim-backed" does not mean "safe": the claims
+VERIFY that the current rule implementation (bare `intersects[FAMILY]`, repeated three times) is the gap
+— the E5 compiler must consume `CL-E31D-REFUTER`'s three-fact minimum (§5), not just confirm
+`CL-E31D-STRUCT`'s existence, to close it.
+
+`claims_digest` pairs (sorted, `claim_id=state`):
+
+```
+CL-E31D-01=VERIFIED
+CL-E31D-DOCS=VERIFIED
+CL-E31D-REFUTER=VERIFIED
+CL-E31D-STRUCT=VERIFIED
+```
+
+## 9. Claim gaps discovered (input for next E2 batch — not queried in this task per brief)
+
+1. E31D borderline-activity boundary and entry-pattern (single/multiple) claim — neither exists in this
+   ledger.
+2. E31D independent financial-proof requirement, if any exists beyond relationship/sponsor-dependency.
+3. E31D filing location / onshore-status prerequisites beyond the on-site field-check timing already
+   claimed.
+4. Explicit E4-facing wording for the age/marital HARD_FILTER recommended in §5 (currently backed by
+   `CL-E31D-REFUTER` at the doctrine level but not yet phrased as a discrete new-fact proposal the way
+   the relationship/marriage facts are) — worth a short confirming query to lock the exact fact name
+   before E4 drafts it, rather than E5 inventing the name unchecked.
+
+## Adversarial review
+
+Cross-family review run via `kimi -p "REFUTA questa doctrine card: cerca fatti senza claim_id, claim
+citati con stato sbagliato, l'over-breadth trattato come già risolto quando non lo è, digest non
+riproducibile" -m kimi-code/k3` (generator≠grader, 8-minute timebox). Findings, re-verified against
+`e2a-claim-ledger.md`, `e2a-conflict-report.md` and `rulepack-prod-007.source.json` before
+dispositioning:
+
+1. **[P0, CONFIRMED, cured]** Same class of risk as E31B.md's P0: §7's rule-status column originally read
+   "SUPPORTED" without qualification. Reworded both to "SUPPORTED-BUT-OVER-BROAD — see §4/§5" and added
+   the explicit distinction paragraph, mirroring E31B.md's cure so both refuter cards carry the same
+   discipline.
+2. **[P1, CONFIRMED, cured]** §5's compilable-fix list originally omitted the age/marital gate
+   (§3.10) as a THIRD required fact alongside relationship and marriage-registration — the ledger's own
+   `CL-E31D-REFUTER` claim covers age/marital eligibility with an equally strong verbatim pinpoint
+   (Pasal 46(2)), but the "compilable doctrine fix" framing in the ledger itself emphasizes only the
+   relationship/sponsor-marriage pair. Added the age/marital gate explicitly as part of the compilable
+   fix, with a note that it is not yet named as a discrete E4 fact proposal (flagged as claim gap #4).
+3. **[P2, CONFIRMED, cured]** §6 did not cross-reference that BOTH `E2A-E31D-REFUTER-PURPOSE-ONLY` and
+   `E2A-E31D-DOCS` independently surfaced the CF-5 swap claim from the same source — read as a single
+   occurrence rather than two independent corroborating sightings of the same internal-source defect.
+   Added "Two independent E31D-sourcing queries this session... both surfaced" sentence.
+
+Net: all 3 raised findings were real and are cured above (1 at P0, matching E31B's own most consequential
+error class — a refuter card must never blur claim-backed with rule-safe).


### PR DESCRIPTION
E3a of the Visa Oracle doctrine-factory execution plan (Fase 3 REV 2, G-E1 approved 2026-08-17). Unlocks E4 on the vertical slice.

## What
Five Product Doctrine Cards under `research/visa/doctrine-factory/cards/`:
- **D1 / D2 / D12** — every doctrinal statement carries a claim_id from the merged E2a ledger (PR #4245: 18 VERIFIED + 3 VERIFIED-WITH-CAVEAT); per-card coverage matrix (rule → required claims → state); reproducible `claims_digest` (documented sha256 recipe).
- **E31B / E31D** — the two fail-open doctrine fixes recorded as E5 compiler input (sponsor-status enum {ITAS_ACTIVE, ITAP_ACTIVE, VITAS_APPROVED} per Permenkumham 22/2023 jo. 11/2024 Pasal 44(2)(b)/44(3); STEPCHILD relation + sponsor marriage-registration per Pasal 46(2)).
- **CF-1** (D2 180-day per-stay vs annual-cumulative) is carried **OPEN/ESCALATED by design** on the D2 card — resolution belongs to the OD-1 re-presentation with audited E2 evidence, never inside a card. CF-2 noted RESOLVED (category error) on D12. Claim gaps for the next E2 batch listed per-card.

## Collision note (adjudicated)
CORRECTED ATTRIBUTION: the implementing agent itself, after a mid-session context compaction, re-executed its brief and produced this second set unaware of its own earlier pass — a within-session self-collision, not a cross-agent race. The earlier pass: it ran 2 new NB-2 queries and minted a claim (CL-D2-04) outside the E2a ledger, declaring CF-1 resolved. The orchestrator adjudicated for this set (claim-ledger discipline: claims are born in E2 with citation audit, never inside a card). The sibling's files remain untracked in the worktree for separate triage as **candidate** CF-1 evidence via a dedicated audited E2 mini-batch.

## Review
Cross-family adversarial review: kimi-code/k3; dispositions in each card's `## Adversarial review` section. R1 self-check PASS on all 5 files.

No pack mutation, no prod surface, no new NB-2 queries in this deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
