### PR TITLE
fix(ci): bound the Playwright browser install — `--with-deps` runs apt inside it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1191,7 +1191,33 @@ jobs:
           }
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          # BOUNDED because `--with-deps` shells out to `apt-get` INSIDE
+          # playwright's own process: this step carries exactly the risk cured
+          # for our explicit apt call sites in scripts/ci/apt_install.sh, in a
+          # place that helper cannot reach.
+          #
+          # Measured over 13 consecutive runs of this workflow (2026-08-18):
+          # eleven finish in 24-32s, one took 8m01s and still succeeded, and one
+          # was 17m33s deep with nothing to show when the job's 20-minute budget
+          # killed it. GitHub reports a budget kill as `cancelled`, NOT
+          # `failure` — and a cancelled REQUIRED context ejects the merge-queue
+          # entry with no failing check anywhere to point at, which is how the
+          # repo sat unmergeable for eleven hours (W118, cicatrix family #2).
+          #
+          # 600s is chosen against the MEASURED distribution, not a round
+          # number: comfortably above the worst observed SUCCESS (8m01s) so a
+          # slow-but-working mirror still passes, and half the job budget so the
+          # remaining 10 minutes still cover build + serve + the tests
+          # themselves. The other half of that arithmetic is the lesson: a bound
+          # sized without leaving room for the rest of the job does not avoid
+          # exhausting the budget, it guarantees it.
+          #
+          # No retry, deliberately. A retry is the remedy that LOOKS right when
+          # the symptom is "slow", and three of them inside one budget is how
+          # the first attempt at the apt cure failed. Failing once, loudly, at a
+          # named step beats being cancelled silently.
+          timeout 600 npx playwright install --with-deps chromium
 
       - name: Run E2E tests
         env:


### PR DESCRIPTION
Found while landing #4286 (the apt bound): **that PR’s own E2E check went `cancelled`**, and the cancelled step was `Install Playwright browsers` at **17m33s** inside a 20-minute job budget.

This is not a second, unrelated slowness. `npx playwright install --with-deps` shells out to **`apt-get` inside playwright’s own process**, so it carries exactly the risk cured for our explicit call sites in `scripts/ci/apt_install.sh` — in a place that helper cannot reach. Curing only the call sites I could *see* would have moved which job dies silently, not reduced the risk (W107).

## Measured before sizing anything

13 consecutive runs of `tests.yml`, step `Install Playwright browsers`:

| outcome | duration |
|---|---|
| success ×11 | 24s – 32s |
| success ×1 | **8m01s** |
| cancelled ×1 | **17m33s** (job killed at its 20-min budget) |

So the tail is real (~15%) but the disease is **not chronic** — which is why this is a bound, not a redesign.

## Why 600s

Against that distribution, not a round number: comfortably **above the worst observed SUCCESS** (8m01s) so a slow-but-working mirror still passes, and **half the 20-minute job budget** so build + serve + the tests still fit in what remains. Sizing a bound without leaving room for the rest of the job does not avoid exhausting the budget — it guarantees it, which is precisely how my first attempt at the apt cure failed.

**No retry, deliberately.** A retry is the remedy that *looks* right when the symptom is "slow". Failing once, loudly, at a named step beats being cancelled silently — and the silence is the whole problem: GitHub reports a budget kill as **`cancelled`**, not `failure`, so a cancelled REQUIRED context ejects the merge-queue entry with nothing red to point at. That is what kept this repo unmergeable for eleven hours (see `W118`, shipped in #4289).

Verified: `actionlint -shellcheck=` RC=0 (the CI’s exact invocation) · `lint_workflow_timeout_floor.py` clean on 123 jobs · YAML parses.