### PR TITLE
fix(deps): force deepmerge-ts >= 8.0.0 — the merge queue has been red repo-wide since 13:32Z

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
         "@types/react-dom": "^19.2.4",
         "autoprefixer": "^10.5.4",
         "eslint": "^8",
-        "eslint-config-next": "^16.3.0",
+        "eslint-config-next": "16.3.0",
         "postcss": "^8.5.26",
         "tailwindcss": "^4.1.18",
         "typescript": "^5",
@@ -567,7 +567,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "eslint": "^8",
-        "eslint-config-next": "^16.3.0",
+        "eslint-config-next": "16.3.0",
         "typescript": "^5",
         "vitest": "^4.1.10"
       }
@@ -13783,10 +13783,20 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
       "devOptional": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "rollup": ">=4.60.0",
     "picomatch": ">=4.0.4",
     "effect": ">=3.20.0",
+    "deepmerge-ts": ">=8.0.0",
     "handlebars": ">=4.7.9",
     "brace-expansion": ">=5.0.9",
     "valibot": ">=1.4.2",


### PR DESCRIPTION
## What this unblocks

**Nothing has merged in this repository since #4265 at `2026-08-17T13:33:40Z`.** Every armed PR — mine and other lanes' — has been queued and then ejected by `github-merge-queue[bot]`, with no reason recorded.

The cause is not in our code and not in the queue.

`GHSA-ggr8-5vv4-36mx` (HIGH — *"DeepmergeTS has stack exhaustion when merging recursive object graphs"*, vulnerable `< 8.0.0`) was published at **`2026-08-17T13:32:13Z`**, **87 seconds before that last merge**. `npm audit` reads the advisory database live, so a third-party publication turned a required check red with no diff on our side.

## The chain, measured end to end

```
prisma@7.9.1 -> @prisma/config -> deepmerge-ts@7.1.5      (production tree)
  -> scripts/ci/npm_audit_gate.py exits 1
  -> job "Frontend Tests (Next.js) (admin-dashboard, false)" FAILS
  -> matrix fail-fast CANCELS its sibling "(mouth, true)"
  -> "(mouth, true)" is a REQUIRED context; a cancelled required check is not green
  -> github-merge-queue[bot] ejects the entry
```

The last step is why this read as a broken queue rather than a red check. Only one of the two matrix legs is required, and **the required one never got to render its own verdict** — it was collateral damage of its sibling. Entries were ejected 3-20 minutes in, with no reason, and a single entry alone in an empty queue was ejected too. The queue was right every time.

## Why an override and not a version bump

`@prisma/config` pins `deepmerge-ts` to `7.1.5` **exactly**, and `prisma@7.9.1` is already the latest published — there is no upstream fix to wait for. Forcing a dependency of `@prisma/config` is already this repo's practice: `effect` is pinned by that same package and already carries an override in this very block.

## Verified, not assumed

- **lockfile**: `deepmerge-ts 7.1.5 -> 8.0.1` is the **only** version change; zero packages added, zero removed
- **the exact gate CI runs**: `npm audit --audit-level=high --omit=dev` + `npm_audit_gate.py` -> exit **0** (`only waived advisories present — gate OK`)
- **the gate's own guilt/innocence corpus**: still **11/11**
- **prisma at runtime, not just at install**: `prisma --version` runs clean with `8.0.1` forced (7.9.1, engines resolve) — the exact pin was not load-bearing here. The repo has **no `prisma.config.ts` and no `schema.prisma`**, so `@prisma/config`'s merge path — the only place `deepmerge-ts` is reached — is not exercised at all.

## On the lockfile diff

Regenerated with **npm 11** to match CI's Node 24. The local npm 10 otherwise rewrote ~100 lines of unrelated `dev`/`peer`/`libc` metadata; with npm 11 the diff is 15 lines.

Two incidental corrections ride along: the lock recorded `eslint-config-next: ^16.3.0` for `apps/admin-dashboard` and `apps/autonomous-lab` while both `package.json` files pin `16.3.0` exactly. **main's lock was stale there** — this makes it match.

## Follow-up, deliberately NOT in this PR

`npm_audit_gate.py` reported the two transitive carriers (`prisma`, `@prisma/config`) as `"waived, but on unexpected paths"` — but their advisory-id set is **empty**, so nothing was ever waived for them. `unwaived = ids - waive.keys()` is falsy on an empty set, so they fall through to the path check, where `any(... for i in ids)` over an empty `ids` is `False` and every node reads as stray. The verdict (block) is right; the **message names the wrong cause** and sends whoever reads it hunting for a waiver that does not exist. It cost real time tonight. Separate concern, separate PR.