### PR TITLE
fix(mata-garuda): detect NOAUTH/WRONGPASS/NOPERM in base_worker.redis_cmd (W89/W104)

### DIFF
--- a/apps/mata-garuda/mata_garuda/workers/base_worker.py
+++ b/apps/mata-garuda/mata_garuda/workers/base_worker.py
@@ -103,6 +103,9 @@ def _redis_env() -> dict[str, str] | None:
     return env
 
 
+_AUTH_ERROR_PREFIXES = ("NOAUTH", "WRONGPASS", "NOPERM")
+
+
 def redis_cmd(*args: str, timeout: int = 10, retries: int = 2) -> str:
     """Execute a redis-cli command and return output.
 
@@ -114,6 +117,15 @@ def redis_cmd(*args: str, timeout: int = 10, retries: int = 2) -> str:
     hammering an already-loaded host immediately. retries=2 means up to
     3 total attempts; set retries=0 to preserve the old single-shot
     behavior for any caller that wants a strict fail-fast.
+
+    W89/W104 NOAUTH-swallow: redis-cli returns an auth-failure reply on
+    STDOUT at exit 0 (never a nonzero returncode), so a caller that only
+    checks `result.startswith("[ERROR]")` — the convention every downstream
+    caller of this SSOT uses — would treat "NOAUTH Authentication
+    required." as a successful XADD/SET/etc reply. nerve.py and
+    check_redis_split_brain.py already carry this same detection
+    independently; it belongs here too since this is the function their
+    own docstrings/tests point to as "the SSOT that carries REDISCLI_AUTH".
     """
     cmd = [REDIS_CLI] + _redis_host_args() + list(args)
     attempts = retries + 1
@@ -125,7 +137,10 @@ def redis_cmd(*args: str, timeout: int = 10, retries: int = 2) -> str:
             )
             if result.returncode != 0:
                 return f"[ERROR] redis-cli: {result.stderr.strip()}"
-            return result.stdout.strip()
+            out = result.stdout.strip()
+            if out.startswith(_AUTH_ERROR_PREFIXES):
+                return f"[ERROR] redis-cli: {out}"
+            return out
         except FileNotFoundError:
             return "[ERROR] redis-cli not found"
         except subprocess.TimeoutExpired:

--- a/apps/mata-garuda/tests/test_base_worker_redis_cmd_noauth_swallow.py
+++ b/apps/mata-garuda/tests/test_base_worker_redis_cmd_noauth_swallow.py
@@ -1,0 +1,72 @@
+"""
+Regression tests for the W89/W104 NOAUTH-swallow family in base_worker.redis_cmd
+— the one SSOT that nerve.py and check_redis_split_brain.py both cite as
+"already carries REDISCLI_AUTH" but that never got their own NOAUTH-in-stdout
+detection (they each reimplemented it independently instead).
+
+Background: redis-cli returns an auth-failure reply ("NOAUTH Authentication
+required.", "WRONGPASS ...", "NOPERM ...") on STDOUT at exit 0 — never a
+nonzero returncode. Every downstream caller of redis_cmd() (stream_tools,
+task_tools, intel_publisher, wr2_bridge_publisher, kita_feed_generator,
+public_channel_publisher, intel_scraper_bridge, run_nlm_feeder_stream, ...)
+checks `result.startswith("[ERROR]")` to detect failure. Without this fix,
+an auth failure on a host missing GARUDA_REDIS_PASSWORD (measured live on
+Mini: com.matagaruda.intel-bridge.daily/normalizer.hourly/sentinel.daily
+plists carry no such key) is silently treated as a successful reply —
+intel_publisher.publish_to_redis() would return "NOAUTH Authentication
+required." as if it were a real XADD entry ID.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mata_garuda.workers import base_worker
+
+
+def _completed(stdout: str, returncode: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_noauth_reply_at_exit_0_is_surfaced_as_error(mock_run):
+    mock_run.return_value = _completed("NOAUTH Authentication required.")
+    out = base_worker.redis_cmd("XADD", "garuda:raw", "*", "k", "v")
+    assert out.startswith("[ERROR]")
+    assert "NOAUTH" in out
+
+
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_wrongpass_reply_at_exit_0_is_surfaced_as_error(mock_run):
+    mock_run.return_value = _completed("WRONGPASS invalid username-password pair")
+    out = base_worker.redis_cmd("PING")
+    assert out.startswith("[ERROR]")
+    assert "WRONGPASS" in out
+
+
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_noperm_reply_at_exit_0_is_surfaced_as_error(mock_run):
+    mock_run.return_value = _completed("NOPERM this user has no permissions")
+    out = base_worker.redis_cmd("XADD", "garuda:raw", "*", "k", "v")
+    assert out.startswith("[ERROR]")
+    assert "NOPERM" in out
+
+
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_healthy_xadd_reply_passes_through_unflagged(mock_run):
+    """Innocence: a genuine stream-id reply must NOT be treated as an error."""
+    mock_run.return_value = _completed("1755000000000-0")
+    out = base_worker.redis_cmd("XADD", "garuda:raw", "*", "k", "v")
+    assert out == "1755000000000-0"
+    assert not out.startswith("[ERROR]")
+
+
+@patch("mata_garuda.workers.base_worker.subprocess.run")
+def test_healthy_pong_reply_passes_through_unflagged(mock_run):
+    mock_run.return_value = _completed("PONG")
+    out = base_worker.redis_cmd("PING")
+    assert out == "PONG"


### PR DESCRIPTION
## Summary
- `base_worker.redis_cmd()` (the SSOT ~10 mata-garuda call sites delegate to for canonical-Redis auth) never detected an auth-failure reply on STDOUT at exit 0 — only nonzero returncode was treated as `[ERROR]`.
- Measured live on Mini: `com.matagaruda.intel-bridge.daily` has been publish-failing since ~26h; its `LaunchAgent` (and `normalizer.hourly`/`sentinel.daily`) carry `GARUDA_REDIS_HOST` but no `GARUDA_REDIS_PASSWORD`, so every `redis-cli` call against the canonical Pro Redis (behind `requirepass` since the 2026-06-29 cutover) returns `NOAUTH Authentication required.` at exit 0. Every caller checks `result.startswith("[ERROR]")`, so this was silently treated as a successful reply — e.g. `intel_publisher.publish_to_redis()` would return the NOAUTH text as if it were the XADD entry ID.
- `nerve.py` and `check_redis_split_brain.py` already carry independent NOAUTH detection for exactly this reason (see `test_redis_auth_nerve_splitbrain.py`, W89 family) — but the one function their own docstrings cite as "the SSOT that carries REDISCLI_AUTH" never got it. This PR closes that gap in the SSOT itself, fixing all downstream callers in one place.
- Does **not** fix the missing `GARUDA_REDIS_PASSWORD` env on the 3 Mini plists — that's a separate operator[secret] action (can't safely read/write the password value). This PR makes the failure mode honest (visible `[ERROR]`) instead of a silent phantom-success.

## Test plan
- [x] New regression tests: `test_base_worker_redis_cmd_noauth_swallow.py` (NOAUTH/WRONGPASS/NOPERM guilt cases + healthy-reply innocence cases)
- [x] Full related suite green: 46/46 (`test_base_worker_redis_cmd_noauth_swallow.py` + `test_base_worker_redis_cmd_retry.py` + `test_redis_auth_nerve_splitbrain.py` + `test_base_worker_parser.py` + `test_redis_host_override.py` + `test_no_bare_redis_cli.py`)
- [x] Full mata-garuda suite (excluding pre-existing unrelated collection errors from missing `httpx`/`cell_core` deps in this venv): 941 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)