### PR TITLE
feat(analytics): wire trackLeadCreated at the lead-capture handoff

### DIFF
--- a/apps/mouth/src/components/lead/WhatsAppLeadButton.test.tsx
+++ b/apps/mouth/src/components/lead/WhatsAppLeadButton.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 
-import { trackLeadWhatsAppCTA } from "@/lib/analytics";
+import { trackLeadCreated, trackLeadWhatsAppCTA } from "@/lib/analytics";
 import { WhatsAppLeadButton, FALLBACK_WA_URL } from "./WhatsAppLeadButton";
 
 vi.mock("@/lib/analytics", () => ({
+  trackLeadCreated: vi.fn(),
   trackLeadWhatsAppCTA: vi.fn(),
 }));
 
@@ -12,6 +13,12 @@ describe("WhatsAppLeadButton", () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
+    // vi.restoreAllMocks() in afterEach restores spies; it does NOT clear the
+    // call history of a vi.fn() from a vi.mock factory (measured: the analytics
+    // mock arrived here holding 3 calls from earlier tests). Every pre-existing
+    // assertion is toHaveBeenCalledWith, which tolerates leftovers, so nothing
+    // caught it until an exact-count assertion was added.
+    vi.clearAllMocks();
     global.fetch = vi.fn(async () => ({
       ok: true,
       json: async () => ({
@@ -31,10 +38,10 @@ describe("WhatsAppLeadButton", () => {
     global.fetch = originalFetch;
   });
 
-  function renderButton() {
+  function renderButton(source = "kbli_navigator") {
     return render(
       <WhatsAppLeadButton
-        source="kbli_navigator"
+        source={source}
         resultHash="56303"
         context={{ code: "56303" }}
         whatsappContext={[{ label: "KBLI", value: "56303" }]}
@@ -120,5 +127,36 @@ describe("WhatsAppLeadButton", () => {
         result_ref: "56303",
       });
     });
+  });
+
+  it("fires trackLeadCreated once with the prop source on a captured lead", async () => {
+    // "article" rather than the helper default: a component that hardcoded a
+    // source instead of forwarding the prop would still pass with the default.
+    const { getByRole } = renderButton("article");
+    fireEvent.click(getByRole("link"));
+
+    await waitFor(() => {
+      expect(trackLeadCreated).toHaveBeenCalledWith("article");
+    });
+    expect(trackLeadCreated).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire trackLeadCreated when capture fails", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    const { getByRole } = renderButton();
+    fireEvent.click(getByRole("link"));
+
+    // Anchored to the fallback navigation, not to a bare assertion: without a
+    // point the handoff has demonstrably finished, "not called" would also be
+    // true of a click that never ran.
+    await waitFor(() => {
+      expect(window.location.href).toBe(FALLBACK_WA_URL);
+    });
+    expect(trackLeadCreated).not.toHaveBeenCalled();
   });
 });

--- a/apps/mouth/src/components/lead/WhatsAppLeadButton.tsx
+++ b/apps/mouth/src/components/lead/WhatsAppLeadButton.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
 } from "react";
 
-import { trackLeadWhatsAppCTA } from "@/lib/analytics";
+import { trackLeadCreated, trackLeadWhatsAppCTA } from "@/lib/analytics";
 
 /** Bare business wa.me link — no-JS href and fallback when capture fails.
  *  Same number used by the backend deeplink builder default. */
@@ -75,6 +75,10 @@ export function WhatsAppLeadButton({
         lead_intent_id: json.lead_intent_id,
         result_ref: resultHash,
       });
+      // Only after the 201 is parsed: a lead_intents row now exists, so the
+      // intent is captured rather than merely attempted. In the catch below
+      // no row was written, which is why this does not fire there.
+      trackLeadCreated(source);
       window.location.href = json.whatsapp_url;
     } catch {
       // Fallback handoff still counts as a CTA click — captured=false

--- a/apps/mouth/src/lib/analytics.ts
+++ b/apps/mouth/src/lib/analytics.ts
@@ -229,7 +229,21 @@ function sendGA4Event(
   win.gtag("event", eventName, params);
 }
 
-/** Track when a new lead/client is created in CRM */
+/**
+ * Track a captured lead intent at the WhatsApp handoff — fired by
+ * WhatsAppLeadButton once POST /api/lead/capture has returned 201 and a
+ * `lead_intents` row exists. `source` is a LeadSource wire value.
+ *
+ * Despite the `lead_created` event name, this is NOT the CRM client row.
+ * That row is written later by `scripts/lead_intent_matcher.py`, a
+ * server-side cron that sets `lead_intents.matched_client_id` and
+ * `clients.lead_source`; with no browser there, the CRM event cannot be
+ * emitted through `window.gtag` at all. So this counts intents, not
+ * clients, and the two numbers are expected to differ.
+ *
+ * The event name is load-bearing for the KPI dashboards that read
+ * `lead_created` — rename only as a deliberate, coordinated change.
+ */
 export function trackLeadCreated(source: string): void {
   sendGA4Event("lead_created", { event_category: "Conversion", source });
   trackEvent("lead_created", { source });


### PR DESCRIPTION
## Studio

No visual change to end users. This adds an analytics call site to an existing lead-capture button and corrects a docstring.

## Problem

`trackLeadCreated` had a definition and no callers. The GA4 `lead_created` event the KPI dashboards read has therefore never fired, so its value is zero because of instrumentation, not performance. Ledger `PENDING-ARMS.md:761` names it explicitly and asks for a call site, "not a funeral", because the bonus/KPI negotiation opened 2026-08-03 rests on GA4 being a usable baseline.

A second, quieter problem sat next to it. The docstring read `Track when a new lead/client is created in CRM`. That is not what this point in the code does, and a comment is a claim — the next reader takes it as verified fact.

## Change

Three files, 61 insertions, 5 deletions.

1. `WhatsAppLeadButton.tsx` — `trackLeadCreated(source)` in the success block, next to the existing `trackLeadWhatsAppCTA` call: after the `!res.ok` throw and after the 201 body is parsed. The prop variable is passed, not a literal.
2. `analytics.ts` — docstring rewritten to state what is actually emitted. Function name, GA4 event name (`lead_created`) and payload are untouched.
3. `WhatsAppLeadButton.test.tsx` — mock extended, two tests added, and `vi.clearAllMocks()` added to `beforeEach` (see Raw Observations).

## Raw Observations

Base of this branch: `9768f7f67cfda2a4d4c569f93273979ec038a887`. Commit as shipped, re-measured while writing this body: `977935d4d`.

**Before — the zero, with its positive control**

```
git grep -n 'trackLeadCreated' origin/main
  -> apps/mouth/src/lib/analytics.ts:233          (the definition)
  -> .claude/skills/final-gate-discipline/SKILL.md:67   (prose)
  -> .claude/skills/modus/PENDING-ARMS.md:761           (prose)
```

1 definition line, 0 call-site lines. Positive control from the same file, so the zero is not a blind probe:

```
git grep -c 'export function track' origin/main -- apps/mouth/src/lib/analytics.ts
  -> 30
```

Three different surfaces give three different export counts and I did not reconcile them, because reconciling was not asked for: `'export function track'` = **30** lines, `'^export function '` = **32** lines, and the ledger says **34** `track*` functions. All three are recorded here rather than one being quietly picked.

**After — the ledger's own proof-of-armed, run verbatim**

```
git grep -l -w trackLeadCreated \
  -- apps/mouth/src ':!apps/mouth/src/lib/analytics.ts' ':!*.test.*'
  -> apps/mouth/src/components/lead/WhatsAppLeadButton.tsx
```

1 file, >= 1 required. The repo-wide form with the same exclusions returns the same single file.

**Source parity — unchanged contract**

12 production call sites of `<WhatsAppLeadButton`, every `source=` value present in the backend `LeadSource` enum (15 members, `services/lead_capture/source.py`): `article` x2, `kbli_builder`, `kbli_decoder`, `kbli_navigator` x2, `tax_gap`, `homepage_hero`, `cta_handoff`, `zoning_check`, `zantara_widget_handoff`, `pricing_modal`.

This PR passes the existing `source` **prop variable**, so it introduces no new `source="..."` literal. The tripwire scans literals only and says so itself (`test_data_invariant_tripwires.py:58-59`: *"Only literals are covered — `source={variable}` is out of reach and is a separate, harder contract"*). No new parity contract is created here.

**Mutation-verify — three mutations, each applied, run, and reverted**

| Mutation | Result | Tests that fell |
|---|---|---|
| (a) remove the `trackLeadCreated` call | 1 failed, 6 passed | `fires trackLeadCreated once with the prop source on a captured lead` |
| (b) move the call into the `catch` | 2 failed, 5 passed | both of the above **and** `does not fire trackLeadCreated when capture fails` |
| (c) move the call before `if (!res.ok) throw` | 1 failed, 6 passed | `does not fire trackLeadCreated when capture fails` |

All three matched prediction. After the third revert the file was confirmed byte-identical to its pre-mutation state (`cmp -s` -> IDENTICAL) and the suite returned 7/7.

On (a): the innocence test cannot fall when the call is deleted, since "not called" stays true. That is correct behaviour for an innocence test, not a weakness — (b) and (c) are what prove it is load-bearing.

**A defect this PR surfaced in the existing test file**

The first run of the new tests failed. Measured cause, not assumed: `vi.restoreAllMocks()` in `afterEach` restores spies but does **not** clear the call history of a `vi.fn()` created in a `vi.mock` factory. The analytics mock reached the new tests already holding 3 calls from earlier tests in the file. Every pre-existing assertion in this file is `toHaveBeenCalledWith`, which tolerates leftovers, so five green tests had been sitting on leaking mock state without anyone noticing. It surfaced only when an exact-count assertion (`toHaveBeenCalledTimes(1)`) was added. Fixed at the source with `vi.clearAllMocks()` in `beforeEach`.

**Local verification**

- `npx vitest run src/components/lead/ src/lib/analytics.test.ts src/lib/analytics-doc-table.test.ts` -> 3 files, **38 passed**
- `npm run build` -> completed; `Compiled successfully in 2.2min`, `Finished TypeScript in 3.2min` with no errors, 1760/1760 static pages, `PUBLIC_LOGIN_BUNDLE_OK`
- `npx tsc --noEmit` -> **RC 0, 0 errors**
- `npx prettier --check` on the three touched files -> clean (no global prettier run)
- backend tripwire `test_frontend_lead_sources_are_all_valid_enum_values` -> **1 passed, RC 0**

Two other tests in that tripwire file fail locally with `ModuleNotFoundError` (`pydantic_settings`, `asyncpg`) — local venv gaps. Marked **UNVERIFIED-environmental**, not clean: this PR changes zero Python files, and both failures are third-party import errors in tests about pricing JSON and PIN serialization. CI is the real gate.

`npm run lint` was **not** run: the known environmental crash (`TypeError: react/display-name … getFilename is not a function`, eslint-plugin-react vs ESLint 10.3.0) reproduces on files this PR does not touch. Note also that `eslint.config.mjs:15` ignores `src/**/*.test.{ts,tsx}`, so a green exit on the test file would have been empty anyway.

**Two measurement traps hit while doing this, recorded because both nearly produced a false report**

1. `git diff --stat origin/main` showed **13 files**, `git status` showed **4**. `origin/main` advanced 4 commits mid-session (`9768f7f67` -> `384271744`, telegram-webhook / ring-gating / cockpit work by others). The two-dot diff against a moved tip attributed main's new files to this branch. The honest measurement is against this branch's own base: **3 files**.
2. A standalone `npx tsc --noEmit` run *while the background build was live* emitted a flood of `TS6053 .next/types/... not found`. That was the build wiping and regenerating `.next`, i.e. my own probe interfering. Re-run after the build finished: RC 0, 0 errors.

Also worth naming: `git status` and `${PIPESTATUS[0]}` disagreed twice — piping a test command into `tail` returned an empty RC, so two "verifications" initially had no verdict at all. Both were re-measured with an explicit `RC=$?` before being written down here.

## Reasoning Path

**Why the call sits at the success block and nowhere else.** `POST /api/lead/capture` returns 201 and writes exactly one `lead_intents` row (`lead_capture.py:77-130`). Only past the `!res.ok` throw and the JSON parse is it true that a row exists. Placed in the `catch`, the event would count handoffs where no row was ever written — inflating the metric with its own failures. Placed before the `!res.ok` check, it would fire on every click including 4xx/5xx, which is the same inflation with an extra step. Mutations (b) and (c) exist to keep those two placements from ever quietly returning.

**Why the docstring is in this PR rather than a follow-up.** Not extra scope: it is the wiring being honest. Wiring the call while leaving a comment that says "created in CRM" would mean shipping, in the same change, a fresh reason for the next reader to believe something false — that `lead_created` counts CRM clients. The docstring now states what it counts (intents), names the actual CRM writer, and says why that event cannot be emitted from a browser.

**Why the event name was not touched.** `lead_created` is read by the KPI dashboards. Renaming it to match the corrected semantics would break the very metric this PR exists to switch on. If the name should change, that is Antonello's call and it belongs in Recommendation, not smuggled into a wiring diff.

## Risk

1. **`lead_created` will now count intents, not clients, and the two numbers will differ.** Anyone reading the GA4 number as "clients acquired" will overcount, because a captured intent is a WhatsApp handoff that may never become a client. The docstring says so, but a docstring is not visible from a dashboard. If the dashboard has a label, it should say *lead intents*.
2. Both `lead_created` and `lead_whatsapp_cta` now fire from the same click (see Recommendation 1), so any dashboard summing "conversion events" will double-count this action.
3. The pre-commit anti-reward-hacking lint printed `no staged test files — nothing to check` while a `.test.tsx` file was staged. That lint appears not to see TypeScript test files, so the new tests were **not** covered by it. Reported, not fixed — it is the W95 family and belongs in its own change.

## Recommendation

Two separate items. Neither is done here, both carry their numbers.

1. **`lead_created` and `lead_whatsapp_cta` now fire from the same point for the same action.** Different names, overlapping information: `trackLeadWhatsAppCTA` already sends `captured: true` plus `lead_intent_id` and `result_ref` from lines 73-77 of the same block, and its docstring names this component explicitly. Whether both should live side by side, or one should be retired, is a decision nobody has yet made. It was deliberately not made inside a wiring PR.
2. **The real "lead created in CRM" event happens in `scripts/lead_intent_matcher.py`** — a server-side cron that updates `lead_intents.matched_client_id` and `clients.lead_source`. It cannot be emitted via `window.gtag`, which returns silently when `typeof window === "undefined"`. If the bonus metric genuinely needs the CRM number rather than the intent number, the surface is the Measurement Protocol from the server, not the frontend — outside the VERDE zone. Raised, not attempted. For scale: the ledger records `clients.lead_source='website'` at 9 rows out of 11,816 all-time, so the web-to-client loop is currently unmeasurable at both ends and this PR fixes only the near end.

## Next Action

After deploy, confirm the event is arriving:

```
# GA4 -> Admin -> DebugView, with the site opened via ?debug_mode=1
# then click any WhatsApp CTA and look for:  lead_created
# params to expect: event_category=Conversion, source=<LeadSource value>

# or, in the browser console before clicking, to see it leave the page:
window.dataLayer.push = new Proxy(window.dataLayer.push, {
  apply: (t, s, a) => (console.log('GA4', a[0]), Reflect.apply(t, s, a))
});
```

Honest caveat on reading that result: GA4 has reporting lag. DebugView is near-real-time, but standard reports can take 24-48h. **"Not visible in the first hour" is not evidence of failure** — check DebugView first, and only treat a standard-report zero as meaningful after a full day.
