### PR TITLE
fix(infra): promote kc-watchdog HOME-fork to repo canon (W1 healer)

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -787,6 +787,12 @@
       "repo": "infra/ghostty/machines/mini.ghostty",
       "machines": ["mini"],
       "_note": "Ghostty fleet profile, added 2026-08-18. ~/.config is not a git repo, so these installed copies had no history and no backup before this. Installed by infra/ghostty/install.sh, which validates and rolls back on failure; infra/ghostty/verify.sh is the local check, this lint the fleet-wide one against origin/main. See the pro entry for why this live path appears three times."
+    },
+    {
+      "live": "~/scripts/kc-watchdog.sh",
+      "repo": "infra/launchagents/wrappers/kc-watchdog.sh",
+      "machines": ["mini"],
+      "_note": "Promoted 2026-08-19 by the healer tick (proprioception finding: launchagent_canon home_fork_target, no repo canon existed). Script kills knowledgeconstructiond (Apple Intelligence / IntelligencePlatformCore), which on this headless server iterates every contact requesting avatars from contactsd forever (~1.3k req/min), blows its own memory cap, gets corpsed by the kernel, and respawns (measured: 40% self-CPU + 85% contactsd; launchctl disable alone insufficient, XPC on-demand respawn). Self-contained, no secrets, kill switch `touch ~/.kc-watchdog-off`. Live copy untouched by this promotion (already correct) — only repo tracking added, plus the plist canon at infra/launchagents/com.nuzantara.kc-watchdog.plist for DR."
     }
   ],
   "allow": [

--- a/infra/launchagents/com.nuzantara.kc-watchdog.plist
+++ b/infra/launchagents/com.nuzantara.kc-watchdog.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.nuzantara.kc-watchdog</string>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/nuzantara/scripts/kc-watchdog.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/Users/nuzantara/logs/kc-watchdog.err</string>
+	<key>StartInterval</key>
+	<integer>15</integer>
+</dict>
+</plist>

--- a/infra/launchagents/wrappers/kc-watchdog.sh
+++ b/infra/launchagents/wrappers/kc-watchdog.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# kc-watchdog.sh — tiene giu knowledgeconstructiond sul Mini.
+#
+# PERCHE ESISTE (misurato 2026-08-19):
+#   knowledgeconstructiond (Apple Intelligence / IntelligencePlatformCore) itera la rubrica
+#   UN CONTATTO ALLA VOLTA chiedendo gli avatar a contactsd: ~1.336 richieste/minuto, ognuna
+#   respinta con "Skipping: required keys missing". Con ~100.000 contatti non finisce MAI:
+#   sfonda il proprio tetto di memoria (ActiveSoft 50 MB, misurato a 145 MB), il kernel lo
+#   uccide ("Full corpse enqueued"), lui riparte da zero e ricomincia. Costo: 40% di CPU su
+#   se stesso + 85% su contactsd, che e solo il servo che risponde.
+#   `launchctl disable` NON basta: rinasce comunque (XPC on-demand + respawn dopo corpse).
+#   Su un server headless senza schermo ne Siri, questo servizio non serve a nulla.
+#
+# KILL SWITCH:  touch ~/.kc-watchdog-off     (il watchdog esce senza fare nulla)
+# DISINSTALLA:  launchctl bootout gui/$(id -u)/com.nuzantara.kc-watchdog
+#               rm ~/Library/LaunchAgents/com.nuzantara.kc-watchdog.plist
+[ -f "$HOME/.kc-watchdog-off" ] && exit 0
+LOG="$HOME/logs/kc-watchdog.log"
+mkdir -p "$(dirname "$LOG")"
+killed=0
+# ancora di fine riga: senza, il pattern prende anche altri processi (lezione della stessa notte)
+for p in $(pgrep -x knowledgeconstructiond 2>/dev/null); do
+  rss=$(ps -o rss= -p "$p" 2>/dev/null | tr -d ' ')
+  if kill -9 "$p" 2>/dev/null; then
+    killed=$((killed+1))
+    echo "$(date '+%Y-%m-%d %H:%M:%S') killed pid=$p rss=${rss}KB" >> "$LOG"
+  fi
+done
+# rotazione semplice: il log non deve crescere all infinito su un server
+if [ -f "$LOG" ] && [ "$(wc -l < "$LOG")" -gt 2000 ]; then
+  tail -500 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+fi
+exit 0


### PR DESCRIPTION
## Summary
- `proprioception.py`'s `launchagent_canon` probe flagged `com.nuzantara.kc-watchdog` as a HOME-fork (superscar #1): live wrapper `~/scripts/kc-watchdog.sh` had no repo canon anywhere.
- The script is a legitimate, self-contained, no-secrets watchdog that kills `knowledgeconstructiond` (Apple Intelligence / IntelligencePlatformCore), which on this headless Mini loops requesting contact avatars from `contactsd` forever, blows its own memory cap, gets corpsed, and respawns endlessly.
- Promotes the wrapper + plist into `infra/launchagents/` and declares the pair in `declared-pairs.json` (machines: mini). Live copy is untouched — this only adds repo tracking + a DR canon for the plist.

## Test plan
- [x] `python3 scripts/lint_home_fork.py --check` → clean (137 declared pairs, mini)
- [x] `python3 scripts/launchagent_reconcile.py` → HOME-fork target section now empty (0)
- [x] `python3 scripts/proprioception.py --json --no-fetch` → `launchagent_canon` probe: DIVERGED → RECONCILED
- [x] `pytest scripts/tests/test_lint_home_fork.py scripts/tests/test_proprioception_home_fork_merge.py` → 36/36 pass

🤖 Autonomous healer tick (Mini-Pro2)