### PR TITLE
feat(ci): manual kill-switch for change-map ring-gating (Merge-OS round-2 Cure #1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,14 @@
 /scripts/ci/test_change_map.py                       @Balizero1987
 /scripts/ci/hotzone_changed_files.sh                 @Balizero1987
 
+# Ring-gating manual kill-switch (Merge-OS v2 round-2 Cure #1, adapted
+# 2026-08-18) — sits in the same trust boundary as the classifier files
+# above: a PR that neuters this script's ability to force the full suite
+# quietly disarms the one operator-controlled emergency lever over the
+# ring-gating the three files above implement.
+/scripts/ci/ring_gating_override.sh                  @Balizero1987
+/scripts/ci/test_ring_gating_override.py             @Balizero1987
+
 # ---------------------------------------------------------------------------
 # Deploy / infra config — TIER 1
 # ---------------------------------------------------------------------------

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,36 @@ jobs:
         with:
           fetch-depth: 0
 
+      # MANUAL OVERRIDE (Merge-OS v2 round-2 Cure #1, adapted 2026-08-18 —
+      # PENDING-ARMS.md "Wave 2 of Merge-OS v2 may be armed ONLY with the
+      # four round-2 cures incorporated"). Round-2 demanded an explicit,
+      # fail-safe-polarity kill switch for ring-gating; by the time this cure
+      # was revisited, ring-gating had already shipped default-ON via #4181
+      # with its own internal fail-open defaults (classifier/extraction/
+      # corpus failure -> run_all=true), so this is a DISCRETIONARY manual
+      # lever additive to those defaults, not a replacement for them — an
+      # operator can force the full suite during an incident regardless of
+      # whether the classifier is technically succeeding. Full truth-table
+      # rationale + why the literal v2 variable would have been a silent
+      # regression: scripts/ci/ring_gating_override.sh (guilt+innocence
+      # corpus: scripts/ci/test_ring_gating_override.py).
+      - name: Manual override — force full suite (Merge-OS round-2 Cure #1)
+        id: override
+        env:
+          MERGEOS_RING_GATING_DISABLED: ${{ vars.MERGEOS_RING_GATING_DISABLED }}
+        run: bash scripts/ci/ring_gating_override.sh >> "$GITHUB_OUTPUT"
+
+      # Self-test, unconditional (mirrors "Self-test changed-file
+      # enumerator" in hot-zone-pr-gate.yml): proves BOTH that the script's
+      # own truth table holds AND that it is actually wired into the `if:`
+      # of every step it is meant to gate (round-2 Cure #3's WIRED-shape
+      # demand, adapted) — never gated behind its own output, which would
+      # be a guard that can disable its own guilt test.
+      - name: Self-test ring-gating override (guilt + innocence)
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 scripts/ci/test_ring_gating_override.py
+
       # ROOT OF TRUST (red-team CRITICAL-1, 2026-08-14): the PR's own checkout
       # cannot be trusted to judge itself — a PR that breaks backend code
       # could, in the SAME commit, edit hotzone_changed_files.sh or
@@ -131,6 +161,7 @@ jobs:
       # added to CODEOWNERS TIER 1 in this same commit.
       - name: Extract trusted classifier (base ref)
         id: extract
+        if: steps.override.outputs.active != 'true'
         env:
           BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
         run: |
@@ -160,6 +191,7 @@ jobs:
       # extraction above, not this checkout's copy (CRITICAL-1).
       - name: Verify change-map guilt and innocence corpus
         id: classifier-tests
+        if: steps.override.outputs.active != 'true'
         continue-on-error: true
         env:
           CLASSIFIER_DIR: ${{ steps.extract.outputs.dir }}
@@ -181,6 +213,7 @@ jobs:
       # is therefore not a live gap, it only narrows the fallback path.
       - name: Enumerate and classify this PR's files
         id: classify
+        if: steps.override.outputs.active != 'true'
         continue-on-error: true
         env:
           BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
@@ -253,6 +286,7 @@ jobs:
           MAP_JSON: ${{ steps.classify.outputs.map }}
           CLASSIFIER_TEST_OUTCOME: ${{ steps.classifier-tests.outcome }}
           CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
+          OVERRIDE_ACTIVE: ${{ steps.override.outputs.active }}
         run: |
           python3 - <<'PY'
           import json
@@ -261,6 +295,25 @@ jobs:
           raw = os.environ.get("MAP_JSON", "")
           if raw:
               result = json.loads(raw)
+          elif os.environ.get("OVERRIDE_ACTIVE") == "true":
+              # Manual override (Merge-OS round-2 Cure #1) — the classifier was
+              # never consulted, this is not a failure. Distinguished from the
+              # classifier_runtime_failure fallback below so the step summary
+              # never misreports an intentional operator action as a defect.
+              result = {
+                  "reason": "manual_override_disabled",
+                  "run_all": True,
+                  "suggested_jobs": [
+                      "backend-tests",
+                      "mcp-tests",
+                      "evaluator-critical-tests",
+                      "frontend-tests",
+                      "packages-core-tests",
+                      "e2e-tests",
+                  ],
+                  "would_skip": [],
+                  "unknown_paths": [],
+              }
           else:
               result = {
                   "reason": "classifier_runtime_failure",

--- a/scripts/ci/ring_gating_override.sh
+++ b/scripts/ci/ring_gating_override.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Merge-OS v2 round-2 Cure #1 (adapted 2026-08-18) — manual emergency
+# override for the change-map ring-gating in tests.yml's `changes` job.
+#
+# WHY THIS IS "ADAPTED" AND NOT A LITERAL PORT of the round-2 finding
+# (PENDING-ARMS.md, "Wave 2 of Merge-OS v2 may be armed ONLY with the four
+# round-2 cures incorporated", opened 2026-08-10):
+#
+# The 2026-08-10 refutation demanded an explicit OPT-IN kill-switch
+# expression (`vars.MERGEOS_RING_GATING != 'on'`) whose ambiguous states
+# (unset, typo, 'off') all resolve to the EXPENSIVE/SAFE direction (full
+# suite) — never to the cheap/risky direction (silent skip) — because at
+# the time ring-gating did not exist yet and was going to be introduced
+# gated OFF by default.
+#
+# By the time this cure was revisited (2026-08-18), ring-gating had
+# already shipped default-ON via #4181 (2026-08-14, "promote change-map
+# from shadow to enforcing"), with its OWN fail-open defaults baked into
+# every internal layer: classifier-extraction failure, guilt/innocence
+# corpus failure, enumeration failure, or an unclassified path all force
+# `run_all=true` (see tests.yml's `changes` job `outputs:` block, every
+# `run_*` key defaults `|| 'true'`). Re-applying the v2 variable literally
+# — `vars.MERGEOS_RING_GATING != 'on'` gating the *entire* classifier off
+# by default — would have SILENTLY REGRESSED #4181's shipped benefit back
+# to always-run-everything the instant this landed, because nothing sets
+# `MERGEOS_RING_GATING=on` anywhere in this repo's config today. That is
+# an own-goal, not a cure.
+#
+# What was still genuinely missing (verified 2026-08-18 against
+# origin/main: no `vars.` reference of any kind exists in tests.yml) is a
+# DISCRETIONARY MANUAL LEVER: something an operator can flip during an
+# incident to force the full suite regardless of what the classifier
+# itself computes — independent of whether the classifier is technically
+# "working" (its own fail-open defaults only catch classifier ERRORS, not
+# an operator's judgment call that they don't trust a specific
+# classification today). That is what this script adds: additive to the
+# existing fail-open defaults, never subtractive from them.
+#
+# Truth table (same invariant as round-2 — an ambiguous value must never
+# resolve to the risky direction — expressed with the opposite-polarity
+# variable this shipped reality actually needs):
+#
+#   MERGEOS_RING_GATING_DISABLED | override state | effect
+#   ------------------------------|----------------|---------------------------
+#   'true' (exact, case-sensitive)| ACTIVE          | force full suite (classifier bypassed entirely)
+#   'false'                       | inactive        | classifier decides (today's shipped default, unchanged)
+#   unset / '' / any other value  | inactive        | classifier decides (today's shipped default, unchanged)
+#
+# Every value except the exact literal string "true" leaves today's
+# behavior completely untouched. By construction, the only reachable
+# effect of misconfiguring this variable is running MORE tests, never
+# fewer — it is structurally impossible to use this override to widen a
+# skip. That property is what makes it safe to wire with a plain `==`
+# check rather than needing the `!=` inversion trick round-2 required for
+# the original (opt-in-to-enable) polarity.
+set -euo pipefail
+
+if [[ "${MERGEOS_RING_GATING_DISABLED:-}" == "true" ]]; then
+  echo "active=true"
+else
+  echo "active=false"
+fi

--- a/scripts/ci/test_ring_gating_override.py
+++ b/scripts/ci/test_ring_gating_override.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Guilt + innocence corpus for the ring-gating manual kill switch.
+
+Merge-OS v2 round-2 Cure #1 (adapted 2026-08-18 — PENDING-ARMS.md "Wave 2
+of Merge-OS v2 may be armed ONLY with the four round-2 cures incorporated").
+Two layers, both exercised here:
+
+1. The SCRIPT's own truth table (`ring_gating_override.sh`), invoked as a
+   real subprocess — never a Python re-implementation of its shell logic,
+   which would only prove the two copies agree with each other (the exact
+   self-referential-guard trap cicatrix-superscar.md family #3 warns about).
+2. The WIRED shape in `.github/workflows/tests.yml` — round-2's third cure
+   ("guilt corpus must test the WIRED needs:-based shape, not only the bare
+   expression, else a skipped classifier job silently skips its dependents",
+   W117-class) demanded exactly this: proving the override script is truly
+   consulted by the `changes` job's `if:` conditions, not merely correct in
+   isolation. A script that behaves perfectly but was never wired into an
+   `if:` would pass every test in layer 1 and gate nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+SCRIPT = Path(__file__).with_name("ring_gating_override.sh")
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "tests.yml"
+
+GATED_STEP_IDS = ("extract", "classifier-tests", "classify")
+EXPECTED_GATE = "steps.override.outputs.active != 'true'"
+
+
+def _run(value: str | None) -> str:
+    env = {}
+    if value is not None:
+        env["MERGEOS_RING_GATING_DISABLED"] = value
+    completed = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+class RingGatingOverrideScriptTests(unittest.TestCase):
+    """Layer 1 — the script's own truth table, executed for real."""
+
+    def test_guilt_exact_true_activates_override(self) -> None:
+        self.assertEqual(_run("true"), "active=true")
+
+    def test_innocence_unset_stays_inactive(self) -> None:
+        self.assertEqual(_run(None), "active=false")
+
+    def test_innocence_empty_string_stays_inactive(self) -> None:
+        self.assertEqual(_run(""), "active=false")
+
+    def test_innocence_literal_false_stays_inactive(self) -> None:
+        self.assertEqual(_run("false"), "active=false")
+
+    def test_innocence_case_variant_stays_inactive(self) -> None:
+        # Case-sensitivity is a deliberate safety property, not an oversight:
+        # only the exact lowercase literal "true" may widen the suite. Any
+        # near-miss must fail toward the classifier's own already-fail-open
+        # default, never toward a silently-neutralized override.
+        self.assertEqual(_run("TRUE"), "active=false")
+        self.assertEqual(_run("True"), "active=false")
+
+    def test_innocence_typo_stays_inactive(self) -> None:
+        for typo in ("1", "yes", "on", "  true  ", "true "):
+            self.assertEqual(
+                _run(typo),
+                "active=false",
+                msg=f"typo value {typo!r} must not activate the override",
+            )
+
+
+class RingGatingOverrideWiringTests(unittest.TestCase):
+    """Layer 2 — the WIRED shape (round-2 Cure #3's demand, adapted)."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        with WORKFLOW.open(encoding="utf-8") as handle:
+            cls.workflow = yaml.safe_load(handle)
+        cls.changes_steps = cls.workflow["jobs"]["changes"]["steps"]
+
+    def _step(self, step_id: str) -> dict:
+        for step in self.changes_steps:
+            if step.get("id") == step_id:
+                return step
+        self.fail(f"no step with id={step_id!r} found in changes job")
+
+    def test_guilt_override_step_exists_before_gated_steps(self) -> None:
+        ids = [s.get("id") for s in self.changes_steps if s.get("id")]
+        self.assertIn("override", ids)
+        override_index = ids.index("override")
+        for gated_id in GATED_STEP_IDS:
+            self.assertIn(gated_id, ids)
+            self.assertLess(
+                override_index,
+                ids.index(gated_id),
+                msg=f"{gated_id} step must run after the override step",
+            )
+
+    def test_guilt_every_classifier_step_is_gated_by_the_override(self) -> None:
+        # This is the exact hazard round-2 named: an override script that is
+        # correct in isolation but whose `if:` was never actually attached
+        # to the steps it is supposed to bypass would leave this assertion
+        # failing while every Layer-1 test above stays green.
+        for step_id in GATED_STEP_IDS:
+            step = self._step(step_id)
+            self.assertEqual(
+                step.get("if"),
+                EXPECTED_GATE,
+                msg=f"step id={step_id!r} is not gated by the override output",
+            )
+
+    def test_innocence_override_step_itself_is_ungated(self) -> None:
+        # The override step must always run (it decides for everyone else) —
+        # gating it on its own output would be a guard that can disable
+        # itself, exactly the pattern cicatrix-superscar.md family #3 forbids.
+        override_step = self._step("override")
+        self.assertNotIn("if", override_step)
+
+    def test_guilt_publish_step_distinguishes_override_from_failure(self) -> None:
+        publish = next(
+            s
+            for s in self.changes_steps
+            if s.get("name") == "Publish change-map decision"
+        )
+        run_text = publish["run"]
+        self.assertIn("manual_override_disabled", run_text)
+        self.assertIn("classifier_runtime_failure", run_text)
+        self.assertIn("OVERRIDE_ACTIVE", publish.get("env", {}))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Closes the last open item of Merge-OS v2 round-2's "four cures" (PENDING-ARMS.md, opened 2026-08-10: *"Wave 2 of Merge-OS v2 may be armed ONLY with the four round-2 cures incorporated"*).

Verified against current `origin/main` before writing any code:

- **Cure #2** (CODEOWNERS + hot-zone protection for the classifier) — already shipped via #4181 (2026-08-14). `scripts/ci/change_map.py`, `test_change_map.py`, `hotzone_changed_files.sh` are CODEOWNERS TIER 1, and the classifier additionally runs a base-ref-extracted trusted copy (root-of-trust, stronger than what round-2 asked for).
- **Cure #3** (guilt corpus on the WIRED `needs:`-based shape) — already shipped via #4181: every downstream job uses `needs: [changes]` + `!cancelled()` + `needs.changes.result != 'success'`, with an explicit W117-class comment, and `test_change_map.py`'s 26-test corpus runs on every PR.
- **Cure #4** (billed/PR attribution formula) — already shipped via #4031, with the pagination-cap bisection fix (#4185/#4189) and the declared even-split/`unattributed_*` accounting.
- **Cure #1** (kill-switch opt-in expression, fail-safe polarity) — **the one still open.** The literal v2 text (`vars.MERGEOS_RING_GATING != 'on'` gating the classifier off by default) would have been a silent regression if applied today: ring-gating already ships default-ON via #4181, with its own internal fail-open defaults. Nobody sets `MERGEOS_RING_GATING=on` anywhere, so re-applying that variable would have turned ring-gating off the instant this PR landed — an own-goal, not a cure.

## What this PR adds

- `scripts/ci/ring_gating_override.sh` — a DISABLE-only manual override, additive to the classifier's existing fail-open defaults, never subtractive from them. Truth table: only the exact literal `MERGEOS_RING_GATING_DISABLED=true` forces the full suite (bypasses the classifier entirely); every other value (unset, empty, `false`, any typo/case-variant) leaves today's shipped behavior untouched. By construction, misconfiguring this variable can only run *more* tests, never fewer.
- Wired into `tests.yml`'s `changes` job ahead of the classifier steps (`extract`, `classifier-tests`, `classify` all gated on `steps.override.outputs.active != 'true'`); the "Publish change-map decision" step distinguishes `manual_override_disabled` from `classifier_runtime_failure` in its summary.
- `scripts/ci/test_ring_gating_override.py` — guilt+innocence corpus with two layers: (1) the script's own truth table, executed as a real subprocess, never a Python re-implementation; (2) the WIRED shape — parses the live workflow YAML and asserts every gated step actually carries the override `if:` condition. Mutation-verified: removing the `if:` from one gated step makes the wiring test fail (confirmed locally before commit).
- CODEOWNERS TIER 1 extended to both new files — same trust boundary as the classifier files they sit beside.

## What this PR deliberately does NOT do

Per the mandate's own constraint ("Wave 2 si arma SOLO con le 4 cure incorporate... se una cura non è implementabile, NON armare Wave 2"): this PR does not declare "Wave 2 armed." Ring-gating is already live on `origin/main` (shipped via #4181, outside any formal wave-authorization process), and the 2026-08-14 `research/operations/2026-08-14-merge-os-v3-research-council.md` council doc — which supersedes v2's wave plan — records that ring-gating's own recommended prerequisites (steps 1-7: suite-growth governance, derived-state deletion, judge root-of-trust as a formal step, flake/retry regime, shadow re-observation) are not yet complete. This PR closes the one genuinely open round-2 cure; it does not retroactively bless the wave-2 gate process that ring-gating bypassed when it shipped.

A companion PR updates the stale PENDING-ARMS ledger rows (914/916, 915/917, 918) to reflect all of the above.

## Test plan

- [x] `python3 scripts/ci/test_ring_gating_override.py` — 10/10 green
- [x] `python3 scripts/ci/test_change_map.py` — 26/26 green (no regression)
- [x] `actionlint .github/workflows/tests.yml` — clean
- [x] `shellcheck scripts/ci/ring_gating_override.sh` — clean
- [x] Mutation check: removed the `if:` gate from one classifier step in a scratch copy, confirmed the wiring guilt test fails
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"` — parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)