### PR TITLE
fix(ci): npm audit gate named a waiver that was never granted

### DIFF
--- a/scripts/ci/npm_audit_gate.py
+++ b/scripts/ci/npm_audit_gate.py
@@ -74,6 +74,27 @@ def evaluate(data: dict, waive: dict[str, set[str] | None] = WAIVE) -> list[tupl
         if vuln.get("severity") not in BLOCKING:
             continue
         ids = advisory_ids(vuln)
+        if not ids:
+            # No advisory id of its OWN: every `via` entry is a bare package
+            # name, i.e. this package is a CARRIER of someone else's advisory.
+            # It still blocks — but it must not fall through to the waiver
+            # branch below, which would report it as "waived, but on unexpected
+            # paths" and so name a waiver that was never granted. On 2026-08-17
+            # `prisma` and `@prisma/config` (carriers of deepmerge-ts's
+            # GHSA-ggr8-5vv4-36mx) read exactly that way, and it sent a session
+            # hunting through WAIVE for entries that do not exist while the repo
+            # sat unmergeable. The verdict was right; the message pointed away
+            # from the cause.
+            carries = sorted(str(x) for x in (vuln.get("via") or []) if isinstance(x, str))
+            bad.append(
+                (
+                    name,
+                    vuln.get("severity"),
+                    [],
+                    f"no advisory of its own — carries: {carries or ['<unknown>']}",
+                )
+            )
+            continue
         unwaived = ids - waive.keys()
         if unwaived:
             bad.append((name, vuln.get("severity"), sorted(ids), "not waived"))

--- a/scripts/ci/test_npm_audit_gate.py
+++ b/scripts/ci/test_npm_audit_gate.py
@@ -129,6 +129,70 @@ def test_the_same_advisory_on_a_production_path_we_never_vetted_blocks():
     assert run_cli(payload) == 1
 
 
+# --- carrier packages: block, but name the right cause ----------------------
+#
+# A package whose `via` holds only bare NAMES has no advisory of its own — it
+# merely carries someone else's. It must still block; the bug being pinned here
+# is the REASON it used to give.
+
+
+def carrier(severity="high", via=("deepmerge-ts",), nodes=("node_modules/prisma",)):
+    """The live 2026-08-17 shape: `via` is strings, so advisory_ids() is empty."""
+    return {"severity": severity, "via": list(via), "nodes": list(nodes)}
+
+
+def test_a_carrier_still_blocks():
+    bad = evaluate({"vulnerabilities": {"prisma": carrier()}}, WAIVE)
+    assert len(bad) == 1, bad
+
+
+def test_a_carrier_does_not_claim_a_waiver_that_was_never_granted():
+    """The scar: it read 'waived, but on unexpected paths' with WAIVE untouched."""
+    bad = evaluate({"vulnerabilities": {"prisma": carrier()}}, WAIVE)
+    assert "waiv" not in bad[0][3], bad
+    assert "deepmerge-ts" in bad[0][3], bad
+
+
+def test_a_carrier_blocks_even_when_its_node_is_a_waived_path():
+    """Path-shape must not rescue it: with no ids, no waiver can apply."""
+    bad = evaluate({"vulnerabilities": {"prisma": carrier(nodes=(GRAY_MATTER,))}}, WAIVE)
+    assert len(bad) == 1 and "waiv" not in bad[0][3], bad
+
+
+def test_a_carrier_with_no_recorded_nodes_now_blocks():
+    """DELIBERATE behaviour change — pinned, not asserted away.
+
+    The old code reached the waiver branch and computed `stray` over
+    `nodes`; with no nodes there was nothing stray, so it appended NOTHING and a
+    high-severity carrier passed the gate. Measured old-vs-new on 2026-08-18:
+    False -> True for both `nodes: []` and absent `nodes`. Blocking is the right
+    answer — "npm recorded no path" is not evidence of no path — but it IS a
+    change, so it gets a test instead of a sentence.
+    """
+    assert len(evaluate({"vulnerabilities": {"prisma": carrier(nodes=())}}, WAIVE)) == 1
+    no_nodes = {"severity": "high", "via": ["deepmerge-ts"]}
+    assert len(evaluate({"vulnerabilities": {"prisma": no_nodes}}, WAIVE)) == 1
+
+
+def test_a_carrier_below_the_threshold_is_still_ignored():
+    """Innocence: the new branch sits AFTER the severity filter, not before it."""
+    assert evaluate({"vulnerabilities": {"prisma": carrier(severity="moderate")}}, WAIVE) == []
+
+
+def test_a_real_advisory_still_reads_not_waived():
+    """Innocence: the new branch must not swallow the ordinary unwaived case."""
+    bad = evaluate({"vulnerabilities": {"lodash": vuln(ids=("GHSA-unknown",))}}, WAIVE)
+    assert bad[0][3] == "not waived", bad
+
+
+def test_a_genuinely_stray_path_still_says_unexpected_paths():
+    """Innocence: the message that IS correct for a real waiver survives."""
+    bad = evaluate(
+        {"vulnerabilities": {"js-yaml": vuln(nodes=("node_modules/js-yaml",))}}, WAIVE
+    )
+    assert "unexpected paths" in bad[0][3], bad
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
Follow-up to #4281, which fixed the advisory. This fixes the **message** that made finding it slower.

## The defect

A package whose `via` list holds only bare package **names** has no advisory id of its own — it is a **carrier** of someone else's. `advisory_ids()` returns an empty set for it, and an empty set makes `unwaived = ids - waive.keys()` falsy, so the finding fell through to the waiver branch. There, `any(... for i in ids)` over an empty `ids` is `False`, every node reads as stray, and the gate reported:

```
('prisma', 'high', [], "waived, but on unexpected paths: [...]")
```

**Nothing was ever waived for `prisma`.** The verdict (block) was right; the reason pointed away from the cause.

Not hypothetical. On 2026-08-17 `GHSA-ggr8-5vv4-36mx` (deepmerge-ts) arrived through `prisma -> @prisma/config`, and both carriers printed exactly that line while the repository sat unmergeable for eleven hours. The message sent a session searching `WAIVE` for entries that do not exist. Same family as **W106**: a diagnosis that inventories a state which was never true reads as authoritative to whoever is hunting the cause at 03:00.

New reason:

```
('prisma', 'high', [], "no advisory of its own — carries: ['deepmerge-ts']")
```

## Behaviour change — one case, deliberate, pinned

An earlier draft of the commit message claimed *"behaviour is UNCHANGED, only the reason string changes"*. **That was false**, and I found it only by running old and new side by side instead of re-reading my own diff:

| case | OLD blocks | NEW blocks |
|---|---|---|
| carrier, nodes present | True | True |
| carrier, `nodes: []` | **False** | **True** |
| carrier, `nodes` absent | **False** | **True** |

The old code reached the waiver branch and computed `stray` over `nodes`; with no nodes there was nothing stray, so it appended nothing and **a high-severity carrier passed the gate**. Blocking is the right answer — *"npm recorded no path"* is not evidence of no path — but it is a change, and a change asserted away in a commit message is worse than the bug it hides (**W113**: the correction is the part nobody re-reads). It now has its own test rather than a sentence.

## Tests — seven added, guilt and innocence

**Guilt**
- a carrier still blocks
- a carrier does not claim a waiver — *the scar itself*
- a carrier blocks even when its node happens to be a waived path (with no ids, no waiver can apply, so path shape must not rescue it)
- a carrier with no recorded nodes blocks — *the divergence above*

**Innocence**
- a moderate-severity carrier is still ignored — proves the new branch sits **after** the severity filter, not before it
- an ordinary unwaived advisory still reads `"not waived"`
- a genuinely stray path still reads `"unexpected paths"` — the message that *is* correct for a real waiver survives

**Mutation-verified: 18/18 with the branch, 15/18 without it.** The three that go red are `does_not_claim_a_waiver`, `blocks_even_when_its_node_is_a_waived_path`, and `with_no_recorded_nodes_now_blocks`. `a carrier still blocks` deliberately **survives** the mutation, because the old code blocked that shape too — it pins what the fix must not change, and a test that cannot go red is worth saying so about rather than counting as coverage.