### PR TITLE
fix(scripts): log the real reason send_telegram fails (W89/W104 family)

### DIFF
--- a/scripts/tg_notify.py
+++ b/scripts/tg_notify.py
@@ -45,6 +45,7 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -394,7 +395,20 @@ def send_telegram(token: str, chat: str, text: str) -> bool:
     try:
         with urllib.request.urlopen(req, timeout=API_TIMEOUT) as resp:
             return json.loads(resp.read().decode()).get("ok", False)
-    except Exception:
+    except urllib.error.HTTPError as e:
+        # Telegram's error body names the real cause (bad token, chat not
+        # found, blocked, rate-limited, ...) — never the token itself, which
+        # lives in the URL, not the response. Swallowing this (bare `except
+        # Exception: return False`) left every past failure undiagnosable:
+        # "SEND FAILED" in the caller's log with no reason, ever.
+        try:
+            detail = e.read().decode(errors="replace")[:300]
+        except Exception:
+            detail = ""
+        print(f"[tg_notify] send_telegram HTTPError {e.code} {e.reason}: {detail}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(f"[tg_notify] send_telegram {type(e).__name__}: {e}", file=sys.stderr)
         return False
 
 


### PR DESCRIPTION
## Summary
- `mini.tg_digest_flush` has failed 6 consecutive runs since 2026-08-14 (`SEND FAILED — spool preserved`, rc=3), with zero diagnostic info — `send_telegram()` swallowed every exception via bare `except Exception: return False`.
- Now logs the HTTPError code/reason/body (Telegram's own error text) or exception type/message to stderr before returning False. Token stays out of every logged string (it lives only in the request URL, never echoed back in an exception).
- Live-reproduced the send with the cron's exact resolved credentials during this investigation — it succeeded (HTTP 200), so the failure is intermittent/transient, not a dead credential. This fix doesn't change behavior, only makes the *next* failure diagnosable instead of a repeat of this same blind spot.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check
- [x] Pre-commit/pre-push hooks green (lint, secret-scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)