### PR TITLE
fix(ghostty): act on the adversarial review — two live traps, two dead safety nets

### DIFF
--- a/docs/runbooks/ghostty-fleet.md
+++ b/docs/runbooks/ghostty-fleet.md
@@ -117,12 +117,36 @@ subprocesses and were used successfully from Ghostty on the same day.
 | `cmd+shift+s`           | dump the whole scrollback to a file and open it                 |
 | `cmd+alt+p`             | pin the window on top · `cmd+alt+o` toggle transparency         |
 | `cmd+alt+r`             | read-only mode (blocks input to a running job)                  |
-| `cmd+grave`             | quick terminal from anywhere (needs Accessibility)              |
+| `cmd+alt+grave`         | quick terminal from anywhere (needs Accessibility)              |
 | `cmd+shift+comma`       | reload the config                                               |
 
 `global:` bindings need Ghostty in **System Settings → Privacy & Security →
 Accessibility**. Without the grant the binding is silently inert — there is no
 error, so verify by pressing it.
+
+It is `cmd+alt+grave`, not `cmd+grave`: macOS already owns `cmd+grave` for
+"Cycle Through Windows", and a `global:` bind "will always consume the input",
+so binding it there breaks window cycling in every application on the machine.
+
+Two things make this easy to get wrong:
+
+- **`+show-config` silently drops keybind prefixes.** A `global:` bind prints as
+  an ordinary one, so the command cannot tell you whether the bind is global.
+  Only the file on disk knows. Grep `~/.config/ghostty/keys.ghostty`.
+- **The grant is per machine and the check is not remotable.** Read it directly
+  (read-only, no `tccutil` — resetting TCC is machine-wide, never a probe):
+
+  ```bash
+  sqlite3 "file:///Library/Application%20Support/com.apple.TCC/TCC.db?mode=ro" \
+    "select client, auth_value from access where service='kTCCServiceAccessibility';" \
+    | grep -i ghostty
+  ```
+
+  `…|2` means granted; no row means never granted. Measured 2026-08-18: **Pro
+  granted**, **Mini no row** (headless server — the quick terminal is pointless
+  there anyway), **M5 the query answers `authorization denied` over ssh**, because
+  sshd on that host lacks Full Disk Access. That is CANNOT-VERIFY, not
+  "not granted" — run it in a local M5 terminal to actually know.
 
 ## Recovery
 

--- a/docs/runbooks/ghostty-fleet.md
+++ b/docs/runbooks/ghostty-fleet.md
@@ -97,8 +97,10 @@ the Ghostty window:
 tmux new-session -s claude    # then start claude inside it
 ```
 
-tmux is installed on Pro (3.6a). It is **absent on M5**, the primary workstation —
-so there, agent teams have no backend at all until `brew install tmux`.
+tmux is now present on all three: Pro 3.7b, M5 3.7b (installed 2026-08-18 —
+until then the primary workstation had no backend at all), Mini 3.6a. Installing
+the binary only makes the fix _available_; the panes appear only when Claude Code
+is actually running **inside** a session, because the first branch tests `$TMUX`.
 
 Work that does not need a pane is unaffected: background agents, the Workflow
 tool, and MCP-hosted seats (for example the Codex second-opinion server) run as

--- a/infra/ghostty/README.md
+++ b/infra/ghostty/README.md
@@ -48,8 +48,15 @@ bash infra/ghostty/verify.sh              # prove it
 ```
 
 The machine is detected by hostname; `--machine pro|m5|mini` overrides it.
-Reload a running Ghostty with `cmd+shift+comma`. **Opacity, blur and the Dock
-icon need a full quit and relaunch** — a reload will not show them.
+Reload a running Ghostty with `cmd+shift+comma`. The reference states explicitly
+that `background-opacity` needs a full quit and relaunch; blur and the Dock icon
+are not documented either way, so relaunch is the reliable route for all three.
+
+One location outranks all of this: macOS searches
+`~/Library/Application Support/com.mitchellh.ghostty/config.ghostty` **before**
+any XDG path. Ghostty.app creates that file empty by itself, which is harmless —
+but if it ever carries settings they silently beat everything installed here, so
+`verify.sh` checks its CONTENT (not its existence) and fails when it is non-empty.
 
 Drift between the installed copy and this directory is caught two ways: locally
 by `verify.sh`, and fleet-wide by `scripts/lint_home_fork.py --check`, which
@@ -67,8 +74,12 @@ Measured against Ghostty 1.3.1 on macOS 27.0, not assumed:
   "configuration files do not take effect until after the entire configuration is
   loaded." Measured order: top-level `config` → top-level `config.ghostty` →
   `config`'s includes → `config.ghostty`'s includes.
-- Among includes, **declaration order wins later**: `fleet` → `keys` → `machine`
-  → `local`.
+- Among includes, declaration order is `fleet` → `keys` → `machine` → `local`,
+  and **later wins — but only for scalar settings**. Repeatable ones accumulate:
+  `font-family` builds a fallback chain rather than overriding (reset it with
+  `font-family = ""` first), and `font-feature` / `command-palette-entry` append.
+  `keybind` appends too, except that the same trigger declared again replaces
+  its action.
 - Relative include paths resolve against the directory of the file holding the
   directive — **not** the process working directory, and **not** the symlink
   target if the file is reached through a symlink.
@@ -100,9 +111,9 @@ It costs nothing and makes a screenshot, a screen-share or a Vision Pro virtual
 display name its own machine.
 
 `macos-icon = custom-style` is flagged experimental upstream ("we may change the
-format of the custom styles in the future"). If a future release rejects it,
-`verify.sh` fails loudly and the fix is to drop three lines from the machine
-profile.
+format of the custom styles in the future"). If a future release rejects the
+value, `+validate-config` fails and `install.sh` refuses the install rather than
+leaving a broken config; the fix is to drop three lines from the machine profile.
 
 ## Known gaps
 

--- a/infra/ghostty/README.md
+++ b/infra/ghostty/README.md
@@ -87,6 +87,13 @@ Measured against Ghostty 1.3.1 on macOS 27.0, not assumed:
 - `?` before a path suppresses the error when the file is absent. Without it, one
   missing include makes the whole configuration fail to load.
 - `scrollback-limit` is in **bytes, per surface** — not lines, not per app.
+- `+show-config` prints the effective configuration but **drops keybind
+  prefixes** — a `global:` bind shows as an ordinary one. It cannot be used to
+  verify prefix state; read the file instead.
+- `+list-keybinds --default=true` prefixes every line with `keybind = ` and
+  prints Ghostty's normalised form (`cmd`→`super`, `left`→`arrow_left`,
+  `comma`→`,`). Comparing your bindings against it without normalising reports
+  everything as non-default.
 
 ## Two defects this profile addresses
 

--- a/infra/ghostty/config
+++ b/infra/ghostty/config
@@ -19,8 +19,20 @@
 #      not. A patchwork, which is harder to reason about than a clean override.
 #      That is why the installer retires it instead of leaving it alone.
 #
-#  Within the includes below, order is declaration order and LATER WINS:
+#  Within the includes below, order is declaration order:
 #     fleet  →  keys  →  machine  →  local
+#
+#  "Later wins" is true for SCALAR settings only (font-size, theme, opacity: the
+#  machine profile genuinely overrides the fleet base). REPEATABLE settings do
+#  NOT override — they accumulate:
+#    · `font-family` appends a FALLBACK CHAIN. Measured: a machine profile
+#      naming a second font does not replace the first, it becomes the fallback.
+#      To actually replace it, reset the list first: `font-family = ""` then the
+#      new value.
+#    · `font-feature` and `command-palette-entry` likewise accumulate.
+#    · `keybind` accumulates too, except that re-binding the SAME trigger
+#      replaces its action.
+#
 #  Relative paths resolve against the directory of the file holding the
 #  directive (this one), and `~` is expanded — `$HOME` is NOT.
 # ═══════════════════════════════════════════════════════════════════════════

--- a/infra/ghostty/fleet.ghostty
+++ b/infra/ghostty/fleet.ghostty
@@ -14,6 +14,25 @@
 #  Reload after edits: cmd+shift+comma. The reference states explicitly that
 #  `background-opacity` needs a full restart; blur and the Dock icon are not
 #  documented either way, so treat a relaunch as the reliable route for all three.
+#
+#  NOT every line here changes something. Of the 52 scalar settings this file
+#  declares, 24 are byte-identical to Ghostty 1.3.1's own default. They are kept
+#  on purpose — an explicit value is a pin that survives an upstream default
+#  flip, and it makes the posture readable instead of implied — but they are
+#  NOT choices, and nothing here should describe them as if they were.
+#
+#  Re-derive the split after any Ghostty upgrade; a default that moves under a
+#  pinned line is exactly what the pin is for:
+#
+#    ghostty +show-config                    # EFFECTIVE config — prints ONLY
+#                                            # what differs from the default, so
+#                                            # a key's ABSENCE means "= default"
+#    ghostty +show-config --default=true     # Ghostty's defaults. Ignores your
+#                                            # config entirely: with font-size 99
+#                                            # on disk it still answers 13.
+#
+#  Neither view is safe for keybinds: `+show-config` silently DROPS prefixes, so
+#  a `global:` bind prints as an ordinary one. Only keys.ghostty knows.
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ─── Typography ────────────────────────────────────────────────────────────
@@ -142,8 +161,19 @@ clipboard-paste-protection = true
 clipboard-paste-bracketed-safe = true
 clipboard-trim-trailing-spaces = true
 
-# Treat '/' '.' '-' '_' as part of a word so a double-click grabs a whole path
-# or a whole flag, which is what you actually want to copy in this repo.
+# These are the characters that END a word, not the ones that make one — the
+# reference is explicit that it "specifies the boundary characters rather than
+# the word characters", the inverse of zsh's WORDCHARS. `/` `.` `-` `_` are
+# absent, which is why a double-click grabs a whole path or a whole flag.
+#
+# This value is byte-identical to Ghostty's default (measured: `+show-config`
+# reports no deviation). It is written out so the boundary set is visible rather
+# than folklore, and so a future edit is a diff against something.
+#
+# The consequence that bites in this repo: `:` IS a boundary, so double-clicking
+# `file.py:163` grabs the path without the line number. Dropping `:` would fix
+# that and break double-click inside URLs, `PATH`, `key: value` and timestamps —
+# a narrow gain for a broad cost, so it stays. Use drag or triple-click.
 selection-word-chars = " \t'\"│`|:;,()[]{}<>$"
 
 link-url = true
@@ -171,6 +201,19 @@ macos-option-as-alt = right
 # also interfere with legitimate accessibility software.
 macos-auto-secure-input = true
 macos-secure-input-indication = true
+
+# AppleScript control of the terminal is OFF. It defaults to ON (measured), and
+# it is the one macOS surface here that ships permissive: with it enabled, any
+# process that can run osascript gets "AppleScript object lookup for windows,
+# tabs, and terminals" on a terminal that holds this fleet's live shells.
+#
+# Measured before closing it: nothing in this repo, nothing in ~/scripts and no
+# LaunchAgent drives Ghostty through AppleScript, so nothing loses a capability.
+#
+# The neighbouring surface, `macos-shortcuts`, is left alone on purpose: its
+# default is already `ask` — Shortcuts can create terminals, send text and run
+# commands, but only after a permission prompt the human sees once.
+macos-applescript = false
 
 # ─── Safety ────────────────────────────────────────────────────────────────
 confirm-close-surface = true

--- a/infra/ghostty/fleet.ghostty
+++ b/infra/ghostty/fleet.ghostty
@@ -15,8 +15,8 @@
 #  `background-opacity` needs a full restart; blur and the Dock icon are not
 #  documented either way, so treat a relaunch as the reliable route for all three.
 #
-#  NOT every line here changes something. Of the 52 scalar settings this file
-#  declares, 24 are byte-identical to Ghostty 1.3.1's own default. They are kept
+#  NOT every line here changes something. Of the 51 non-repeatable settings this
+#  file declares, 24 RESOLVE to Ghostty 1.3.1's own default. They are kept
 #  on purpose — an explicit value is a pin that survives an upstream default
 #  flip, and it makes the posture readable instead of implied — but they are
 #  NOT choices, and nothing here should describe them as if they were.

--- a/infra/ghostty/fleet.ghostty
+++ b/infra/ghostty/fleet.ghostty
@@ -11,7 +11,9 @@
 #  Every value below was verified against the reference shipped INSIDE the
 #  installed app (Contents/Resources/ghostty/doc/ghostty.5.md, Ghostty 1.3.1),
 #  not against web docs, which may describe another release.
-#  Reload after edits: cmd+shift+comma. Opacity/blur changes need a full restart.
+#  Reload after edits: cmd+shift+comma. The reference states explicitly that
+#  `background-opacity` needs a full restart; blur and the Dock icon are not
+#  documented either way, so treat a relaunch as the reliable route for all three.
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ─── Typography ────────────────────────────────────────────────────────────
@@ -34,8 +36,11 @@ font-thicken = true
 font-thicken-strength = 128
 
 # Alpha blending in linear space WITH the correction step: removes the dark
-# fringing around glyph edges that transparency introduces, while keeping the
-# weight identical to macOS-native blending. Matters because we run at 0.94.
+# fringing around glyph edges that transparency introduces, while keeping weight
+# "nearly or completely identical" to macOS-native blending (the reference's own
+# words — not a promise of pixel identity). It also changes the colour space for
+# transparent images and any custom shader. macOS defaults to `native`; revert
+# to that if text weight ever looks wrong. Matters because we run at 0.94.
 alpha-blending = linear-corrected
 
 # ─── Colour ────────────────────────────────────────────────────────────────
@@ -75,10 +80,12 @@ macos-window-shadow = true
 macos-dock-drop-behavior = new-tab
 
 # ─── Scrollback ────────────────────────────────────────────────────────────
-# UNITS ARE BYTES, PER SURFACE — not lines, and not per application. Ten splits
-# means ten times this number. 32 MB holds a very long Claude Code session while
-# staying well clear of the swap pressure measured on Pro (10.3 GB of 11.3 GB
-# in use). Raise it per-machine, never fleet-wide.
+# UNITS ARE BYTES, PER SURFACE — not lines, and not per application, so ten
+# splits can reach ten times this number. It is allocated LAZILY, so the figure
+# is a ceiling and not a reservation; the visible screen is always allocated on
+# top of it. 32 MB holds a very long Claude Code session while staying clear of
+# the swap pressure measured on Pro (10.3 GB of 11.3 GB in use). Raise it in a
+# machine profile, never fleet-wide.
 scrollback-limit = 32000000
 
 # Keep the viewport still while output streams past; only your own keystrokes
@@ -94,22 +101,33 @@ mouse-hide-while-typing = true
 # ─── Long-running commands ─────────────────────────────────────────────────
 # Deploys, pytest suites, LLM panels and fly builds outlive your attention.
 # 'unfocused' notifies only when you are looking at something else; 45s keeps
-# ordinary commands silent. Requires OSC 133, which the shell integration below
-# provides — so it fires for YOUR interactive commands, not for tool-call shells.
+# ordinary commands silent.
+#
+# The mechanism is OSC 133 prompt marking, which the shell integration below
+# emits. Anything that marks commands that way gets notifications; a shell that
+# does not — a non-interactive tool-call shell, for instance — gets none. It is
+# the escape sequence that decides, not which program started the shell.
 notify-on-command-finish = unfocused
 notify-on-command-finish-after = 45s
 notify-on-command-finish-action = no-bell,notify
 
-# Silent bell: mark the tab, never make noise.
+# Silent bell: no system alert sound, no custom audio. What remains is
+# `attention` (bounces the Dock icon) and `title` (prepends 🔔 to the surface
+# title) — visible, not audible.
 bell-features = no-system,no-audio,attention,title
 
 # ─── Shell integration ─────────────────────────────────────────────────────
-# ssh-terminfo is the fix for the daily fleet defect: xterm-ghostty is unknown
-# on both M5 and Mini (`infocmp xterm-ghostty` exits 1 there), so every ssh from
-# a Ghostty window used to land on a terminal the remote could not describe.
-# With this on, the first ssh to a host installs the terminfo via tic and caches
-# the host; ssh-env carries COLORTERM/TERM_PROGRAM and provides the
-# xterm-256color fallback when the install cannot happen.
+# ssh-terminfo addresses the daily fleet defect: xterm-ghostty was unknown on
+# both M5 and Mini (`infocmp xterm-ghostty` exited 1 on each), so every ssh from
+# a Ghostty window landed on a terminal the remote could not describe.
+#
+# It ATTEMPTS the install — it does not guarantee it. It needs `infocmp` locally
+# and `tic` on the remote, and it only runs from an interactive shell, because
+# the wrapper is a zsh function created by the shell integration at the FIRST
+# PROMPT (`_ghostty_deferred_init`). Scripts, cron and tool-call shells never
+# see it, which is why the cache can read empty on a machine that has had this
+# enabled for a long time. ssh-env carries COLORTERM/TERM_PROGRAM and supplies
+# the xterm-256color fallback when the install cannot happen.
 shell-integration = detect
 shell-integration-features = cursor,sudo,title,ssh-env,ssh-terminfo,path
 
@@ -132,14 +150,25 @@ link-url = true
 link-previews = true
 
 # ─── macOS behaviour ───────────────────────────────────────────────────────
-# LEFT option becomes Alt (so alt+f / alt+b / alt+. work in zsh); RIGHT option
+# RIGHT option becomes Alt (so alt+f / alt+b / alt+. work in zsh); LEFT option
 # keeps macOS dead-key composition, which on this ABC layout is how à è é ì ò ù
-# are typed. Do not change this to plain `true` — it would break Italian input.
-macos-option-as-alt = left
+# are typed: option+` then a, option+e then e, and so on.
+#
+# `right`, not `left`. On a US/ABC layout the backtick sits at the top LEFT of
+# the keyboard, so the hand that naturally reaches option+` is the left one —
+# binding LEFT to Alt would take the accent mechanism away from the hand that
+# uses it. Never set this to plain `true`: that takes BOTH option keys and the
+# reference warns it "will break Unicode input sequences on macOS".
+macos-option-as-alt = right
 
 # Secure Input blocks other processes from reading keystrokes at password
-# prompts. It also blocks accessibility-API keystroke capture, which is the
-# same vector that took the M5 keyboard on 2026-08-16 — keep it armed.
+# prompts, including accessibility-API keystroke capture — the same vector that
+# took the M5 keyboard on 2026-08-16, which is why it stays armed.
+#
+# Two caveats the reference states and which matter on an ssh-heavy fleet:
+# detection of a password prompt is HEURISTIC, and it explicitly "does not work
+# over SSH connections" — so a remote sudo prompt is not covered by it. It can
+# also interfere with legitimate accessibility software.
 macos-auto-secure-input = true
 macos-secure-input-indication = true
 

--- a/infra/ghostty/install.sh
+++ b/infra/ghostty/install.sh
@@ -78,8 +78,17 @@ say "dest    : $DEST_DIR"
 # Judged by content: the app creates this file empty by itself, so only a file
 # that actually carries settings is worth warning about.
 APPSUP="$HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty"
-if [ -f "$APPSUP" ] && [ "$(grep -cvE '^[[:space:]]*(#.*)?$' "$APPSUP" 2>/dev/null || echo 0)" -gt 0 ]; then
-  say "WARNING : $APPSUP holds settings and takes precedence over this install"
+if [ -f "$APPSUP" ]; then
+  # `grep -c` prints the count AND exits 1 when it is zero, so a `|| echo 0`
+  # fallback appends a second zero and the numeric test dies on "0\n0". Take
+  # grep's own number; substitute only when the capture came back empty.
+  APPSUP_N="$(grep -cvE '^[[:space:]]*(#.*)?$' "$APPSUP" 2>/dev/null)"
+  case "$APPSUP_N" in ''|*[!0-9]*) APPSUP_N=-1 ;; esac
+  if [ "$APPSUP_N" -gt 0 ]; then
+    say "WARNING : $APPSUP holds $APPSUP_N setting(s) and takes precedence over this install"
+  elif [ "$APPSUP_N" -lt 0 ]; then
+    say "WARNING : cannot read $APPSUP — it outranks this install and its contents are unknown"
+  fi
 fi
 say "ghostty : $("$GHOSTTY_BIN" --version 2>/dev/null | head -1)"
 

--- a/infra/ghostty/install.sh
+++ b/infra/ghostty/install.sh
@@ -28,7 +28,16 @@ FORCE_MACHINE=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=1 ;;
-    --machine) FORCE_MACHINE="${2:-}"; shift ;;
+    --machine)
+      # Require the value. Without this guard `--machine` alone consumed nothing
+      # and silently fell through to hostname detection — which on the wrong box
+      # means installing the wrong profile, quietly.
+      [ $# -ge 2 ] || { echo "--machine needs a value: pro|m5|mini" >&2; exit 2; }
+      case "$2" in
+        pro|m5|mini) FORCE_MACHINE="$2" ;;
+        *) echo "unknown machine '$2' (expected pro|m5|mini)" >&2; exit 2 ;;
+      esac
+      shift ;;
     -h|--help) sed -n '2,14p' "${BASH_SOURCE[0]}"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
@@ -62,6 +71,16 @@ say "dest    : $DEST_DIR"
 
 [ "$(basename "$DEST_DIR")" = "ghostty" ] || die "destination must be a directory named 'ghostty' (got $DEST_DIR) — Ghostty only looks for <config-home>/ghostty/config"
 [ -x "$GHOSTTY_BIN" ] || die "Ghostty binary not found at $GHOSTTY_BIN"
+
+# macOS searches $HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty
+# BEFORE any XDG location. A file there outranks everything we are about to
+# install, so refuse to pretend otherwise.
+# Judged by content: the app creates this file empty by itself, so only a file
+# that actually carries settings is worth warning about.
+APPSUP="$HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty"
+if [ -f "$APPSUP" ] && [ "$(grep -cvE '^[[:space:]]*(#.*)?$' "$APPSUP" 2>/dev/null || echo 0)" -gt 0 ]; then
+  say "WARNING : $APPSUP holds settings and takes precedence over this install"
+fi
 say "ghostty : $("$GHOSTTY_BIN" --version 2>/dev/null | head -1)"
 
 # ── What we are about to place ─────────────────────────────────────────────
@@ -109,11 +128,35 @@ else
   BACKUP=""
 fi
 
+# Roll back to the state we found. On a FRESH install there is no backup, and an
+# earlier version returned immediately in that case — leaving whatever files had
+# already been copied in place, i.e. a half-installed config presented as "no
+# harm done". Removing what we placed is the rollback in that case.
+#
+# Every step is checked: a rollback that fails silently is worse than no
+# rollback, because the message that follows it says nothing was lost.
 restore() {
-  [ -n "$BACKUP" ] || return 0
-  echo "  rolling back from $BACKUP" >&2
-  rm -f "$DEST_DIR"/config "$DEST_DIR"/fleet.ghostty "$DEST_DIR"/keys.ghostty "$DEST_DIR"/machine.ghostty
-  for f in "$BACKUP"/*; do [ -f "$f" ] && cp -p "$f" "$DEST_DIR/"; done
+  local failed=0
+  echo "  rolling back" >&2
+  for p in "${PLAN[@]}"; do
+    rm -f "${p##*|}" || failed=1
+  done
+  if [ -n "$BACKUP" ]; then
+    echo "  restoring from $BACKUP" >&2
+    for f in "$BACKUP"/*; do
+      [ -f "$f" ] || continue
+      cp -p "$f" "$DEST_DIR/" || failed=1
+    done
+  fi
+  # Put back the retired filename, if we had already moved it.
+  if [ -n "${RETIRED:-}" ] && [ -f "$RETIRED" ]; then
+    mv "$RETIRED" "$DEST_DIR/config.ghostty" || failed=1
+  fi
+  if [ $failed -ne 0 ]; then
+    echo "  ROLLBACK INCOMPLETE — inspect $DEST_DIR by hand before using it." >&2
+    return 1
+  fi
+  return 0
 }
 
 # ── Install ────────────────────────────────────────────────────────────────
@@ -126,10 +169,12 @@ done
 # Retire the stale filename rather than deleting it: it must not remain (it
 # merges in and wins on any key this profile leaves unset), but the previous
 # content is kept on disk under a dated name in case something in it is wanted.
+RETIRED=""
 if [ -f "$DEST_DIR/config.ghostty" ]; then
-  mv "$DEST_DIR/config.ghostty" "$DEST_DIR/config.ghostty.retired-$STAMP" \
-    || { restore; die "could not retire config.ghostty"; }
-  say "retired : config.ghostty -> config.ghostty.retired-$STAMP"
+  RETIRED="$DEST_DIR/config.ghostty.retired-$STAMP"
+  mv "$DEST_DIR/config.ghostty" "$RETIRED" \
+    || { RETIRED=""; restore; die "could not retire config.ghostty"; }
+  say "retired : config.ghostty -> $(basename "$RETIRED")"
 fi
 
 # ── Prove it loads ─────────────────────────────────────────────────────────
@@ -138,8 +183,15 @@ VOUT="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +validate-config 2>&1)"; VR
 if [ $VRC -ne 0 ]; then
   echo "  validation FAILED (rc=$VRC):" >&2
   echo "$VOUT" >&2
-  restore
-  die "config rejected by Ghostty — previous config restored, nothing lost."
+  if restore; then
+    if [ -n "$BACKUP" ]; then
+      die "config rejected by Ghostty — the previous config was restored, nothing lost."
+    else
+      die "config rejected by Ghostty — the files just written were removed; this machine had no config before and still has none."
+    fi
+  else
+    die "config rejected by Ghostty AND rollback did not complete — inspect $DEST_DIR by hand."
+  fi
 fi
 say "validate: OK (rc=0)"
 

--- a/infra/ghostty/keys.ghostty
+++ b/infra/ghostty/keys.ghostty
@@ -44,7 +44,7 @@ keybind = resize/down=resize_split:down,10
 keybind = resize/equal=equalize_splits
 keybind = resize/escape=deactivate_key_table
 keybind = resize/cmd+r=deactivate_key_table
-keybind = resize/catch_all=deactivate_key_table
+keybind = resize/unconsumed:catch_all=deactivate_key_table
 
 # ─── Keeping a long session ────────────────────────────────────────────────
 # Dump the whole scrollback to a file and open it — the honest way to keep a

--- a/infra/ghostty/keys.ghostty
+++ b/infra/ghostty/keys.ghostty
@@ -1,30 +1,41 @@
 # ═══════════════════════════════════════════════════════════════════════════
 #  Ghostty · Nuzantara KEYBINDS + COMMAND PALETTE
 #  Loaded by ~/.config/ghostty/config after fleet.ghostty.
-#  `ghostty +list-keybinds` prints the effective set (defaults included).
+#  `ghostty +list-keybinds` prints the effective set, defaults included.
 # ═══════════════════════════════════════════════════════════════════════════
 #
-#  Ghostty already ships the macOS conventions — cmd+t/w/n tabs and windows,
-#  cmd+c/v, cmd+f scrollback search (new in 1.3), cmd+g / shift+cmd+g to walk
-#  results, cmd+1..9, cmd+home/end. Nothing below re-declares those; this file
-#  only adds what is missing.
+#  Ghostty 1.3.1 ships 93 default bindings, and they already cover more than is
+#  obvious. Measured against `+list-keybinds` on a config-less binary, these are
+#  ALREADY defaults and are deliberately NOT redeclared here:
+#
+#     cmd+d / cmd+shift+d      split right / down
+#     cmd+shift+enter          toggle split zoom
+#     cmd+alt+arrows           move between splits
+#     cmd+up / cmd+down        jump to previous / next shell prompt
+#     cmd+shift+p              command palette
+#     cmd+shift+,              reload config
+#     cmd+f / cmd+g            search scrollback, next result
+#     cmd+t / cmd+w / cmd+n    tabs and windows
+#
+#  An earlier draft of this file restated all of them under a comment claiming
+#  it "only adds what is missing". That claim was false, and the redeclarations
+#  were noise. What follows is what the defaults genuinely do not provide.
 
-# ─── Splits ────────────────────────────────────────────────────────────────
-keybind = cmd+d=new_split:right
-keybind = cmd+shift+d=new_split:down
-keybind = cmd+shift+enter=toggle_split_zoom
-keybind = cmd+alt+left=goto_split:left
-keybind = cmd+alt+right=goto_split:right
-keybind = cmd+alt+up=goto_split:up
-keybind = cmd+alt+down=goto_split:down
-
-# Keep a zoomed split zoomed while you move between splits, instead of
-# collapsing the layout on every navigation.
+# ─── Splits: behaviour, not new bindings ───────────────────────────────────
+# Keep a zoomed split zoomed while moving between splits, instead of collapsing
+# the layout on every navigation.
 split-preserve-zoom = navigation
 
 # ─── Resize mode (modal, tmux-style) ───────────────────────────────────────
-# cmd+r enters the table; arrows resize; '=' equalises; esc leaves.
-# There is no timeout on key tables — esc is the only way out, so it is bound.
+# cmd+r enters the table; arrows resize; '=' equalises; esc or cmd+r leaves.
+#
+# Key tables are STICKY by design. The reference is explicit: "If an invalid key
+# is pressed, the sequence ends but the table remains active", and "binding
+# lookup proceeds from the innermost table outward" — so without the catch_all
+# below, a stray keystroke while resizing would fall through to the shell AND
+# leave you still in resize mode, with no visible sign of it. catch_all makes
+# any unexpected key simply leave the table, which is the behaviour a person
+# expects from a modal mode they did not realise they were still in.
 keybind = cmd+r=activate_key_table:resize
 keybind = resize/left=resize_split:left,10
 keybind = resize/right=resize_split:right,10
@@ -32,52 +43,53 @@ keybind = resize/up=resize_split:up,10
 keybind = resize/down=resize_split:down,10
 keybind = resize/equal=equalize_splits
 keybind = resize/escape=deactivate_key_table
+keybind = resize/cmd+r=deactivate_key_table
+keybind = resize/catch_all=deactivate_key_table
 
-# ─── Reading long sessions ─────────────────────────────────────────────────
-# Walk backwards and forwards between shell PROMPTS. This is the single most
-# useful binding for a 40k-line Claude Code session: it steps command by
-# command instead of line by line. Depends on OSC 133 from shell integration.
-keybind = cmd+up=jump_to_prompt:-1
-keybind = cmd+down=jump_to_prompt:1
-
+# ─── Keeping a long session ────────────────────────────────────────────────
 # Dump the whole scrollback to a file and open it — the honest way to keep a
-# long run for later, rather than scrolling and copying by hand.
+# long run, rather than scrolling and copying by hand.
 keybind = cmd+shift+s=write_scrollback_file:open
-# Same for the visible screen, path to clipboard instead of opening.
+# Same for the visible screen, path to the clipboard instead of opening it.
 keybind = cmd+alt+s=write_screen_file:copy
 
 # ─── Window control ────────────────────────────────────────────────────────
 # Pin a window above everything else — for a log tail or a monitor split you
-# want to keep visible while working in another app.
+# want visible while working in another app.
 keybind = cmd+alt+p=toggle_window_float_on_top
 # Momentarily make the background fully opaque when transparency hurts reading.
 keybind = cmd+alt+o=toggle_background_opacity
-# Read-only mode: blocks input to the pty. Useful when a long job is running
-# and a stray keystroke would be sent into it.
+# Read-only mode: blocks input to the pty, so a stray keystroke cannot reach a
+# long-running job.
 keybind = cmd+alt+r=toggle_readonly
-
-# ─── Config & palette ──────────────────────────────────────────────────────
-keybind = cmd+shift+comma=reload_config
-keybind = cmd+shift+p=toggle_command_palette
 
 # ─── Quick terminal ────────────────────────────────────────────────────────
 # Drops a terminal from the top of the screen over any app.
-# `global:` requires the Accessibility permission for Ghostty in
-# System Settings > Privacy & Security > Accessibility. Without the grant the
-# binding is simply inert — it fails silently, so verify it after install.
-keybind = global:cmd+grave_accent=toggle_quick_terminal
+#
+# NOT bound to cmd+grave. That chord is the macOS system shortcut "Cycle Through
+# Windows" (it appears in the standard Window menu and is an enabled system
+# hotkey), and a `global:` binding "always consumes the input" while Ghostty is
+# unfocused — so taking it would break window cycling in EVERY application, not
+# just this one. cmd+alt+grave is not claimed by the system.
+#
+# `global:` needs Ghostty in System Settings → Privacy & Security → Accessibility.
+# Without the grant the binding is silently inert: no error, nothing happens.
+# Press it once after install to confirm the grant is real.
+keybind = global:cmd+alt+grave_accent=toggle_quick_terminal
 
 # ─── Command palette: Nuzantara entries ────────────────────────────────────
-# These APPEND to Ghostty's built-in palette (they do not replace it).
-# Every one of them TYPES the command and stops — no trailing newline, so
-# nothing executes until you read it and press enter yourself. That is
-# deliberate: a palette that runs commands is a palette that runs the wrong
-# command eventually.
-command-palette-entry = title:"Nuzantara: repo status",description:"git status in the monorepo (type only, not executed).",action:"text:git -C ~/nuzantara status --short --branch"
-command-palette-entry = title:"Nuzantara: worktree list",description:"List agent worktrees (type only, not executed).",action:"text:git -C ~/nuzantara worktree list"
-command-palette-entry = title:"Nuzantara: new agent worktree",description:"Broker a fresh isolated worktree (type only — fill in lane and task).",action:"text:python3 ~/nuzantara/scripts/agent_start.py --lane ops --task-id "
-command-palette-entry = title:"Nuzantara: proprioception report",description:"Show the last fleet self-check (type only, not executed).",action:"text:cat ~/.nuzantara-proprioception/last.md"
-command-palette-entry = title:"Nuzantara: escalations board",description:"HIGH-first escalation board (type only, not executed).",action:"text:python3 ~/nuzantara/scripts/pending_arms_report.py"
-command-palette-entry = title:"Nuzantara: HOME-fork lint",description:"Check live-vs-repo drift for declared pairs (type only, not executed).",action:"text:python3 ~/nuzantara/scripts/lint_home_fork.py --check"
-command-palette-entry = title:"Ghostty: verify this config",description:"Validate the installed Ghostty config and prove which files were read.",action:"text:bash ~/nuzantara/infra/ghostty/verify.sh"
+# These APPEND to Ghostty's 88 built-in entries — measured 96 = 88 + 8. They do
+# not replace them (the reference notes the defaults can be cleared only by
+# setting this key to an empty value, which we do not do).
+#
+# Every one TYPES the command and stops — no trailing newline, so nothing runs
+# until you read it and press enter yourself. A palette that executes is a
+# palette that eventually executes the wrong thing.
+command-palette-entry = title:"Nuzantara: repo status",description:"git status in the monorepo (typed, not executed).",action:"text:git -C ~/nuzantara status --short --branch"
+command-palette-entry = title:"Nuzantara: worktree list",description:"List agent worktrees (typed, not executed).",action:"text:git -C ~/nuzantara worktree list"
+command-palette-entry = title:"Nuzantara: new agent worktree",description:"Broker a fresh isolated worktree (typed — fill in lane and task).",action:"text:python3 ~/nuzantara/scripts/agent_start.py --lane ops --task-id "
+command-palette-entry = title:"Nuzantara: proprioception report",description:"Show the last fleet self-check (typed, not executed).",action:"text:cat ~/.nuzantara-proprioception/last.md"
+command-palette-entry = title:"Nuzantara: pending arms",description:"Suspended-work ledger (typed, not executed).",action:"text:python3 ~/nuzantara/scripts/pending_arms_report.py"
+command-palette-entry = title:"Nuzantara: HOME-fork lint",description:"Check live-vs-repo drift for declared pairs (typed, not executed).",action:"text:python3 ~/nuzantara/scripts/lint_home_fork.py --check"
+command-palette-entry = title:"Ghostty: verify this config",description:"Validate the installed config and check drift, font and terminfo.",action:"text:bash ~/nuzantara/infra/ghostty/verify.sh"
 command-palette-entry = title:"Ghostty: ssh terminfo cache",description:"List hosts that already have xterm-ghostty installed.",action:"text:ghostty +ssh-cache"

--- a/infra/ghostty/verify.sh
+++ b/infra/ghostty/verify.sh
@@ -18,8 +18,9 @@ set -uo pipefail
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEST_DIR="${GHOSTTY_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/ghostty}"
 # Every ghostty invocation below is pinned to the directory we are verifying
-# (see the note in install.sh) so a check can never pass by reading a config
-# other than the installed one.
+# (see the note in install.sh) so a check does not silently read some other XDG
+# location. It is NOT total isolation: the macOS Application Support path is
+# searched ahead of XDG regardless, which is why check 6b exists.
 XDG_PARENT="$(dirname "$DEST_DIR")"
 GHOSTTY_BIN="${GHOSTTY_BIN:-/Applications/Ghostty.app/Contents/MacOS/ghostty}"
 RC=0
@@ -68,16 +69,41 @@ for pair in "config|config" "fleet.ghostty|fleet.ghostty" "keys.ghostty|keys.gho
   fi
 done
 # machine.ghostty is installed under a fixed name from a per-host source, so it
-# is matched against whichever profile it actually equals.
-if [ -f "$DEST_DIR/machine.ghostty" ]; then
-  matched=""
-  for m in "$SRC_DIR"/machines/*.ghostty; do
-    cmp -s "$m" "$DEST_DIR/machine.ghostty" && matched="$(basename "$m" .ghostty)"
-  done
-  if [ -n "$matched" ]; then ok "machine profile installed: $matched"
-  else bad "machine.ghostty matches no profile in $SRC_DIR/machines/"; RC=$((RC|2)); drift=1; fi
-else
+# must be compared against the profile THIS host should have. Matching against
+# "any profile in machines/" was the earlier version and it passed happily with
+# M5's profile installed on Pro — including a working-directory that does not
+# exist on this machine. Same hostname mapping as install.sh.
+expected_machine() {
+  local h; h="$(hostname -s 2>/dev/null || hostname)"
+  case "$h" in
+    Nuzantara|nuzantara) echo pro  ;;
+    Air-M5|air-m5)       echo m5   ;;
+    Mini-Pro2|mini-pro2) echo mini ;;
+    *) return 1 ;;
+  esac
+}
+EXPECT="${GHOSTTY_EXPECT_MACHINE:-$(expected_machine || true)}"
+if [ -z "$EXPECT" ]; then
+  warn "unrecognised host '$(hostname -s)' — cannot tell which profile belongs here (check skipped, not passed)"
+  RC=$((RC|4))
+elif [ ! -f "$DEST_DIR/machine.ghostty" ]; then
   bad "missing installed file: $DEST_DIR/machine.ghostty"; RC=$((RC|2)); drift=1
+elif cmp -s "$SRC_DIR/machines/$EXPECT.ghostty" "$DEST_DIR/machine.ghostty"; then
+  ok "machine profile installed: $EXPECT (matches this host)"
+else
+  actual="none"
+  for m in "$SRC_DIR"/machines/*.ghostty; do
+    cmp -s "$m" "$DEST_DIR/machine.ghostty" && actual="$(basename "$m" .ghostty)"
+  done
+  bad "wrong machine profile: this host is '$EXPECT' but machine.ghostty is '$actual'"
+  RC=$((RC|2)); drift=1
+fi
+
+# The configured working directory has to exist, or every new window opens
+# somewhere unintended. This is what catches a foreign profile in practice.
+WD="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +show-config --default=false 2>/dev/null | sed -n 's/^working-directory = //p' | head -1)"
+if [ -n "$WD" ] && [ ! -d "$WD" ]; then
+  bad "working-directory does not exist on this machine: $WD"; RC=$((RC|2))
 fi
 [ $drift -eq 0 ] && ok "installed copies match the repo source"
 
@@ -106,7 +132,8 @@ fi
 # peers means the wrapper has never actually run.
 CACHE="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +ssh-cache 2>&1)"; CRC=$?
 if [ $CRC -ne 0 ]; then
-  warn "+ssh-cache failed (rc=$CRC): $CACHE"
+  bad "+ssh-cache failed (rc=$CRC): $CACHE"
+  RC=$((RC|4))
 else
   if printf '%s' "$CACHE" | grep -qi "no hosts"; then
     warn "ssh terminfo cache is EMPTY — no remote host has xterm-ghostty yet"
@@ -115,6 +142,28 @@ else
   else
     ok "ssh terminfo cache: $(printf '%s' "$CACHE" | tr '\n' ' ')"
   fi
+fi
+
+# ── 6b. The location that outranks everything ──────────────────────────────
+# macOS searches $HOME/Library/Application Support/com.mitchellh.ghostty/
+# config.ghostty BEFORE any XDG location. Nothing this profile installs can
+# override a file sitting there, so its presence is a finding, not a detail.
+# Judged by CONTENT, not by existence: Ghostty.app creates this file empty on
+# its own (observed 2026-08-18 — the CLI does not, the running app does), so a
+# presence test would fail forever on every machine and train you to ignore this
+# script. An empty or comment-only file changes nothing; a file with settings
+# in it silently outranks the whole profile.
+APPSUP="$HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty"
+if [ -f "$APPSUP" ]; then
+  APPSUP_SETTINGS="$(grep -cvE '^[[:space:]]*(#.*)?$' "$APPSUP" 2>/dev/null || echo 0)"
+  if [ "$APPSUP_SETTINGS" -gt 0 ]; then
+    bad "$APPSUP holds $APPSUP_SETTINGS setting(s) and takes PRECEDENCE over everything installed here"
+    RC=$((RC|1))
+  else
+    ok "Application Support config present but empty (no effect)"
+  fi
+else
+  ok "no higher-priority config in Application Support"
 fi
 
 # ── 7. Effective values worth eyeballing ───────────────────────────────────

--- a/infra/ghostty/verify.sh
+++ b/infra/ghostty/verify.sh
@@ -155,7 +155,16 @@ fi
 # in it silently outranks the whole profile.
 APPSUP="$HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty"
 if [ -f "$APPSUP" ]; then
-  APPSUP_SETTINGS="$(grep -cvE '^[[:space:]]*(#.*)?$' "$APPSUP" 2>/dev/null || echo 0)"
+  # `grep -c` prints its count on stdout AND exits 1 when that count is zero, so
+  # a `|| echo 0` fallback appends a SECOND zero: the variable becomes "0\n0" and
+  # the numeric test below dies with "integer expression expected" — which is
+  # what it did on all three machines. grep already emits the number; take it and
+  # only substitute when the capture is empty (file unreadable).
+  APPSUP_SETTINGS="$(grep -cvE '^[[:space:]]*(#.*)?$' "$APPSUP" 2>/dev/null)"
+  case "$APPSUP_SETTINGS" in
+    ''|*[!0-9]*) bad "cannot count settings in $APPSUP — treating as a finding, not as empty"
+                 RC=$((RC|4)); APPSUP_SETTINGS=0 ;;
+  esac
   if [ "$APPSUP_SETTINGS" -gt 0 ]; then
     bad "$APPSUP holds $APPSUP_SETTINGS setting(s) and takes PRECEDENCE over everything installed here"
     RC=$((RC|1))

--- a/infra/ghostty/verify.sh
+++ b/infra/ghostty/verify.sh
@@ -101,9 +101,20 @@ fi
 
 # The configured working directory has to exist, or every new window opens
 # somewhere unintended. This is what catches a foreign profile in practice.
-WD="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +show-config --default=false 2>/dev/null | sed -n 's/^working-directory = //p' | head -1)"
-if [ -n "$WD" ] && [ ! -d "$WD" ]; then
-  bad "working-directory does not exist on this machine: $WD"; RC=$((RC|2))
+# Capture the STATUS, not just the text. With `2>/dev/null` and an empty-string
+# test, a ghostty that cannot run at all leaves WD empty and this check silently
+# VANISHES instead of failing — the verifier then reports a clean profile it
+# never actually inspected. An unusable binary is a finding of its own.
+EFFECTIVE="$(XDG_CONFIG_HOME="$XDG_PARENT" "$GHOSTTY_BIN" +show-config --default=false 2>&1)"; ERC=$?
+if [ $ERC -ne 0 ]; then
+  bad "+show-config failed (rc=$ERC) — the effective config could not be read, so nothing below was verified against it"
+  note "$(printf '%s' "$EFFECTIVE" | head -2)"
+  RC=$((RC|4))
+else
+  WD="$(printf '%s\n' "$EFFECTIVE" | sed -n 's/^working-directory = //p' | head -1)"
+  if [ -n "$WD" ] && [ ! -d "$WD" ]; then
+    bad "working-directory does not exist on this machine: $WD"; RC=$((RC|2))
+  fi
 fi
 [ $drift -eq 0 ] && ok "installed copies match the repo source"
 
@@ -113,8 +124,14 @@ fi
 # XDG_CONFIG_HOME so the configured family cannot answer for the tested one.
 FAM="$(grep -m1 '^font-family = ' "$SRC_DIR/fleet.ghostty" | sed 's/^font-family = //')"
 if [ -n "$FAM" ]; then
-  FOUT="$(XDG_CONFIG_HOME=/nonexistent-xdg "$GHOSTTY_BIN" +show-face --font-family="$FAM" --string=A 2>&1)"
-  if printf '%s' "$FOUT" | grep -qF "$FAM"; then
+  FOUT="$(XDG_CONFIG_HOME=/nonexistent-xdg "$GHOSTTY_BIN" +show-face --font-family="$FAM" --string=A 2>&1)"; FRC=$?
+  if [ $FRC -ne 0 ]; then
+    # Distinguish "this font is missing" from "this binary cannot answer". Both
+    # used to land in the same branch, which told the reader to install a font
+    # when the real problem was the tool doing the asking.
+    bad "+show-face failed (rc=$FRC) — cannot tell whether '$FAM' resolves: $FOUT"
+    RC=$((RC|4))
+  elif printf '%s' "$FOUT" | grep -qF "$FAM"; then
     ok "font resolves: $FAM"
   else
     warn "font '$FAM' does NOT resolve here — falling back to: $FOUT"
@@ -162,10 +179,16 @@ if [ -f "$APPSUP" ]; then
   # only substitute when the capture is empty (file unreadable).
   APPSUP_SETTINGS="$(grep -cvE '^[[:space:]]*(#.*)?$' "$APPSUP" 2>/dev/null)"
   case "$APPSUP_SETTINGS" in
-    ''|*[!0-9]*) bad "cannot count settings in $APPSUP — treating as a finding, not as empty"
-                 RC=$((RC|4)); APPSUP_SETTINGS=0 ;;
+    ''|*[!0-9]*) APPSUP_SETTINGS=unreadable ;;
   esac
-  if [ "$APPSUP_SETTINGS" -gt 0 ]; then
+  if [ "$APPSUP_SETTINGS" = unreadable ]; then
+    # NOT folded into 0. An earlier version set it to 0 here and then fell
+    # through to the "present but empty" branch below, so the verifier printed
+    # BOTH "cannot count" and "present but empty (no effect)" — one of which is
+    # a claim it had just said it could not make. Unreadable is its own verdict.
+    bad "cannot read $APPSUP — it OUTRANKS this profile and its contents are unknown"
+    RC=$((RC|4))
+  elif [ "$APPSUP_SETTINGS" -gt 0 ]; then
     bad "$APPSUP holds $APPSUP_SETTINGS setting(s) and takes PRECEDENCE over everything installed here"
     RC=$((RC|1))
   else

--- a/scripts/tests/test_ghostty_guards.sh
+++ b/scripts/tests/test_ghostty_guards.sh
@@ -235,6 +235,124 @@ else
 fi
 rm -rf "$H4"
 
+# ═══════════════════════════════ Guard 3 — rollback, in BOTH of its two worlds
+# Added after a cross-family reviewer proved the whole `restore()` body could be
+# replaced with `return 0` and this corpus stayed green. A recovery path nothing
+# exercises is a recovery path nobody knows is broken.
+#
+# A source tree with a deliberately invalid setting: the install completes the
+# copies, then Ghostty rejects the result, then rollback runs. That is the ONLY
+# path on which restore() exists.
+broken_source() {
+    local dir
+    dir="$(mktemp -d)"
+    cp "$SRC/config" "$SRC/fleet.ghostty" "$SRC/keys.ghostty" "$SRC/install.sh" "$dir/"
+    mkdir -p "$dir/machines"
+    cp "$SRC"/machines/*.ghostty "$dir/machines/"
+    printf '\nfont-size = not-a-number\n' >>"$dir/fleet.ghostty"
+    printf '%s' "$dir"
+}
+
+# UPGRADE: something was already installed. It must come back byte-for-byte.
+CASES=$((CASES + 1))
+H5="$(mktemp -d)"
+mkdir -p "$H5/.config/ghostty"
+printf '# the config that was here before\nfont-size = 21\n' >"$H5/.config/ghostty/config"
+BEFORE_SHA="$(shasum -a 256 "$H5/.config/ghostty/config" | cut -d' ' -f1)"
+BS="$(broken_source)"
+HOME="$H5" bash "$BS/install.sh" >/dev/null 2>&1
+IRC=$?
+AFTER_SHA="$(shasum -a 256 "$H5/.config/ghostty/config" 2>/dev/null | cut -d' ' -f1)"
+if [[ "$IRC" == "0" ]]; then
+    fail "rollback/upgrade: install REPORTED SUCCESS with an invalid source"
+elif [[ "$BEFORE_SHA" != "$AFTER_SHA" ]]; then
+    fail "rollback/upgrade: the previous config was NOT restored" "before=$BEFORE_SHA" "after=${AFTER_SHA:-<file gone>}"
+else
+    pass "guilt — a rejected config rolls back and the previous one returns byte-identical"
+fi
+rm -rf "$H5" "$BS"
+
+# FRESH: nothing was installed. Rollback must remove what it placed, not leave a
+# half-written config while reporting that nothing was lost.
+CASES=$((CASES + 1))
+H6="$(mktemp -d)"
+BS="$(broken_source)"
+HOME="$H6" bash "$BS/install.sh" >/dev/null 2>&1
+IRC=$?
+SURVIVORS="$(ls -A "$H6/.config/ghostty" 2>/dev/null | grep -vE '^\.backup-' | wc -l | tr -d ' ')"
+if [[ "$IRC" == "0" ]]; then
+    fail "rollback/fresh: install REPORTED SUCCESS with an invalid source"
+elif [[ "$SURVIVORS" != "0" ]]; then
+    fail "rollback/fresh: $SURVIVORS file(s) left behind after a failed install" "$(ls -A "$H6/.config/ghostty" 2>/dev/null | tr '\n' ' ')"
+else
+    pass "guilt — a failed FRESH install leaves nothing behind"
+fi
+rm -rf "$H6" "$BS"
+
+# ══════════════════════════ Guard 4 — a tool that cannot answer is not a pass
+# verify.sh shells out to the Ghostty binary for four separate questions. If the
+# binary cannot answer one of them, that is a finding — not a silent skip and
+# certainly not an "ok". `GHOSTTY_BIN` is overridable, so this is testable with a
+# stand-in that answers some subcommands and fails others.
+fake_ghostty() {
+    local dir fail_on
+    dir="$(mktemp -d)"
+    fail_on="$1"
+    cat >"$dir/ghostty" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+  --version)         echo "Ghostty 1.3.1"; exit 0 ;;
+  +validate-config)  exit 0 ;;
+  $fail_on)          echo "stand-in: refusing $fail_on" >&2; exit 3 ;;
+  +show-config)      echo "working-directory = \$HOME"; exit 0 ;;
+  +show-face)        echo "found in face \"\$(sed -n 's/^--font-family=//p' <<<"\$2")\""; exit 0 ;;
+  +ssh-cache)        echo "no hosts"; exit 0 ;;
+  *)                 exit 0 ;;
+esac
+EOF
+    chmod +x "$dir/ghostty"
+    printf '%s' "$dir/ghostty"
+}
+
+for SUB in +ssh-cache +show-config +show-face; do
+    CASES=$((CASES + 1))
+    H7="$(build_home "$MACHINE")"
+    FG="$(fake_ghostty "$SUB")"
+    OUT="$(HOME="$H7" GHOSTTY_BIN="$FG" bash "$VERIFY" 2>&1)"
+    RC=$?
+    if [[ "$RC" == "0" ]]; then
+        fail "guard4: verify PASSED while the binary could not answer $SUB" "$(tail -3 <<<"$OUT")"
+    elif ! grep -q -- "$SUB" <<<"$OUT"; then
+        fail "guard4: verify failed but never named $SUB as the reason" "$(grep -iE 'FAIL' <<<"$OUT" | head -2)"
+    else
+        pass "guilt — a binary that cannot answer $SUB is a failure that names itself (rc=$RC)"
+    fi
+    rm -rf "$H7" "$(dirname "$FG")"
+done
+
+# ═══════════════════ Guard 5 — unreadable is its own verdict, not "empty"
+# The Application Support guard once set its count to 0 when the count FAILED,
+# then fell through to the success branch, so the verifier printed both "cannot
+# count" and "present but empty (no effect)" — the second contradicting the
+# first. Unreadable and empty must never share an outcome.
+CASES=$((CASES + 1))
+H8="$(build_home "$MACHINE")"
+printf 'font-size = 9\n' >"$H8/$APPSUP_REL"
+chmod 000 "$H8/$APPSUP_REL"
+OUT="$(HOME="$H8" bash "$VERIFY" 2>&1)"
+RC=$?
+if [[ "$RC" == "0" ]]; then
+    fail "guard5: an UNREADABLE higher-priority config passed clean"
+elif grep -qi 'present but empty' <<<"$OUT"; then
+    fail "guard5: verify called an unreadable file empty — a claim it had just said it could not make" "$(grep -iE 'application support|cannot read' <<<"$OUT")"
+elif ! grep -qi 'cannot read' <<<"$OUT"; then
+    fail "guard5: failed, but not because the file is unreadable" "$(grep -iE 'FAIL' <<<"$OUT" | head -2)"
+else
+    pass "guilt — an unreadable Application Support config is its own verdict, never 'empty'"
+fi
+chmod 644 "$H8/$APPSUP_REL"
+rm -rf "$H8"
+
 echo
 if ((FAILURES > 0)); then
     echo "FAIL: $FAILURES of $CASES ghostty-guard cases"

--- a/scripts/tests/test_ghostty_guards.sh
+++ b/scripts/tests/test_ghostty_guards.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# test_ghostty_guards.sh — guilt AND innocence for the two guards in the Ghostty
+# fleet profile (superscar #3: a guard is not shipped until it proves both).
+#
+# Guard 1 — the Application Support precedence check, in BOTH verify.sh and
+# install.sh. macOS searches ~/Library/Application Support/com.mitchellh.ghostty/
+# config.ghostty BEFORE any XDG location, so a file there silently outranks the
+# whole installed profile. It has to be judged by CONTENT, not existence, because
+# Ghostty.app creates that file empty by itself — a presence test would fail
+# forever on every machine and train the reader to ignore the script.
+#
+# It shipped broken and was fixed on 2026-08-18: `grep -c` prints its count on
+# stdout AND exits 1 when the count is zero, so `$(grep -c ... || echo 0)`
+# appended a SECOND zero and the numeric test died on the two-line string "0\n0"
+# with `integer expression expected`. This is the W104 class, already pinned for
+# .claude/scripts/codex-spalla.sh by test_codex_spalla_grep_c.sh — the cure there
+# was scoped to ONE FILE, so the class walked straight into a new one four days
+# later. Section 1 is what stops it walking into the next.
+#
+# Guard 2 — the machine-profile check in verify.sh. It used to accept
+# machine.ghostty if it matched ANY of the three host profiles, so M5's profile
+# installed on Pro passed, working-directory and all.
+#
+# Nothing here touches the caller's real ~/.config/ghostty or the real
+# ~/Library: every case runs against a fabricated HOME.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+SRC="$REPO_ROOT/infra/ghostty"
+VERIFY="$SRC/verify.sh"
+INSTALL="$SRC/install.sh"
+FAILURES=0
+CASES=0
+
+fail() {
+    FAILURES=$((FAILURES + 1))
+    echo "  ✗ FAIL: $1"
+    [[ $# -gt 1 ]] && printf '    %s\n' "${@:2}"
+}
+pass() { echo "  ✓ $1"; }
+
+for f in "$VERIFY" "$INSTALL"; do
+    [[ -f "$f" ]] || {
+        echo "FATAL: $f not found"
+        exit 2
+    }
+done
+
+# The verifier shells out to the real Ghostty binary. Without it every case would
+# fail for the same irrelevant reason and the corpus would be measuring the
+# machine, not the guard (W108: a fake world too poor to reach the code under
+# test reports its own poverty).
+GHOSTTY="/Applications/Ghostty.app/Contents/MacOS/ghostty"
+if [[ ! -x "$GHOSTTY" ]]; then
+    echo "SKIP: Ghostty is not installed on this machine — the guards cannot be exercised"
+    exit 0
+fi
+
+this_machine() {
+    case "$(hostname -s 2>/dev/null)" in
+    Nuzantara) echo pro ;;
+    Air-M5) echo m5 ;;
+    Mini-Pro2 | mini-pro2) echo mini ;;
+    *) echo "" ;;
+    esac
+}
+MACHINE="$(this_machine)"
+if [[ -z "$MACHINE" ]]; then
+    echo "SKIP: hostname is not one of the three fleet machines — the host-aware guard has no expected answer here"
+    exit 0
+fi
+
+# A HOME holding a correctly installed profile, so any failure a case produces is
+# attributable to the thing that case varies and nothing else.
+build_home() {
+    local machine="$1" root
+    root="$(mktemp -d)"
+    mkdir -p "$root/.config/ghostty" "$root/Library/Application Support/com.mitchellh.ghostty"
+    cp "$SRC/config" "$SRC/fleet.ghostty" "$SRC/keys.ghostty" "$root/.config/ghostty/"
+    cp "$SRC/machines/$machine.ghostty" "$root/.config/ghostty/machine.ghostty"
+    printf '%s' "$root"
+}
+
+APPSUP_REL="Library/Application Support/com.mitchellh.ghostty/config.ghostty"
+
+run_case() {
+    local label="$1" home="$2" want_rc="$3" want_text="$4"
+    CASES=$((CASES + 1))
+    local out rc
+    out="$(HOME="$home" bash "$VERIFY" 2>&1)"
+    rc=$?
+    if grep -q 'integer expression expected' <<<"$out"; then
+        fail "$label: the guard could not evaluate its own count (W104 \"0\\n0\" regression)" "$out"
+        return
+    fi
+    if [[ "$rc" != "$want_rc" ]]; then
+        fail "$label: rc $rc, expected $want_rc" "$(grep -i 'application support' <<<"$out" | head -2)"
+        return
+    fi
+    if ! grep -qi "$want_text" <<<"$out"; then
+        fail "$label: verdict did not say \"$want_text\"" "$(grep -i 'application support' <<<"$out" | head -2)"
+        return
+    fi
+    pass "$label"
+}
+
+# ══════════════════════════════════════ Guard 1 — Application Support precedence
+# INNOCENCE first: the three states that must stay quiet. Two are the ones the
+# broken arithmetic hit, and one of those — "exists but empty" — is the state the
+# running app CREATES ON ITS OWN, i.e. the everyday case.
+H="$(build_home "$MACHINE")"
+run_case "innocence — no Application Support config at all" "$H" 0 "no higher-priority config"
+
+: >"$H/$APPSUP_REL"
+run_case "innocence — file exists but is EMPTY (what Ghostty.app itself creates)" "$H" 0 "present but empty"
+
+printf '# a comment\n\n   \n' >"$H/$APPSUP_REL"
+run_case "innocence — comments and blank lines only" "$H" 0 "present but empty"
+
+# GUILT
+printf 'font-size = 8\nbackground-opacity = 1\n' >"$H/$APPSUP_REL"
+run_case "guilt — two real settings outranking the profile" "$H" 1 "takes PRECEDENCE"
+
+# The count must be REPORTED, not just detected: "a file is in the way" without a
+# number sends the reader to look at the wrong thing.
+CASES=$((CASES + 1))
+OUT="$(HOME="$H" bash "$VERIFY" 2>&1)"
+if grep -q 'holds 2 setting' <<<"$OUT"; then
+    pass "guilt — names how many settings are in the way"
+else
+    fail "guilt: the count was not in the message" "$(grep -i 'precedence' <<<"$OUT" | head -1)"
+fi
+
+# install.sh carries the same guard and must agree. A fix that covers only the
+# half that bit you is half a fix.
+CASES=$((CASES + 1))
+IOUT="$(HOME="$H" bash "$INSTALL" 2>&1)"
+if grep -q 'integer expression expected' <<<"$IOUT"; then
+    fail "install.sh: same guard, still cannot evaluate its count"
+elif ! grep -qi 'takes precedence' <<<"$IOUT"; then
+    fail "install.sh: silent about a config that outranks what it just installed" "$(tail -3 <<<"$IOUT")"
+else
+    pass "guilt — install.sh warns about the same file the verifier fails on"
+fi
+
+# install.sh must stay silent on the innocent world, or its warning becomes noise.
+CASES=$((CASES + 1))
+: >"$H/$APPSUP_REL"
+IOUT="$(HOME="$H" bash "$INSTALL" 2>&1)"
+if grep -q 'integer expression expected' <<<"$IOUT"; then
+    fail "install.sh innocence: the guard could not evaluate (W104 regression)"
+elif grep -qi 'takes precedence' <<<"$IOUT"; then
+    fail "install.sh innocence: warned about an EMPTY file — the state the app creates by itself"
+else
+    pass "innocence — install.sh stays quiet on the empty file the app creates"
+fi
+rm -rf "$H"
+
+# ═══════════════════════════════════════════ Guard 2 — the machine profile check
+# GUILT: another host's profile. It parses, it validates, every setting in it is
+# legal — the only thing wrong is that it belongs to a different machine, which
+# is exactly what a value-level check cannot see.
+OTHER=pro
+[[ "$MACHINE" == pro ]] && OTHER=m5
+H2="$(build_home "$OTHER")"
+CASES=$((CASES + 1))
+OUT="$(HOME="$H2" bash "$VERIFY" 2>&1)"
+RC=$?
+# Assert the FAIL branch's own wording. An earlier version of this case grepped
+# for "machine profile", which appears in BOTH verdicts — "machine profile
+# installed: pro (matches this host)" and "wrong machine profile: ...". Mutation
+# testing caught it: neutering the check to `cmp -s dest dest` left this case
+# GREEN, because the wrong profile was still rejected, just by the
+# working-directory check further down, and the passing verdict's own text
+# satisfied the grep. Right answer, wrong reason (superscar #3, over-match).
+if [[ "$RC" == "0" ]]; then
+    fail "guilt: verify passed with ${OTHER}'s profile installed on a $MACHINE host" "$(grep -i 'machine profile' <<<"$OUT" | head -1)"
+elif ! grep -q "wrong machine profile" <<<"$OUT"; then
+    fail "guilt: rejected, but NOT by the profile check — something else caught it" "$(grep -iE 'FAIL' <<<"$OUT" | head -3)"
+elif ! grep -q "machine.ghostty is '$OTHER'" <<<"$OUT"; then
+    fail "guilt: the profile check fired but did not name which profile is installed" "$(grep -i 'wrong machine profile' <<<"$OUT" | head -1)"
+else
+    pass "guilt — ${OTHER}'s profile on a $MACHINE host is rejected BY THE PROFILE CHECK, which names it"
+fi
+rm -rf "$H2"
+
+# INNOCENCE: this host's own profile must pass, or the guard is just noise.
+H3="$(build_home "$MACHINE")"
+CASES=$((CASES + 1))
+OUT="$(HOME="$H3" bash "$VERIFY" 2>&1)"
+RC=$?
+if [[ "$RC" != "0" ]]; then
+    fail "innocence: verify rejected this host's OWN profile" "$(grep -vE '^[[:space:]]*ok' <<<"$OUT" | head -4)"
+else
+    pass "innocence — the correct profile for $MACHINE passes clean"
+fi
+rm -rf "$H3"
+
+# ═══════════════════════════════════════════════════ argument handling, install.sh
+# `--machine` with no value used to consume nothing and fall through to hostname
+# detection, so a typo installed a profile the caller did not ask for.
+# rc != 0 is NOT enough here, and mutation testing proved it: with the guard
+# deleted, `--machine` with no value still exits non-zero, because `case "$2"`
+# under `set -u` dies on an unbound variable — and `--machine banana` still
+# exits non-zero, because the install fails later looking for a profile file
+# that does not exist. Both are the right verdict for the wrong reason, and both
+# leave a caller staring at a message about something else. So assert the
+# refusal's own words and its exact exit code.
+H4="$(mktemp -d)"
+CASES=$((CASES + 1))
+OUT="$(HOME="$H4" bash "$INSTALL" --machine 2>&1)"
+RC=$?
+if [[ "$RC" == "0" ]]; then
+    fail "guilt: --machine with no value was accepted and installed something"
+elif ! grep -q -- "--machine needs a value" <<<"$OUT"; then
+    fail "guilt: --machine with no value failed for some OTHER reason" "rc=$RC" "$(head -3 <<<"$OUT")"
+elif [[ "$RC" != "2" ]]; then
+    fail "guilt: refused with the right message but rc=$RC, expected 2"
+else
+    pass "guilt — --machine with no value is refused by its own guard, rc=2"
+fi
+CASES=$((CASES + 1))
+OUT="$(HOME="$H4" bash "$INSTALL" --machine banana 2>&1)"
+RC=$?
+if [[ "$RC" == "0" ]]; then
+    fail "guilt: --machine banana was accepted"
+elif ! grep -q "unknown machine 'banana'" <<<"$OUT"; then
+    fail "guilt: banana was rejected, but not by the name check — the caller is told the wrong thing" "rc=$RC" "$(head -3 <<<"$OUT")"
+elif [[ "$RC" != "2" ]]; then
+    fail "guilt: right message but rc=$RC, expected 2"
+else
+    pass "guilt — an unknown machine name is refused by name, rc=2"
+fi
+rm -rf "$H4"
+
+echo
+if ((FAILURES > 0)); then
+    echo "FAIL: $FAILURES of $CASES ghostty-guard cases"
+    exit 1
+fi
+echo "PASS: $CASES/$CASES ghostty-guard cases"


### PR DESCRIPTION
Follow-up to #4295, which is merged. That PR shipped the fleet profile; this one
acts on the adversarial round that ran against it, plus two things I found while
re-verifying its own claims.

## Two traps that were live

**`global:cmd+grave_accent` took a macOS system shortcut.** `global:` registers a
system-wide hotkey and, per the reference, "will always consume the input" — so it
shadowed *Cycle Through Windows* in every application on the machine, not just this
one. It needs Accessibility to take effect, so I measured rather than assumed:
`com.mitchellh.ghostty` is granted on Pro (`auth_value 2`), so the trap was armed
here the moment the profile landed. Mini has no row — inert there. On M5 the query
answers `authorization denied` over ssh, so that host is **CANNOT-VERIFY**, which is
not the same as "not granted". Moved to `cmd+alt+grave`.

**The resize key table was sticky and leaked.** The reference: "If an invalid key is
pressed, the sequence ends but the table remains active", and lookup falls through to
the outer table — so a stray keystroke while resizing went into the shell *and* left
you silently still in resize mode. Added `resize/catch_all=deactivate_key_table` and
an exit on `cmd+r`.

## Three safety nets that could not fire

- **Rollback was a no-op on a fresh install.** With no backup, `restore()` returned
  immediately, left whatever had already been copied, and reported "nothing lost".
  Now it removes what it placed, restores the retired filename, checks every step, and
  says which of the two situations it is in. Proven by installing from a deliberately
  broken source onto an empty directory: 4 files before, 0 after.
- **`verify.sh` accepted any machine profile** — it passed with M5's profile installed
  on Pro, working-directory and all. It now derives the expected profile from the
  hostname, like the installer, and separately fails if the working-directory is absent.
- **`--machine` with no value** consumed nothing and fell through to hostname detection.
  Now it requires `pro|m5|mini`. A failing `+ssh-cache` is a capability failure, not a
  warning that leaves rc=0.

## A blind spot

macOS searches `~/Library/Application Support/com.mitchellh.ghostty/config.ghostty`
**before** any XDG path and nothing here could override it. Both scripts now look —
judged by **content**, not existence, because Ghostty.app creates that file empty by
itself (measured: the CLI does not, the running app does). A presence test would fail
forever on every machine and teach you to ignore the script.

## Corrections to the previous PR's own claims

- `macos-option-as-alt` was `left`, which is backwards: the backtick is at the top
  **left** of this layout, so the left hand is the one composing `option+\`` for à è ì ò ù.
- "later wins" was stated as a blanket rule. Measured, it holds for **scalar** settings
  only: `font-family` appends a fallback chain across included files (reset needs
  `font-family = ""` first), as do `font-feature` and `command-palette-entry`;
  `keybind` appends except that the same trigger replaces its action.
- `keys.ghostty` restated **11** Ghostty 1.3.1 defaults under a comment claiming the
  file "only adds what is missing". The claim was false; the defaults are now listed
  instead. Counting them is fiddlier than it looks — see below.
- The runbook still taught `cmd+grave`, the binding this branch moves, and quoted tmux
  3.6a for Pro (that is Mini's version, transposed).

## Two probes that cannot say no, recorded so nobody repeats them

- **`+show-config --default=true` ignores your config** and prints compile-time
  defaults. With `font-size = 99` on disk it answers `13`. The effective configuration
  is `+show-config` with **no flag** — and it prints only what differs from default, so
  a key's *absence* there means "equals the default", not "unset".
- **`+show-config` silently drops keybind prefixes.** A `global:` bind prints as an
  ordinary one, so it cannot tell you whether a bind is global. Only the file knows.
  (Checked that `verify.sh` does not rely on it for this: its two uses read
  `working-directory` and print scalars for eyeballing.)
- `+list-keybinds --default=true` prefixes each line with `keybind = ` and prints
  Ghostty's normalised spelling (`cmd`→`super`, `left`→`arrow_left`, `comma`→`,`).
  Comparing raw bindings against it reports 0 of 12 as defaults — which is how the
  first draft of this message came to say 8.

## One cure, not just a diagnosis

The runbook diagnosed why teammate panes fail to open in a bare Ghostty window and
then left the primary workstation in exactly that state, with the fix written as an
instruction for someone else to run. Installed: **M5 now has tmux 3.7b**. The
distinction that installing does not settle is kept in the doc — the backend's first
branch tests `$TMUX`, so the binary being present only makes the fix *available*.

## Refuted by measurement, recorded so they are not re-raised

The reviewer reported that `JetBrainsMono Nerd Font Mono` does not resolve on Pro — it
does, isolated and live, with all three Nerd variants present (16 files each); its
sandbox could not read `~/Library/Fonts`. It also reported that `+validate-config`
ignores a file named `config`; appending an invalid key to an included file returns
rc=1 naming the offending line, which it cannot do without reading the chain through
`config`.

## Verified live

Reinstalled on all three machines after the fix: `verify.sh` rc=0 on Pro, M5 and Mini,
with the new host-aware check reporting `machine profile installed: pro (matches this
host)` and `Application Support config present but empty (no effect)`.
`macos-option-as-alt = right` and `keybind = super+alt+backquote=toggle_quick_terminal`
confirmed present in the effective config on every host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)