### PR TITLE
docs(visa-oracle): E28D/E28F consumer map (CF-13/CF-14 blast radius)

### DIFF
--- a/research/visa/doctrine-factory/e28-consumer-map.md
+++ b/research/visa/doctrine-factory/e28-consumer-map.md
@@ -1,0 +1,144 @@
+---
+date: 2026-08-17
+domain: visa
+client_case: none
+sources:
+  - path: research/visa/doctrine-factory/claims/e2b-batch2-conflict-report.md
+    note: "CF-13 (E28D) / CF-14 (E28F) — the two findings this map traces to blast radius, read via git show FETCH_HEAD on branch agent/air-m5/ops/e2b-batch2 (PR #4258)"
+  - path: apps/backend-rag/backend/migrations/scripts/seed_visa_types_complete_2026.py
+    note: "current seed script — E28D/E28F both law-aligned in this file"
+  - path: apps/backend-rag/backend/migrations/migration_125_fix_visa_family_descendant_hygiene.py
+    note: "ad-hoc data-hygiene migration; fixed E28F live 2026-07-19, did NOT touch E28D"
+  - path: apps/backend-rag/backend/app/routers/knowledge_visa.py
+    note: "reads visa_types table directly, unfiltered, unauthenticated GET"
+  - path: apps/backend-rag/backend/app/rag_proxy.py
+    note: "HEAVY_PREFIXES includes /api/knowledge/visa — proxied public via the api process"
+  - path: apps/backend-rag/backend/app/auth/public_endpoints.py
+    note: "/api/knowledge/visa listed as a public (no-auth) endpoint"
+  - path: apps/nuzantara-mcp/nuzantara_mcp/tools/knowledge.py
+    note: "MCP list_visa_types/get_visa_details tools call the live endpoint directly"
+  - path: apps/backend-rag/backend/services/agents/team_agent_config.py
+    note: "4 internal team-agent personas (incl. Damar, visa+marketing) are granted get_visa_details/list_visa_types"
+  - path: apps/backend-rag/backend/services/visa_check/catalogue.py
+    note: "VisaType enum — E28D/E28F absent entirely"
+  - path: apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json
+    note: "law-aligned product labels for E28D/E28F, but zero SUPPORT rules per reachability report"
+  - path: research/visa/doctrine-factory/reachability/rulepack-prod-007-reachability.md
+    note: "confirms E28D/E28F in the 'Blocked (zero SUPPORT rules)' list — evaluate() never recommends them"
+  - path: research/visa/2026-07-24-w2-factbase-e28-full.md
+    note: "independent 2026-07-24 factbase, also law-aligned — the correct doctrine was known 3 separate times and never armed onto the live DB row for E28D"
+  - path: mcp__nuzantara-knowledge__get_visa_details("E28D") / ("E28F")
+    note: "live empirical query run in this session 2026-08-17 — E28D still wrong, E28F confirmed fixed"
+adversarial_review: kimi-k3
+---
+
+# E28D / E28F consumer map — CF-13 / CF-14 blast radius
+
+## TL;DR
+
+**E28D is live-wrong right now.** I queried the production endpoint through the same MCP tool Bali
+Zero staff/agents use (`mcp__nuzantara-knowledge__get_visa_details`) during this investigation and got:
+
+```
+E28D → "E28D - Investor KITAS (Bonds)" / "Investor obligasi pemerintah, Surat berharga negara"
+        (last_updated: 2026-01-14 — never touched since initial seed)
+E28F → "Investor Visa Pendirian Cabang atau Anak Perusahaan di Indonesian New Capital (IKN)"
+        (last_updated: 2026-07-19 — already fixed, law-aligned)
+```
+
+**E28F was already fixed live on 2026-07-19** (migration_125, PR #2859, prove-live verified at the
+time) — CF-14's finding is stale as of the live DB, though the NB-2 NotebookLM source snapshot that
+CF-13/14 read from (`nb2_visa_types_final.txt`, dated March 2026 per the batch-1 P0-REPORT citation)
+was never refreshed and still tells the wrong story for BOTH codes.
+
+**E28D was never touched by any migration.** The correct law-aligned text exists TODAY in this repo in
+three independent places — the current seed script, the 2026-07-24 W2 factbase, and the active
+RulePack's product labels — and was never armed onto the one live database row that three real
+consumers actually read. (The exact publish date of the e2b-batch2 conflict report itself is not
+stated in this map's sources, so "known before the conflict was logged" is asserted only for the
+factbase/seed/RulePack relative to TODAY, not proven as a strict timeline against CF-13's own write
+date.) This is the organism's own "Esiste≠Armato" pattern (cicatrix family #2), applied to a data row
+instead of a code path: the fix existed, it just never got run.
+
+## Store inventory
+
+| Store | E28D content | E28F content | Note |
+|---|---|---|---|
+| `seed_visa_types_complete_2026.py` (current, on main) | LAW-ALIGNED — "Investor Visa Pendirian Cabang atau Anak Perusahaan Golden Visa" (branch/subsidiary director) | LAW-ALIGNED — "…di Indonesian New Capital (IKN)" | Source script; NOT re-run since original seed for E28D |
+| Live Postgres `visa_types` table | **WRONG** — "Investor KITAS (Bonds)" / govt bonds & securities (confirmed live 2026-08-17) | LAW-ALIGNED (fixed 2026-07-19, migration_125/PR #2859) | The one table 3 real consumers read from |
+| RulePack `rulepack-prod-007.source.json` (`visa_engine/contracts/packs/`) | LAW-ALIGNED — "Investor Golden Visa — Branch or Subsidiary (E28D)" | LAW-ALIGNED — "…New Capital (IKN) Subsidiary (E28F)" | Zero SUPPORT rules for either code (reachability report) — never recommended by `/visa-oracle evaluate` regardless of label correctness |
+| NB-2 NotebookLM source `nb2_visa_types_final.txt` | **WRONG** — "bond investor" | **WRONG (stale)** — "Bali real-estate investor 5bn+" | March-2026 snapshot, per batch-1 P0-REPORT citation; predates the 2026-07-19 E28F DB fix and was never refreshed |
+| Qdrant `visa_oracle` collection | Not audited (semantic content, out of static-code scope) | Not audited | No ingestion script found that references `nb2_visa_types_final.txt` (the stale-story source) — that grep result is solid, but WHAT this collection is actually populated from was not independently confirmed in this pass, so "presumed low risk" rests on an absence-of-evidence, not a positive one. **Unverified.** |
+| 2026-07-24 W2 factbase (`research/visa/2026-07-24-w2-factbase-e28-full.md`) | LAW-ALIGNED, cites Kepmen M.IP-08.GR.01.01/2025 directly | LAW-ALIGNED | Research artifact, not a runtime store — cited as evidence the correct doctrine was known and simply never armed |
+
+## Consumer map — who reads which store, and what they'd serve today
+
+| Consumer | Reads | Client/staff-facing? | Verdict |
+|---|---|---|---|
+| `/api/knowledge/visa/` and `/api/knowledge/visa/code/{code}` (`knowledge_visa.py`) | Live Postgres `visa_types`, unfiltered, GET unauthenticated | Yes — public. Registered `_RAG`-only in the manifest but `rag_proxy.py` puts `/api/knowledge/visa` in `HEAVY_PREFIXES`, so the public `api` process proxies it through, and `public_endpoints.py` lists it as no-auth. Should be reachable unauthenticated from the internet by this static config; not independently confirmed with an anonymous curl in this session (the live empirical check below went through the role-gated MCP path, not a bare HTTP call). | **SERVES_WRONG_STORY** for E28D · SERVES_LAW_ALIGNED for E28F |
+| MCP `list_visa_types` / `get_visa_details` (`apps/nuzantara-mcp/nuzantara_mcp/tools/knowledge.py`) | Calls the endpoint above directly | Yes — gated by role `visa_specialist`/`company_setup`, but this is the exact tool class available to me (`mcp__nuzantara-knowledge__*`) and to any Bali Zero agent/session with that role. **Confirmed live 2026-08-17** by direct query in this investigation. | **SERVES_WRONG_STORY** for E28D (confirmed empirically) · SERVES_LAW_ALIGNED for E28F |
+| Internal team-agent tool grants (`team_agent_config.py`) — Junior Consultant (Damar, visa+marketing), Executive Consultant, CRM Full Access, Tax Specialist | Grants those 4 personas `get_visa_details`/`list_visa_types` | Staff-facing — if any of these 4 team-agent personas is asked about E28D, it can call the tool above and repeat the wrong story to whoever's asking, including forwarding it to a client. | **SERVES_WRONG_STORY** for E28D via the same chain, for 4 named staff roles |
+| `apps/mouth` frontend (kita/knowledge.balizero.com) | Only a generated OpenAPI type stub in `schema.d.ts` — grepped for any actual fetch call site in `apps/mouth/src` and `apps/web/src`; zero hits | No live UI wired | **DOES_NOT_SERVE** — dead type reference only |
+| `visa_check.catalogue.py` (the `/visa` intake decision-tree engine's `VisaType` enum) | Its own hardcoded enum, sourced from the seed script's naming convention but a much smaller finite set | Yes, client-facing (visa-finder flow) | **UNREACHABLE-BY-DESIGN** — E28D and E28F are not members of the `VisaType` enum at all; the engine cannot recommend or describe either code |
+| `/visa-oracle evaluate` (`evaluate_path.py` + active RulePack) | RulePack JSON (law-aligned labels) | Yes, client-facing (the flagship funnel) | **UNREACHABLE-BY-DESIGN** in current traffic — reachability audit confirms zero SUPPORT rules ever recommend E28D/E28F, so the (correct) labels never actually reach a client through this path. Would flip to SERVES_LAW_ALIGNED automatically if rule content is ever added for these codes, since the pack's own text is already correct |
+| WhatsApp / Telegram / Instagram / Web chat (`backend/channels/`) | No direct code reference found to `knowledge_visa`, `get_visa_details`, or `visa_types` inside `channels/` — routes through `agentic_rag` (Qdrant retrieval + RulePack) instead | Yes, client-facing (4 live channels) | **UNVERIFIED** — not `DOES_NOT_SERVE`: the store this consumer actually reads (Qdrant `visa_oracle`) is itself inventoried above as not-audited/unverified, so a `DOES_NOT_SERVE` label would overstate what was checked. The RulePack half of the path is confirmed harmless (zero SUPPORT rules for either code); the Qdrant-chunk half is the open item |
+| wr3-brief-interpreter (sole NB-2 consumer for WR3 video ground truth per its own agent contract) | NB-2 NotebookLM, including `nb2_visa_types_final.txt` | Yes, if it ever produces a video episode on E28D/E28F | **DOES_NOT_SERVE today** — no WR2/WR3 published episode or carousel about E28D/E28F found (searched `apps/war-room` and the WR2/WR3 output trees); this is a **latent** risk, not an active one |
+| E2b/doctrine-factory NB-2 query pipeline itself (`research/visa/doctrine-factory/**`) | NB-2 | No — research/investigatory tool, not a runtime consumer | **DOES_NOT_SERVE by design** — this is the diagnostic instrument that surfaced CF-13/CF-14 in the first place |
+
+## Headline: SERVES_WRONG_STORY today
+
+1. `/api/knowledge/visa/code/E28D` — public, unauthenticated HTTP endpoint
+2. MCP `get_visa_details("E28D")` / `list_visa_types()` — role-gated but live, and the exact channel any
+   Claude session or staff member with `visa_specialist`/`company_setup` role uses
+3. Team-agent personas Junior Consultant (Damar), Executive Consultant, CRM Full Access, Tax Specialist
+   — same wrong story, one hop further into staff conversations
+
+All three share a single root cause: **the live Postgres `visa_types` row for `code = 'E28D'` was never
+patched**, even though the correct text has existed in the seed script, the RulePack, and a dedicated
+factbase research doc since before this conflict was ever logged. E28F shows the fix already exists as
+a template (migration_125) and already worked — it just wasn't repeated for its sibling code.
+
+## Proposed correction plan (priority order — owner decides, not executed here)
+
+1. **P0 — patch the live `visa_types` row for `code = 'E28D'`.** Same pattern as migration_125's E28F
+   fix: `name`/`description`/`allowed_activities`/`restrictions` set to the law-aligned text already
+   present in `seed_visa_types_complete_2026.py` and independently corroborated in the 2026-07-24 W2
+   factbase (Kepmen M.IP-08.GR.01.01/2025 cite). This single write closes all three
+   SERVES_WRONG_STORY rows above in one shot — they all read the same table.
+2. **P1 — refresh the NB-2 `nb2_visa_types_final.txt` source.** It is stale on BOTH codes (E28D never
+   right, E28F right-until-2026-07-19-fix-then-stale-again-relative-to-the-fix). Re-export from the
+   corrected live table (post P0) and re-upload as the NB-2 source, or explicitly timestamp/flag the
+   existing one as historical so future NB-2 queries (doctrine-factory batches, wr3-brief-interpreter,
+   human NotebookLM lookups) stop treating a March snapshot as current.
+3. **P2 — re-run the CF-13/CF-14 cross-check** in the e2b claim ledger once P0 lands, so the ledger
+   reflects CONFLICTING → RESOLVED rather than leaving a stale open finding once the underlying data
+   changes.
+4. **P3 — add a data-invariant tripwire** (in the spirit of `test_data_invariant_tripwires.py`) that
+   diffs `seed_visa_types_complete_2026.py`'s canonical `name`/`description` text against the live
+   `visa_types` table for every code, so a future divergence like E28D's (fix written, never armed) is
+   caught in CI instead of by a research batch nine months later.
+5. **P4 (optional, unverified) — audit Qdrant `visa_oracle` collection chunk content** for E28D/E28F
+   strings to close the one open uncertainty in this map (the chat-channel path). Not urgent given no
+   ingestion script points at the stale internal file, but not proven clean either.
+
+## Adversarial review
+
+**Round 1** — `kimi -m kimi-code/k3`, timeboxed 8 minutes, scope: internal coherence of this report
+against its own cited evidence, plus one cheap repo spot-check the reviewer chose to run
+(directory-existence check on the frontend grep claim).
+
+| # | Finding | Disposition |
+|---|---|---|
+| 1 | Chat-channel row was labeled `DOES_NOT_SERVE` while the Qdrant store it reads is inventoried as not-audited/unverified — verdict overstated the evidence | **VALID — fixed**: relabeled to `UNVERIFIED` |
+| 2 | "Directly curlable from the internet today" is an empirical claim resting only on static config; no anonymous curl was actually run this session (only the role-gated MCP path was tested live) | **VALID — fixed**: reworded to "should be reachable… not independently confirmed" |
+| 3 | "Known 3 separate times… since before the conflict report was written" has no cited date for the conflict report itself, so the strict ordering isn't proven from sources listed | **VALID — fixed**: hedged, dropped the unproven "before the conflict was logged" framing |
+| 4 | "Qdrant… populated from a different source pipeline (primary-doc ingestion)" is an affirmative claim with no header source backing it; only the negative grep (nothing references the stale NB-2 file) is actually supported | **VALID — fixed**: reworded to state only the negative grep result, not an affirmative claim about what Qdrant IS populated from |
+| 5 | wr3-brief-interpreter reads a wrong-story store (NB-2) but is verdicted `DOES_NOT_SERVE` — candidate violation of "consumer reads wrong-story store but verdicted as if it doesn't" | **REJECTED** — verdict is explicitly time-scoped ("today") and the report already labels it a latent risk with the no-episode search disclosed; no contradiction |
+| 6 | Frontend `DOES_NOT_SERVE` might rest on grepping directories that don't exist (`apps/mouth/src`, `apps/web/src`) | **REJECTED** — reviewer independently verified: both directories exist; grep across `apps/mouth` and `apps/web` returns only the `schema.d.ts` type stub, zero call sites |
+| 7 | Team-agent "4 personas" count mismatch between header note and consumer table | **REJECTED** — counts match (Junior Consultant/Damar, Executive Consultant, CRM Full Access, Tax Specialist) |
+| 8 | Store-inventory vs consumer-table internal consistency on the RulePack row (zero SUPPORT rules → `UNREACHABLE-BY-DESIGN`, labels law-aligned, conditional flip-to-`SERVES_LAW_ALIGNED`) | **REJECTED** — internally consistent, no defect |
+
+Reviewer's own summary: "no structural contradiction between the two tables; the headline
+`SERVES_WRONG_STORY` verdict for E28D stands. The real defects are verdict-strength on the chat-channel
+row and three evidentiary overclaims — all fixable by relabeling, none change the correction plan."
+All 4 VALID findings were applied above; the correction plan (P0–P4) is unchanged by this round.


### PR DESCRIPTION
## Summary
- Read-only investigation report for CF-13/CF-14 (E2b batch-2 conflict report, PR #4258): traces every store and consumer of the E28D/E28F visa-type data.
- **Live-empirical finding**: E28D is still wrong in production TODAY — `mcp__nuzantara-knowledge__get_visa_details("E28D")` returned "Investor KITAS (Bonds)" (government-bonds investor), reachable via the public `/api/knowledge/visa/code/E28D` endpoint, the MCP `get_visa_details`/`list_visa_types` tools, and 4 internal team-agent personas (incl. Damar, visa+marketing).
- E28F was already fixed live on 2026-07-19 (migration_125, PR #2859) — CF-14 is stale relative to the live DB, but its source (NB-2 `nb2_visa_types_final.txt`, a March-2026 snapshot) was never refreshed and still tells the wrong story for both codes.
- Correction plan proposed (P0: patch the live E28D row using the already-correct seed script text — same pattern as the E28F fix — through P4: audit Qdrant); **no correction executed, no PR merge/arm** — this is a report only.
- Kimi-k3 adversarial round: 8 findings reviewed, 4 VALID (applied — softened chat-channel verdict to UNVERIFIED, hedged an unproven "curlable" claim, hedged a temporal ordering claim, trimmed an unsupported Qdrant provenance claim), 4 REJECTED.

## Test plan
- N/A — documentation-only change (`research/visa/doctrine-factory/e28-consumer-map.md`), no code touched, no DB mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)