### PR TITLE
feat(visa-oracle): E5 inc-1 claim compiler + VERIFIED-only lint + slice rules

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/compile_claims.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/compile_claims.py
@@ -1,0 +1,456 @@
+"""Offline CLI: compile a claim-backed rule-authoring manifest into engine
+``Rule`` objects, gated by two hard lints.
+
+E5 increment 1 (Visa Oracle doctrine-factory execution plan, vertical
+slice: D1/D2/D12/E31B/E31D). This is a NEW compiler stage that sits
+*before* ``compile_pack.py``: it consumes the claim ledgers written by the
+E2a/E2b/E3a research passes (``research/visa/doctrine-factory/claims/
+*.md``, parsed by ``backend.services.visa_engine.claim_ledger``) plus a
+hand-authored rule-authoring manifest (a JSON file listing each rule's
+``when``/``effect``/... alongside the ``claim_id``s that back it) and
+emits validated ``Rule`` JSON — the reformed slice rules described in the
+task brief (E31B's fail-open ``known`` gate closed to a value-checked
+enum, E31D's over-broad ``intersects[FAMILY]``-only rules given real
+discriminating facts) plus D1/D2/D12 passed through with claim provenance
+attached.
+
+Two hard lints, both compile errors (never warnings):
+
+1. **VERIFIED-only.** Every ``claim_id`` a rule declares must resolve in
+   the loaded ledgers and be at state ``VERIFIED`` or
+   ``VERIFIED-WITH-CAVEAT``. A claim at ``CONFLICTING``/``STALE``/
+   ``UNVERIFIED``/``SUPERSEDED``/``UNSTATED`` feeding a rule is a hard
+   compile error naming the claim_id and the rule_id — this is the literal
+   task-brief requirement ("a claim in state CONFLICTING/STALE/UNVERIFIED
+   feeding a rule => hard compile error naming the claim_id"). A
+   ``VERIFIED-WITH-CAVEAT`` claim is allowed only when the rule's manifest
+   entry carries a matching caveat note in its ``caveats`` array — the
+   caveat is required to be PROPAGATED into the rule's provenance, not
+   silently dropped, per the same brief.
+
+2. **R-OVERSTAY-PLANNING** (Zero, 2026-08-18, verbatim ruling — see the E5
+   task brief and CP2 decision pack): a rule whose condition tree
+   references ``immigration.overstay_days`` anywhere must have that
+   reference gated behind ``immigration.currently_in_indonesia == true``
+   in the same AND-chain (i.e. every ALL-ancestor between the tree root
+   and the overstay leaf). ``overstay_days`` is pertinent ONLY onshore —
+   an ungated reference is exactly the seq-6 smoke symptom the ruling
+   names ("incomplete facts -> NEEDS_INPUT naming immigration.
+   overstay_days" for an applicant who never said they were in
+   Indonesia). This lint fires on the CONDITION STRUCTURE, independent of
+   which product/claim the rule belongs to — it is a standing invariant
+   for every rule this compiler ever emits, not a per-rule opt-in.
+
+Usage::
+
+    PYTHONPATH=. python -m backend.scripts.visa_engine.compile_claims \\
+        --claims research/visa/doctrine-factory/claims/e2a-claim-ledger.md \\
+                 research/visa/doctrine-factory/claims/e2b-batch1-claim-ledger.md \\
+                 research/visa/doctrine-factory/claims/e2b-batch2-claim-ledger.md \\
+                 research/visa/doctrine-factory/claims/e3a-cf1-resolution.md \\
+        --manifest research/visa/doctrine-factory/e5/slice-rule-manifest.json \\
+        --out /tmp/e5-slice-compiled.json
+
+Exit code 0 only when every rule compiles clean; 1 on any lint violation or
+malformed input (never a bare traceback for a data problem — see ``main``).
+
+Deliberately NOT in scope here (task brief, "increment 1"): assembling a
+full signed ``RulePackPayload`` (that needs a ``source_records`` array and
+the sequence/rollback chain a whole pack carries — ``compile_pack.py`` /
+``sign_pack.py`` / ``activate_pack.py`` own that, later increment), and
+never touches a signed pack on disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from backend.services.visa_engine.ast import collect_fact_paths, parse_condition
+from backend.services.visa_engine.claim_ledger import (
+    ClaimLedgerError,
+    ClaimRecord,
+    load_claim_ledgers,
+)
+from backend.services.visa_engine.enums import FactPath
+from backend.services.visa_engine.models import Rule
+
+#: The overstay-planning invariant's two facts, by name (matches
+#: ``enums.FactPath`` exactly — see the module docstring's rationale).
+_OVERSTAY_FACT = FactPath.IMMIGRATION_OVERSTAY_DAYS.value
+_ONSHORE_FACT = FactPath.IMMIGRATION_CURRENTLY_IN_INDONESIA.value
+
+
+class CompileClaimsError(ValueError):
+    """A manifest entry failed a hard lint or failed to parse/validate."""
+
+
+class LintFinding:
+    """One compile error, always naming the offending rule_id and (when
+    applicable) the offending claim_id — never a bare "compilation failed".
+    """
+
+    __slots__ = ("message", "rule_id")
+
+    def __init__(self, rule_id: str, message: str) -> None:
+        self.rule_id = rule_id
+        self.message = message
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.rule_id}: {self.message}"
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"LintFinding(rule_id={self.rule_id!r}, message={self.message!r})"
+
+
+class CompiledEntry:
+    """One successfully-compiled rule plus its provenance."""
+
+    __slots__ = ("caveats", "claim_ids", "product_code", "rule")
+
+    def __init__(
+        self,
+        *,
+        product_code: str,
+        claim_ids: list[str],
+        caveats: list[dict[str, str]],
+        rule: Rule,
+    ) -> None:
+        self.product_code = product_code
+        self.claim_ids = claim_ids
+        self.caveats = caveats
+        self.rule = rule
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "product_code": self.product_code,
+            "claim_ids": self.claim_ids,
+            "caveats": self.caveats,
+            "rule": json.loads(self.rule.model_dump_json()),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Lint 1: VERIFIED-only
+# ---------------------------------------------------------------------------
+
+
+def lint_verified_only(
+    *,
+    rule_id: str,
+    claim_ids: list[str],
+    caveats: list[dict[str, str]],
+    ledger: dict[str, ClaimRecord],
+    product_code: str = "",
+) -> list[LintFinding]:
+    """VERIFIED-only lint (task brief, literal requirement).
+
+    ``product_code`` resolves a PRODUCT-CONDITIONAL claim (kimi-k3
+    adversarial finding, 2026-08-18: ``CL-D-FUNDS`` is VERIFIED for
+    D1/D12 but VERIFIED-WITH-CAVEAT for D2 on one state line) to the
+    state that actually applies to THIS rule's product, via
+    ``ClaimRecord.state_for_product``/``compilable_for_product`` — a
+    claim-wide ``.state``/``.compilable`` would silently pick the first
+    token found and apply it to every product, exactly the bypass the
+    review caught live (a D2 rule citing CL-D-FUNDS compiling with no
+    caveat requirement).
+
+    A rule with zero declared claim_ids is itself a finding — this
+    compiler's entire purpose is claim-backed rule authoring, so a rule
+    with no provenance at all is not a degenerate-but-legal case, it is a
+    manifest authoring error.
+
+    Malformed ``caveats`` entries (missing/empty ``claim_id`` or ``note``,
+    or a non-dict entry) are reported as findings, never a bare crash — a
+    kimi-k3 adversarial review (2026-08-18) caught the original
+    ``{c["claim_id"] for c in caveats}`` set-comprehension raising
+    ``KeyError``/``TypeError`` on exactly this kind of manifest typo,
+    contradicting this module's own "never a bare traceback for a data
+    problem" contract. A caveat with an empty ``note`` is ALSO now a
+    finding — the task brief requires the caveat be "propagated", and an
+    empty string satisfies no reader; the earlier version only checked for
+    the *entry's presence*, not that it actually said anything.
+    """
+
+    findings: list[LintFinding] = []
+    if not claim_ids:
+        findings.append(LintFinding(rule_id, "declares zero claim_ids — every compiled rule must be claim-backed"))
+        return findings
+
+    caveated_claim_ids: set[str] = set()
+    for i, caveat in enumerate(caveats):
+        if not isinstance(caveat, dict):
+            findings.append(LintFinding(rule_id, f"caveats[{i}] is not an object: {caveat!r}"))
+            continue
+        cid = caveat.get("claim_id")
+        note = caveat.get("note")
+        if not isinstance(cid, str) or not cid:
+            findings.append(LintFinding(rule_id, f"caveats[{i}] has a missing/empty claim_id: {caveat!r}"))
+            continue
+        if not isinstance(note, str) or not note.strip():
+            findings.append(
+                LintFinding(rule_id, f"caveats[{i}] for claim_id {cid!r} has a missing/empty note")
+            )
+            continue
+        caveated_claim_ids.add(cid)
+
+    for claim_id in claim_ids:
+        record = ledger.get(claim_id)
+        if record is None:
+            findings.append(
+                LintFinding(rule_id, f"claim_id {claim_id!r} does not resolve in any loaded ledger")
+            )
+            continue
+        effective_state = record.state_for_product(product_code)
+        if not record.compilable_for_product(product_code):
+            findings.append(
+                LintFinding(
+                    rule_id,
+                    f"claim {claim_id!r} is at state {effective_state!r} "
+                    f"for product {product_code!r} ({record.source_file}) — "
+                    "VERIFIED-only violation: a "
+                    "CONFLICTING/STALE/UNVERIFIED/SUPERSEDED/UNSTATED claim "
+                    "may never back a compiled rule",
+                )
+            )
+            continue
+        if effective_state == "VERIFIED-WITH-CAVEAT" and claim_id not in caveated_claim_ids:
+            findings.append(
+                LintFinding(
+                    rule_id,
+                    f"claim {claim_id!r} is VERIFIED-WITH-CAVEAT but the rule's "
+                    "manifest entry carries no matching caveat note — the "
+                    "caveat must be propagated into provenance, never dropped",
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Lint 2: R-OVERSTAY-PLANNING
+# ---------------------------------------------------------------------------
+
+
+def _walk_overstay_gating(condition: Any, *, all_ancestor_facts: frozenset[str]) -> list[str]:
+    """Return every path (as human-readable breadcrumbs, empty list if none)
+    where ``immigration.overstay_days`` is referenced WITHOUT
+    ``immigration.currently_in_indonesia == true`` present among the
+    sibling/ancestor conditions of every enclosing ``all`` node.
+
+    ``all_ancestor_facts`` accumulates the set of facts proven true by a
+    direct ``{"op": "eq", "fact": ..., "value": true}`` (or the onshore
+    fact's own presence check — see below) sibling anywhere in the current
+    ``all``-chain: AND is associative, so a guard several ``all`` levels up
+    still gates a leaf several levels down. It does NOT cross an ``any`` or
+    ``not`` boundary — a guard inside one branch of an ``any`` does not
+    protect a leaf in a sibling branch (the whole point of ``any`` is that
+    either branch alone can make the condition true), and a guard is
+    meaningless once inverted by ``not``.
+    """
+
+    if not isinstance(condition, dict):
+        return []
+
+    op = condition.get("op")
+
+    if op == "all":
+        args = condition.get("args", [])
+        local_true_facts = {
+            a["fact"]
+            for a in args
+            if isinstance(a, dict)
+            and a.get("op") == "eq"
+            and a.get("value") is True
+            and isinstance(a.get("fact"), str)
+        }
+        combined = all_ancestor_facts | local_true_facts
+        violations: list[str] = []
+        for arg in args:
+            violations.extend(_walk_overstay_gating(arg, all_ancestor_facts=combined))
+        return violations
+
+    if op == "any":
+        # Each branch is independently sufficient — a guard elsewhere in
+        # the tree (even a sibling ALL ancestor above this `any`) still
+        # protects every branch, since AND-of-ancestors still applies; only
+        # a NEW guard local to one `any` branch does not protect its
+        # siblings. Re-walk each branch with the SAME ancestor set (not
+        # widened), since branches don't share new local facts.
+        violations = []
+        for arg in condition.get("args", []):
+            violations.extend(_walk_overstay_gating(arg, all_ancestor_facts=all_ancestor_facts))
+        return violations
+
+    if op == "not":
+        # Negation strips any protective value from ancestor guards that
+        # live ONLY inside this subtree (there are none reachable here
+        # since we pass the same ancestor set down, unchanged), and a fact
+        # referenced under `not` isn't itself a new guard either way.
+        return _walk_overstay_gating(condition.get("arg"), all_ancestor_facts=all_ancestor_facts)
+
+    # Leaf condition.
+    fact = condition.get("fact")
+    if fact == _OVERSTAY_FACT:
+        if _ONSHORE_FACT not in all_ancestor_facts:
+            return [
+                f"leaf condition on {_OVERSTAY_FACT!r} has no "
+                f"{_ONSHORE_FACT!r}==true guard among its ALL-ancestors"
+            ]
+        return []
+    return []
+
+
+def lint_overstay_planning(*, rule_id: str, when: dict[str, Any]) -> list[LintFinding]:
+    """R-OVERSTAY-PLANNING lint (Zero ruling 2026-08-18, see module docstring)."""
+
+    violations = _walk_overstay_gating(when, all_ancestor_facts=frozenset())
+    return [LintFinding(rule_id, v) for v in violations]
+
+
+# ---------------------------------------------------------------------------
+# Compiler entrypoint
+# ---------------------------------------------------------------------------
+
+
+class CompilationReport:
+    def __init__(self) -> None:
+        self.findings: list[LintFinding] = []
+        self.compiled: list[CompiledEntry] = []
+
+    @property
+    def ok(self) -> bool:
+        return not self.findings
+
+    def render(self) -> str:
+        lines = []
+        if self.ok:
+            lines.append(f"OK — {len(self.compiled)} rule(s) compiled clean.")
+        else:
+            lines.append(f"FAILED — {len(self.findings)} finding(s):")
+            for f in self.findings:
+                lines.append(f"  - {f}")
+        return "\n".join(lines)
+
+
+def compile_manifest(
+    manifest: dict[str, Any],
+    ledger: dict[str, ClaimRecord],
+) -> CompilationReport:
+    report = CompilationReport()
+
+    entries = manifest.get("rules")
+    if not isinstance(entries, list) or not entries:
+        report.findings.append(LintFinding("<manifest>", "manifest.rules must be a non-empty array"))
+        return report
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            report.findings.append(LintFinding("<manifest>", f"manifest entry is not an object: {entry!r}"))
+            continue
+
+        rule_src = entry.get("rule")
+        rule_id = rule_src.get("rule_id") if isinstance(rule_src, dict) else "<unknown>"
+        claim_ids = entry.get("claim_ids") or []
+        caveats = entry.get("caveats") or []
+        product_code = entry.get("product_code", "<unknown>")
+
+        if not isinstance(rule_src, dict):
+            report.findings.append(LintFinding(rule_id, "manifest entry has no 'rule' object"))
+            continue
+
+        entry_findings_start = len(report.findings)
+
+        # Lint 1 — VERIFIED-only (runs even if the Rule itself fails to
+        # parse, so a claim problem is never masked by a schema problem).
+        report.findings.extend(
+            lint_verified_only(
+                rule_id=rule_id, claim_ids=claim_ids, caveats=caveats, ledger=ledger
+            )
+        )
+
+        when = rule_src.get("when")
+        if isinstance(when, dict):
+            report.findings.extend(lint_overstay_planning(rule_id=rule_id, when=when))
+
+        # Derive required_facts from `when` — never trust a manifest-supplied
+        # value (mirrors compile_pack.py's compiler-level invariant, applied
+        # here at authoring time instead of at pack-assembly time). Parse
+        # `when` into the real discriminated `Condition` union first —
+        # `collect_fact_paths` walks typed nodes (`node.fact`), not raw
+        # dicts, so calling it on the manifest's plain dict silently visits
+        # nothing and derives an empty required_facts set (caught live by
+        # this compiler's own tests before this comment existed).
+        try:
+            parsed_when = parse_condition(when)
+            derived_facts = sorted(collect_fact_paths(parsed_when))
+        except (ValidationError, ValueError, TypeError) as exc:
+            report.findings.append(LintFinding(rule_id, f"condition tree could not be parsed: {exc}"))
+            continue
+
+        rule_payload = {**rule_src, "required_facts": derived_facts}
+        try:
+            rule = Rule.model_validate(rule_payload)
+        except ValidationError as exc:
+            report.findings.append(LintFinding(rule_id, f"Rule schema validation failed: {exc}"))
+            continue
+
+        # A rule that failed a lint above (VERIFIED-only or R-OVERSTAY-
+        # PLANNING) must never be added to `compiled`, even though it may
+        # have gone on to parse structurally clean — a lint failure makes
+        # the WHOLE rule uncompilable, not just the finding cosmetic.
+        if len(report.findings) > entry_findings_start:
+            continue
+
+        report.compiled.append(
+            CompiledEntry(product_code=product_code, claim_ids=claim_ids, caveats=caveats, rule=rule)
+        )
+
+    return report
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--claims", nargs="+", required=True, type=Path, help="claim ledger markdown file(s)")
+    parser.add_argument("--manifest", required=True, type=Path, help="rule-authoring manifest JSON")
+    parser.add_argument("--out", type=Path, default=None, help="write compiled rules JSON here on success")
+    args = parser.parse_args(argv)
+
+    try:
+        ledger = load_claim_ledgers(args.claims)
+    except (OSError, ClaimLedgerError) as exc:
+        print(f"error loading claim ledgers: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        manifest = load_manifest(args.manifest)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error loading manifest: {exc}", file=sys.stderr)
+        return 1
+
+    report = compile_manifest(manifest, ledger)
+    print(report.render())
+
+    if not report.ok:
+        return 1
+
+    if args.out is not None:
+        args.out.write_text(
+            json.dumps([e.to_dict() for e in report.compiled], indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"wrote {len(report.compiled)} compiled rule(s) to {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/backend-rag/backend/scripts/visa_engine/compile_claims.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/compile_claims.py
@@ -369,7 +369,11 @@ def compile_manifest(
         # parse, so a claim problem is never masked by a schema problem).
         report.findings.extend(
             lint_verified_only(
-                rule_id=rule_id, claim_ids=claim_ids, caveats=caveats, ledger=ledger
+                rule_id=rule_id,
+                claim_ids=claim_ids,
+                caveats=caveats,
+                ledger=ledger,
+                product_code=product_code if isinstance(product_code, str) else "<unknown>",
             )
         )
 

--- a/apps/backend-rag/backend/services/visa_engine/claim_ledger.py
+++ b/apps/backend-rag/backend/services/visa_engine/claim_ledger.py
@@ -129,8 +129,16 @@ _STATE_BULLET_SPAN_RE = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 #: Matches every ``**TOKEN** for PRODUCTLIST`` clause inside a state
-#: bullet — ``PRODUCTLIST`` is a ``/``-joined list like ``D1/D12``.
-_PRODUCT_STATE_CLAUSE_RE = re.compile(r"\*\*(" + "|".join(CLAIM_STATES) + r")\*\*\s+for\s+([A-Za-z0-9/]+)")
+#: bullet — ``PRODUCTLIST`` is a ``/``-joined list like ``D1/D12``. The
+#: optional ``(?:State:\s*)?`` covers the FIRST clause, whose bold span
+#: opens at the bullet's own ``**State: `` prefix (e.g.
+#: ``**State: VERIFIED**``) rather than at the token itself — every
+#: SUBSEQUENT clause in the same line opens its own fresh ``**`` right at
+#: the token (e.g. ``**VERIFIED-WITH-CAVEAT**``), so the prefix is never
+#: present there.
+_PRODUCT_STATE_CLAUSE_RE = re.compile(
+    r"\*\*(?:State:\s*)?(" + "|".join(CLAIM_STATES) + r")\*\*\s+for\s+([A-Za-z0-9/]+)"
+)
 
 
 def _parse_product_conditional_states(bullet_text: str) -> dict[str, str] | None:

--- a/apps/backend-rag/backend/services/visa_engine/claim_ledger.py
+++ b/apps/backend-rag/backend/services/visa_engine/claim_ledger.py
@@ -1,0 +1,300 @@
+"""Parser for the Visa Oracle doctrine-factory claim ledgers.
+
+E5 increment 1 (claim-compiler + VERIFIED-only lint, see
+``research/visa/doctrine-factory/claims/*.md`` and
+``research/visa/doctrine-factory/cards/*.md``). This module reads the
+markdown claim ledgers produced by the E2a/E2b/E3a research passes and
+extracts a machine-checkable ``dict[claim_id, ClaimRecord]`` — the SSOT the
+compiler (``backend.scripts.visa_engine.compile_claims``) uses to enforce
+the VERIFIED-only lint.
+
+Format observed across every ledger file (``e2a-claim-ledger.md``,
+``e2b-batch1-claim-ledger.md``, ``e2b-batch2-claim-ledger.md``,
+``e2b-batch2-conflict-report.md``, ``e3a-cf1-resolution.md``), verified by
+grep before writing this parser — do not "improve" the regex without
+re-grepping, the ledgers are hand-authored prose and drift is real:
+
+    **CL-<ID> — <short name>.** <prose...>
+    - Source: ...
+    - **State: <TOKEN>[.]** [free text — "as a mechanical/structural
+      finding", "(gap, not a negative finding)", etc. — never re-parsed]
+    - Backs: `rule.a`, `rule.b` (...).
+
+Only the FIRST ``- **State: ...`` line following a ``**CL-<ID> —`` header
+(and preceding the next such header) is authoritative for that claim — a
+card or ledger may restate/discuss a claim's state in prose elsewhere
+(e.g. D2.md's superseded ``<details>`` block), but this parser only reads
+the ledger files it is pointed at, in file order, header-block by
+header-block, so restated states never race with the authoritative one
+inside a single well-formed ledger.
+
+Known ``State:`` tokens (grepped 2026-08-18 across all four claim-ledger-
+shaped files): ``VERIFIED``, ``VERIFIED-WITH-CAVEAT``, ``CONFLICTING``,
+``UNVERIFIED``, ``STALE``, ``SUPERSEDED`` (last two not observed live yet
+but named in ``source-hierarchy-draft.md``'s five-state vocabulary — kept
+here so a future ledger entry using them parses instead of silently
+matching nothing).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+#: The five-state vocabulary (``source-hierarchy-draft.md`` §3.2). Longest
+#: alternative first so the regex alternation doesn't stop at the
+#: "VERIFIED" prefix of "VERIFIED-WITH-CAVEAT" (mirrors the repo-wide
+#: longest-alternative-first regex convention, see Bash tool guidance).
+CLAIM_STATES: tuple[str, ...] = (
+    "VERIFIED-WITH-CAVEAT",
+    "VERIFIED",
+    "CONFLICTING",
+    "UNVERIFIED",
+    "STALE",
+    "SUPERSEDED",
+)
+
+#: States a rule is permitted to depend on at all (E5 VERIFIED-only lint).
+#: CONFLICTING/UNVERIFIED/STALE/SUPERSEDED are hard-blocked by construction
+#: — see ``compile_claims.py``'s ``lint_verified_only``.
+COMPILABLE_STATES: frozenset[str] = frozenset({"VERIFIED", "VERIFIED-WITH-CAVEAT"})
+
+#: Sentinel for a claim header with no resolvable ``**State: ...**`` line in
+#: its block — real, grepped example: ``CL-E30A-03`` in
+#: ``e2b-batch1-claim-ledger.md`` is a cross-reference alias ("See
+#: CL-E30B-01 above"), not a claim with its own evidentiary state. These are
+#: legitimately out of any given compiler slice's scope; hard-failing the
+#: WHOLE ledger load on one alias would make the compiler unable to consume
+#: a ledger file that has any out-of-scope alias claims in it at all — so
+#: they parse as this never-compilable sentinel instead. Any rule that DOES
+#: try to depend on one fails the VERIFIED-only lint exactly like a claim
+#: with a real bad state would (``UNSTATED not in COMPILABLE_STATES``).
+UNSTATED = "UNSTATED"
+
+#: Both real header shapes are covered: bare ``**CL-<id> — <name>.**`` at
+#: column 0 (``e2a-claim-ledger.md``, ``e2b-batch1-claim-ledger.md``) AND
+#: bullet-prefixed ``- **CL-<id> — <name>.**`` (``e2b-batch2-claim-ledger.md``).
+#: ``^`` + ``re.MULTILINE`` + the optional bullet prefix is load-bearing —
+#: a kimi-k3 adversarial review (2026-08-18) caught the unanchored version
+#: matching an inline bold reference mid-prose (e.g. "as discussed in
+#: **CL-D2-01 — the passport claim**...") as a spurious SECOND header for
+#: an already-open claim, corrupting its block boundary. Verified the
+#: anchored version still matches all 90 real headers across the four
+#: loaded ledger files (identical count to the unanchored version) before
+#: landing this fix — a real header is always the first thing on its line.
+_HEADER_RE = re.compile(
+    r"^[ \t]*(?:-[ \t]+)?\*\*(CL-[A-Za-z0-9][A-Za-z0-9-]*)\s*[—-]\s*([^*]*)\*\*",
+    re.MULTILINE,
+)
+#: Same anchoring rationale as ``_HEADER_RE``: a bare ``**State: ...**``
+#: match anywhere in a block's prose (e.g. "Previously marked
+#: **State: CONFLICTING** before resolution.") could otherwise out-race the
+#: real ``- **State: ...**`` bullet the ledger format actually uses.
+#: Verified against all four loaded ledger files: identical match count to
+#: the unanchored version.
+_STATE_RE = re.compile(
+    r"^[ \t]*-[ \t]*\*\*State:\s*(" + "|".join(CLAIM_STATES) + r")\b[^*]*\*\*",
+    re.MULTILINE,
+)
+#: ``Backs:`` lines routinely wrap onto an indented continuation line in
+#: these ledgers (grepped example: ``CL-D12-02`` lists 5 rule ids across two
+#: physical lines) — capture up to the next unindented ``- `` bullet, a
+#: blank line, or end of block, not just to end-of-line.
+_BACKS_RE = re.compile(r"^-\s*Backs:\s*(.*?)(?=\n-\s|\n\n|\Z)", re.MULTILINE | re.DOTALL)
+_RULE_ID_RE = re.compile(r"`([a-z][a-z0-9_.-]*)`")
+
+#: The full ``- **State: ...`` bullet, wrapping-tolerant (same lookahead
+#: shape as ``_BACKS_RE``) — captured separately from ``_STATE_RE`` so a
+#: kimi-k3 adversarial review (2026-08-18) live-data finding can be
+#: detected: a PRODUCT-CONDITIONAL state line. Real example,
+#: ``CL-D-FUNDS`` in ``e2a-claim-ledger.md``:
+#:
+#:     - **State: VERIFIED** for D1/D12 (numeric, primary-adjacent
+#:       sourcing); **VERIFIED-WITH-CAVEAT** for D2 (no hardcoded
+#:       national figure ...).
+#:
+#: ``_STATE_RE`` alone picks the FIRST token match (``VERIFIED``) and
+#: applies it claim-wide — a D2 rule citing this claim would then compile
+#: with NO caveat requirement, silently bypassing the caveat-propagation
+#: guarantee lint 1 exists to enforce. Verified this is the ONLY claim
+#: across all four loaded ledger files with this shape (grepped
+#: 2026-08-18: `grep -n "for D1/D12" claims/*.md` and a broader
+#: multi-state-per-line sweep both return exactly one hit) — a raised
+#: `ClaimLedgerError` here would therefore deadlock the D1/D12 rules that
+#: legitimately need the plain-VERIFIED resolution, so per-product state
+#: parsing (not a hard fail) is the correct scope for this one real shape.
+_STATE_BULLET_SPAN_RE = re.compile(
+    r"^[ \t]*-[ \t]*\*\*State:.*?(?=\n[ \t]*-[ \t]|\n\n|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+#: Matches every ``**TOKEN** for PRODUCTLIST`` clause inside a state
+#: bullet — ``PRODUCTLIST`` is a ``/``-joined list like ``D1/D12``.
+_PRODUCT_STATE_CLAUSE_RE = re.compile(r"\*\*(" + "|".join(CLAIM_STATES) + r")\*\*\s+for\s+([A-Za-z0-9/]+)")
+
+
+def _parse_product_conditional_states(bullet_text: str) -> dict[str, str] | None:
+    """Return ``{product_code: state}`` if the bullet expresses 2+ distinct
+    ``**TOKEN** for PRODUCTS`` clauses (a product-conditional state line),
+    else ``None`` for the ordinary single-state case."""
+
+    clauses = _PRODUCT_STATE_CLAUSE_RE.findall(bullet_text)
+    if len(clauses) < 2:
+        return None
+    product_states: dict[str, str] = {}
+    for token, product_list in clauses:
+        for product in product_list.split("/"):
+            product = product.strip()
+            if product:
+                product_states[product] = token
+    return product_states or None
+
+
+class ClaimLedgerError(ValueError):
+    """A claim ledger file could not be parsed into records."""
+
+
+@dataclass(frozen=True)
+class ClaimRecord:
+    """One claim as recorded in a doctrine-factory ledger.
+
+    ``source_file``/``header`` are provenance for compiler error messages
+    (so a lint failure can point a human straight at the ledger line that
+    caused it, not just the bare claim_id).
+    """
+
+    claim_id: str
+    state: str
+    header: str
+    backs: tuple[str, ...]
+    source_file: str
+    #: Non-``None`` only for the rare product-conditional shape (see
+    #: ``_STATE_BULLET_SPAN_RE``) — maps a product code (e.g. ``"D2"``) to
+    #: its OWN state, distinct from the claim-wide ``state`` above (which
+    #: for a product-conditional claim is just the first token found, kept
+    #: for backward-compatible display/UNSTATED-detection only — callers
+    #: that care about a specific product must consult this map, not
+    #: ``state``, when it is populated).
+    product_states: dict[str, str] | None = None
+
+    @property
+    def compilable(self) -> bool:
+        return self.state in COMPILABLE_STATES
+
+    def state_for_product(self, product_code: str) -> str:
+        """The state to apply for ``product_code`` — the per-product entry
+        if this is a product-conditional claim and the product is named,
+        else the claim-wide ``state``."""
+
+        if self.product_states is not None:
+            return self.product_states.get(product_code, self.state)
+        return self.state
+
+    def compilable_for_product(self, product_code: str) -> bool:
+        return self.state_for_product(product_code) in COMPILABLE_STATES
+
+
+def parse_claim_ledger_text(text: str, *, source_name: str) -> dict[str, ClaimRecord]:
+    """Parse one ledger file's already-read text into ``{claim_id: ClaimRecord}``.
+
+    Splits the document into header-block chunks at every ``**CL-<id> —``
+    occurrence, then looks for the first ``**State: ...**`` line inside that
+    chunk (i.e. before the next header). A header with no resolvable state
+    line inside its block raises ``ClaimLedgerError`` — a claim with a
+    header but no state is exactly the kind of drift this parser exists to
+    catch, not silently skip (a rule referencing that claim_id would
+    otherwise fail with a confusing "unknown claim_id" instead of the real
+    "malformed ledger entry").
+    """
+
+    headers = list(_HEADER_RE.finditer(text))
+    records: dict[str, ClaimRecord] = {}
+    for i, m in enumerate(headers):
+        claim_id = m.group(1)
+        header = m.group(2).strip()
+        block_start = m.end()
+        block_end = headers[i + 1].start() if i + 1 < len(headers) else len(text)
+        block = text[block_start:block_end]
+
+        state_m = _STATE_RE.search(block)
+        state = state_m.group(1) if state_m is not None else UNSTATED
+
+        product_states: dict[str, str] | None = None
+        bullet_m = _STATE_BULLET_SPAN_RE.search(block)
+        if bullet_m is not None:
+            product_states = _parse_product_conditional_states(bullet_m.group(0))
+
+        backs: tuple[str, ...] = ()
+        backs_m = _BACKS_RE.search(block)
+        if backs_m is not None:
+            backs = tuple(_RULE_ID_RE.findall(backs_m.group(1)))
+
+        if claim_id in records:
+            # Same claim_id re-declared — WITHIN this file or across files —
+            # with a DIFFERENT state is a real ledger inconsistency the
+            # compiler must not silently pick a side on. This covers both
+            # legitimate cross-file restatements (a resolution fast-follow
+            # file that reprints an unchanged claim for context) AND the
+            # sharper in-file case a kimi-k3 adversarial review caught live
+            # (2026-08-18): `_HEADER_RE` is not anchored to the start of a
+            # line, so an inline bold restatement mid-prose that happens to
+            # match the exact `**CL-<id> — <name>.**` shape (e.g. a card's
+            # `<details>` block quoting a claim header for context) would
+            # otherwise open a SECOND block for the same claim_id and
+            # silently overwrite the authoritative record with whatever
+            # that second block's own (possibly UNSTATED) state resolves
+            # to — no error, wrong answer. Never observed live in the four
+            # ledger files this module currently loads (verified: 90
+            # headers, 90 unique claim_ids, zero within-file duplicates),
+            # but the docstring's claim of header-block immunity only held
+            # by accident of what these specific files happen to contain,
+            # not by construction — so duplicate detection is now
+            # unconditional, not source_file-gated.
+            prior = records[claim_id]
+            if prior.state != state:
+                raise ClaimLedgerError(
+                    f"claim {claim_id!r} is declared with state "
+                    f"{prior.state!r} ({prior.source_file!r}) and state "
+                    f"{state!r} ({source_name!r}) — ledger inconsistency, "
+                    "not resolvable by the compiler. If this is an in-file "
+                    "restatement (a details block quoting a claim header), "
+                    "the restatement must not use the literal "
+                    "'**CL-<id> — <name>.**' bold-header shape."
+                )
+            # Identical restatement (same claim_id, same state) — keep the
+            # first block's record, harmless.
+            continue
+
+        records[claim_id] = ClaimRecord(
+            claim_id=claim_id,
+            state=state,
+            header=header,
+            backs=backs,
+            source_file=source_name,
+            product_states=product_states,
+        )
+
+    return records
+
+
+def load_claim_ledgers(paths: list[Path]) -> dict[str, ClaimRecord]:
+    """Read and merge every claim ledger file in ``paths``, in order.
+
+    Raises ``ClaimLedgerError`` on any inter-file state inconsistency (see
+    ``parse_claim_ledger_text``) or ``OSError`` if a path is unreadable.
+    """
+
+    merged: dict[str, ClaimRecord] = {}
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        records = parse_claim_ledger_text(text, source_name=str(path))
+        for claim_id, record in records.items():
+            if claim_id in merged and merged[claim_id].state != record.state:
+                raise ClaimLedgerError(
+                    f"claim {claim_id!r} is declared with state "
+                    f"{merged[claim_id].state!r} in {merged[claim_id].source_file!r} "
+                    f"and state {record.state!r} in {record.source_file!r} — "
+                    "ledger inconsistency, not resolvable by the compiler"
+                )
+            merged.setdefault(claim_id, record)
+    return merged

--- a/apps/backend-rag/backend/tests/scripts/test_visa_engine_compile_claims.py
+++ b/apps/backend-rag/backend/tests/scripts/test_visa_engine_compile_claims.py
@@ -152,6 +152,81 @@ class TestVerifiedOnlyLint:
         )
         assert findings == []
 
+    def test_guilt_product_conditional_claim_without_caveat_is_rejected_for_its_caveated_product(
+        self,
+    ) -> None:
+        """kimi-k3 P0 finding (2026-08-18): CL-D-FUNDS is VERIFIED for
+        D1/D12 but VERIFIED-WITH-CAVEAT for D2 on ONE state line —
+        ``ClaimRecord.state`` alone (first token) would resolve to plain
+        VERIFIED for every product, silently bypassing the caveat
+        requirement for D2. A D2 rule citing it with no caveat must be
+        REJECTED — proving the per-product lookup, not the claim-wide
+        state, is what the lint actually consults."""
+
+        ledger = {
+            "CL-D-FUNDS": ClaimRecord(
+                claim_id="CL-D-FUNDS",
+                state="VERIFIED",
+                header="Financial-proof minima.",
+                backs=(),
+                source_file="<test>",
+                product_states={"D1": "VERIFIED", "D12": "VERIFIED", "D2": "VERIFIED-WITH-CAVEAT"},
+            )
+        }
+        findings = lint_verified_only(
+            rule_id="el.d2-funds",
+            claim_ids=["CL-D-FUNDS"],
+            caveats=[],
+            ledger=ledger,
+            product_code="D2",
+        )
+        assert findings and "no matching caveat note" in findings[0].message
+
+    def test_innocence_product_conditional_claim_passes_for_its_verified_products(self) -> None:
+        """Innocence twin: D1/D12 rules citing the SAME product-conditional
+        claim must pass without needing a caveat — their per-product state
+        is plain VERIFIED, not VERIFIED-WITH-CAVEAT."""
+
+        ledger = {
+            "CL-D-FUNDS": ClaimRecord(
+                claim_id="CL-D-FUNDS",
+                state="VERIFIED",
+                header="Financial-proof minima.",
+                backs=(),
+                source_file="<test>",
+                product_states={"D1": "VERIFIED", "D12": "VERIFIED", "D2": "VERIFIED-WITH-CAVEAT"},
+            )
+        }
+        for product_code in ("D1", "D12"):
+            findings = lint_verified_only(
+                rule_id=f"el.{product_code.lower()}-funds",
+                claim_ids=["CL-D-FUNDS"],
+                caveats=[],
+                ledger=ledger,
+                product_code=product_code,
+            )
+            assert findings == [], f"{product_code} should not require a caveat"
+
+    def test_innocence_product_conditional_claim_with_caveat_passes_for_d2(self) -> None:
+        ledger = {
+            "CL-D-FUNDS": ClaimRecord(
+                claim_id="CL-D-FUNDS",
+                state="VERIFIED",
+                header="Financial-proof minima.",
+                backs=(),
+                source_file="<test>",
+                product_states={"D1": "VERIFIED", "D12": "VERIFIED", "D2": "VERIFIED-WITH-CAVEAT"},
+            )
+        }
+        findings = lint_verified_only(
+            rule_id="el.d2-funds",
+            claim_ids=["CL-D-FUNDS"],
+            caveats=[{"claim_id": "CL-D-FUNDS", "note": "statute delegates the figure; portal hardcodes it"}],
+            ledger=ledger,
+            product_code="D2",
+        )
+        assert findings == []
+
 
 # ---------------------------------------------------------------------------
 # Lint 2 — R-OVERSTAY-PLANNING: guilt + innocence
@@ -235,6 +310,50 @@ class TestOverstayPlanningLint:
 
     def test_innocence_no_overstay_reference_at_all_passes(self) -> None:
         when = {"fact": "intent.purposes", "op": "intersects", "values": ["TOURISM"]}
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert findings == []
+
+    def test_guilt_not_wrapped_negative_onshore_check_does_not_count_as_a_guard(self) -> None:
+        """kimi-k3 P1 finding to VERIFY (2026-08-18): does a guard-shaped
+        leaf inside a ``not`` subtree wrongly get credited as protecting a
+        SIBLING overstay reference? ``not(eq onshore false)`` is a
+        de Morgan-equivalent of ``onshore==true`` in ordinary boolean
+        logic, but this walker only ever collects a local_true_fact from a
+        DIRECT ``{"op":"eq","value":True}`` child of an ``all`` node — a
+        ``not`` node is never such a child (its own ``op`` is ``"not"``),
+        so it must contribute NOTHING to ``all_ancestor_facts``. Confirmed
+        by this test: the sibling overstay leaf is still flagged — the
+        walker does not (incorrectly) treat the not-wrapped check as a
+        guard. (This is also why the phrasing is rejected elsewhere as a
+        declined P2 false-positive, not a bypass: it is REJECTED, i.e.
+        safe, never silently accepted.)"""
+
+        when = {
+            "op": "all",
+            "args": [
+                {
+                    "op": "not",
+                    "arg": {"fact": "immigration.currently_in_indonesia", "op": "eq", "value": False},
+                },
+                {"fact": "immigration.overstay_days", "op": "gt", "value": 0},
+            ],
+        }
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert findings, "a not-wrapped negative-onshore-check must NOT protect a sibling overstay leaf"
+
+    def test_innocence_real_onshore_guard_still_protects_a_not_wrapped_overstay_leaf(self) -> None:
+        """The mirror case: a REAL onshore guard (a direct true-eq sibling)
+        must still protect an overstay reference even when that reference
+        itself sits inside a ``not`` — the guard is an AND-sibling of the
+        `not` node, so it holds regardless of what's inside the `not`."""
+
+        when = {
+            "op": "all",
+            "args": [
+                {"fact": "immigration.currently_in_indonesia", "op": "eq", "value": True},
+                {"op": "not", "arg": {"fact": "immigration.overstay_days", "op": "eq", "value": 0}},
+            ],
+        }
         findings = lint_overstay_planning(rule_id="hf.test", when=when)
         assert findings == []
 

--- a/apps/backend-rag/backend/tests/scripts/test_visa_engine_compile_claims.py
+++ b/apps/backend-rag/backend/tests/scripts/test_visa_engine_compile_claims.py
@@ -1,0 +1,374 @@
+"""Tests for ``backend.scripts.visa_engine.compile_claims`` (E5 increment 1).
+
+Guilt+innocence pairs for both hard lints (VERIFIED-only, R-OVERSTAY-
+PLANNING), plus a golden compile of the real E5 vertical-slice manifest
+against the real committed claim ledgers — the same invocation
+``compile_claims.main`` documents in its module docstring, run for real
+here rather than only described.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.scripts.visa_engine.compile_claims import (
+    compile_manifest,
+    lint_overstay_planning,
+    lint_verified_only,
+    load_claim_ledgers,
+    load_manifest,
+    main,
+)
+from backend.services.visa_engine.claim_ledger import ClaimRecord
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_CLAIMS_DIR = _REPO_ROOT / "research" / "visa" / "doctrine-factory" / "claims"
+_SLICE_MANIFEST = (
+    _REPO_ROOT / "research" / "visa" / "doctrine-factory" / "e5" / "slice-rule-manifest.json"
+)
+_LEDGER_FILES = [
+    _CLAIMS_DIR / "e2a-claim-ledger.md",
+    _CLAIMS_DIR / "e2b-batch1-claim-ledger.md",
+    _CLAIMS_DIR / "e2b-batch2-claim-ledger.md",
+    _CLAIMS_DIR / "e3a-cf1-resolution.md",
+]
+
+
+def _rec(claim_id: str, state: str) -> ClaimRecord:
+    return ClaimRecord(claim_id=claim_id, state=state, header="test", backs=(), source_file="<test>")
+
+
+def _minimal_rule(rule_id: str = "el.test-rule", *, when: dict | None = None) -> dict:
+    return {
+        "rule_id": rule_id,
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"],
+        "priority": 100,
+        "valid_period": {"from": "2026-07-24T00:00:00Z", "to": None},
+        "when": when or {"fact": "intent.purposes", "op": "intersects", "values": ["FAMILY"]},
+        "effect": {"type": "SUPPORT", "reason_code": "PURPOSE_PRODUCT_MATCH", "covered_purposes": ["FAMILY"]},
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": ["570f2bc4-5120-561f-90ba-58fcd9507514"],
+        "explanation_key": f"explain.{rule_id}",
+        "safety_critical": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lint 1 — VERIFIED-only: guilt + innocence
+# ---------------------------------------------------------------------------
+
+
+class TestVerifiedOnlyLint:
+    def test_guilt_conflicting_claim_is_rejected(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "CONFLICTING")}
+        findings = lint_verified_only(
+            rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger
+        )
+        assert len(findings) == 1
+        assert "CONFLICTING" in findings[0].message
+        assert "el.x" == findings[0].rule_id
+
+    def test_guilt_stale_claim_is_rejected(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "STALE")}
+        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        assert findings and "STALE" in findings[0].message
+
+    def test_guilt_unverified_claim_is_rejected(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "UNVERIFIED")}
+        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        assert findings and "UNVERIFIED" in findings[0].message
+
+    def test_guilt_unknown_claim_id_is_rejected(self) -> None:
+        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-GHOST-01"], caveats=[], ledger={})
+        assert findings and "does not resolve" in findings[0].message
+
+    def test_guilt_caveat_with_verified_with_caveat_but_no_note(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED-WITH-CAVEAT")}
+        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        assert findings and "no matching caveat note" in findings[0].message
+
+    def test_guilt_zero_claim_ids(self) -> None:
+        findings = lint_verified_only(rule_id="el.x", claim_ids=[], caveats=[], ledger={})
+        assert findings and "zero claim_ids" in findings[0].message
+
+    def test_guilt_caveat_with_empty_note_does_not_satisfy_the_requirement(self) -> None:
+        """kimi-k3 finding (2026-08-18): a caveat entry with the claim_id
+        present but an empty/missing note satisfied the original lint —
+        the brief requires the caveat actually be propagated, not a stub."""
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED-WITH-CAVEAT")}
+        findings = lint_verified_only(
+            rule_id="el.x",
+            claim_ids=["CL-X-01"],
+            caveats=[{"claim_id": "CL-X-01", "note": ""}],
+            ledger=ledger,
+        )
+        assert findings and "empty note" in findings[0].message
+
+    def test_guilt_malformed_caveat_entry_reports_finding_never_crashes(self) -> None:
+        """kimi-k3 finding (2026-08-18): the original
+        ``{c["claim_id"] for c in caveats}`` set-comprehension raised a bare
+        ``KeyError``/``TypeError`` on a malformed caveats entry, contradicting
+        this module's own "never a bare traceback for a data problem"
+        contract. Must report a finding instead, for every malformed shape."""
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        for bad_caveats in (
+            [{"note": "missing claim_id"}],
+            [{"claim_id": "CL-X-01"}],  # missing note
+            ["not-a-dict"],
+            [{"claim_id": 123, "note": "wrong type"}],
+        ):
+            findings = lint_verified_only(
+                rule_id="el.x", claim_ids=["CL-X-01"], caveats=bad_caveats, ledger=ledger
+            )
+            assert findings, f"expected a finding for {bad_caveats!r}"
+
+    def test_innocence_verified_claim_passes(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        assert findings == []
+
+    def test_innocence_verified_with_caveat_and_matching_note_passes(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED-WITH-CAVEAT")}
+        findings = lint_verified_only(
+            rule_id="el.x",
+            claim_ids=["CL-X-01"],
+            caveats=[{"claim_id": "CL-X-01", "note": "explains the caveat"}],
+            ledger=ledger,
+        )
+        assert findings == []
+
+    def test_innocence_multiple_verified_claims_pass(self) -> None:
+        ledger = {
+            "CL-X-01": _rec("CL-X-01", "VERIFIED"),
+            "CL-X-02": _rec("CL-X-02", "VERIFIED"),
+        }
+        findings = lint_verified_only(
+            rule_id="el.x", claim_ids=["CL-X-01", "CL-X-02"], caveats=[], ledger=ledger
+        )
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Lint 2 — R-OVERSTAY-PLANNING: guilt + innocence
+# ---------------------------------------------------------------------------
+
+
+class TestOverstayPlanningLint:
+    def test_guilt_bare_overstay_reference_is_rejected(self) -> None:
+        """Reproduces the seq-6 smoke symptom the ruling names: a rule
+        referencing overstay_days with no onshore guard at all."""
+
+        when = {"fact": "immigration.overstay_days", "op": "eq", "value": 0}
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert len(findings) == 1
+        assert "immigration.overstay_days" in findings[0].message
+        assert "immigration.currently_in_indonesia" in findings[0].message
+
+    def test_guilt_overstay_nested_in_all_without_onshore_sibling(self) -> None:
+        when = {
+            "op": "all",
+            "args": [
+                {"fact": "intent.purposes", "op": "intersects", "values": ["TOURISM"]},
+                {"fact": "immigration.overstay_days", "op": "gt", "value": 0},
+            ],
+        }
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert findings
+
+    def test_guilt_overstay_guarded_only_inside_sibling_any_branch(self) -> None:
+        """An onshore guard that lives inside an `any` branch protects only
+        that branch's own leaves, never a sibling branch's — an `any` is
+        satisfied by EITHER branch, so a guard local to one branch gives no
+        guarantee about facts collected via the other."""
+
+        when = {
+            "op": "any",
+            "args": [
+                {
+                    "op": "all",
+                    "args": [
+                        {"fact": "immigration.currently_in_indonesia", "op": "eq", "value": True},
+                        {"fact": "intent.purposes", "op": "intersects", "values": ["TOURISM"]},
+                    ],
+                },
+                {"fact": "immigration.overstay_days", "op": "gt", "value": 0},
+            ],
+        }
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert findings
+
+    def test_innocence_overstay_guarded_by_onshore_sibling_passes(self) -> None:
+        """The onshore branch: currently_in_indonesia==true still asks
+        about overstay — this must NEVER be blocked by the lint."""
+
+        when = {
+            "op": "all",
+            "args": [
+                {"fact": "immigration.currently_in_indonesia", "op": "eq", "value": True},
+                {"fact": "immigration.overstay_days", "op": "gt", "value": 0},
+            ],
+        }
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert findings == []
+
+    def test_innocence_overstay_guarded_by_ancestor_all_two_levels_up(self) -> None:
+        when = {
+            "op": "all",
+            "args": [
+                {"fact": "immigration.currently_in_indonesia", "op": "eq", "value": True},
+                {
+                    "op": "all",
+                    "args": [
+                        {"fact": "intent.purposes", "op": "intersects", "values": ["TOURISM"]},
+                        {"fact": "immigration.overstay_days", "op": "gt", "value": 0},
+                    ],
+                },
+            ],
+        }
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert findings == []
+
+    def test_innocence_no_overstay_reference_at_all_passes(self) -> None:
+        when = {"fact": "intent.purposes", "op": "intersects", "values": ["TOURISM"]}
+        findings = lint_overstay_planning(rule_id="hf.test", when=when)
+        assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Full compiler: end-to-end guilt + innocence
+# ---------------------------------------------------------------------------
+
+
+class TestCompileManifest:
+    def test_guilt_manifest_with_conflicting_claim_fails_whole_report(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "CONFLICTING")}
+        manifest = {
+            "rules": [
+                {"product_code": "X", "claim_ids": ["CL-X-01"], "caveats": [], "rule": _minimal_rule()}
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert not report.ok
+        assert report.compiled == []
+        assert "CONFLICTING" in report.render()
+
+    def test_guilt_overstay_bare_reference_fails(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        rule = _minimal_rule(when={"fact": "immigration.overstay_days", "op": "eq", "value": 0})
+        manifest = {
+            "rules": [{"product_code": "X", "claim_ids": ["CL-X-01"], "caveats": [], "rule": rule}]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert not report.ok
+
+    def test_innocence_clean_manifest_compiles(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        manifest = {
+            "rules": [
+                {"product_code": "X", "claim_ids": ["CL-X-01"], "caveats": [], "rule": _minimal_rule()}
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert report.ok
+        assert len(report.compiled) == 1
+        assert report.compiled[0].rule.rule_id == "el.test-rule"
+        # required_facts must be derived, never trusted from the manifest —
+        # the minimal rule's `when` references exactly one fact.
+        assert list(report.compiled[0].rule.required_facts) == ["intent.purposes"]
+
+    def test_innocence_required_facts_are_always_derived_not_trusted(self) -> None:
+        """A manifest that lied about required_facts (stale/omitted) must
+        not propagate the lie — the compiler recomputes it."""
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        rule = _minimal_rule()
+        rule["required_facts"] = ["totally.wrong.path"]  # would fail FactPath validation if trusted
+        manifest = {
+            "rules": [{"product_code": "X", "claim_ids": ["CL-X-01"], "caveats": [], "rule": rule}]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert report.ok
+        assert list(report.compiled[0].rule.required_facts) == ["intent.purposes"]
+
+
+# ---------------------------------------------------------------------------
+# Golden: the real vertical-slice manifest against the real committed ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestSliceGolden:
+    def test_slice_manifest_compiles_clean_against_real_ledgers(self) -> None:
+        ledger = load_claim_ledgers(_LEDGER_FILES)
+        manifest = load_manifest(_SLICE_MANIFEST)
+        report = compile_manifest(manifest, ledger)
+        assert report.ok, report.render()
+        assert len(report.compiled) == 26
+
+        by_product: dict[str, int] = {}
+        for entry in report.compiled:
+            by_product[entry.product_code] = by_product.get(entry.product_code, 0) + 1
+        assert by_product == {"D1": 6, "D2": 6, "D12": 7, "E31B": 2, "E31D": 5}
+
+    def test_slice_e31b_gate_is_no_longer_value_blind(self) -> None:
+        ledger = load_claim_ledgers(_LEDGER_FILES)
+        manifest = load_manifest(_SLICE_MANIFEST)
+        report = compile_manifest(manifest, ledger)
+        sponsor_rule = next(
+            e for e in report.compiled if e.rule.rule_id == "el.e31b-sponsor-itas-itap"
+        )
+        rendered = json.loads(sponsor_rule.rule.model_dump_json())
+        assert "known" not in json.dumps(rendered["when"])
+        assert "ITAS_ACTIVE" in json.dumps(rendered["when"])
+
+    def test_slice_e31d_rules_no_longer_reduce_to_bare_family_purpose(self) -> None:
+        ledger = load_claim_ledgers(_LEDGER_FILES)
+        manifest = load_manifest(_SLICE_MANIFEST)
+        report = compile_manifest(manifest, ledger)
+        e31d_eligibility = [
+            e
+            for e in report.compiled
+            if e.product_code == "E31D" and e.rule.stage.value == "ELIGIBILITY"
+        ]
+        assert len(e31d_eligibility) == 3
+        for entry in e31d_eligibility:
+            required = set(entry.rule.required_facts)
+            assert "family.relation_to_sponsor" in required, entry.rule.rule_id
+
+        hard_filters = {e.rule.rule_id for e in report.compiled if e.product_code == "E31D"} & {
+            "hf.e31d-adult-excluded",
+            "hf.e31d-married-excluded",
+        }
+        assert hard_filters == {"hf.e31d-adult-excluded", "hf.e31d-married-excluded"}
+
+    def test_cli_main_runs_clean_on_the_real_slice(self, tmp_path: Path) -> None:
+        out = tmp_path / "compiled.json"
+        rc = main(
+            [
+                "--claims",
+                *[str(p) for p in _LEDGER_FILES],
+                "--manifest",
+                str(_SLICE_MANIFEST),
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 0
+        assert out.exists()
+        compiled = json.loads(out.read_text(encoding="utf-8"))
+        assert len(compiled) == 26
+
+    def test_cli_main_fails_cleanly_on_missing_manifest(self, tmp_path: Path) -> None:
+        rc = main(
+            [
+                "--claims",
+                *[str(p) for p in _LEDGER_FILES],
+                "--manifest",
+                str(tmp_path / "does-not-exist.json"),
+            ]
+        )
+        assert rc == 1

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_claim_ledger.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_claim_ledger.py
@@ -181,8 +181,64 @@ def test_backs_line_wraps_onto_continuation_line() -> None:
     assert records["CL-X-04"].backs == ("el.a", "el.b", "el.c", "el.d", "el.e")
 
 
+def test_product_conditional_state_line_parses_per_product_map() -> None:
+    """kimi-k3 adversarial finding (2026-08-18): real example ``CL-D-FUNDS``
+    has a MIXED state line — VERIFIED for D1/D12, VERIFIED-WITH-CAVEAT for
+    D2 — that ``_STATE_RE`` alone would resolve to plain VERIFIED for
+    every product. Guilt: a D2 lookup must resolve VERIFIED-WITH-CAVEAT.
+    Innocence: D1/D12 lookups must still resolve plain VERIFIED (not
+    downgraded, not deadlocked by a hard ledger-inconsistency error)."""
+
+    text = """
+**CL-Q-01 — Financial-proof minima.** D1/D12 numeric; D2 no hardcoded figure.
+- **State: VERIFIED** for D1/D12 (numeric, primary-adjacent sourcing); **VERIFIED-WITH-CAVEAT** for D2 (no
+  hardcoded national figure).
+- Products: D1, D2, D12.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    rec = records["CL-Q-01"]
+    assert rec.product_states == {"D1": "VERIFIED", "D12": "VERIFIED", "D2": "VERIFIED-WITH-CAVEAT"}
+    assert rec.state_for_product("D2") == "VERIFIED-WITH-CAVEAT"
+    assert rec.compilable_for_product("D2") is True
+    assert rec.state_for_product("D1") == "VERIFIED"
+    assert rec.state_for_product("D12") == "VERIFIED"
+    # An unnamed product falls back to the claim-wide (first-token) state
+    # rather than crashing or silently defaulting to compilable.
+    assert rec.state_for_product("E31B") == rec.state
+
+
+def test_ordinary_single_state_claim_has_no_product_states() -> None:
+    """Innocence twin: the ordinary (non-product-conditional) shape must
+    NOT be mistaken for one — a single ``**TOKEN**`` with no ``for X``
+    clause leaves ``product_states`` ``None``."""
+
+    text = """
+**CL-Q-02 — Ordinary claim.** Text.
+- **State: VERIFIED.** Products: Q.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert records["CL-Q-02"].product_states is None
+
+
 @pytest.mark.skipif(not _CLAIMS_DIR.exists(), reason="doctrine-factory claims not present in this checkout")
 class TestRealLedgers:
+    def test_cl_d_funds_is_product_conditional_with_correct_per_product_states(self) -> None:
+        """The real live example that triggered the kimi-k3 finding."""
+
+        paths = [
+            _CLAIMS_DIR / "e2a-claim-ledger.md",
+            _CLAIMS_DIR / "e2b-batch1-claim-ledger.md",
+            _CLAIMS_DIR / "e2b-batch2-claim-ledger.md",
+            _CLAIMS_DIR / "e3a-cf1-resolution.md",
+        ]
+        ledger = load_claim_ledgers(paths)
+        rec = ledger["CL-D-FUNDS"]
+        assert rec.product_states == {"D1": "VERIFIED", "D12": "VERIFIED", "D2": "VERIFIED-WITH-CAVEAT"}
+        assert rec.compilable_for_product("D2") is True
+        assert rec.state_for_product("D2") == "VERIFIED-WITH-CAVEAT"
+        assert rec.state_for_product("D1") == "VERIFIED"
+        assert rec.state_for_product("D12") == "VERIFIED"
+
     def test_all_slice_claims_resolve_and_are_compilable(self) -> None:
         paths = [
             _CLAIMS_DIR / "e2a-claim-ledger.md",

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_claim_ledger.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_claim_ledger.py
@@ -1,0 +1,220 @@
+"""Tests for ``backend.services.visa_engine.claim_ledger`` (E5 increment 1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.services.visa_engine.claim_ledger import (
+    ClaimLedgerError,
+    load_claim_ledgers,
+    parse_claim_ledger_text,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_CLAIMS_DIR = _REPO_ROOT / "research" / "visa" / "doctrine-factory" / "claims"
+
+
+def test_parses_a_verified_claim_with_backs() -> None:
+    text = """
+### D1 — Tourism Multiple Entry
+
+**CL-D1-01 — Purpose/scope.** D1 authorizes multiple tourism-purpose entries.
+- Source: NB-2 whatever.
+- **State: VERIFIED.** Products: D1. Provenance: VO-NB2-003.
+- Backs: `el.d1-multi-entry-support` (`PURPOSE_PRODUCT_MATCH`).
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert set(records) == {"CL-D1-01"}
+    rec = records["CL-D1-01"]
+    assert rec.state == "VERIFIED"
+    assert rec.compilable is True
+    assert rec.backs == ("el.d1-multi-entry-support",)
+
+
+def test_parses_verified_with_caveat() -> None:
+    text = """
+**CL-X-01 — Something.** Text.
+- **State: VERIFIED-WITH-CAVEAT.** Products: X.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert records["CL-X-01"].state == "VERIFIED-WITH-CAVEAT"
+    assert records["CL-X-01"].compilable is True
+
+
+def test_parses_conflicting_as_not_compilable() -> None:
+    text = """
+**CL-X-02 — Something disputed.** Text.
+- **State: CONFLICTING.** Products: X.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert records["CL-X-02"].state == "CONFLICTING"
+    assert records["CL-X-02"].compilable is False
+
+
+def test_state_with_trailing_free_text_still_parses() -> None:
+    """Real example: ``**State: VERIFIED as a mechanical/structural
+    finding.**`` — the leading token is what matters, not the trailing
+    prose."""
+
+    text = """
+**CL-X-03 — Structural finding.** Text.
+- **State: VERIFIED as a mechanical/structural finding.** Products: X.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert records["CL-X-03"].state == "VERIFIED"
+
+
+def test_header_with_no_state_line_becomes_unstated_not_a_crash() -> None:
+    """Real example: ``CL-E30A-03`` is a cross-reference alias ("See
+    CL-E30B-01 above") with no state line of its own — must not crash the
+    whole ledger parse."""
+
+    text = """
+**CL-E30A-03 — Sibling mismatch with E30B.** See CL-E30B-01 above.
+
+### Next section
+
+**CL-Y-01 — Real claim.** Text.
+- **State: VERIFIED.** Products: Y.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert records["CL-E30A-03"].state == "UNSTATED"
+    assert records["CL-E30A-03"].compilable is False
+    assert records["CL-Y-01"].state == "VERIFIED"
+
+
+def test_inter_file_state_conflict_raises() -> None:
+    text_a = "**CL-Z-01 — X.** T.\n- **State: VERIFIED.** Products: Z.\n"
+    text_b = "**CL-Z-01 — X.** T.\n- **State: CONFLICTING.** Products: Z.\n"
+    a = parse_claim_ledger_text(text_a, source_name="a.md")
+    b = parse_claim_ledger_text(text_b, source_name="b.md")
+    assert a["CL-Z-01"].state != b["CL-Z-01"].state
+
+
+def test_load_claim_ledgers_merges_multiple_files(tmp_path: Path) -> None:
+    f1 = tmp_path / "one.md"
+    f1.write_text("**CL-A-01 — X.** T.\n- **State: VERIFIED.** Products: A.\n", encoding="utf-8")
+    f2 = tmp_path / "two.md"
+    f2.write_text("**CL-B-01 — Y.** T.\n- **State: CONFLICTING.** Products: B.\n", encoding="utf-8")
+
+    merged = load_claim_ledgers([f1, f2])
+    assert merged["CL-A-01"].state == "VERIFIED"
+    assert merged["CL-B-01"].state == "CONFLICTING"
+
+
+def test_load_claim_ledgers_raises_on_cross_file_inconsistency(tmp_path: Path) -> None:
+    f1 = tmp_path / "one.md"
+    f1.write_text("**CL-A-01 — X.** T.\n- **State: VERIFIED.** Products: A.\n", encoding="utf-8")
+    f2 = tmp_path / "two.md"
+    f2.write_text("**CL-A-01 — X.** T.\n- **State: CONFLICTING.** Products: A.\n", encoding="utf-8")
+
+    with pytest.raises(ClaimLedgerError):
+        load_claim_ledgers([f1, f2])
+
+
+def test_header_mid_prose_is_never_mistaken_for_a_real_header() -> None:
+    """kimi-k3 adversarial finding (2026-08-18): the original ``_HEADER_RE``
+    was not line-anchored, so an inline bold reference mid-prose matching
+    the exact ``**CL-<id> — <name>.**`` shape (e.g. "as discussed in
+    **CL-D2-01 — the passport claim**...") would open a SPURIOUS second
+    block for that claim_id, corrupting the first block's boundary. Fixed
+    by anchoring the header regex to the start of a line (optionally
+    bullet-prefixed, to cover both real ledger header shapes). This is the
+    innocence proof: the prose mention below must NOT create a second
+    ``CL-W-01`` block, and the real claim's own (later) State line must
+    still resolve correctly."""
+
+    text = """
+**CL-W-01 — First.** Real claim, as discussed in **CL-W-01 — First.** right here mid-sentence.
+- **State: VERIFIED.** Products: W.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert set(records) == {"CL-W-01"}
+    assert records["CL-W-01"].state == "VERIFIED"
+
+
+def test_in_file_duplicate_header_with_different_state_raises() -> None:
+    """Guilt twin for the duplicate-detection safety net itself: two
+    genuine line-anchored headers for the same claim_id (e.g. a copy-paste
+    accident during authoring) with DIFFERENT states must raise, never
+    silently overwrite with last-wins."""
+
+    text = """
+**CL-W-01 — First.** Real claim.
+- **State: VERIFIED.** Products: W.
+
+**CL-W-01 — First.** Accidentally duplicated block.
+- **State: CONFLICTING.** (stale duplicate)
+"""
+    with pytest.raises(ClaimLedgerError):
+        parse_claim_ledger_text(text, source_name="<test>")
+
+
+def test_in_file_duplicate_header_with_same_state_is_harmless() -> None:
+    """Innocence twin: an identical restatement (same claim_id, same state)
+    must not raise — this is the legitimate case the docstring names."""
+
+    text = """
+**CL-W-02 — Second.** Real claim.
+- **State: VERIFIED.** Products: W.
+
+**CL-W-02 — Second.** Restated identically elsewhere.
+- **State: VERIFIED.** Products: W.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert records["CL-W-02"].state == "VERIFIED"
+
+
+def test_backs_line_wraps_onto_continuation_line() -> None:
+    """Real example: ``CL-D12-02`` lists 5 rule ids across two physical
+    lines in the committed ledger."""
+
+    text = """
+**CL-X-04 — Bundle.** T.
+- **State: VERIFIED.** Products: X.
+- Backs: `el.a`, `el.b`, `el.c`,
+  `el.d`, `el.e`.
+"""
+    records = parse_claim_ledger_text(text, source_name="<test>")
+    assert records["CL-X-04"].backs == ("el.a", "el.b", "el.c", "el.d", "el.e")
+
+
+@pytest.mark.skipif(not _CLAIMS_DIR.exists(), reason="doctrine-factory claims not present in this checkout")
+class TestRealLedgers:
+    def test_all_slice_claims_resolve_and_are_compilable(self) -> None:
+        paths = [
+            _CLAIMS_DIR / "e2a-claim-ledger.md",
+            _CLAIMS_DIR / "e2b-batch1-claim-ledger.md",
+            _CLAIMS_DIR / "e2b-batch2-claim-ledger.md",
+            _CLAIMS_DIR / "e3a-cf1-resolution.md",
+        ]
+        ledger = load_claim_ledgers(paths)
+        expected_states = {
+            "CL-D1-01": "VERIFIED",
+            "CL-D1-02": "VERIFIED",
+            "CL-D1-03": "VERIFIED",
+            "CL-D2-01": "VERIFIED-WITH-CAVEAT",
+            "CL-D2-02": "VERIFIED",
+            "CL-D2-03": "VERIFIED-WITH-CAVEAT",
+            "CL-D2-04": "VERIFIED",
+            "CL-D12-01": "VERIFIED",
+            "CL-D12-02": "VERIFIED",
+            "CL-D12-03": "VERIFIED",
+            "CL-D12-04": "VERIFIED",
+            "CL-D12-06": "VERIFIED",
+            "CL-E31B-01": "VERIFIED",
+            "CL-E31B-REFUTER": "VERIFIED",
+            "CL-E31B-STRUCT": "VERIFIED",
+            "CL-E31D-01": "VERIFIED",
+            "CL-E31D-REFUTER": "VERIFIED",
+            "CL-E31D-STRUCT": "VERIFIED",
+            "CL-D-FUNDS": "VERIFIED",
+            "CL-D-COMPARE": "VERIFIED",
+        }
+        for claim_id, expected_state in expected_states.items():
+            rec = ledger.get(claim_id)
+            assert rec is not None, f"{claim_id} missing from parsed ledger"
+            assert rec.state == expected_state, f"{claim_id}: {rec.state} != {expected_state}"
+            assert rec.compilable is True

--- a/research/visa/doctrine-factory/e5/2026-08-18-e5-increment1-compiler.md
+++ b/research/visa/doctrine-factory/e5/2026-08-18-e5-increment1-compiler.md
@@ -1,0 +1,173 @@
+---
+date: 2026-08-18
+domain: visa
+client_case: none
+sources:
+  - path: research/visa/doctrine-factory/claims/e2a-claim-ledger.md
+  - path: research/visa/doctrine-factory/claims/e2b-batch1-claim-ledger.md
+  - path: research/visa/doctrine-factory/claims/e2b-batch2-claim-ledger.md
+  - path: research/visa/doctrine-factory/claims/e3a-cf1-resolution.md
+  - path: research/visa/doctrine-factory/cards/D1.md
+  - path: research/visa/doctrine-factory/cards/D2.md
+  - path: research/visa/doctrine-factory/cards/D12.md
+  - path: research/visa/doctrine-factory/cards/E31B.md
+  - path: research/visa/doctrine-factory/cards/E31D.md
+  - path: research/visa/doctrine-factory/e4/CP2-decision-request.md
+    note: "CP2 decision pack approved by Zero 2026-08-18 with its own defaults — unblocks this increment"
+adversarial_review: kimi-k3
+---
+
+# E5 increment 1 — claim compiler + VERIFIED-only lint + reformed slice rules
+
+Task: E5 increment 1 (Visa Oracle doctrine-factory execution plan), vertical slice
+D1/D2/D12/E31B/E31D. CP2 approved 2026-08-18 with the decision pack's defaults (dates
+gated on consuming rules; 3 candidate lanes wait for E3; 7 misidentified codes re-scoped
+to E3). Scope is explicitly increment 1 only: compiler + lint + reformed rules for the
+5-product slice — not the full 38-product pack assembly, not ~200 gold personas, not
+seq-9 build+CP3.
+
+## What was built
+
+1. **`backend/services/visa_engine/claim_ledger.py`** — a real markdown parser for the
+   claim ledgers (`research/visa/doctrine-factory/claims/*.md`), not a hand-transcription.
+   Extracts `{claim_id: ClaimRecord(state, backs, header, source_file)}` from the
+   `**CL-<id> — <name>.** ... - **State: <TOKEN>.** ... - Backs: \`rule_id\`, ...`
+   pattern grepped across every ledger file before writing the regex. Handles the real
+   drift found live: state tokens with trailing free text (`VERIFIED as a mechanical/
+   structural finding`), `Backs:` lines wrapping onto an indented continuation line
+   (`CL-D12-02` lists 5 rule ids across two physical lines), and a claim header with no
+   state line at all (`CL-E30A-03`, a cross-reference alias — parses to a never-compilable
+   `UNSTATED` sentinel rather than crashing the whole ledger load). Cross-file state
+   conflicts (same `claim_id`, different `state` in two files) raise
+   `ClaimLedgerError` rather than silently picking a side.
+
+2. **`backend/scripts/visa_engine/compile_claims.py`** — the compiler CLI. Consumes N
+   claim ledger files + one rule-authoring manifest JSON, runs two hard lints, and emits
+   validated `Rule` objects (the real Pydantic model from `models.py`, so a compiled rule
+   is guaranteed structurally acceptable to `compile_pack.py`/`sign_pack.py` downstream —
+   just not assembled into a full `RulePackPayload` in this increment, per the task
+   brief's explicit exclusion). `required_facts` is always DERIVED from `when` via
+   `ast.collect_fact_paths` (after parsing the raw dict into a real `Condition` via
+   `ast.parse_condition` — a manifest-supplied `required_facts` is never trusted, proven
+   by a test that plants a wrong value and shows the compiler overwrites it).
+
+   - **Lint 1 — VERIFIED-only** (literal task-brief requirement): a claim at
+     `CONFLICTING`/`STALE`/`UNVERIFIED`/`SUPERSEDED`/`UNSTATED` feeding a rule is a hard
+     compile error naming the `claim_id` and `rule_id`. `VERIFIED-WITH-CAVEAT` is allowed
+     only when the rule's manifest entry carries a matching `caveats` entry — the caveat
+     is required to be propagated into the rule's provenance sidecar, never silently
+     dropped.
+   - **Lint 2 — R-OVERSTAY-PLANNING** (Zero ruling, 2026-08-18, verbatim): a rule whose
+     condition tree references `immigration.overstay_days` anywhere must have that
+     reference gated behind `immigration.currently_in_indonesia == true` in the same
+     AND-chain — walks every `all`-ancestor's true-boolean siblings (AND is associative,
+     so a guard several `all` levels up still protects a leaf several levels down),
+     explicitly does NOT let a guard inside one `any` branch protect a sibling branch,
+     and strips protective value under `not`. Standing invariant for every rule this
+     compiler ever emits, not a per-rule opt-in.
+
+3. **`research/visa/doctrine-factory/e5/slice-rule-manifest.json`** — the 26-rule
+   authoring manifest for the vertical slice (D1 6 / D2 6 / D12 7 / E31B 2 / E31D 5),
+   each entry carrying `claim_ids` + `caveats` + the `Rule` fields. Base condition trees
+   for D1/D2/D12/E31B/E31D were extracted from the live `rulepack-prod-008.source.json`
+   (the current unsigned draft pack on main) to guarantee the reform is a real diff
+   against production logic, not an invented shape.
+
+## Rules emitted — per product, claim coverage
+
+| Product | Rules | Reformed? | Claims used |
+|---|---|---|---|
+| D1 | 6 (all ELIGIBILITY) | No — card disposition is REACHABLE_AND_SUPPORTED, no defect; claim provenance attached only | `CL-D1-01/02/03`, `CL-D-COMPARE`, `CL-D-FUNDS` |
+| D2 | 6 (all ELIGIBILITY) | No — same disposition; 3 rules carry propagated `VERIFIED-WITH-CAVEAT` provenance | `CL-D2-01/02/03/04`, `CL-D-COMPARE`, `CL-D-FUNDS` |
+| D12 | 6 ELIGIBILITY + 1 HARD_FILTER | No — same disposition | `CL-D12-01/02/03/04`, `CL-D-COMPARE`, `CL-D-FUNDS` |
+| E31B | 2 (ELIGIBILITY) | **Yes** — value-blind `{"fact":"family.sponsor_status_code","op":"known"}` gate replaced with `{"op":"in","values":["ITAS_ACTIVE","ITAP_ACTIVE","VITAS_APPROVED"]}` per `CL-E31B-REFUTER` | `CL-E31B-01`, `CL-E31B-REFUTER`, `CL-E31B-STRUCT` |
+| E31D | 3 ELIGIBILITY + 2 new HARD_FILTER | **Yes** — 3 rules that reduced to bare `intersects[FAMILY]` now require `family.relation_to_sponsor == CHILD` (+ `family.marriage_registered == true` on the sponsor-marriage rule); 2 new HARD_FILTER rules mirror `hf.e31e-adult-excluded`/`hf.e31e-married-excluded` exactly | `CL-E31D-01`, `CL-E31D-REFUTER`, `CL-E31D-STRUCT` |
+
+**26 rules total, every one claim-backed, every claim VERIFIED or VERIFIED-WITH-CAVEAT
+(with propagated caveat).** CF-6's co-cited-CHANGED-source caveat is carried as a
+provenance note on all 15 D1/D2/D12 requirement-bundle rules (passport/funds/CV/
+itinerary/support-letter), per the doctrine cards' explicit "carried, not silently
+dropped" instruction.
+
+### E31D fact-vocabulary decision (documented, not silently made)
+
+`CL-E31D-REFUTER`/E31D.md §5 phrase the relation fact as `family.relation_to_sponsor ==
+STEPCHILD (-equivalent)`. `RelationType` (enums.py) has no `STEPCHILD` member — only
+`SPOUSE/CHILD/PARENT/SIBLING/DEPENDENT/OTHER`. Adding one would touch `enums.py`,
+`fact_registry.py`'s `allowed_values` set, and require regenerating
+`contract.schema.json` — a real fact-schema change, and CP2's own text is explicit that
+such changes should be scoped and deliberate, not invented mid-rule-authoring. This
+increment reuses the existing `CHILD` value instead: within THIS slice (no other
+child-relation product is being authored in the same batch) it is a legitimate,
+non-breaking discriminator — a large improvement over bare `intersects[FAMILY]` even
+though it is not yet STEPCHILD-specific. Flagged here as an E4/E5 fact-vocabulary
+follow-up, not silently resolved. `family.marriage_registered` (already used identically
+by E31B) is reused for the sponsor's own marriage-registration fact rather than
+inventing `family.stepparent_marriage_registered` as the card's draft text names it —
+same semantic, zero schema change.
+
+## Lint proofs (guilt + innocence)
+
+`backend/tests/scripts/test_visa_engine_compile_claims.py` and
+`backend/tests/services/visa_engine/test_claim_ledger.py`, 25 + 11 = 36 tests, all green:
+
+- **VERIFIED-only**: guilt on CONFLICTING/STALE/UNVERIFIED/unknown-claim_id/zero-claim_ids/
+  missing-caveat-note; innocence on VERIFIED, VERIFIED-WITH-CAVEAT-with-note, multiple
+  VERIFIED claims.
+- **R-OVERSTAY-PLANNING**: guilt on a bare `overstay_days` reference (reproduces the
+  seq-6 smoke symptom — "incomplete facts -> NEEDS_INPUT naming
+  immigration.overstay_days"), guilt on `overstay_days` nested inside an `all` with no
+  onshore sibling, guilt on an onshore guard that lives only inside a SIBLING `any`
+  branch (does not protect the other branch); innocence on `overstay_days` guarded by a
+  direct onshore sibling, innocence on the guard living two `all`-levels up the tree,
+  innocence on a rule with no `overstay_days` reference at all.
+- **Full compiler**: guilt end-to-end (CONFLICTING claim / bare overstay both fail the
+  whole report, `compiled` stays empty); innocence end-to-end (clean manifest compiles,
+  required_facts always derived even when the manifest lies about it).
+- **Golden**: the real 26-rule slice manifest compiles clean against the real committed
+  ledgers (`e2a`/`e2b-batch1`/`e2b-batch2`/`e3a-cf1-resolution`), per-product rule counts
+  match the doctrine cards exactly, the E31B gate is provably no longer value-blind
+  (`"known" not in <compiled when>`, `"ITAS_ACTIVE" in <compiled when>`), and every
+  E31D ELIGIBILITY rule provably requires `family.relation_to_sponsor` in
+  `required_facts` (no longer reducible to bare `intersects[FAMILY]`).
+
+`backend/tests/services/visa_engine/` full existing suite re-run: no regression from this
+diff — the only red is pre-existing/environmental (local Postgres role `nuzantara`
+absent for the DB-backed write-substrate tests, one unrelated pre-existing
+`test_bundle_verify.py` failure) and touches zero files this PR modified.
+
+## Review dispositions
+
+Kimi K3 refutation run against the diff (`compile_claims.py` + `claim_ledger.py`,
+generator≠grader, 8-minute timebox) — dispositions recorded below once the run
+completes; this file is updated in place rather than a second file, per the repo's
+"correction, not duplicate" convention.
+
+## Flag-veto RC-1 reform (slice scope) — not attempted this increment
+
+Per task brief item 3, the flag-veto RC-1 reform ("ogni flag ri-derivato come fatto
+reale + regole mirate, o domanda REVIEW_ONLY con ragione claim-backed, o eliminato") for
+the slice's review rules was scoped for this increment but the 5 doctrine cards
+(D1/D2/D12/E31B/E31D) carry **zero HUMAN_REVIEW-stage rules of their own** — every
+HUMAN_REVIEW rule touching these products in the active pack is GLOBAL
+(`review.calling-visa`, `review.citizenship-conflict`), out of the cards' claim scope
+per their own §3.9/§6 notes. There is no slice-scoped flag-veto surface to reform in
+this increment; noted here rather than silently skipped. The monotone
+disclosed-uncertainty adapter (`evaluate_path.py`) is untouched, per the task brief's
+explicit "not to be touched in this increment (it is live containment)" — the reformed
+E31B/E31D rules make their SUPPORT/EXCLUDE gates precise, which narrows what reaches
+that adapter's HUMAN_REVIEW fallback for these two products (fewer false-negative
+SUPPORT candidates masking a genuinely-eligible applicant), but does not change the
+adapter's own logic.
+
+## OD-1 / OD-2 — noted, not built (per binding rulings)
+
+- **OD-1** (D2 dual-outcome design: document-as-legal-precondition vs
+  document-as-operational-requirement): noted as later-increment E5 scope, not built
+  here, per the task brief.
+- **OD-2** (fold seq-8→seq-9 + chain gate + pricing_key check): later increment (pack
+  assembly), not attempted.
+
+## Adversarial review
+
+<!-- filled in after the kimi run completes -->

--- a/research/visa/doctrine-factory/e5/2026-08-18-e5-increment1-compiler.md
+++ b/research/visa/doctrine-factory/e5/2026-08-18-e5-increment1-compiler.md
@@ -109,7 +109,8 @@ same semantic, zero schema change.
 ## Lint proofs (guilt + innocence)
 
 `backend/tests/scripts/test_visa_engine_compile_claims.py` and
-`backend/tests/services/visa_engine/test_claim_ledger.py`, 25 + 11 = 36 tests, all green:
+`backend/tests/services/visa_engine/test_claim_ledger.py`, 31 + 16 = 47 tests, all green
+(counts after the kimi-k3 review round below — see per-finding test additions):
 
 - **VERIFIED-only**: guilt on CONFLICTING/STALE/UNVERIFIED/unknown-claim_id/zero-claim_ids/
   missing-caveat-note; innocence on VERIFIED, VERIFIED-WITH-CAVEAT-with-note, multiple
@@ -170,4 +171,95 @@ adapter's own logic.
 
 ## Adversarial review
 
-<!-- filled in after the kimi run completes -->
+Kimi K3 refutation run against the diff (`claim_ledger.py` + `compile_claims.py`,
+generator≠grader, ~8 minute timebox, full transcript inspected turn-by-turn). Dispositions:
+
+1. **[P0, CONFIRMED, cured]** `_HEADER_RE`/`_STATE_RE` were not line-anchored — an inline bold
+   reference mid-prose matching the exact `**CL-<id> — <name>.**` shape could open a spurious
+   second header block for an already-open claim, corrupting its boundary. Fixed: both regexes
+   anchored to line start (optional bullet prefix, covers both real header shapes across the
+   four ledger files) — verified identical 90-header match count before/after.
+2. **[P1, CONFIRMED, cured]** Same-file duplicate `claim_id` headers with different states would
+   silently last-wins-overwrite (the corruption vector for finding 1). Fixed: duplicate detection
+   is now unconditional (same-file AND cross-file), raising `ClaimLedgerError` on any state
+   mismatch.
+3. **[P1, CONFIRMED, cured]** `{c["claim_id"] for c in caveats}` raised a bare
+   `KeyError`/`TypeError` on a malformed caveats entry (missing key, non-dict entry, wrong type),
+   contradicting the module's "never a bare traceback for a data problem" contract. Fixed:
+   per-entry type/presence checks emit a `LintFinding` instead.
+4. **[P1, CONFIRMED, cured]** A caveat entry with an empty/missing `note` satisfied the lint —
+   the brief requires the caveat be propagated, not stubbed. Fixed: `note` must be a non-empty
+   (`.strip()`-truthy) string.
+5. **[P0, CONFIRMED, cured]** Live-data finding: `CL-D-FUNDS` (`e2a-claim-ledger.md:229`) has a
+   product-conditional state line on ONE bullet — `VERIFIED` for D1/D12, `VERIFIED-WITH-CAVEAT`
+   for D2 — which `_STATE_RE` alone resolves to plain `VERIFIED` claim-wide (first-token match).
+   A D2 rule citing `CL-D-FUNDS` would then compile with NO caveat requirement, silently
+   bypassing lint 1's core guarantee for exactly the product that needs it. Confirmed by grep
+   this is the ONLY claim across all four loaded ledger files with this shape
+   (`grep -n "for D1/D12" claims/*.md` and a broader multi-state-per-line sweep both return one
+   hit) — raising a hard `ClaimLedgerError` here would therefore deadlock the D1/D12 rules that
+   legitimately need the plain-VERIFIED resolution, so **option (b), per-product state parsing**,
+   was chosen over a hard reject: `ClaimRecord.product_states: dict[str, str] | None` (populated
+   only for this narrow "two-or-more `**TOKEN** for PRODUCTS`" clause shape) +
+   `state_for_product()`/`compilable_for_product()`, and `lint_verified_only` now takes
+   `product_code` and consults the per-product state, not the claim-wide one. Verified: the real
+   26-rule manifest's D2 `el.d2-funds-usd-2000` entry already carried a `CL-D-FUNDS` caveat note
+   defensively (the manifest author had already anticipated this) — the fix makes that caveat
+   actually load-bearing rather than a no-op, and the D1/D12 funds rules (plain VERIFIED for
+   their product) still pass without needing one. Guilt/innocence tests added at both layers:
+   `test_product_conditional_state_line_parses_per_product_map` /
+   `test_cl_d_funds_is_product_conditional_with_correct_per_product_states` (parser), and
+   `test_guilt_product_conditional_claim_without_caveat_is_rejected_for_its_caveated_product` /
+   `test_innocence_product_conditional_claim_passes_for_its_verified_products` /
+   `test_innocence_product_conditional_claim_with_caveat_passes_for_d2` (lint).
+6. **[P1, VERIFIED NOT-AN-ISSUE, no change]** Kimi flagged "overstay lint trusts guards
+   collected inside `not` subtrees" as a possible bypass — e.g. does
+   `not(eq immigration.currently_in_indonesia false)`, sitting as an `all`-sibling of an
+   unguarded `overstay_days` reference, get wrongly credited as a protective onshore guard?
+   Traced `_walk_overstay_gating`: `local_true_facts` is only ever populated from a DIRECT
+   `{"op":"eq","value":true}` child of an `all` node; a `not` node's own `op` is `"not"`, so it
+   is never such a direct child and contributes NOTHING to `all_ancestor_facts` regardless of
+   what its subtree contains — confirmed with a concrete repro
+   (`test_guilt_not_wrapped_negative_onshore_check_does_not_count_as_a_guard`): the sibling
+   overstay leaf is still flagged, i.e. the phrasing is *rejected* (a declined P2 false-positive
+   elsewhere in this review, not a bypass — rejection is the safe direction). Independently,
+   team-lead's Kleene-logic read reaches the same conclusion from the runtime-semantics side:
+   for an OFFSHORE applicant, `immigration.currently_in_indonesia` is `false`, so
+   `not(all[onshore==true, overstay...])` — even in the shape kimi worried about at the
+   *condition-tree* level — evaluates to `not(FALSE) = TRUE` without ever needing
+   `overstay_days`; the only state where it could matter is `onshore == UNKNOWN`, and
+   R-OVERSTAY-PLANNING's own binding ruling already requires the onshore fact to be asked before
+   overstay is ever reached in the interview flow, so that branch resolves before the rule tree
+   is even evaluated with overstay unknown. Two independent readings (structural walker-code
+   trace + runtime Kleene-logic trace) agree: no fix needed. Mirror innocence test added
+   (`test_innocence_real_onshore_guard_still_protects_a_not_wrapped_overstay_leaf`): a REAL
+   onshore guard as an `all`-sibling of a `not`-wrapped overstay leaf still protects it, as
+   expected.
+7. **[P2, declined, out of scope]** `not(eq value:false)` / `neq false` guard phrasings are
+   rejected (false positives, safe) rather than recognized as de-Morgan-equivalent guards —
+   would bite real authoring eventually but is not a hole; declined this increment.
+8. **[P2, declined, out of scope]** The docstring's `known(onshore)`-as-alternative-guard
+   promise is not implemented (and would be semantically wrong if it were — `known` is not
+   `== true`). Documented gap, not fixed.
+9. **[P2, declined, out of scope]** `compile_claims.py` does not enforce the full
+   `compile_pack.py` invariant set (AST depth/node limits, `FACT_LITERAL_KIND_MISMATCH`,
+   "eligibility cannot derive support solely from known/unknown", etc.) — this increment only
+   builds a `Rule`-schema-valid intermediate, not a pack-ready one; those invariants are
+   `compile_pack.py`'s job in a later increment.
+10. **[P2, declined, out of scope]** `manifest` is not dict-checked at the top level before
+    `.get("rules")` — a malformed JSON root (array/scalar) raises `AttributeError` rather than a
+    `LintFinding`.
+11. **[P2, declined, out of scope]** `claim_ids` entries of a non-`str` type (dict/None) raise
+    `TypeError` on `ledger.get(...)` rather than reporting a finding.
+12. **[P2, declined, out of scope]** `--out` write failures (e.g. missing parent directory) are
+    uncaught.
+13. **[P2, declined, out of scope]** `rule_id` uniqueness across manifest entries is not
+    enforced — two entries with the same `rule_id` both compile, ambiguous for downstream pack
+    assembly.
+14. **[P2, declined, out of scope]** `product_code` is a free string with no enum/allow-list
+    validation.
+
+**Net: 2 P0 + 3 P1 confirmed and cured, 1 P1 independently verified as a non-issue (two
+independent readings — walker-code trace and runtime Kleene-logic trace — agree), 8 P2 declined
+as out of scope for this increment's literal brief (VERIFIED-only lint + R-OVERSTAY-PLANNING
+lint + slice rules).**

--- a/research/visa/doctrine-factory/e5/slice-rule-manifest.json
+++ b/research/visa/doctrine-factory/e5/slice-rule-manifest.json
@@ -1,0 +1,1909 @@
+{
+  "slice": "E5-INCREMENT-1",
+  "rules": [
+    {
+      "product_code": "D1",
+      "claim_ids": [
+        "CL-D1-02",
+        "CL-D1-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D1-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d1-cv-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "op": "all",
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "CV_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d1-cv-required",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D1",
+      "claim_ids": [
+        "CL-D1-02",
+        "CL-D-FUNDS",
+        "CL-D1-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D-FUNDS",
+          "note": "statute delegates the exact figure to the DG rather than hardcoding it; OFFICIAL_PORTAL layer states USD 2,000 operationally \u2014 reconciled two-layer fact, not a conflict, see D2.md \u00a73.12."
+        },
+        {
+          "claim_id": "CL-D1-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d1-funds-usd-2000",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "op": "all",
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PROOF_OF_FUNDS_D1",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d1-funds-usd-2000",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D1",
+      "claim_ids": [
+        "CL-D1-02",
+        "CL-D1-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D1-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d1-itinerary-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "op": "all",
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "ITINERARY_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d1-itinerary-required",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D1",
+      "claim_ids": [
+        "CL-D1-01",
+        "CL-D1-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "el.d1-multi-entry-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ]
+            },
+            {
+              "op": "eq",
+              "fact": "intent.entry_pattern",
+              "value": "MULTIPLE"
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "TOURISM",
+            "FAMILY",
+            "TRANSIT",
+            "BUSINESS_MEETINGS"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d1-multi-entry-support",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D1",
+      "claim_ids": [
+        "CL-D1-02",
+        "CL-D1-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D1-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d1-passport-validity",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "op": "all",
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d1-passport-validity",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D1",
+      "claim_ids": [
+        "CL-D1-02",
+        "CL-D1-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D1-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d1-support-letter",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "374e79e0-f0bf-5291-8cba-974e794e210a"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "TOURISM",
+                    "FAMILY",
+                    "TRANSIT",
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "op": "all",
+                  "args": [
+                    {
+                      "fact": "intent.purposes",
+                      "op": "intersects",
+                      "values": [
+                        "TOURISM",
+                        "FAMILY",
+                        "TRANSIT",
+                        "BUSINESS_MEETINGS"
+                      ]
+                    },
+                    {
+                      "fact": "intent.stay_days",
+                      "op": "lte",
+                      "value": 60
+                    }
+                  ]
+                },
+                {
+                  "op": "eq",
+                  "fact": "intent.entry_pattern",
+                  "value": "MULTIPLE"
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS",
+            "FAMILY",
+            "TOURISM",
+            "TRANSIT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d1-support-letter",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D12",
+      "claim_ids": [
+        "CL-D12-02",
+        "CL-D12-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D12-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d12-cv-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "op": "neq",
+                  "fact": "investment.pt_pma_committed",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "CV_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d12-cv-required",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D12",
+      "claim_ids": [
+        "CL-D12-02",
+        "CL-D-FUNDS",
+        "CL-D12-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D-FUNDS",
+          "note": "statute delegates the exact figure to the DG rather than hardcoding it; OFFICIAL_PORTAL layer states USD 2,000 operationally \u2014 reconciled two-layer fact, not a conflict, see D2.md \u00a73.12."
+        },
+        {
+          "claim_id": "CL-D12-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d12-funds-usd-5000",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "op": "neq",
+                  "fact": "investment.pt_pma_committed",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PROOF_OF_FUNDS_D12",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d12-funds-usd-5000",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D12",
+      "claim_ids": [
+        "CL-D12-02",
+        "CL-D12-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D12-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d12-itinerary-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "op": "neq",
+                  "fact": "investment.pt_pma_committed",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "ITINERARY_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d12-itinerary-required",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D12",
+      "claim_ids": [
+        "CL-D12-01",
+        "CL-D12-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "el.d12-multi-entry-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "INVESTMENT"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 180
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d12-multi-entry-support",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D12",
+      "claim_ids": [
+        "CL-D12-02",
+        "CL-D12-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D12-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d12-passport-validity",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "op": "neq",
+                  "fact": "investment.pt_pma_committed",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d12-passport-validity",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D12",
+      "claim_ids": [
+        "CL-D12-02",
+        "CL-D12-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D12-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d12-support-letter",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "op": "neq",
+                  "fact": "investment.pt_pma_committed",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "INVESTMENT"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 180
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "covered_purposes": [
+            "INVESTMENT"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d12-support-letter",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D12",
+      "claim_ids": [
+        "CL-D12-04"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "hf.d12-onshore-conversion-excluded",
+        "stage": "HARD_FILTER",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "process.wants_onshore_conversion",
+          "op": "eq",
+          "value": true
+        },
+        "effect": {
+          "type": "EXCLUDE",
+          "reason_code": "D12_NOT_CONVERTIBLE"
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"
+        ],
+        "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+        "safety_critical": true
+      }
+    },
+    {
+      "product_code": "D2",
+      "claim_ids": [
+        "CL-D2-02",
+        "CL-D2-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D2-03",
+          "note": "category-error caveat only (per-stay vs calendar-year), unrelated to the now-closed CF-1 extension-count question \u2014 see D2.md \u00a75."
+        },
+        {
+          "claim_id": "CL-D2-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d2-cv-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "CV_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d2-cv-required",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D2",
+      "claim_ids": [
+        "CL-D2-02",
+        "CL-D-FUNDS",
+        "CL-D2-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D-FUNDS",
+          "note": "statute delegates the exact figure to the DG rather than hardcoding it; OFFICIAL_PORTAL layer states USD 2,000 operationally \u2014 reconciled two-layer fact, not a conflict, see D2.md \u00a73.12."
+        },
+        {
+          "claim_id": "CL-D2-03",
+          "note": "category-error caveat only (per-stay vs calendar-year), unrelated to the now-closed CF-1 extension-count question \u2014 see D2.md \u00a75."
+        },
+        {
+          "claim_id": "CL-D2-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d2-funds-usd-2000",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PROOF_OF_FUNDS_D2",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d2-funds-usd-2000",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D2",
+      "claim_ids": [
+        "CL-D2-02",
+        "CL-D2-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D2-03",
+          "note": "category-error caveat only (per-stay vs calendar-year), unrelated to the now-closed CF-1 extension-count question \u2014 see D2.md \u00a75."
+        },
+        {
+          "claim_id": "CL-D2-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d2-itinerary-required",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "ITINERARY_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d2-itinerary-required",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D2",
+      "claim_ids": [
+        "CL-D2-01",
+        "CL-D2-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D2-01",
+          "note": "sole NB-2 citation is an internal guide, upgraded via OFFICIAL_PORTAL corroboration only (CF-3) \u2014 see D2.md \u00a73.1."
+        },
+        {
+          "claim_id": "CL-D2-03",
+          "note": "category-error caveat only (per-stay vs calendar-year), unrelated to the now-closed CF-1 extension-count question \u2014 see D2.md \u00a75."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d2-multi-entry-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "fact": "intent.stay_days",
+              "op": "lte",
+              "value": 60
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.d2-multi-entry-support",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D2",
+      "claim_ids": [
+        "CL-D2-02",
+        "CL-D2-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D2-03",
+          "note": "category-error caveat only (per-stay vs calendar-year), unrelated to the now-closed CF-1 extension-count question \u2014 see D2.md \u00a75."
+        },
+        {
+          "claim_id": "CL-D2-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d2-passport-validity",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d2-passport-validity",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "D2",
+      "claim_ids": [
+        "CL-D2-02",
+        "CL-D2-03",
+        "CL-D-COMPARE"
+      ],
+      "caveats": [
+        {
+          "claim_id": "CL-D2-03",
+          "note": "category-error caveat only (per-stay vs calendar-year), unrelated to the now-closed CF-1 extension-count question \u2014 see D2.md \u00a75."
+        },
+        {
+          "claim_id": "CL-D2-02",
+          "note": "requirement-bundle rule co-cites source ee8fe5b8-... flagged CHANGED in freshness-recheck-2026-08-16.md record #4 (Conflict Report CF-6); the product-specific OFFICIAL_PORTAL record backing this claim is unaffected (still CURRENT) but the co-citation is carried, not silently dropped."
+        }
+      ],
+      "rule": {
+        "rule_id": "el.d2-support-letter",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "306725c1-7269-5c45-a4b8-188265fcf4d8"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "BUSINESS_MEETINGS"
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "BUSINESS_MEETINGS"
+                  ]
+                },
+                {
+                  "fact": "intent.stay_days",
+                  "op": "lte",
+                  "value": 60
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "SUPPORT_LETTER_REQUIRED",
+          "covered_purposes": [
+            "BUSINESS_MEETINGS"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715",
+          "ee8fe5b8-b0b4-544a-bf9a-fe53c3e316f2"
+        ],
+        "explanation_key": "explain.el.d2-support-letter",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "E31B",
+      "claim_ids": [
+        "CL-E31B-REFUTER",
+        "CL-E31B-STRUCT"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "el.e31b-sponsor-itas-itap",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "5d5f9bd4-349b-54d7-841a-784c0afba068"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                }
+              ]
+            },
+            {
+              "op": "all",
+              "args": [
+                {
+                  "fact": "intent.purposes",
+                  "op": "intersects",
+                  "values": [
+                    "FAMILY"
+                  ]
+                },
+                {
+                  "fact": "family.relation_to_sponsor",
+                  "op": "eq",
+                  "value": "SPOUSE"
+                },
+                {
+                  "fact": "family.marriage_registered",
+                  "op": "eq",
+                  "value": true
+                },
+                {
+                  "fact": "family.sponsor_status_code",
+                  "op": "in",
+                  "values": [
+                    "ITAS_ACTIVE",
+                    "ITAP_ACTIVE",
+                    "VITAS_APPROVED"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "E31B",
+      "claim_ids": [
+        "CL-E31B-01",
+        "CL-E31B-STRUCT"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "el.e31b-spouse-itas-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "5d5f9bd4-349b-54d7-841a-784c0afba068"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "SPOUSE"
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            },
+            {
+              "fact": "family.sponsor_status_code",
+              "op": "in",
+              "values": [
+                "ITAS_ACTIVE",
+                "ITAP_ACTIVE",
+                "VITAS_APPROVED"
+              ]
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "570f2bc4-5120-561f-90ba-58fcd9507514",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31b-spouse-itas-support",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "E31D",
+      "claim_ids": [
+        "CL-E31D-REFUTER",
+        "CL-E31D-STRUCT"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "el.e31d-sponsor-mixed-marriage",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            },
+            {
+              "fact": "family.marriage_registered",
+              "op": "eq",
+              "value": true
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31d-sponsor-mixed-marriage",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "E31D",
+      "claim_ids": [
+        "CL-E31D-REFUTER",
+        "CL-E31D-STRUCT"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "el.e31d-step-parent-relation",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "REQ_STEP_PARENT_RELATION",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31d-step-parent-relation",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "E31D",
+      "claim_ids": [
+        "CL-E31D-01",
+        "CL-E31D-STRUCT"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "el.e31d-stepchild-support",
+        "stage": "ELIGIBILITY",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "op": "all",
+          "args": [
+            {
+              "fact": "intent.purposes",
+              "op": "intersects",
+              "values": [
+                "FAMILY"
+              ]
+            },
+            {
+              "fact": "family.relation_to_sponsor",
+              "op": "eq",
+              "value": "CHILD"
+            }
+          ]
+        },
+        "effect": {
+          "type": "SUPPORT",
+          "reason_code": "PURPOSE_PRODUCT_MATCH",
+          "covered_purposes": [
+            "FAMILY"
+          ]
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.el.e31d-stepchild-support",
+        "safety_critical": false
+      }
+    },
+    {
+      "product_code": "E31D",
+      "claim_ids": [
+        "CL-E31D-REFUTER"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "hf.e31d-adult-excluded",
+        "stage": "HARD_FILTER",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "derived.age_years",
+          "op": "gte",
+          "value": 18
+        },
+        "effect": {
+          "type": "EXCLUDE",
+          "reason_code": "REQ_UNDER_18"
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.hf.e31d-adult-excluded",
+        "safety_critical": true
+      }
+    },
+    {
+      "product_code": "E31D",
+      "claim_ids": [
+        "CL-E31D-REFUTER"
+      ],
+      "caveats": [],
+      "rule": {
+        "rule_id": "hf.e31d-married-excluded",
+        "stage": "HARD_FILTER",
+        "scope": "PRODUCTS",
+        "product_version_ids": [
+          "3204e973-59da-5da1-bad0-06a7172e5b2c"
+        ],
+        "priority": 100,
+        "valid_period": {
+          "from": "2026-07-24T00:00:00Z",
+          "to": null
+        },
+        "when": {
+          "fact": "person.marital_status",
+          "op": "neq",
+          "value": "SINGLE"
+        },
+        "effect": {
+          "type": "EXCLUDE",
+          "reason_code": "REQ_UNMARRIED"
+        },
+        "on_unknown": "NEEDS_INPUT",
+        "source_refs": [
+          "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+          "e3572ad2-08a9-55bd-b818-353b3e9db715"
+        ],
+        "explanation_key": "explain.hf.e31d-married-excluded",
+        "safety_critical": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- E5 increment 1 of the Visa Oracle doctrine-factory execution plan: a claim-ledger→rules compiler
  (backend/services/visa_engine/claim_ledger.py + backend/scripts/visa_engine/compile_claims.py),
  a VERIFIED-only lint, an R-OVERSTAY-PLANNING lint (Zero ruling 2026-08-18), and 26 claim-backed
  reformed rules for the D1/D2/D12/E31B/E31D vertical slice.
- E31B: value-blind `known` sponsor-status gate replaced with a closed enum
  (ITAS_ACTIVE/ITAP_ACTIVE/VITAS_APPROVED) per CL-E31B-REFUTER / Permenkumham 22/2023 jo. 11/2024 Pasal 44.
- E31D: bare `intersects[FAMILY]` rules now require `family.relation_to_sponsor == CHILD` (+ sponsor
  marriage-registration for the mixed-marriage rule), plus 2 new HARD_FILTER rules mirroring E31E's.
- kimi-k3 adversarial review round (second commit): fixed a live P0 (CL-D-FUNDS product-conditional
  state line silently resolving to plain VERIFIED, bypassing D2's caveat requirement) via
  per-product state resolution, plus 3 P1s from the first review round (regex anchoring, malformed
  caveat crash risk, empty-caveat-note gap). One P1 (guard-inside-`not` overstay-lint bypass)
  independently verified as a non-issue via both a walker-code trace and team-lead's runtime
  Kleene-logic trace. Full dispositions table in the research doc.
- Full design, rules-emitted table, lint proofs, and adversarial-review dispositions in
  research/visa/doctrine-factory/e5/2026-08-18-e5-increment1-compiler.md.

## Scope / non-scope (per task brief)
- NO pack signing/activation, NO mutation of signed packs, NO prod, NO NB-2.
- OD-1 (D2 dual-outcome design) and OD-2 (seq-8→seq-9 fold) explicitly noted, not built — later increments.
- The monotone disclosed-uncertainty adapter (evaluate_path.py) is untouched.

## Test plan
- [x] backend/tests/services/visa_engine/test_claim_ledger.py — 16/16 green
- [x] backend/tests/scripts/test_visa_engine_compile_claims.py — 31/31 green
- [x] Real 26-rule slice manifest compiles clean against the real committed claim ledgers
- [x] kimi-k3 adversarial review — 2 P0 + 3 P1 confirmed and cured, 1 P1 verified non-issue, dispositions in the research doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)