### PR TITLE
fix(ci): production never skips its own build — the previous SHA is the last attempt, not what is live

### DIFF
--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -73,32 +73,50 @@ BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
 
 log() { printf 'should-build: %s\n' "$1" >&2; }
 
-# The production branch never skips. Not on a missing previous SHA, and not on a present one.
+# Production never skips. Not on a missing previous SHA, and not on a present one.
 #
-# The guard used to live inside the `[ -z "$BASE" ]` block below, on the reasoning that the
-# danger was comparing main against main and reading the empty diff as "nothing to build". That
-# named the right danger and only half the doors. On main `VERCEL_GIT_PREVIOUS_SHA` is normally
-# SET, so the block was skipped entirely and the production guard inside it never ran.
+# The guard used to live inside the `[ -z "$BASE" ]` block below, on the reasoning that the danger
+# was comparing main against main and reading the empty diff as "nothing to build". That named the
+# right danger and only half the doors. On main `VERCEL_GIT_PREVIOUS_SHA` is normally SET, so the
+# block was skipped whole and the guard inside it never ran.
 #
-# What that variable actually holds is the previous *attempted* deployment — including attempts
-# this script itself skipped, and attempts Vercel cancelled because a newer commit superseded
-# them. It does NOT hold what is live. So the base walks forward past a frontend commit whose own
-# build never shipped, and every later commit is judged against that base and correctly finds no
-# frontend change. The stranded commit is then unreachable: no future diff ever spans it again.
+# WHAT VERCEL_GIT_PREVIOUS_SHA ACTUALLY CONTAINED, measured rather than read off the docs. Vercel
+# documents it as the last SUCCESSFUL deployment for the project and branch. On 2026-08-18 that
+# was demonstrably not what arrived. The production build of 98ab65ab logged:
 #
-# Measured on 2026-08-18. balizero.com was serving f6dfda99, built 2026-08-15, while main was 75
-# commits ahead: 272 files changed in between, 30 of them frontend paths. The individual builds
-# saw 4 and 18 files and skipped, each of them right about its own base and all of them wrong
-# about production. Among the stranded commits was #4178, which removed `Avg reply: 2 min` — a
-# claim measured false against 189 message pairs (average ~9h) — so the page kept serving a
-# number we had already proven wrong, for three days, with every check green.
+#     should-build: no frontend path in 18 changed file(s) -> SKIP
 #
-# The asymmetry at the top of this file settles which way to fail: an unnecessary production
-# build costs ~6 minutes, a wrongly skipped one serves stale code across the whole public surface
-# until a human happens to notice. The savings were never here anyway — the 2026-07-29
-# measurement put 83% of build minutes in PR previews, and that is where they stay.
-if [ -n "$REF" ] && [ "$REF" = "$PROD_BRANCH" ]; then
-  log "production branch '$REF' -> BUILD (a previous SHA names the last attempt, not what is live)"
+# Eighteen. Walking main's first-parent history and diffing each candidate against 98ab65ab, the
+# only commits that produce exactly 18 changed files are 5deddb30e / 41cd6b786 / e61c9e076 /
+# b6cb85034 — all landed the SAME DAY. The last successful production deployment, f6dfda99 from
+# 2026-08-15, sits 272 files back with 30 frontend paths among them, and would have produced
+# BUILD. #4178 sits 39 files back, also with frontend paths. So the base was neither: it had
+# already advanced past both, onto commits that never shipped anything.
+#
+# The exact SHA cannot be pinned from the log (four candidates give 18, the log does not print
+# the base). What IS established is the direction, and it is the whole point: the base advances
+# past commits whose builds never shipped, so a frontend commit that is superseded once is never
+# seen by any later diff again. It is stranded for good.
+#
+# The visible cost: balizero.com served the 2026-08-15 build for three days while main ran 75
+# commits ahead, and kept publishing `Avg reply: 2 min` — measured false against 189 message
+# pairs, average ~9h — for three days after #4178 removed it. Every check was green throughout.
+#
+# WHY THE TEST IS `VERCEL_ENV` FIRST. The branch comparison alone is not the deployment
+# environment: `vercel --prod` can promote a non-production branch, and that deployment is
+# production no matter what its ref says. `VERCEL_ENV` is the documented system variable for
+# exactly this question, so it leads; the branch test stays as the second arm because
+# `VERCEL_GIT_PROD_BRANCH` may be absent (the `:-main` fallback is correct for this repo) and
+# because the corpus runs the script outside Vercel entirely, where only the ref exists.
+#
+# Direction of failure is settled by the asymmetry at the top of this file: an unnecessary
+# production build costs ~6 minutes, a wrongly skipped one serves stale code across the whole
+# public surface until a human happens to notice. NOT claimed: that this is free. The 2026-07-29
+# measurement (83% of build minutes in PR previews) says where the historical minutes went, and
+# cannot price builds that were skipped and so never appear in it. The marginal cost of building
+# every production commit is unmeasured here; it is accepted, not shown to be zero.
+if [ "${VERCEL_ENV:-}" = "production" ] || { [ -n "$REF" ] && [ "$REF" = "$PROD_BRANCH" ]; }; then
+  log "production deployment (env='${VERCEL_ENV:-unset}' ref='${REF:-unset}') -> BUILD (a previous SHA names an earlier ATTEMPT, not what is live)"
   exit 1
 fi
 
@@ -117,9 +135,11 @@ if [ -z "$BASE" ]; then
   # "cannot fetch" and nothing else. A fail-open branch that does not say WHICH stage opened
   # cannot be repaired from its own evidence. So: cheapest-first resolution, each stage
   # announcing itself without replaying Git stderr, which may contain an authenticated URL.
-  # (The production check that used to sit here has moved above this block, where it can also see
-  # the deployments that DO have a previous SHA — which is all of them, on main. Leaving a copy
-  # here would be unreachable code that reads like a second line of defence.)
+  # (The production check that used to sit here has moved above this block, where it also sees the
+  # deployments that DO carry a previous SHA — the case this block never reaches, and the one that
+  # froze production. A first deployment with no previous SHA still exists and is still covered,
+  # now by the same check one level up. Leaving a copy here would be unreachable code that reads
+  # like a second line of defence.)
 
   # (1) The merge queue puts the BASE COMMIT in the ref name:
   #     gh-readonly-queue/<base-branch>/pr-<n>-<base-sha>

--- a/scripts/ci/vercel_should_build.sh
+++ b/scripts/ci/vercel_should_build.sh
@@ -73,6 +73,35 @@ BASE="${VERCEL_GIT_PREVIOUS_SHA:-}"
 
 log() { printf 'should-build: %s\n' "$1" >&2; }
 
+# The production branch never skips. Not on a missing previous SHA, and not on a present one.
+#
+# The guard used to live inside the `[ -z "$BASE" ]` block below, on the reasoning that the
+# danger was comparing main against main and reading the empty diff as "nothing to build". That
+# named the right danger and only half the doors. On main `VERCEL_GIT_PREVIOUS_SHA` is normally
+# SET, so the block was skipped entirely and the production guard inside it never ran.
+#
+# What that variable actually holds is the previous *attempted* deployment — including attempts
+# this script itself skipped, and attempts Vercel cancelled because a newer commit superseded
+# them. It does NOT hold what is live. So the base walks forward past a frontend commit whose own
+# build never shipped, and every later commit is judged against that base and correctly finds no
+# frontend change. The stranded commit is then unreachable: no future diff ever spans it again.
+#
+# Measured on 2026-08-18. balizero.com was serving f6dfda99, built 2026-08-15, while main was 75
+# commits ahead: 272 files changed in between, 30 of them frontend paths. The individual builds
+# saw 4 and 18 files and skipped, each of them right about its own base and all of them wrong
+# about production. Among the stranded commits was #4178, which removed `Avg reply: 2 min` — a
+# claim measured false against 189 message pairs (average ~9h) — so the page kept serving a
+# number we had already proven wrong, for three days, with every check green.
+#
+# The asymmetry at the top of this file settles which way to fail: an unnecessary production
+# build costs ~6 minutes, a wrongly skipped one serves stale code across the whole public surface
+# until a human happens to notice. The savings were never here anyway — the 2026-07-29
+# measurement put 83% of build minutes in PR previews, and that is where they stay.
+if [ -n "$REF" ] && [ "$REF" = "$PROD_BRANCH" ]; then
+  log "production branch '$REF' -> BUILD (a previous SHA names the last attempt, not what is live)"
+  exit 1
+fi
+
 if [ -z "$BASE" ]; then
   # No previous deployment on this ref — this is the case that matters. Measured on the real
   # billing data, first deployments are 89% of the waste: most PRs here are one or two commits
@@ -88,10 +117,9 @@ if [ -z "$BASE" ]; then
   # "cannot fetch" and nothing else. A fail-open branch that does not say WHICH stage opened
   # cannot be repaired from its own evidence. So: cheapest-first resolution, each stage
   # announcing itself without replaying Git stderr, which may contain an authenticated URL.
-  if [ "$REF" = "$PROD_BRANCH" ]; then
-    log "production branch with no previous deployment -> BUILD (never risk a stale production)"
-    exit 1
-  fi
+  # (The production check that used to sit here has moved above this block, where it can also see
+  # the deployments that DO have a previous SHA — which is all of them, on main. Leaving a copy
+  # here would be unreachable code that reads like a second line of defence.)
 
   # (1) The merge queue puts the BASE COMMIT in the ref name:
   #     gh-readonly-queue/<base-branch>/pr-<n>-<base-sha>

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -15,11 +15,20 @@
 #   * inverting the exit contract            -> 7 of 11 fail
 #   * dropping vercel.json from the paths    -> 1 fails
 #   * fetch failure treated as SKIP          -> 1 fails
-#   * removing BOTH production guards        -> 2 fail
-#   * removing ONLY the `$REF = main` guard  -> 0 fail.  Not a missing test: the `base == HEAD`
-#     guard below catches the same case, because on main the merge-base with main IS HEAD. The
-#     two guards are redundant on purpose and the suite asserts the OUTCOME (main always builds),
-#     which is the thing that matters. Removing both does fail, above.
+#   * removing the production guard          -> 3 fail  (re-measured 2026-08-18)
+#   * keying it on the literal "main" instead of $PROD_BRANCH -> 2 fail, one in each direction
+#
+#   CORRECTED 2026-08-18, and the wrong version is quoted because it is the reason nobody looked.
+#   This header used to say: removing the `$REF = main` guard fails nothing, the `base == HEAD`
+#   guard covers the same case, "the two guards are redundant on purpose and the suite asserts the
+#   OUTCOME (main always builds), which is the thing that matters." The first two clauses were
+#   true. The last one was not, and it is the one that got believed. The suite asserted main
+#   always builds in the only two shapes it had: no previous SHA, and a previous SHA equal to
+#   HEAD. Every real production deployment has a previous SHA pointing at an EARLIER commit —
+#   the one shape that was never written down. In it both guards were bypassed and main skipped,
+#   which is what froze balizero.com for three days from 2026-08-15. A mutation that kills
+#   nothing is worth a second look: here it was not redundancy, it was a guard that could not be
+#   reached from the case that mattered, and the note explained the zero away instead of chasing it.
 #   * grep exiting >=2                       -> 0 fail. Genuinely UNCOVERED: this corpus has no
 #     way to make grep itself error. The branch is written fail-open and reviewed, not proven.
 #   * pointer reverted to a bare invocation  -> 4 fail, every one as `rc=127 (DEPLOYMENT ERROR)`.
@@ -126,7 +135,7 @@ VERCEL_GIT_COMMIT_REF=ops/cron VERCEL_GIT_PREVIOUS_SHA= \
   run SKIP "first deploy of a multi-commit backend/ops branch"
 
 echo
-echo "=== THE PRODUCTION GUARD: main must never skip on a missing previous SHA"
+echo "=== THE PRODUCTION GUARD: main must never skip, with or without a previous SHA"
 # Comparing main against main gives an empty diff. Without the guard this single case would
 # freeze balizero.com and every subdomain — the 2026-07-27 outage, re-created by an optimisation.
 git -C "$WORK" checkout -q main
@@ -134,6 +143,41 @@ VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA= \
   run BUILD "main with no previous deployment"
 VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$MAIN_TIP" \
   run BUILD "main against its own tip (base == HEAD)"
+
+# The shape that actually froze production on 2026-08-18, and that neither line above can reach.
+# On main `VERCEL_GIT_PREVIOUS_SHA` is normally SET and names an EARLIER commit, so the empty-BASE
+# guard never runs and the base==HEAD guard never fires: the diff decides. The diff is honest and
+# the verdict is still wrong, because that variable holds the last ATTEMPTED deployment — skips
+# and cancellations included — not what is live. A frontend commit whose own build was superseded
+# falls behind the base and no later diff ever spans it again.
+#
+# Both of these were SKIP before the guard moved out of the empty-BASE block. Live consequence:
+# balizero.com served a 2026-08-15 build for three days while main ran 75 commits ahead with 30
+# frontend files among them, and kept publishing `Avg reply: 2 min` after we had measured it false.
+PROD_PREV=$MAIN_TIP
+commit "docs/prod-note.md" "a docs-only commit landing on main"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
+  run BUILD "main, docs-only delta vs an EARLIER main commit (the 2026-08-18 freeze)"
+
+PROD_PREV=$(git -C "$WORK" rev-parse HEAD)
+commit ".claude/skills/modus/PENDING-ARMS.md" "a ledger line, also on main"
+VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
+  run BUILD "main, a second docs-only delta in a row (how the freeze persists)"
+
+# INNOCENCE. The guard must key on "is this the production branch", not on the literal string
+# main. Point production elsewhere and main is an ordinary branch again, skipping exactly as
+# before — without this, a hardcoded name would silently disable the whole optimisation on every
+# other branch the day production is renamed, and nothing would say so.
+VERCEL_GIT_PROD_BRANCH=release VERCEL_GIT_COMMIT_REF=main VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
+  run SKIP "main is NOT production when VERCEL_GIT_PROD_BRANCH names another branch"
+
+# ...and whichever branch IS production inherits the guard.
+git -C "$WORK" checkout -q -b release main
+PROD_PREV=$(git -C "$WORK" rev-parse HEAD)
+commit "docs/release-note.md" "docs only, on the configured production branch"
+VERCEL_GIT_PROD_BRANCH=release VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
+  run BUILD "the configured production branch gets the guard, whatever it is called"
+git -C "$WORK" checkout -q main
 
 echo
 echo "=== OFFLINE BASE RESOLUTION (added 2026-07-30 after the armed guard proved inert)"

--- a/scripts/tests/test_vercel_should_build.sh
+++ b/scripts/tests/test_vercel_should_build.sh
@@ -15,8 +15,11 @@
 #   * inverting the exit contract            -> 7 of 11 fail
 #   * dropping vercel.json from the paths    -> 1 fails
 #   * fetch failure treated as SKIP          -> 1 fails
-#   * removing the production guard          -> 3 fail  (re-measured 2026-08-18)
+#   * removing the production guard entirely -> 4 fail  (measured 2026-08-18)
 #   * keying it on the literal "main" instead of $PROD_BRANCH -> 2 fail, one in each direction
+#   * dropping the VERCEL_ENV arm, leaving the branch test alone -> 1 fail
+#   * making the guard unconditional (`if true`) -> 11 fail. Recorded because it is the shape a
+#     future "just always build, it is safer" edit would take, and it must not pass quietly.
 #
 #   CORRECTED 2026-08-18, and the wrong version is quoted because it is the reason nobody looked.
 #   This header used to say: removing the `$REF = main` guard fails nothing, the `base == HEAD`
@@ -24,11 +27,11 @@
 #   OUTCOME (main always builds), which is the thing that matters." The first two clauses were
 #   true. The last one was not, and it is the one that got believed. The suite asserted main
 #   always builds in the only two shapes it had: no previous SHA, and a previous SHA equal to
-#   HEAD. Every real production deployment has a previous SHA pointing at an EARLIER commit —
-#   the one shape that was never written down. In it both guards were bypassed and main skipped,
-#   which is what froze balizero.com for three days from 2026-08-15. A mutation that kills
-#   nothing is worth a second look: here it was not redundancy, it was a guard that could not be
-#   reached from the case that mattered, and the note explained the zero away instead of chasing it.
+#   HEAD. It never asserted the shape a production deployment takes once the project has one
+#   behind it — a previous SHA pointing at an EARLIER commit. There both guards were bypassed and
+#   main skipped, which is what froze balizero.com for three days from 2026-08-15. A mutation that
+#   kills nothing is worth a second look: here it was not redundancy, it was a guard unreachable
+#   from the case that mattered, and the note explained the zero away instead of chasing it.
 #   * grep exiting >=2                       -> 0 fail. Genuinely UNCOVERED: this corpus has no
 #     way to make grep itself error. The branch is written fail-open and reviewed, not proven.
 #   * pointer reverted to a bare invocation  -> 4 fail, every one as `rc=127 (DEPLOYMENT ERROR)`.
@@ -49,6 +52,12 @@ set -uo pipefail
 
 SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../ci" && pwd)/vercel_should_build.sh"
 [ -f "$SCRIPT" ] || { echo "FATAL: script not found at $SCRIPT"; exit 2; }
+
+# The guard reads VERCEL_ENV, so the corpus must own its value rather than inherit one. A shell
+# that happens to export VERCEL_ENV=production would turn every SKIP case green-to-red at once and
+# the failure would look like a code defect. Empty is neither "production" nor unset-and-guessed;
+# per-case assignments below still win, because the caller's environment beats this default.
+export VERCEL_ENV=
 
 PASS=0; FAIL=0
 ROOT=$(mktemp -d)
@@ -177,6 +186,19 @@ PROD_PREV=$(git -C "$WORK" rev-parse HEAD)
 commit "docs/release-note.md" "docs only, on the configured production branch"
 VERCEL_GIT_PROD_BRANCH=release VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
   run BUILD "the configured production branch gets the guard, whatever it is called"
+
+# The ref is not the environment. `vercel --prod` promotes whatever branch it is pointed at, and
+# that deployment is production however its ref reads — so a branch test alone can skip a real
+# production build. VERCEL_ENV is the documented variable for this question and answers it
+# directly. Raised by an adversarial review of the first version of this fix, which keyed on the
+# branch alone; the case below is that review's own repro.
+VERCEL_ENV=production VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
+  run BUILD "VERCEL_ENV=production on a NON-production branch (vercel --prod)"
+
+# INNOCENCE for that arm: a preview is still a preview, and a docs-only preview still skips.
+# Without this, keying on the environment could quietly become "always build".
+VERCEL_ENV=preview VERCEL_GIT_COMMIT_REF=release VERCEL_GIT_PREVIOUS_SHA="$PROD_PREV" \
+  run SKIP "VERCEL_ENV=preview, docs-only delta -> still skips"
 git -C "$WORK" checkout -q main
 
 echo


### PR DESCRIPTION
## What was wrong

balizero.com served a build from **2026-08-15** for three days while `main` ran **75 commits ahead**. Nothing was red. Every production deployment in the window was reported `Canceled` after ~30 seconds — which is what Vercel calls a build the Ignored Build Step declined:

```
should-build: no frontend path in 18 changed file(s) -> SKIP
```

Each verdict was correct about its own diff and wrong about production.

`scripts/ci/vercel_should_build.sh` already carried a production guard — *main must never skip* — but it sat **inside** the `[ -z "$BASE" ]` block, which only runs when there is no previous deployment to compare against. On `main` there almost always is one, so the block was skipped whole and the guard never ran.

## What the base actually was — measured, not read off the docs

Vercel documents `VERCEL_GIT_PREVIOUS_SHA` as the last **successful** deployment for the project and branch. That is not what arrived.

The log recorded **18** changed files. Walking main's first-parent history and diffing each candidate against the deployed commit, the only commits that produce exactly 18 are `5deddb30e` / `41cd6b786` / `e61c9e076` / `b6cb85034` — **all landed the same day**.

| reference point | distance from the deployed commit |
|---|---|
| last successful production deploy (`f6dfda99`) | 272 files, **30 frontend** → would have BUILT |
| #4178 (`2613c512`) | 39 files, frontend among them |
| the actual base | 18 files, **0 frontend** → SKIP |

The base had already advanced past both, onto commits that shipped nothing. Once a frontend commit is stepped over, no later diff ever spans it again — it is stranded for good.

**Declared limit:** the exact SHA cannot be pinned (four candidates give 18; the log does not print its base). The *direction* is what the fix rests on, and the direction is established.

## The visible cost

Among the stranded commits was **#4178**, which removed `Avg reply: 2 min` — a claim measured false against 189 message pairs (average ~9h). Measured on the live homepage while writing this: `Avg reply` ×2, `2 min` ×3, positive control `<title>` ×1. Three days of serving a number we had already disproved, with every check green.

## The fix

The guard moves **above** the block and keys on **`VERCEL_ENV`** first, with the branch comparison as its second arm.

`VERCEL_ENV` leads because the ref is not the environment: `vercel --prod` promotes whatever branch it is pointed at, and that deployment is production however its ref reads. The branch test stays because `VERCEL_GIT_PROD_BRANCH` may be absent (the `:-main` fallback is right for this repo) and because the corpus runs the script outside Vercel, where only the ref exists.

## Corpus — 35 pass, 0 fail

New cases: two reproducing the freeze (docs-only delta on `main` against an *earlier* main commit, twice in a row — both SKIP before this change), production-on-a-non-production-branch, preview-still-skips, plus innocence for the branch arm.

Mutation-verified:

| mutation | fails |
|---|---|
| production guard removed entirely | **4** |
| keyed on literal `"main"` not `$PROD_BRANCH` | **2** (one each direction) |
| `VERCEL_ENV` arm dropped, branch test alone | **1** |
| guard made unconditional (`if true`) | **11** |

The suite now also owns `VERCEL_ENV` rather than inheriting it, so an exported value in someone's shell cannot turn every SKIP case red and read as a code defect.

## Adversarial review

Reviewed by a cross-family seat under orders to refute (generator ≠ grader — the diff is mine, so I do not grade it). Four objections; three applied:

- **the ref is not the environment** → `VERCEL_ENV` arm added, with its own guilt and innocence cases
- **two overstatements** ("which is all of them, on main"; "every real production deployment has a previous SHA") → both contradicted this suite's own first-deployment case; corrected
- **the cost claim did not follow** → the 83%-in-previews figure cannot price builds that were skipped and so never entered it; the file now says the marginal cost is accepted, not zero

The fourth — that the old script would have built, because the docs define the previous SHA as the last successful deployment — is **refuted by the 18-file measurement above**. That reading of the docs does not describe what the build actually received.

## The header note is corrected, not dropped

It is the reason nobody looked. It recorded that removing the `$REF = main` guard killed nothing and explained the zero as deliberate redundancy — *"the suite asserts the OUTCOME (main always builds)"*. It did not. It asserted main builds in the two shapes it had, and never in the shape a production deployment takes once the project has one behind it.

A mutation that kills nothing is worth chasing, not explaining away.

## Landing effect

The Ignored Build Step runs from the commit being deployed, so this commit's own production build takes the new path and ships the 30 stranded frontend files, including the #4178 removal.

## Rollback

Revert. No DB, no migration, no config change outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)