### PR TITLE
feat(visa-oracle): E5 inc-2 claim compiler — UNSATISFIABLE-CONDITION + VACUOUS-RULE lints

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/compile_claims.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/compile_claims.py
@@ -41,6 +41,43 @@ Two hard lints, both compile errors (never warnings):
    which product/claim the rule belongs to — it is a standing invariant
    for every rule this compiler ever emits, not a per-rule opt-in.
 
+E5 increment 2 (2026-08-18) adds two more hard lints, each motivated by a
+real defect confirmed in the active pack ``rulepack-prod-007.source.json``:
+
+3. **UNSATISFIABLE-CONDITION.** ``el.e33e.deposit-income-basis`` is
+   logically unsatisfiable: brute-force over the boolean abstraction (each
+   *distinct* leaf condition — by canonical-JSON identity — treated as an
+   independent atom) finds zero of its 64 assignments (6 distinct leaves)
+   that satisfy the ``when``. Treating identical leaves as the SAME atom is
+   what makes the contradiction visible at all — E33E's outer ``all``
+   re-asserts ``bank_deposit_usd/at_state_bank/in_own_name/
+   passive_monthly_income_usd`` as a plain conjunction while its inner
+   branch demands their XOR, and only sharing the atom across both
+   occurrences lets brute-force see that. This check is sound for
+   UNSAT-by-*structure* (independent atoms is the most permissive possible
+   reading: if even that has no satisfying assignment, the rule can never
+   fire under any stricter, arithmetic-aware semantics either) but
+   deliberately blind to *arithmetic* contradictions — e.g. it cannot see
+   that ``x > 5`` and ``x < 3`` are the same variable and treats them as
+   two unrelated atoms. Do not extend this into an arithmetic solver; that
+   is a different, much harder tool. Guarded: a ``when`` with more than 20
+   distinct leaves is not brute-forced (2**20 is already over a million
+   assignments per rule) — the compiler emits an explicit
+   "satisfiability not checked (N leaves > 20)" report note instead of
+   silently skipping.
+
+4. **VACUOUS-RULE.** ``el.e33g.income-60k-manual`` claims (by name) to
+   gate on income but its ``when`` is the same remote-work block
+   literally duplicated twice — it references zero income facts, and the
+   literal ``60000`` appears nowhere in the pack. Two purely mechanical
+   checks (never rule-name/intent inference — that is form, not entity):
+   (a) duplicate-subtree: an ``all``/``any`` node with two
+   structurally-identical (canonical-JSON-equal) children is a compile
+   error — the duplication itself is the smell; (b) an OPTIONAL manifest
+   entry field ``must_reference_facts: [fact paths]`` lets an author
+   assert "this rule is about fact X" and have the compiler prove every
+   listed fact actually appears in the derived ``required_facts``.
+
 Usage::
 
     PYTHONPATH=. python -m backend.scripts.visa_engine.compile_claims \\
@@ -179,7 +216,11 @@ def lint_verified_only(
 
     findings: list[LintFinding] = []
     if not claim_ids:
-        findings.append(LintFinding(rule_id, "declares zero claim_ids — every compiled rule must be claim-backed"))
+        findings.append(
+            LintFinding(
+                rule_id, "declares zero claim_ids — every compiled rule must be claim-backed"
+            )
+        )
         return findings
 
     caveated_claim_ids: set[str] = set()
@@ -190,7 +231,9 @@ def lint_verified_only(
         cid = caveat.get("claim_id")
         note = caveat.get("note")
         if not isinstance(cid, str) or not cid:
-            findings.append(LintFinding(rule_id, f"caveats[{i}] has a missing/empty claim_id: {caveat!r}"))
+            findings.append(
+                LintFinding(rule_id, f"caveats[{i}] has a missing/empty claim_id: {caveat!r}")
+            )
             continue
         if not isinstance(note, str) or not note.strip():
             findings.append(
@@ -313,6 +356,238 @@ def lint_overstay_planning(*, rule_id: str, when: dict[str, Any]) -> list[LintFi
 
 
 # ---------------------------------------------------------------------------
+# Lint 3: UNSATISFIABLE-CONDITION
+# ---------------------------------------------------------------------------
+
+#: Above this many DISTINCT leaves, 2**N brute-force assignments becomes
+#: too expensive to run per-rule at compile time (2**21 already exceeds two
+#: million). This is a declared limit, not a silent skip — the compiler
+#: reports the exact leaf count in a report note when it is hit.
+_MAX_LEAVES_FOR_SAT_CHECK = 20
+
+
+def _canonical_key(node: Any) -> str:
+    """Canonical-JSON identity for a condition node — the basis on which
+    two leaves (Lint 3) or two subtrees (Lint 4) are considered "the same".
+    """
+
+    return json.dumps(node, sort_keys=True)
+
+
+def _safe_args(condition: dict[str, Any]) -> list[Any]:
+    """``condition.get("args", [])`` is not safe on its own: a manifest can
+    carry the KEY with a JSON ``null`` (or any non-list) value, in which
+    case the default never applies and iterating the result raises —
+    exactly the "bare traceback for a data problem" this module's own
+    docstring forbids (kimi-k3 finding, 2026-08-18). Malformed ``args`` is
+    treated as "no children" here; ``Rule.model_validate`` (later in
+    ``compile_manifest``) is what actually rejects the malformed shape.
+    """
+
+    args = condition.get("args")
+    return args if isinstance(args, list) else []
+
+
+#: A compiled boolean "shape" node: ``("const", bool)`` for a fixed truth
+#: value, ``("leaf", canonical_key)`` for a boolean atom, or
+#: ``("all"|"any", tuple[_Shape, ...])`` / ``("not", _Shape)`` for a
+#: combinator. Compiling `when` into this form ONCE means the brute-force
+#: loop below evaluates plain tuples/strings — no `json.dumps` re-run per
+#: leaf per assignment (kimi-k3 perf finding, 2026-08-18: the naive
+#: re-serialize-every-lookup approach did ~2**20 x leaf-count `json.dumps`
+#: calls at exactly the boundary this lint is documented to still check).
+_Shape = tuple[Any, ...]
+
+
+def _compile_boolean_shape(condition: Any, leaves: dict[str, Any]) -> _Shape:
+    """Compile ``condition`` into a ``_Shape`` AND collect every distinct
+    leaf (by canonical-JSON identity) into ``leaves`` — same traversal that
+    used to be two separate functions, now one pass so collection and
+    evaluation can never disagree about what counts as a leaf.
+    """
+
+    if not isinstance(condition, dict):
+        # Malformed/non-dict node: never fabricate an UNSAT finding out of
+        # a shape this walker doesn't understand — `Rule.model_validate`
+        # owns rejecting it.
+        return ("const", True)
+
+    op = condition.get("op")
+    if op in ("all", "any"):
+        children = tuple(_compile_boolean_shape(a, leaves) for a in _safe_args(condition))
+        return (op, children)
+    if op == "not":
+        return ("not", _compile_boolean_shape(condition.get("arg"), leaves))
+
+    key = _canonical_key(condition)
+    leaves[key] = condition
+    return ("leaf", key)
+
+
+def _evaluate_boolean_shape(shape: _Shape, assignment: dict[str, bool]) -> bool:
+    """Evaluate a pre-compiled ``_Shape`` under a full leaf assignment —
+    pure structural boolean algebra (AND/OR/NOT), no arithmetic, no fact
+    semantics.
+    """
+
+    kind = shape[0]
+    if kind == "const":
+        return bool(shape[1])
+    if kind == "all":
+        return all(_evaluate_boolean_shape(c, assignment) for c in shape[1])
+    if kind == "any":
+        return any(_evaluate_boolean_shape(c, assignment) for c in shape[1])
+    if kind == "not":
+        return not _evaluate_boolean_shape(shape[1], assignment)
+    return assignment[shape[1]]  # kind == "leaf"
+
+
+def lint_unsatisfiable_condition(
+    *, rule_id: str, when: dict[str, Any]
+) -> tuple[list[LintFinding], str | None]:
+    """UNSATISFIABLE-CONDITION lint (see module docstring, Lint 3).
+
+    Returns ``(findings, skip_note)`` — ``skip_note`` is set (and
+    ``findings`` empty) when the leaf count exceeds
+    ``_MAX_LEAVES_FOR_SAT_CHECK``: the check was NOT run, and that must be
+    visible in the report rather than silently indistinguishable from
+    "checked and satisfiable".
+
+    A `when` with ZERO distinct leaves (e.g. ``{"op": "any", "args": []}``)
+    is still fully evaluated, not short-circuited as trivially satisfiable
+    — an empty ``any`` is Kleene-FALSE and genuinely unsatisfiable, and an
+    early "no leaves -> pass" return would have missed exactly that
+    (kimi-k3 finding, 2026-08-18). The brute-force loop below handles this
+    for free: 0 leaves means ``2**0 == 1`` assignment (the empty one), and
+    that single evaluation IS the answer.
+    """
+
+    leaves: dict[str, Any] = {}
+    shape = _compile_boolean_shape(when, leaves)
+
+    if len(leaves) > _MAX_LEAVES_FOR_SAT_CHECK:
+        return [], (
+            f"{rule_id}: satisfiability not checked "
+            f"({len(leaves)} leaves > {_MAX_LEAVES_FOR_SAT_CHECK})"
+        )
+
+    keys = list(leaves.keys())
+    total = 1 << len(keys)
+    for bits in range(total):
+        assignment = {key: bool((bits >> i) & 1) for i, key in enumerate(keys)}
+        if _evaluate_boolean_shape(shape, assignment):
+            return [], None
+
+    return (
+        [
+            LintFinding(
+                rule_id,
+                "condition is UNSATISFIABLE — brute-force over "
+                f"{len(keys)} distinct leaf condition(s) (each treated as an "
+                f"independent boolean atom) finds zero of {total} assignments "
+                "that satisfy `when`; this rule can never fire. NOTE: this "
+                "check is sound for UNSAT-by-structure but blind to "
+                "arithmetic contradictions between different leaves (e.g. "
+                "x>5 AND x<3) — if this fired, the tree really is "
+                "structurally self-contradictory, not merely "
+                "arithmetic-narrow.",
+            )
+        ],
+        None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lint 4: VACUOUS-RULE
+# ---------------------------------------------------------------------------
+
+
+def _find_duplicate_subtrees(condition: Any, rule_id: str) -> list[LintFinding]:
+    """Mechanical duplicate-subtree detection (see module docstring, Lint 4a):
+    an ``all``/``any`` node with two structurally-identical
+    (canonical-JSON-equal) children is a compile error — the duplication
+    itself is the smell, independent of what the rule is named or what it
+    claims to be about.
+    """
+
+    findings: list[LintFinding] = []
+    if not isinstance(condition, dict):
+        return findings
+
+    op = condition.get("op")
+    if op in ("all", "any"):
+        args = _safe_args(condition)
+        seen: dict[str, int] = {}
+        for i, arg in enumerate(args):
+            key = _canonical_key(arg)
+            first_index = seen.get(key)
+            if first_index is not None:
+                findings.append(
+                    LintFinding(
+                        rule_id,
+                        f"{op!r} node has two structurally identical children "
+                        f"(args[{first_index}] == args[{i}]) — a duplicated "
+                        "child adds no logical content beyond a single copy "
+                        "(VACUOUS-RULE): if the intent was two DIFFERENT "
+                        "conditions, one of them was never actually written",
+                    )
+                )
+            else:
+                seen[key] = i
+        for arg in args:
+            findings.extend(_find_duplicate_subtrees(arg, rule_id))
+    elif op == "not":
+        findings.extend(_find_duplicate_subtrees(condition.get("arg"), rule_id))
+
+    return findings
+
+
+def lint_duplicate_subtree(*, rule_id: str, when: dict[str, Any]) -> list[LintFinding]:
+    """VACUOUS-RULE lint, part (a): duplicate-subtree detection (see module
+    docstring, Lint 4).
+    """
+
+    return _find_duplicate_subtrees(when, rule_id)
+
+
+def lint_must_reference_facts(
+    *, rule_id: str, must_reference_facts: list[str], derived_facts: list[str]
+) -> list[LintFinding]:
+    """VACUOUS-RULE lint, part (b): the OPTIONAL manifest field
+    ``must_reference_facts`` (see module docstring, Lint 4). An author
+    declares "this rule is about fact X"; the compiler proves every listed
+    fact actually appears in the ``when``-derived ``required_facts`` — a
+    mechanical proof, never an inference from the rule's name or claim_ids.
+    """
+
+    findings: list[LintFinding] = []
+    derived_set = set(derived_facts)
+    for i, fact in enumerate(must_reference_facts):
+        if not isinstance(fact, str):
+            # A non-string (and possibly unhashable, e.g. a dict/list)
+            # entry must never crash `fact not in derived_set` — that is
+            # exactly the bare-traceback-on-a-data-problem contract this
+            # module's own docstring forbids (kimi-review-adjacent finding,
+            # 2026-08-18: team-lead's parallel gate on this diff).
+            findings.append(
+                LintFinding(rule_id, f"must_reference_facts[{i}] is not a string: {fact!r}")
+            )
+            continue
+        if fact not in derived_set:
+            findings.append(
+                LintFinding(
+                    rule_id,
+                    f"manifest entry declares must_reference_facts includes "
+                    f"{fact!r} but the rule's condition tree never references "
+                    f"it (derived required_facts: {sorted(derived_set)!r}) — "
+                    "VACUOUS-RULE: the rule claims to be about a fact it "
+                    "never actually checks",
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Compiler entrypoint
 # ---------------------------------------------------------------------------
 
@@ -321,6 +596,10 @@ class CompilationReport:
     def __init__(self) -> None:
         self.findings: list[LintFinding] = []
         self.compiled: list[CompiledEntry] = []
+        #: Declared-limit notes (never silent) — e.g. Lint 3's
+        #: satisfiability-not-checked skip when a `when` has too many
+        #: distinct leaves to brute-force.
+        self.notes: list[str] = []
 
     @property
     def ok(self) -> bool:
@@ -334,6 +613,10 @@ class CompilationReport:
             lines.append(f"FAILED — {len(self.findings)} finding(s):")
             for f in self.findings:
                 lines.append(f"  - {f}")
+        if self.notes:
+            lines.append(f"NOTES — {len(self.notes)} declared-limit note(s):")
+            for note in self.notes:
+                lines.append(f"  - {note}")
         return "\n".join(lines)
 
 
@@ -345,12 +628,16 @@ def compile_manifest(
 
     entries = manifest.get("rules")
     if not isinstance(entries, list) or not entries:
-        report.findings.append(LintFinding("<manifest>", "manifest.rules must be a non-empty array"))
+        report.findings.append(
+            LintFinding("<manifest>", "manifest.rules must be a non-empty array")
+        )
         return report
 
     for entry in entries:
         if not isinstance(entry, dict):
-            report.findings.append(LintFinding("<manifest>", f"manifest entry is not an object: {entry!r}"))
+            report.findings.append(
+                LintFinding("<manifest>", f"manifest entry is not an object: {entry!r}")
+            )
             continue
 
         rule_src = entry.get("rule")
@@ -381,6 +668,15 @@ def compile_manifest(
         if isinstance(when, dict):
             report.findings.extend(lint_overstay_planning(rule_id=rule_id, when=when))
 
+            # Lint 3 — UNSATISFIABLE-CONDITION.
+            unsat_findings, skip_note = lint_unsatisfiable_condition(rule_id=rule_id, when=when)
+            report.findings.extend(unsat_findings)
+            if skip_note is not None:
+                report.notes.append(skip_note)
+
+            # Lint 4a — VACUOUS-RULE: duplicate-subtree detection.
+            report.findings.extend(lint_duplicate_subtree(rule_id=rule_id, when=when))
+
         # Derive required_facts from `when` — never trust a manifest-supplied
         # value (mirrors compile_pack.py's compiler-level invariant, applied
         # here at authoring time instead of at pack-assembly time). Parse
@@ -393,8 +689,34 @@ def compile_manifest(
             parsed_when = parse_condition(when)
             derived_facts = sorted(collect_fact_paths(parsed_when))
         except (ValidationError, ValueError, TypeError) as exc:
-            report.findings.append(LintFinding(rule_id, f"condition tree could not be parsed: {exc}"))
+            report.findings.append(
+                LintFinding(rule_id, f"condition tree could not be parsed: {exc}")
+            )
             continue
+
+        # Lint 4b — VACUOUS-RULE: optional must_reference_facts assertion.
+        # Absent (key missing, or explicit JSON null) means "not declared" —
+        # anything else that isn't a list is malformed and must be flagged,
+        # never silently coerced to "not declared" (kimi-k3 finding,
+        # 2026-08-18: `entry.get(...) or []` previously swallowed falsy-but-
+        # present values like `""`/`0` as if the field were simply absent).
+        raw_must_reference_facts = entry.get("must_reference_facts")
+        if raw_must_reference_facts is None:
+            pass
+        elif isinstance(raw_must_reference_facts, list):
+            report.findings.extend(
+                lint_must_reference_facts(
+                    rule_id=rule_id,
+                    must_reference_facts=raw_must_reference_facts,
+                    derived_facts=derived_facts,
+                )
+            )
+        else:
+            report.findings.append(
+                LintFinding(
+                    rule_id, "manifest entry's must_reference_facts must be a list when present"
+                )
+            )
 
         rule_payload = {**rule_src, "required_facts": derived_facts}
         try:
@@ -411,7 +733,9 @@ def compile_manifest(
             continue
 
         report.compiled.append(
-            CompiledEntry(product_code=product_code, claim_ids=claim_ids, caveats=caveats, rule=rule)
+            CompiledEntry(
+                product_code=product_code, claim_ids=claim_ids, caveats=caveats, rule=rule
+            )
         )
 
     return report
@@ -423,9 +747,13 @@ def load_manifest(path: Path) -> dict[str, Any]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--claims", nargs="+", required=True, type=Path, help="claim ledger markdown file(s)")
+    parser.add_argument(
+        "--claims", nargs="+", required=True, type=Path, help="claim ledger markdown file(s)"
+    )
     parser.add_argument("--manifest", required=True, type=Path, help="rule-authoring manifest JSON")
-    parser.add_argument("--out", type=Path, default=None, help="write compiled rules JSON here on success")
+    parser.add_argument(
+        "--out", type=Path, default=None, help="write compiled rules JSON here on success"
+    )
     args = parser.parse_args(argv)
 
     try:

--- a/apps/backend-rag/backend/tests/scripts/test_visa_engine_compile_claims.py
+++ b/apps/backend-rag/backend/tests/scripts/test_visa_engine_compile_claims.py
@@ -14,13 +14,26 @@ from pathlib import Path
 
 from backend.scripts.visa_engine.compile_claims import (
     compile_manifest,
+    lint_duplicate_subtree,
+    lint_must_reference_facts,
     lint_overstay_planning,
+    lint_unsatisfiable_condition,
     lint_verified_only,
     load_claim_ledgers,
     load_manifest,
     main,
 )
 from backend.services.visa_engine.claim_ledger import ClaimRecord
+
+_PACK_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "backend"
+    / "services"
+    / "visa_engine"
+    / "contracts"
+    / "packs"
+    / "rulepack-prod-007.source.json"
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[5]
 _CLAIMS_DIR = _REPO_ROOT / "research" / "visa" / "doctrine-factory" / "claims"
@@ -36,7 +49,9 @@ _LEDGER_FILES = [
 
 
 def _rec(claim_id: str, state: str) -> ClaimRecord:
-    return ClaimRecord(claim_id=claim_id, state=state, header="test", backs=(), source_file="<test>")
+    return ClaimRecord(
+        claim_id=claim_id, state=state, header="test", backs=(), source_file="<test>"
+    )
 
 
 def _minimal_rule(rule_id: str = "el.test-rule", *, when: dict | None = None) -> dict:
@@ -48,7 +63,11 @@ def _minimal_rule(rule_id: str = "el.test-rule", *, when: dict | None = None) ->
         "priority": 100,
         "valid_period": {"from": "2026-07-24T00:00:00Z", "to": None},
         "when": when or {"fact": "intent.purposes", "op": "intersects", "values": ["FAMILY"]},
-        "effect": {"type": "SUPPORT", "reason_code": "PURPOSE_PRODUCT_MATCH", "covered_purposes": ["FAMILY"]},
+        "effect": {
+            "type": "SUPPORT",
+            "reason_code": "PURPOSE_PRODUCT_MATCH",
+            "covered_purposes": ["FAMILY"],
+        },
         "on_unknown": "NEEDS_INPUT",
         "source_refs": ["570f2bc4-5120-561f-90ba-58fcd9507514"],
         "explanation_key": f"explain.{rule_id}",
@@ -73,21 +92,29 @@ class TestVerifiedOnlyLint:
 
     def test_guilt_stale_claim_is_rejected(self) -> None:
         ledger = {"CL-X-01": _rec("CL-X-01", "STALE")}
-        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        findings = lint_verified_only(
+            rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger
+        )
         assert findings and "STALE" in findings[0].message
 
     def test_guilt_unverified_claim_is_rejected(self) -> None:
         ledger = {"CL-X-01": _rec("CL-X-01", "UNVERIFIED")}
-        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        findings = lint_verified_only(
+            rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger
+        )
         assert findings and "UNVERIFIED" in findings[0].message
 
     def test_guilt_unknown_claim_id_is_rejected(self) -> None:
-        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-GHOST-01"], caveats=[], ledger={})
+        findings = lint_verified_only(
+            rule_id="el.x", claim_ids=["CL-GHOST-01"], caveats=[], ledger={}
+        )
         assert findings and "does not resolve" in findings[0].message
 
     def test_guilt_caveat_with_verified_with_caveat_but_no_note(self) -> None:
         ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED-WITH-CAVEAT")}
-        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        findings = lint_verified_only(
+            rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger
+        )
         assert findings and "no matching caveat note" in findings[0].message
 
     def test_guilt_zero_claim_ids(self) -> None:
@@ -129,7 +156,9 @@ class TestVerifiedOnlyLint:
 
     def test_innocence_verified_claim_passes(self) -> None:
         ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
-        findings = lint_verified_only(rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger)
+        findings = lint_verified_only(
+            rule_id="el.x", claim_ids=["CL-X-01"], caveats=[], ledger=ledger
+        )
         assert findings == []
 
     def test_innocence_verified_with_caveat_and_matching_note_passes(self) -> None:
@@ -221,7 +250,12 @@ class TestVerifiedOnlyLint:
         findings = lint_verified_only(
             rule_id="el.d2-funds",
             claim_ids=["CL-D-FUNDS"],
-            caveats=[{"claim_id": "CL-D-FUNDS", "note": "statute delegates the figure; portal hardcodes it"}],
+            caveats=[
+                {
+                    "claim_id": "CL-D-FUNDS",
+                    "note": "statute delegates the figure; portal hardcodes it",
+                }
+            ],
             ledger=ledger,
             product_code="D2",
         )
@@ -333,13 +367,19 @@ class TestOverstayPlanningLint:
             "args": [
                 {
                     "op": "not",
-                    "arg": {"fact": "immigration.currently_in_indonesia", "op": "eq", "value": False},
+                    "arg": {
+                        "fact": "immigration.currently_in_indonesia",
+                        "op": "eq",
+                        "value": False,
+                    },
                 },
                 {"fact": "immigration.overstay_days", "op": "gt", "value": 0},
             ],
         }
         findings = lint_overstay_planning(rule_id="hf.test", when=when)
-        assert findings, "a not-wrapped negative-onshore-check must NOT protect a sibling overstay leaf"
+        assert findings, (
+            "a not-wrapped negative-onshore-check must NOT protect a sibling overstay leaf"
+        )
 
     def test_innocence_real_onshore_guard_still_protects_a_not_wrapped_overstay_leaf(self) -> None:
         """The mirror case: a REAL onshore guard (a direct true-eq sibling)
@@ -359,6 +399,417 @@ class TestOverstayPlanningLint:
 
 
 # ---------------------------------------------------------------------------
+# Lint 3 — UNSATISFIABLE-CONDITION: guilt + innocence
+# ---------------------------------------------------------------------------
+
+#: Copied verbatim from ``el.e33e.deposit-income-basis`` in
+#: ``backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json``
+#: (2026-08-18) — the real E5-increment-2 defect this lint exists to catch.
+#: The outer `all` re-asserts the same four deposit/state-bank/own-name/
+#: passive-income leaves that the inner `any` demands an XOR of, so the
+#: whole tree is unsatisfiable once identical leaves are treated as the
+#: SAME boolean atom.
+_E33E_DEPOSIT_INCOME_BASIS_WHEN: dict = {
+    "op": "all",
+    "args": [
+        {
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["RETIREMENT"]},
+                {"op": "gte", "fact": "derived.age_years", "value": 55},
+                {
+                    "op": "any",
+                    "args": [
+                        {
+                            "op": "all",
+                            "args": [
+                                {
+                                    "op": "all",
+                                    "args": [
+                                        {
+                                            "op": "gte",
+                                            "fact": "secondhome.bank_deposit_usd",
+                                            "value": 50000,
+                                        },
+                                        {
+                                            "op": "eq",
+                                            "fact": "secondhome.bank_deposit_at_state_bank",
+                                            "value": True,
+                                        },
+                                        {
+                                            "op": "eq",
+                                            "fact": "secondhome.bank_deposit_in_own_name",
+                                            "value": True,
+                                        },
+                                    ],
+                                },
+                                {
+                                    "op": "not",
+                                    "arg": {
+                                        "op": "gte",
+                                        "fact": "secondhome.passive_monthly_income_usd",
+                                        "value": 3000,
+                                    },
+                                },
+                            ],
+                        },
+                        {
+                            "op": "all",
+                            "args": [
+                                {
+                                    "op": "not",
+                                    "arg": {
+                                        "op": "all",
+                                        "args": [
+                                            {
+                                                "op": "gte",
+                                                "fact": "secondhome.bank_deposit_usd",
+                                                "value": 50000,
+                                            },
+                                            {
+                                                "op": "eq",
+                                                "fact": "secondhome.bank_deposit_at_state_bank",
+                                                "value": True,
+                                            },
+                                            {
+                                                "op": "eq",
+                                                "fact": "secondhome.bank_deposit_in_own_name",
+                                                "value": True,
+                                            },
+                                        ],
+                                    },
+                                },
+                                {
+                                    "op": "gte",
+                                    "fact": "secondhome.passive_monthly_income_usd",
+                                    "value": 3000,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["RETIREMENT"]},
+                {"op": "gte", "fact": "derived.age_years", "value": 55},
+                {
+                    "op": "all",
+                    "args": [
+                        {"op": "gte", "fact": "secondhome.bank_deposit_usd", "value": 50000},
+                        {
+                            "op": "eq",
+                            "fact": "secondhome.bank_deposit_at_state_bank",
+                            "value": True,
+                        },
+                        {"op": "eq", "fact": "secondhome.bank_deposit_in_own_name", "value": True},
+                    ],
+                },
+                {"op": "gte", "fact": "secondhome.passive_monthly_income_usd", "value": 3000},
+            ],
+        },
+    ],
+}
+
+
+class TestUnsatisfiableConditionLint:
+    def test_guilt_e33e_deposit_income_basis_is_unsatisfiable(self) -> None:
+        """The real E33E defect: brute-force over 6 distinct leaves finds
+        zero of 64 assignments that satisfy `when`."""
+
+        findings, skip_note = lint_unsatisfiable_condition(
+            rule_id="el.e33e.deposit-income-basis", when=_E33E_DEPOSIT_INCOME_BASIS_WHEN
+        )
+        assert skip_note is None
+        assert len(findings) == 1
+        assert "UNSATISFIABLE" in findings[0].message
+        assert "6 distinct leaf" in findings[0].message
+        assert "64 assignments" in findings[0].message
+
+    def test_guilt_e33e_matches_pack_on_disk(self) -> None:
+        """Anti-drift: the frozen fixture above must still equal the live
+        pack's `when` — if the pack changes, this test forces the fixture
+        (and the finding it proves) to be re-verified, not silently stale."""
+
+        pack = json.loads(_PACK_PATH.read_text(encoding="utf-8"))
+        rule = next(r for r in pack["rules"] if r["rule_id"] == "el.e33e.deposit-income-basis")
+        assert rule["when"] == _E33E_DEPOSIT_INCOME_BASIS_WHEN
+
+    def test_innocence_satisfiable_condition_passes(self) -> None:
+        when = {
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["RETIREMENT"]},
+                {"op": "gte", "fact": "derived.age_years", "value": 55},
+            ],
+        }
+        findings, skip_note = lint_unsatisfiable_condition(rule_id="hf.test", when=when)
+        assert findings == []
+        assert skip_note is None
+
+    def test_guilt_simple_contradiction_by_shared_leaf_is_caught(self) -> None:
+        """A minimal `A AND NOT A` (same leaf, negated) must be flagged —
+        sanity check the shared-atom mechanism independent of E33E's size.
+
+        (Renamed from a stray "innocence" prefix — kimi-k3 finding,
+        2026-08-18: the assertion was always correct, the test's own
+        guilt/innocence naming convention was violated by the name.)
+        """
+
+        leaf = {"op": "eq", "fact": "immigration.currently_in_indonesia", "value": True}
+        when = {"op": "all", "args": [leaf, {"op": "not", "arg": leaf}]}
+        findings, skip_note = lint_unsatisfiable_condition(rule_id="hf.test", when=when)
+        assert skip_note is None
+        assert findings and "UNSATISFIABLE" in findings[0].message
+
+    def test_innocence_no_leaves_passes(self) -> None:
+        findings, skip_note = lint_unsatisfiable_condition(
+            rule_id="hf.test", when={"op": "all", "args": []}
+        )
+        assert findings == []
+        assert skip_note is None
+
+    def test_guilt_empty_any_is_unsatisfiable(self) -> None:
+        """kimi-k3 finding (2026-08-18): `{"op": "any", "args": []}` is
+        Kleene-FALSE (an `any` of nothing has nothing to make it true) —
+        genuinely unsatisfiable, and has ZERO leaves. The original
+        `if not leaves: return [], None` early-return would have missed
+        this entirely; the fix removed that special case so the general
+        brute-force (with `2**0 == 1` assignment) evaluates it for real."""
+
+        findings, skip_note = lint_unsatisfiable_condition(
+            rule_id="hf.empty-any", when={"op": "any", "args": []}
+        )
+        assert skip_note is None
+        assert findings and "UNSATISFIABLE" in findings[0].message
+
+    def test_guilt_empty_any_nested_under_all_with_other_leaves_is_unsatisfiable(self) -> None:
+        """The same defect nested one level down, alongside a real leaf —
+        confirms the fix isn't special-casing "when IS exactly empty-any"."""
+
+        when = {
+            "op": "all",
+            "args": [
+                {"fact": "intent.purposes", "op": "intersects", "values": ["TOURISM"]},
+                {"op": "any", "args": []},
+            ],
+        }
+        findings, skip_note = lint_unsatisfiable_condition(rule_id="hf.test", when=when)
+        assert skip_note is None
+        assert findings and "UNSATISFIABLE" in findings[0].message
+
+    def test_innocence_malformed_null_args_does_not_crash(self) -> None:
+        """kimi-k3 finding (2026-08-18): `condition.get("args", [])` only
+        applies its default when the KEY is absent — a manifest with
+        `"args": null` (or any non-list) previously crashed the compiler
+        with an uncaught TypeError instead of degrading gracefully. Must
+        never raise; malformed `args` is treated as "no children" here
+        (schema validation elsewhere is what actually rejects the shape)."""
+
+        for malformed in (None, "not-a-list", 5, {"not": "a-list-either"}):
+            findings, skip_note = lint_unsatisfiable_condition(
+                rule_id="hf.test", when={"op": "all", "args": malformed}
+            )
+            # Must not raise. `all` with (effectively) zero children is
+            # vacuously satisfiable, never a finding.
+            assert findings == []
+            assert skip_note is None
+
+    def test_guilt_more_than_twenty_leaves_is_skipped_with_declared_note(self) -> None:
+        """21 distinct leaves must NOT be brute-forced (2**21 is too much
+        per-rule compute) — the compiler must emit an explicit note, never
+        silence. Silence is not success (task brief, verbatim)."""
+
+        leaves = [{"op": "eq", "fact": f"synthetic.leaf_{i}", "value": True} for i in range(21)]
+        when = {"op": "all", "args": leaves}
+        findings, skip_note = lint_unsatisfiable_condition(rule_id="hf.synthetic-21", when=when)
+        assert findings == []
+        assert skip_note is not None
+        assert "21 leaves > 20" in skip_note
+        assert "hf.synthetic-21" in skip_note
+
+    def test_innocence_exactly_twenty_leaves_is_checked_not_skipped(self) -> None:
+        """The boundary: 20 leaves (all True, trivially satisfiable) must
+        still be brute-forced, not skipped — the limit is `> 20`."""
+
+        leaves = [{"op": "eq", "fact": f"synthetic.leaf_{i}", "value": True} for i in range(20)]
+        when = {"op": "all", "args": leaves}
+        findings, skip_note = lint_unsatisfiable_condition(rule_id="hf.synthetic-20", when=when)
+        assert findings == []
+        assert skip_note is None
+
+
+# ---------------------------------------------------------------------------
+# Lint 4 — VACUOUS-RULE: guilt + innocence
+# ---------------------------------------------------------------------------
+
+#: Copied verbatim from ``el.e33g.income-60k-manual`` in
+#: ``backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json``
+#: (2026-08-18) — the real E5-increment-2 defect: the rule's name promises
+#: an income check, but its `when` is the same remote-work block literally
+#: duplicated twice, and references zero income facts (the literal 60000
+#: appears nowhere in the pack).
+_E33G_INCOME_60K_MANUAL_WHEN: dict = {
+    "op": "all",
+    "args": [
+        {
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["REMOTE_WORK"]},
+                {"op": "eq", "fact": "work.employer_is_indonesian_entity", "value": False},
+                {"op": "eq", "fact": "work.serves_indonesian_clients", "value": False},
+                {"op": "eq", "fact": "work.indonesia_source_compensation", "value": False},
+            ],
+        },
+        {
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["REMOTE_WORK"]},
+                {"op": "eq", "fact": "work.employer_is_indonesian_entity", "value": False},
+                {"op": "eq", "fact": "work.serves_indonesian_clients", "value": False},
+                {"op": "eq", "fact": "work.indonesia_source_compensation", "value": False},
+            ],
+        },
+    ],
+}
+
+
+class TestDuplicateSubtreeLint:
+    def test_guilt_e33g_income_60k_manual_has_duplicate_subtree(self) -> None:
+        findings = lint_duplicate_subtree(
+            rule_id="el.e33g.income-60k-manual", when=_E33G_INCOME_60K_MANUAL_WHEN
+        )
+        assert len(findings) == 1
+        assert "structurally identical children" in findings[0].message
+        assert "args[0] == args[1]" in findings[0].message
+
+    def test_guilt_e33g_matches_pack_on_disk(self) -> None:
+        pack = json.loads(_PACK_PATH.read_text(encoding="utf-8"))
+        rule = next(r for r in pack["rules"] if r["rule_id"] == "el.e33g.income-60k-manual")
+        assert rule["when"] == _E33G_INCOME_60K_MANUAL_WHEN
+
+    def test_guilt_duplicate_detected_nested_inside_any(self) -> None:
+        leaf = {"op": "eq", "fact": "immigration.currently_in_indonesia", "value": True}
+        when = {"op": "any", "args": [leaf, leaf]}
+        findings = lint_duplicate_subtree(rule_id="hf.test", when=when)
+        assert findings
+
+    def test_guilt_duplicate_detected_deep_in_tree(self) -> None:
+        leaf = {"op": "eq", "fact": "immigration.currently_in_indonesia", "value": True}
+        when = {
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["TOURISM"]},
+                {"op": "all", "args": [leaf, leaf]},
+            ],
+        }
+        findings = lint_duplicate_subtree(rule_id="hf.test", when=when)
+        assert findings
+
+    def test_innocence_two_different_children_pass(self) -> None:
+        when = {
+            "op": "all",
+            "args": [
+                {"op": "intersects", "fact": "intent.purposes", "values": ["TOURISM"]},
+                {"op": "eq", "fact": "intent.entry_pattern", "value": "MULTIPLE"},
+            ],
+        }
+        findings = lint_duplicate_subtree(rule_id="hf.test", when=when)
+        assert findings == []
+
+    def test_innocence_slightly_different_children_do_not_false_positive(self) -> None:
+        """Two leaves that differ by a single value must NOT be flagged —
+        this is a structural-equality check, not a fuzzy one."""
+
+        when = {
+            "op": "any",
+            "args": [
+                {"op": "eq", "fact": "intent.entry_pattern", "value": "MULTIPLE"},
+                {"op": "eq", "fact": "intent.entry_pattern", "value": "SINGLE"},
+            ],
+        }
+        findings = lint_duplicate_subtree(rule_id="hf.test", when=when)
+        assert findings == []
+
+    def test_innocence_malformed_null_args_does_not_crash(self) -> None:
+        """kimi-k3 finding (2026-08-18), same class as the satisfiability
+        lint's fix: `"args": null` (or any non-list) must never raise."""
+
+        for malformed in (None, "not-a-list", 5, {"not": "a-list-either"}):
+            findings = lint_duplicate_subtree(
+                rule_id="hf.test", when={"op": "any", "args": malformed}
+            )
+            assert findings == []
+
+
+class TestMustReferenceFactsLint:
+    def test_guilt_declared_fact_never_derived_is_rejected(self) -> None:
+        findings = lint_must_reference_facts(
+            rule_id="el.e33g.income-60k-manual",
+            must_reference_facts=["secondhome.passive_monthly_income_usd"],
+            derived_facts=["intent.purposes", "work.employer_is_indonesian_entity"],
+        )
+        assert findings and "secondhome.passive_monthly_income_usd" in findings[0].message
+
+    def test_innocence_absent_field_means_no_check(self) -> None:
+        """The field is OPTIONAL — a manifest entry that doesn't declare it
+        must never be flagged for anything (checked at the compile_manifest
+        level via an empty list default, see TestCompileManifest)."""
+
+        findings = lint_must_reference_facts(
+            rule_id="el.x", must_reference_facts=[], derived_facts=["intent.purposes"]
+        )
+        assert findings == []
+
+    def test_innocence_declared_fact_is_derived_passes(self) -> None:
+        findings = lint_must_reference_facts(
+            rule_id="el.x",
+            must_reference_facts=["intent.purposes"],
+            derived_facts=["intent.purposes", "work.employer_is_indonesian_entity"],
+        )
+        assert findings == []
+
+    def test_guilt_unhashable_entry_reports_finding_never_crashes(self) -> None:
+        """team-lead parallel-gate finding (2026-08-18): a non-string (and
+        possibly unhashable, e.g. a dict) entry in must_reference_facts
+        must never blow up `fact not in derived_set` with a bare TypeError
+        — that is exactly the "never a bare traceback for a data problem"
+        contract this module's own docstring commits to."""
+
+        for bad_entry in ({"typo": 1}, ["nested", "list"], 123, None):
+            findings = lint_must_reference_facts(
+                rule_id="el.x",
+                must_reference_facts=[bad_entry],
+                derived_facts=["intent.purposes"],
+            )
+            assert findings, f"expected a finding for {bad_entry!r}"
+            assert "is not a string" in findings[0].message
+
+    def test_guilt_unhashable_entry_end_to_end_via_compile_manifest(self) -> None:
+        """Same defect, exercised through the real entrypoint so a future
+        refactor of compile_manifest's must_reference_facts wiring can't
+        silently reopen the crash."""
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        manifest = {
+            "rules": [
+                {
+                    "product_code": "X",
+                    "claim_ids": ["CL-X-01"],
+                    "caveats": [],
+                    "must_reference_facts": [{"typo": 1}],
+                    "rule": _minimal_rule(),
+                }
+            ]
+        }
+        report = compile_manifest(manifest, ledger)  # must not raise
+        assert not report.ok
+        assert "is not a string" in report.render()
+
+
+# ---------------------------------------------------------------------------
 # Full compiler: end-to-end guilt + innocence
 # ---------------------------------------------------------------------------
 
@@ -368,7 +819,12 @@ class TestCompileManifest:
         ledger = {"CL-X-01": _rec("CL-X-01", "CONFLICTING")}
         manifest = {
             "rules": [
-                {"product_code": "X", "claim_ids": ["CL-X-01"], "caveats": [], "rule": _minimal_rule()}
+                {
+                    "product_code": "X",
+                    "claim_ids": ["CL-X-01"],
+                    "caveats": [],
+                    "rule": _minimal_rule(),
+                }
             ]
         }
         report = compile_manifest(manifest, ledger)
@@ -389,7 +845,12 @@ class TestCompileManifest:
         ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
         manifest = {
             "rules": [
-                {"product_code": "X", "claim_ids": ["CL-X-01"], "caveats": [], "rule": _minimal_rule()}
+                {
+                    "product_code": "X",
+                    "claim_ids": ["CL-X-01"],
+                    "caveats": [],
+                    "rule": _minimal_rule(),
+                }
             ]
         }
         report = compile_manifest(manifest, ledger)
@@ -413,6 +874,158 @@ class TestCompileManifest:
         report = compile_manifest(manifest, ledger)
         assert report.ok
         assert list(report.compiled[0].rule.required_facts) == ["intent.purposes"]
+
+    def test_guilt_unsatisfiable_when_fails_whole_report(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        rule = _minimal_rule(
+            rule_id="el.e33e.deposit-income-basis", when=_E33E_DEPOSIT_INCOME_BASIS_WHEN
+        )
+        manifest = {
+            "rules": [
+                {"product_code": "E33E", "claim_ids": ["CL-X-01"], "caveats": [], "rule": rule}
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert not report.ok
+        assert report.compiled == []
+        assert "UNSATISFIABLE" in report.render()
+
+    def test_guilt_duplicate_subtree_when_fails_whole_report(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        rule = _minimal_rule(rule_id="el.e33g.income-60k-manual", when=_E33G_INCOME_60K_MANUAL_WHEN)
+        manifest = {
+            "rules": [
+                {"product_code": "E33G", "claim_ids": ["CL-X-01"], "caveats": [], "rule": rule}
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert not report.ok
+        assert report.compiled == []
+        assert "structurally identical children" in report.render()
+
+    def test_guilt_must_reference_facts_declared_but_absent_fails(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        manifest = {
+            "rules": [
+                {
+                    "product_code": "X",
+                    "claim_ids": ["CL-X-01"],
+                    "caveats": [],
+                    "must_reference_facts": ["secondhome.passive_monthly_income_usd"],
+                    "rule": _minimal_rule(),
+                }
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert not report.ok
+        assert "secondhome.passive_monthly_income_usd" in report.render()
+
+    def test_innocence_must_reference_facts_declared_and_present_passes(self) -> None:
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        manifest = {
+            "rules": [
+                {
+                    "product_code": "X",
+                    "claim_ids": ["CL-X-01"],
+                    "caveats": [],
+                    "must_reference_facts": ["intent.purposes"],
+                    "rule": _minimal_rule(),
+                }
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert report.ok
+
+    def test_innocence_manifest_without_must_reference_facts_field_passes(self) -> None:
+        """Confirms the field is genuinely optional at the compile_manifest
+        level, not merely optional in the helper's signature."""
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        manifest = {
+            "rules": [
+                {
+                    "product_code": "X",
+                    "claim_ids": ["CL-X-01"],
+                    "caveats": [],
+                    "rule": _minimal_rule(),
+                }
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert report.ok
+
+    def test_guilt_falsy_non_list_must_reference_facts_is_rejected_not_swallowed(self) -> None:
+        """kimi-k3 finding (2026-08-18): `entry.get(...) or []` treated any
+        FALSY-but-present value (`""`, `0`, `False`) as if the field were
+        simply absent, silently skipping the "must be a list" check. Only
+        an explicit JSON null (or a genuinely missing key) should mean
+        "not declared"; anything else non-list is malformed."""
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        for falsy_non_list in ("", 0, False):
+            manifest = {
+                "rules": [
+                    {
+                        "product_code": "X",
+                        "claim_ids": ["CL-X-01"],
+                        "caveats": [],
+                        "must_reference_facts": falsy_non_list,
+                        "rule": _minimal_rule(),
+                    }
+                ]
+            }
+            report = compile_manifest(manifest, ledger)
+            assert not report.ok, f"expected rejection for must_reference_facts={falsy_non_list!r}"
+            assert "must be a list" in report.render()
+
+    def test_innocence_null_must_reference_facts_means_not_declared(self) -> None:
+        """Explicit JSON null IS treated as absent — distinguishing "not
+        declared" from "declared wrong" is the point of the fix above."""
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        manifest = {
+            "rules": [
+                {
+                    "product_code": "X",
+                    "claim_ids": ["CL-X-01"],
+                    "caveats": [],
+                    "must_reference_facts": None,
+                    "rule": _minimal_rule(),
+                }
+            ]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert report.ok
+
+    def test_guilt_synthetic_21_leaves_reports_note_and_still_compiles(self) -> None:
+        """End-to-end through `compile_manifest`: a `when` with 21 distinct
+        (real, FactPath-valid) leaves must skip the satisfiability check —
+        never brute-force it — and the skip note must be visible in the
+        rendered report even though the rule has no OTHER defect and
+        compiles clean. Silence is not success (task brief, verbatim)."""
+
+        from backend.services.visa_engine.enums import FactPath
+
+        # Exclude immigration.overstay_days — Lint 2 (R-OVERSTAY-PLANNING)
+        # flags any reference to it regardless of `op`, and this fixture is
+        # testing Lint 3's skip-note in isolation.
+        fact_paths = [f.value for f in FactPath if f.value != "immigration.overstay_days"]
+        assert len(fact_paths) >= 21, "need >=21 real FactPath members for this fixture"
+        leaves = [{"op": "known", "fact": fp} for fp in fact_paths[:21]]
+        when = {"op": "all", "args": leaves}
+
+        ledger = {"CL-X-01": _rec("CL-X-01", "VERIFIED")}
+        rule = _minimal_rule(rule_id="hf.synthetic-21", when=when)
+        manifest = {
+            "rules": [{"product_code": "X", "claim_ids": ["CL-X-01"], "caveats": [], "rule": rule}]
+        }
+        report = compile_manifest(manifest, ledger)
+        assert report.ok, report.render()
+        assert len(report.notes) == 1
+        assert "21 leaves > 20" in report.notes[0]
+        rendered = report.render()
+        assert "NOTES" in rendered
+        assert "21 leaves > 20" in rendered
 
 
 # ---------------------------------------------------------------------------

--- a/research/visa/doctrine-factory/e5/2026-08-18-e5-increment2-lints.md
+++ b/research/visa/doctrine-factory/e5/2026-08-18-e5-increment2-lints.md
@@ -1,0 +1,110 @@
+---
+date: 2026-08-18
+domain: visa
+client_case: none
+sources:
+  - apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-007.source.json (el.e33e.deposit-income-basis, el.e33g.income-60k-manual — real defects motivating this increment)
+  - apps/backend-rag/backend/scripts/visa_engine/compile_claims.py (E5 increment-1 compiler, PR #4283)
+adversarial_review: kimi-k3
+---
+
+# E5 doctrine-factory — increment 2: two more hard compile-time lints
+
+Increment 1 (PR #4283) shipped the claim-backed rule compiler
+(`compile_claims.py`) with two hard lints: VERIFIED-only (claim state) and
+R-OVERSTAY-PLANNING (condition structure). This increment adds two more,
+each motivated by a **real, currently-active defect** in
+`rulepack-prod-007.source.json` — not a hypothetical.
+
+## Lint 3 — UNSATISFIABLE-CONDITION
+
+`el.e33e.deposit-income-basis`'s `when` is logically unsatisfiable. Its
+outer `all` re-asserts the same four leaves (`bank_deposit_usd`,
+`bank_deposit_at_state_bank`, `bank_deposit_in_own_name`,
+`passive_monthly_income_usd`) that an inner branch demands the XOR of:
+one branch requires `D ∧ I` (deposit-conditions AND income all true), the
+other requires `(D ∧ ¬I) ∨ (¬D ∧ I)` (exactly one true). `D ∧ I ∧ (XOR)`
+is a contradiction — the rule can never fire, silently, forever.
+
+Verified by brute force over the boolean abstraction (every distinct leaf
+— by canonical-JSON identity — is an independent atom): 6 distinct
+leaves, 64 assignments, zero satisfy `when`.
+
+Implementation: `_compile_boolean_shape` walks `when` once, collecting
+every distinct leaf into a dict keyed by canonical JSON (so two
+occurrences of the *same* leaf collapse onto the *same* atom — this
+sharing is exactly what makes the E33E contradiction visible) and
+producing a compact `_Shape` tuple tree. `lint_unsatisfiable_condition`
+then brute-forces all `2**N` assignments against that shape. Sound for
+UNSAT-*by-structure* (independent atoms is the most permissive possible
+reading — if even that has no satisfying assignment, no stricter
+arithmetic-aware semantics can have one either); deliberately blind to
+*arithmetic* contradictions (`x>5 AND x<3` as two unrelated atoms) — that
+is a different, harder tool this lint does not attempt.
+
+**Declared limit**: a `when` with more than 20 distinct leaves is not
+brute-forced (2**20 assignments is already over a million per rule) — the
+compiler emits an explicit `"satisfiability not checked (N leaves > 20)"`
+report note instead of silently skipping. Verified by a dedicated test
+(`test_guilt_more_than_twenty_leaves_is_skipped_with_declared_note`) that
+asserts the note text is present, and by an end-to-end test through
+`compile_manifest` that a 21-leaf rule still compiles clean *with* the
+note visible in `report.render()`.
+
+## Lint 4 — VACUOUS-RULE
+
+`el.e33g.income-60k-manual` claims (by name) to gate on income, but its
+`when` is the same remote-work block literally duplicated twice — it
+references zero income facts, and the literal `60000` appears nowhere in
+the pack.
+
+Two mechanical checks (deliberately never inferring intent from the rule
+name or claim_ids — that is form, not entity):
+
+- **4a — duplicate-subtree**: an `all`/`any` node with two
+  structurally-identical (canonical-JSON-equal) children is a compile
+  error. The duplication itself is the smell; E33G's `all[A, A]` is
+  exactly this shape.
+- **4b — `must_reference_facts`** (optional manifest field): an author
+  declares `must_reference_facts: [fact paths]` on a rule entry, and the
+  compiler proves every listed fact actually appears in the `when`-derived
+  `required_facts` — a mechanical proof, not an inference.
+
+## Adversarial review
+
+kimi-k3 (`kimi -m kimi-code/k3`) reviewed the full diff. First attempt
+(8-minute timebox) got stuck in meta-planning about how to orchestrate
+the review and produced no disposition before being killed — noted, then
+retried once with a tighter "answer directly from the diff, no tools"
+prompt, which succeeded within its 5-minute timebox.
+
+| # | Finding | Disposition | Action |
+|---|---|---|---|
+| 1 | `condition.get("args", [])` doesn't apply its default when the manifest has `"args": null` (or any non-list) — iterating raises `TypeError` before schema validation ever runs, crashing the whole compile instead of producing a finding | ACCEPT | Added `_safe_args()` helper (treats non-list `args` as `[]`); used in `_compile_boolean_shape` and `_find_duplicate_subtrees`. Added guilt tests with `None`/string/int/dict `args` proving no crash. |
+| 2 | `{"op": "any", "args": []}` is Kleene-FALSE (genuinely unsatisfiable) but the original `if not leaves: return [], None` early-return passed it silently — a 0-leaf `when` was never actually evaluated | ACCEPT | Removed the early-return special case; the general brute-force loop already handles 0 leaves correctly (`2**0 == 1` assignment, evaluated for real). Added guilt tests for bare empty-`any` and empty-`any` nested under a real leaf. |
+| 3 | `_canonical_key` (via `json.dumps`) was re-run on every leaf for every one of up to `2**20` assignments — ~20M redundant serializations at the exact boundary the lint is documented to still check | ACCEPT | Merged leaf-collection and shape-compilation into one pass (`_compile_boolean_shape` → `_Shape` tuple tree with leaf keys pre-resolved); evaluation (`_evaluate_boolean_shape`) now touches plain tuples/strings, zero `json.dumps` per assignment. Measured: the 20-leaf boundary test dropped from ~3.0s to ~1.3s locally. |
+| 4 | `entry.get("must_reference_facts") or []` treated any falsy-but-present value (`""`, `0`, `False`) as if the field were absent, silently bypassing the "must be a list" rejection | ACCEPT (minor) | Rewrote to distinguish `None`/missing-key (→ not declared) from any other non-list value (→ rejected). Added guilt tests for `""`/`0`/`False` and an innocence test confirming explicit `null` still means "not declared". |
+| 5 | `test_innocence_simple_contradiction_by_shared_leaf_is_caught` asserts the lint *fires* — by the file's own guilt/innocence naming convention that's a guilt test; only the name was wrong | ACCEPT (cosmetic) | Renamed to `test_guilt_simple_contradiction_by_shared_leaf_is_caught`. |
+| 6 | The `>20` guard's off-by-one | DECLINE | 20-checked / 21-skipped matches the docstring and both boundary tests exactly; no logic error. |
+| 7 | Soundness of the independent-atoms abstraction | DECLINE | Correct relaxation argument, verified by hand: if the most permissive reading is UNSAT, no stricter arithmetic-aware semantics can be SAT. Documented arithmetic blindness is a disclosed completeness gap, not a soundness bug. |
+| 8 | The E33E fixture's UNSAT claim itself | DECLINE | Verified by hand (kimi and independently, here): 6 distinct leaves, `D ∧ I ∧ ((D∧¬I)∨(¬D∧I))`, genuinely UNSAT; fixture also does not false-positive Lint 4a. |
+| 9 | Possible `KeyError` on leaf lookup during evaluation | DECLINE | Collection and evaluation now share one traversal (`_compile_boolean_shape`), so this class of desync is structurally impossible — every leaf key evaluated was necessarily collected. |
+| 10 | Duplicate-subtree walk edge cases (`not`/`any` interaction, `first_index == 0`) | DECLINE | `is not None` (not truthiness) handles index 0 correctly; `not` recurses into `arg`; nested/deep duplicates are caught as the tests claim. |
+| 11 | Skip-note semantics (`report.ok` ignoring notes) | DECLINE | Intentional and tested — "declared limit, not silent skip" is the literal task-brief requirement. |
+| 12 | Test infrastructure (`_PACK_PATH`/`_REPO_ROOT` path arithmetic, boundary tests proving what they claim) | DECLINE | Verified: `parents[3]` from the test file resolves to `apps/backend-rag`; the 20-leaf test's `skip_note is None` assertion is only possible if the brute force actually ran. |
+
+Out-of-scope, explicitly declined by design (not raised by kimi, stated up
+front in the module docstring): arithmetic-contradiction solving
+(`x>5 AND x<3` as the same variable) — a different, much harder tool.
+
+## Verification
+
+```
+PYTHONPATH=. pytest backend/tests/scripts/test_visa_engine_compile_claims.py -v
+```
+
+61 passed (up from 26 pre-review, 53 after the initial guilt/innocence
+pass, +8 from the kimi-k3 findings above). Golden slice (26 rules across
+D1/D2/D12/E31B/E31D) unaffected — new lints report clean on every rule in
+`research/visa/doctrine-factory/e5/slice-rule-manifest.json`. `ruff
+format --check` / `ruff check` clean.


### PR DESCRIPTION
## Summary

Two more hard compile-time lints for the E5 claim-backed rule compiler (`compile_claims.py`, following PR #4283's VERIFIED-only + R-OVERSTAY-PLANNING), each motivated by a REAL defect confirmed in the active pack `rulepack-prod-007.source.json`:

- **UNSATISFIABLE-CONDITION**: brute-force satisfiability over a boolean abstraction (each distinct leaf condition, by canonical-JSON identity, treated as an independent atom) catches `el.e33e.deposit-income-basis` — its `when` requires both `D ∧ I` and `XOR(D, I)` simultaneously (D = deposit-conditions, I = passive income threshold), a genuine contradiction: the rule can never fire. Sound for UNSAT-by-*structure*; explicitly documented as blind to *arithmetic* contradictions (that's a different, harder tool). Skips — with an explicit report note, never silently — past 20 distinct leaves (2**20 assignments is already over a million per rule).
- **VACUOUS-RULE**: (a) duplicate-subtree detection catches `el.e33g.income-60k-manual`, whose `when` is the same remote-work block literally duplicated twice and references zero income facts despite the rule's name; (b) an optional `must_reference_facts` manifest field lets an author declare "this rule is about fact X" and have the compiler mechanically prove every listed fact actually appears in the derived `required_facts`.

Both lints run in `compile_manifest` alongside lints 1-2, findings named per `rule_id`, same `LintFinding` pattern. Guilt fixtures for both new lints use the REAL `when` trees copied verbatim from the pack (with anti-drift tests confirming they still match the pack on disk).

## Adversarial review

kimi-k3 reviewed the full diff (disposition table in `research/visa/doctrine-factory/e5/2026-08-18-e5-increment2-lints.md`). 5 real findings, all fixed:
1. Crash on malformed `args: null` (or any non-list) before schema validation ever runs — fixed with a `_safe_args()` guard.
2. Empty `any` (`{"op": "any", "args": []}`) is genuinely UNSAT but bypassed the check via an early "no leaves → pass" return — fixed by removing the special case (the general brute-force already handles 0 leaves correctly).
3. Perf: `json.dumps` was re-run per leaf per assignment (~20M calls at the 20-leaf boundary) — fixed by compiling `when` into a boolean shape once, then evaluating cheap tuples. Measured: the 20-leaf boundary test dropped from ~3.0s to ~1.3s locally.
4. `must_reference_facts` validation silently swallowed falsy-but-present non-list values (`""`, `0`, `False`) as "not declared" — fixed to only treat explicit `null`/missing-key as absent.
5. One misnamed test (asserted guilt, named "innocence") — renamed.

7 other candidate issues were examined and declined (verified correct: the >20 boundary, abstraction soundness, the E33E UNSAT claim by hand, KeyError-impossibility, duplicate-walk edge cases, skip-note semantics, test-path arithmetic) — full reasoning in the research note.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/scripts/test_visa_engine_compile_claims.py -v` → 61 passed
- [x] Golden slice (26 rules, D1/D2/D12/E31B/E31D) still compiles clean — unaffected by the new lints
- [x] `ruff format --check` / `ruff check` clean
- [x] kimi-k3 adversarial review — 5 findings fixed, 7 declined with reasoning (research note)

Not armed for auto-merge — orchestrator gates and arms per repo convention.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>