### PR TITLE
feat(ghostty): one fleet profile for Pro/M5/Mini, with install + verify

### DIFF
--- a/docs/runbooks/ghostty-fleet.md
+++ b/docs/runbooks/ghostty-fleet.md
@@ -1,0 +1,142 @@
+# Runbook — Ghostty across the fleet
+
+Config source and design: [`infra/ghostty/README.md`](../../infra/ghostty/README.md).
+This runbook covers operating it: installing, reloading, the ssh terminfo mesh,
+and the one integration that does **not** work in Ghostty.
+
+## Install / reinstall
+
+```bash
+bash infra/ghostty/install.sh --dry-run   # what would change
+bash infra/ghostty/install.sh             # backs up, installs, validates
+bash infra/ghostty/verify.sh              # proves it
+```
+
+The host is detected by hostname (`Nuzantara`→pro, `Air-M5`→m5, `Mini-Pro2`→mini);
+`--machine` overrides. If validation fails the installer restores the backup and
+exits non-zero — a machine is never left with a config Ghostty cannot load.
+
+**What a reload does and does not pick up.** `cmd+shift+comma` re-reads the
+config, but `background-opacity`, `background-blur` and the Dock icon only change
+on a full quit and relaunch. A reload that "did nothing" is usually this.
+
+## The two filenames trap
+
+Ghostty auto-reads **`config` and `config.ghostty`** and merges both. Measured
+load order on 1.3.1:
+
+1. top-level `config`
+2. top-level `config.ghostty`
+3. the files `config` included
+4. the files `config.ghostty` included
+
+An **included** file therefore always beats a top-level value — the reference is
+explicit that "configuration files do not take effect until after the entire
+configuration is loaded". A leftover `config.ghostty` does not cleanly override
+this profile: it loses every key the included files set and wins every key they
+do not. The installer retires it to `config.ghostty.retired-<stamp>`;
+`verify.sh` fails if one reappears.
+
+## SSH terminfo mesh
+
+`TERM=xterm-ghostty` is meaningless to a host that has never seen Ghostty. Before
+2026-08-18 neither M5 nor Mini knew it (`infocmp xterm-ghostty` exited 1 on both),
+so every ssh out of a Ghostty window degraded silently.
+
+`shell-integration-features = ssh-terminfo` installs it on first connect and
+caches the host. The cache is per-machine:
+
+```bash
+ghostty +ssh-cache                      # what this machine has already set up
+ghostty +ssh-cache --host=user@host     # is this one done?  (exit 1 = no)
+ghostty +ssh-cache --add=user@host      # record a manual install
+ghostty +ssh-cache --remove=user@host   # forget one
+```
+
+Cache targets are `user@hostname` **as `ssh -G <alias>` resolves them**, not the
+alias you type. Check with `ssh -G mini | awk '/^user |^hostname /'`. An alias
+that does not exist on that machine resolves to a literal, which caches a host
+that cannot be reached — remove such entries rather than leaving them.
+
+To install by hand (what the shell wrapper does internally):
+
+```bash
+infocmp -0 -x xterm-ghostty | ssh <host> 'tic -x -'
+ssh <host> 'infocmp xterm-ghostty >/dev/null 2>&1; echo rc=$?'   # 0 = installed
+```
+
+The `tic` warning about "older tic versions may treat the description field as an
+alias" is benign; judge by the `infocmp` exit code afterwards, not by the warning.
+
+**The wrapper is a shell function.** It exists only in interactive shells that
+loaded the shell integration. Ssh from a script, a cron job or an agent tool-call
+shell and none of this runs — which is why the cache can sit empty on a machine
+whose config has had `ssh-terminfo` enabled for a long time.
+
+## Agent-team panes do not open in Ghostty
+
+Claude Code hosts teammate panes in **tmux or iTerm2 only**. With
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set (it is, in `~/.claude/settings.json`)
+its backend registry resolves, in order:
+
+- inside tmux (`$TMUX` set) → panes in the current tmux session
+- inside iTerm2 → panes via the `it2` CLI, which additionally needs iTerm2's
+  Python API enabled _and iTerm2 running_
+- otherwise, tmux installed → an **external** tmux session you cannot see
+- otherwise → `No pane backend available`
+
+In a bare Ghostty window the third or fourth branch is taken. Observed live on
+2026-08-18: subagent spawns failing with _"Failed to create iTerm2 split pane —
+there was a problem connecting to iTerm2"_ while the operator was in Ghostty and
+iTerm2 was not running.
+
+**The fix is to run Claude Code inside tmux**, which makes the panes appear inside
+the Ghostty window:
+
+```bash
+tmux new-session -s claude    # then start claude inside it
+```
+
+tmux is installed on Pro (3.6a). It is **absent on M5**, the primary workstation —
+so there, agent teams have no backend at all until `brew install tmux`.
+
+Work that does not need a pane is unaffected: background agents, the Workflow
+tool, and MCP-hosted seats (for example the Codex second-opinion server) run as
+subprocesses and were used successfully from Ghostty on the same day.
+
+## Keys worth remembering
+
+|                         |                                                                 |
+| ----------------------- | --------------------------------------------------------------- |
+| `cmd+shift+p`           | command palette (built-ins **plus** the Nuzantara entries)      |
+| `cmd+f`                 | search the scrollback · `cmd+g` / `shift+cmd+g` next / previous |
+| `cmd+up` / `cmd+down`   | jump to the previous / next **shell prompt**                    |
+| `cmd+d` / `cmd+shift+d` | split right / down · `cmd+alt+arrows` to move between           |
+| `cmd+r` then arrows     | resize mode; `=` equalises, `esc` leaves                        |
+| `cmd+shift+enter`       | zoom the current split                                          |
+| `cmd+shift+s`           | dump the whole scrollback to a file and open it                 |
+| `cmd+alt+p`             | pin the window on top · `cmd+alt+o` toggle transparency         |
+| `cmd+alt+r`             | read-only mode (blocks input to a running job)                  |
+| `cmd+grave`             | quick terminal from anywhere (needs Accessibility)              |
+| `cmd+shift+comma`       | reload the config                                               |
+
+`global:` bindings need Ghostty in **System Settings → Privacy & Security →
+Accessibility**. Without the grant the binding is silently inert — there is no
+error, so verify by pressing it.
+
+## Recovery
+
+Every install leaves `~/.config/ghostty/.backup-<stamp>/`. To go back:
+
+```bash
+cp ~/.config/ghostty/.backup-<stamp>/* ~/.config/ghostty/
+```
+
+For a one-machine tweak that must survive reinstalls, use
+`~/.config/ghostty/local.ghostty` — loaded last, never installed, never in git.
+It is included with a `?` prefix, so it is optional; but if it exists and is
+**invalid**, the whole config fails to load. Validate after editing:
+
+```bash
+ghostty +validate-config; echo "rc=$?"
+```

--- a/infra/ghostty/README.md
+++ b/infra/ghostty/README.md
@@ -1,0 +1,117 @@
+# Ghostty — Nuzantara fleet profile
+
+The terminal Antonello actually works in, on Pro / M5 / Mini, kept in one place
+and under review instead of drifting per machine.
+
+## Why this exists
+
+Before this, the fleet ran three different terminals under one name. Measured
+on 2026-08-18:
+
+| | Pro | M5 | Mini |
+|---|---|---|---|
+| config file | `config.ghostty` (53 keys) | `config` (22 keys) | none at all |
+| theme | Catppuccin Mocha | Catppuccin Macchiato | Ghostty default |
+| font | `…Nerd Font Mono` | `…Nerd Font` | no Nerd font installed |
+| ssh terminfo | on | **off** | — |
+| splits / resize keys | none | yes | — |
+| clipboard guards | yes | **none** | — |
+
+Neither machine was wrong; they had simply been written months apart and never
+reconciled. `~/.config` is not a git repository, so there was also no history
+and no backup of either.
+
+## Layout
+
+```
+infra/ghostty/
+├── config              → installed as ~/.config/ghostty/config   (the entry point)
+├── fleet.ghostty       → ~/.config/ghostty/fleet.ghostty         (shared base)
+├── keys.ghostty        → ~/.config/ghostty/keys.ghostty          (keybinds + palette)
+├── machines/
+│   ├── pro.ghostty     ─┐
+│   ├── m5.ghostty       ├→ ~/.config/ghostty/machine.ghostty     (one per host)
+│   └── mini.ghostty    ─┘
+├── install.sh          back up → install → validate → roll back on failure
+└── verify.sh           prove it is installed, current, and working
+```
+
+`~/.config/ghostty/local.ghostty` is yours: never installed, never in git,
+loaded last, optional (`?` prefix). Put one-machine experiments there.
+
+## Use
+
+```bash
+bash infra/ghostty/install.sh --dry-run   # what would change
+bash infra/ghostty/install.sh             # do it (backs up first)
+bash infra/ghostty/verify.sh              # prove it
+```
+
+The machine is detected by hostname; `--machine pro|m5|mini` overrides it.
+Reload a running Ghostty with `cmd+shift+comma`. **Opacity, blur and the Dock
+icon need a full quit and relaunch** — a reload will not show them.
+
+Drift between the installed copy and this directory is caught two ways: locally
+by `verify.sh`, and fleet-wide by `scripts/lint_home_fork.py --check`, which
+arbitrates against `origin/main` rather than the local checkout (that
+distinction is the W106b scar: on a machine whose checkout is behind, the naive
+comparison blames the copy that is actually current).
+
+## Config mechanics worth knowing
+
+Measured against Ghostty 1.3.1 on macOS 27.0, not assumed:
+
+- Ghostty auto-reads **two** filenames: `config` and `config.ghostty`. Both are
+  read and merged when both exist.
+- **An included file always beats a top-level value.** The reference is explicit:
+  "configuration files do not take effect until after the entire configuration is
+  loaded." Measured order: top-level `config` → top-level `config.ghostty` →
+  `config`'s includes → `config.ghostty`'s includes.
+- Among includes, **declaration order wins later**: `fleet` → `keys` → `machine`
+  → `local`.
+- Relative include paths resolve against the directory of the file holding the
+  directive — **not** the process working directory, and **not** the symlink
+  target if the file is reached through a symlink.
+- `~` is expanded in include paths. `$HOME` is **not** (it fails loudly).
+- `?` before a path suppresses the error when the file is absent. Without it, one
+  missing include makes the whole configuration fail to load.
+- `scrollback-limit` is in **bytes, per surface** — not lines, not per app.
+
+## Two defects this profile addresses
+
+**`xterm-ghostty` is unknown across the fleet.** `infocmp xterm-ghostty` exits 1
+on both M5 and Mini, so every ssh out of a Ghostty window landed on a host that
+could not describe the terminal. `shell-integration-features` now carries
+`ssh-terminfo` (installs it on first connect, then caches the host) and
+`ssh-env` (carries `COLORTERM`, and falls back to `xterm-256color` when the
+install cannot happen). Check what has been cached with `ghostty +ssh-cache`.
+
+**Nothing told you a long job had finished.** `notify-on-command-finish =
+unfocused` with a 45s floor sends a macOS notification for deploys, test suites
+and LLM panels — but only when you are looking elsewhere, and only for your own
+interactive commands (it rides on OSC 133, which non-interactive tool shells do
+not emit).
+
+## Machine identity
+
+Each host owns a colour, carried by the cursor, the split dividers and the Dock
+icon: **Pro peach `#fab387`**, **M5 blue `#89b4fa`**, **Mini green `#a6e3a1`**.
+It costs nothing and makes a screenshot, a screen-share or a Vision Pro virtual
+display name its own machine.
+
+`macos-icon = custom-style` is flagged experimental upstream ("we may change the
+format of the custom styles in the future"). If a future release rejects it,
+`verify.sh` fails loudly and the fix is to drop three lines from the machine
+profile.
+
+## Known gaps
+
+- **Mini has no Nerd font.** The fleet `font-family` silently falls back to plain
+  `JetBrains Mono`, which has no icon glyphs, so prompt segments render as tofu.
+  `verify.sh` reports this rather than letting it pass unseen. Fix:
+  `brew install --cask font-jetbrains-mono-nerd-font`.
+- **Agent-team panes do not open in Ghostty.** Claude Code hosts teammate panes
+  in tmux or iTerm2 only; in a bare Ghostty window it falls back to an external
+  tmux session or fails outright. Running Claude Code inside `tmux` makes panes
+  appear in the Ghostty window. tmux is installed on Pro (3.6a) and absent on M5.
+  See `docs/runbooks/ghostty-fleet.md`.

--- a/infra/ghostty/config
+++ b/infra/ghostty/config
@@ -1,0 +1,35 @@
+# ═══════════════════════════════════════════════════════════════════════════
+#  Ghostty · ENTRY POINT  →  installed as ~/.config/ghostty/config
+#
+#  Ghostty auto-reads exactly two filenames in this directory: `config` and
+#  `config.ghostty`. When both exist BOTH are read and merged. Measured load
+#  order on 1.3.1 (four compositions, 2026-08-18):
+#
+#     1. config              (top-level values)
+#     2. config.ghostty      (top-level values — these beat config's)
+#     3. the files config included
+#     4. the files config.ghostty included   (these beat everything)
+#
+#  Two consequences, both counter-intuitive:
+#    · An INCLUDED file always beats a top-level value, in either file. That is
+#      documented: "configuration files do not take effect until after the
+#      entire configuration is loaded."
+#    · So a leftover `config.ghostty` does not cleanly override this setup — it
+#      loses on every key our included files set, and wins on every key they do
+#      not. A patchwork, which is harder to reason about than a clean override.
+#      That is why the installer retires it instead of leaving it alone.
+#
+#  Within the includes below, order is declaration order and LATER WINS:
+#     fleet  →  keys  →  machine  →  local
+#  Relative paths resolve against the directory of the file holding the
+#  directive (this one), and `~` is expanded — `$HOME` is NOT.
+# ═══════════════════════════════════════════════════════════════════════════
+
+config-file = fleet.ghostty
+config-file = keys.ghostty
+config-file = machine.ghostty
+
+# Optional, never in git, always last: scratch overrides for one machine or one
+# afternoon. The leading `?` means "no error if absent" — verified: without it,
+# a missing file makes the whole config fail to load.
+config-file = ?local.ghostty

--- a/infra/ghostty/fleet.ghostty
+++ b/infra/ghostty/fleet.ghostty
@@ -1,0 +1,159 @@
+# ═══════════════════════════════════════════════════════════════════════════
+#  Ghostty · Nuzantara FLEET BASE
+#  Shared by Pro / M5 / Mini. Machine-specific settings live in machine.ghostty,
+#  which is loaded AFTER this file and therefore wins.
+#
+#  Canonical source: infra/ghostty/fleet.ghostty  (this repo)
+#  Installed copy:   ~/.config/ghostty/fleet.ghostty
+#  Drift is caught by scripts/lint_home_fork.py (declared in
+#  infra/home-fork/declared-pairs.json) — never edit the installed copy.
+#
+#  Every value below was verified against the reference shipped INSIDE the
+#  installed app (Contents/Resources/ghostty/doc/ghostty.5.md, Ghostty 1.3.1),
+#  not against web docs, which may describe another release.
+#  Reload after edits: cmd+shift+comma. Opacity/blur changes need a full restart.
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ─── Typography ────────────────────────────────────────────────────────────
+# "…Nerd Font Mono" (not plain "…Nerd Font") is deliberate: the Mono variant
+# constrains icon glyphs to a single cell, so powerline/devicon segments in the
+# starship prompt cannot overlap the next column. Both names resolve on Pro and
+# M5; an unresolvable name silently falls back to plain "JetBrains Mono", which
+# has NO Nerd glyphs — so this string is load-bearing, not cosmetic.
+font-family = JetBrainsMono Nerd Font Mono
+font-size = 14
+
+# Ligatures OFF. In a terminal that shows diffs, regexes and shell operators,
+# `!=` `->` `=>` `>=` rendered as single glyphs hide the real character count.
+font-feature = -calt
+font-feature = -liga
+font-feature = -dlig
+
+# Retina stem-darkening. 128 = midpoint of the documented 0-255 range.
+font-thicken = true
+font-thicken-strength = 128
+
+# Alpha blending in linear space WITH the correction step: removes the dark
+# fringing around glyph edges that transparency introduces, while keeping the
+# weight identical to macOS-native blending. Matters because we run at 0.94.
+alpha-blending = linear-corrected
+
+# ─── Colour ────────────────────────────────────────────────────────────────
+# Catppuccin Mocha fleet-wide. Chosen (over Macchiato, which M5 previously ran)
+# because BAT_THEME is already 'Catppuccin Mocha': one palette, whole terminal.
+theme = Catppuccin Mocha
+
+# WCAG contrast floor. 1 = no floor, 21 = max. 1.5 rescues unreadable
+# foreground/background pairs emitted by TUIs without repainting the theme.
+minimum-contrast = 1.5
+
+# ─── Window & glass ────────────────────────────────────────────────────────
+# macos-glass-regular is a real value on macOS >= 26 and needs background-opacity
+# < 1 to have any effect. Measured 2026-08-18: Pro and M5 run 27.0, Mini runs
+# 26.6.1 — all three clear the floor, but the fleet is NOT on one OS version.
+background-opacity = 0.94
+background-blur = macos-glass-regular
+unfocused-split-opacity = 0.82
+
+window-padding-x = 12
+window-padding-y = 10
+window-padding-balance = true
+window-padding-color = background
+window-vsync = true
+window-save-state = always
+window-inherit-working-directory = true
+window-inherit-font-size = true
+tab-inherit-working-directory = true
+split-inherit-working-directory = true
+
+# 'transparent' is Ghostty's own default and lets the window background reach
+# the titlebar. If the glass effect ever renders artefacts against it, the
+# escape hatch is `macos-titlebar-style = hidden` in machine.ghostty — at the
+# cost of losing titlebar window-dragging.
+macos-titlebar-style = transparent
+macos-window-shadow = true
+macos-dock-drop-behavior = new-tab
+
+# ─── Scrollback ────────────────────────────────────────────────────────────
+# UNITS ARE BYTES, PER SURFACE — not lines, and not per application. Ten splits
+# means ten times this number. 32 MB holds a very long Claude Code session while
+# staying well clear of the swap pressure measured on Pro (10.3 GB of 11.3 GB
+# in use). Raise it per-machine, never fleet-wide.
+scrollback-limit = 32000000
+
+# Keep the viewport still while output streams past; only your own keystrokes
+# jump to the bottom. Without this, reading scrollback during a long build is
+# a fight against the terminal.
+scroll-to-bottom = keystroke,no-output
+
+# ─── Cursor & mouse ────────────────────────────────────────────────────────
+cursor-style = block
+cursor-style-blink = false
+mouse-hide-while-typing = true
+
+# ─── Long-running commands ─────────────────────────────────────────────────
+# Deploys, pytest suites, LLM panels and fly builds outlive your attention.
+# 'unfocused' notifies only when you are looking at something else; 45s keeps
+# ordinary commands silent. Requires OSC 133, which the shell integration below
+# provides — so it fires for YOUR interactive commands, not for tool-call shells.
+notify-on-command-finish = unfocused
+notify-on-command-finish-after = 45s
+notify-on-command-finish-action = no-bell,notify
+
+# Silent bell: mark the tab, never make noise.
+bell-features = no-system,no-audio,attention,title
+
+# ─── Shell integration ─────────────────────────────────────────────────────
+# ssh-terminfo is the fix for the daily fleet defect: xterm-ghostty is unknown
+# on both M5 and Mini (`infocmp xterm-ghostty` exits 1 there), so every ssh from
+# a Ghostty window used to land on a terminal the remote could not describe.
+# With this on, the first ssh to a host installs the terminfo via tic and caches
+# the host; ssh-env carries COLORTERM/TERM_PROGRAM and provides the
+# xterm-256color fallback when the install cannot happen.
+shell-integration = detect
+shell-integration-features = cursor,sudo,title,ssh-env,ssh-terminfo,path
+
+# ─── Clipboard & selection ─────────────────────────────────────────────────
+# copy-on-select stays OFF: selecting text to READ it must never overwrite the
+# clipboard you were about to paste. Middle-click paste keeps working regardless.
+copy-on-select = false
+selection-clear-on-copy = true
+clipboard-read = ask
+clipboard-write = allow
+clipboard-paste-protection = true
+clipboard-paste-bracketed-safe = true
+clipboard-trim-trailing-spaces = true
+
+# Treat '/' '.' '-' '_' as part of a word so a double-click grabs a whole path
+# or a whole flag, which is what you actually want to copy in this repo.
+selection-word-chars = " \t'\"│`|:;,()[]{}<>$"
+
+link-url = true
+link-previews = true
+
+# ─── macOS behaviour ───────────────────────────────────────────────────────
+# LEFT option becomes Alt (so alt+f / alt+b / alt+. work in zsh); RIGHT option
+# keeps macOS dead-key composition, which on this ABC layout is how à è é ì ò ù
+# are typed. Do not change this to plain `true` — it would break Italian input.
+macos-option-as-alt = left
+
+# Secure Input blocks other processes from reading keystrokes at password
+# prompts. It also blocks accessibility-API keystroke capture, which is the
+# same vector that took the M5 keyboard on 2026-08-16 — keep it armed.
+macos-auto-secure-input = true
+macos-secure-input-indication = true
+
+# ─── Safety ────────────────────────────────────────────────────────────────
+confirm-close-surface = true
+# Closing a split or tab stays undoable for two minutes instead of five seconds.
+# Deliberately not longer: an un-expired undo keeps the closed session ALIVE, and
+# the reference warns that a large timeout makes "terminal sessions never
+# actually quit". Pro was measured at 10.3 GB of 11.3 GB swap in use — two
+# minutes is enough to catch a mis-click, short enough that things actually die.
+undo-timeout = 2m
+
+# ─── Updates ───────────────────────────────────────────────────────────────
+# Download in the background, install on your say-so. Never silently swap the
+# binary under a running session.
+auto-update = download
+auto-update-channel = stable

--- a/infra/ghostty/install.sh
+++ b/infra/ghostty/install.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════
+#  Install the Nuzantara Ghostty profile onto THIS machine.
+#
+#    bash infra/ghostty/install.sh              # install (backs up first)
+#    bash infra/ghostty/install.sh --dry-run    # show what would change
+#    bash infra/ghostty/install.sh --machine m5 # force a profile
+#
+#  Safe by construction: it backs up whatever is already there, installs, then
+#  VALIDATES — and if validation fails it restores the backup and exits non-zero.
+#  A machine is never left with a config Ghostty cannot load.
+# ═══════════════════════════════════════════════════════════════════════════
+set -uo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST_DIR="${GHOSTTY_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/ghostty}"
+# Ghostty discovers its config as <XDG_CONFIG_HOME>/ghostty/config, so to make
+# any check act on the directory we are actually writing to — not on whatever
+# the invoking shell happens to point at — we validate with XDG_CONFIG_HOME set
+# to this directory's parent. With the default destination that is exactly the
+# normal lookup; with an overridden one it is the difference between proving
+# this install and proving an unrelated file.
+XDG_PARENT="$(dirname "$DEST_DIR")"
+GHOSTTY_BIN="${GHOSTTY_BIN:-/Applications/Ghostty.app/Contents/MacOS/ghostty}"
+DRY_RUN=0
+FORCE_MACHINE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --machine) FORCE_MACHINE="${2:-}"; shift ;;
+    -h|--help) sed -n '2,14p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+die() { echo "FAIL: $*" >&2; exit 1; }
+say() { echo "  $*"; }
+
+# ── Which machine is this? ─────────────────────────────────────────────────
+# By hostname, because the username is not unique across the fleet (Pro and
+# Mini are both `nuzantara`) and the hostname is.
+detect_machine() {
+  local h; h="$(hostname -s 2>/dev/null || hostname)"
+  case "$h" in
+    Nuzantara|nuzantara)     echo pro  ;;
+    Air-M5|air-m5)           echo m5   ;;
+    Mini-Pro2|mini-pro2)     echo mini ;;
+    *) return 1 ;;
+  esac
+}
+
+MACHINE="${FORCE_MACHINE:-$(detect_machine || true)}"
+[ -n "$MACHINE" ] || die "unrecognised host '$(hostname -s)'. Pass --machine pro|m5|mini."
+[ -f "$SRC_DIR/machines/$MACHINE.ghostty" ] || die "no profile for machine '$MACHINE'"
+
+echo "Ghostty profile install"
+say "machine : $MACHINE  ($(hostname -s), $(sw_vers -productVersion 2>/dev/null))"
+say "source  : $SRC_DIR"
+say "dest    : $DEST_DIR"
+
+[ "$(basename "$DEST_DIR")" = "ghostty" ] || die "destination must be a directory named 'ghostty' (got $DEST_DIR) — Ghostty only looks for <config-home>/ghostty/config"
+[ -x "$GHOSTTY_BIN" ] || die "Ghostty binary not found at $GHOSTTY_BIN"
+say "ghostty : $("$GHOSTTY_BIN" --version 2>/dev/null | head -1)"
+
+# ── What we are about to place ─────────────────────────────────────────────
+# machine.ghostty is a COPY of machines/<machine>.ghostty under a fixed name,
+# so ~/.config/ghostty/config can include one stable filename on every host.
+declare -a PLAN=(
+  "$SRC_DIR/config|$DEST_DIR/config"
+  "$SRC_DIR/fleet.ghostty|$DEST_DIR/fleet.ghostty"
+  "$SRC_DIR/keys.ghostty|$DEST_DIR/keys.ghostty"
+  "$SRC_DIR/machines/$MACHINE.ghostty|$DEST_DIR/machine.ghostty"
+)
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo
+  echo "DRY RUN — nothing will be written."
+  for p in "${PLAN[@]}"; do
+    src="${p%%|*}"; dst="${p##*|}"
+    if [ -f "$dst" ] && cmp -s "$src" "$dst"; then
+      say "same     $dst"
+    elif [ -f "$dst" ]; then
+      say "REPLACE  $dst"
+    else
+      say "create   $dst"
+    fi
+  done
+  # The stale-name trap: `config.ghostty` is read TOO and merged in, winning on
+  # every key this profile does not set. Leaving it produces a patchwork config.
+  [ -f "$DEST_DIR/config.ghostty" ] && say "RETIRE   $DEST_DIR/config.ghostty  (merges in and wins on keys this profile leaves unset)"
+  exit 0
+fi
+
+# ── Back up ────────────────────────────────────────────────────────────────
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP="$DEST_DIR/.backup-$STAMP"
+mkdir -p "$DEST_DIR" || die "cannot create $DEST_DIR"
+if compgen -G "$DEST_DIR/*" >/dev/null 2>&1; then
+  mkdir -p "$BACKUP" || die "cannot create backup dir"
+  for f in "$DEST_DIR"/*; do
+    [ -f "$f" ] || continue
+    cp -p "$f" "$BACKUP/" || die "backup of $f failed"
+  done
+  say "backup  : $BACKUP  ($(find "$BACKUP" -type f | wc -l | tr -d ' ') file/s)"
+else
+  say "backup  : nothing to back up (fresh install)"
+  BACKUP=""
+fi
+
+restore() {
+  [ -n "$BACKUP" ] || return 0
+  echo "  rolling back from $BACKUP" >&2
+  rm -f "$DEST_DIR"/config "$DEST_DIR"/fleet.ghostty "$DEST_DIR"/keys.ghostty "$DEST_DIR"/machine.ghostty
+  for f in "$BACKUP"/*; do [ -f "$f" ] && cp -p "$f" "$DEST_DIR/"; done
+}
+
+# ── Install ────────────────────────────────────────────────────────────────
+for p in "${PLAN[@]}"; do
+  src="${p%%|*}"; dst="${p##*|}"
+  cp "$src" "$dst" || { restore; die "copy failed: $src -> $dst"; }
+  say "wrote   : $dst"
+done
+
+# Retire the stale filename rather than deleting it: it must not remain (it
+# merges in and wins on any key this profile leaves unset), but the previous
+# content is kept on disk under a dated name in case something in it is wanted.
+if [ -f "$DEST_DIR/config.ghostty" ]; then
+  mv "$DEST_DIR/config.ghostty" "$DEST_DIR/config.ghostty.retired-$STAMP" \
+    || { restore; die "could not retire config.ghostty"; }
+  say "retired : config.ghostty -> config.ghostty.retired-$STAMP"
+fi
+
+# ── Prove it loads ─────────────────────────────────────────────────────────
+# rc captured on its own line: a pipe would hide it (this is the W97 lesson).
+VOUT="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +validate-config 2>&1)"; VRC=$?
+if [ $VRC -ne 0 ]; then
+  echo "  validation FAILED (rc=$VRC):" >&2
+  echo "$VOUT" >&2
+  restore
+  die "config rejected by Ghostty — previous config restored, nothing lost."
+fi
+say "validate: OK (rc=0)"
+
+echo
+echo "Installed. Reload a running Ghostty with cmd+shift+comma."
+echo "Opacity, blur and the Dock icon need a full quit and relaunch."
+echo "Verify with: bash $SRC_DIR/verify.sh"

--- a/infra/ghostty/keys.ghostty
+++ b/infra/ghostty/keys.ghostty
@@ -1,0 +1,83 @@
+# ═══════════════════════════════════════════════════════════════════════════
+#  Ghostty · Nuzantara KEYBINDS + COMMAND PALETTE
+#  Loaded by ~/.config/ghostty/config after fleet.ghostty.
+#  `ghostty +list-keybinds` prints the effective set (defaults included).
+# ═══════════════════════════════════════════════════════════════════════════
+#
+#  Ghostty already ships the macOS conventions — cmd+t/w/n tabs and windows,
+#  cmd+c/v, cmd+f scrollback search (new in 1.3), cmd+g / shift+cmd+g to walk
+#  results, cmd+1..9, cmd+home/end. Nothing below re-declares those; this file
+#  only adds what is missing.
+
+# ─── Splits ────────────────────────────────────────────────────────────────
+keybind = cmd+d=new_split:right
+keybind = cmd+shift+d=new_split:down
+keybind = cmd+shift+enter=toggle_split_zoom
+keybind = cmd+alt+left=goto_split:left
+keybind = cmd+alt+right=goto_split:right
+keybind = cmd+alt+up=goto_split:up
+keybind = cmd+alt+down=goto_split:down
+
+# Keep a zoomed split zoomed while you move between splits, instead of
+# collapsing the layout on every navigation.
+split-preserve-zoom = navigation
+
+# ─── Resize mode (modal, tmux-style) ───────────────────────────────────────
+# cmd+r enters the table; arrows resize; '=' equalises; esc leaves.
+# There is no timeout on key tables — esc is the only way out, so it is bound.
+keybind = cmd+r=activate_key_table:resize
+keybind = resize/left=resize_split:left,10
+keybind = resize/right=resize_split:right,10
+keybind = resize/up=resize_split:up,10
+keybind = resize/down=resize_split:down,10
+keybind = resize/equal=equalize_splits
+keybind = resize/escape=deactivate_key_table
+
+# ─── Reading long sessions ─────────────────────────────────────────────────
+# Walk backwards and forwards between shell PROMPTS. This is the single most
+# useful binding for a 40k-line Claude Code session: it steps command by
+# command instead of line by line. Depends on OSC 133 from shell integration.
+keybind = cmd+up=jump_to_prompt:-1
+keybind = cmd+down=jump_to_prompt:1
+
+# Dump the whole scrollback to a file and open it — the honest way to keep a
+# long run for later, rather than scrolling and copying by hand.
+keybind = cmd+shift+s=write_scrollback_file:open
+# Same for the visible screen, path to clipboard instead of opening.
+keybind = cmd+alt+s=write_screen_file:copy
+
+# ─── Window control ────────────────────────────────────────────────────────
+# Pin a window above everything else — for a log tail or a monitor split you
+# want to keep visible while working in another app.
+keybind = cmd+alt+p=toggle_window_float_on_top
+# Momentarily make the background fully opaque when transparency hurts reading.
+keybind = cmd+alt+o=toggle_background_opacity
+# Read-only mode: blocks input to the pty. Useful when a long job is running
+# and a stray keystroke would be sent into it.
+keybind = cmd+alt+r=toggle_readonly
+
+# ─── Config & palette ──────────────────────────────────────────────────────
+keybind = cmd+shift+comma=reload_config
+keybind = cmd+shift+p=toggle_command_palette
+
+# ─── Quick terminal ────────────────────────────────────────────────────────
+# Drops a terminal from the top of the screen over any app.
+# `global:` requires the Accessibility permission for Ghostty in
+# System Settings > Privacy & Security > Accessibility. Without the grant the
+# binding is simply inert — it fails silently, so verify it after install.
+keybind = global:cmd+grave_accent=toggle_quick_terminal
+
+# ─── Command palette: Nuzantara entries ────────────────────────────────────
+# These APPEND to Ghostty's built-in palette (they do not replace it).
+# Every one of them TYPES the command and stops — no trailing newline, so
+# nothing executes until you read it and press enter yourself. That is
+# deliberate: a palette that runs commands is a palette that runs the wrong
+# command eventually.
+command-palette-entry = title:"Nuzantara: repo status",description:"git status in the monorepo (type only, not executed).",action:"text:git -C ~/nuzantara status --short --branch"
+command-palette-entry = title:"Nuzantara: worktree list",description:"List agent worktrees (type only, not executed).",action:"text:git -C ~/nuzantara worktree list"
+command-palette-entry = title:"Nuzantara: new agent worktree",description:"Broker a fresh isolated worktree (type only — fill in lane and task).",action:"text:python3 ~/nuzantara/scripts/agent_start.py --lane ops --task-id "
+command-palette-entry = title:"Nuzantara: proprioception report",description:"Show the last fleet self-check (type only, not executed).",action:"text:cat ~/.nuzantara-proprioception/last.md"
+command-palette-entry = title:"Nuzantara: escalations board",description:"HIGH-first escalation board (type only, not executed).",action:"text:python3 ~/nuzantara/scripts/pending_arms_report.py"
+command-palette-entry = title:"Nuzantara: HOME-fork lint",description:"Check live-vs-repo drift for declared pairs (type only, not executed).",action:"text:python3 ~/nuzantara/scripts/lint_home_fork.py --check"
+command-palette-entry = title:"Ghostty: verify this config",description:"Validate the installed Ghostty config and prove which files were read.",action:"text:bash ~/nuzantara/infra/ghostty/verify.sh"
+command-palette-entry = title:"Ghostty: ssh terminfo cache",description:"List hosts that already have xterm-ghostty installed.",action:"text:ghostty +ssh-cache"

--- a/infra/ghostty/machines/m5.ghostty
+++ b/infra/ghostty/machines/m5.ghostty
@@ -1,0 +1,25 @@
+# ── Ghostty · machine profile: M5 (balizero@Air-M5, M5 24GB) ───────────────
+# Loaded AFTER fleet.ghostty, so anything here overrides the fleet base.
+# Role: THE interactive workstation. Antonello works here 100% of the time.
+# Deliberately light: no daemons, no cron, no Ollama.
+# NOTE the different home — this machine's user is `balizero`, not `nuzantara`.
+
+working-directory = /Users/balizero/nuzantara
+
+# Slightly larger type than Pro: this is a laptop panel and it is where the
+# actual reading happens. Preserved from the profile that was already here.
+font-size = 15
+
+# Identity: BLUE. M5 is the primary seat.
+cursor-color = #89b4fa
+cursor-text = #1e1e2e
+split-divider-color = #89b4fa
+
+macos-icon = custom-style
+macos-icon-frame = chrome
+macos-icon-ghost-color = #89b4fa
+macos-icon-screen-color = #1e1e2e,#1e2a3a
+
+# 24 GB and a full interactive load — keep scrollback at the fleet default.
+window-width = 124
+window-height = 36

--- a/infra/ghostty/machines/mini.ghostty
+++ b/infra/ghostty/machines/mini.ghostty
@@ -1,0 +1,29 @@
+# ── Ghostty · machine profile: MINI (nuzantara@Mini-Pro2, M4 Pro 24GB) ─────
+# Loaded AFTER fleet.ghostty, so anything here overrides the fleet base.
+# Role: H24 server — Ollama, heavy cron, batch. Sits in the office on its own
+# ISP line and is reached over Tailscale, never the LAN.
+# Ghostty here is for the occasional hands-on session, not daily driving.
+
+working-directory = /Users/nuzantara/nuzantara
+
+# Identity: GREEN. Mini is the one that is supposed to be always up.
+cursor-color = #a6e3a1
+cursor-text = #1e1e2e
+split-divider-color = #a6e3a1
+
+macos-icon = custom-style
+macos-icon-frame = plastic
+macos-icon-ghost-color = #a6e3a1
+macos-icon-screen-color = #1e1e2e,#1e2f24
+
+# Measured 2026-08-18: this machine has NO Nerd Font installed, so the fleet's
+# font-family falls back to plain "JetBrains Mono" and powerline/devicon glyphs
+# in the starship prompt render as tofu. Fix by installing the font
+# (`brew install --cask font-jetbrains-mono-nerd-font`) rather than by changing
+# the fleet font — the fallback is silent, which is exactly why it is noted here.
+
+# Server: a hands-on session is rare and usually short. Smaller buffer, and the
+# box is doing real work with its 24 GB.
+scrollback-limit = 16000000
+window-width = 120
+window-height = 34

--- a/infra/ghostty/machines/pro.ghostty
+++ b/infra/ghostty/machines/pro.ghostty
@@ -1,0 +1,23 @@
+# ── Ghostty · machine profile: PRO (nuzantara@Nuzantara, M4 Pro 48GB) ──────
+# Loaded AFTER fleet.ghostty, so anything here overrides the fleet base.
+# Role: primary dev + H24 workhorse. Runs the daemons, the heavy models, cron.
+
+working-directory = /Users/nuzantara/nuzantara
+
+# Identity: PEACH. Pro is the workhorse.
+# Cursor, split dividers and the Dock icon carry the machine colour, so a
+# screenshot, a screen-share or a Vision Pro virtual display names its own
+# machine without you reading the prompt.
+cursor-color = #fab387
+cursor-text = #1e1e2e
+split-divider-color = #fab387
+
+macos-icon = custom-style
+macos-icon-frame = aluminum
+macos-icon-ghost-color = #fab387
+macos-icon-screen-color = #1e1e2e,#302438
+
+# 48 GB of RAM, but swap measured at 10.3 GB of 11.3 GB in use on 2026-08-18.
+# The fleet's 32 MB per surface stands; raise it here only after re-measuring.
+window-width = 132
+window-height = 38

--- a/infra/ghostty/verify.sh
+++ b/infra/ghostty/verify.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════
+#  Prove the installed Ghostty profile is real, current, and doing its job.
+#
+#    bash infra/ghostty/verify.sh
+#
+#  Exit codes are a bit field, so several problems report at once:
+#      1  config invalid or absent
+#      2  installed copy has DRIFTED from the repo source
+#      4  a declared capability is not actually working
+#  0 means every check below passed.
+#
+#  This script reports; it never repairs. Each check states what it measured,
+#  and a check that cannot run says so rather than passing quietly.
+# ═══════════════════════════════════════════════════════════════════════════
+set -uo pipefail
+
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST_DIR="${GHOSTTY_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/ghostty}"
+# Every ghostty invocation below is pinned to the directory we are verifying
+# (see the note in install.sh) so a check can never pass by reading a config
+# other than the installed one.
+XDG_PARENT="$(dirname "$DEST_DIR")"
+GHOSTTY_BIN="${GHOSTTY_BIN:-/Applications/Ghostty.app/Contents/MacOS/ghostty}"
+RC=0
+ok()   { echo "  ok    $*"; }
+bad()  { echo "  FAIL  $*"; }
+warn() { echo "  warn  $*"; }
+note() { echo "        $*"; }
+
+echo "Ghostty profile verification — $(hostname -s), macOS $(sw_vers -productVersion 2>/dev/null)"
+echo
+
+# ── 1. The binary ──────────────────────────────────────────────────────────
+if [ ! -x "$GHOSTTY_BIN" ]; then
+  bad "Ghostty not installed at $GHOSTTY_BIN"; exit 1
+fi
+ok "binary $("$GHOSTTY_BIN" --version 2>/dev/null | head -1)"
+
+# ── 2. The config loads ────────────────────────────────────────────────────
+VOUT="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +validate-config 2>&1)"; VRC=$?
+if [ $VRC -eq 0 ]; then ok "config validates (rc=0)"
+else bad "config rejected (rc=$VRC): $VOUT"; RC=$((RC|1)); fi
+
+# ── 3. The stale-filename trap ─────────────────────────────────────────────
+# Ghostty reads `config` AND `config.ghostty` and merges them. Measured order:
+# top-level config, top-level config.ghostty, config's includes, then
+# config.ghostty's includes. So a leftover config.ghostty does not override this
+# profile wholesale — it loses every key our included files set and wins every
+# key they do not. Partial, silent, and position-dependent: retire it.
+if [ -f "$DEST_DIR/config.ghostty" ]; then
+  bad "$DEST_DIR/config.ghostty exists — it merges with 'config' and wins on every key this profile does not set"
+  RC=$((RC|1))
+else
+  ok "no shadowing config.ghostty"
+fi
+
+# ── 4. Drift: installed copy vs repo source ────────────────────────────────
+# Compared against the repo working tree. On a machine whose checkout is behind
+# origin/main this can read as drift when the live copy is simply newer — the
+# fleet-wide authority is scripts/lint_home_fork.py, which compares against
+# origin/main. This check is the local, fast one.
+drift=0
+for pair in "config|config" "fleet.ghostty|fleet.ghostty" "keys.ghostty|keys.ghostty"; do
+  s="$SRC_DIR/${pair%%|*}"; d="$DEST_DIR/${pair##*|}"
+  if [ ! -f "$d" ]; then bad "missing installed file: $d"; RC=$((RC|2)); drift=1
+  elif ! cmp -s "$s" "$d"; then bad "drift: $d differs from $s"; RC=$((RC|2)); drift=1
+  fi
+done
+# machine.ghostty is installed under a fixed name from a per-host source, so it
+# is matched against whichever profile it actually equals.
+if [ -f "$DEST_DIR/machine.ghostty" ]; then
+  matched=""
+  for m in "$SRC_DIR"/machines/*.ghostty; do
+    cmp -s "$m" "$DEST_DIR/machine.ghostty" && matched="$(basename "$m" .ghostty)"
+  done
+  if [ -n "$matched" ]; then ok "machine profile installed: $matched"
+  else bad "machine.ghostty matches no profile in $SRC_DIR/machines/"; RC=$((RC|2)); drift=1; fi
+else
+  bad "missing installed file: $DEST_DIR/machine.ghostty"; RC=$((RC|2)); drift=1
+fi
+[ $drift -eq 0 ] && ok "installed copies match the repo source"
+
+# ── 5. The font actually resolves ──────────────────────────────────────────
+# An unresolvable family does NOT error — it silently falls back to a face with
+# no Nerd glyphs, so this must be measured, not assumed. Probed with an isolated
+# XDG_CONFIG_HOME so the configured family cannot answer for the tested one.
+FAM="$(grep -m1 '^font-family = ' "$SRC_DIR/fleet.ghostty" | sed 's/^font-family = //')"
+if [ -n "$FAM" ]; then
+  FOUT="$(XDG_CONFIG_HOME=/nonexistent-xdg "$GHOSTTY_BIN" +show-face --font-family="$FAM" --string=A 2>&1)"
+  if printf '%s' "$FOUT" | grep -qF "$FAM"; then
+    ok "font resolves: $FAM"
+  else
+    warn "font '$FAM' does NOT resolve here — falling back to: $FOUT"
+    note "install it: brew install --cask font-jetbrains-mono-nerd-font"
+    RC=$((RC|4))
+  fi
+else
+  warn "could not read font-family from fleet.ghostty (check skipped, not passed)"
+  RC=$((RC|4))
+fi
+
+# ── 6. SSH terminfo — the fleet's daily defect ─────────────────────────────
+# xterm-ghostty is unknown on a fresh remote host; the shell integration
+# installs it on first ssh and caches the host. Empty cache with reachable
+# peers means the wrapper has never actually run.
+CACHE="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +ssh-cache 2>&1)"; CRC=$?
+if [ $CRC -ne 0 ]; then
+  warn "+ssh-cache failed (rc=$CRC): $CACHE"
+else
+  if printf '%s' "$CACHE" | grep -qi "no hosts"; then
+    warn "ssh terminfo cache is EMPTY — no remote host has xterm-ghostty yet"
+    note "it fills on your first interactive ssh from a Ghostty window"
+    note "(the wrapper is a shell function; it does not exist in non-interactive shells)"
+  else
+    ok "ssh terminfo cache: $(printf '%s' "$CACHE" | tr '\n' ' ')"
+  fi
+fi
+
+# ── 7. Effective values worth eyeballing ───────────────────────────────────
+echo
+echo "  effective (non-default) values:"
+XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +show-config --default=false 2>/dev/null \
+  | grep -E '^(theme|font-family|font-size|scrollback-limit|background-opacity|background-blur|cursor-color|working-directory|shell-integration-features|notify-on-command-finish|macos-option-as-alt|macos-icon) =' \
+  | sed 's/^/        /'
+
+echo
+if [ $RC -eq 0 ]; then echo "ALL CHECKS PASSED (rc=0)"; else echo "PROBLEMS FOUND (rc=$RC)"; fi
+exit $RC

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -745,6 +745,42 @@
       "live": "/Library/LaunchDaemons/com.nuzantara.fw-guard.plist",
       "repo": "infra/launchagents/mini/com.nuzantara.fw-guard.plist",
       "machines": ["mini"]
+    },
+    {
+      "live": "~/.config/ghostty/config",
+      "repo": "infra/ghostty/config",
+      "machines": ["all"],
+      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. Entry point: it only declares the include chain."
+    },
+    {
+      "live": "~/.config/ghostty/fleet.ghostty",
+      "repo": "infra/ghostty/fleet.ghostty",
+      "machines": ["all"],
+      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. Shared base, identical on all three hosts."
+    },
+    {
+      "live": "~/.config/ghostty/keys.ghostty",
+      "repo": "infra/ghostty/keys.ghostty",
+      "machines": ["all"],
+      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. Keybinds and command-palette entries, identical on all three hosts."
+    },
+    {
+      "live": "~/.config/ghostty/machine.ghostty",
+      "repo": "infra/ghostty/machines/pro.ghostty",
+      "machines": ["pro"],
+      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. Installed under a FIXED live name from a per-host source, so the entry point can include one stable filename everywhere; hence three entries sharing this live path, each scoped to its own machine."
+    },
+    {
+      "live": "~/.config/ghostty/machine.ghostty",
+      "repo": "infra/ghostty/machines/m5.ghostty",
+      "machines": ["m5"],
+      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. See the pro entry for why this live path appears three times."
+    },
+    {
+      "live": "~/.config/ghostty/machine.ghostty",
+      "repo": "infra/ghostty/machines/mini.ghostty",
+      "machines": ["mini"],
+      "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. See the pro entry for why this live path appears three times."
     }
   ],
   "allow": [


### PR DESCRIPTION
## What

The three machines ran three different terminals under one name. Measured 2026-08-18:

| | Pro | M5 | Mini |
|---|---|---|---|
| config file | `config.ghostty` (53 keys) | `config` (22 keys) | none at all |
| theme | Catppuccin Mocha | Catppuccin **Macchiato** | Ghostty default |
| font | `…Nerd Font Mono` | `…Nerd Font` | no Nerd font installed |
| ssh terminfo | on | **off** | — |
| splits / resize keys | none | yes | — |
| clipboard guards | yes | **none** | — |

`~/.config` is not a git repository, so neither machine had history or a backup of its config.

This adds one source under `infra/ghostty/`: a shared `fleet.ghostty`, a `keys.ghostty`, and one profile per host, assembled by an entry `config` that includes them in order (`fleet` → `keys` → `machine` → `?local`, later wins).

Every value was checked against the `ghostty.5` reference shipped **inside the installed app** (1.3.1), not against web docs — those may describe another release.

## Two defects it fixes, measured before and after

**`xterm-ghostty` was unknown across the fleet.** `infocmp xterm-ghostty` exited 1 on both M5 and Mini, so every `ssh` out of a Ghostty window landed on a host that could not describe the terminal, and Pro's terminfo cache had never recorded a single host. `ssh-terminfo` + `ssh-env` are now on fleet-wide, the entry has been installed on both peers (`infocmp` now exits 0 on each) and the caches populated on all three machines.

**Nothing signalled that a long job had ended.** `notify-on-command-finish = unfocused` with a 45s floor now notifies for deploys, test suites and LLM panels — only when you are looking elsewhere, and only for interactive commands (it rides on OSC 133, which tool-call shells do not emit).

## Mechanics that are easy to get wrong

Measured, not assumed, and written into the files so the next reader inherits the measurement:

- `config` **and** `config.ghostty` are both read and merged. An **included** file always beats a top-level value, so a leftover `config.ghostty` yields a patchwork — losing every key our includes set, winning every key they do not. The installer retires it; `verify.sh` fails if one reappears.
- Relative include paths resolve against the **including file's** directory, and are **not** resolved through a symlink (a symlinked entry file with relative includes fails — this killed the first design).
- `~` expands in include paths; `$HOME` does not.
- `scrollback-limit` is **bytes, per surface** — not lines, not per application.
- Custom `command-palette-entry` lines **append** to the 88 built-ins (measured 96 = 88 + 8), they do not replace them.

## Safety

`install.sh` backs up → installs → validates → **restores the backup and exits non-zero if validation fails**. Proven by installing from a deliberately broken source: the previous config came back byte-for-byte and revalidated.

`verify.sh` was shown to FAIL on each condition it claims to catch (drift, shadowing filename, missing profile, unresolvable font) before passing on the real state — a check that cannot say no is not a check.

The six installed copies are declared in `infra/home-fork/declared-pairs.json`, so the existing drift lint watches them against `origin/main`.

## Already live

Installed and verified on all three machines: Pro `rc=0`, M5 `rc=0`, Mini `rc=0` (Mini required `font-jetbrains-mono-nerd-font`, which the verifier flagged and which is now installed). Previous configs preserved under `~/.config/ghostty/.backup-<stamp>/`.

## Not in this PR

- Claude Code hosts agent-team panes in tmux or iTerm2 only, never Ghostty; in a bare Ghostty window it falls back to an invisible external tmux session or fails outright (observed live). The workaround — run Claude Code inside tmux — is documented in the runbook. tmux is **absent on M5**.
- `fzf` on Pro is themed Tokyo Night inside a Catppuccin terminal, and paints an opaque background over the window glass. The one-line fix is staged for the operator to run: `~/.zshrc` is behind the `host_boundary` guardrail and is deliberately not touched from a session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)