### PR TITLE
fix(intake): harden health report failure liveness

### DIFF
--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -554,21 +554,57 @@ def _timeouts_from_env() -> tuple[int, float]:
 
 
 async def _close_connection(conn: Any, *, timeout_seconds: float) -> None:
-    """Close an asyncpg connection within the configured liveness bound."""
+    """Close an asyncpg connection within the configured liveness bound.
+
+    asyncpg exposes both ``Connection.close(timeout=...)`` and the synchronous
+    ``Connection.terminate()`` escape hatch.  The driver's timeout is the
+    primary bound; the matching loop watchdog is defense-in-depth for a close
+    coroutine that catches cancellation and keeps waiting.  Deliberately use
+    the *current* task rather than spawning a close task: ``asyncio.run()``
+    waits for cancellation-resistant pending tasks during shutdown, which
+    would otherwise move the hang from this function to runner teardown.
+    """
     loop = asyncio.get_running_loop()
     started_at = loop.time()
+    deadline = started_at + timeout_seconds
+    forced_termination = False
+
+    def force_terminate() -> None:
+        nonlocal forced_termination
+        forced_termination = True
+        try:
+            conn.terminate()
+        except Exception as exc:  # noqa: BLE001 — close error remains canonical
+            logger.warning(
+                "[intake_health_report] connection terminate failed: %s",
+                type(exc).__name__,
+            )
+
+    timeout = asyncio.timeout_at(deadline)
+    watchdog: asyncio.TimerHandle | None = None
     try:
-        await asyncio.wait_for(conn.close(), timeout=timeout_seconds)
-    except Exception:  # noqa: BLE001 — caller owns canonical phase reporting
+        async with timeout:
+            # __aenter__ schedules the task cancellation first; scheduling the
+            # terminate callback second at the same absolute deadline means a
+            # cancellation-resistant close sees both signals without leaving a
+            # child task behind for asyncio.run() to reap.
+            watchdog = loop.call_at(deadline, force_terminate)
+            await conn.close(timeout=timeout_seconds)
+        # asyncio.Timeout only raises automatically when CancelledError escapes
+        # the body.  A broken close can suppress it and return after terminate;
+        # keep the failure verdict rather than laundering that path as success.
+        if timeout.expired():
+            raise TimeoutError("connection close exceeded deadline")
+    except (Exception, asyncio.CancelledError):  # caller owns phase reporting
         # Mirrors the established asyncpg cleanup convention in the PG bridge
         # and WR2 supervisors: a close failure/timeout must not leave the
         # transport alive after this run releases its single-instance flock.
-        try:
-            conn.terminate()
-        except Exception:  # noqa: BLE001 — retain the original close failure
-            pass
+        if not forced_termination:
+            force_terminate()
         raise
     finally:
+        if watchdog is not None:
+            watchdog.cancel()
         logger.debug(
             "[intake_health_report] connection close elapsed_seconds=%.3f "
             "timeout_seconds=%.3f",
@@ -592,14 +628,12 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
         # meant the organ went fully dark (no digest, no P0, no heartbeat)
         # until a human found the hung process by hand. Now it says so.
         date_key = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        # W0 recheck fast-follow (2026-08-18): "error" put this organ outside
-        # healer_receptor_registry.py's HEALTHY_STATUSES set, so a normal
-        # lock-contention tick (a manual debug run, a launchd overlap) got
-        # classified dead and triggered the autonomous healer session against
-        # a perfectly healthy organ — the exact failure class #4223 existed to
-        # kill, reopened through this branch. Lock-held-and-skipped is a
-        # no-op, not a failure.
-        _heartbeat("ok", "lock held, skipped")
+        # A skipped contender has learned nothing about the lock owner's
+        # health.  Keep rc=0 and the operator digest, but do NOT refresh the
+        # shared heartbeat sidecar: publishing either `ok` or `error` here
+        # overwrites the owner's last real verdict with a claim this process
+        # cannot support.  The healer therefore continues to consume the
+        # previous run's status/timestamp and can still detect it as dead/stale.
         _tg_notify(
             "digest",
             f"intake-health:lock-held:{date_key}",

--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -30,9 +30,11 @@ Env:
   INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS        default 60000 (statement_timeout for the C-07b query)
 
 Flags: --dry-run (skip Telegram + state-file write; heartbeat still fires) ·
-       --json-only (pure read: skip Telegram + state-file write + heartbeat too)
+       --json-only (pure read on success: skip Telegram + state-file write + ok
+       heartbeat; failures still emit heartbeat=error)
 
-Exit: 0 always, except a DSN/connect failure (logged, heartbeat status=error) -> 1.
+Exit: 0 after a completed/disabled/lock-held run; 1 after a connect, gather,
+      report-build, persistence, or connection-close failure (heartbeat=error).
 """
 from __future__ import annotations
 
@@ -239,7 +241,13 @@ def _write_state(report: dict[str, Any]) -> None:
         tmp.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         os.replace(tmp, STATE_PATH)
     except OSError as exc:
-        logger.warning("[intake_health_report] state write failed: %s", exc)
+        # Persistence is part of completing this organ's run. Swallowing an
+        # OSError here made launchd see rc=0 and the final heartbeat say `ok`
+        # even though the durable report was never updated. Log only the type
+        # (the exception message may contain a local/client-derived path), then
+        # let run() emit the canonical error heartbeat and rc=1.
+        logger.warning("[intake_health_report] state write failed: %s", type(exc).__name__)
+        raise
 
 
 def _acquire_lock_or_exit() -> int | None:
@@ -543,8 +551,8 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
         return 0
     try:
         dsn = os.getenv("INTAKE_DATABASE_URL") or os.getenv("LOCAL_DATABASE_URL") or DEFAULT_DSN
-        timeout_ms = int(os.getenv("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", "60000"))
         try:
+            timeout_ms = int(os.getenv("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", "60000"))
             # statement_timeout at the SESSION level (verbale #7): every
             # gather() query except _fetch_superseded_orphans ran unbounded —
             # a hung jsonb-heavy join could hold the single-instance flock
@@ -562,26 +570,53 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
                 timeout=20,
             )
         except Exception as exc:  # noqa: BLE001
-            logger.error("[intake_health_report] DB connect failed: %s", exc)
-            _heartbeat("error", f"db connect failed: {exc}")
+            error_type = type(exc).__name__
+            logger.error("[intake_health_report] DB connect failed: %s", error_type)
+            _heartbeat("error", f"db connect failed: {error_type}")
             return 1
 
+        failure: Exception | None = None
+        failure_phase = "gather"
         try:
-            report = await gather(conn, superseded_timeout_ms=timeout_ms)
+            try:
+                report = await gather(conn, superseded_timeout_ms=timeout_ms)
+
+                failure_phase = "report"
+                thresholds = _thresholds_from_env()
+                breaches = evaluate_breaches(report, thresholds)
+                report["breaches"] = breaches
+
+                print(json.dumps(report, indent=2, sort_keys=True))
+
+                if not json_only and not dry_run:
+                    failure_phase = "persist"
+                    _write_state(report)
+            except Exception as exc:  # noqa: BLE001 — canonical liveness boundary
+                failure = exc
         finally:
-            await conn.close()
+            try:
+                await conn.close()
+            except Exception as exc:  # noqa: BLE001 — close is part of run completion
+                if failure is None:
+                    failure = exc
+                    failure_phase = "connection close"
 
-        thresholds = _thresholds_from_env()
-        breaches = evaluate_breaches(report, thresholds)
-        report["breaches"] = breaches
-
-        print(json.dumps(report, indent=2, sort_keys=True))
+        if failure is not None:
+            # Never serialize the exception message into observability: gather
+            # can touch Intake rows, so a message could carry PII. The stable
+            # phase plus exception TYPE is sufficient for triage and safe for
+            # the shared heartbeat channel.
+            error_type = type(failure).__name__
+            logger.error(
+                "[intake_health_report] %s failed: %s",
+                failure_phase,
+                error_type,
+            )
+            _heartbeat("error", f"{failure_phase} failed: {error_type}")
+            return 1
 
         if json_only:
             return 0
-
-        if not dry_run:
-            _write_state(report)
 
         # Heartbeat reflects the ORGAN (did the report complete?), never the
         # FINDING (are there breaches?) — same rule as wa_mirror_freshness_

--- a/scripts/intake_health_report.py
+++ b/scripts/intake_health_report.py
@@ -28,10 +28,12 @@ Env:
   INTAKE_HEALTH_ALL_EMPTY_MAX                default 0.5 (breach if quarantine all-pages-empty rate > N)
   INTAKE_HEALTH_ZOMBIE_MAX                   default 0  (breach if zombie count > N)
   INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS        default 60000 (statement_timeout for the C-07b query)
+  INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS
+                                               default 5 (asyncpg connection-close bound)
 
 Flags: --dry-run (skip Telegram + state-file write; heartbeat still fires) ·
-       --json-only (pure read on success: skip Telegram + state-file write + ok
-       heartbeat; failures still emit heartbeat=error)
+       --json-only (no success side effects: skip Telegram + state-file write +
+       success heartbeat; failures still emit heartbeat=error)
 
 Exit: 0 after a completed/disabled/lock-held run; 1 after a connect, gather,
       report-build, persistence, or connection-close failure (heartbeat=error).
@@ -43,6 +45,7 @@ import asyncio
 import fcntl
 import json
 import logging
+import math
 import os
 import plistlib
 import subprocess
@@ -68,6 +71,12 @@ ORGAN_ID = "pro.intake_health_report"
 STATE_PATH = Path.home() / ".agent" / "decisions" / "state" / "intake_health_report.json"
 LOCK_FILE = Path.home() / ".cell-bridge-state" / "intake_health_report.lock"
 DEFAULT_DSN = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+DEFAULT_SUPERSEDED_TIMEOUT_MS = 60_000
+# Matches the five-second asyncpg close bound used by the PG bridge and both
+# WR2 supervisors. Set INTAKE_HEALTH_LOG_LEVEL=DEBUG to record actual close
+# latency, then tune the env override if a future driver/proxy needs a
+# different measured bound; no code edit or frozen re-estimate is required.
+DEFAULT_CONNECTION_CLOSE_TIMEOUT_SECONDS = 5.0
 REPO_WORKER_PLIST_PATH = _REPO / "infra" / "launchagents" / "com.nuzantara.intake-worker.plist"
 # The INSTALLED launchd plist — the one actually driving the running worker —
 # takes precedence over the repo copy (verbale #8, superscar #1 HOME-fork):
@@ -520,6 +529,54 @@ def _thresholds_from_env() -> dict[str, float]:
     }
 
 
+def _timeouts_from_env() -> tuple[int, float]:
+    """Parse and validate every operator-configurable timeout before connect."""
+    superseded_timeout_ms = int(
+        os.getenv(
+            "INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS",
+            str(DEFAULT_SUPERSEDED_TIMEOUT_MS),
+        )
+    )
+    connection_close_timeout_seconds = float(
+        os.getenv(
+            "INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS",
+            str(DEFAULT_CONNECTION_CLOSE_TIMEOUT_SECONDS),
+        )
+    )
+    if superseded_timeout_ms <= 0:
+        raise ValueError("superseded timeout must be positive")
+    if (
+        not math.isfinite(connection_close_timeout_seconds)
+        or connection_close_timeout_seconds <= 0
+    ):
+        raise ValueError("connection-close timeout must be finite and positive")
+    return superseded_timeout_ms, connection_close_timeout_seconds
+
+
+async def _close_connection(conn: Any, *, timeout_seconds: float) -> None:
+    """Close an asyncpg connection within the configured liveness bound."""
+    loop = asyncio.get_running_loop()
+    started_at = loop.time()
+    try:
+        await asyncio.wait_for(conn.close(), timeout=timeout_seconds)
+    except Exception:  # noqa: BLE001 — caller owns canonical phase reporting
+        # Mirrors the established asyncpg cleanup convention in the PG bridge
+        # and WR2 supervisors: a close failure/timeout must not leave the
+        # transport alive after this run releases its single-instance flock.
+        try:
+            conn.terminate()
+        except Exception:  # noqa: BLE001 — retain the original close failure
+            pass
+        raise
+    finally:
+        logger.debug(
+            "[intake_health_report] connection close elapsed_seconds=%.3f "
+            "timeout_seconds=%.3f",
+            loop.time() - started_at,
+            timeout_seconds,
+        )
+
+
 async def run(*, dry_run: bool, json_only: bool) -> int:
     if os.getenv("INTAKE_HEALTH_REPORT_ENABLED", "true").strip().lower() in ("0", "false", "no"):
         logger.info("[intake_health_report] disabled via INTAKE_HEALTH_REPORT_ENABLED — no-op")
@@ -550,9 +607,19 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
         )
         return 0
     try:
+        try:
+            timeout_ms, connection_close_timeout_seconds = _timeouts_from_env()
+        except (TypeError, ValueError, OverflowError) as exc:
+            error_type = type(exc).__name__
+            logger.error(
+                "[intake_health_report] timeout configuration failed: %s",
+                error_type,
+            )
+            _heartbeat("error", f"timeout configuration failed: {error_type}")
+            return 1
+
         dsn = os.getenv("INTAKE_DATABASE_URL") or os.getenv("LOCAL_DATABASE_URL") or DEFAULT_DSN
         try:
-            timeout_ms = int(os.getenv("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", "60000"))
             # statement_timeout at the SESSION level (verbale #7): every
             # gather() query except _fetch_superseded_orphans ran unbounded —
             # a hung jsonb-heavy join could hold the single-instance flock
@@ -595,11 +662,21 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
                 failure = exc
         finally:
             try:
-                await conn.close()
+                await _close_connection(
+                    conn,
+                    timeout_seconds=connection_close_timeout_seconds,
+                )
             except Exception as exc:  # noqa: BLE001 — close is part of run completion
                 if failure is None:
                     failure = exc
                     failure_phase = "connection close"
+                else:
+                    logger.warning(
+                        "[intake_health_report] connection close also failed after %s "
+                        "failure: %s",
+                        failure_phase,
+                        type(exc).__name__,
+                    )
 
         if failure is not None:
             # Never serialize the exception message into observability: gather
@@ -649,7 +726,14 @@ async def run(*, dry_run: bool, json_only: bool) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
     parser.add_argument("--dry-run", action="store_true", help="no Telegram, no state-file write")
-    parser.add_argument("--json-only", action="store_true", help="pure read: JSON to stdout, no side effects at all")
+    parser.add_argument(
+        "--json-only",
+        action="store_true",
+        help=(
+            "JSON to stdout with no success side effects; failures still emit "
+            "heartbeat=error"
+        ),
+    )
     args = parser.parse_args()
     return asyncio.run(run(dry_run=args.dry_run, json_only=args.json_only))
 

--- a/scripts/intake_health_report_run.sh
+++ b/scripts/intake_health_report_run.sh
@@ -41,4 +41,11 @@ esac
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 PYBIN="$REPO_ROOT/apps/backend-rag/.venv/bin/python"
+if [[ ! -x "$PYBIN" ]]; then
+  # The interpreter cannot report its own absence. Use the shell heartbeat
+  # helper already sourced above, with a static PII-free note.
+  organism_heartbeat "$ORGAN_ID" "error" "venv python unavailable"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) ERROR intake health report venv python unavailable" >&2
+  exit 1
+fi
 exec "$PYBIN" -u "$REPO_ROOT/scripts/intake_health_report.py" "$@"

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -16,8 +16,11 @@ Run:  python3 scripts/tests/test_intake_health_report.py
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import pathlib
+import shutil
+import subprocess
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -328,6 +331,35 @@ class _FakeConn:
         return None
 
 
+class _TrackingConn(_FakeConn):
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+def _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats):
+    async def _fake_connect(*_args, **_kwargs):
+        return conn
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _fake_connect)
+    monkeypatch.setattr(ihr, "_tg_notify", lambda *a, **k: True)
+    monkeypatch.setattr(
+        ihr,
+        "_heartbeat",
+        lambda status, note="": heartbeats.append((status, note)),
+    )
+    monkeypatch.setattr(ihr, "STATE_PATH", tmp_path / "state.json")
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setattr(
+        ihr,
+        "worker_log_path",
+        lambda: (tmp_path / "does-not-exist.log", "repo"),
+    )
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+
 # ---------------------------------------------------------------- connect timeouts (verbale #7)
 
 
@@ -357,6 +389,123 @@ def test_connect_sets_session_statement_timeout_and_connect_timeout(tmp_path, mo
     assert recorded["kwargs"].get("timeout") is not None and recorded["kwargs"]["timeout"] <= 20
     assert recorded["kwargs"]["server_settings"]["statement_timeout"] == "120000"
     assert recorded["kwargs"]["server_settings"]["default_transaction_read_only"] == "on"
+
+
+def test_connect_failure_emits_type_only_error_heartbeat(tmp_path, monkeypatch):
+    heartbeats = []
+
+    async def _failing_connect(*_args, **_kwargs):
+        raise RuntimeError("client-record-should-never-reach-heartbeat")
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _failing_connect)
+    monkeypatch.setattr(
+        ihr,
+        "_heartbeat",
+        lambda status, note="": heartbeats.append((status, note)),
+    )
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+
+    assert rc == 1
+    assert heartbeats == [("error", "db connect failed: RuntimeError")]
+    assert "client-record" not in heartbeats[0][1]
+
+
+def test_gather_failure_emits_error_heartbeat_and_closes_connection(tmp_path, monkeypatch):
+    conn = _TrackingConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+
+    async def _failing_gather(*_args, **_kwargs):
+        raise LookupError("passport-value-should-never-reach-heartbeat")
+
+    monkeypatch.setattr(ihr, "gather", _failing_gather)
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+
+    assert rc == 1
+    assert conn.closed is True
+    assert heartbeats == [("error", "gather failed: LookupError")]
+    assert "passport-value" not in heartbeats[0][1]
+
+
+def test_report_failure_emits_error_heartbeat_and_closes_connection(tmp_path, monkeypatch):
+    conn = _TrackingConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+
+    def _failing_thresholds():
+        raise ValueError("company-name-should-never-reach-heartbeat")
+
+    monkeypatch.setattr(ihr, "_thresholds_from_env", _failing_thresholds)
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+
+    assert rc == 1
+    assert conn.closed is True
+    assert heartbeats == [("error", "report failed: ValueError")]
+    assert "company-name" not in heartbeats[0][1]
+
+
+def test_persist_failure_emits_error_heartbeat_and_closes_connection(tmp_path, monkeypatch):
+    conn = _TrackingConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+
+    def _failing_replace(*_args, **_kwargs):
+        raise PermissionError("client-path-should-never-reach-heartbeat")
+
+    monkeypatch.setattr(ihr.os, "replace", _failing_replace)
+
+    rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
+
+    assert rc == 1
+    assert conn.closed is True
+    assert heartbeats == [("error", "persist failed: PermissionError")]
+    assert "client-path" not in heartbeats[0][1]
+
+
+def test_wrapper_missing_or_non_executable_python_emits_error_heartbeat(tmp_path):
+    for python_state in ("missing", "not-executable"):
+        fake_repo = tmp_path / python_state / "repo"
+        fake_scripts = fake_repo / "scripts"
+        fake_lib = fake_scripts / "lib"
+        fake_lib.mkdir(parents=True)
+        shutil.copy2(REPO_ROOT / "scripts" / "intake_health_report_run.sh", fake_scripts)
+        shutil.copy2(REPO_ROOT / "scripts" / "lib" / "heartbeat.sh", fake_lib)
+
+        if python_state == "not-executable":
+            fake_python = fake_repo / "apps" / "backend-rag" / ".venv" / "bin" / "python"
+            fake_python.parent.mkdir(parents=True)
+            fake_python.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            fake_python.chmod(0o644)
+
+        heartbeat_dir = tmp_path / python_state / "heartbeats"
+        env = os.environ.copy()
+        env.update(
+            {
+                "HOME": str(tmp_path / python_state / "home"),
+                "INTAKE_HEALTH_REPORT_ENABLED": "true",
+                "ORGANISM_LAST_SEEN_DIR": str(heartbeat_dir),
+            }
+        )
+
+        result = subprocess.run(
+            ["/bin/bash", str(fake_scripts / "intake_health_report_run.sh")],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        heartbeat = json.loads(
+            (heartbeat_dir / "pro.intake_health_report.json").read_text(encoding="utf-8")
+        )
+        assert heartbeat["status"] == "error"
+        assert heartbeat["note"] == "venv python unavailable"
 
 
 # ---------------------------------------------------------------- worker plist resolution (verbale #8)

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -23,6 +23,7 @@ import pathlib
 import shutil
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -330,43 +331,69 @@ class _FakeConn:
     async def execute(self, query, *args):
         return "SET"
 
-    async def close(self):
+    async def close(self, *, timeout=None):
         return None
 
 
 class _TrackingConn(_FakeConn):
     def __init__(self):
         self.closed = False
+        self.close_timeout = None
+        self.terminated = False
 
-    async def close(self):
+    async def close(self, *, timeout=None):
+        self.close_timeout = timeout
         self.closed = True
+
+    def terminate(self):
+        self.terminated = True
 
 
 class _CloseFailureConn(_FakeConn):
     def __init__(self):
         self.terminated = False
 
-    async def close(self):
+    async def close(self, *, timeout=None):
         raise RuntimeError("client-close-detail-should-never-reach-heartbeat")
 
     def terminate(self):
         self.terminated = True
 
 
-class _HangingCloseConn(_FakeConn):
+class _CancellationResistantCloseConn(_FakeConn):
     def __init__(self):
-        self.close_cancelled = False
+        self.close_cancellations = 0
+        self.close_returned = False
+        self.close_timeout = None
         self.terminated = False
+        self._terminated = asyncio.Event()
 
-    async def close(self):
+    async def close(self, *, timeout=None):
+        self.close_timeout = timeout
+        # Test-process failsafe only: a regression must FAIL after a measurable
+        # 500ms instead of hanging the whole pytest worker forever.  Production
+        # is required to call terminate near the configured 10ms deadline.
+        safety_release = asyncio.get_running_loop().call_later(
+            0.5,
+            self._terminated.set,
+        )
         try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            self.close_cancelled = True
-            raise
+            while not self._terminated.is_set():
+                try:
+                    await self._terminated.wait()
+                except asyncio.CancelledError:
+                    # Intentionally suppress every cancellation.  The old
+                    # asyncio.wait_for implementation waited here until the
+                    # failsafe; the production helper must reach its
+                    # synchronous terminate watchdog instead.
+                    self.close_cancellations += 1
+            self.close_returned = True
+        finally:
+            safety_release.cancel()
 
     def terminate(self):
         self.terminated = True
+        self._terminated.set()
 
 
 def _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats):
@@ -501,26 +528,25 @@ def test_connection_close_failure_emits_type_only_error_heartbeat(tmp_path, monk
 
 
 def test_connection_close_timeout_is_bounded_and_releases_lock(tmp_path, monkeypatch):
-    conn = _HangingCloseConn()
+    conn = _CancellationResistantCloseConn()
     heartbeats = []
     _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
     monkeypatch.setenv("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "0.01")
 
-    rc = asyncio.run(
-        asyncio.wait_for(
-            ihr.run(dry_run=True, json_only=True),
-            timeout=1.0,
-        )
-    )
+    started_at = time.monotonic()
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+    elapsed = time.monotonic() - started_at
 
     assert rc == 1
-    assert conn.close_cancelled is True
+    assert elapsed < 0.25
+    assert conn.close_cancellations >= 1
+    assert conn.close_returned is True
+    assert conn.close_timeout == pytest.approx(0.01)
     assert conn.terminated is True
     assert heartbeats == [("error", "connection close failed: TimeoutError")]
 
     # The timeout path must reach run()'s outer finally and release its flock;
-    # otherwise the next scheduled tick would emit a misleading healthy
-    # lock-held heartbeat forever.
+    # otherwise the next scheduled tick would remain lock-held forever.
     next_lock_fd = ihr._acquire_lock_or_exit()
     try:
         assert next_lock_fd is not None
@@ -573,7 +599,7 @@ def test_primary_failure_is_preserved_when_connection_close_times_out(
     tmp_path,
     monkeypatch,
 ):
-    conn = _HangingCloseConn()
+    conn = _CancellationResistantCloseConn()
     heartbeats = []
     _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
     monkeypatch.setenv("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "0.01")
@@ -583,18 +609,38 @@ def test_primary_failure_is_preserved_when_connection_close_times_out(
 
     monkeypatch.setattr(ihr, "gather", _fail_gather)
 
-    rc = asyncio.run(
-        asyncio.wait_for(
-            ihr.run(dry_run=True, json_only=True),
-            timeout=1.0,
-        )
-    )
+    started_at = time.monotonic()
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+    elapsed = time.monotonic() - started_at
 
     assert rc == 1
-    assert conn.close_cancelled is True
+    assert elapsed < 0.25
+    assert conn.close_cancellations >= 1
+    assert conn.close_returned is True
     assert conn.terminated is True
     assert heartbeats == [("error", "gather failed: LookupError")]
     assert "connection close failed" not in heartbeats[0][1]
+
+
+def test_cooperative_connection_close_uses_driver_timeout_without_terminate(
+    tmp_path,
+    monkeypatch,
+):
+    conn = _TrackingConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+    monkeypatch.setenv("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "0.05")
+
+    started_at = time.monotonic()
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+    elapsed = time.monotonic() - started_at
+
+    assert rc == 0
+    assert elapsed < 0.25
+    assert conn.closed is True
+    assert conn.close_timeout == pytest.approx(0.05)
+    assert conn.terminated is False
+    assert heartbeats == []
 
 
 def test_gather_failure_emits_error_heartbeat_and_closes_connection(tmp_path, monkeypatch):
@@ -880,16 +926,31 @@ def test_heartbeat_is_ok_even_with_breaches_organ_not_finding(tmp_path, monkeypa
     assert "breaches=" in note
 
 
-def test_lock_held_writes_ok_heartbeat_and_digest_instead_of_exiting_silently(monkeypatch):
-    # W0 recheck fast-follow (2026-08-18): this used to assert ("error", "lock
-    # held") — but "error" sits outside healer_receptor_registry.py's
-    # HEALTHY_STATUSES set, so a normal lock-contention tick (a manual debug
-    # run, a launchd overlap) got classified DEAD and triggered the autonomous
-    # healer session against a perfectly healthy organ. Lock-held-and-skipped
-    # is a no-op, not a failure — the heartbeat must read "ok".
-    hb = []
+def test_lock_held_preserves_nonhealthy_sidecar_and_consumer_verdict(
+    tmp_path,
+    monkeypatch,
+):
+    sidecar_dir = tmp_path / "last_seen"
+    sidecar_dir.mkdir()
+    sidecar_path = sidecar_dir / "pro.intake_health_report.json"
+    previous_payload = {
+        "ts": "2026-08-19T00:00:00Z",
+        "status": "error",
+        "note": "previous run failed: RuntimeError",
+    }
+    previous_bytes = (json.dumps(previous_payload) + "\n").encode("utf-8")
+    sidecar_path.write_bytes(previous_bytes)
+
+    heartbeat_calls = []
     sent = []
-    monkeypatch.setattr(ihr, "_heartbeat", lambda status, note="": hb.append((status, note)))
+    real_heartbeat = ihr._heartbeat
+
+    def _recording_heartbeat(status, note=""):
+        heartbeat_calls.append((status, note))
+        real_heartbeat(status, note)
+
+    monkeypatch.setenv("ORGANISM_LAST_SEEN_DIR", str(sidecar_dir))
+    monkeypatch.setattr(ihr, "_heartbeat", _recording_heartbeat)
     monkeypatch.setattr(ihr, "_tg_notify", lambda tier, key, text: sent.append((tier, key, text)) or True)
     monkeypatch.setattr(ihr, "_acquire_lock_or_exit", lambda: None)
     monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
@@ -897,19 +958,43 @@ def test_lock_held_writes_ok_heartbeat_and_digest_instead_of_exiting_silently(mo
     rc = asyncio.run(ihr.run(dry_run=False, json_only=False))
 
     assert rc == 0
-    assert hb == [("ok", "lock held, skipped")]
+    assert heartbeat_calls == []
+    assert sidecar_path.read_bytes() == previous_bytes
+    assert json.loads(sidecar_path.read_text(encoding="utf-8")) == previous_payload
     assert len(sent) == 1
     tier, key, _text = sent[0]
     assert tier == "digest"
     assert key.startswith("intake-health:lock-held:")
 
-    # Cross-module tripwire: the whole point of this fix is that a
-    # lock-contention tick must NOT be classified dead by the healer. Assert
-    # directly against the registry's own set, not a hardcoded "ok" literal,
-    # so a future rename of that set still catches the regression here.
+    # Consumer contract: a skipped contender cannot launder the lock owner's
+    # last real error into HEALTHY_STATUSES.  Exercise the actual healer reader
+    # against a minimal registry rather than restating its status vocabulary.
     import healer_receptor_registry as hrr
 
-    assert hb[0][0] in hrr.HEALTHY_STATUSES
+    registry_path = tmp_path / "registry.yaml"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "organs": [
+                    {
+                        "id": "pro.intake_health_report",
+                        "runtime": "pro_launchd",
+                        "type": "cron",
+                        "expected_hb_seconds": 90_000,
+                        "severity_on_silence": "warning",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    consumer_report = hrr.run("pro", registry_path, sidecar_dir)
+
+    assert consumer_report["exit"] == 1
+    assert [entry["id"] for entry in consumer_report["dead"]] == [
+        "pro.intake_health_report"
+    ]
+    assert consumer_report["ok"] == []
 
 
 def test_acquire_lock_hardens_a_pre_existing_loose_lock_file(tmp_path, monkeypatch):

--- a/scripts/tests/test_intake_health_report.py
+++ b/scripts/tests/test_intake_health_report.py
@@ -16,12 +16,15 @@ Run:  python3 scripts/tests/test_intake_health_report.py
 from __future__ import annotations
 
 import asyncio
+import fcntl
 import json
 import os
 import pathlib
 import shutil
 import subprocess
 import sys
+
+import pytest
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
@@ -339,6 +342,33 @@ class _TrackingConn(_FakeConn):
         self.closed = True
 
 
+class _CloseFailureConn(_FakeConn):
+    def __init__(self):
+        self.terminated = False
+
+    async def close(self):
+        raise RuntimeError("client-close-detail-should-never-reach-heartbeat")
+
+    def terminate(self):
+        self.terminated = True
+
+
+class _HangingCloseConn(_FakeConn):
+    def __init__(self):
+        self.close_cancelled = False
+        self.terminated = False
+
+    async def close(self):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.close_cancelled = True
+            raise
+
+    def terminate(self):
+        self.terminated = True
+
+
 def _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats):
     async def _fake_connect(*_args, **_kwargs):
         return conn
@@ -358,6 +388,8 @@ def _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats):
         lambda: (tmp_path / "does-not-exist.log", "repo"),
     )
     monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+    monkeypatch.delenv("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", raising=False)
+    monkeypatch.delenv("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", raising=False)
 
 
 # ---------------------------------------------------------------- connect timeouts (verbale #7)
@@ -391,6 +423,48 @@ def test_connect_sets_session_statement_timeout_and_connect_timeout(tmp_path, mo
     assert recorded["kwargs"]["server_settings"]["default_transaction_read_only"] == "on"
 
 
+@pytest.mark.parametrize(
+    ("env_name", "invalid_value"),
+    (
+        ("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", "client-name-not-an-integer"),
+        ("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "client-name-not-a-float"),
+        ("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "nan"),
+        ("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "0"),
+    ),
+)
+def test_invalid_timeout_configuration_is_reported_before_connect(
+    tmp_path,
+    monkeypatch,
+    env_name,
+    invalid_value,
+):
+    heartbeats = []
+    connect_calls = []
+
+    async def _unexpected_connect(*args, **kwargs):
+        connect_calls.append((args, kwargs))
+        return _FakeConn()
+
+    monkeypatch.setattr(ihr.asyncpg, "connect", _unexpected_connect)
+    monkeypatch.setattr(
+        ihr,
+        "_heartbeat",
+        lambda status, note="": heartbeats.append((status, note)),
+    )
+    monkeypatch.setattr(ihr, "LOCK_FILE", tmp_path / "lock")
+    monkeypatch.setenv("INTAKE_HEALTH_REPORT_ENABLED", "true")
+    monkeypatch.delenv("INTAKE_HEALTH_SUPERSEDED_TIMEOUT_MS", raising=False)
+    monkeypatch.delenv("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setenv(env_name, invalid_value)
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+
+    assert rc == 1
+    assert connect_calls == []
+    assert heartbeats == [("error", "timeout configuration failed: ValueError")]
+    assert "client-name" not in heartbeats[0][1]
+
+
 def test_connect_failure_emits_type_only_error_heartbeat(tmp_path, monkeypatch):
     heartbeats = []
 
@@ -411,6 +485,116 @@ def test_connect_failure_emits_type_only_error_heartbeat(tmp_path, monkeypatch):
     assert rc == 1
     assert heartbeats == [("error", "db connect failed: RuntimeError")]
     assert "client-record" not in heartbeats[0][1]
+
+
+def test_connection_close_failure_emits_type_only_error_heartbeat(tmp_path, monkeypatch):
+    conn = _CloseFailureConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+
+    rc = asyncio.run(ihr.run(dry_run=True, json_only=True))
+
+    assert rc == 1
+    assert conn.terminated is True
+    assert heartbeats == [("error", "connection close failed: RuntimeError")]
+    assert "client-close-detail" not in heartbeats[0][1]
+
+
+def test_connection_close_timeout_is_bounded_and_releases_lock(tmp_path, monkeypatch):
+    conn = _HangingCloseConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+    monkeypatch.setenv("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "0.01")
+
+    rc = asyncio.run(
+        asyncio.wait_for(
+            ihr.run(dry_run=True, json_only=True),
+            timeout=1.0,
+        )
+    )
+
+    assert rc == 1
+    assert conn.close_cancelled is True
+    assert conn.terminated is True
+    assert heartbeats == [("error", "connection close failed: TimeoutError")]
+
+    # The timeout path must reach run()'s outer finally and release its flock;
+    # otherwise the next scheduled tick would emit a misleading healthy
+    # lock-held heartbeat forever.
+    next_lock_fd = ihr._acquire_lock_or_exit()
+    try:
+        assert next_lock_fd is not None
+    finally:
+        if next_lock_fd is not None:
+            fcntl.flock(next_lock_fd, fcntl.LOCK_UN)
+            os.close(next_lock_fd)
+
+
+@pytest.mark.parametrize("primary_phase", ("gather", "report", "persist"))
+def test_primary_failure_is_preserved_when_connection_close_also_fails(
+    tmp_path,
+    monkeypatch,
+    primary_phase,
+):
+    conn = _CloseFailureConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+
+    if primary_phase == "gather":
+        async def _fail_gather(*_args, **_kwargs):
+            raise LookupError("primary-detail-must-stay-private")
+
+        monkeypatch.setattr(ihr, "gather", _fail_gather)
+    elif primary_phase == "report":
+        def _fail_report():
+            raise LookupError("primary-detail-must-stay-private")
+
+        monkeypatch.setattr(ihr, "_thresholds_from_env", _fail_report)
+    else:
+        def _fail_persist(_report):
+            raise LookupError("primary-detail-must-stay-private")
+
+        monkeypatch.setattr(ihr, "_write_state", _fail_persist)
+
+    rc = asyncio.run(
+        ihr.run(
+            dry_run=primary_phase != "persist",
+            json_only=primary_phase != "persist",
+        )
+    )
+
+    assert rc == 1
+    assert conn.terminated is True
+    assert heartbeats == [("error", f"{primary_phase} failed: LookupError")]
+    assert "connection close failed" not in heartbeats[0][1]
+
+
+def test_primary_failure_is_preserved_when_connection_close_times_out(
+    tmp_path,
+    monkeypatch,
+):
+    conn = _HangingCloseConn()
+    heartbeats = []
+    _install_run_fakes(monkeypatch, tmp_path, conn, heartbeats)
+    monkeypatch.setenv("INTAKE_HEALTH_CONNECTION_CLOSE_TIMEOUT_SECONDS", "0.01")
+
+    async def _fail_gather(*_args, **_kwargs):
+        raise LookupError("primary-detail-must-stay-private")
+
+    monkeypatch.setattr(ihr, "gather", _fail_gather)
+
+    rc = asyncio.run(
+        asyncio.wait_for(
+            ihr.run(dry_run=True, json_only=True),
+            timeout=1.0,
+        )
+    )
+
+    assert rc == 1
+    assert conn.close_cancelled is True
+    assert conn.terminated is True
+    assert heartbeats == [("error", "gather failed: LookupError")]
+    assert "connection close failed" not in heartbeats[0][1]
 
 
 def test_gather_failure_emits_error_heartbeat_and_closes_connection(tmp_path, monkeypatch):
@@ -630,6 +814,22 @@ def test_json_only_skips_all_side_effects(tmp_path, monkeypatch, capsys):
     assert not (tmp_path / "state.json").exists()
     out = capsys.readouterr().out
     assert '"review_pending_total"' in out
+
+
+def test_json_only_help_distinguishes_success_from_failure_side_effects(
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(sys, "argv", ["intake_health_report.py", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        ihr.main()
+
+    assert exc_info.value.code == 0
+    normalized_help = " ".join(capsys.readouterr().out.split())
+    assert "no success side effects" in normalized_help
+    assert "failures still emit heartbeat=error" in normalized_help
+    assert "no success side effects" in (ihr.__doc__ or "")
 
 
 def test_digest_dedup_key_is_date_stamped_not_a_bare_constant(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- emit a bounded, type-only failure heartbeat when the Intake health report cannot complete
- bound asynchronous database cleanup and terminate the connection if close suppresses cancellation
- keep lock-contention runs from overwriting the shared heartbeat
- add a static wrapper fallback when the managed Python runtime is unavailable

## Safety

- no schema or migration changes
- no client records, identifiers, or record content are logged
- completed-with-findings remains a successful reporter run
- lock-held runs preserve the existing shared heartbeat
- successful json-only runs remain side-effect free

## Validation

- targeted Intake health reporter suite: 53 passed
- adjacent Intake health and consumer suite: 194 passed
- cancellation-resistant cleanup and lock-ownership probes: passed
- causal mutation checks: 9/9 rejected
- Ruff, mypy, bash syntax, AST, and diff checks: passed
- independent Fable 5 final on-disk gate: **PASS**
- frozen candidate: cdaa8475473aaa77c4150abc69025c9fdd9bdef3
