### PR TITLE
fix(intake): lock-held heartbeat reads ok, not error

### DIFF
--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -527,7 +527,14 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
         # meant the organ went fully dark (no digest, no P0, no heartbeat)
         # until a human found the hung process by hand. Now it says so.
         date_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        _heartbeat("error", "lock held")
+        # W0 recheck fast-follow (2026-08-18): "error" put this organ outside
+        # healer_receptor_registry.py's HEALTHY_STATUSES set, so a normal
+        # lock-contention tick (a manual debug run, a launchd overlap) got
+        # classified dead and triggered the autonomous healer session against
+        # a perfectly healthy organ — the exact failure class #4223 existed to
+        # kill, reopened through this branch. Lock-held-and-skipped is a
+        # no-op, not a failure.
+        _heartbeat("ok", "lock held, skipped")
         _tg_notify(
             "digest",
             f"intake-health:lock-held:{date_key}",

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -531,7 +531,13 @@ def test_heartbeat_is_ok_even_with_breaches_organ_not_finding(tmp_path, monkeypa
     assert "breaches=" in note
 
 
-def test_lock_held_writes_error_heartbeat_and_digest_instead_of_exiting_silently(monkeypatch):
+def test_lock_held_writes_ok_heartbeat_and_digest_instead_of_exiting_silently(monkeypatch):
+    # W0 recheck fast-follow (2026-08-18): this used to assert ("error", "lock
+    # held") — but "error" sits outside healer_receptor_registry.py's
+    # HEALTHY_STATUSES set, so a normal lock-contention tick (a manual debug
+    # run, a launchd overlap) got classified DEAD and triggered the autonomous
+    # healer session against a perfectly healthy organ. Lock-held-and-skipped
+    # is a no-op, not a failure — the heartbeat must read "ok".
     hb = []
     sent = []
     monkeypatch.setattr(ihr, "_heartbeat", lambda status, note="": hb.append((status, note)))
@@ -542,11 +548,19 @@ def test_lock_held_writes_error_heartbeat_and_digest_instead_of_exiting_silently
     rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
 
     assert rc == 0
-    assert hb == [("error", "lock held")]
+    assert hb == [("ok", "lock held, skipped")]
     assert len(sent) == 1
     tier, key, _text = sent[0]
     assert tier == "digest"
     assert key.startswith("intake-health:lock-held:")
+
+    # Cross-module tripwire: the whole point of this fix is that a
+    # lock-contention tick must NOT be classified dead by the healer. Assert
+    # directly against the registry's own set, not a hardcoded "ok" literal,
+    # so a future rename of that set still catches the regression here.
+    import healer_receptor_registry as hrr
+
+    assert hb[0][0] in hrr.HEALTHY_STATUSES
 
 
 def test_acquire_lock_hardens_a_pre_existing_loose_lock_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fast-follow to merged PR #4243 (W0 intake guardians). A cross-family
(Qwen 3.8 Max) adversarial re-check + independent live-execution
verification found that `scripts/intake_health_report.py` wrote
`_heartbeat("error", "lock held")` when its single-instance flock was
already held — a normal lock-contention event (manual debug run,
launchd overlap), not a failure.

`scripts/healer_receptor_registry.py`'s `HEALTHY_STATUSES` set is
`{"ok", "success", "healthy", "starting", "running"}` — it does NOT
include `"error"`. So a harmless lock-contention tick got classified
as a DEAD organ, and the autonomous healer
(`infra/launchagents/wrappers/pro-healer.sh`) would spawn a full
`--dangerously-skip-permissions --max-budget-usd 10` Claude session
against a perfectly healthy organ. This is the exact failure class
#4223 was chartered to kill, reopened through a different door.

## Changes

- `scripts/intake_health_report.py`: lock-held path now writes
  `_heartbeat("ok", "lock held, skipped")` instead of `"error"`, with
  an explanatory comment.
- `scripts/tests/test_intake_health_report.py`: renamed test to
  `test_lock_held_writes_ok_heartbeat_and_digest_instead_of_exiting_silently`,
  updated assertion to `[("ok", "lock held, skipped")]`, and added a
  cross-module tripwire asserting the heartbeat status is a member of
  `healer_receptor_registry.HEALTHY_STATUSES` directly (not a
  hardcoded literal), so a future rename of that set still catches
  the regression.
- Grepped the worktree for any other `"error"`/`"lock held"`
  pairing — none found.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_intake_health_report.py -q` — 36 passed, 0 failures (run independently, twice: once by the implementer, once by me).
- [x] Confirmed `HEALTHY_STATUSES` in `scripts/healer_receptor_registry.py:41` does not include `"error"`.
- [x] Confirmed no other file asserts the old `("error", "lock held")` pairing.

No deploy needed — read-only guardian script change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>