### PR TITLE
feat(ghostty): the extraordinary layer — P3 gamut, NUZ table, quick-terminal tuning, refuter-hardened

### DIFF
--- a/docs/runbooks/ghostty-fleet.md
+++ b/docs/runbooks/ghostty-fleet.md
@@ -119,8 +119,38 @@ subprocesses and were used successfully from Ghostty on the same day.
 | `cmd+shift+s`           | dump the whole scrollback to a file and open it                 |
 | `cmd+alt+p`             | pin the window on top · `cmd+alt+o` toggle transparency         |
 | `cmd+alt+r`             | read-only mode (blocks input to a running job)                  |
+| `cmd+alt+t`             | rename the current tab (name the lane)                          |
+| `cmd+alt+m`             | flip mouse reporting (escape a mouse-grabbing TUI)              |
+| `cmd+alt+n` then letter | NUZ table: types a fleet command (see below)                    |
 | `cmd+alt+grave`         | quick terminal from anywhere (needs Accessibility)              |
 | `cmd+shift+comma`       | reload the config                                               |
+
+## The NUZ table
+
+`cmd+alt+n` arms a **single-shot** key table (it deactivates after one binding,
+so there is no sticky-mode trap). The next letter TYPES a fleet command into the
+prompt — nothing executes until you read it and press enter, the same convention
+as every Nuzantara palette entry:
+
+|     |                    |     |                     |
+| --- | ------------------ | --- | ------------------- |
+| `s` | repo status        | `w` | worktree list       |
+| `p` | proprioception     | `a` | pending-arms ledger |
+| `l` | HOME-fork lint     | `v` | ghostty verify      |
+| `q` | merge-queue status | `t` | claude tmux session |
+
+The command palette (`cmd+shift+p`) carries the same commands with descriptions,
+plus per-machine `SSH:` entries contributed by each machine profile — the table
+is the muscle-memory path, the palette is the discoverable one.
+
+## What the 2026-08-18 layer changes on screen
+
+- **Display P3** (`window-colorspace`): terminal colours use the panel's full
+  gamut — Mocha accents render slightly more vivid than under sRGB. Revert to
+  `srgb` in `local.ghostty` if colour-matched screenshots matter.
+- **Focus follows mouse** across splits, scoped to the focused window.
+- **Quick terminal** is pinned top, sized 35% of the screen. Changing the
+  position needs a full Ghostty restart, not a reload.
 
 `global:` bindings need Ghostty in **System Settings → Privacy & Security →
 Accessibility**. Without the grant the binding is silently inert — there is no

--- a/docs/runbooks/ghostty-fleet.md
+++ b/docs/runbooks/ghostty-fleet.md
@@ -127,10 +127,12 @@ subprocesses and were used successfully from Ghostty on the same day.
 
 ## The NUZ table
 
-`cmd+alt+n` arms a **single-shot** key table (it deactivates after one binding,
-so there is no sticky-mode trap). The next letter TYPES a fleet command into the
-prompt — nothing executes until you read it and press enter, the same convention
-as every Nuzantara palette entry:
+`cmd+alt+n` arms a **single-shot** key table. One-shot alone is not trap-free —
+the reference deactivates it only on a **valid** binding from the table, so a
+stray key would leave it armed; its `unconsumed:catch_all` is what guarantees
+any other keystroke disarms it (and still reaches the shell). The next letter
+TYPES a fleet command into the prompt — nothing executes until you read it and
+press enter, the same convention as every Nuzantara palette entry:
 
 |     |                    |     |                     |
 | --- | ------------------ | --- | ------------------- |

--- a/infra/ghostty/README.md
+++ b/infra/ghostty/README.md
@@ -124,12 +124,19 @@ leaving a broken config; the fix is to drop three lines from the machine profile
 
 ## Known gaps
 
-- **Mini has no Nerd font.** The fleet `font-family` silently falls back to plain
-  `JetBrains Mono`, which has no icon glyphs, so prompt segments render as tofu.
-  `verify.sh` reports this rather than letting it pass unseen. Fix:
-  `brew install --cask font-jetbrains-mono-nerd-font`.
 - **Agent-team panes do not open in Ghostty.** Claude Code hosts teammate panes
   in tmux or iTerm2 only; in a bare Ghostty window it falls back to an external
   tmux session or fails outright. Running Claude Code inside `tmux` makes panes
-  appear in the Ghostty window. tmux is installed on Pro (3.6a) and absent on M5.
-  See `docs/runbooks/ghostty-fleet.md`.
+  appear in the Ghostty window. The tmux binary is present on all three machines
+  (measured 2026-08-18: Pro 3.7b, M5 3.7b, Mini 3.6a) but the binary is only the
+  prerequisite — the panes appear when Claude Code actually runs INSIDE a
+  session. The palette entry "Claude: agent-pane session (tmux)" and `cmd+alt+n,
+  t` both type the attach command. See `docs/runbooks/ghostty-fleet.md`.
+- **`global:` keybinds need a per-machine Accessibility grant.** Without it the
+  quick-terminal binding is silently inert — no error, nothing happens. The
+  grant cannot be probed remotely (the runbook documents the read-only local
+  check); press the chord once after install to know.
+
+Two gaps this file used to list are cured and guarded: Mini's missing Nerd font
+(installed 2026-08-18; `verify.sh` still checks resolution) and M5's missing
+tmux (installed 2026-08-18).

--- a/infra/ghostty/fleet.ghostty
+++ b/infra/ghostty/fleet.ghostty
@@ -15,10 +15,12 @@
 #  `background-opacity` needs a full restart; blur and the Dock icon are not
 #  documented either way, so treat a relaunch as the reliable route for all three.
 #
-#  NOT every line here changes something. Of the 57 non-repeatable settings this
+#  NOT every line here changes something. Of the 56 non-repeatable settings this
 #  file declares, 26 RESOLVE to Ghostty 1.3.1's own default (both numbers
 #  measured 2026-08-18 with the method below, this file alone in an isolated
-#  XDG_CONFIG_HOME — absence from `+show-config --default=false` = pin). They are kept
+#  XDG_CONFIG_HOME — absence from `+show-config --default=false` = pin;
+#  font-family and font-feature are excluded as REPEATABLE, per the entry
+#  point's own documentation). They are kept
 #  on purpose — an explicit value is a pin that survives an upstream default
 #  flip, and it makes the posture readable instead of implied — but they are
 #  NOT choices, and nothing here should describe them as if they were.

--- a/infra/ghostty/fleet.ghostty
+++ b/infra/ghostty/fleet.ghostty
@@ -15,8 +15,10 @@
 #  `background-opacity` needs a full restart; blur and the Dock icon are not
 #  documented either way, so treat a relaunch as the reliable route for all three.
 #
-#  NOT every line here changes something. Of the 51 non-repeatable settings this
-#  file declares, 24 RESOLVE to Ghostty 1.3.1's own default. They are kept
+#  NOT every line here changes something. Of the 57 non-repeatable settings this
+#  file declares, 26 RESOLVE to Ghostty 1.3.1's own default (both numbers
+#  measured 2026-08-18 with the method below, this file alone in an isolated
+#  XDG_CONFIG_HOME — absence from `+show-config --default=false` = pin). They are kept
 #  on purpose — an explicit value is a pin that survives an upstream default
 #  flip, and it makes the posture readable instead of implied — but they are
 #  NOT choices, and nothing here should describe them as if they were.
@@ -71,6 +73,15 @@ theme = Catppuccin Mocha
 # foreground/background pairs emitted by TUIs without repainting the theme.
 minimum-contrast = 1.5
 
+# Interpret terminal colours in Display P3 instead of sRGB. Every panel this
+# fleet renders on is P3 (M5 laptop, Pro's displays, the Vision Pro virtual
+# display), so sRGB was leaving gamut on the table; Mocha's saturated accents
+# are exactly the colours that gain. This is a CHOICE with a visible effect:
+# colours render slightly more vivid than the theme's sRGB authors saw. If a
+# colour-matched screenshot comparison ever matters, revert to `srgb`.
+# macOS-only key; inert elsewhere.
+window-colorspace = display-p3
+
 # ─── Window & glass ────────────────────────────────────────────────────────
 # macos-glass-regular is a real value on macOS >= 26 and needs background-opacity
 # < 1 to have any effect. Measured 2026-08-18: Pro and M5 run 27.0, Mini runs
@@ -117,6 +128,13 @@ cursor-style = block
 cursor-style-blink = false
 mouse-hide-while-typing = true
 
+# Hovering a split focuses it — no click, no chord. On a screen holding an
+# agent session, a log tail and a shell, the pane you are reading is the pane
+# your keystrokes reach. Scoped by Ghostty to the FOCUSED WINDOW only: mousing
+# over an unfocused window neither raises nor focuses anything, so this cannot
+# steal focus across windows.
+focus-follows-mouse = true
+
 # ─── Long-running commands ─────────────────────────────────────────────────
 # Deploys, pytest suites, LLM panels and fly builds outlive your attention.
 # 'unfocused' notifies only when you are looking at something else; 45s keeps
@@ -149,6 +167,15 @@ bell-features = no-system,no-audio,attention,title
 # the xterm-256color fallback when the install cannot happen.
 shell-integration = detect
 shell-integration-features = cursor,sudo,title,ssh-env,ssh-terminfo,path
+
+# ─── Quick terminal ────────────────────────────────────────────────────────
+# The drop-down surface behind cmd+alt+` (bound in keys.ghostty). Position is
+# a PIN (top is the default); the size is a choice: 35% of the screen height,
+# full width — enough for a log peek or a one-liner without covering the work
+# underneath. Changing position requires a full Ghostty restart (documented);
+# autohide-on-focus-loss and follow-the-space are the defaults and are right.
+quick-terminal-position = top
+quick-terminal-size = 35%
 
 # ─── Clipboard & selection ─────────────────────────────────────────────────
 # copy-on-select stays OFF: selecting text to READ it must never overwrite the
@@ -216,6 +243,14 @@ macos-secure-input-indication = true
 macos-applescript = false
 
 # ─── Safety ────────────────────────────────────────────────────────────────
+# PIN of the upstream default, kept explicit for the same reason as
+# macos-applescript above: title reporting (CSI 21 t) lets the running program
+# read the window title back — the reference calls it "a common security
+# issue", escalating to code execution with a crafted title plus minor user
+# interaction. A terminal that ssh's into three machines keeps this closed on
+# purpose, visibly.
+title-report = false
+
 confirm-close-surface = true
 # Closing a split or tab stays undoable for two minutes instead of five seconds.
 # Deliberately not longer: an un-expired undo keeps the closed session ALIVE, and

--- a/infra/ghostty/keys.ghostty
+++ b/infra/ghostty/keys.ghostty
@@ -78,11 +78,15 @@ keybind = cmd+alt+t=prompt_tab_title
 keybind = cmd+alt+m=toggle_mouse_reporting
 
 # ─── NUZ table: the fleet's daily commands, two keystrokes away ────────────
-# cmd+alt+n arms a SINGLE-SHOT table (`activate_key_table_once`: the table
-# deactivates itself after one binding fires — no sticky-mode trap, which is
-# why this one needs no catch_all). The letter then TYPES the command and
-# stops, same convention as the palette below: no trailing newline, nothing
-# runs until you read it and press enter.
+# cmd+alt+n arms a SINGLE-SHOT table (`activate_key_table_once`). One-shot is
+# NOT trap-free by itself: the reference deactivates it only on "the first
+# VALID keybinding from that table" — a key the table does not bind falls
+# through to the shell and LEAVES THE TABLE ARMED, so a forgotten cmd+alt+n
+# would hijack the next 's' you type mid-word. The catch_all below is what
+# actually closes that hole (same cure as the resize table above); the
+# unconsumed: prefix lets the stray key still reach the shell. The letter
+# then TYPES the command and stops, same convention as the palette below: no
+# trailing newline, nothing runs until you read it and press enter.
 #
 #   cmd+alt+n, s   git status            cmd+alt+n, w   worktree list
 #   cmd+alt+n, p   proprioception        cmd+alt+n, a   pending arms
@@ -98,6 +102,7 @@ keybind = nuz/v=text:bash ~/nuzantara/infra/ghostty/verify.sh
 keybind = nuz/q=text:bash ~/nuzantara/scripts/mq.sh status
 keybind = nuz/t=text:tmux new -As claude
 keybind = nuz/escape=deactivate_key_table
+keybind = nuz/unconsumed:catch_all=deactivate_key_table
 
 # ─── Quick terminal ────────────────────────────────────────────────────────
 # Drops a terminal from the top of the screen over any app.
@@ -114,8 +119,9 @@ keybind = nuz/escape=deactivate_key_table
 keybind = global:cmd+alt+grave_accent=toggle_quick_terminal
 
 # ─── Command palette: Nuzantara entries ────────────────────────────────────
-# These APPEND to Ghostty's 88 built-in entries — measured 96 = 88 + 8. They do
-# not replace them (the reference notes the defaults can be cleared only by
+# These APPEND to Ghostty's 88 built-in entries — measured 2026-08-18:
+# 99 = 88 + the 11 below; the machine profile adds 2 more (101 composed). They
+# do not replace them (the reference notes the defaults can be cleared only by
 # setting this key to an empty value, which we do not do).
 #
 # Every one TYPES the command and stops — no trailing newline, so nothing runs

--- a/infra/ghostty/keys.ghostty
+++ b/infra/ghostty/keys.ghostty
@@ -63,6 +63,42 @@ keybind = cmd+alt+o=toggle_background_opacity
 # long-running job.
 keybind = cmd+alt+r=toggle_readonly
 
+# ─── Naming a lane ─────────────────────────────────────────────────────────
+# Rename the current tab (1.3 editable titles). With three machines and a
+# handful of lanes per session, an unnamed tab is a tab you will mis-click.
+# NOT cmd+shift+t: that is Ghostty's default `undo` (reopen closed surface),
+# measured via +list-keybinds — taking it would shadow the safety net that
+# undo-timeout exists for.
+keybind = cmd+alt+t=prompt_tab_title
+
+# ─── Mouse escape hatch ────────────────────────────────────────────────────
+# A TUI that grabs mouse reporting (htop, lazygit, a stuck vim) owns your
+# scroll wheel and your clicks until it exits — or until you flip reporting
+# off from the terminal side. This is the flip.
+keybind = cmd+alt+m=toggle_mouse_reporting
+
+# ─── NUZ table: the fleet's daily commands, two keystrokes away ────────────
+# cmd+alt+n arms a SINGLE-SHOT table (`activate_key_table_once`: the table
+# deactivates itself after one binding fires — no sticky-mode trap, which is
+# why this one needs no catch_all). The letter then TYPES the command and
+# stops, same convention as the palette below: no trailing newline, nothing
+# runs until you read it and press enter.
+#
+#   cmd+alt+n, s   git status            cmd+alt+n, w   worktree list
+#   cmd+alt+n, p   proprioception        cmd+alt+n, a   pending arms
+#   cmd+alt+n, l   home-fork lint        cmd+alt+n, v   ghostty verify
+#   cmd+alt+n, q   merge-queue status    cmd+alt+n, t   claude tmux session
+keybind = cmd+alt+n=activate_key_table_once:nuz
+keybind = nuz/s=text:git -C ~/nuzantara status --short --branch
+keybind = nuz/w=text:git -C ~/nuzantara worktree list
+keybind = nuz/p=text:cat ~/.nuzantara-proprioception/last.md
+keybind = nuz/a=text:python3 ~/nuzantara/scripts/pending_arms_report.py
+keybind = nuz/l=text:python3 ~/nuzantara/scripts/lint_home_fork.py --check
+keybind = nuz/v=text:bash ~/nuzantara/infra/ghostty/verify.sh
+keybind = nuz/q=text:bash ~/nuzantara/scripts/mq.sh status
+keybind = nuz/t=text:tmux new -As claude
+keybind = nuz/escape=deactivate_key_table
+
 # ─── Quick terminal ────────────────────────────────────────────────────────
 # Drops a terminal from the top of the screen over any app.
 #
@@ -93,3 +129,6 @@ command-palette-entry = title:"Nuzantara: pending arms",description:"Suspended-w
 command-palette-entry = title:"Nuzantara: HOME-fork lint",description:"Check live-vs-repo drift for declared pairs (typed, not executed).",action:"text:python3 ~/nuzantara/scripts/lint_home_fork.py --check"
 command-palette-entry = title:"Ghostty: verify this config",description:"Validate the installed config and check drift, font and terminfo.",action:"text:bash ~/nuzantara/infra/ghostty/verify.sh"
 command-palette-entry = title:"Ghostty: ssh terminfo cache",description:"List hosts that already have xterm-ghostty installed.",action:"text:ghostty +ssh-cache"
+command-palette-entry = title:"Claude: agent-pane session (tmux)",description:"Agent-team panes need tmux or iTerm2 — attach or create the session Claude Code can split (typed, not executed).",action:"text:tmux new -As claude"
+command-palette-entry = title:"Nuzantara: merge queue status",description:"queue_doctor snapshot via mq.sh (typed, not executed).",action:"text:bash ~/nuzantara/scripts/mq.sh status"
+command-palette-entry = title:"Nuzantara: scar query",description:"Search the cicatrix scar corpus (typed — add your search terms).",action:"text:scar query "

--- a/infra/ghostty/machines/m5.ghostty
+++ b/infra/ghostty/machines/m5.ghostty
@@ -23,3 +23,10 @@ macos-icon-screen-color = #1e1e2e,#1e2a3a
 # 24 GB and a full interactive load — keep scrollback at the fleet default.
 window-width = 124
 window-height = 36
+
+# ─── Fleet reach (palette, per-machine) ────────────────────────────────────
+# command-palette-entry ACCUMULATES across included files, so per-machine
+# entries live here. Same convention as keys.ghostty: TYPED, never executed —
+# no trailing newline, nothing runs until you press enter.
+command-palette-entry = title:"SSH: pro (dev + runtime)",description:"Pro workhorse — mDNS at home, Tailscale elsewhere (typed, not executed).",action:"text:ssh pro"
+command-palette-entry = title:"SSH: mini (server H24)",description:"Tailscale-only — Mini is in the office on a separate ISP (typed, not executed).",action:"text:ssh mini"

--- a/infra/ghostty/machines/mini.ghostty
+++ b/infra/ghostty/machines/mini.ghostty
@@ -27,3 +27,10 @@ macos-icon-screen-color = #1e1e2e,#1e2f24
 scrollback-limit = 16000000
 window-width = 120
 window-height = 34
+
+# ─── Fleet reach (palette, per-machine) ────────────────────────────────────
+# command-palette-entry ACCUMULATES across included files, so per-machine
+# entries live here. Same convention as keys.ghostty: TYPED, never executed —
+# no trailing newline, nothing runs until you press enter.
+command-palette-entry = title:"SSH: pro (dev + runtime)",description:"Pro workhorse (typed, not executed).",action:"text:ssh pro"
+command-palette-entry = title:"SSH: air (M5 workstation)",description:"Antonello's primary seat (typed, not executed).",action:"text:ssh air"

--- a/infra/ghostty/machines/pro.ghostty
+++ b/infra/ghostty/machines/pro.ghostty
@@ -21,3 +21,10 @@ macos-icon-screen-color = #1e1e2e,#302438
 # The fleet's 32 MB per surface stands; raise it here only after re-measuring.
 window-width = 132
 window-height = 38
+
+# ─── Fleet reach (palette, per-machine) ────────────────────────────────────
+# command-palette-entry ACCUMULATES across included files, so per-machine
+# entries live here. Same convention as keys.ghostty: TYPED, never executed —
+# no trailing newline, nothing runs until you press enter.
+command-palette-entry = title:"SSH: mini (server H24)",description:"Tailscale-only — Mini is in the office on a separate ISP (typed, not executed).",action:"text:ssh mini"
+command-palette-entry = title:"SSH: air (M5 workstation)",description:"Antonello's primary seat (typed, not executed).",action:"text:ssh air"


### PR DESCRIPTION
## What

The third Ghostty wave (after #4295 base profile and #4299 refuter fixes): the
config layer that makes the fleet terminal *extraordinary* for Nuzantara work on
macOS 27, plus stale-fact cures in README/runbook.

**fleet.ghostty — 5 new keys, each measured against the in-app 1.3.1 reference:**
- `window-colorspace = display-p3` — every panel this fleet renders on is P3;
  choice + revert path documented
- `focus-follows-mouse = true` — hover selects the split (window-scoped by Ghostty)
- `quick-terminal-position = top` (pin) + `quick-terminal-size = 35%`
- `title-report = false` — security pin next to macos-applescript

**keys.ghostty:**
- `cmd+alt+t` rename lane · `cmd+alt+m` mouse-reporting escape hatch
- **NUZ table** (`cmd+alt+n`, one-shot + `unconsumed:catch_all`): one letter TYPES
  a fleet command — status / worktrees / proprioception / pending-arms /
  home-fork lint / ghostty verify / mq status / claude-in-tmux. Never executes.
- 3 palette entries (tmux agent-pane cure, mq status, scar query)

**machines/*.ghostty:** per-machine `SSH:` palette entries (palette accumulates
across includes by design).

**Docs:** runbook gains the NUZ table + what-changes-on-screen section; README's
two cured gaps (M5 tmux, Mini Nerd font — both measured live today) replaced by
the real remaining ones.

## Adversarial review (generator≠grader)

GLM probe-failed on the agentic task → **Kimi K3** refuted: 3 DEFECT, all
verified against `ghostty.5.md` then cured in the second commit — (1) the
one-shot table WAS a sticky landmine (`ghostty.5.md:2058`), now catch_all-closed;
(2) header count 57→56 (font-family is repeatable; the old 51 was right);
(3) stale "96 = 88 + 8" re-measured to 99/101.

## Proof

- guard corpus 17/17 (rollback both worlds, cannot-answer paths, profile cross-checks)
- composed pro-home install rc=0; `+validate-config` guilt control rejects a bogus value rc=1
- palette 101 = 88 built-in + 13 custom; 10 nuz binds incl catch_all
- keybind chords verified free against the 93 defaults (`cmd+shift+t` deliberately
  avoided — it is default undo)

Known degradation, ledgered: `nuz/v` types a path M5's behind-by-policy checkout
does not have yet (`infra/ghostty/verify.sh`); heals at M5's next natural realign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)