### PR TITLE
feat(bot): deterministic WA codex-route context-package builder (BOT-V4 S2 PR-4)

### DIFF
--- a/apps/backend-rag/backend/app/routers/wa_package.py
+++ b/apps/backend-rag/backend/app/routers/wa_package.py
@@ -1,0 +1,94 @@
+"""
+WA codex-route package-build endpoint (BOT-V4 S2, D2).
+
+``POST /api/wa-package/build`` — internal-only, RAG process group. Builds
+the deterministic ``ContextPackage`` (D1, ``wa_package_builder.py``) for one
+WA turn, or reports the query as unbuildable so the caller routes it to the
+Gemini leg (spec §2.2, "unclassifiable -> Gemini leg").
+
+Auth: no route-level dependency here by design. ``HybridAuthMiddleware``
+(``backend/middleware/hybrid_auth.py``) already fail-closed rejects any
+request without a recognized credential (X-API-Key / X-Internal-Key / JWT)
+before it reaches this router, and this path is deliberately NOT added to
+``PUBLIC_ENDPOINTS`` (``backend/app/auth/public_endpoints.py``). No new auth
+scheme is invented here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from backend.app.dependencies import get_orchestrator
+from backend.services.rag.agentic.query_planner import QueryPlanner
+from backend.services.rag.agentic.wa_package_builder import (
+    PackageUnbuildable,
+    build_context_package,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/wa-package", tags=["channels", "wa-broker"])
+
+
+class WaPackageHistoryMessage(BaseModel):
+    role: str
+    content: str
+
+
+class WaPackageBuildRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=4096)
+    history: list[WaPackageHistoryMessage] = Field(default_factory=list, max_length=24)
+    thread_epoch: int
+
+
+class WaPackageBuildResponse(BaseModel):
+    """Exactly one of `package` / `unbuildable` is populated.
+
+    HTTP 200 either way: an unbuildable intent is a ROUTE decision for the
+    worker (send this row to the Gemini leg), not a server error — see
+    ``PackageUnbuildable``'s docstring.
+    """
+
+    package: dict[str, Any] | None = None
+    unbuildable: str | None = None
+
+
+@router.post("/build", response_model=WaPackageBuildResponse)
+async def build_wa_package(
+    request: WaPackageBuildRequest,
+    orchestrator: Any = Depends(get_orchestrator),
+) -> WaPackageBuildResponse:
+    """Build the deterministic context package for one WA codex-route turn."""
+    history = [{"role": m.role, "content": m.content} for m in request.history]
+
+    # Domain lookup for the curated-QA gate (D3) is a second, cheap call to
+    # the same pure heuristic `build_context_package` runs internally — no
+    # I/O, <50ms, deterministic for a given query. Duplicating the plan()
+    # call here (rather than threading a precomputed plan through
+    # `build_context_package`) keeps the "is this query unbuildable"
+    # decision owned by exactly one function — D1's own GREETING /
+    # no-collections gate — so the router and the builder can never
+    # disagree about what counts as classifiable.
+    plan = QueryPlanner().plan(request.query)
+    curated_qa_block = await orchestrator.core.curated_qa_grounding_block(
+        request.query,
+        {"domain": plan.domain.value},
+    )
+
+    try:
+        package = await build_context_package(
+            query=request.query,
+            history=history,
+            thread_epoch=request.thread_epoch,
+            retriever=orchestrator.core.retriever,
+            curated_qa_block=curated_qa_block,
+        )
+    except PackageUnbuildable as exc:
+        logger.info("wa_package: unbuildable reason=%s", exc.reason)
+        return WaPackageBuildResponse(unbuildable=exc.reason)
+
+    return WaPackageBuildResponse(package=package.to_payload())

--- a/apps/backend-rag/backend/app/routers/wa_package.py
+++ b/apps/backend-rag/backend/app/routers/wa_package.py
@@ -6,12 +6,15 @@ the deterministic ``ContextPackage`` (D1, ``wa_package_builder.py``) for one
 WA turn, or reports the query as unbuildable so the caller routes it to the
 Gemini leg (spec §2.2, "unclassifiable -> Gemini leg").
 
-Auth: no route-level dependency here by design. ``HybridAuthMiddleware``
-(``backend/middleware/hybrid_auth.py``) already fail-closed rejects any
-request without a recognized credential (X-API-Key / X-Internal-Key / JWT)
-before it reaches this router, and this path is deliberately NOT added to
-``PUBLIC_ENDPOINTS`` (``backend/app/auth/public_endpoints.py``). No new auth
-scheme is invented here.
+Auth: two layers, neither invented here (S2 cross-family review, finding 7).
+``HybridAuthMiddleware`` (``backend/middleware/hybrid_auth.py``) fail-closed
+rejects any request without a recognized credential before it reaches this
+router, and this path is deliberately NOT in ``PUBLIC_ENDPOINTS``. On top of
+that, ``require_internal_caller`` below enforces the per-endpoint SCOPE the
+middleware alone cannot: authentication is not authorization, and a portal
+user's valid JWT must not be able to drive this internal builder (embedding
++ Qdrant cost on every call). Only the middleware's ``internal`` service
+identity (X-Internal-Key) or an ``admin`` may call it.
 """
 
 from __future__ import annotations
@@ -19,10 +22,11 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from backend.app.dependencies import get_orchestrator
+from backend.services.rag.agentic.query_plan import QueryDomain
 from backend.services.rag.agentic.query_planner import QueryPlanner
 from backend.services.rag.agentic.wa_package_builder import (
     PackageUnbuildable,
@@ -34,9 +38,26 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/wa-package", tags=["channels", "wa-broker"])
 
 
+def require_internal_caller(request: Request) -> None:
+    """Per-endpoint scope on top of HybridAuthMiddleware's authentication.
+
+    The middleware stores the authenticated identity on ``request.state.user``
+    (``hybrid_auth.py``: X-Internal-Key -> role "internal"). Fail-closed: a
+    missing/unshaped state (middleware disabled, unexpected wiring) is a 403,
+    never a pass.
+    """
+    user = getattr(request.state, "user", None)
+    role = user.get("role") if isinstance(user, dict) else None
+    if role not in ("internal", "admin"):
+        raise HTTPException(status_code=403, detail="internal callers only")
+
+
 class WaPackageHistoryMessage(BaseModel):
-    role: str
-    content: str
+    # Bounded at the transport (S2 cross-family review, finding 8): an
+    # annotation caps nothing — 24 unbounded contents would be parsed,
+    # hashed and re-serialized in full. 4096 matches the WA message ceiling.
+    role: str = Field(..., max_length=32)
+    content: str = Field(..., max_length=4096)
 
 
 class WaPackageBuildRequest(BaseModel):
@@ -57,7 +78,11 @@ class WaPackageBuildResponse(BaseModel):
     unbuildable: str | None = None
 
 
-@router.post("/build", response_model=WaPackageBuildResponse)
+@router.post(
+    "/build",
+    response_model=WaPackageBuildResponse,
+    dependencies=[Depends(require_internal_caller)],
+)
 async def build_wa_package(
     request: WaPackageBuildRequest,
     orchestrator: Any = Depends(get_orchestrator),
@@ -74,10 +99,19 @@ async def build_wa_package(
     # no-collections gate — so the router and the builder can never
     # disagree about what counts as classifiable.
     plan = QueryPlanner().plan(request.query)
-    curated_qa_block = await orchestrator.core.curated_qa_grounding_block(
-        request.query,
-        {"domain": plan.domain.value},
-    )
+
+    # Cost guard, not a routing decision (S2 cross-family review, finding
+    # 9): a GREETING query is about to be declared unbuildable by D1's own
+    # gate — prefetching curated-QA for it would spend an embedding + a
+    # Qdrant search per "ciao". Same pure function, same query, so this can
+    # never disagree with the builder's verdict; the builder still OWNS
+    # the unbuildable decision.
+    curated_qa_block = ""
+    if plan.domain is not QueryDomain.GREETING:
+        curated_qa_block = await orchestrator.core.curated_qa_grounding_block(
+            request.query,
+            {"domain": plan.domain.value},
+        )
 
     try:
         package = await build_context_package(

--- a/apps/backend-rag/backend/app/setup/router_manifest.py
+++ b/apps/backend-rag/backend/app/setup/router_manifest.py
@@ -394,6 +394,9 @@ ROUTER_MANIFEST: tuple[RouterEntry, ...] = (
     RouterEntry(
         name="wa_mirror_messages", process_groups=_API, tags=("channels", "crm", "wa-mirror")
     ),
+    # BOT-V4 S2 (D2): deterministic codex-route context-package builder —
+    # RAG-heavy (needs SearchService + AgenticRAGOrchestrator), internal-only.
+    RouterEntry(name="wa_package", process_groups=_RAG, tags=("channels", "wa-broker")),
     RouterEntry(name="whatsapp_chat", process_groups=_BOTH, tags=("channels", "rag")),
     RouterEntry(name="whatsapp_conversations", process_groups=_API, tags=("channels",)),
     # ── Workflow ──

--- a/apps/backend-rag/backend/app/setup/router_registration.py
+++ b/apps/backend-rag/backend/app/setup/router_registration.py
@@ -149,6 +149,7 @@ def include_routers(api: FastAPI) -> None:
         wa_actions,
         wa_inbox,  # /api/wa-inbox/* WA Meta Inbox console (scoped key auth)
         wa_mirror_messages,
+        wa_package,  # [BOT-V4 S2] /api/wa-package/build deterministic codex-route package builder
         war_room_dashboard,
         webhooks,
         websocket,
@@ -338,6 +339,7 @@ def include_routers(api: FastAPI) -> None:
     api.include_router(wa_mirror_messages.router)  # Read-only wa-mirror CRM timeline API
     api.include_router(wa_actions.router)  # WA Copilot S1.10 action_queue CRUD
     api.include_router(wa_inbox.router)  # /api/wa-inbox/* WA Meta Inbox console (scoped key)
+    api.include_router(wa_package.router)  # [BOT-V4 S2] deterministic codex-route package builder
     api.include_router(instagram_chat.router)  # Instagram DM auto-reply via RAG
     api.include_router(instagram_chat.webhook_router)  # [NEW] Instagram webhook
     api.include_router(intel_lake.router)  # Intel Lake Wave 1 ingest (mig 168)
@@ -897,6 +899,7 @@ def include_heavy_routers(api: FastAPI) -> None:
         oracle_ingest,
         oracle_universal,
         voice,
+        wa_package,  # [BOT-V4 S2] /api/wa-package/build deterministic codex-route package builder
         whatsapp_chat,
     )
 
@@ -984,6 +987,9 @@ def include_heavy_routers(api: FastAPI) -> None:
 
     # WhatsApp Chat (RAG-backed intelligent triage)
     api.include_router(whatsapp_chat.router)
+
+    # BOT-V4 S2: deterministic codex-route context-package builder (internal-only)
+    api.include_router(wa_package.router)
 
     # Dashboard aggregation routers (all under /api/dashboard — proxied to rag)
     api.include_router(dashboard.router)

--- a/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
+++ b/apps/backend-rag/backend/services/rag/agentic/orchestrator_core.py
@@ -722,6 +722,22 @@ class OrchestratorCore:
             )
             return ""
 
+    async def curated_qa_grounding_block(
+        self,
+        query: str,
+        extracted_entities: dict[str, Any] | None = None,
+    ) -> str:
+        """Public passthrough to `_inject_curated_qa_grounding` (BOT-V4 S2, D3).
+
+        Exists so the WA codex-route package builder
+        (`wa_package_builder.build_context_package`) reuses the SAME
+        domain-gated, staleness-gated curated_qa injection logic instead of a
+        drifting copy — a caller outside this class cannot reach the
+        underscore-prefixed method directly. Behavior-neutral: this does not
+        touch `_inject_curated_qa_grounding` itself.
+        """
+        return await self._inject_curated_qa_grounding(query, extracted_entities)
+
     async def extract_entities_and_kg_context(
         self,
         query: str,

--- a/apps/backend-rag/backend/services/rag/agentic/query_planner.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_planner.py
@@ -190,11 +190,18 @@ _GREETING_KEYWORDS: frozenset[str] = frozenset(
 # zeroes the collection list. The boundary must NOT reject the colloquial
 # elongation WhatsApp greetings actually arrive in ("hii", "heyy",
 # "ciaooo") — a strict \b after the keyword regressed exactly those
-# (Codex round 3; the over-match cure birthing its under-match twin, W94),
-# so the final letter may repeat before the boundary. Sorted for
+# (Codex round 3; the over-match cure birthing its under-match twin, W94).
+# The elongated form (final letter repeated ≥1) is accepted only at the
+# START of the message: colloquial greetings open a message, while an
+# elongated-looking token mid-sentence is jargon — "What is an HII
+# region?" lowercases to a mid-sentence "hii" and must NOT gate (Codex
+# round 4). The exact keyword stays boundary-matched anywhere. Sorted for
 # deterministic order (never iterate a set into anything order-bearing).
 _GREETING_WORD_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
-    re.compile(r"\b" + re.escape(kw) + re.escape(kw[-1]) + r"*\b")
+    re.compile(
+        r"\b" + re.escape(kw) + r"\b"
+        r"|^\W*" + re.escape(kw) + re.escape(kw[-1]) + r"+\b"
+    )
     for kw in sorted(_GREETING_KEYWORDS)
 )
 

--- a/apps/backend-rag/backend/services/rag/agentic/query_planner.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_planner.py
@@ -179,6 +179,18 @@ _GREETING_KEYWORDS: frozenset[str] = frozenset(
     }
 )
 
+# Word-boundary patterns for the greeting keywords, precompiled once. The
+# greeting lane needs boundaries where the domain lanes do not: its keywords
+# are short ordinary-language tokens ("hi", "hey") that live INSIDE common
+# English words — bare substring scoring classified "Which visa options are
+# available?" as GREETING via the "hi" in "which" (Codex S2 re-verdict,
+# major; scar family #3 over-match), and GREETING is the one verdict that
+# zeroes the collection list. Sorted for deterministic order (never iterate
+# a set into anything order-bearing).
+_GREETING_WORD_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(r"\b" + re.escape(kw) + r"\b") for kw in sorted(_GREETING_KEYWORDS)
+)
+
 _NEWS_KEYWORDS: frozenset[str] = frozenset(
     {
         "news",
@@ -382,8 +394,8 @@ class QueryPlanner:
         # Keyword-based classification
         scores: dict[QueryDomain, int] = dict.fromkeys(QueryDomain, 0)
 
-        for kw in _GREETING_KEYWORDS:
-            if kw in query_lower:
+        for pattern in _GREETING_WORD_PATTERNS:
+            if pattern.search(query_lower):
                 scores[QueryDomain.GREETING] += 3  # High weight for greetings
 
         for kw in _PRICING_KEYWORDS:

--- a/apps/backend-rag/backend/services/rag/agentic/query_planner.py
+++ b/apps/backend-rag/backend/services/rag/agentic/query_planner.py
@@ -176,6 +176,8 @@ _GREETING_KEYWORDS: frozenset[str] = frozenset(
         "thank you",
         "grazie",
         "terima kasih",
+        "makasih",
+        "terimakasih",
     }
 )
 
@@ -185,10 +187,15 @@ _GREETING_KEYWORDS: frozenset[str] = frozenset(
 # English words — bare substring scoring classified "Which visa options are
 # available?" as GREETING via the "hi" in "which" (Codex S2 re-verdict,
 # major; scar family #3 over-match), and GREETING is the one verdict that
-# zeroes the collection list. Sorted for deterministic order (never iterate
-# a set into anything order-bearing).
+# zeroes the collection list. The boundary must NOT reject the colloquial
+# elongation WhatsApp greetings actually arrive in ("hii", "heyy",
+# "ciaooo") — a strict \b after the keyword regressed exactly those
+# (Codex round 3; the over-match cure birthing its under-match twin, W94),
+# so the final letter may repeat before the boundary. Sorted for
+# deterministic order (never iterate a set into anything order-bearing).
 _GREETING_WORD_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
-    re.compile(r"\b" + re.escape(kw) + r"\b") for kw in sorted(_GREETING_KEYWORDS)
+    re.compile(r"\b" + re.escape(kw) + re.escape(kw[-1]) + r"*\b")
+    for kw in sorted(_GREETING_KEYWORDS)
 )
 
 _NEWS_KEYWORDS: frozenset[str] = frozenset(

--- a/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
+++ b/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
@@ -278,6 +278,17 @@ def _sanitize_pricing_block(raw: Any) -> dict[str, Any] | None:
     number + wa.me link), `disclaimer`, `official_notice`, error/suggestion
     prose, and the internal `_sub_block` annotation (S2 cross-family
     review, finding 2). Returns None when nothing price-shaped survives.
+
+    The wire (measured on `PricingService.search_service`, and pinned by the
+    real-service contract test in `test_wa_package_builder.py` — S2 re-verdict
+    round, W114) carries per-category values in TWO shapes:
+      - 2026 data: `{service_name: entry_dict}` — a dict keyed by the public
+        service name (`filtered_results[category_name] = items` on the dict
+        path of the scorer);
+      - legacy list fixtures: `[entry_dict, ...]`.
+    A dict whose values are dicts is a service map, never a single entry —
+    the earlier draft read it as one entry and silently dropped every real
+    2026 match (Codex re-verdict, blocker).
     """
     if not isinstance(raw, dict):
         return None
@@ -292,15 +303,28 @@ def _sanitize_pricing_block(raw: Any) -> dict[str, Any] | None:
         return kept or None
 
     clean_results: dict[str, Any] = {}
+    dropped_categories = 0
     for category, items in results.items():
         if isinstance(items, list):
             kept_items = [e for e in (_filter_entry(item) for item in items) if e]
             if kept_items:
                 clean_results[str(category)] = kept_items
-        else:
-            kept_entry = _filter_entry(items)
-            if kept_entry:
-                clean_results[str(category)] = kept_entry
+                continue
+        elif isinstance(items, dict):
+            kept_services = {}
+            for service_name, entry in items.items():
+                kept_entry = _filter_entry(entry)
+                if kept_entry:
+                    kept_services[str(service_name)] = kept_entry
+            if kept_services:
+                clean_results[str(category)] = kept_services
+                continue
+        dropped_categories += 1
+    if dropped_categories:
+        logger.info(
+            "wa_package_builder: dropped %d pricing categor(ies) with no allowlisted entries",
+            dropped_categories,
+        )
     if not clean_results:
         return None
     return {"search_query": str(raw.get("search_query", "")), "results": clean_results}

--- a/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
+++ b/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
@@ -1,0 +1,346 @@
+"""
+WA codex-route context package builder (BOT-V4 S2, D1).
+
+Deterministic pipeline (spec §2.2,
+research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md):
+    intent/domain gate -> domain->collection map (QueryPlanner, pure
+    heuristic) -> hybrid dense+sparse search per collection -> curated-QA
+    injection (pre-gated by the caller via
+    OrchestratorCore.curated_qa_grounding_block, D3) -> PricingTool
+    resolution on pricing intent -> persona digest -> frozen evidence
+    inputs -> content-addressed package_hash.
+
+S2 acceptance criterion (spec §2.2): "the codex-route package builder
+invokes zero LLMs" — this module MUST NOT import `backend.llm` (directly,
+in its own new code) or call any LLM client. Verified at runtime by
+`test_codex_package_builder_invokes_zero_llms` (monkeypatched tripwires)
+AND statically (an AST/source scan for a `backend.llm` import in this
+file's own source).
+
+Unclassifiable intent (GREETING domain, or a domain plan whose collection
+list is empty) raises `PackageUnbuildable` — the caller (the wa_package
+router) routes that row to the Gemini leg rather than borrowing an LLM
+planner into the codex path (spec §2.2, "unclassifiable -> Gemini leg").
+
+Allowlist schema (spec §2.2, Codex M22/CR1): `ContextPackage.to_payload()`
+serializes EXACTLY 7 fields — `history`, `chunks`, `pricing_block`,
+`persona_digest`, `evidence_inputs`, `thread_epoch`, `package_hash`. No
+phone, no `wa:` subject, no CRM fields, no source paths.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from backend.prompts.channel_overlays import CHANNEL_CONFIGS
+from backend.prompts.zantara_core import (
+    CITATION_RULES,
+    GREETING_RULES,
+    LANGUAGE_PROTOCOL,
+)
+from backend.services.misc.pricing_intent import has_pricing_intent
+from backend.services.pricing.pricing_service import get_pricing_service
+from backend.services.rag.agentic._abstain_policy import build_abstain_policy
+from backend.services.rag.agentic.query_plan import QueryDomain
+from backend.services.rag.agentic.query_planner import QueryPlanner
+from backend.services.rag.agentic.reasoning_utils import calculate_evidence_score
+
+logger = logging.getLogger(__name__)
+
+# Package hygiene caps (spec §2.2 hygiene). Enforced with a LOG line on every
+# drop/truncation — a silent cap reads downstream as "the complete set"
+# (scar family #2, W97: three tools once printed a truncated [:40] slice
+# that four separate audits mistook for the full list).
+_MAX_CHUNKS = 8
+_MAX_CHUNK_CHARS = 4000
+_CHUNKS_PER_COLLECTION_LIMIT = 3
+
+# Fixed, documented access level for this deterministic, unauthenticated WA
+# path — matches `VectorSearchTool.__init__`'s own default (tools.py:89),
+# the closest existing analog for "no elevated tier, anonymous caller".
+_SEARCH_USER_LEVEL = 1
+
+# Persona digest: a MINIMAL, deterministic set of the existing SSOT prompt
+# sections from backend/prompts/zantara_core.py (the sole prompt SSOT per
+# apps/backend-rag/CLAUDE.md "Prompt Architecture") — chosen because they
+# most directly constrain HOW a WA reply gets written (language selection,
+# citation discipline, greeting handling). Deliberately excluded: the
+# creator/team personas, the master template, and the internal-monologue /
+# escalation / crash-protocol sections — those are orchestration-only
+# (deciding what tools to call, how to escalate) and irrelevant to a
+# downstream text generator that receives an already-built evidence
+# package and just has to write the reply.
+_PERSONA_SECTIONS: tuple[str, ...] = (LANGUAGE_PROTOCOL, CITATION_RULES, GREETING_RULES)
+
+
+class PackageUnbuildable(Exception):
+    """The deterministic pipeline cannot build a package for this query.
+
+    The caller (the wa_package router) treats this as a ROUTE decision, not
+    an error: the whole row goes to the Gemini leg, never an LLM-borrowed
+    fallback inside the codex path (spec §2.2).
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+@dataclass(frozen=True)
+class ContextPackage:
+    """The deterministic context package for the codex-route WA generation leg.
+
+    Allowlist schema (spec §2.2) — EXACTLY these 7 fields serialize via
+    `to_payload()`. Adding an 8th field to this dataclass does NOT
+    automatically leak it into the wire payload: `to_payload()` builds the
+    dict literally (never `dataclasses.asdict()` plus extras), so the
+    allowlist is enforced by construction, not by convention.
+    """
+
+    history: list[dict[str, str]]
+    chunks: list[dict[str, Any]]
+    pricing_block: dict[str, Any] | None
+    persona_digest: str
+    evidence_inputs: dict[str, Any]
+    thread_epoch: int
+    package_hash: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialize to the exact 7-key allowlist. No extras, ever."""
+        return {
+            "history": self.history,
+            "chunks": self.chunks,
+            "pricing_block": self.pricing_block,
+            "persona_digest": self.persona_digest,
+            "evidence_inputs": self.evidence_inputs,
+            "thread_epoch": self.thread_epoch,
+            "package_hash": self.package_hash,
+        }
+
+
+def _build_persona_digest(channel: str = "whatsapp") -> str:
+    """Deterministic persona digest assembled ONLY from imported prompt SSOT.
+
+    No new persona prose is authored here — every fragment originates in
+    `backend/prompts/zantara_core.py` or, for the channel-specific tail,
+    `backend/prompts/channel_overlays.py` (the sole channel-constraint SSOT).
+    """
+    parts = [text.strip() for text in _PERSONA_SECTIONS if text and text.strip()]
+    channel_config = CHANNEL_CONFIGS.get(channel)
+    if channel_config and channel_config.extra_instructions:
+        parts.append(channel_config.extra_instructions.strip())
+    return "\n\n".join(parts)
+
+
+async def _search_collection_chunks(
+    retriever: Any,
+    collection: str,
+    query: str,
+) -> list[dict[str, Any]]:
+    """One collection's chunks, in the allowlisted `{collection, text, score}` shape.
+
+    Dispatch choice (documented per the D1 contract): `tools.py`'s
+    `VectorSearchTool.execute` picks between `hybrid_search_with_reranking`
+    / `search_with_reranking` / plain `search` based on retriever capability
+    and a global `enable_hybrid_search` feature flag, running all target
+    collections in a `TaskGroup`. This pipeline queries a FIXED, already
+    domain-ranked collection list from `QueryPlanner` — there is no LLM tool
+    call choosing among them and no reranking loop — so the simpler,
+    spec-permitted branch is used instead: a plain
+    `retriever.hybrid_search(..., collection_override=collection)` call per
+    collection (true dense+sparse RRF fusion — "hybrid dense+sparse search"
+    per spec §2.2 — as opposed to `search_collection`, which is dense-only
+    and reserved for the always-small curated_qa lookup).
+    """
+    try:
+        result = await retriever.hybrid_search(
+            query=query,
+            user_level=_SEARCH_USER_LEVEL,
+            limit=_CHUNKS_PER_COLLECTION_LIMIT,
+            collection_override=collection,
+        )
+    except Exception:
+        logger.warning(
+            "wa_package_builder: hybrid_search failed for collection=%s",
+            collection,
+            exc_info=True,
+        )
+        return []
+
+    if not isinstance(result, dict):
+        return []
+
+    chunks: list[dict[str, Any]] = []
+    for hit in result.get("results", []):
+        if not isinstance(hit, dict):
+            continue
+        text = hit.get("text")
+        if not text:
+            continue
+        chunks.append(
+            {
+                "collection": collection,
+                "text": text,
+                "score": hit.get("score", 0.0),
+            },
+        )
+    return chunks
+
+
+def _cap_chunks(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Enforce the chunk-count and per-chunk-length hygiene caps, LOGGING every drop."""
+    capped: list[dict[str, Any]] = []
+    truncated_count = 0
+    for chunk in chunks:
+        text = chunk["text"]
+        if len(text) > _MAX_CHUNK_CHARS:
+            text = text[:_MAX_CHUNK_CHARS]
+            truncated_count += 1
+        capped.append({**chunk, "text": text})
+
+    dropped_count = max(0, len(capped) - _MAX_CHUNKS)
+    if dropped_count:
+        logger.info(
+            "wa_package_builder: dropping %d/%d chunks over the %d-chunk cap",
+            dropped_count,
+            len(capped),
+            _MAX_CHUNKS,
+        )
+    if truncated_count:
+        logger.info(
+            "wa_package_builder: truncated %d chunk(s) over the %d-char cap",
+            truncated_count,
+            _MAX_CHUNK_CHARS,
+        )
+    return capped[:_MAX_CHUNKS]
+
+
+def _package_hash(
+    history: list[dict[str, str]],
+    chunks: list[dict[str, Any]],
+    pricing_block: dict[str, Any] | None,
+    persona_digest: str,
+    evidence_inputs: dict[str, Any],
+    thread_epoch: int,
+) -> str:
+    """Content-addressed sha256 hex digest over the 6 non-hash fields.
+
+    `sort_keys=True` makes the digest independent of dict insertion order;
+    the compact `separators` plus `ensure_ascii=False` keep the
+    serialization deterministic for identical logical content.
+    """
+    payload = {
+        "history": history,
+        "chunks": chunks,
+        "pricing_block": pricing_block,
+        "persona_digest": persona_digest,
+        "evidence_inputs": evidence_inputs,
+        "thread_epoch": thread_epoch,
+    }
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+async def build_context_package(
+    *,
+    query: str,
+    history: list[dict[str, str]],
+    thread_epoch: int,
+    retriever: Any,
+    curated_qa_block: str = "",
+) -> ContextPackage:
+    """Build the deterministic context package for the WA codex-route leg.
+
+    Zero LLM calls anywhere in this function or its helpers (S2 acceptance
+    criterion, spec §2.2) — see `test_codex_package_builder_invokes_zero_llms`.
+
+    Args:
+        query: The user's raw message text.
+        history: Up to 12 turns of `{"role", "content"}` conversation
+            history (spec §2.2 "12-turn history") — passed through verbatim,
+            this function does not truncate or otherwise validate it.
+        thread_epoch: The caller's monotonic thread-epoch counter, frozen
+            into the package and re-verified unchanged at finalization
+            (spec §2.3).
+        retriever: A `SearchService`-shaped object exposing `hybrid_search`
+            (see `_search_collection_chunks`).
+        curated_qa_block: Pre-gated curated-QA evidence text, or "" for
+            none. MUST come from `OrchestratorCore.curated_qa_grounding_block`
+            (D3) — this function trusts the caller's domain/staleness gating
+            and never re-derives it.
+
+    Raises:
+        PackageUnbuildable: the deterministic domain gate could not classify
+            this query into a non-empty collection set (GREETING domain, or
+            any domain plan whose `collections` list is empty). The caller
+            routes the row to the Gemini leg instead of borrowing an LLM
+            planner into this path.
+    """
+    plan = QueryPlanner().plan(query)
+
+    if plan.domain == QueryDomain.GREETING:
+        raise PackageUnbuildable(reason="greeting_domain")
+    if not plan.collections:
+        raise PackageUnbuildable(reason="no_collections")
+
+    # Dedup collections while preserving QueryPlanner's priority order.
+    seen_collections: set[str] = set()
+    ordered_collections: list[str] = []
+    for collection in plan.collections:
+        if collection not in seen_collections:
+            seen_collections.add(collection)
+            ordered_collections.append(collection)
+
+    chunks: list[dict[str, Any]] = []
+    if curated_qa_block:
+        chunks.append({"collection": "curated_qa", "text": curated_qa_block, "score": 1.0})
+
+    for collection in ordered_collections:
+        chunks.extend(await _search_collection_chunks(retriever, collection, query))
+
+    chunks = _cap_chunks(chunks)
+
+    pricing_block: dict[str, Any] | None = None
+    if has_pricing_intent(query):
+        pricing_block = get_pricing_service().search_service(query)
+
+    persona_digest = _build_persona_digest()
+
+    # Evidence inputs are FROZEN here — finalization (spec §2.3) reads these
+    # fields, it never recomputes them against a possibly-drifted retrieval.
+    abstain_policy = build_abstain_policy(query)
+    evidence_score = calculate_evidence_score(
+        sources=[{"score": chunk["score"]} for chunk in chunks],
+        context_gathered=[chunk["text"] for chunk in chunks],
+        query=query,
+    )
+    evidence_inputs: dict[str, Any] = {
+        "evidence_score": evidence_score,
+        "context_length": len(chunks),
+        "domain": plan.domain.value,
+        "label_threshold": abstain_policy.label_threshold,
+        "abstain": abstain_policy.label_abstains(evidence_score),
+    }
+
+    package_hash = _package_hash(
+        history=history,
+        chunks=chunks,
+        pricing_block=pricing_block,
+        persona_digest=persona_digest,
+        evidence_inputs=evidence_inputs,
+        thread_epoch=thread_epoch,
+    )
+
+    return ContextPackage(
+        history=history,
+        chunks=chunks,
+        pricing_block=pricing_block,
+        persona_digest=persona_digest,
+        evidence_inputs=evidence_inputs,
+        thread_epoch=thread_epoch,
+        package_hash=package_hash,
+    )

--- a/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
+++ b/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
@@ -30,6 +30,7 @@ phone, no `wa:` subject, no CRM fields, no source paths.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -58,6 +59,28 @@ logger = logging.getLogger(__name__)
 _MAX_CHUNKS = 8
 _MAX_CHUNK_CHARS = 4000
 _CHUNKS_PER_COLLECTION_LIMIT = 3
+
+# History hygiene (S2 cross-family review, findings 3+8): the builder OWNS
+# its payload allowlist, so history entries are rebuilt to exactly
+# {"role", "content"} — a caller-supplied extra key (phone, crm_id, ...)
+# is dropped, never forwarded. Content is capped at the WA message ceiling.
+_MAX_HISTORY_ROLE_CHARS = 32
+_MAX_HISTORY_CONTENT_CHARS = 4096
+
+# pricing_block per-field allowlist (S2 cross-family review, finding 2):
+# PricingService.search_service() returns contact_info (WhatsApp number,
+# wa.me link), disclaimers and raw catalogue entries with internal
+# annotations (_sub_block). Only these fields may cross into the package —
+# "no phone" is part of the spec's allowlist contract.
+_PRICING_ENTRY_FIELDS: tuple[str, ...] = (
+    "key",
+    "name",
+    "price",
+    "tier_range",
+    "duration",
+    "validity",
+    "notes",
+)
 
 # Fixed, documented access level for this deterministic, unauthenticated WA
 # path — matches `VectorSearchTool.__init__`'s own default (tools.py:89),
@@ -110,16 +133,25 @@ class ContextPackage:
     package_hash: str
 
     def to_payload(self) -> dict[str, Any]:
-        """Serialize to the exact 7-key allowlist. No extras, ever."""
-        return {
-            "history": self.history,
-            "chunks": self.chunks,
-            "pricing_block": self.pricing_block,
-            "persona_digest": self.persona_digest,
-            "evidence_inputs": self.evidence_inputs,
-            "thread_epoch": self.thread_epoch,
-            "package_hash": self.package_hash,
-        }
+        """Serialize to the exact 7-key allowlist. No extras, ever.
+
+        Returns a DEEP COPY (S2 cross-family review, finding 5):
+        `frozen=True` freezes the field BINDINGS, not the mutable
+        lists/dicts inside them — handing out the internal references
+        would let a caller mutate content after `package_hash` was
+        computed, silently divorcing the payload from its own hash.
+        """
+        return copy.deepcopy(
+            {
+                "history": self.history,
+                "chunks": self.chunks,
+                "pricing_block": self.pricing_block,
+                "persona_digest": self.persona_digest,
+                "evidence_inputs": self.evidence_inputs,
+                "thread_epoch": self.thread_epoch,
+                "package_hash": self.package_hash,
+            }
+        )
 
 
 def _build_persona_digest(channel: str = "whatsapp") -> str:
@@ -157,11 +189,17 @@ async def _search_collection_chunks(
     and reserved for the always-small curated_qa lookup).
     """
     try:
+        # fallback_to_plain=False is LOAD-BEARING for the zero-LLM criterion
+        # (S2 cross-family review, finding 1): SearchService.hybrid_search's
+        # default error fallback is self.search(), which runs Gemini query
+        # expansion. With False it re-raises instead, and this except block
+        # is the whole degradation — no LLM is reachable from this call.
         result = await retriever.hybrid_search(
             query=query,
             user_level=_SEARCH_USER_LEVEL,
             limit=_CHUNKS_PER_COLLECTION_LIMIT,
             collection_override=collection,
+            fallback_to_plain=False,
         )
     except Exception:
         logger.warning(
@@ -189,6 +227,83 @@ async def _search_collection_chunks(
             },
         )
     return chunks
+
+
+def _sanitize_history(history: list[dict[str, str]], query: str) -> list[dict[str, str]]:
+    """Rebuild history to EXACTLY {"role", "content"} entries + the current turn.
+
+    S2 cross-family review, findings 3, 4 and 8:
+      - extra keys on a caller-supplied entry (phone, crm_id, ...) are
+        DROPPED, never forwarded — the builder owns its allowlist at
+        runtime, not just in a type annotation;
+      - role/content are capped (a type annotation bounds nothing) with the
+        drop LOGGED (W97);
+      - the CURRENT query is appended as the final user turn, so the
+        generator receives the question it must answer and `package_hash`
+        distinguishes two different questions over identical history.
+    """
+    sanitized: list[dict[str, str]] = []
+    dropped_keys = 0
+    truncated = 0
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        role = str(entry.get("role", ""))[:_MAX_HISTORY_ROLE_CHARS]
+        content = str(entry.get("content", ""))
+        if len(content) > _MAX_HISTORY_CONTENT_CHARS:
+            content = content[:_MAX_HISTORY_CONTENT_CHARS]
+            truncated += 1
+        dropped_keys += len(set(entry.keys()) - {"role", "content"})
+        sanitized.append({"role": role, "content": content})
+    if dropped_keys:
+        logger.info(
+            "wa_package_builder: dropped %d non-allowlisted history key(s)",
+            dropped_keys,
+        )
+    if truncated:
+        logger.info(
+            "wa_package_builder: truncated %d history content(s) over the %d-char cap",
+            truncated,
+            _MAX_HISTORY_CONTENT_CHARS,
+        )
+    sanitized.append({"role": "user", "content": query[:_MAX_HISTORY_CONTENT_CHARS]})
+    return sanitized
+
+
+def _sanitize_pricing_block(raw: Any) -> dict[str, Any] | None:
+    """Reduce PricingService.search_service() output to the per-field allowlist.
+
+    Keeps: `search_query` and, per category, each entry filtered to
+    `_PRICING_ENTRY_FIELDS`. Drops by construction: `contact_info` (WhatsApp
+    number + wa.me link), `disclaimer`, `official_notice`, error/suggestion
+    prose, and the internal `_sub_block` annotation (S2 cross-family
+    review, finding 2). Returns None when nothing price-shaped survives.
+    """
+    if not isinstance(raw, dict):
+        return None
+    results = raw.get("results")
+    if not isinstance(results, dict) or not results:
+        return None
+
+    def _filter_entry(entry: Any) -> dict[str, Any] | None:
+        if not isinstance(entry, dict):
+            return None
+        kept = {k: entry[k] for k in _PRICING_ENTRY_FIELDS if k in entry}
+        return kept or None
+
+    clean_results: dict[str, Any] = {}
+    for category, items in results.items():
+        if isinstance(items, list):
+            kept_items = [e for e in (_filter_entry(item) for item in items) if e]
+            if kept_items:
+                clean_results[str(category)] = kept_items
+        else:
+            kept_entry = _filter_entry(items)
+            if kept_entry:
+                clean_results[str(category)] = kept_entry
+    if not clean_results:
+        return None
+    return {"search_query": str(raw.get("search_query", "")), "results": clean_results}
 
 
 def _cap_chunks(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -259,10 +374,15 @@ async def build_context_package(
     criterion, spec §2.2) — see `test_codex_package_builder_invokes_zero_llms`.
 
     Args:
-        query: The user's raw message text.
+        query: The user's raw message text. Appended to the payload history
+            as the final user turn (and therefore hashed) — the generator
+            must receive the question it is answering, and two different
+            questions over identical history must never share a
+            `package_hash` (S2 cross-family review, finding 4).
         history: Up to 12 turns of `{"role", "content"}` conversation
-            history (spec §2.2 "12-turn history") — passed through verbatim,
-            this function does not truncate or otherwise validate it.
+            history (spec §2.2 "12-turn history") — SANITIZED here to
+            exactly those two keys with capped lengths, extras dropped and
+            logged (S2 cross-family review, findings 3+8).
         thread_epoch: The caller's monotonic thread-epoch counter, frozen
             into the package and re-verified unchanged at finalization
             (spec §2.3).
@@ -299,14 +419,26 @@ async def build_context_package(
     if curated_qa_block:
         chunks.append({"collection": "curated_qa", "text": curated_qa_block, "score": 1.0})
 
+    retrieved: list[dict[str, Any]] = []
     for collection in ordered_collections:
-        chunks.extend(await _search_collection_chunks(retriever, collection, query))
+        retrieved.extend(await _search_collection_chunks(retriever, collection, query))
+    # Deterministic total order BEFORE the cap (S2 cross-family review,
+    # finding 6): QueryPlanner merges cross-domain collections through a
+    # set, whose iteration order varies per process (PYTHONHASHSEED) — two
+    # workers building the same turn must not disagree on which chunks
+    # survive the cap, their order, or the resulting package_hash. Sorting
+    # by (-score, collection, text) removes collection-arrival order from
+    # the outcome entirely. The curated_qa chunk stays pinned first.
+    retrieved.sort(key=lambda c: (-float(c["score"]), c["collection"], c["text"]))
+    chunks.extend(retrieved)
 
     chunks = _cap_chunks(chunks)
 
     pricing_block: dict[str, Any] | None = None
     if has_pricing_intent(query):
-        pricing_block = get_pricing_service().search_service(query)
+        pricing_block = _sanitize_pricing_block(get_pricing_service().search_service(query))
+
+    payload_history = _sanitize_history(history, query)
 
     persona_digest = _build_persona_digest()
 
@@ -327,7 +459,7 @@ async def build_context_package(
     }
 
     package_hash = _package_hash(
-        history=history,
+        history=payload_history,
         chunks=chunks,
         pricing_block=pricing_block,
         persona_digest=persona_digest,
@@ -336,7 +468,7 @@ async def build_context_package(
     )
 
     return ContextPackage(
-        history=history,
+        history=payload_history,
         chunks=chunks,
         pricing_block=pricing_block,
         persona_digest=persona_digest,

--- a/apps/backend-rag/backend/services/search/search_service.py
+++ b/apps/backend-rag/backend/services/search/search_service.py
@@ -1057,6 +1057,7 @@ class SearchService:
         tier_filter: list[TierLevel] = None,
         collection_override: str | None = None,
         apply_filters: bool | None = None,
+        fallback_to_plain: bool = True,
     ) -> dict[str, Any]:
         """
         Hybrid search combining dense vectors and BM25 sparse vectors.
@@ -1074,6 +1075,13 @@ class SearchService:
             tier_filter: Optional specific tier filter
             collection_override: Force specific collection
             apply_filters: If True, apply tier/exclude_repealed filters
+            fallback_to_plain: If True (default, historical behavior), any
+                error in the hybrid path falls back to `self.search()` —
+                which runs LLM query expansion (Gemini, via QueryExpander).
+                Pass False on paths with a zero-LLM contract (the WA
+                codex-route package builder, BOT-V4 S2): the error is
+                re-raised so the caller degrades WITHOUT an LLM ever being
+                reachable from this call.
 
         Returns:
             Search results with hybrid search metadata
@@ -1187,6 +1195,12 @@ class SearchService:
 
         except Exception as e:
             logger.error("Hybrid search error: %s", e, exc_info=True)
+            if not fallback_to_plain:
+                # Zero-LLM contract path (BOT-V4 S2): `self.search()` runs
+                # Gemini query expansion, so falling back here would put an
+                # LLM call on a path that promised none. Re-raise instead —
+                # the caller owns the degradation.
+                raise
             # Fallback to regular search on error
             return await self.search(
                 query=query,

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_wa_package_router.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_wa_package_router.py
@@ -1,0 +1,96 @@
+"""BOT-V4 S2 (D2/D4): the wa-package router — thin wiring test.
+
+The deterministic pipeline itself (domain gate, retrieval, caps, hashing) is
+covered exhaustively in
+`backend/tests/unit/services/rag/agentic/test_wa_package_builder.py`. This
+file only proves the router's OWN two jobs: (1) it acquires the retriever
+and calls the D3 curated-QA wrapper off the injected orchestrator, never a
+new/duplicated dependency; (2) it translates `PackageUnbuildable` into the
+`{"unbuildable": reason}` HTTP-200 shape instead of letting the exception
+propagate as a 500 — an unbuildable intent is a ROUTE decision for the
+worker, not a server error.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backend.app.routers.wa_package import (
+    WaPackageBuildRequest,
+    build_wa_package,
+)
+
+
+class FakeRetriever:
+    async def hybrid_search(
+        self,
+        *,
+        query: str,
+        user_level: int,
+        limit: int,
+        collection_override: str,
+    ) -> dict[str, Any]:
+        return {
+            "query": query,
+            "results": [
+                {"id": "d1", "text": "KITAS requires a sponsor letter.", "score": 0.7},
+            ],
+            "collection": collection_override,
+        }
+
+
+class FakeCore:
+    def __init__(self) -> None:
+        self.retriever = FakeRetriever()
+        self.curated_qa_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def curated_qa_grounding_block(
+        self,
+        query: str,
+        extracted_entities: dict[str, Any] | None = None,
+    ) -> str:
+        self.curated_qa_calls.append((query, extracted_entities))
+        return ""
+
+
+class FakeOrchestrator:
+    def __init__(self) -> None:
+        self.core = FakeCore()
+
+
+class TestBuildWaPackageRoute:
+    async def test_visa_query_returns_package_with_full_allowlist(self) -> None:
+        orchestrator = FakeOrchestrator()
+        request = WaPackageBuildRequest(
+            query="What documents do I need for a KITAS work permit?",
+            history=[],
+            thread_epoch=0,
+        )
+
+        response = await build_wa_package(request, orchestrator=orchestrator)
+
+        assert response.unbuildable is None
+        assert response.package is not None
+        assert set(response.package.keys()) == {
+            "history",
+            "chunks",
+            "pricing_block",
+            "persona_digest",
+            "evidence_inputs",
+            "thread_epoch",
+            "package_hash",
+        }
+        # The router calls the D3 wrapper off the SAME orchestrator.core it
+        # got via Depends(get_orchestrator) — never a second/new retriever.
+        assert orchestrator.core.curated_qa_calls
+        assert orchestrator.core.curated_qa_calls[0][0] == request.query
+        assert orchestrator.core.curated_qa_calls[0][1] == {"domain": "visa"}
+
+    async def test_greeting_query_returns_unbuildable_not_an_error(self) -> None:
+        orchestrator = FakeOrchestrator()
+        request = WaPackageBuildRequest(query="ciao!", history=[], thread_epoch=0)
+
+        response = await build_wa_package(request, orchestrator=orchestrator)
+
+        assert response.package is None
+        assert response.unbuildable == "greeting_domain"

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_wa_package_router.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_wa_package_router.py
@@ -3,21 +3,36 @@
 The deterministic pipeline itself (domain gate, retrieval, caps, hashing) is
 covered exhaustively in
 `backend/tests/unit/services/rag/agentic/test_wa_package_builder.py`. This
-file only proves the router's OWN two jobs: (1) it acquires the retriever
-and calls the D3 curated-QA wrapper off the injected orchestrator, never a
+file only proves the router's OWN jobs: (1) it acquires the retriever and
+calls the D3 curated-QA wrapper off the injected orchestrator, never a
 new/duplicated dependency; (2) it translates `PackageUnbuildable` into the
 `{"unbuildable": reason}` HTTP-200 shape instead of letting the exception
 propagate as a 500 — an unbuildable intent is a ROUTE decision for the
-worker, not a server error.
+worker, not a server error; (3) S2 cross-family review round: the
+`require_internal_caller` scope gate (finding 7 — fail-closed, guilt AND
+innocence, plus the armed-check that the route actually carries it: a
+dependency that exists but is not wired is suspended, not alive — scar
+family #2); (4) transport bounds on history entries (finding 8 — an
+annotation caps nothing, `Field(max_length=...)` does); (5) the GREETING
+cost guard (finding 9 — no embedding+Qdrant spend on a query the builder is
+about to declare unbuildable).
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from fastapi.routing import APIRoute
+from pydantic import ValidationError
 
 from backend.app.routers.wa_package import (
     WaPackageBuildRequest,
     build_wa_package,
+    require_internal_caller,
+    router,
 )
 
 
@@ -29,6 +44,7 @@ class FakeRetriever:
         user_level: int,
         limit: int,
         collection_override: str,
+        fallback_to_plain: bool = True,
     ) -> dict[str, Any]:
         return {
             "query": query,
@@ -56,6 +72,12 @@ class FakeCore:
 class FakeOrchestrator:
     def __init__(self) -> None:
         self.core = FakeCore()
+
+
+def _request_with_user(user: Any) -> SimpleNamespace:
+    """The middleware contract this router reads: `request.state.user`
+    (set by HybridAuthMiddleware after a successful authentication)."""
+    return SimpleNamespace(state=SimpleNamespace(user=user))
 
 
 class TestBuildWaPackageRoute:
@@ -94,3 +116,85 @@ class TestBuildWaPackageRoute:
 
         assert response.package is None
         assert response.unbuildable == "greeting_domain"
+
+    async def test_greeting_query_never_spends_the_curated_qa_lookup(self) -> None:
+        """finding 9 (GUILT): a GREETING query is about to be declared
+        unbuildable by the builder's own gate — the router must not pay an
+        embedding + a Qdrant search for it first. The visa test above is the
+        innocence pair (a buildable domain DOES get the lookup)."""
+        orchestrator = FakeOrchestrator()
+        request = WaPackageBuildRequest(query="ciao!", history=[], thread_epoch=0)
+
+        await build_wa_package(request, orchestrator=orchestrator)
+
+        assert orchestrator.core.curated_qa_calls == []
+
+
+class TestRequireInternalCaller:
+    """finding 7: authentication is not authorization — any portal JWT
+    passes HybridAuthMiddleware, but only the middleware's `internal`
+    service identity (X-Internal-Key) or an `admin` may drive this
+    internal builder."""
+
+    def test_portal_user_role_is_refused_403(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            require_internal_caller(_request_with_user({"role": "user", "sub": "someone"}))
+        assert exc_info.value.status_code == 403
+
+    def test_missing_state_user_is_refused_403_fail_closed(self) -> None:
+        """Middleware disabled / unexpected wiring must FAIL CLOSED — a
+        missing identity is a refusal, never a pass."""
+        with pytest.raises(HTTPException) as exc_info:
+            require_internal_caller(SimpleNamespace(state=SimpleNamespace()))
+        assert exc_info.value.status_code == 403
+
+    def test_non_dict_user_is_refused_403(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            require_internal_caller(_request_with_user("internal"))
+        assert exc_info.value.status_code == 403
+
+    def test_internal_and_admin_roles_pass(self) -> None:
+        assert require_internal_caller(_request_with_user({"role": "internal"})) is None
+        assert require_internal_caller(_request_with_user({"role": "admin"})) is None
+
+    def test_the_build_route_actually_carries_the_dependency(self) -> None:
+        """Armed-check (scar family #2, esiste ≠ armato): a correct guard
+        that no route declares protects nothing. The /build route must list
+        `require_internal_caller` among its dependencies."""
+        build_routes = [
+            r
+            for r in router.routes
+            if isinstance(r, APIRoute) and r.path == "/api/wa-package/build"
+        ]
+        assert build_routes, "expected the /api/wa-package/build route to exist"
+        deps = [d.dependency for d in build_routes[0].dependencies]
+        assert require_internal_caller in deps
+
+
+class TestTransportBounds:
+    """finding 8: the history entry fields are bounded at the transport —
+    `Field(max_length=...)`, because a bare annotation validates nothing."""
+
+    def test_oversized_history_content_is_rejected_422(self) -> None:
+        with pytest.raises(ValidationError):
+            WaPackageBuildRequest(
+                query="What documents do I need for a KITAS?",
+                history=[{"role": "user", "content": "x" * 5000}],
+                thread_epoch=0,
+            )
+
+    def test_oversized_history_role_is_rejected_422(self) -> None:
+        with pytest.raises(ValidationError):
+            WaPackageBuildRequest(
+                query="What documents do I need for a KITAS?",
+                history=[{"role": "r" * 64, "content": "hello"}],
+                thread_epoch=0,
+            )
+
+    def test_content_at_the_ceiling_is_accepted(self) -> None:
+        request = WaPackageBuildRequest(
+            query="What documents do I need for a KITAS?",
+            history=[{"role": "user", "content": "x" * 4096}],
+            thread_epoch=0,
+        )
+        assert len(request.history) == 1

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
@@ -1,0 +1,356 @@
+"""BOT-V4 S2 (D1/D4): the deterministic WA codex-route package builder.
+
+S2 acceptance criterion (spec §2.2,
+research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md): "the
+codex-route package builder invokes zero LLMs" — a test, not a claim. This
+file proves it two ways: (1) runtime tripwires on every known LLM entry
+point the codebase exposes, monkeypatched to raise if ever called while a
+full package (including the pricing-intent path) is built; (2) a static
+AST scan of the module's own source proving it carries no `backend.llm`
+import at all — so the runtime tripwire isn't the only thing standing
+between this path and an LLM call.
+
+Also covers: the allowlist schema (exactly 7 payload keys, exactly 3 keys
+per chunk even when the fake retriever hands back extra metadata), the
+GREETING/no-collections `PackageUnbuildable` gate, the pricing-intent gate
+(independent of QueryPlanner's domain — "quanto costa il KITAS?" classifies
+as VISA by entity, but still fires the price gate), hash determinism, the
+evidence-inputs freeze against the `_abstain_policy` SSOT (never a literal),
+and the declared chunk cap with its log line (no silent caps — scar family
+#2, W97).
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from backend.services.rag.agentic import wa_package_builder as wpb_module
+from backend.services.rag.agentic._abstain_policy import build_abstain_policy
+from backend.services.rag.agentic.wa_package_builder import (
+    ContextPackage,
+    PackageUnbuildable,
+    build_context_package,
+)
+
+
+class FakeRetriever:
+    """Stand-in for `SearchService` — canned `hybrid_search` results per collection.
+
+    Deliberately ignores the `limit` kwarg (the fake owns exactly how many
+    hits come back per collection, so a test can hand back more than the
+    module's own cap to prove the cap fires) and records nothing beyond
+    what a test needs — `search_collection` is intentionally NOT
+    implemented, since D1 uses `hybrid_search` only (see the dispatch-choice
+    docstring in `wa_package_builder.py`).
+    """
+
+    def __init__(self, hits_by_collection: dict[str, list[dict[str, Any]]] | None = None) -> None:
+        self._hits_by_collection = hits_by_collection or {}
+        self.calls: list[str] = []
+
+    async def hybrid_search(
+        self,
+        *,
+        query: str,
+        user_level: int,
+        limit: int,
+        collection_override: str,
+    ) -> dict[str, Any]:
+        self.calls.append(collection_override)
+        hits = self._hits_by_collection.get(collection_override, [])
+        return {"query": query, "results": list(hits), "collection": collection_override}
+
+
+def _hit(text: str, score: float, **extra_metadata: Any) -> dict[str, Any]:
+    """A raw hybrid_search hit shaped like `format_search_results()`'s output —
+    carrying extra fields (id/metadata/source paths) a real retriever would
+    include, so the allowlist test proves they get dropped, not just that
+    the happy path has few enough fields to look clean by accident.
+    """
+    return {
+        "id": "doc-xyz",
+        "text": text,
+        "score": score,
+        "metadata": {"source_path": "/internal/repo/path.md", **extra_metadata},
+    }
+
+
+VISA_QUERY = "What documents do I need for a KITAS work permit?"
+GREETING_QUERY = "ciao!"
+PRICING_VISA_QUERY = "quanto costa il KITAS?"
+KBLI_QUERY = "KBLI business classification codes lookup"
+
+
+def _visa_retriever() -> FakeRetriever:
+    return FakeRetriever(
+        {
+            "visa_oracle": [_hit("KITAS requires a sponsor letter and passport copy.", 0.82)],
+            "legal_unified_hybrid": [_hit("Immigration law UU 6/2011 governs stay permits.", 0.55)],
+        },
+    )
+
+
+class FakePricingService:
+    def __init__(self, result: dict[str, Any]) -> None:
+        self._result = result
+        self.queries: list[str] = []
+
+    def search_service(self, query: str) -> dict[str, Any]:
+        self.queries.append(query)
+        return self._result
+
+
+# ============================================================================
+# 1. Zero-LLM acceptance criterion
+# ============================================================================
+
+
+class TestZeroLLMAcceptanceCriterion:
+    async def test_codex_package_builder_invokes_zero_llms(self, monkeypatch) -> None:
+        """S2's named acceptance criterion. Every known LLM entry point is
+        monkeypatched to explode; a FULL package build (pricing-intent query,
+        multi-collection retrieval, curated_qa block present) must complete
+        without tripping any of them.
+        """
+
+        def _explode(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("LLM invoked in codex package path")
+
+        monkeypatch.setattr("backend.llm.genai_client.get_genai_client", _explode)
+        monkeypatch.setattr("backend.llm.claude_oauth_client.complete_async", _explode)
+        monkeypatch.setattr("backend.llm.claude_oauth_client.complete", _explode)
+        monkeypatch.setattr("backend.llm.ollama_client.ollama_generate", _explode)
+        monkeypatch.setattr("backend.llm.ollama_client.ollama_chat", _explode)
+
+        fake_pricing = FakePricingService({"key": "kitas_permits", "price": "Rp 5.000.000"})
+        with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
+            package = await build_context_package(
+                query=PRICING_VISA_QUERY,
+                history=[{"role": "user", "content": "hi"}],
+                thread_epoch=1,
+                retriever=_visa_retriever(),
+                curated_qa_block="[CURATED · vetted 2026-08-01]\nKITAS costs vary by category.",
+            )
+
+        assert isinstance(package, ContextPackage)
+        assert set(package.to_payload().keys()) == {
+            "history",
+            "chunks",
+            "pricing_block",
+            "persona_digest",
+            "evidence_inputs",
+            "thread_epoch",
+            "package_hash",
+        }
+        assert package.pricing_block == {"key": "kitas_permits", "price": "Rp 5.000.000"}
+
+    def test_module_source_has_no_backend_llm_import(self) -> None:
+        """Static proof, independent of the runtime tripwires above: the
+        module's own SOURCE carries no `backend.llm` import statement — an
+        AST walk, not a substring search, because the module's docstrings
+        and comments legitimately mention "backend.llm" in prose.
+        """
+        source = Path(wpb_module.__file__).read_text()
+        tree = ast.parse(source)
+        offending: list[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                offending.extend(
+                    alias.name for alias in node.names if alias.name.startswith("backend.llm")
+                )
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module.startswith("backend.llm"):
+                    offending.append(module)
+        assert offending == [], f"wa_package_builder.py imports backend.llm: {offending}"
+
+
+# ============================================================================
+# 2. Allowlist schema
+# ============================================================================
+
+
+class TestAllowlistSchema:
+    async def test_to_payload_has_exactly_the_seven_keys(self) -> None:
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=_visa_retriever(),
+        )
+        assert set(package.to_payload().keys()) == {
+            "history",
+            "chunks",
+            "pricing_block",
+            "persona_digest",
+            "evidence_inputs",
+            "thread_epoch",
+            "package_hash",
+        }
+
+    async def test_chunks_drop_retriever_extras_to_exactly_three_keys(self) -> None:
+        """The fake retriever hands back `id` + `metadata.source_path` on every
+        hit (mirroring a real `format_search_results()` result) — every
+        chunk in the built package must carry ONLY collection/text/score.
+        """
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=_visa_retriever(),
+        )
+        assert package.chunks, "expected at least one chunk from the fake retriever"
+        for chunk in package.chunks:
+            assert set(chunk.keys()) == {"collection", "text", "score"}
+
+
+# ============================================================================
+# 3. GREETING / no-collections gate
+# ============================================================================
+
+
+class TestUnbuildableGate:
+    async def test_greeting_query_raises_unbuildable(self) -> None:
+        with pytest.raises(PackageUnbuildable) as exc_info:
+            await build_context_package(
+                query=GREETING_QUERY,
+                history=[],
+                thread_epoch=0,
+                retriever=FakeRetriever(),
+            )
+        assert exc_info.value.reason == "greeting_domain"
+
+    async def test_real_visa_query_builds(self) -> None:
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=_visa_retriever(),
+        )
+        assert isinstance(package, ContextPackage)
+        assert package.package_hash
+
+
+# ============================================================================
+# 4. Pricing-intent gate (independent of QueryPlanner's domain)
+# ============================================================================
+
+
+class TestPricingGate:
+    async def test_pricing_intent_query_populates_pricing_block(self) -> None:
+        fake_pricing = FakePricingService({"key": "kitas_permits", "price": "Rp 5.000.000"})
+        with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
+            package = await build_context_package(
+                query=PRICING_VISA_QUERY,
+                history=[],
+                thread_epoch=0,
+                retriever=_visa_retriever(),
+            )
+        assert package.pricing_block == {"key": "kitas_permits", "price": "Rp 5.000.000"}
+        assert fake_pricing.queries == [PRICING_VISA_QUERY]
+
+    async def test_non_pricing_query_leaves_pricing_block_none(self) -> None:
+        fake_pricing = FakePricingService({"key": "should-not-be-used"})
+        with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
+            package = await build_context_package(
+                query=VISA_QUERY,
+                history=[],
+                thread_epoch=0,
+                retriever=_visa_retriever(),
+            )
+        assert package.pricing_block is None
+        assert fake_pricing.queries == []
+
+
+# ============================================================================
+# 5. Hash determinism
+# ============================================================================
+
+
+class TestHashDeterminism:
+    async def test_identical_inputs_produce_identical_hash(self) -> None:
+        package_a = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": "hi"}],
+            thread_epoch=3,
+            retriever=_visa_retriever(),
+        )
+        package_b = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": "hi"}],
+            thread_epoch=3,
+            retriever=_visa_retriever(),
+        )
+        assert package_a.package_hash == package_b.package_hash
+
+    async def test_mutated_chunk_text_changes_the_hash(self) -> None:
+        baseline = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": "hi"}],
+            thread_epoch=3,
+            retriever=_visa_retriever(),
+        )
+        mutated_retriever = FakeRetriever(
+            {
+                "visa_oracle": [_hit("KITAS requires a DIFFERENT document set entirely.", 0.82)],
+                "legal_unified_hybrid": [
+                    _hit("Immigration law UU 6/2011 governs stay permits.", 0.55),
+                ],
+            },
+        )
+        mutated = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": "hi"}],
+            thread_epoch=3,
+            retriever=mutated_retriever,
+        )
+        assert baseline.package_hash != mutated.package_hash
+
+
+# ============================================================================
+# 6. Evidence freeze against the abstain-policy SSOT
+# ============================================================================
+
+
+class TestEvidenceFreeze:
+    async def test_label_threshold_matches_abstain_policy_ssot(self) -> None:
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=_visa_retriever(),
+        )
+        expected = build_abstain_policy(VISA_QUERY).label_threshold
+        assert package.evidence_inputs["label_threshold"] == expected
+        assert package.evidence_inputs["domain"] == "visa"
+        assert package.evidence_inputs["context_length"] == len(package.chunks)
+
+
+# ============================================================================
+# 7. Declared chunk cap
+# ============================================================================
+
+
+class TestChunkCap:
+    async def test_ten_chunks_in_eight_kept_and_drop_is_logged(self, caplog) -> None:
+        ten_hits = [_hit(f"KBLI code entry number {i}.", 0.9 - i * 0.01) for i in range(10)]
+        retriever = FakeRetriever({"kbli_2025_final": ten_hits})
+
+        with caplog.at_level(
+            logging.INFO, logger="backend.services.rag.agentic.wa_package_builder"
+        ):
+            package = await build_context_package(
+                query=KBLI_QUERY,
+                history=[],
+                thread_epoch=0,
+                retriever=retriever,
+            )
+
+        assert len(package.chunks) == 8
+        assert "dropping" in caplog.text and "chunk" in caplog.text

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
@@ -546,7 +546,13 @@ class TestGreetingWordBoundary:
     """
 
     async def test_real_questions_containing_hi_substrings_build_packages(self) -> None:
-        for query in ("Which visa options are available?", "What is this visa?"):
+        # "history" doubles as the innocence case for the elongation
+        # tolerance: \b + "hi" + i* must not fire inside it.
+        for query in (
+            "Which visa options are available?",
+            "What is this visa?",
+            "What is the history of visa regulations?",
+        ):
             package = await build_context_package(
                 query=query,
                 history=[],
@@ -556,7 +562,24 @@ class TestGreetingWordBoundary:
             assert isinstance(package, ContextPackage), f"{query!r} was declared unbuildable"
 
     async def test_actual_greetings_still_gate(self) -> None:
-        for query in ("hi", "hey", "ciao!", "thank you", "hi there"):
+        # Includes the colloquial elongations WhatsApp greetings actually
+        # arrive in (Codex round 3: a strict trailing \b regressed these)
+        # and the Indonesian colloquial thanks the old substring matcher
+        # never covered either.
+        for query in (
+            "hi",
+            "hey",
+            "ciao!",
+            "thank you",
+            "hi there",
+            "hii",
+            "heyy",
+            "hellooo",
+            "ciaooo",
+            "halooo",
+            "makasih",
+            "terimakasih",
+        ):
             with pytest.raises(PackageUnbuildable):
                 await build_context_package(
                     query=query,

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
@@ -10,6 +10,25 @@ AST scan of the module's own source proving it carries no `backend.llm`
 import at all — so the runtime tripwire isn't the only thing standing
 between this path and an LLM call.
 
+S2 cross-family (Codex) review round — each finding carries its own
+guilt+innocence pair here:
+  - finding 1: the builder must pass `fallback_to_plain=False` to
+    `hybrid_search` (SearchService's default error fallback runs Gemini
+    query expansion — the wiring assertion is the guard the FakeRetriever
+    can actually witness);
+  - finding 2: `pricing_block` is reduced to a per-field allowlist —
+    contact_info (WhatsApp number, wa.me link), disclaimers and internal
+    annotations are dropped by construction (the fake speaks the REAL wire
+    shape measured on `PricingService.search_service`, W114);
+  - findings 3+8: history is rebuilt to exactly {"role","content"} with
+    capped lengths — extra keys (phone, crm_id) never reach the payload;
+  - finding 4: the current query is appended as the final user turn, so it
+    is in the payload AND in the hash;
+  - finding 5: `to_payload()` returns a deep copy — mutating one payload
+    cannot corrupt the package or a later payload;
+  - finding 6: chunk order is a deterministic total order (-score,
+    collection, text), independent of collection-arrival order.
+
 Also covers: the allowlist schema (exactly 7 payload keys, exactly 3 keys
 per chunk even when the fake retriever hands back extra metadata), the
 GREETING/no-collections `PackageUnbuildable` gate, the pricing-intent gate
@@ -47,12 +66,15 @@ class FakeRetriever:
     module's own cap to prove the cap fires) and records nothing beyond
     what a test needs — `search_collection` is intentionally NOT
     implemented, since D1 uses `hybrid_search` only (see the dispatch-choice
-    docstring in `wa_package_builder.py`).
+    docstring in `wa_package_builder.py`). `fallback_to_plain` defaults to
+    True to mirror the REAL signature, so only an explicit False from the
+    builder can make the flag assertion pass.
     """
 
     def __init__(self, hits_by_collection: dict[str, list[dict[str, Any]]] | None = None) -> None:
         self._hits_by_collection = hits_by_collection or {}
         self.calls: list[str] = []
+        self.fallback_flags: list[bool] = []
 
     async def hybrid_search(
         self,
@@ -61,8 +83,10 @@ class FakeRetriever:
         user_level: int,
         limit: int,
         collection_override: str,
+        fallback_to_plain: bool = True,
     ) -> dict[str, Any]:
         self.calls.append(collection_override)
+        self.fallback_flags.append(fallback_to_plain)
         hits = self._hits_by_collection.get(collection_override, [])
         return {"query": query, "results": list(hits), "collection": collection_override}
 
@@ -96,6 +120,55 @@ def _visa_retriever() -> FakeRetriever:
     )
 
 
+def _real_pricing_result(query: str) -> dict[str, Any]:
+    """The REAL wire shape of `PricingService.search_service()` (measured on
+    backend/services/pricing/pricing_service.py, success branch). A fake that
+    speaks the code's imagination instead of the wire's is two copies of the
+    same hypothesis confirming each other (W114). This one carries the exact
+    fields the sanitizer must DROP.
+    """
+    return {
+        "official_notice": "🔒 PREZZI UFFICIALI BALI ZERO 2026",
+        "search_query": query,
+        "results": {
+            "kitas_permits": [
+                {
+                    "name": "Working KITAS (E23)",
+                    "price": "Rp 5.000.000",
+                    "duration": "12 months",
+                    "validity": "1 year",
+                    "notes": "sponsor required",
+                    "_sub_block": "monthly_tax_basic",
+                    "icon_id": "kitas",
+                    "description_en": "internal-facing description",
+                }
+            ]
+        },
+        "contact_info": {
+            "whatsapp": "+62 821 3454 721",
+            "wa_link": "https://wa.me/6282134547211",
+            "email": "zero@balizero.com",
+        },
+        "disclaimer": {"it": "prezzi soggetti a variazione"},
+    }
+
+
+_SANITIZED_PRICING = {
+    "search_query": PRICING_VISA_QUERY,
+    "results": {
+        "kitas_permits": [
+            {
+                "name": "Working KITAS (E23)",
+                "price": "Rp 5.000.000",
+                "duration": "12 months",
+                "validity": "1 year",
+                "notes": "sponsor required",
+            }
+        ]
+    },
+}
+
+
 class FakePricingService:
     def __init__(self, result: dict[str, Any]) -> None:
         self._result = result
@@ -127,8 +200,14 @@ class TestZeroLLMAcceptanceCriterion:
         monkeypatch.setattr("backend.llm.claude_oauth_client.complete", _explode)
         monkeypatch.setattr("backend.llm.ollama_client.ollama_generate", _explode)
         monkeypatch.setattr("backend.llm.ollama_client.ollama_chat", _explode)
+        # The retriever-fallback LLM (S2 review, finding 1): GeminiService is
+        # what SearchService's plain-search fallback would construct.
+        monkeypatch.setattr(
+            "backend.services.llm_clients.gemini_service.GeminiService",
+            _explode,
+        )
 
-        fake_pricing = FakePricingService({"key": "kitas_permits", "price": "Rp 5.000.000"})
+        fake_pricing = FakePricingService(_real_pricing_result(PRICING_VISA_QUERY))
         with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
             package = await build_context_package(
                 query=PRICING_VISA_QUERY,
@@ -148,7 +227,7 @@ class TestZeroLLMAcceptanceCriterion:
             "thread_epoch",
             "package_hash",
         }
-        assert package.pricing_block == {"key": "kitas_permits", "price": "Rp 5.000.000"}
+        assert package.pricing_block == _SANITIZED_PRICING
 
     def test_module_source_has_no_backend_llm_import(self) -> None:
         """Static proof, independent of the runtime tripwires above: the
@@ -169,6 +248,22 @@ class TestZeroLLMAcceptanceCriterion:
                 if module.startswith("backend.llm"):
                     offending.append(module)
         assert offending == [], f"wa_package_builder.py imports backend.llm: {offending}"
+
+    async def test_builder_disables_the_hybrid_search_llm_fallback(self) -> None:
+        """finding 1 (BLOCKER): SearchService.hybrid_search's default error
+        fallback is `self.search()`, which runs Gemini query expansion. The
+        builder must pass fallback_to_plain=False on EVERY collection call —
+        the wiring this fake can actually witness.
+        """
+        retriever = _visa_retriever()
+        await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=retriever,
+        )
+        assert retriever.calls, "expected at least one hybrid_search call"
+        assert retriever.fallback_flags == [False] * len(retriever.calls)
 
 
 # ============================================================================
@@ -209,6 +304,71 @@ class TestAllowlistSchema:
         for chunk in package.chunks:
             assert set(chunk.keys()) == {"collection", "text", "score"}
 
+    async def test_history_extra_keys_are_dropped(self) -> None:
+        """findings 3+8 (GUILT): a caller-supplied entry smuggling phone /
+        crm_id keys must reach the payload as {"role","content"} ONLY."""
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[
+                {
+                    "role": "user",
+                    "content": "earlier question",
+                    "phone": "+62 812 0000 0000",
+                    "crm_id": "client-42",
+                }
+            ],
+            thread_epoch=0,
+            retriever=_visa_retriever(),
+        )
+        for turn in package.history:
+            assert set(turn.keys()) == {"role", "content"}
+        assert "+62 812 0000 0000" not in str(package.to_payload())
+
+    async def test_history_content_is_capped_and_logged(self, caplog) -> None:
+        """findings 3+8: an annotation caps nothing — the builder truncates
+        oversized content defensively and DECLARES the truncation (W97)."""
+        with caplog.at_level(
+            logging.INFO, logger="backend.services.rag.agentic.wa_package_builder"
+        ):
+            package = await build_context_package(
+                query=VISA_QUERY,
+                history=[{"role": "user", "content": "x" * 10_000}],
+                thread_epoch=0,
+                retriever=_visa_retriever(),
+            )
+        assert len(package.history[0]["content"]) == wpb_module._MAX_HISTORY_CONTENT_CHARS
+        assert "truncat" in caplog.text and "history" in caplog.text
+
+    async def test_current_query_is_the_final_user_turn(self) -> None:
+        """finding 4 (BLOCKER): the generator must receive the question it is
+        answering — the payload history ends with the current query."""
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+            thread_epoch=0,
+            retriever=_visa_retriever(),
+        )
+        assert package.history[-1] == {"role": "user", "content": VISA_QUERY}
+
+    async def test_to_payload_returns_an_independent_copy(self) -> None:
+        """finding 5 (INNOCENCE of the frozen claim): mutating one payload
+        must not corrupt the package or a later payload."""
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=_visa_retriever(),
+        )
+        first = package.to_payload()
+        first["chunks"].clear()
+        first["history"].append({"role": "user", "content": "injected"})
+        second = package.to_payload()
+        assert second["chunks"], "second payload lost its chunks to the first's mutation"
+        assert second["history"][-1] == {"role": "user", "content": VISA_QUERY}
+
 
 # ============================================================================
 # 3. GREETING / no-collections gate
@@ -243,8 +403,8 @@ class TestUnbuildableGate:
 
 
 class TestPricingGate:
-    async def test_pricing_intent_query_populates_pricing_block(self) -> None:
-        fake_pricing = FakePricingService({"key": "kitas_permits", "price": "Rp 5.000.000"})
+    async def test_pricing_intent_query_populates_sanitized_pricing_block(self) -> None:
+        fake_pricing = FakePricingService(_real_pricing_result(PRICING_VISA_QUERY))
         with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
             package = await build_context_package(
                 query=PRICING_VISA_QUERY,
@@ -252,8 +412,49 @@ class TestPricingGate:
                 thread_epoch=0,
                 retriever=_visa_retriever(),
             )
-        assert package.pricing_block == {"key": "kitas_permits", "price": "Rp 5.000.000"}
+        assert package.pricing_block == _SANITIZED_PRICING
         assert fake_pricing.queries == [PRICING_VISA_QUERY]
+
+    async def test_pricing_block_never_carries_contact_or_internal_fields(self) -> None:
+        """finding 2 (BLOCKER, GUILT): the WhatsApp number, wa.me link,
+        disclaimer and _sub_block annotation from the REAL wire shape must
+        be dropped by construction — 'no contact info' is part of the
+        allowlist, not a hope about upstream."""
+        fake_pricing = FakePricingService(_real_pricing_result(PRICING_VISA_QUERY))
+        with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
+            package = await build_context_package(
+                query=PRICING_VISA_QUERY,
+                history=[],
+                thread_epoch=0,
+                retriever=_visa_retriever(),
+            )
+        rendered = str(package.to_payload())
+        assert "+62 821 3454 721" not in rendered
+        assert "wa.me" not in rendered
+        assert "_sub_block" not in rendered
+        assert "disclaimer" not in rendered
+        assert "contact_info" not in rendered
+
+    async def test_priceless_pricing_result_becomes_none(self) -> None:
+        """finding 2 (INNOCENCE): the no-match wire shape (message +
+        suggestion + contact_info, no `results`) sanitizes to None, not to
+        a contact-info-only block."""
+        no_match = {
+            "official_notice": "🔒 PREZZI UFFICIALI BALI ZERO 2026",
+            "search_query": PRICING_VISA_QUERY,
+            "message": "No service found",
+            "suggestion": "Contact support",
+            "contact_info": {"whatsapp": "+62 821 3454 721"},
+        }
+        fake_pricing = FakePricingService(no_match)
+        with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
+            package = await build_context_package(
+                query=PRICING_VISA_QUERY,
+                history=[],
+                thread_epoch=0,
+                retriever=_visa_retriever(),
+            )
+        assert package.pricing_block is None
 
     async def test_non_pricing_query_leaves_pricing_block_none(self) -> None:
         fake_pricing = FakePricingService({"key": "should-not-be-used"})
@@ -311,6 +512,46 @@ class TestHashDeterminism:
             retriever=mutated_retriever,
         )
         assert baseline.package_hash != mutated.package_hash
+
+    async def test_different_query_same_history_changes_the_hash(self) -> None:
+        """finding 4 (GUILT): two different questions over identical history
+        and identical retrieval must never share a package_hash."""
+        hits = {
+            "visa_oracle": [_hit("KITAS requires a sponsor letter and passport copy.", 0.82)],
+            "legal_unified_hybrid": [_hit("Immigration law UU 6/2011 governs stay permits.", 0.55)],
+        }
+        package_a = await build_context_package(
+            query="What documents do I need for a KITAS work permit?",
+            history=[{"role": "user", "content": "hi"}],
+            thread_epoch=3,
+            retriever=FakeRetriever(hits),
+        )
+        package_b = await build_context_package(
+            query="How long does a KITAS work permit renewal take?",
+            history=[{"role": "user", "content": "hi"}],
+            thread_epoch=3,
+            retriever=FakeRetriever(hits),
+        )
+        assert package_a.package_hash != package_b.package_hash
+
+    async def test_chunk_order_is_independent_of_collection_arrival_order(self) -> None:
+        """finding 6 (MAJOR): QueryPlanner merges cross-domain collections
+        through a set (per-process iteration order). The package must not
+        depend on it — proven with score-TIED hits, where only the
+        deterministic (collection, text) tiebreak keeps the order stable."""
+        hits = {
+            "visa_oracle": [_hit("Visa fact.", 0.60)],
+            "legal_unified_hybrid": [_hit("Legal fact.", 0.60)],
+        }
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=FakeRetriever(hits),
+        )
+        assert [c["collection"] for c in package.chunks] == sorted(
+            c["collection"] for c in package.chunks
+        )
 
 
 # ============================================================================

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
@@ -561,6 +561,16 @@ class TestGreetingWordBoundary:
             )
             assert isinstance(package, ContextPackage), f"{query!r} was declared unbuildable"
 
+    def test_elongation_does_not_fire_mid_sentence(self) -> None:
+        """Codex round 4: 'What is an HII region?' lowercases to a
+        mid-sentence 'hii' — the elongated form is a colloquial OPENER, so
+        it only counts at the start of the message; mid-sentence it is
+        jargon, never a greeting."""
+        from backend.services.rag.agentic.query_planner import QueryDomain, QueryPlanner
+
+        plan = QueryPlanner().plan("What is an HII region?")
+        assert plan.domain is not QueryDomain.GREETING
+
     async def test_actual_greetings_still_gate(self) -> None:
         # Includes the colloquial elongations WhatsApp greetings actually
         # arrive in (Codex round 3: a strict trailing \b regressed these)

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_package_builder.py
@@ -121,18 +121,22 @@ def _visa_retriever() -> FakeRetriever:
 
 
 def _real_pricing_result(query: str) -> dict[str, Any]:
-    """The REAL wire shape of `PricingService.search_service()` (measured on
-    backend/services/pricing/pricing_service.py, success branch). A fake that
-    speaks the code's imagination instead of the wire's is two copies of the
-    same hypothesis confirming each other (W114). This one carries the exact
-    fields the sanitizer must DROP.
+    """The REAL wire shape of `PricingService.search_service()` — 2026 data:
+    per-category values are DICTS keyed by the public service name
+    (`filtered_results[category_name] = items` on the scorer's dict path),
+    NOT lists. The first draft of this fake modeled a list and thereby
+    masked a sanitizer that dropped every real 2026 match (Codex S2
+    re-verdict, blocker) — a fake speaking the code's imagination instead
+    of the wire's is two copies of one hypothesis confirming each other
+    (W114). The real-service contract test below is the standing cure: this
+    fake's shape is pinned against the live JSON, not against memory.
     """
     return {
         "official_notice": "🔒 PREZZI UFFICIALI BALI ZERO 2026",
         "search_query": query,
         "results": {
-            "kitas_permits": [
-                {
+            "kitas_permits": {
+                "Working KITAS (E23)": {
                     "name": "Working KITAS (E23)",
                     "price": "Rp 5.000.000",
                     "duration": "12 months",
@@ -142,7 +146,7 @@ def _real_pricing_result(query: str) -> dict[str, Any]:
                     "icon_id": "kitas",
                     "description_en": "internal-facing description",
                 }
-            ]
+            }
         },
         "contact_info": {
             "whatsapp": "+62 821 3454 721",
@@ -156,15 +160,15 @@ def _real_pricing_result(query: str) -> dict[str, Any]:
 _SANITIZED_PRICING = {
     "search_query": PRICING_VISA_QUERY,
     "results": {
-        "kitas_permits": [
-            {
+        "kitas_permits": {
+            "Working KITAS (E23)": {
                 "name": "Working KITAS (E23)",
                 "price": "Rp 5.000.000",
                 "duration": "12 months",
                 "validity": "1 year",
                 "notes": "sponsor required",
             }
-        ]
+        }
     },
 }
 
@@ -467,6 +471,99 @@ class TestPricingGate:
             )
         assert package.pricing_block is None
         assert fake_pricing.queries == []
+
+    async def test_legacy_list_category_shape_still_sanitizes(self) -> None:
+        """The scorer's legacy-fixture path emits `[entry, ...]` per category
+        — both wire shapes must survive the allowlist (symmetry: a fix that
+        covers only the shape that bit is half a fix)."""
+        legacy = _real_pricing_result(PRICING_VISA_QUERY)
+        legacy["results"] = {
+            "kitas_permits": [
+                {
+                    "name": "Working KITAS (E23)",
+                    "price": "Rp 5.000.000",
+                    "icon_id": "kitas",
+                }
+            ]
+        }
+        fake_pricing = FakePricingService(legacy)
+        with patch.object(wpb_module, "get_pricing_service", return_value=fake_pricing):
+            package = await build_context_package(
+                query=PRICING_VISA_QUERY,
+                history=[],
+                thread_epoch=0,
+                retriever=_visa_retriever(),
+            )
+        assert package.pricing_block == {
+            "search_query": PRICING_VISA_QUERY,
+            "results": {
+                "kitas_permits": [{"name": "Working KITAS (E23)", "price": "Rp 5.000.000"}]
+            },
+        }
+
+    async def test_real_pricing_service_contract_survives_the_sanitizer(self) -> None:
+        """W114 antidote at the TRUE boundary: run the REAL PricingService
+        (its wire is the official 2026 JSON on disk — no network) through the
+        sanitizer. This is the test the fake could never carry: if the wire
+        shape drifts, THIS goes red while the fake stays green. It is exactly
+        the test that would have caught the first sanitizer dropping every
+        real 2026 match.
+        """
+        from backend.services.pricing.pricing_service import get_pricing_service
+
+        raw = get_pricing_service().search_service("quanto costa il KITAS?")
+        assert isinstance(raw.get("results"), dict) and raw["results"], (
+            "real pricing lookup for KITAS returned no results — "
+            "the contract test needs a matching query"
+        )
+        sanitized = wpb_module._sanitize_pricing_block(raw)
+        assert sanitized is not None, "sanitizer dropped a REAL 2026 pricing match"
+        assert set(sanitized.keys()) == {"search_query", "results"}
+        rendered = str(sanitized)
+        assert "contact_info" not in rendered
+        assert "wa.me" not in rendered
+        assert "_sub_block" not in rendered
+        for category_value in sanitized["results"].values():
+            entries = (
+                category_value.values() if isinstance(category_value, dict) else category_value
+            )
+            for entry in entries:
+                assert set(entry.keys()) <= set(wpb_module._PRICING_ENTRY_FIELDS)
+
+
+# ============================================================================
+# 4bis. Greeting word-boundary (Codex S2 re-verdict, major — scar family #3)
+# ============================================================================
+
+
+class TestGreetingWordBoundary:
+    """`_GREETING_KEYWORDS` are short ordinary-language tokens; bare substring
+    scoring turned "Which visa options are available?" into GREETING via the
+    "hi" inside "which" — and GREETING is the one verdict that zeroes the
+    collection list, so this PR's route would have sent real visa questions
+    to the Gemini leg as `unbuildable`. Guilt AND innocence, per the family
+    #3 antidote: no guard ships without both.
+    """
+
+    async def test_real_questions_containing_hi_substrings_build_packages(self) -> None:
+        for query in ("Which visa options are available?", "What is this visa?"):
+            package = await build_context_package(
+                query=query,
+                history=[],
+                thread_epoch=0,
+                retriever=_visa_retriever(),
+            )
+            assert isinstance(package, ContextPackage), f"{query!r} was declared unbuildable"
+
+    async def test_actual_greetings_still_gate(self) -> None:
+        for query in ("hi", "hey", "ciao!", "thank you", "hi there"):
+            with pytest.raises(PackageUnbuildable):
+                await build_context_package(
+                    query=query,
+                    history=[],
+                    thread_epoch=0,
+                    retriever=FakeRetriever(),
+                )
 
 
 # ============================================================================


### PR DESCRIPTION
## What

BOT-V4 S2 PR-4 of 6 (spec: `research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md`, #4333 — section 2.2 "deterministic package builder").

- **D1 — `backend/services/rag/agentic/wa_package_builder.py`**: builds the frozen `ContextPackage` for one WA codex-route turn. **Zero LLM invocations** — the spec's named acceptance criterion — proven two independent ways in the test file: runtime tripwires monkeypatching all five known LLM entry points to explode during a full build, and an AST scan asserting the module carries no `backend.llm` import. Payload is a literal 7-key allowlist (`history`, `chunks`, `pricing_block`, `persona_digest`, `evidence_inputs`, `thread_epoch`, `package_hash`); each chunk carries exactly `collection`/`text`/`score` (retriever extras dropped by construction). Caps declared and logged (`MAX_CHUNKS=8`, `MAX_CHUNK_CHARS=4000` — W97, no silent caps). `evidence_inputs` frozen from the `_abstain_policy` SSOT (label_threshold + label_abstains), never literals. GREETING / no-collections → `PackageUnbuildable` → the worker routes that row to the Gemini leg.
- **D2 — `POST /api/wa-package/build`** (RAG process group, internal-only): deliberately NOT added to `PUBLIC_ENDPOINTS`, so the fail-closed `HybridAuthMiddleware` covers it; no new auth scheme. Unbuildable is an HTTP-200 route decision (`{"unbuildable": reason}`), not a 500.
- **D3 — `OrchestratorCore.curated_qa_grounding_block`**: behavior-neutral public passthrough to `_inject_curated_qa_grounding`, so the builder reuses the SAME domain-gated, staleness-gated curated_qa logic instead of a drifting copy.
- Router registered in manifest + `include_routers` + `include_heavy_routers`; both parity gates green.

## Verification (session final gate — full read + own runs)

- 88 tests green (builder suite + router suite + `test_router_manifest.py` + `test_manifest_registration_parity.py`), RC=0.
- Zero-LLM guard **mutation-verified**: injecting a `backend.llm` import turns the AST test red (RC=1); restored green.
- `ruff check` + `ruff format --check` clean on all 7 files.
- `docs_sync.py`: OK, no changes.
- Flag-OFF by design: nothing calls this endpoint yet — the worker broker-leg (PR-5) is its only intended consumer, behind `WA_PROVIDER=codex_broker` which stays OFF until the owner-gated cutover (S4).

## Adversarial review

Cross-family Codex review to follow on this diff (S2 gate: CI + cross-family diff review); disposition will be posted here before merge completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011C4qM1z1deVxKwqBgVUuW5