### PR TITLE
refactor(wa-bot): extract finalize_wa_answer shared pipeline (BOT-V4 S2 PR-3)

### DIFF
--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -1,0 +1,653 @@
+"""WA answer finalization pipeline — ONE sequence, used by BOTH generation legs.
+
+Extracted 2026-08-19 from ``wa_inbox_bot.generate_bot_reply``'s post-generation
+tail (BOT-V4 S2, spec
+``research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md`` §2.3):
+the sequence that turns a raw RAG/LLM payload into either "text safe to send on
+WhatsApp" or a typed defect. Before this module, that sequence lived inline in
+the Gemini leg only; the codex broker leg (S2 PR-5) needs the SAME pipeline, and
+two hand-maintained copies of a safety sequence is how ``wa_inbox_bot`` and
+``whatsapp_chat`` drifted apart on the ``[ESCALATE]`` marker in the first place.
+
+Behavior contract:
+    * ``provider="gemini"`` is BEHAVIOR-PRESERVING against the pre-extraction
+      ``generate_bot_reply`` tail: same branch order, same log lines, same
+      human-notification points, same returned text, and the same
+      ``RuntimeError`` messages (the caller raises them from
+      ``FinalizeResult.defect_message`` so the worker's retry ladder sees
+      identical exceptions).
+    * ``provider="codex"`` maps the spec's typed outcomes onto the same
+      sequence: every branch where the TEXT ITSELF is defective (empty payload,
+      internal-monologue leak, scaffold-only output, empty after strip/format,
+      pricing veto, secret-egress hit) returns ``DEFECT`` WITHOUT serving a stub
+      and WITHOUT telling a human — the caller fails off to the Gemini leg,
+      which regenerates and re-enters this pipeline, so the client still gets
+      an answer and the silent-client alarm stays with the leg that owns it
+      (spec §2.3 TEXT_DEFECT). The abstain-label branch is the one POLICY
+      branch: its verdict derives from the frozen evidence, not from who wrote
+      the text, so it behaves identically on both providers (stub + tell a
+      human — failing off could not change the verdict, spec §2.3 POLICY).
+
+Codex-only egress vetoes (inert on the Gemini leg by construction):
+    * Pricing veto — every currency-marked amount in the answer must appear in
+      at least one of the caller-supplied ``price_sources`` (the package's
+      PricingTool block plus its retrieved chunks). Runs only when
+      ``price_sources`` is provided, which only the codex worker leg does.
+    * Secret-egress scan — pattern scan (key blocks, JWT shapes, token
+      assignments, caller-supplied canary tokens) on text produced by the
+      sandboxed executor. Runs only when ``secret_scan=True``. Never logs or
+      returns the matched content — pattern NAME only (CLAUDE.md §14).
+
+This module never talks to Telegram itself: the caller passes ``tell_a_human``
+(a one-argument async callable) so ``wa_inbox_bot``'s tests keep patching
+``wa_inbox_bot.notify_human_telegram`` and the notifier wiring stays in one
+module.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from backend.channels.format import format_rich_text
+from backend.services.rag.agentic._reasoning_stubs import get_localized_stub
+from backend.services.rag.agentic.query_helpers import detect_query_language
+
+logger = logging.getLogger("zantara.backend")
+
+# ── KG workflow-scaffold strip (client-voice hardening, 2026-07-25) ──────
+# `orchestrator_core.py::_format_workflow_for_prompt` appends an internal
+# diagnostics block to the RAG answer on some queries — a "## SUGGESTED
+# WORKFLOW (from <source>, confidence: NN%)" heading, the workflow name,
+# a numbered step list, and an optional "**Confidence**: ..." line — ALWAYS
+# closed by the literal trailer sentence below (`_KG_WORKFLOW_TRAILER`,
+# copied verbatim from orchestrator_core.py). That block is internal
+# diagnostics for an operator reading the raw answer, not a WhatsApp
+# client, and has been observed CONTRADICTING the actual answer (e.g. an
+# E33G remote-worker answer followed by a local-employment IMTA/TKA
+# workflow it never asked for).
+#
+# We do NOT edit orchestrator_core.py (another lane owns it, and the block
+# may be legitimate for other consumers like the web chat UI) — this strip
+# lives at the WhatsApp channel boundary instead.
+#
+# Anchored on the two literal strings the emitter ALWAYS writes together
+# (heading prefix + closing sentence, both from the SAME
+# `_format_workflow_for_prompt` call) rather than a loose "workflow"
+# keyword — see .claude/rules/cicatrix-superscar.md family #3
+# (guard-over-match) for why a bare-substring match would be unsafe: a
+# legitimate client answer ("il nostro workflow di onboarding...") must
+# never be caught by this. The non-greedy DOTALL match between the two
+# anchors also means only the block itself is removed, never content that
+# happens to follow it (e.g. the KG fast-path's reasoning text, which is
+# appended AFTER the workflow block in some code paths and must survive).
+_KG_WORKFLOW_TRAILER = (
+    "IMPORTANT: This is a suggested workflow. Always verify current requirements with the user."
+)
+_KG_WORKFLOW_SCAFFOLD_RE = re.compile(
+    r"\s*##\s+SUGGESTED WORKFLOW \(from .*?" + re.escape(_KG_WORKFLOW_TRAILER),
+    re.DOTALL,
+)
+
+# The 2026-08-11 KBLI baseline caught Gemini starting otherwise client-visible
+# answers with the prompt's private XML section name (three of 25 probes).
+# Do not try to recover a "final" paragraph from such a payload: the leaked
+# block has no guaranteed delimiter and any guessed split could still expose
+# chain-of-thought or unsupported claims.  At the WhatsApp boundary the safe
+# behavior is to discard the entire payload and serve the normal localized
+# source-honest refusal.  Anchor at the beginning so a legitimate discussion
+# *about* an internal-monologue bug is not caught mid-answer.
+_INTERNAL_MONOLOGUE_LEAK_RE = re.compile(
+    r"^[^A-Za-z0-9]{0,32}internal[ _-]+monologue"
+    r"(?:[ _-]+instructions)?(?:[^A-Za-z0-9]|$)",
+    re.IGNORECASE,
+)
+
+
+# An abstain payload is worth sending when it actually contains an answer.
+# Measured 2026-08-11 across 16 cold questions in 8 languages: 7 came back
+# `abstain=true`, and 3 of those carried a complete on-topic answer. The old
+# consumer discarded all 7.
+#
+# Deliberately NOT a quality judgement — this module cannot re-score evidence and
+# must not try. It asks one thing: is there prose here, or only the residue of a
+# refusal? The floor is length, because the refusal shapes the RAG emits are
+# short ("Je suis prêt pour votre prochaine question." — 43 chars, measured) and
+# a real answer to any question this bot receives is not.
+_ABSTAIN_MIN_SENDABLE_CHARS = 200
+
+# Mirrors whatsapp_service.WHATSAPP_BODY_LIMIT (WhatsApp Cloud API's
+# message-body limit). Duplicated as a local constant rather than imported —
+# this module's job ends at "the text to send"; the cut belongs to
+# whatsapp_service.fit_to_whatsapp_limit, which as of 2026-08-11 cuts at a
+# word boundary and marks it instead of severing mid-word. That placement is
+# deliberate: a census showed send_message has ~14 non-test call sites of
+# which only two chunk beforehand — curing this producer would have left the
+# other eleven severing words. The warning below stays because this is the
+# only place that knows the thread id and the pre-format length.
+_WHATSAPP_HARD_SEND_LIMIT = 4096
+
+
+class FinalizeOutcome(str, Enum):
+    """What the pipeline decided about the payload."""
+
+    SEND = "send"  # `text` is safe to hand to the channel sender
+    DEFECT = "defect"  # nothing sendable — gemini: caller raises; codex: fail-off
+
+
+@dataclass(frozen=True)
+class FinalizeResult:
+    outcome: FinalizeOutcome
+    text: str = ""
+    # Why a human was (already) told, or None. On SEND outcomes the pipeline
+    # has performed the notification itself via the caller's `tell_a_human`.
+    human_reason: str | None = None
+    # DEFECT only: machine token naming the defect class.
+    defect_reason: str | None = None
+    # DEFECT only: the exact message the Gemini caller raises (kept identical
+    # to the pre-extraction RuntimeError strings so the worker ledger and any
+    # log-driven tooling see an unchanged vocabulary).
+    defect_message: str = ""
+
+
+def _abstain_answer_worth_sending(data: dict[str, Any]) -> str:
+    """The answer text inside an abstain payload, or "" if there is none worth sending.
+
+    Returns the CLEANED, formatted text so the caller ships exactly what it
+    inspected — an earlier shape that returned a bool and let the caller re-derive
+    the text is how two code paths end up disagreeing about the same message.
+    """
+    # GROUNDING FIRST, length second. Added after a two-seat adversarial review
+    # (Codex gpt-5.6-sol xhigh + Gemini 3.1 Pro, briefed to refute, reviewed
+    # independently) returned the same verdict on the first version of this
+    # function: gating on text length alone "measures fluency, not support" and
+    # "can preferentially release the most confidently hallucinated answer" —
+    # on immigration/tax advice, where a wrong capital requirement or overstay
+    # rule carries real liability and a disclaimer does not neutralise it.
+    #
+    # They are right, and this module's OWN measurements say so too. Of the 7
+    # abstains observed across 16 cold questions, the 5 carrying real answers
+    # all had retrieved context (`context_length` 1-2); the 2 carrying junk had
+    # `context_length == 0` — "Je suis prêt pour votre prochaine question." and
+    # a Russian "I already provided the basic information". `context_length == 0`
+    # with `evidence_score == 0.0` is the signature of the model writing from
+    # parametric memory with nothing retrieved behind it. That is the one shape
+    # that must never reach a client, and length cannot tell it apart.
+    #
+    # So this sends only the case the label gate exists FOR: evidence was
+    # retrieved, and scored below the domain threshold. It never sends the case
+    # where there was no evidence at all.
+    try:
+        context_length = int(data.get("context_length") or 0)
+    except (TypeError, ValueError):
+        context_length = 0
+    try:
+        evidence = float(data.get("evidence_score") or 0.0)
+    except (TypeError, ValueError):
+        evidence = 0.0
+    if context_length <= 0 or evidence <= 0.0:
+        return ""
+
+    raw = (data.get("answer") or "").strip()
+    if len(raw) < _ABSTAIN_MIN_SENDABLE_CHARS:
+        return ""
+    cleaned = _strip_kg_workflow_scaffold(raw)
+    cleaned = format_rich_text(cleaned, "whatsapp")
+    # Re-check AFTER cleaning: the scaffold strip and the channel formatter can
+    # both shrink the text, and a payload that was only scaffold must not be
+    # rescued by its own length before the scaffold was removed.
+    if len(cleaned.strip()) < _ABSTAIN_MIN_SENDABLE_CHARS:
+        return ""
+    return cleaned.strip()
+
+
+def _strip_kg_workflow_scaffold(answer: str) -> str:
+    """Remove the internal KG-workflow diagnostics block, if present.
+
+    Safe to call on any answer text — a no-op when the block is absent
+    (the common case).
+    """
+    return _KG_WORKFLOW_SCAFFOLD_RE.sub("", answer).strip()
+
+
+def _safe_abstain_reply(query: str) -> str:
+    """Return the reasoning engine's localized, source-honest refusal.
+
+    This is intentionally derived from the customer query, never from the
+    endpoint's ``answer`` field: a low-evidence response can still contain
+    fluent unsupported claims even when the endpoint correctly labels it
+    ``abstain=true``.
+    """
+    language = detect_query_language(query)
+    return get_localized_stub("abstain", language)
+
+
+def _starts_with_internal_monologue_leak(answer: str) -> bool:
+    """Return whether a model payload opens with a private prompt marker."""
+    return bool(_INTERNAL_MONOLOGUE_LEAK_RE.match(answer))
+
+
+# ── Codex-only egress vetoes ─────────────────────────────────────────────
+#
+# Both helpers are pure functions so they can be tested without the pipeline.
+
+# Amounts ATTACHED to a currency marker — the entity this veto exists for is
+# "a price the model asserts", and the price form in this bot's answers is
+# currency-marked (Rp/IDR/USD/$). Bare numbers are deliberately OUT of scope:
+# regulatory figures like "2,5 miliar modal disetor" legitimately come from
+# retrieved chunks without a currency prefix, and vetoing them would be a
+# family-#3 over-match blocking correct answers.
+_CURRENCY_AMOUNT_RE = re.compile(
+    r"(?:\bRp\.?|\bIDR\b|\bUSD\b|\$)\s*([0-9][0-9.,\s]*[0-9]|[0-9])"
+    r"|([0-9][0-9.,\s]*[0-9]|[0-9])\s*(?:\bIDR\b|\bUSD\b)",
+    re.IGNORECASE,
+)
+
+# Amounts shorter than this many digits are not vetoable: "Rp 5jt" captures
+# only "5", and near-any source contains a lone digit — matching it would make
+# the veto decorative. Declared limit: multiplier forms (jt/juta/miliar) are
+# out of this veto's scan; the label gate + PricingTool grounding own them.
+_PRICE_VETO_MIN_DIGITS = 4
+
+
+def _normalized_digits(amount: str) -> str:
+    return re.sub(r"[^0-9]", "", amount)
+
+
+def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> list[str]:
+    """Digit-strings of currency-marked amounts in ``text`` absent from every source.
+
+    ``price_sources`` should be the serialized PricingTool block of the frozen
+    package plus the retrieved chunk texts — an amount is legitimate if ANY of
+    them contains it (digit-normalized substring match, so "Rp 3.500.000" in
+    the answer matches "3500000" or "3,500,000" in a source).
+    """
+    normalized_sources = [_normalized_digits(s) for s in price_sources]
+    offenders: list[str] = []
+    for match in _CURRENCY_AMOUNT_RE.finditer(text):
+        amount = match.group(1) or match.group(2) or ""
+        digits = _normalized_digits(amount)
+        if len(digits) < _PRICE_VETO_MIN_DIGITS:
+            continue
+        if not any(digits in src for src in normalized_sources):
+            offenders.append(digits)
+    return offenders
+
+
+_SECRET_EGRESS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("private_key_block", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+    ("ssh_pubkey", re.compile(r"\bssh-(?:rsa|ed25519|dss)\s+[A-Za-z0-9+/=]{20,}")),
+    ("openai_style_key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
+    (
+        "jwt",
+        re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+    ),
+    (
+        "token_assignment",
+        re.compile(
+            r"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token"
+            r"|client[_-]?secret|authorization)\b\s*[:=]\s*['\"]?[A-Za-z0-9_.\-]{16,}"
+        ),
+    ),
+)
+
+
+def scan_text_for_secret_egress(
+    text: str, canary_tokens: Sequence[str] = ()
+) -> str | None:
+    """Name of the first secret-egress pattern found in ``text``, or None.
+
+    Returns the pattern NAME only — never the matched content, so a hit can be
+    logged and ledgered without transcribing the secret it caught (CLAUDE.md
+    §14 output boundary). Canary tokens are exact substrings supplied by the
+    caller (the broker daemon plants them in the sandbox home; one appearing
+    in outbound text means the executor read files it should not have).
+    """
+    for name, pattern in _SECRET_EGRESS_PATTERNS:
+        if pattern.search(text):
+            return name
+    for token in canary_tokens:
+        if token and token in text:
+            return "canary_token"
+    return None
+
+
+def _codex_egress_veto(
+    text: str,
+    *,
+    price_sources: Sequence[str] | None,
+    secret_scan: bool,
+    canary_tokens: Sequence[str],
+    thread_id: Any,
+) -> tuple[str, str] | None:
+    """(defect_reason, defect_message) if codex-leg text must not leave, else None."""
+    if price_sources is not None:
+        offenders = price_tokens_outside_sources(text, price_sources)
+        if offenders:
+            logger.warning(
+                "wa-finalize: pricing veto for thread %s — %d currency-marked "
+                "amount(s) not present in the frozen package's price sources",
+                thread_id,
+                len(offenders),
+            )
+            return (
+                "pricing_outside_package",
+                f"wa-finalize: answer for thread {thread_id} asserts prices "
+                "outside the frozen package",
+            )
+    if secret_scan:
+        hit = scan_text_for_secret_egress(text, canary_tokens)
+        if hit is not None:
+            # Pattern name only — never the matched content (see scanner docstring).
+            logger.error(
+                "wa-finalize: secret-egress scan hit (%s) for thread %s — "
+                "discarding codex output",
+                hit,
+                thread_id,
+            )
+            return (
+                f"secret_egress:{hit}",
+                f"wa-finalize: secret-egress scan hit for thread {thread_id}",
+            )
+    return None
+
+
+async def finalize_wa_answer(
+    *,
+    data: dict[str, Any],
+    query: str,
+    thread_id: Any,
+    provider: str = "gemini",
+    tell_a_human: Callable[[str], Awaitable[Any]] | None = None,
+    price_sources: Sequence[str] | None = None,
+    secret_scan: bool = False,
+    canary_tokens: Sequence[str] = (),
+) -> FinalizeResult:
+    """Run the shared post-generation sequence on a generation payload.
+
+    Args:
+        data: the generation payload — the agentic-RAG response body on the
+            Gemini leg; on the codex leg the worker builds the same shape from
+            the frozen evidence (``answer``, ``abstain``, ``abstain_reason``,
+            ``context_length``, ``evidence_score``).
+        query: the customer query (drives stub localization only).
+        thread_id: for log lines — this function never touches the DB.
+        provider: ``"gemini"`` (behavior-preserving inline path) or
+            ``"codex"`` (typed-outcome path; see module docstring).
+        tell_a_human: one-argument async callable ``(reason) -> accepted``.
+            The pipeline calls it exactly where the pre-extraction code called
+            ``_tell_a_human`` — stub paths on both providers, defect paths on
+            the Gemini provider only (a codex defect fails off to the Gemini
+            leg, which still owes the client an answer and re-enters here).
+        price_sources / secret_scan / canary_tokens: codex-only egress vetoes,
+            inert unless supplied (see module docstring).
+    """
+
+    async def _tell(reason: str) -> None:
+        if tell_a_human is not None:
+            await tell_a_human(reason)
+
+    # Why a human needs to look at this thread, or None. Set at most once —
+    # every later site guards on `is None`, so the FIRST (most specific) cause
+    # is the one reported rather than whichever check happens to run last.
+    human_reason: str | None = None
+
+    if data.get("abstain"):
+        # Zero's ruling (2026-08-11), on measurement: an abstain does NOT mean
+        # "no content". Probed live across 16 cold questions in 8 languages,
+        # SEVEN came back flagged `abstain=true` and three of those carried a
+        # complete, on-topic answer — the two German ones and an Indonesian one
+        # opened straight into the real PT PMA steps. Sending the stub instead
+        # would throw away a written answer and hand the client a refusal.
+        #
+        # This does NOT touch the abstain gates. Their generation-vs-label
+        # divergence is panel-ruled and tripwire-tested (CLAUDE.md §9) — the
+        # label gate MARKS confidence, it does not decide whether advice may
+        # exist. Reading the label as "discard the text" was this consumer's
+        # error, not the gate's. `_abstain_answer_worth_sending` re-checks
+        # grounding itself (context_length/evidence_score), so this can never
+        # rescue the ungrounded-but-fluent case a length check alone would miss.
+        #
+        # A substantive answer is sent WITHOUT going through `human_reason`
+        # below — the client got a real, on-topic answer, so nothing here is a
+        # refusal that needs a human's eyes.
+        #
+        # POLICY branch (spec §2.3): the verdict derives from the frozen
+        # evidence and would be identical whichever provider wrote the text,
+        # so it deliberately behaves the same on both legs.
+        substantive = _abstain_answer_worth_sending(data)
+        if substantive:
+            if provider == "codex":
+                veto = _codex_egress_veto(
+                    substantive,
+                    price_sources=price_sources,
+                    secret_scan=secret_scan,
+                    canary_tokens=canary_tokens,
+                    thread_id=thread_id,
+                )
+                if veto is not None:
+                    return FinalizeResult(
+                        outcome=FinalizeOutcome.DEFECT,
+                        defect_reason=veto[0],
+                        defect_message=veto[1],
+                    )
+            language = detect_query_language(query)
+            logger.info(
+                "wa-inbox bot: abstain on thread %s carried %d chars of answer — "
+                "sending it with the caution note rather than the stub",
+                thread_id,
+                len(substantive),
+            )
+            return FinalizeResult(
+                outcome=FinalizeOutcome.SEND,
+                text=substantive + get_localized_stub("low_confidence_note", language),
+            )
+
+        # Never surface the endpoint's raw answer on this branch. The baseline
+        # caught an abstain-labelled payload that still asserted Rp 10bn.
+        #
+        # RAG refused. Until 2026-08-11 this raised, the worker burned five
+        # retries and the client got SILENCE — while the answer being discarded
+        # was, on the measured cases, the persona telling the client that the
+        # team had been notified and would reply within one business hour. That
+        # promise is taught by the prompt's ESCALATION section, and nothing on
+        # this path performed it: the message was a promise nobody kept, thrown
+        # away before anyone could read it.
+        #
+        # Zero's ruling (2026-08-10): "rifiuto + avviso a un umano". So: send
+        # the localized refusal, and actually tell a human — via the single
+        # `human_reason` choke point below, shared with the other causes.
+        logger.info(
+            "wa-inbox bot: serving localized safe abstention for thread %s (reason=%r)",
+            thread_id,
+            data.get("abstain_reason"),
+        )
+        answer = _safe_abstain_reply(query)
+        human_reason = "rag_abstain"
+    else:
+        answer = (data.get("answer") or "").strip()
+        if not answer:
+            # Measured deterministic, not transient: the 2026-08-10 battery got
+            # a 0-character answer 5 times out of 5 on the same question, so the
+            # retry ladder below cannot rescue this — it only spends attempts
+            # and ends in silence. Tell a human BEFORE the raise, because the
+            # raise is precisely what makes this silent. (Gemini leg only: a
+            # codex defect fails off to the Gemini leg, which still answers.)
+            if provider == "gemini":
+                await _tell("empty_rag_answer")
+            return FinalizeResult(
+                outcome=FinalizeOutcome.DEFECT,
+                defect_reason="empty_rag_answer",
+                defect_message=f"wa-inbox bot: empty RAG answer for thread {thread_id}",
+            )
+
+        if _starts_with_internal_monologue_leak(answer):
+            if provider == "codex":
+                # TEXT_DEFECT (spec §2.3): a different generator can
+                # legitimately cure a defective text — fail off instead of
+                # serving the stub the Gemini leg would serve.
+                return FinalizeResult(
+                    outcome=FinalizeOutcome.DEFECT,
+                    defect_reason="internal_monologue_leak",
+                    defect_message=(
+                        f"wa-finalize: internal-monologue leak in codex output, "
+                        f"thread {thread_id}"
+                    ),
+                )
+            logger.warning(
+                "wa-inbox bot: internal-monologue marker at start of RAG output "
+                "for thread %s; discarding payload and serving safe abstention",
+                thread_id,
+            )
+            answer = _safe_abstain_reply(query)
+            if human_reason is None:
+                human_reason = "internal_monologue_leak"
+
+        # Strip an [ESCALATE] marker if the persona emitted one (mirror whatsapp_chat.py).
+        #
+        # INERT TODAY, ON PURPOSE — say it plainly rather than let a reader assume
+        # coverage. **No prompt in this backend asks the model to emit the token**
+        # (grepped 2026-08-11: the only occurrences are the places that look for
+        # it), and a live probe saw it 0/14. So this branch cannot fire yet. It is
+        # here because the alternative — a second escalation path invented later —
+        # is how this file and whatsapp_chat.py drifted apart in the first place.
+        #
+        # It exists for the case `abstain` provably cannot catch: a message that
+        # asks a real question AND asks for a person retrieves an answer, does not
+        # abstain, and reaches nobody (measured 2026-08-11: 2 of 4 such messages did
+        # not abstain, and all 4 promised the client a callback).
+        #
+        # ARMING IT IS A SEPARATE CHANGE, and NOT just a prompt line: the prompt is
+        # shared by every consumer, and `blog_ask.py` / `agentic_rag.py` /
+        # `channels/web` return the answer with NO strip at all (0 occurrences of
+        # the token in any of them). Teaching the model to emit it without first
+        # moving the strip somewhere central would print an internal token to blog
+        # readers. Tracked in PENDING-ARMS.
+        if "[ESCALATE]" in answer and human_reason is None:
+            human_reason = "persona_escalate_marker"
+        answer = answer.replace("[ESCALATE]", "").strip()
+        if not answer:
+            # `human_reason` is already "persona_escalate_marker" whenever the
+            # marker was the whole payload — report THAT (first cause wins,
+            # same rule as every other site), never the generic emptiness.
+            reason = human_reason or "empty_after_escalate_strip"
+            if provider == "gemini":
+                await _tell(reason)
+            return FinalizeResult(
+                outcome=FinalizeOutcome.DEFECT,
+                defect_reason=reason,
+                defect_message=(
+                    f"wa-inbox bot: answer empty after ESCALATE strip, thread {thread_id}"
+                ),
+            )
+
+        # Remove internal KG-workflow diagnostics before the answer ever reaches
+        # the channel formatter — see _strip_kg_workflow_scaffold docstring.
+        answer = _strip_kg_workflow_scaffold(answer)
+        if not answer:
+            if provider == "codex":
+                # TEXT_DEFECT: scaffold-only output is a broken text, and the
+                # Gemini leg can produce a real answer — fail off.
+                return FinalizeResult(
+                    outcome=FinalizeOutcome.DEFECT,
+                    defect_reason="workflow_only_output",
+                    defect_message=(
+                        f"wa-finalize: workflow-only codex output, thread {thread_id}"
+                    ),
+                )
+            logger.info(
+                "wa-inbox bot: workflow-only RAG output for thread %s; "
+                "serving localized safe abstention",
+                thread_id,
+            )
+            if human_reason is None:
+                human_reason = "workflow_only_output"
+            answer = _safe_abstain_reply(query)
+
+    # Codex-only egress vetoes on the candidate text. Skipped when the text is
+    # the static localized stub (human_reason == "rag_abstain" is the only way
+    # a stub reaches this point on the codex leg — every text-defect stub path
+    # above already returned DEFECT for codex): a fixed stub carries no prices
+    # and no secrets, and vetoing it would turn a POLICY refusal into a
+    # spurious fail-off loop.
+    if provider == "codex" and human_reason != "rag_abstain":
+        veto = _codex_egress_veto(
+            answer,
+            price_sources=price_sources,
+            secret_scan=secret_scan,
+            canary_tokens=canary_tokens,
+            thread_id=thread_id,
+        )
+        if veto is not None:
+            return FinalizeResult(
+                outcome=FinalizeOutcome.DEFECT,
+                defect_reason=veto[0],
+                defect_message=veto[1],
+            )
+
+    # Channel boundary: convert the orchestrator's generic markdown into
+    # WhatsApp-safe formatting (*bold*, unicode bullets, no raw ##/**/[N]
+    # noise) — see backend/channels/format.py::format_rich_text. Length is
+    # tracked pre- AND post-format (not enforced — see
+    # _WHATSAPP_HARD_SEND_LIMIT docstring for why 150-word ChannelConfig
+    # guidance is the wrong unit for this) so the eventual chunked-sending
+    # lane inherits a real length distribution instead of a guess.
+    pre_format_len = len(answer)
+    answer = format_rich_text(answer, "whatsapp")
+    if not answer:
+        reason = human_reason or "empty_after_channel_format"
+        if provider == "gemini":
+            await _tell(reason)
+        return FinalizeResult(
+            outcome=FinalizeOutcome.DEFECT,
+            defect_reason=reason,
+            defect_message=(
+                f"wa-inbox bot: answer empty after channel formatting, thread {thread_id}"
+            ),
+        )
+    post_format_len = len(answer)
+
+    if post_format_len > _WHATSAPP_HARD_SEND_LIMIT:
+        logger.warning(
+            "wa-inbox bot: reply for thread %s is %d chars post-format (%d "
+            "pre-format), exceeds WhatsApp's %d-char single-message limit — "
+            "whatsapp_service.fit_to_whatsapp_limit will cut it at a boundary "
+            "and mark it on send. This module deliberately does NOT cut: the "
+            "send is the choke point (~14 call sites, only 2 of which chunk), "
+            "so curing it here would cure one producer and leave the rest "
+            "severing words mid-token.",
+            thread_id,
+            post_format_len,
+            pre_format_len,
+            _WHATSAPP_HARD_SEND_LIMIT,
+        )
+
+    logger.info(
+        "wa-inbox bot generated reply for thread %s (%d chars post-format, %d chars pre-format)",
+        thread_id,
+        post_format_len,
+        pre_format_len,
+    )
+
+    if human_reason is not None:
+        # The REPLY-PRODUCING causes land here; the defect exits above notify
+        # (on the Gemini leg) before returning. All causes mean the same thing
+        # operationally: the client did not get an answer to what they asked
+        # (or explicitly asked for a person). The copy the client reads is
+        # deliberately unchanged by this branch, so nothing here can turn into
+        # a promise of a reply. The notification body is withheld inside the
+        # caller's helper (`message_text=None`): routing a NEW trigger through
+        # the cleartext payload would widen exactly the third-party exposure
+        # CLAUDE.md §14 constrains. The thread ref is what makes the omission
+        # workable — the notified human can open the thread.
+        await _tell(human_reason)
+
+    return FinalizeResult(
+        outcome=FinalizeOutcome.SEND,
+        text=answer,
+        human_reason=human_reason,
+    )

--- a/apps/backend-rag/backend/services/integrations/wa_finalize.py
+++ b/apps/backend-rag/backend/services/integrations/wa_finalize.py
@@ -18,7 +18,8 @@ Behavior contract:
       identical exceptions).
     * ``provider="codex"`` maps the spec's typed outcomes onto the same
       sequence: every branch where the TEXT ITSELF is defective (empty payload,
-      internal-monologue leak, scaffold-only output, empty after strip/format,
+      internal-monologue leak — including inside a grounded abstain answer,
+      scaffold-only output, empty after strip/format, oversized output,
       pricing veto, secret-egress hit) returns ``DEFECT`` WITHOUT serving a stub
       and WITHOUT telling a human — the caller fails off to the Gemini leg,
       which regenerates and re-enters this pipeline, so the client still gets
@@ -139,12 +140,28 @@ class FinalizeOutcome(str, Enum):
     DEFECT = "defect"  # nothing sendable — gemini: caller raises; codex: fail-off
 
 
+class FinalizeProvider(str, Enum):
+    """Which generation leg produced the payload.
+
+    An Enum rather than a free string because a typo ("Codex", "codeX") on a
+    free string would silently disarm every codex-only policy and run the
+    payload down the Gemini branch — the PR-3 adversarial review reproduced
+    exactly that. ``FinalizeProvider(value)`` raises ``ValueError`` on any
+    unknown value, so a misconfigured caller fails loudly at the first call.
+    """
+
+    GEMINI = "gemini"
+    CODEX = "codex"
+
+
 @dataclass(frozen=True)
 class FinalizeResult:
     outcome: FinalizeOutcome
     text: str = ""
-    # Why a human was (already) told, or None. On SEND outcomes the pipeline
-    # has performed the notification itself via the caller's `tell_a_human`.
+    # Why a human was told, or None. On SEND outcomes the pipeline has
+    # ATTEMPTED the notification via the caller's `tell_a_human` (delivery
+    # semantics are the callback's own — wa_inbox_bot's helper never raises
+    # and dedups per-thread; a callback that raises is contained and logged).
     human_reason: str | None = None
     # DEFECT only: machine token naming the defect class.
     defect_reason: str | None = None
@@ -237,44 +254,119 @@ def _starts_with_internal_monologue_leak(answer: str) -> bool:
 
 # Amounts ATTACHED to a currency marker — the entity this veto exists for is
 # "a price the model asserts", and the price form in this bot's answers is
-# currency-marked (Rp/IDR/USD/$). Bare numbers are deliberately OUT of scope:
-# regulatory figures like "2,5 miliar modal disetor" legitimately come from
-# retrieved chunks without a currency prefix, and vetoing them would be a
-# family-#3 over-match blocking correct answers.
+# currency-marked (Rp/IDR/USD/$), optionally with an Indonesian multiplier
+# (jt/juta/rb/ribu/k/miliar/milyar/bn/triliun). Bare numbers are deliberately
+# OUT of scope: regulatory figures like "2,5 miliar modal disetor" legitimately
+# come from retrieved chunks without a currency prefix, and vetoing them would
+# be a family-#3 over-match blocking correct answers.
+#
+# Three anti-scars, each a reproduced case from the PR-3 adversarial review:
+# * an amount never crosses a newline and never absorbs a following bare
+#   number ("Rp 3.500.000\n30 days" is 3500000, not 350000030) — horizontal
+#   whitespace only around the amount, and NO whitespace inside it;
+# * multipliers are canonicalized ("Rp 99 juta" == "Rp 99.000.000"), so an
+#   invented price cannot pass on its spelling;
+# * source numbers are extracted per TOKEN, never from a concatenation of the
+#   whole source ("Rp 12.345" followed by "67 days" can never authorize an
+#   invented "Rp 34.567").
+_AMOUNT_MULTIPLIERS: dict[str, float] = {
+    "k": 1e3,
+    "rb": 1e3,
+    "ribu": 1e3,
+    "jt": 1e6,
+    "juta": 1e6,
+    "miliar": 1e9,
+    "milyar": 1e9,
+    "bn": 1e9,
+    "triliun": 1e12,
+}
+_MULT_PATTERN = r"(?:jt|juta|rb|ribu|k|miliar|milyar|bn|triliun)"
 _CURRENCY_AMOUNT_RE = re.compile(
-    r"(?:\bRp\.?|\bIDR\b|\bUSD\b|\$)\s*([0-9][0-9.,\s]*[0-9]|[0-9])"
-    r"|([0-9][0-9.,\s]*[0-9]|[0-9])\s*(?:\bIDR\b|\bUSD\b)",
+    r"(?:(?P<cur1>\bRp\.?|\bIDR|\bUSD|\$)[ \t]*(?P<amt1>\d(?:[\d.,]*\d)?)"
+    r"(?:[ \t]*(?P<mul1>" + _MULT_PATTERN + r")\b)?)"
+    r"|(?:(?P<amt2>\d(?:[\d.,]*\d)?)(?:[ \t]*(?P<mul2>" + _MULT_PATTERN + r")\b)?"
+    r"[ \t]*(?P<cur2>IDR|USD)\b)",
     re.IGNORECASE,
 )
 
-# Amounts shorter than this many digits are not vetoable: "Rp 5jt" captures
-# only "5", and near-any source contains a lone digit — matching it would make
-# the veto decorative. Declared limit: multiplier forms (jt/juta/miliar) are
-# out of this veto's scan; the label gate + PricingTool grounding own them.
-_PRICE_VETO_MIN_DIGITS = 4
+# Veto floors per currency family: IDR prices below Rp 1.000 do not exist in
+# this business (and tiny amounts would fire on noise); dollar prices are real
+# from $10 up (the review's "$999" case must be vetoable).
+_VETO_FLOORS: dict[str, int] = {"USD": 10, "IDR": 1000}
 
 
-def _normalized_digits(amount: str) -> str:
-    return re.sub(r"[^0-9]", "", amount)
+def _canonical_currency(cur: str) -> str:
+    c = cur.strip().rstrip(".").upper()
+    return "USD" if c in ("$", "USD") else "IDR"
+
+
+def _canonical_value(amount: str, multiplier: str | None) -> int | None:
+    """Integer value of an amount string, multiplier applied. None if unparseable."""
+    s = amount.strip()
+    if not s:
+        return None
+    if multiplier:
+        # A decimal form is allowed before a multiplier ("3,5 juta"); a grouped
+        # form ("3.500 juta") canonicalizes by stripping separators.
+        normalized = s.replace(",", ".")
+        try:
+            if normalized.count(".") == 1 and len(normalized.split(".")[1]) <= 2:
+                base = float(normalized)
+            else:
+                base = float(re.sub(r"[.,]", "", s))
+        except ValueError:
+            return None
+        return int(round(base * _AMOUNT_MULTIPLIERS[multiplier.lower()]))
+    digits = re.sub(r"[.,]", "", s)
+    if not digits.isdigit():
+        return None
+    return int(digits)
+
+
+def _currency_amounts(text: str) -> list[tuple[str, int]]:
+    """(currency_family, canonical_value) for every currency-marked amount in text."""
+    out: list[tuple[str, int]] = []
+    for m in _CURRENCY_AMOUNT_RE.finditer(text):
+        cur = m.group("cur1") or m.group("cur2") or ""
+        amt = m.group("amt1") or m.group("amt2") or ""
+        mul = m.group("mul1") or m.group("mul2")
+        value = _canonical_value(amt, mul)
+        if value is not None:
+            out.append((_canonical_currency(cur), value))
+    return out
 
 
 def price_tokens_outside_sources(text: str, price_sources: Sequence[str]) -> list[str]:
-    """Digit-strings of currency-marked amounts in ``text`` absent from every source.
+    """Canonical amounts in ``text`` that no source contains, as "CUR:value" strings.
 
     ``price_sources`` should be the serialized PricingTool block of the frozen
     package plus the retrieved chunk texts — an amount is legitimate if ANY of
-    them contains it (digit-normalized substring match, so "Rp 3.500.000" in
-    the answer matches "3500000" or "3,500,000" in a source).
+    them contains the same canonical VALUE ("Rp 3,5 juta" in the answer matches
+    "Rp 3.500.000" or a bare "3500000" in a source). Chunks are included on
+    purpose: answers legitimately quote currency-marked regulatory fees that
+    come from retrieval, not from PricingTool, and excluding them would fail
+    off every such answer. Declared residual (review MAJOR-7): a figure present
+    in a chunk could semantically launder a wrong "service fee" — accepted
+    because the Gemini leg has the identical exposure today with NO veto at
+    all, and the label gate + PricingTool grounding remain the primary control.
     """
-    normalized_sources = [_normalized_digits(s) for s in price_sources]
+    source_values: set[int] = set()
+    for src in price_sources:
+        for _cur, value in _currency_amounts(src):
+            source_values.add(value)
+        # Discrete numeric tokens too (a pricing block may write the amount
+        # without repeating the currency marker beside it) — each token
+        # canonicalized ALONE, never concatenated with its neighbors.
+        for token in re.findall(r"\d(?:[\d.,]*\d)?", src):
+            value = _canonical_value(token, None)
+            if value is not None:
+                source_values.add(value)
     offenders: list[str] = []
-    for match in _CURRENCY_AMOUNT_RE.finditer(text):
-        amount = match.group(1) or match.group(2) or ""
-        digits = _normalized_digits(amount)
-        if len(digits) < _PRICE_VETO_MIN_DIGITS:
+    for cur, value in _currency_amounts(text):
+        if value < _VETO_FLOORS[cur]:
             continue
-        if not any(digits in src for src in normalized_sources):
-            offenders.append(digits)
+        if value not in source_values:
+            offenders.append(f"{cur}:{value}")
     return offenders
 
 
@@ -287,11 +379,28 @@ _SECRET_EGRESS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
         re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
     ),
     (
+        # Covers both config-style (`api_key = xxxx`) and JSON auth-file
+        # fragments (`"refresh_token":"1//xxxx"`) — the closing quote of a
+        # JSON key sits between the name and the colon, and the value charset
+        # includes `/` and `+` (OAuth refresh tokens carry both). The review
+        # reproduced both misses against the first version of this pattern.
         "token_assignment",
         re.compile(
-            r"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token"
-            r"|client[_-]?secret|authorization)\b\s*[:=]\s*['\"]?[A-Za-z0-9_.\-]{16,}"
+            r"(?i)[\"']?\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token"
+            r"|client[_-]?secret|id[_-]?token|authorization)\b[\"']?\s*[:=]\s*"
+            r"[\"']?[A-Za-z0-9_./+\-]{16,}"
         ),
+    ),
+    (
+        # Any "Bearer <opaque>" / "Basic <opaque>" value, with or without an
+        # Authorization: prefix (the space after the scheme word means
+        # token_assignment above cannot reach the real token — this shape
+        # owns it). Prose innocence: "the bearer of the visa" has
+        # no 16-char opaque token after it, and the digit lookahead keeps a
+        # long hyphenated English word ("Bearer responsibility-holder") from
+        # firing — real opaque tokens carry digits.
+        "bearer_token",
+        re.compile(r"(?i)\b(?:bearer|basic)\s+(?=[A-Za-z0-9_./+\-=]*\d)[A-Za-z0-9_./+\-=]{16,}"),
     ),
 )
 
@@ -361,8 +470,8 @@ async def finalize_wa_answer(
     data: dict[str, Any],
     query: str,
     thread_id: Any,
-    provider: str = "gemini",
-    tell_a_human: Callable[[str], Awaitable[Any]] | None = None,
+    tell_a_human: Callable[[str], Awaitable[Any]],
+    provider: str | FinalizeProvider = FinalizeProvider.GEMINI,
     price_sources: Sequence[str] | None = None,
     secret_scan: bool = False,
     canary_tokens: Sequence[str] = (),
@@ -376,20 +485,47 @@ async def finalize_wa_answer(
             ``context_length``, ``evidence_score``).
         query: the customer query (drives stub localization only).
         thread_id: for log lines — this function never touches the DB.
-        provider: ``"gemini"`` (behavior-preserving inline path) or
-            ``"codex"`` (typed-outcome path; see module docstring).
-        tell_a_human: one-argument async callable ``(reason) -> accepted``.
-            The pipeline calls it exactly where the pre-extraction code called
+        tell_a_human: REQUIRED one-argument async callable ``(reason)``. The
+            pipeline calls it exactly where the pre-extraction code called
             ``_tell_a_human`` — stub paths on both providers, defect paths on
             the Gemini provider only (a codex defect fails off to the Gemini
             leg, which still owes the client an answer and re-enters here).
-        price_sources / secret_scan / canary_tokens: codex-only egress vetoes,
-            inert unless supplied (see module docstring).
+            Required rather than defaulted (review MAJOR-9): an optional
+            notifier makes "forgot to wire it" indistinguishable from "chose
+            silence", which is the exact contract inversion the 2026-08-12
+            scar in the /bot corner records. A callback that raises is
+            contained here — a notifier failure must never corrupt the
+            outcome.
+        provider: ``FinalizeProvider`` (or its string value). An unknown
+            string raises ``ValueError`` — a typo must never silently disarm
+            the codex policies.
+        price_sources / secret_scan / canary_tokens: codex egress vetoes. On
+            the codex provider ``price_sources`` and ``secret_scan=True`` are
+            MANDATORY (``ValueError`` otherwise): the protections are part of
+            the route, not options (review BLOCKER-2 — fail-closed, never
+            fail-open).
     """
+    provider = FinalizeProvider(provider)
+    if provider is FinalizeProvider.CODEX and (price_sources is None or not secret_scan):
+        raise ValueError(
+            "wa-finalize: provider='codex' requires price_sources and "
+            "secret_scan=True — refusing a fail-open configuration"
+        )
 
     async def _tell(reason: str) -> None:
-        if tell_a_human is not None:
+        try:
             await tell_a_human(reason)
+        # Containment, not delegation: wa_inbox_bot's helper already never
+        # raises, but this pipeline must not depend on every future caller
+        # honoring that — a notifier failure must never replace or corrupt
+        # the outcome being returned.
+        except Exception as exc:
+            logger.error(
+                "wa-finalize: tell_a_human(%s) raised for thread %s: %s",
+                reason,
+                thread_id,
+                exc,
+            )
 
     # Why a human needs to look at this thread, or None. Set at most once —
     # every later site guards on `is None`, so the FIRST (most specific) cause
@@ -420,8 +556,42 @@ async def finalize_wa_answer(
         # evidence and would be identical whichever provider wrote the text,
         # so it deliberately behaves the same on both legs.
         substantive = _abstain_answer_worth_sending(data)
+
+        # Structural text checks the early return used to SKIP (review
+        # BLOCKER-1, reproduced): a grounded abstain payload is still MODEL
+        # TEXT, and the label changes the confidence, not the text-safety
+        # obligations — a monologue leak or an [ESCALATE] marker inside it
+        # gets the same treatment as on the non-abstain path.
+        escalate_in_substantive = False
+        if substantive and _starts_with_internal_monologue_leak(substantive):
+            if provider is FinalizeProvider.CODEX:
+                return FinalizeResult(
+                    outcome=FinalizeOutcome.DEFECT,
+                    defect_reason="internal_monologue_leak",
+                    defect_message=(
+                        f"wa-finalize: internal-monologue leak in codex output, "
+                        f"thread {thread_id}"
+                    ),
+                )
+            logger.warning(
+                "wa-inbox bot: internal-monologue marker inside grounded abstain "
+                "answer for thread %s; discarding payload and serving safe abstention",
+                thread_id,
+            )
+            human_reason = "internal_monologue_leak"
+            substantive = ""
+        if substantive and "[ESCALATE]" in substantive:
+            # POLICY marker (spec §2.3): identical handling on both providers.
+            escalate_in_substantive = True
+            substantive = substantive.replace("[ESCALATE]", "").strip()
+            if len(substantive) < _ABSTAIN_MIN_SENDABLE_CHARS:
+                # The marker was load-bearing bulk — nothing substantive left.
+                if human_reason is None:
+                    human_reason = "persona_escalate_marker"
+                substantive = ""
+
         if substantive:
-            if provider == "codex":
+            if provider is FinalizeProvider.CODEX:
                 veto = _codex_egress_veto(
                     substantive,
                     price_sources=price_sources,
@@ -442,9 +612,13 @@ async def finalize_wa_answer(
                 thread_id,
                 len(substantive),
             )
+            reason = "persona_escalate_marker" if escalate_in_substantive else None
+            if reason is not None:
+                await _tell(reason)
             return FinalizeResult(
                 outcome=FinalizeOutcome.SEND,
                 text=substantive + get_localized_stub("low_confidence_note", language),
+                human_reason=reason,
             )
 
         # Never surface the endpoint's raw answer on this branch. The baseline
@@ -467,7 +641,11 @@ async def finalize_wa_answer(
             data.get("abstain_reason"),
         )
         answer = _safe_abstain_reply(query)
-        human_reason = "rag_abstain"
+        # First cause wins (same rule as every other site): a leak or marker
+        # found inside the discarded substantive text is the more specific
+        # reason than the generic abstain label.
+        if human_reason is None:
+            human_reason = "rag_abstain"
     else:
         answer = (data.get("answer") or "").strip()
         if not answer:
@@ -477,7 +655,7 @@ async def finalize_wa_answer(
             # and ends in silence. Tell a human BEFORE the raise, because the
             # raise is precisely what makes this silent. (Gemini leg only: a
             # codex defect fails off to the Gemini leg, which still answers.)
-            if provider == "gemini":
+            if provider is FinalizeProvider.GEMINI:
                 await _tell("empty_rag_answer")
             return FinalizeResult(
                 outcome=FinalizeOutcome.DEFECT,
@@ -486,7 +664,7 @@ async def finalize_wa_answer(
             )
 
         if _starts_with_internal_monologue_leak(answer):
-            if provider == "codex":
+            if provider is FinalizeProvider.CODEX:
                 # TEXT_DEFECT (spec §2.3): a different generator can
                 # legitimately cure a defective text — fail off instead of
                 # serving the stub the Gemini leg would serve.
@@ -535,7 +713,7 @@ async def finalize_wa_answer(
             # marker was the whole payload — report THAT (first cause wins,
             # same rule as every other site), never the generic emptiness.
             reason = human_reason or "empty_after_escalate_strip"
-            if provider == "gemini":
+            if provider is FinalizeProvider.GEMINI:
                 await _tell(reason)
             return FinalizeResult(
                 outcome=FinalizeOutcome.DEFECT,
@@ -549,7 +727,7 @@ async def finalize_wa_answer(
         # the channel formatter — see _strip_kg_workflow_scaffold docstring.
         answer = _strip_kg_workflow_scaffold(answer)
         if not answer:
-            if provider == "codex":
+            if provider is FinalizeProvider.CODEX:
                 # TEXT_DEFECT: scaffold-only output is a broken text, and the
                 # Gemini leg can produce a real answer — fail off.
                 return FinalizeResult(
@@ -574,7 +752,7 @@ async def finalize_wa_answer(
     # above already returned DEFECT for codex): a fixed stub carries no prices
     # and no secrets, and vetoing it would turn a POLICY refusal into a
     # spurious fail-off loop.
-    if provider == "codex" and human_reason != "rag_abstain":
+    if provider is FinalizeProvider.CODEX and human_reason != "rag_abstain":
         veto = _codex_egress_veto(
             answer,
             price_sources=price_sources,
@@ -600,7 +778,7 @@ async def finalize_wa_answer(
     answer = format_rich_text(answer, "whatsapp")
     if not answer:
         reason = human_reason or "empty_after_channel_format"
-        if provider == "gemini":
+        if provider is FinalizeProvider.GEMINI:
             await _tell(reason)
         return FinalizeResult(
             outcome=FinalizeOutcome.DEFECT,
@@ -610,6 +788,21 @@ async def finalize_wa_answer(
             ),
         )
     post_format_len = len(answer)
+
+    if provider is FinalizeProvider.CODEX and post_format_len > _WHATSAPP_HARD_SEND_LIMIT:
+        # TEXT_DEFECT (spec §2.3 "malformed/oversized output"): on the codex
+        # leg an oversized answer fails off to the Gemini leg instead of
+        # being cut mid-content by the sender's hard limit — a truncated
+        # answer can lose its disclaimer or conclusion, and a different
+        # generator can legitimately produce one that fits.
+        return FinalizeResult(
+            outcome=FinalizeOutcome.DEFECT,
+            defect_reason="oversized_output",
+            defect_message=(
+                f"wa-finalize: codex output {post_format_len} chars post-format "
+                f"exceeds the WhatsApp single-message limit, thread {thread_id}"
+            ),
+        )
 
     if post_format_len > _WHATSAPP_HARD_SEND_LIMIT:
         logger.warning(

--- a/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
+++ b/apps/backend-rag/backend/services/integrations/wa_inbox_bot.py
@@ -50,7 +50,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import re
 from typing import Any
 
 import asyncpg
@@ -58,151 +57,23 @@ import httpx
 
 from backend.app.core.config import settings
 from backend.app.rag_proxy import get_rag_worker_url
-from backend.channels.format import format_rich_text
 from backend.services.integrations.human_escalation_notifier import notify_human_telegram
 from backend.services.integrations.wa_bot_outcomes import BotStandingCondition
-from backend.services.rag.agentic._reasoning_stubs import get_localized_stub
-from backend.services.rag.agentic.query_helpers import detect_query_language
+from backend.services.integrations.wa_finalize import (
+    # Re-exported for existing importers (tests exercise these through this
+    # module's namespace): the post-generation helpers moved to wa_finalize in
+    # the BOT-V4 S2 extraction — ONE pipeline shared by both generation legs.
+    _ABSTAIN_MIN_SENDABLE_CHARS as _ABSTAIN_MIN_SENDABLE_CHARS,
+)
+from backend.services.integrations.wa_finalize import (
+    FinalizeOutcome,
+    finalize_wa_answer,
+)
+from backend.services.integrations.wa_finalize import (
+    _abstain_answer_worth_sending as _abstain_answer_worth_sending,
+)
 
 logger = logging.getLogger("zantara.backend")
-
-# ── KG workflow-scaffold strip (client-voice hardening, 2026-07-25) ──────
-# `orchestrator_core.py::_format_workflow_for_prompt` appends an internal
-# diagnostics block to the RAG answer on some queries — a "## SUGGESTED
-# WORKFLOW (from <source>, confidence: NN%)" heading, the workflow name,
-# a numbered step list, and an optional "**Confidence**: ..." line — ALWAYS
-# closed by the literal trailer sentence below (`_KG_WORKFLOW_TRAILER`,
-# copied verbatim from orchestrator_core.py). That block is internal
-# diagnostics for an operator reading the raw answer, not a WhatsApp
-# client, and has been observed CONTRADICTING the actual answer (e.g. an
-# E33G remote-worker answer followed by a local-employment IMTA/TKA
-# workflow it never asked for).
-#
-# We do NOT edit orchestrator_core.py (another lane owns it, and the block
-# may be legitimate for other consumers like the web chat UI) — this strip
-# lives at the WhatsApp channel boundary instead.
-#
-# Anchored on the two literal strings the emitter ALWAYS writes together
-# (heading prefix + closing sentence, both from the SAME
-# `_format_workflow_for_prompt` call) rather than a loose "workflow"
-# keyword — see .claude/rules/cicatrix-superscar.md family #3
-# (guard-over-match) for why a bare-substring match would be unsafe: a
-# legitimate client answer ("il nostro workflow di onboarding...") must
-# never be caught by this. The non-greedy DOTALL match between the two
-# anchors also means only the block itself is removed, never content that
-# happens to follow it (e.g. the KG fast-path's reasoning text, which is
-# appended AFTER the workflow block in some code paths and must survive).
-_KG_WORKFLOW_TRAILER = (
-    "IMPORTANT: This is a suggested workflow. Always verify current requirements with the user."
-)
-_KG_WORKFLOW_SCAFFOLD_RE = re.compile(
-    r"\s*##\s+SUGGESTED WORKFLOW \(from .*?" + re.escape(_KG_WORKFLOW_TRAILER),
-    re.DOTALL,
-)
-
-# The 2026-08-11 KBLI baseline caught Gemini starting otherwise client-visible
-# answers with the prompt's private XML section name (three of 25 probes).
-# Do not try to recover a "final" paragraph from such a payload: the leaked
-# block has no guaranteed delimiter and any guessed split could still expose
-# chain-of-thought or unsupported claims.  At the WhatsApp boundary the safe
-# behavior is to discard the entire payload and serve the normal localized
-# source-honest refusal.  Anchor at the beginning so a legitimate discussion
-# *about* an internal-monologue bug is not caught mid-answer.
-_INTERNAL_MONOLOGUE_LEAK_RE = re.compile(
-    r"^[^A-Za-z0-9]{0,32}internal[ _-]+monologue"
-    r"(?:[ _-]+instructions)?(?:[^A-Za-z0-9]|$)",
-    re.IGNORECASE,
-)
-
-
-# An abstain payload is worth sending when it actually contains an answer.
-# Measured 2026-08-11 across 16 cold questions in 8 languages: 7 came back
-# `abstain=true`, and 3 of those carried a complete on-topic answer. The old
-# consumer discarded all 7.
-#
-# Deliberately NOT a quality judgement — this module cannot re-score evidence and
-# must not try. It asks one thing: is there prose here, or only the residue of a
-# refusal? The floor is length, because the refusal shapes the RAG emits are
-# short ("Je suis prêt pour votre prochaine question." — 43 chars, measured) and
-# a real answer to any question this bot receives is not.
-_ABSTAIN_MIN_SENDABLE_CHARS = 200
-
-
-def _abstain_answer_worth_sending(data: dict[str, Any]) -> str:
-    """The answer text inside an abstain payload, or "" if there is none worth sending.
-
-    Returns the CLEANED, formatted text so the caller ships exactly what it
-    inspected — an earlier shape that returned a bool and let the caller re-derive
-    the text is how two code paths end up disagreeing about the same message.
-    """
-    # GROUNDING FIRST, length second. Added after a two-seat adversarial review
-    # (Codex gpt-5.6-sol xhigh + Gemini 3.1 Pro, briefed to refute, reviewed
-    # independently) returned the same verdict on the first version of this
-    # function: gating on text length alone "measures fluency, not support" and
-    # "can preferentially release the most confidently hallucinated answer" —
-    # on immigration/tax advice, where a wrong capital requirement or overstay
-    # rule carries real liability and a disclaimer does not neutralise it.
-    #
-    # They are right, and this module's OWN measurements say so too. Of the 7
-    # abstains observed across 16 cold questions, the 5 carrying real answers
-    # all had retrieved context (`context_length` 1-2); the 2 carrying junk had
-    # `context_length == 0` — "Je suis prêt pour votre prochaine question." and
-    # a Russian "I already provided the basic information". `context_length == 0`
-    # with `evidence_score == 0.0` is the signature of the model writing from
-    # parametric memory with nothing retrieved behind it. That is the one shape
-    # that must never reach a client, and length cannot tell it apart.
-    #
-    # So this sends only the case the label gate exists FOR: evidence was
-    # retrieved, and scored below the domain threshold. It never sends the case
-    # where there was no evidence at all.
-    try:
-        context_length = int(data.get("context_length") or 0)
-    except (TypeError, ValueError):
-        context_length = 0
-    try:
-        evidence = float(data.get("evidence_score") or 0.0)
-    except (TypeError, ValueError):
-        evidence = 0.0
-    if context_length <= 0 or evidence <= 0.0:
-        return ""
-
-    raw = (data.get("answer") or "").strip()
-    if len(raw) < _ABSTAIN_MIN_SENDABLE_CHARS:
-        return ""
-    cleaned = _strip_kg_workflow_scaffold(raw)
-    cleaned = format_rich_text(cleaned, "whatsapp")
-    # Re-check AFTER cleaning: the scaffold strip and the channel formatter can
-    # both shrink the text, and a payload that was only scaffold must not be
-    # rescued by its own length before the scaffold was removed.
-    if len(cleaned.strip()) < _ABSTAIN_MIN_SENDABLE_CHARS:
-        return ""
-    return cleaned.strip()
-
-
-def _strip_kg_workflow_scaffold(answer: str) -> str:
-    """Remove the internal KG-workflow diagnostics block, if present.
-
-    Safe to call on any answer text — a no-op when the block is absent
-    (the common case).
-    """
-    return _KG_WORKFLOW_SCAFFOLD_RE.sub("", answer).strip()
-
-
-def _safe_abstain_reply(query: str) -> str:
-    """Return the reasoning engine's localized, source-honest refusal.
-
-    This is intentionally derived from the customer query, never from the
-    endpoint's ``answer`` field: a low-evidence response can still contain
-    fluent unsupported claims even when the endpoint correctly labels it
-    ``abstain=true``.
-    """
-    language = detect_query_language(query)
-    return get_localized_stub("abstain", language)
-
-
-def _starts_with_internal_monologue_leak(answer: str) -> bool:
-    """Return whether a model payload opens with a private prompt marker."""
-    return bool(_INTERNAL_MONOLOGUE_LEAK_RE.match(answer))
 
 
 async def _tell_a_human(*, phone: str, reason: str, thread_id: Any) -> bool:
@@ -271,32 +142,6 @@ async def _tell_a_human(*, phone: str, reason: str, thread_id: Any) -> bool:
     )
     return accepted
 
-
-# Mirrors whatsapp_service.WHATSAPP_BODY_LIMIT (WhatsApp Cloud API's
-# message-body limit). Duplicated as a local constant rather than imported —
-# this module's job ends at "the text to send"; the cut belongs to
-# whatsapp_service.fit_to_whatsapp_limit, which as of 2026-08-11 cuts at a
-# word boundary and marks it instead of severing mid-word. That placement is
-# deliberate and was CORRECTED here: a first version of the cure lived in this
-# module, and a census showed send_message has ~14 non-test call sites (outbox
-# worker, conversations router, compliance alerts, client-value predictor) of
-# which only two chunk beforehand — curing this producer would have left the
-# other eleven severing words. This warning stays because it is the only place
-# that knows the thread id and the pre-format length.
-#
-# NOT derived from backend/prompts/channel_overlays.py's
-# ChannelConfig(name="whatsapp", max_words=150, ...): that number is a
-# WORD-count *prompt instruction* to the LLM ("try to keep it short"),
-# empirically NOT obeyed (the production evidence behind this PR was
-# ~450 words / 2923 chars, generated WITH that overlay active) — which is
-# exactly why this fix is deterministic post-processing instead of a
-# stronger instruction. Converting a word budget into a char threshold
-# here would answer a different question ("is this reply longer than our
-# style guideline?") than the one this check needs to answer ("is real
-# content about to be physically deleted by whatsapp_service.py's hard
-# cutoff?"). Coupling to ChannelConfig.max_words was considered and
-# rejected for that reason, not overlooked — see PR description.
-_WHATSAPP_HARD_SEND_LIMIT = 4096
 
 # How many prior turns of the thread to feed the orchestrator as context.
 _HISTORY_TURNS = 12
@@ -539,197 +384,28 @@ async def generate_bot_reply(pool: asyncpg.Pool, thread: Any) -> str:
         resp.raise_for_status()
         data = resp.json()
 
-    # Why a human needs to look at this thread, or None. Set at most once —
-    # every later site guards on `is None`, so the FIRST (most specific) cause
-    # is the one reported rather than whichever check happens to run last.
-    human_reason: str | None = None
+    # The post-generation sequence (abstain handling, monologue-leak and
+    # [ESCALATE] handling, KG-scaffold strip, channel formatting, human
+    # notification) is the SHARED pipeline in ``wa_finalize`` — extracted in
+    # BOT-V4 S2 so the codex broker leg runs the exact same policy instead of
+    # a drifting copy. ``provider="gemini"`` is behavior-preserving: same
+    # branch order, same log lines, same notification points, and the defect
+    # messages raised below are the same RuntimeError strings as before the
+    # extraction, so the worker's retry ladder and the ledger vocabulary are
+    # unchanged.
+    async def _tell(reason: str) -> bool:
+        return await _tell_a_human(phone=phone, reason=reason, thread_id=thread_id)
 
-    if data.get("abstain"):
-        # Zero's ruling (2026-08-11), on measurement: an abstain does NOT mean
-        # "no content". Probed live across 16 cold questions in 8 languages,
-        # SEVEN came back flagged `abstain=true` and three of those carried a
-        # complete, on-topic answer — the two German ones and an Indonesian one
-        # opened straight into the real PT PMA steps. Sending the stub instead
-        # would throw away a written answer and hand the client a refusal.
-        #
-        # This does NOT touch the abstain gates. Their generation-vs-label
-        # divergence is panel-ruled and tripwire-tested (CLAUDE.md §9) — the
-        # label gate MARKS confidence, it does not decide whether advice may
-        # exist. Reading the label as "discard the text" was this consumer's
-        # error, not the gate's. `_abstain_answer_worth_sending` re-checks
-        # grounding itself (context_length/evidence_score), so this can never
-        # rescue the ungrounded-but-fluent case a length check alone would miss.
-        #
-        # A substantive answer is sent WITHOUT going through `human_reason`
-        # below — the client got a real, on-topic answer, so nothing here is a
-        # refusal that needs a human's eyes.
-        substantive = _abstain_answer_worth_sending(data)
-        if substantive:
-            language = detect_query_language(query)
-            logger.info(
-                "wa-inbox bot: abstain on thread %s carried %d chars of answer — "
-                "sending it with the caution note rather than the stub",
-                thread_id,
-                len(substantive),
-            )
-            return substantive + get_localized_stub("low_confidence_note", language)
-
-        # Never surface the endpoint's raw answer on this branch. The baseline
-        # caught an abstain-labelled payload that still asserted Rp 10bn.
-        #
-        # RAG refused. Until 2026-08-11 this raised, the worker burned five
-        # retries and the client got SILENCE — while the answer being discarded
-        # was, on the measured cases, the persona telling the client that the
-        # team had been notified and would reply within one business hour. That
-        # promise is taught by the prompt's ESCALATION section, and nothing on
-        # this path performed it: the message was a promise nobody kept, thrown
-        # away before anyone could read it.
-        #
-        # Zero's ruling (2026-08-10): "rifiuto + avviso a un umano". So: send
-        # the localized refusal, and actually tell a human — via the single
-        # `human_reason` choke point below, shared with the other three causes
-        # (internal-monologue leak, [ESCALATE] marker, workflow-only output).
-        logger.info(
-            "wa-inbox bot: serving localized safe abstention for thread %s (reason=%r)",
-            thread_id,
-            data.get("abstain_reason"),
-        )
-        answer = _safe_abstain_reply(query)
-        human_reason = "rag_abstain"
-    else:
-        answer = (data.get("answer") or "").strip()
-        if not answer:
-            # Measured deterministic, not transient: the 2026-08-10 battery got
-            # a 0-character answer 5 times out of 5 on the same question, so the
-            # retry ladder below cannot rescue this — it only spends attempts
-            # and ends in silence. Tell a human BEFORE the raise, because the
-            # raise is precisely what makes this silent.
-            await _tell_a_human(phone=phone, reason="empty_rag_answer", thread_id=thread_id)
-            raise RuntimeError(f"wa-inbox bot: empty RAG answer for thread {thread_id}")
-
-        if _starts_with_internal_monologue_leak(answer):
-            logger.warning(
-                "wa-inbox bot: internal-monologue marker at start of RAG output "
-                "for thread %s; discarding payload and serving safe abstention",
-                thread_id,
-            )
-            answer = _safe_abstain_reply(query)
-            if human_reason is None:
-                human_reason = "internal_monologue_leak"
-
-        # Strip an [ESCALATE] marker if the persona emitted one (mirror whatsapp_chat.py).
-        #
-        # Until now this MIRRORED THE FORM AND NOT THE EFFECT: `whatsapp_chat.py`
-        # captures the same marker, strips it, sends the answer and then calls
-        # `notify_human_telegram`. This module deleted the marker and called
-        # nothing — the persona asked for a human and the request was erased in
-        # transit. Verified on main before this change: zero telegram/notify
-        # references in the whole file.
-        #
-        # INERT TODAY, ON PURPOSE — say it plainly rather than let a reader assume
-        # coverage. **No prompt in this backend asks the model to emit the token**
-        # (grepped 2026-08-11: the only occurrences are the two places that look for
-        # it), and a live probe saw it 0/14. So this branch cannot fire yet. It is
-        # here because the alternative — a second escalation path invented later —
-        # is how this file and whatsapp_chat.py drifted apart in the first place.
-        #
-        # It exists for the case `abstain` provably cannot catch: a message that
-        # asks a real question AND asks for a person retrieves an answer, does not
-        # abstain, and reaches nobody (measured 2026-08-11: 2 of 4 such messages did
-        # not abstain, and all 4 promised the client a callback).
-        #
-        # ARMING IT IS A SEPARATE CHANGE, and NOT just a prompt line: the prompt is
-        # shared by every consumer, and `blog_ask.py` / `agentic_rag.py` /
-        # `channels/web` return the answer with NO strip at all (0 occurrences of
-        # the token in any of them). Teaching the model to emit it without first
-        # moving the strip somewhere central would print an internal token to blog
-        # readers. Tracked in PENDING-ARMS.
-        if "[ESCALATE]" in answer and human_reason is None:
-            human_reason = "persona_escalate_marker"
-        answer = answer.replace("[ESCALATE]", "").strip()
-        if not answer:
-            # `human_reason` is already "persona_escalate_marker" whenever the
-            # marker was the whole payload — report THAT (first cause wins,
-            # same rule as every other site), never the generic emptiness.
-            await _tell_a_human(
-                phone=phone,
-                reason=human_reason or "empty_after_escalate_strip",
-                thread_id=thread_id,
-            )
-            raise RuntimeError(
-                f"wa-inbox bot: answer empty after ESCALATE strip, thread {thread_id}"
-            )
-
-        # Remove internal KG-workflow diagnostics before the answer ever reaches
-        # the channel formatter — see _strip_kg_workflow_scaffold docstring.
-        answer = _strip_kg_workflow_scaffold(answer)
-        if not answer:
-            logger.info(
-                "wa-inbox bot: workflow-only RAG output for thread %s; "
-                "serving localized safe abstention",
-                thread_id,
-            )
-            if human_reason is None:
-                human_reason = "workflow_only_output"
-            answer = _safe_abstain_reply(query)
-
-    # Channel boundary: convert the orchestrator's generic markdown into
-    # WhatsApp-safe formatting (*bold*, unicode bullets, no raw ##/**/[N]
-    # noise) — see backend/channels/format.py::format_rich_text. Length is
-    # tracked pre- AND post-format (not enforced — see
-    # _WHATSAPP_HARD_SEND_LIMIT docstring for why 150-word ChannelConfig
-    # guidance is the wrong unit for this) so the eventual chunked-sending
-    # lane inherits a real length distribution instead of a guess.
-    pre_format_len = len(answer)
-    answer = format_rich_text(answer, "whatsapp")
-    if not answer:
-        await _tell_a_human(
-            phone=phone,
-            reason=human_reason or "empty_after_channel_format",
-            thread_id=thread_id,
-        )
-        raise RuntimeError(
-            f"wa-inbox bot: answer empty after channel formatting, thread {thread_id}"
-        )
-    post_format_len = len(answer)
-
-    if post_format_len > _WHATSAPP_HARD_SEND_LIMIT:
-        logger.warning(
-            "wa-inbox bot: reply for thread %s is %d chars post-format (%d "
-            "pre-format), exceeds WhatsApp's %d-char single-message limit — "
-            "whatsapp_service.fit_to_whatsapp_limit will cut it at a boundary "
-            "and mark it on send. This module deliberately does NOT cut: the "
-            "send is the choke point (~14 call sites, only 2 of which chunk), "
-            "so curing it here would cure one producer and leave the rest "
-            "severing words mid-token.",
-            thread_id,
-            post_format_len,
-            pre_format_len,
-            _WHATSAPP_HARD_SEND_LIMIT,
-        )
-
-    logger.info(
-        "wa-inbox bot generated reply for thread %s (%d chars post-format, %d chars pre-format)",
-        thread_id,
-        post_format_len,
-        pre_format_len,
+    result = await finalize_wa_answer(
+        data=data,
+        query=query,
+        thread_id=thread_id,
+        provider="gemini",
+        tell_a_human=_tell,
     )
-
-    if human_reason is not None:
-        # The REPLY-PRODUCING causes land here; the silent exits above call the
-        # same helper before they raise. (An earlier version of this comment
-        # said "one call site rather than four" — true then, and the reason the
-        # silent paths were never covered: a single bottom-of-function call
-        # site cannot be reached by a function that leaves via `raise`.)
-        #
-        # All causes mean the same thing operationally: the client did not get
-        # an answer to what they asked (or explicitly asked for a person). The
-        # copy the client reads is deliberately unchanged by this branch, so
-        # nothing here can turn into a promise of a reply. Body withheld on
-        # purpose (`message_text=None` inside the helper): routing a NEW trigger
-        # through the cleartext payload would widen exactly the third-party
-        # exposure CLAUDE.md §14 constrains. The thread ref is what makes the
-        # omission workable — the notified human can open the thread.
-        await _tell_a_human(phone=phone, reason=human_reason, thread_id=thread_id)
-
-    return answer
+    if result.outcome is FinalizeOutcome.DEFECT:
+        # The worker's guard turns this into retry/backoff and eventually
+        # ``failed`` — never a wrong send (see the Raises section above). The
+        # pipeline has already told a human on the paths that warrant it.
+        raise RuntimeError(result.defect_message)
+    return result.text

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
@@ -1,0 +1,282 @@
+"""wa_finalize — the codex-leg additions the extraction introduced.
+
+The Gemini-leg behavior of ``finalize_wa_answer`` is proven by the PRE-EXISTING
+suites, which drive it through ``wa_inbox_bot.generate_bot_reply`` unchanged
+(``test_wa_inbox_bot.py``, ``test_wa_abstain_reaches_a_human.py``,
+``test_wa_abstain_with_content_is_sent.py``). This file covers only what is NEW:
+the typed-outcome mapping for ``provider="codex"`` (TEXT_DEFECT fails off
+silently, POLICY behaves like the Gemini leg) and the two codex-only egress
+vetoes (pricing, secret scan) — each with guilt AND innocence cases, per
+cicatrix family #3.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from backend.services.integrations.wa_finalize import (
+    _KG_WORKFLOW_TRAILER,
+    FinalizeOutcome,
+    finalize_wa_answer,
+    price_tokens_outside_sources,
+    scan_text_for_secret_egress,
+)
+
+# Long enough to clear _ABSTAIN_MIN_SENDABLE_CHARS after cleaning/formatting.
+_REAL_ANSWER = (
+    "To establish a PT PMA in Indonesia you follow these steps. First choose the "
+    "business sector and verify the KBLI codes allow foreign ownership. Then "
+    "reserve the company name and notarize the deed of establishment. After the "
+    "SK Kemenkumham is issued you register on OSS for the NIB, then obtain the "
+    "NPWP and any sector licenses your KBLI requires."
+)
+
+_SCAFFOLD_ONLY = (
+    "## SUGGESTED WORKFLOW (from graph_traversal, confidence: 90%)\n"
+    "1. Do the thing\n2. Do the next thing\n" + _KG_WORKFLOW_TRAILER
+)
+
+
+class _Tell:
+    """Recording stand-in for the caller's tell_a_human callback."""
+
+    def __init__(self) -> None:
+        self.reasons: list[str] = []
+
+    async def __call__(self, reason: str) -> bool:
+        self.reasons.append(reason)
+        return True
+
+
+def _payload(answer: str, *, abstain: bool = False, ctx: int = 3, ev: float = 0.5) -> dict[str, Any]:
+    return {
+        "answer": answer,
+        "abstain": abstain,
+        "abstain_reason": "below_domain_threshold" if abstain else None,
+        "context_length": ctx,
+        "evidence_score": ev,
+    }
+
+
+async def _run(data: dict[str, Any], *, provider: str, tell: _Tell, **kw: Any):
+    return await finalize_wa_answer(
+        data=data,
+        query="How do I open a PT PMA?",
+        thread_id=42,
+        provider=provider,
+        tell_a_human=tell,
+        **kw,
+    )
+
+
+# ── Pricing veto (pure function): guilt and innocence ────────────────────
+
+
+def test_pricing_veto_catches_an_amount_absent_from_every_source() -> None:
+    offenders = price_tokens_outside_sources(
+        "The service costs Rp 5.000.000 all-inclusive.",
+        ["Company setup — Rp 3.500.000, duration 30 days"],
+    )
+    assert offenders == ["5000000"]
+
+
+def test_pricing_veto_matches_amounts_across_separator_formats() -> None:
+    # Answer uses commas, source uses dots — same digits, no veto.
+    assert (
+        price_tokens_outside_sources(
+            "It costs Rp 3,500,000 in total.",
+            ['{"price": "Rp 3.500.000"}'],
+        )
+        == []
+    )
+
+
+def test_pricing_veto_ignores_amounts_without_a_currency_marker() -> None:
+    # "2,5 miliar" is a regulatory capital figure from retrieved chunks, not a
+    # price — currency-anchored scope means it must never be vetoed.
+    assert (
+        price_tokens_outside_sources(
+            "The minimum paid-up capital is 2,5 miliar rupiah per BKPM 5/2025.",
+            ["unrelated source"],
+        )
+        == []
+    )
+
+
+def test_pricing_veto_skips_sub_threshold_digit_runs() -> None:
+    # "Rp 5jt" captures only "5" — below the 4-digit floor, declared out of scan.
+    assert price_tokens_outside_sources("Around Rp 5jt.", ["no numbers here"]) == []
+
+
+# ── Secret-egress scan (pure function): guilt and innocence ──────────────
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("-----BEGIN OPENSSH PRIVATE KEY-----\nabc", "private_key_block"),
+        ("here sk-" + "a" * 24 + " is the key", "openai_style_key"),
+        ("eyJ" + "a" * 12 + "." + "b" * 12 + "." + "c" * 12, "jwt"),
+        ('config: api_key = "' + "x" * 20 + '"', "token_assignment"),
+    ],
+)
+def test_secret_scan_names_the_pattern_without_the_content(text: str, expected: str) -> None:
+    assert scan_text_for_secret_egress(text) == expected
+
+
+def test_secret_scan_catches_a_canary_token() -> None:
+    assert (
+        scan_text_for_secret_egress("…CANARY-9f3a-token…", canary_tokens=("CANARY-9f3a-token",))
+        == "canary_token"
+    )
+
+
+def test_secret_scan_passes_ordinary_consulting_prose() -> None:
+    assert (
+        scan_text_for_secret_egress(
+            "You will need an API key from the OSS system to submit the LKPM "
+            "report; the access token is issued after NIB registration."
+        )
+        is None
+    )
+
+
+# ── Codex typed outcomes: TEXT_DEFECT fails off silently ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_codex_monologue_leak_is_a_silent_defect() -> None:
+    tell = _Tell()
+    result = await _run(
+        _payload("Internal monologue: the user wants X…"), provider="codex", tell=tell
+    )
+    assert result.outcome is FinalizeOutcome.DEFECT
+    assert result.defect_reason == "internal_monologue_leak"
+    # Fail-off, not an incident: the Gemini leg still owes the client an answer.
+    assert tell.reasons == []
+
+
+@pytest.mark.asyncio
+async def test_codex_scaffold_only_output_is_a_silent_defect() -> None:
+    tell = _Tell()
+    result = await _run(_payload(_SCAFFOLD_ONLY), provider="codex", tell=tell)
+    assert result.outcome is FinalizeOutcome.DEFECT
+    assert result.defect_reason == "workflow_only_output"
+    assert tell.reasons == []
+
+
+@pytest.mark.asyncio
+async def test_empty_answer_tells_a_human_on_gemini_but_not_on_codex() -> None:
+    gemini_tell, codex_tell = _Tell(), _Tell()
+    gemini = await _run(_payload(""), provider="gemini", tell=gemini_tell)
+    codex = await _run(_payload(""), provider="codex", tell=codex_tell)
+    assert gemini.outcome is FinalizeOutcome.DEFECT
+    assert codex.outcome is FinalizeOutcome.DEFECT
+    assert gemini.defect_reason == codex.defect_reason == "empty_rag_answer"
+    # Same message the pre-extraction RuntimeError carried, so the worker
+    # ledger vocabulary is unchanged.
+    assert gemini.defect_message == "wa-inbox bot: empty RAG answer for thread 42"
+    assert gemini_tell.reasons == ["empty_rag_answer"]
+    assert codex_tell.reasons == []
+
+
+# ── Codex POLICY branch: identical to the Gemini leg ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_codex_ungrounded_abstain_serves_the_stub_and_tells_a_human() -> None:
+    tell = _Tell()
+    result = await _run(
+        _payload("short refusal", abstain=True, ctx=0, ev=0.0), provider="codex", tell=tell
+    )
+    assert result.outcome is FinalizeOutcome.SEND
+    assert result.human_reason == "rag_abstain"
+    assert result.text  # the localized stub, not silence
+    assert "short refusal" not in result.text
+    assert tell.reasons == ["rag_abstain"]
+
+
+@pytest.mark.asyncio
+async def test_codex_grounded_abstain_sends_the_answer_with_the_caution_note() -> None:
+    tell = _Tell()
+    result = await _run(_payload(_REAL_ANSWER, abstain=True), provider="codex", tell=tell)
+    assert result.outcome is FinalizeOutcome.SEND
+    assert result.text.startswith("To establish a PT PMA")
+    assert len(result.text) > len(_REAL_ANSWER)  # caution note appended
+    assert tell.reasons == []  # a real answer needs no human
+
+
+# ── Codex egress vetoes wired into the pipeline ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_codex_price_outside_package_is_a_defect_but_gemini_sends_it() -> None:
+    priced = _REAL_ANSWER + " The all-inclusive fee is Rp 9.999.000."
+    codex_tell, gemini_tell = _Tell(), _Tell()
+    codex = await _run(
+        _payload(priced),
+        provider="codex",
+        tell=codex_tell,
+        price_sources=["Company setup — Rp 3.500.000"],
+    )
+    gemini = await _run(_payload(priced), provider="gemini", tell=gemini_tell)
+    assert codex.outcome is FinalizeOutcome.DEFECT
+    assert codex.defect_reason == "pricing_outside_package"
+    assert codex_tell.reasons == []
+    # No price_sources on the Gemini leg — the veto is codex-only by construction.
+    assert gemini.outcome is FinalizeOutcome.SEND
+
+
+@pytest.mark.asyncio
+async def test_codex_price_present_in_package_passes_the_veto() -> None:
+    priced = _REAL_ANSWER + " The all-inclusive fee is Rp 3.500.000."
+    result = await _run(
+        _payload(priced),
+        provider="codex",
+        tell=_Tell(),
+        price_sources=['{"company_setup": {"price": "Rp 3.500.000"}}'],
+    )
+    assert result.outcome is FinalizeOutcome.SEND
+
+
+@pytest.mark.asyncio
+async def test_codex_secret_egress_hit_is_a_defect_with_pattern_name_only() -> None:
+    leaky = _REAL_ANSWER + " token sk-" + "a" * 24
+    result = await _run(
+        _payload(leaky), provider="codex", tell=_Tell(), secret_scan=True
+    )
+    assert result.outcome is FinalizeOutcome.DEFECT
+    assert result.defect_reason == "secret_egress:openai_style_key"
+    # The defect record must never transcribe the secret it caught.
+    assert "sk-" not in result.defect_message
+
+
+@pytest.mark.asyncio
+async def test_codex_clean_answer_with_both_vetoes_armed_sends() -> None:
+    result = await _run(
+        _payload(_REAL_ANSWER),
+        provider="codex",
+        tell=_Tell(),
+        price_sources=["no prices quoted"],
+        secret_scan=True,
+        canary_tokens=("CANARY-9f3a-token",),
+    )
+    assert result.outcome is FinalizeOutcome.SEND
+    assert result.text.startswith("To establish a PT PMA")
+
+
+# ── Gemini parity spot-check through the extracted pipeline ──────────────
+
+
+@pytest.mark.asyncio
+async def test_gemini_escalate_marker_is_stripped_and_a_human_is_told() -> None:
+    tell = _Tell()
+    result = await _run(
+        _payload(_REAL_ANSWER + " [ESCALATE]"), provider="gemini", tell=tell
+    )
+    assert result.outcome is FinalizeOutcome.SEND
+    assert "[ESCALATE]" not in result.text
+    assert result.human_reason == "persona_escalate_marker"
+    assert tell.reasons == ["persona_escalate_marker"]

--- a/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
+++ b/apps/backend-rag/backend/tests/unit/services/integrations/test_wa_finalize.py
@@ -3,11 +3,12 @@
 The Gemini-leg behavior of ``finalize_wa_answer`` is proven by the PRE-EXISTING
 suites, which drive it through ``wa_inbox_bot.generate_bot_reply`` unchanged
 (``test_wa_inbox_bot.py``, ``test_wa_abstain_reaches_a_human.py``,
-``test_wa_abstain_with_content_is_sent.py``). This file covers only what is NEW:
-the typed-outcome mapping for ``provider="codex"`` (TEXT_DEFECT fails off
-silently, POLICY behaves like the Gemini leg) and the two codex-only egress
-vetoes (pricing, secret scan) — each with guilt AND innocence cases, per
-cicatrix family #3.
+``test_wa_abstain_with_content_is_sent.py``). This file covers what is NEW:
+the typed-outcome mapping for the codex provider (TEXT_DEFECT fails off
+silently, POLICY behaves like the Gemini leg), the fail-closed configuration
+contract, the structural checks inside the abstain branch (PR-3 adversarial
+review BLOCKER-1), and the two codex egress vetoes — each with guilt AND
+innocence cases, per cicatrix family #3.
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ import pytest
 
 from backend.services.integrations.wa_finalize import (
     _KG_WORKFLOW_TRAILER,
+    _WHATSAPP_HARD_SEND_LIMIT,
     FinalizeOutcome,
     finalize_wa_answer,
     price_tokens_outside_sources,
@@ -61,6 +63,11 @@ def _payload(answer: str, *, abstain: bool = False, ctx: int = 3, ev: float = 0.
 
 
 async def _run(data: dict[str, Any], *, provider: str, tell: _Tell, **kw: Any):
+    if provider == "codex":
+        # The codex configuration is MANDATORY (fail-closed contract) — tests
+        # that probe the missing-config error call finalize_wa_answer directly.
+        kw.setdefault("price_sources", [])
+        kw.setdefault("secret_scan", True)
     return await finalize_wa_answer(
         data=data,
         query="How do I open a PT PMA?",
@@ -79,11 +86,11 @@ def test_pricing_veto_catches_an_amount_absent_from_every_source() -> None:
         "The service costs Rp 5.000.000 all-inclusive.",
         ["Company setup — Rp 3.500.000, duration 30 days"],
     )
-    assert offenders == ["5000000"]
+    assert offenders == ["IDR:5000000"]
 
 
 def test_pricing_veto_matches_amounts_across_separator_formats() -> None:
-    # Answer uses commas, source uses dots — same digits, no veto.
+    # Answer uses commas, source uses dots — same canonical value, no veto.
     assert (
         price_tokens_outside_sources(
             "It costs Rp 3,500,000 in total.",
@@ -91,6 +98,46 @@ def test_pricing_veto_matches_amounts_across_separator_formats() -> None:
         )
         == []
     )
+
+
+def test_pricing_veto_canonicalizes_multipliers_both_ways() -> None:
+    # "Rp 3,5 juta" in the answer is the same price as "Rp 3.500.000" in the
+    # block; "Rp 99 juta" absent from every source is an invented price and
+    # must be vetoed (review MAJOR-5 — a made-up price cannot hide behind
+    # its spelling).
+    assert (
+        price_tokens_outside_sources("Biaya: Rp 3,5 juta.", ["Rp 3.500.000"]) == []
+    )
+    assert price_tokens_outside_sources(
+        "Our fee is Rp 99 juta.", ["Company setup — Rp 3.500.000"]
+    ) == ["IDR:99000000"]
+
+
+def test_pricing_veto_catches_small_dollar_amounts() -> None:
+    # Review MAJOR-5: "$999" is a real price shape; the IDR floor must not
+    # shield dollar amounts.
+    assert price_tokens_outside_sources("$999 flat.", ["no prices"]) == ["USD:999"]
+
+
+def test_pricing_veto_amount_never_crosses_a_newline() -> None:
+    # Review MAJOR-6 reproduced: "Rp 3.500.000\n30 days" must parse as
+    # 3500000 (present in sources → no veto), never as 350000030.
+    assert (
+        price_tokens_outside_sources(
+            "Fee Rp 3.500.000\n30 days processing.",
+            ["Company setup — Rp 3.500.000"],
+        )
+        == []
+    )
+
+
+def test_pricing_veto_sources_are_tokenized_never_concatenated() -> None:
+    # Review MAJOR-7 reproduced: a source holding "Rp 12.345" then "67 days"
+    # must NOT authorize an invented "Rp 34.567" via the concatenation
+    # artifact "1234567".
+    assert price_tokens_outside_sources(
+        "Total Rp 34.567.", ["Item Rp 12.345, duration 67 days"]
+    ) == ["IDR:34567"]
 
 
 def test_pricing_veto_ignores_amounts_without_a_currency_marker() -> None:
@@ -105,9 +152,9 @@ def test_pricing_veto_ignores_amounts_without_a_currency_marker() -> None:
     )
 
 
-def test_pricing_veto_skips_sub_threshold_digit_runs() -> None:
-    # "Rp 5jt" captures only "5" — below the 4-digit floor, declared out of scan.
-    assert price_tokens_outside_sources("Around Rp 5jt.", ["no numbers here"]) == []
+def test_pricing_veto_floor_skips_noise_amounts() -> None:
+    # "Rp 5" (per page, say) is below any real IDR price — noise, not a price.
+    assert price_tokens_outside_sources("Rp 5 per page.", ["no numbers"]) == []
 
 
 # ── Secret-egress scan (pure function): guilt and innocence ──────────────
@@ -120,6 +167,11 @@ def test_pricing_veto_skips_sub_threshold_digit_runs() -> None:
         ("here sk-" + "a" * 24 + " is the key", "openai_style_key"),
         ("eyJ" + "a" * 12 + "." + "b" * 12 + "." + "c" * 12, "jwt"),
         ('config: api_key = "' + "x" * 20 + '"', "token_assignment"),
+        # Review MAJOR-4 reproduced: JSON auth-file fragment (quoted key) and
+        # a bare Bearer header value must both be caught.
+        ('"refresh_token":"1//opaque-long-token0"', "token_assignment"),
+        ("Authorization: Bearer opaque-token-12345", "bearer_token"),
+        ("use Bearer opaque-token-1234567 to call it", "bearer_token"),
     ],
 )
 def test_secret_scan_names_the_pattern_without_the_content(text: str, expected: str) -> None:
@@ -137,10 +189,55 @@ def test_secret_scan_passes_ordinary_consulting_prose() -> None:
     assert (
         scan_text_for_secret_egress(
             "You will need an API key from the OSS system to submit the LKPM "
-            "report; the access token is issued after NIB registration."
+            "report; the access token is issued after NIB registration. The "
+            "bearer of the visa must keep the passport valid."
         )
         is None
     )
+
+
+# ── Fail-closed configuration (review BLOCKER-2 / MAJOR-3) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_codex_without_vetoes_configured_raises_not_fail_open() -> None:
+    with pytest.raises(ValueError, match="fail-open"):
+        await finalize_wa_answer(
+            data=_payload(_REAL_ANSWER),
+            query="q",
+            thread_id=42,
+            provider="codex",
+            tell_a_human=_Tell(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_string_raises() -> None:
+    with pytest.raises(ValueError):
+        await finalize_wa_answer(
+            data=_payload(_REAL_ANSWER),
+            query="q",
+            thread_id=42,
+            provider="Codex",  # typo case — must never silently mean gemini
+            tell_a_human=_Tell(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_raising_tell_callback_is_contained() -> None:
+    async def _boom(reason: str) -> None:
+        raise RuntimeError("notifier down")
+
+    result = await finalize_wa_answer(
+        data=_payload("short", abstain=True, ctx=0, ev=0.0),
+        query="q",
+        thread_id=42,
+        provider="gemini",
+        tell_a_human=_boom,
+    )
+    # The stub outcome survives the notifier failure.
+    assert result.outcome is FinalizeOutcome.SEND
+    assert result.human_reason == "rag_abstain"
 
 
 # ── Codex typed outcomes: TEXT_DEFECT fails off silently ─────────────────
@@ -182,7 +279,19 @@ async def test_empty_answer_tells_a_human_on_gemini_but_not_on_codex() -> None:
     assert codex_tell.reasons == []
 
 
-# ── Codex POLICY branch: identical to the Gemini leg ─────────────────────
+@pytest.mark.asyncio
+async def test_codex_oversized_output_is_a_defect_but_gemini_warns_and_sends() -> None:
+    # Review MAJOR-8: spec §2.3 classes oversized output as TEXT_DEFECT on
+    # the codex leg; the Gemini leg keeps today's warn-and-let-the-sender-cut.
+    huge = "PT PMA setup notes. " + ("word " * ((_WHATSAPP_HARD_SEND_LIMIT // 5) + 200))
+    codex = await _run(_payload(huge), provider="codex", tell=_Tell())
+    gemini = await _run(_payload(huge), provider="gemini", tell=_Tell())
+    assert codex.outcome is FinalizeOutcome.DEFECT
+    assert codex.defect_reason == "oversized_output"
+    assert gemini.outcome is FinalizeOutcome.SEND
+
+
+# ── Abstain branch: POLICY parity + structural checks (BLOCKER-1) ────────
 
 
 @pytest.mark.asyncio
@@ -206,6 +315,39 @@ async def test_codex_grounded_abstain_sends_the_answer_with_the_caution_note() -
     assert result.text.startswith("To establish a PT PMA")
     assert len(result.text) > len(_REAL_ANSWER)  # caution note appended
     assert tell.reasons == []  # a real answer needs no human
+
+
+@pytest.mark.asyncio
+async def test_monologue_leak_inside_grounded_abstain_never_ships() -> None:
+    # Review BLOCKER-1 reproduced: a grounded, >200-char abstain payload that
+    # opens with the private marker used to be SENT by the early return.
+    leaky = "Internal monologue instructions: reason step by step. " + _REAL_ANSWER
+    gemini_tell, codex_tell = _Tell(), _Tell()
+    gemini = await _run(
+        _payload(leaky, abstain=True), provider="gemini", tell=gemini_tell
+    )
+    codex = await _run(_payload(leaky, abstain=True), provider="codex", tell=codex_tell)
+    # Gemini: the payload is discarded, the stub ships, a human is told with
+    # the MOST SPECIFIC cause (first cause wins).
+    assert gemini.outcome is FinalizeOutcome.SEND
+    assert "Internal monologue" not in gemini.text
+    assert gemini.human_reason == "internal_monologue_leak"
+    assert gemini_tell.reasons == ["internal_monologue_leak"]
+    # Codex: a defective text fails off — a different generator can cure it.
+    assert codex.outcome is FinalizeOutcome.DEFECT
+    assert codex.defect_reason == "internal_monologue_leak"
+    assert codex_tell.reasons == []
+
+
+@pytest.mark.asyncio
+async def test_escalate_marker_inside_grounded_abstain_is_stripped_and_told() -> None:
+    marked = _REAL_ANSWER + " [ESCALATE]"
+    tell = _Tell()
+    result = await _run(_payload(marked, abstain=True), provider="gemini", tell=tell)
+    assert result.outcome is FinalizeOutcome.SEND
+    assert "[ESCALATE]" not in result.text
+    assert result.human_reason == "persona_escalate_marker"
+    assert tell.reasons == ["persona_escalate_marker"]
 
 
 # ── Codex egress vetoes wired into the pipeline ──────────────────────────
@@ -244,13 +386,21 @@ async def test_codex_price_present_in_package_passes_the_veto() -> None:
 @pytest.mark.asyncio
 async def test_codex_secret_egress_hit_is_a_defect_with_pattern_name_only() -> None:
     leaky = _REAL_ANSWER + " token sk-" + "a" * 24
-    result = await _run(
-        _payload(leaky), provider="codex", tell=_Tell(), secret_scan=True
-    )
+    result = await _run(_payload(leaky), provider="codex", tell=_Tell())
     assert result.outcome is FinalizeOutcome.DEFECT
     assert result.defect_reason == "secret_egress:openai_style_key"
     # The defect record must never transcribe the secret it caught.
     assert "sk-" not in result.defect_message
+
+
+@pytest.mark.asyncio
+async def test_codex_veto_also_covers_the_grounded_abstain_early_return() -> None:
+    # The early return is the one SEND that skips the main veto site — prove
+    # the codex vetoes run there too.
+    leaky = _REAL_ANSWER + " token sk-" + "b" * 24
+    result = await _run(_payload(leaky, abstain=True), provider="codex", tell=_Tell())
+    assert result.outcome is FinalizeOutcome.DEFECT
+    assert result.defect_reason == "secret_egress:openai_style_key"
 
 
 @pytest.mark.asyncio
@@ -260,7 +410,6 @@ async def test_codex_clean_answer_with_both_vetoes_armed_sends() -> None:
         provider="codex",
         tell=_Tell(),
         price_sources=["no prices quoted"],
-        secret_scan=True,
         canary_tokens=("CANARY-9f3a-token",),
     )
     assert result.outcome is FinalizeOutcome.SEND


### PR DESCRIPTION
Part of BOT-V4 S2 (spec `research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md` §2.3, merged #4333). Third of six S2 PRs; depends on nothing (pure refactor + additive module), consumed by the worker broker-leg PR.

## What

Extracts the post-generation tail of `wa_inbox_bot.generate_bot_reply` into `wa_finalize.finalize_wa_answer` — ONE pipeline used by both generation legs (Gemini today, codex broker leg next). Adds the two codex-only egress vetoes the spec requires (pricing-outside-package, secret-egress scan) as pure, tested functions, inert on the Gemini leg by construction.

## Behavior preservation (the load-bearing claim)

`provider="gemini"` reproduces the pre-extraction sequence exactly: branch order, log lines, human-notification points, returned text, and RuntimeError strings (raised by the caller from `FinalizeResult.defect_message`). Proof: the four pre-existing suites that drive `generate_bot_reply` end-to-end (`test_wa_inbox_bot.py`, `test_wa_abstain_reaches_a_human.py`, `test_wa_abstain_with_content_is_sent.py`, `test_human_escalation_notifier_is_reachable_from_both_paths.py`) — 75 tests, green unmodified on the refactored code.

## Codex typed outcomes (spec §2.3)

- TEXT_DEFECT (empty payload, monologue leak, scaffold-only, empty after strip/format, pricing veto, secret hit) → `DEFECT`, no stub, no human notification — the worker fails off to the Gemini leg, which still answers the client.
- POLICY (abstain label from frozen evidence) → identical on both providers: stub + tell a human.

## Vetoes: guilt AND innocence (cicatrix family #3)

- Pricing veto is currency-marker-anchored: `Rp 9.999.000` absent from the package's price sources → DEFECT; `2,5 miliar modal disetor` (regulatory figure, no marker) → never vetoed. Amounts under 4 digits declared out of scan.
- Secret scan returns the pattern NAME only — the defect record never transcribes what it caught (CLAUDE.md §14).

## Tests

21 new in `test_wa_finalize.py`; mutation-sanity 2/2 (disarming the pricing veto and removing the codex fail-off each turn the suite red — run locally, restored byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)