### PR TITLE
test(intake): harden liveness corpus process cleanup

### DIFF
--- a/scripts/tests/test_intake_review_reader_liveness_5xx.sh
+++ b/scripts/tests/test_intake_review_reader_liveness_5xx.sh
@@ -45,10 +45,23 @@ check_true() {  # check_true <name> <shell-test-exit-code>
 
 TMP="$(mktemp -d)"
 SERVER_PID=""
+SERVER_PORT=""
+
+stop_fake_server() {
+    local pid="${SERVER_PID:-}"
+    SERVER_PID=""
+    SERVER_PORT=""
+    [ -n "$pid" ] || return 0
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+}
+
 cleanup() {
-    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
-    wait "$SERVER_PID" 2>/dev/null
-    rm -rf "$TMP"
+    local status=$?
+    trap - EXIT
+    stop_fake_server
+    rm -rf -- "$TMP"
+    exit "$status"
 }
 trap cleanup EXIT
 
@@ -83,21 +96,21 @@ with http.server.HTTPServer(("127.0.0.1", port), Handler) as httpd:
     httpd.serve_forever()
 PYEOF
 
-start_fake_server() {  # start_fake_server <http-code>  -> prints the port
-    [ -n "$SERVER_PID" ] && { kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null; }
+start_fake_server() {  # start_fake_server <http-code> -> sets SERVER_PORT
+    stop_fake_server
     rm -f "$TMP/port.txt"
     python3 "$TMP/fake_server.py" "$1" >"$TMP/port.txt" 2>"$TMP/server.err" &
     SERVER_PID=$!
     for _ in $(seq 1 50); do
-        [ -s "$TMP/port.txt" ] && break
+        if [ -s "$TMP/port.txt" ]; then
+            IFS= read -r SERVER_PORT < "$TMP/port.txt"
+            [ -n "$SERVER_PORT" ] && return 0
+        fi
         sleep 0.1
     done
-    cat "$TMP/port.txt"
-}
-
-stop_fake_server() {
-    [ -n "$SERVER_PID" ] && { kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null; }
-    SERVER_PID=""
+    echo "fake HTTP server failed to publish a port" >&2
+    stop_fake_server
+    return 1
 }
 
 # A port nothing is listening on (bind-then-close, never serve): curl gets an
@@ -168,7 +181,8 @@ file_mode() {  # file_mode <path> -> octal mode (e.g. "600"), empty if missing
 echo "GUILT — a 5xx must page as SICK, not fold into ALIVE"
 
 ROOT="$TMP/w-sick-guilt"; make_world "$ROOT"; install_plist "$ROOT"
-PORT="$(start_fake_server 500)"
+start_fake_server 500 || exit 1
+PORT="$SERVER_PORT"
 RC="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=0)"
 check "500 with plist present -> wrapper exits 1 (alert sent)" 1 "$RC"
 check "exactly one page recorded" 1 "$(n_pages "$ROOT")"
@@ -195,7 +209,8 @@ echo
 echo "INNOCENCE — process up and CORRECT must not page"
 
 ROOT="$TMP/w-ok-200"; make_world "$ROOT"; install_plist "$ROOT"
-PORT="$(start_fake_server 200)"
+start_fake_server 200 || exit 1
+PORT="$SERVER_PORT"
 RC="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=0)"
 check "200 -> wrapper exits 0" 0 "$RC"
 check "no page sent" 0 "$(n_pages "$ROOT")"
@@ -204,7 +219,8 @@ check_true "log names the state ALIVE" \
 stop_fake_server
 
 ROOT="$TMP/w-ok-401"; make_world "$ROOT"; install_plist "$ROOT"
-PORT="$(start_fake_server 401)"
+start_fake_server 401 || exit 1
+PORT="$SERVER_PORT"
 RC="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=0)"
 check "401 (JWT-gated, still up) -> wrapper exits 0" 0 "$RC"
 check "no page sent" 0 "$(n_pages "$ROOT")"
@@ -230,7 +246,8 @@ echo "GUILT/INNOCENCE — SICK mirrors DEAD's two shared guards, not just its me
 
 # Active-active guard: no plist here + no FORCE_CHECK => stay silent even SICK.
 ROOT="$TMP/w-sick-noop"; make_world "$ROOT"
-PORT="$(start_fake_server 503)"
+start_fake_server 503 || exit 1
+PORT="$SERVER_PORT"
 RC="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=0)"
 check "503, no plist, no FORCE_CHECK -> no-op exit 0 (not this host)" 0 "$RC"
 check "no page sent" 0 "$(n_pages "$ROOT")"
@@ -251,11 +268,13 @@ stop_fake_server
 # and the cooldown gate exactly as production does; it fails on the reverted commit
 # (single shared last_action_ts suppresses the SICK page) and passes on the fix.
 ROOT="$TMP/w-sick-recent-ok-does-not-suppress"; make_world "$ROOT"; install_plist "$ROOT"
-PORT="$(start_fake_server 200)"
+start_fake_server 200 || exit 1
+PORT="$SERVER_PORT"
 RC0="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=1800)"
 check "priming healthy tick -> wrapper exits 0 (writes its own ok state)" 0 "$RC0"
 stop_fake_server
-PORT="$(start_fake_server 500)"
+start_fake_server 500 || exit 1
+PORT="$SERVER_PORT"
 RC="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=1800)"
 check "500 right after a recent HEALTHY tick -> exit 1 (fresh incident pages immediately)" 1 "$RC"
 check "a recent last_ok_ts does NOT suppress the first SICK page" 1 "$(n_pages "$ROOT")"
@@ -270,7 +289,8 @@ stop_fake_server
 # real SICK tick primes the alert state via write_alert_state, then an immediate second
 # real SICK tick against the same root must be suppressed by the cooldown it just wrote.
 ROOT="$TMP/w-sick-recent-alert-suppresses"; make_world "$ROOT"; install_plist "$ROOT"
-PORT="$(start_fake_server 500)"
+start_fake_server 500 || exit 1
+PORT="$SERVER_PORT"
 RC0="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=1800)"
 check "priming SICK tick -> wrapper exits 1 (alert sent)" 1 "$RC0"
 check "priming SICK tick pages exactly once" 1 "$(n_pages "$ROOT")"

--- a/scripts/tests/test_intake_review_reader_liveness_5xx.sh
+++ b/scripts/tests/test_intake_review_reader_liveness_5xx.sh
@@ -49,11 +49,14 @@ SERVER_PORT=""
 
 stop_fake_server() {
     local pid="${SERVER_PID:-}"
-    SERVER_PID=""
-    SERVER_PORT=""
-    [ -n "$pid" ] || return 0
+    if [ -z "$pid" ]; then
+        SERVER_PORT=""
+        return 0
+    fi
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
+    SERVER_PID=""
+    SERVER_PORT=""
 }
 
 cleanup() {

--- a/scripts/tests/test_intake_review_reader_liveness_5xx.sh
+++ b/scripts/tests/test_intake_review_reader_liveness_5xx.sh
@@ -242,11 +242,19 @@ stop_fake_server
 # the SAME last_action_ts field the cooldown gate reads, so a healthy tick right before a
 # fresh incident could mute its first alert for up to COOLDOWN_S. A fresh incident must
 # always page on its first detection, no matter how recently the reader was healthy.
+#
+# ORGANIC, not hand-seeded (fast-follow, 2026-08-18 — refuter finding N1 on #4247: the
+# hand-seeded state JSON below matched ONLY the post-fix field semantics, so this
+# scenario stayed green even against a full revert of the cooldown-split commit —
+# reverting-and-rerunning the shipped corpus proved 24/25 still pass, both PART 1 and
+# PART 2 among them. A real ALIVE tick, then a real SICK tick, exercises write_ok_state
+# and the cooldown gate exactly as production does; it fails on the reverted commit
+# (single shared last_action_ts suppresses the SICK page) and passes on the fix.
 ROOT="$TMP/w-sick-recent-ok-does-not-suppress"; make_world "$ROOT"; install_plist "$ROOT"
-mkdir -p "$ROOT/home/.agent/decisions/state"
-cat > "$ROOT/home/.agent/decisions/state/intake_review_reader_liveness.json" <<EOF
-{"last_action_ts": 0, "last_ok_ts": $(date +%s), "last_action": "ok", "last_http_code": "200", "probe": "x"}
-EOF
+PORT="$(start_fake_server 200)"
+RC0="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=1800)"
+check "priming healthy tick -> wrapper exits 0 (writes its own ok state)" 0 "$RC0"
+stop_fake_server
 PORT="$(start_fake_server 500)"
 RC="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=1800)"
 check "500 right after a recent HEALTHY tick -> exit 1 (fresh incident pages immediately)" 1 "$RC"
@@ -257,15 +265,18 @@ stop_fake_server
 # suppress the next page within COOLDOWN_S, so a flapping backend does not page every
 # tick (the defect this mirrors DEAD to avoid: an un-throttled SICK path would page every
 # 5min).
+#
+# ORGANIC, not hand-seeded (fast-follow, 2026-08-18, same finding as PART 1 above): a
+# real SICK tick primes the alert state via write_alert_state, then an immediate second
+# real SICK tick against the same root must be suppressed by the cooldown it just wrote.
 ROOT="$TMP/w-sick-recent-alert-suppresses"; make_world "$ROOT"; install_plist "$ROOT"
-mkdir -p "$ROOT/home/.agent/decisions/state"
-cat > "$ROOT/home/.agent/decisions/state/intake_review_reader_liveness.json" <<EOF
-{"last_action_ts": $(date +%s), "last_ok_ts": 0, "last_action": "sick", "last_http_code": "500", "probe": "x"}
-EOF
 PORT="$(start_fake_server 500)"
+RC0="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=1800)"
+check "priming SICK tick -> wrapper exits 1 (alert sent)" 1 "$RC0"
+check "priming SICK tick pages exactly once" 1 "$(n_pages "$ROOT")"
 RC="$(run_wrapper "$ROOT" "$PORT" COOLDOWN_S=1800)"
 check "500 right after a recent SICK alert -> exit 1 (still unhealthy) but suppressed" 1 "$RC"
-check "cooldown suppresses the repeat page" 0 "$(n_pages "$ROOT")"
+check "cooldown suppresses the repeat page (page count unchanged)" 1 "$(n_pages "$ROOT")"
 check_true "log says cooldown active" \
     "$(grep -q 'cooldown active' "$ROOT/home/logs/intake-review-reader-liveness.log" 2>/dev/null; echo $?)"
 stop_fake_server


### PR DESCRIPTION
## Summary

- cover the complete cooldown transition sequence in the review-reader liveness corpus
- track and reap fake server processes on every exit path
- preserve caller ownership when a fake server PID is supplied externally
- make signal-termination and no-port fixtures fail closed

## Safety

- test-only change
- no production runtime, schema, or client-data path changes
- cleanup is limited to processes created by the corpus
- externally supplied fake server processes remain caller-owned

## Validation

- liveness corpus: 28/28 passed
- stress runs: 12 sequential and 8 concurrent passed without leaked fake servers
- signal-termination and startup-failure probes: passed
- historical cooldown mutant: rejected
- bash syntax, ShellCheck, action lint, diff, and PII scans: passed
- independent Fable 5 final on-disk gate: **PASS**
- frozen candidate: c51c799cc982868e7e6f81bf95acd75f673fa46c
