### PR TITLE
fix(fleet-watch): re-escalate a dark peer instead of alerting once and going quiet

### DIFF
--- a/scripts/fleet_watch.py
+++ b/scripts/fleet_watch.py
@@ -15,8 +15,17 @@ Verdict per peer (structured signals, never substring — W82):
   not report green).
 
 Alerting (via tg gateway, never the Bot API directly):
-- dark ≥ DARK_AFTER_S (default 1800s) → ONE p0 per dark-transition
-  (state file remembers; the gateway's 6h dedup is the second belt)
+- dark ≥ DARK_AFTER_S (default 1800s) → first p0 for the dark-transition
+- then RE-ESCALATION on a widening ladder (6h, 24h, daily thereafter).
+  Genesis 2026-08-17: the Mini was dark 2026-08-14→17. fleet_watch alerted
+  correctly at minute 30 and then logged the dark for 236762s (~65h) in
+  silence, because one bool said "already alerted". A single message that
+  is missed makes a three-day-dead node indistinguishable from a recovered
+  one — the outage stops being reported the moment it stops being news.
+  State carries the stage reached, so a skipped ladder rung (watcher itself
+  down) collapses into ONE message for the CURRENT stage, never a burst.
+  Dedup keys are per-stage, otherwise the gateway's own 6h dedup — the
+  second belt against spam — would swallow every re-alert.
 - recovery after an alerted dark → digest event
 State: ``~/.organism/fleet_watch/state.json``.
 
@@ -39,6 +48,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PEERS_CONFIG = REPO_ROOT / "infra" / "fleet-watch" / "peers.json"
 DARK_AFTER_S = int(os.environ.get("FLEET_WATCH_DARK_AFTER_S", "1800"))
 SSH_TIMEOUT_S = 8
+
+
+def _ladder() -> tuple[int, ...]:
+    raw = os.environ.get("FLEET_WATCH_REALERT_LADDER_S", "21600,86400")
+    return tuple(sorted(int(x) for x in raw.split(",") if x.strip()))
+
+
+def _realert_period() -> int:
+    return int(os.environ.get("FLEET_WATCH_REALERT_PERIOD_S", "86400"))
 
 TAILSCALE_CANDIDATES = (
     "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
@@ -114,6 +132,34 @@ def check_ssh(alias: str, run: Runner = _run) -> bool | None:
     return proc.returncode == 0
 
 
+def due_alert_stage(dark_for: float) -> int:
+    """How many p0s SHOULD have been sent by now for a dark of this length.
+
+    0 = below threshold, 1 = the transition alert, 2+ = re-escalations.
+    Monotonic in ``dark_for`` by construction: the caller compares it to the
+    stage already sent, so an unsent rung is never replayed twice and a
+    skipped one collapses to a single current-stage message.
+    """
+    if dark_for < DARK_AFTER_S:
+        return 0
+    stage = 1
+    for rung in _ladder():
+        if dark_for >= rung:
+            stage += 1
+    period = _realert_period()
+    if period > 0 and dark_for >= period:
+        stage += int((dark_for - period) // period)
+    return stage
+
+
+def _sent_stage(entry: dict) -> int:
+    """Stage already delivered, tolerating state files written before this."""
+    raw = entry.get("alert_stage")
+    if isinstance(raw, int) and raw >= 0:
+        return raw
+    return 1 if entry.get("alerted") else 0
+
+
 def notify_gateway(
     tier: str, dedup_key: str, text: str, run: Runner = _run
 ) -> str:
@@ -156,13 +202,19 @@ def tick(
         signals = [s for s in (ts_ok, ssh_ok) if s is not None]
         probes_run += len(signals)
         entry = state.setdefault(
-            name, {"dark_since": None, "alerted": False, "last_ok": None}
+            name,
+            {
+                "dark_since": None,
+                "alerted": False,
+                "alert_stage": 0,
+                "last_ok": None,
+            },
         )
         if not signals:
             print(f"fleet_watch: {name} UNPROBEABLE (no signal ran)")
             continue
         if any(signals):
-            if entry["alerted"]:
+            if _sent_stage(entry) > 0:
                 outcome = notify(
                     "digest",
                     f"fleet:{name}-recovered:{day}",
@@ -171,25 +223,36 @@ def tick(
                     f"{socket.gethostname().split('.')[0]}).",
                 )
                 print(f"fleet_watch: {name} recovered -> digest ({outcome})")
-            entry.update({"dark_since": None, "alerted": False, "last_ok": now})
+            entry.update(
+                {
+                    "dark_since": None,
+                    "alerted": False,
+                    "alert_stage": 0,
+                    "last_ok": now,
+                }
+            )
             continue
         # both signals explicitly failed → dark
         if entry["dark_since"] is None:
             entry["dark_since"] = now
         dark_for = now - entry["dark_since"]
-        if dark_for >= DARK_AFTER_S and not entry["alerted"]:
+        due = due_alert_stage(dark_for)
+        sent = _sent_stage(entry)
+        if due > sent:
             mins = int(dark_for // 60)
+            still = "" if sent == 0 else "STILL "
             outcome = notify(
                 "p0",
-                f"fleet:{name}-dark:{day}",
-                f"P0 fleet-watch: {name} is DARK — Tailscale offline AND ssh "
-                f"unreachable for {mins}m (watched from "
+                f"fleet:{name}-dark:{day}:s{due}",
+                f"P0 fleet-watch: {name} is {still}DARK — Tailscale offline "
+                f"AND ssh unreachable for {mins}m (watched from "
                 f"{socket.gethostname().split('.')[0]}). Its own watchdogs "
                 f"die with it: this is the only alarm. Needs power/network "
                 f"check on site.",
             )
+            entry["alert_stage"] = due
             entry["alerted"] = True
-            print(f"fleet_watch: {name} DARK {mins}m -> p0 ({outcome})")
+            print(f"fleet_watch: {name} DARK {mins}m -> p0 stage {due} ({outcome})")
         else:
             print(f"fleet_watch: {name} dark {int(dark_for)}s (threshold {DARK_AFTER_S}s)")
     return state, probes_run

--- a/scripts/tests/test_fleet_watch.py
+++ b/scripts/tests/test_fleet_watch.py
@@ -148,3 +148,105 @@ def test_real_peers_config_watch_is_mutual():
     (mini_entry,) = [p for p in peers["nuzantara"] if p["name"] == "mini"]
     assert mini_entry["tailscale_host"] == "mini-pro2"
     assert mini_entry["ssh_alias"] == "mini"
+
+
+# --- re-escalation ladder (2026-08-17) --------------------------------------
+# Genesis: the Mini was dark 2026-08-14 18:16 → 2026-08-17 12:27 (Internet
+# Sharing had claimed its Wi-Fi card, so it could never associate). fleet_watch
+# did its job at minute 30 — "mini DARK 30m -> p0 (sent)" — and then logged
+# "mini dark 236762s" for ~65 hours without another word, because one bool
+# said "already alerted". Guilt below is that exact silence.
+
+H = 3600.0
+
+
+def dark_state(seconds_dark, **over):
+    entry = {"dark_since": NOW - seconds_dark, "alerted": True,
+             "alert_stage": 1, "last_ok": None}
+    entry.update(over)
+    return {"pro": entry}
+
+
+def test_no_repeat_between_rungs_is_still_quiet():
+    # innocence: 90 minutes dark, first alert already out → nothing new.
+    state, _, spy = run_tick(dark_state(1.5 * H), ts=False, ssh=False)
+    assert spy.calls == []
+    assert state["pro"]["alert_stage"] == 1
+
+
+def test_re_escalates_at_six_hours():
+    state, _, spy = run_tick(dark_state(6 * H), ts=False, ssh=False)
+    assert [c[0] for c in spy.calls] == ["p0"]
+    assert "STILL DARK" in spy.calls[0][2]
+    assert state["pro"]["alert_stage"] == 2
+    # and then goes quiet again until the next rung
+    _, _, spy2 = run_tick(state, ts=False, ssh=False)
+    assert spy2.calls == []
+
+
+def test_re_escalates_at_24h_then_daily():
+    assert fw.due_alert_stage(24 * H) == 3
+    assert fw.due_alert_stage(48 * H) == 4
+    assert fw.due_alert_stage(72 * H) == 5
+
+
+def test_the_65h_silence_cannot_happen_again():
+    """The literal scar: 236762s dark after one alert must NOT be silent."""
+    state, _, spy = run_tick(dark_state(236762), ts=False, ssh=False)
+    assert spy.calls, "65h of dark produced no alarm — W107/W116 all over again"
+    assert spy.calls[0][0] == "p0"
+
+
+def test_skipped_rungs_collapse_to_one_message():
+    # The watcher itself was down across several rungs: stage jumps 1 -> 5,
+    # and that must be ONE message, not a burst of four.
+    state, _, spy = run_tick(dark_state(72 * H), ts=False, ssh=False)
+    assert len(spy.calls) == 1
+    assert state["pro"]["alert_stage"] == 5
+
+
+def test_dedup_key_is_per_stage():
+    # The gateway dedups on this key for 6h; a constant key would swallow
+    # every re-alert and the ladder would be decorative.
+    s1, _, spy1 = run_tick(dark_state(1 * H, alert_stage=0, alerted=False),
+                           ts=False, ssh=False)
+    s2, _, spy2 = run_tick(dark_state(6 * H), ts=False, ssh=False)
+    assert spy1.calls[0][1] != spy2.calls[0][1]
+    assert spy1.calls[0][1].endswith(":s1")
+    assert spy2.calls[0][1].endswith(":s2")
+
+
+def test_legacy_state_without_alert_stage_still_escalates():
+    # State files written before this change carry only `alerted: True`.
+    legacy = {"pro": {"dark_since": NOW - 6 * H, "alerted": True,
+                      "last_ok": None}}
+    state, _, spy = run_tick(legacy, ts=False, ssh=False)
+    assert [c[0] for c in spy.calls] == ["p0"]
+    assert state["pro"]["alert_stage"] == 2
+
+
+def test_legacy_state_is_not_re_alerted_from_scratch():
+    """Innocence twin of the test above — and the one with teeth.
+
+    Reading `alerted: True` as stage 0 would re-send the TRANSITION alert to
+    every peer already dark when this ships. The escalation test cannot see
+    that (a p0 fires either way); only silence below the next rung can.
+    """
+    legacy = {"pro": {"dark_since": NOW - 1.5 * H, "alerted": True,
+                      "last_ok": None}}
+    _, _, spy = run_tick(legacy, ts=False, ssh=False)
+    assert spy.calls == [], "legacy state replayed the first alert"
+
+
+def test_recovery_from_a_re_escalated_dark_still_resets():
+    state, _, spy = run_tick(dark_state(30 * H, alert_stage=4),
+                             ts=True, ssh=True)
+    assert [c[0] for c in spy.calls] == ["digest"]
+    assert state["pro"]["alert_stage"] == 0
+    assert state["pro"]["dark_since"] is None
+
+
+def test_below_threshold_is_stage_zero():
+    assert fw.due_alert_stage(0) == 0
+    assert fw.due_alert_stage(fw.DARK_AFTER_S - 1) == 0
+    assert fw.due_alert_stage(fw.DARK_AFTER_S) == 1


### PR DESCRIPTION
## The defect

`fleet_watch` sent **one** p0 per dark-transition and then went silent for the
whole outage. Measured live this morning on the Pro's log:

```
fleet_watch: mini DARK 30m -> p0 (sent)      ← 2026-08-14
fleet_watch: mini dark 236762s               ← ~65h, no further word
```

The alarm was correct and the delivery was real (`fleet_watch.py` records the
gateway's own reply, not an exit code). The gap is the design: one bool said
"already alerted", so a node dead for three days became indistinguishable from
a recovered one. If that single message is missed, the organism accepts the
corpse in silence — which is exactly what happened between 2026-08-14 18:16 and
2026-08-17 12:27.

(Root cause of the Mini outage itself was unrelated and is already fixed:
Internet Sharing had `en1` in `SharingDevices`, so macOS drove the Wi-Fi card as
an access point and it could never associate as a client. Not in scope here.)

## The change

The state carries the **stage reached** instead of a bool, and the ladder
widens: **30m → 6h → 24h → daily**.

Three details that are load-bearing, not cosmetic:

- **Dedup keys are per-stage** (`:s2`, `:s3`). The gateway dedups the same key
  for 6h, so a constant key would swallow every re-alert and the ladder would
  be decorative — a cure that exists and cannot bite.
- **A skipped rung collapses to one message.** If the watcher itself was down
  across several rungs, stage jumps (say) 1 → 5 and exactly one message goes
  out for the current stage, never a burst of four.
- **Old state files keep working.** Entries written before this carry only
  `alerted: true`; they read as stage 1, so a peer already dark escalates on
  the next tick with nothing reset by hand.

## Verification

`scripts/tests/test_fleet_watch.py`: 21 passed (11 pre-existing + 10 new).

Guilt: re-alert at 6h, ladder values at 24h/48h/72h, the literal 236762s
silence, skipped-rungs collapse, per-stage dedup key, legacy escalation.
Innocence: quiet between rungs; recovery from a re-escalated dark still resets;
**a legacy entry below the next rung stays quiet** — the twin with teeth.

**Mutation-verified by an independent seat** (generator≠grader — the seat that
graded did not write the diff). Four mutations, none survived:

| Mutation | Killed by |
|---|---|
| M1 — ladder never climbs past 1 (**restores the original defect**) | 6 tests |
| M2 — dedup key loses the stage suffix | 1 test |
| M3 — recovery does not reset the stage | 1 test |
| M4 — legacy `alerted` fallback removed | 2 tests |

That seat also found a real weakness in my first corpus: the test whose *name*
targets legacy compatibility did **not** kill M4, because it only asserted that
a p0 fires — which happens either way. Its innocence twin
(`test_legacy_state_is_not_re_alerted_from_scratch`) was added in response and
kills it. Recorded here because the finding is the seat's, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)