### PR TITLE
fix(mouth): stop sending kita users to three subdomains that 404

### DIFF
--- a/apps/mouth/src/__tests__/middleware.test.ts
+++ b/apps/mouth/src/__tests__/middleware.test.ts
@@ -630,6 +630,17 @@ describe("Middleware - Multi-domain Routing", () => {
           "https://kita.balizero.com/dashboard",
         );
       });
+
+      // The app-domain block noindexes every response it produces, but a newly
+      // created redirect does not inherit the header — the /portal redirect two
+      // branches up re-sets it for the same reason. /calendar is not covered by
+      // robots.ts either, so without this the retirement is crawlable.
+      it(`[guilt] keeps the app-domain noindex header on ${retired}`, () => {
+        const request = createRequest(`https://kita.balizero.com${retired}`);
+        const response = proxy(request);
+
+        expect(response.headers.get("X-Robots-Tag")).toBe("noindex, nofollow");
+      });
     }
 
     it("[guilt] a deep retired path also lands on the dashboard", () => {

--- a/apps/mouth/src/__tests__/middleware.test.ts
+++ b/apps/mouth/src/__tests__/middleware.test.ts
@@ -585,16 +585,14 @@ describe("Middleware - Multi-domain Routing", () => {
   });
 
   // =======================================================================
-  // Ghost internal routes (/email, /calendar, /knowledge, /documents) →
-  // real standalone-app subdomains. These paths have no route on kita and
-  // used to fall through to the (blog)/[category] catch-all.
+  // Ghost internal routes (/email, /knowledge) → their real destination, and
+  // retired ones (/calendar, /documents) → the dashboard. These paths have no
+  // route on kita and used to fall through to the (blog)/[category] catch-all.
   // =======================================================================
-  describe("Ghost internal routes redirect to standalone app subdomains", () => {
+  describe("Ghost internal routes redirect to their real destination", () => {
     const cases: Array<[string, string]> = [
-      ["/email", "https://mail.balizero.com/"],
-      ["/calendar", "https://calendar.balizero.com/"],
+      ["/email", "https://mail.zoho.com/zm/"],
       ["/knowledge", "https://knowledge.balizero.com/"],
-      ["/documents", "https://drive.balizero.com/"],
     ];
 
     for (const [from, to] of cases) {
@@ -607,7 +605,34 @@ describe("Middleware - Multi-domain Routing", () => {
       });
     }
 
-    it("preserves deep path and query when redirecting /calendar/event/123", () => {
+    it("preserves deep path and query when redirecting /knowledge/doc/123", () => {
+      const request = createRequest(
+        "https://kita.balizero.com/knowledge/doc/123?tab=details",
+      );
+      const response = proxy(request);
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe(
+        "https://knowledge.balizero.com/doc/123?tab=details",
+      );
+    });
+
+    // The standalone calendar/drive apps were deleted in 7f287c623 and their
+    // DNS answers 404 DEPLOYMENT_NOT_FOUND. Sending a logged-in user there is
+    // the bug these two pin: the destination must stay on kita.
+    for (const retired of ["/calendar", "/documents"]) {
+      it(`[guilt] keeps ${retired} on kita instead of a dead subdomain`, () => {
+        const request = createRequest(`https://kita.balizero.com${retired}`);
+        const response = proxy(request);
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get("location")).toBe(
+          "https://kita.balizero.com/dashboard",
+        );
+      });
+    }
+
+    it("[guilt] a deep retired path also lands on the dashboard", () => {
       const request = createRequest(
         "https://kita.balizero.com/calendar/event/123?tab=details",
       );
@@ -615,7 +640,7 @@ describe("Middleware - Multi-domain Routing", () => {
 
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe(
-        "https://calendar.balizero.com/event/123?tab=details",
+        "https://kita.balizero.com/dashboard",
       );
     });
 
@@ -627,10 +652,10 @@ describe("Middleware - Multi-domain Routing", () => {
       expect(response.headers.get("x-pathname")).toBe("/dashboard");
     });
 
-    // The ghost-route redirect is cross-origin (kita → mail/calendar/...), so
-    // an RSC prefetch of <Link href="/email"> must get 204, not a 302 that
-    // trips a console CORS error. The original ghost-route block redirected
-    // manually and skipped the RSC guard — this pins that it no longer does.
+    // The /email and /knowledge redirects are cross-origin, so an RSC prefetch
+    // of <Link href="/email"> must get 204, not a 302 that trips a console CORS
+    // error. The original ghost-route block redirected manually and skipped the
+    // RSC guard — this pins that it no longer does.
     it("[guilt] returns 204 for an RSC prefetch of a ghost route (/email)", () => {
       const request = createRequest("https://kita.balizero.com/email", {
         accept: "text/x-component",
@@ -648,7 +673,7 @@ describe("Middleware - Multi-domain Routing", () => {
 
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe(
-        "https://mail.balizero.com/",
+        "https://mail.zoho.com/zm/",
       );
     });
   });

--- a/apps/mouth/src/proxy.ts
+++ b/apps/mouth/src/proxy.ts
@@ -27,15 +27,21 @@ const INTERNAL_ROUTES = [
   "/notifications",
 ];
 
-// /email, /calendar, /knowledge, /documents are NOT routes on kita — they map
-// 1:1 to standalone apps on their own subdomains (mail/calendar/knowledge/
-// drive.balizero.com). See APP_SUBDOMAIN_ROUTE_MAP in the APP DOMAIN block.
+// /knowledge is NOT a route on kita — it maps 1:1 to a standalone app on its
+// own subdomain. See APP_SUBDOMAIN_ROUTE_MAP in the APP DOMAIN block.
 const APP_SUBDOMAIN_ROUTE_MAP: Record<string, string> = {
-  "/email": "mail.balizero.com",
-  "/calendar": "calendar.balizero.com",
   "/knowledge": "knowledge.balizero.com",
-  "/documents": "drive.balizero.com",
 };
+
+// /email leaves the fleet: mail.balizero.com is gone, and Bali Zero mail lives
+// in Zoho. An existing Zoho session lands straight in the inbox; without one,
+// Zoho bounces through its own login and comes back here.
+const ZOHO_MAILBOX_URL = "https://mail.zoho.com/zm/";
+
+// Retired: the standalone calendar/drive apps were deleted in 7f287c623
+// (2026-04-17) and their DNS now answers 404 DEPLOYMENT_NOT_FOUND, so these
+// paths must not be redirected off-site any more.
+const RETIRED_APP_ROUTES = ["/calendar", "/documents"];
 
 // Public routes for balizero.com
 const PUBLIC_CATEGORIES = [
@@ -462,10 +468,32 @@ export function proxy(request: NextRequest) {
       return redirectResponse;
     }
 
-    // Redirect ghost internal routes (/email, /calendar, /knowledge, /documents)
-    // to their real standalone-app subdomains. These paths have no route on kita
-    // and previously fell through to the (blog)/[category] catch-all, rendering
-    // "Category not found" with public nav instead of the actual app.
+    // /email → the Zoho mailbox. Zoho has no path that corresponds to a kita
+    // one, so every /email/* lands on the inbox rather than composing a path.
+    if (pathname === "/email" || pathname.startsWith("/email/")) {
+      return crossOriginRedirect(request, new URL(ZOHO_MAILBOX_URL), 302);
+    }
+
+    // Retired app routes go to the dashboard. Same reason the ghost-route
+    // redirect below exists: without this they fall through to the
+    // (blog)/[category] catch-all and render "Category not found".
+    if (
+      RETIRED_APP_ROUTES.some(
+        (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+      )
+    ) {
+      const redirectResponse = NextResponse.redirect(
+        new URL("/dashboard", request.url),
+        302,
+      );
+      redirectResponse.headers.set("x-pathname", pathname);
+      return redirectResponse;
+    }
+
+    // Redirect ghost internal routes (/knowledge) to their real standalone-app
+    // subdomains. These paths have no route on kita and previously fell through
+    // to the (blog)/[category] catch-all, rendering "Category not found" with
+    // public nav instead of the actual app.
     for (const [routePrefix, targetHost] of Object.entries(
       APP_SUBDOMAIN_ROUTE_MAP,
     )) {
@@ -473,9 +501,9 @@ export function proxy(request: NextRequest) {
         const deepPath = pathname.slice(routePrefix.length) || "/";
         const targetUrl = new URL(deepPath, `https://${targetHost}`);
         targetUrl.search = request.nextUrl.search;
-        // Cross-origin (kita → mail/calendar/drive/knowledge): route through
-        // crossOriginRedirect so an RSC prefetch of <Link href="/email"> gets
-        // 204 instead of a cross-origin 302 that trips a console CORS error.
+        // Cross-origin (kita → knowledge): route through crossOriginRedirect
+        // so an RSC prefetch of <Link href="/knowledge"> gets 204 instead of a
+        // cross-origin 302 that trips a console CORS error.
         return crossOriginRedirect(request, targetUrl, 302);
       }
     }

--- a/apps/mouth/src/proxy.ts
+++ b/apps/mouth/src/proxy.ts
@@ -469,7 +469,9 @@ export function proxy(request: NextRequest) {
     }
 
     // /email → the Zoho mailbox. Zoho has no path that corresponds to a kita
-    // one, so every /email/* lands on the inbox rather than composing a path.
+    // one, so /email and /email/<segment> both land on the inbox rather than
+    // composing a path. A path containing a dot never reaches this middleware
+    // at all — the matcher below excludes it — so /email/first.last 404s.
     if (pathname === "/email" || pathname.startsWith("/email/")) {
       return crossOriginRedirect(request, new URL(ZOHO_MAILBOX_URL), 302);
     }
@@ -487,6 +489,9 @@ export function proxy(request: NextRequest) {
         302,
       );
       redirectResponse.headers.set("x-pathname", pathname);
+      // Re-set what the app-domain block set on the response we are replacing:
+      // a new response does not inherit it, and /calendar is not in robots.ts.
+      redirectResponse.headers.set("X-Robots-Tag", "noindex, nofollow");
       return redirectResponse;
     }
 

--- a/apps/mouth/src/types/navigation.ts
+++ b/apps/mouth/src/types/navigation.ts
@@ -56,23 +56,14 @@ export const navigation: NavSection[] = [
     // Block 3: Collaborative
     items: [
       { title: "LKPM", href: "/lkpm", icon: "ClipboardCheck" },
-      {
-        title: "Documents",
-        href: "https://drive.balizero.com",
-        icon: "FolderOpen",
-        external: true,
-      },
       { title: "Partners", href: "/partners", icon: "Handshake" },
       {
         title: "Email",
-        href: "https://mail.balizero.com",
+        // The Zoho mailbox itself. An existing Zoho session lands straight in
+        // the inbox; without one, Zoho bounces through its login and returns
+        // here via ?serviceurl=%2Fzm%2F.
+        href: "https://mail.zoho.com/zm/",
         icon: "Mail",
-        external: true,
-      },
-      {
-        title: "Calendar",
-        href: "https://calendar.balizero.com",
-        icon: "Calendar",
         external: true,
       },
       {
@@ -162,12 +153,10 @@ export const routeTitles: Record<string, string> = {
   "/process/new": "New Process",
   "/process/deadlines": "Deadlines",
   "/review": "Document Review",
-  "/documents": "Documents (Drive)",
   "/knowledge": "Knowledge Base",
   "/team": "Team",
   "/team/timesheet": "Timesheet",
   "/team/calendar": "Team Calendar",
-  "/calendar": "Bali Zero Calendar",
   "/partners": "Partners",
   "/partners/new": "New Partner",
   "/partners/orphaned": "Orphaned Partners",


### PR DESCRIPTION
## What was measured

`calendar.balizero.com`, `mail.balizero.com` and `drive.balizero.com` all answer **HTTP 404
`DEPLOYMENT_NOT_FOUND`** — measured today, alongside a positive control: `kita`/`my`/`prime`/`zantara`
share the CNAME `d1f6f632c0ab4f36.vercel-dns-016.com` and all serve. The three broken ones each point
at a distinct unique endpoint, i.e. three separate Vercel projects, and only two projects exist in the
`nuzantara-2026` scope. Orphan DNS for projects that were deleted.

The apps behind them were removed in `7f287c623` (2026-04-17) — 173 files across mail/calendar/drive/knowledge.
**The routing that pointed at them was never removed**, and was in fact re-engineered as recently as
`f8e51c233` / `9ddc9e55f` (2026-07-07), whose commit bodies treat those hosts as live destinations.

Two live paths sent a logged-in user into a 404:

| Surface | Behaviour before |
|---|---|
| `src/types/navigation.ts` | Kita-Space sidebar: **Documents**, **Email**, **Calendar** as external `href`s |
| `src/proxy.ts` | 302 cross-origin redirect from `/documents`, `/email`, `/calendar` |

## What changes

- **Documents / Calendar — retired.** Sidebar entries removed; `/calendar` and `/documents` now
  redirect **same-origin to `/dashboard`**, carrying the app-domain `X-Robots-Tag`. They cannot simply
  be dropped from the route map: without a branch they fall through to the `(blog)/[category]`
  catch-all and render *"Category not found"* with public nav — the exact bug `f8e51c233` fixed.
- **Email — kept, repointed at Zoho.** `https://mail.zoho.com/zm/`. Measured: logged out it answers
  `302 → /biz/login?serviceurl=%2Fzm%2F`, so an existing Zoho session lands straight in the inbox and a
  cold visitor is returned there after login. No path is composed from the kita route — Zoho has no
  corresponding paths, so `/email` and `/email/<segment>` both go to the inbox. **A path containing a
  dot never reaches this middleware** (the matcher excludes `.*\..*`), so `/email/first.last` 404s as
  it always has.
- **`/knowledge` untouched** — `knowledge.balizero.com` answers 307 and is alive.

## Verification

- `npm run typecheck -w apps/mouth` → **0 errors**
- `vitest run src/__tests__/middleware.test.ts` → **81/81 pass**
- **Mutation-verified** (the corpus bites, it is not decorative):
  - emptying `RETIRED_APP_ROUTES` → **3 tests fail**
  - pointing the mailbox constant back at `mail.balizero.com` → **2 tests fail**
  - deleting the `X-Robots-Tag` line → **2 tests fail**
- **Adversarial gate**: Codex `gpt-5.6-sol` at `xhigh`, ordered to refute (generator ≠ grader). It
  produced two real findings — the missing `X-Robots-Tag` on the new redirect, and a false claim in my
  own commit message about `/email/*`. Both are fixed in `c7a0dc8a7`, and I confirmed each by reading
  the file rather than trusting the refuter. It could not break the ordering, the `/dashboard` target,
  the 302 choice, the sidebar consumers, or the Zoho URL, and said so explicitly for each.

## Deliberately NOT in this PR

The three hostnames are still named by `.github/workflows/cron-cert-monitor.yml` (armed, runs daily,
**green** — it checks the certificate, and Vercel still serves a valid cert for a host that 404s),
`apps/cell/cell/sensors/vercel_sensor.py` (**inert** — constructed only in tests),
`infra/vision-deck/index.html` (three clickable cards on the tailnet-only deck), the backend CORS
default lists, `apps/backend-rag/fly.toml`'s `ZANTARA_ALLOWED_ORIGINS` (off-limits file), and
`CLAUDE.md` §11's post-deploy QA URL list. Retiring those is a separate concern and a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)