### PR TITLE
fix(auth): a service account is not a colleague

### DIFF
--- a/apps/backend-rag/backend/app/routers/admin_team_activity.py
+++ b/apps/backend-rag/backend/app/routers/admin_team_activity.py
@@ -14,6 +14,10 @@ from pydantic import BaseModel
 
 from backend.app.dependencies import get_current_user, get_database_pool
 from backend.app.utils.crm_utils import is_crm_admin
+from backend.app.utils.service_accounts import (
+    NON_HUMAN_ROLES_SQL,
+    non_human_roles_sql_array,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +103,7 @@ async def get_overview(
 
             # Team members count
             total_team = await conn.fetchval(
-                "SELECT COUNT(*) FROM team_members WHERE role NOT IN ('client')",
+                f"SELECT COUNT(*) FROM team_members WHERE role NOT IN ({NON_HUMAN_ROLES_SQL})",
             )
 
             # Active today (clocked in)
@@ -315,13 +319,13 @@ async def get_team_stats(
                     LEFT JOIN crm_stats cs ON tm.email = cs.email
                     LEFT JOIN email_stats es ON tm.email = es.email
                     LEFT JOIN kb_stats kb ON tm.email = kb.email
-                    WHERE tm.role NOT IN ('client')
+                    WHERE tm.role <> ALL($2::text[])
                       AND tm.email NOT LIKE '%test%'
                       AND tm.email NOT LIKE '%demo%'
                       AND tm.email NOT LIKE '%example%'
                     ORDER BY COALESCE(ms.messages, 0) DESC
                 """
-                rows = await conn.fetch(query, start_date_obj)
+                rows = await conn.fetch(query, start_date_obj, non_human_roles_sql_array())
                 period_info = f"from {start_date}"
             else:
                 query = """
@@ -383,13 +387,13 @@ async def get_team_stats(
                     LEFT JOIN crm_stats cs ON tm.email = cs.email
                     LEFT JOIN email_stats es ON tm.email = es.email
                     LEFT JOIN kb_stats kb ON tm.email = kb.email
-                    WHERE tm.role NOT IN ('client')
+                    WHERE tm.role <> ALL($2::text[])
                       AND tm.email NOT LIKE '%test%'
                       AND tm.email NOT LIKE '%demo%'
                       AND tm.email NOT LIKE '%example%'
                     ORDER BY COALESCE(ms.messages, 0) DESC
                 """
-                rows = await conn.fetch(query, days)
+                rows = await conn.fetch(query, days, non_human_roles_sql_array())
                 period_info = f"last {days} days"
 
         return {

--- a/apps/backend-rag/backend/app/routers/auth.py
+++ b/apps/backend-rag/backend/app/routers/auth.py
@@ -19,6 +19,7 @@ from backend.app.dependencies import get_database_pool
 from backend.app.models import UserProfile
 from backend.app.utils.cookie_auth import clear_auth_cookies, get_jwt_from_cookie, set_auth_cookies
 from backend.app.utils.logging_utils import get_logger, log_error, log_warning
+from backend.app.utils.service_accounts import is_human_team_member
 from backend.services.common.background import spawn
 from backend.services.pii.violation_store import hash_subject
 
@@ -231,9 +232,6 @@ async def get_current_user(
 # PANOPTICON: Auto Clock-In
 # ============================================================================
 
-_CLIENT_ROLES = frozenset({"client"})
-
-
 async def _auto_clockin_if_needed(
     pool: asyncpg.Pool,
     user_id: str,
@@ -241,7 +239,11 @@ async def _auto_clockin_if_needed(
     role: str,
 ) -> bool:
     """Auto-clock-in team member on first login of the day. Never raises."""
-    if role in _CLIENT_ROLES or not email.endswith("@balizero.com"):
+    # Clients were already excluded here; service accounts are excluded for the
+    # same reason and were not, because they had no role of their own. The
+    # login-healthcheck probe signs in every 5 minutes on a @balizero.com
+    # address, so the email guard below cannot see it — only the role can.
+    if not is_human_team_member(role) or not email.endswith("@balizero.com"):
         return False
     try:
         async with pool.acquire() as conn:

--- a/apps/backend-rag/backend/app/routers/team_members.py
+++ b/apps/backend-rag/backend/app/routers/team_members.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 
 from backend.app.dependencies import get_current_user, get_database_pool
+from backend.app.utils.service_accounts import NON_HUMAN_ROLES_SQL
 
 router = APIRouter(prefix="/api/team", tags=["team"])
 
@@ -18,11 +19,14 @@ async def list_team_members(
 ) -> dict[str, Any]:
     """List active team members. Used by CRM dropdowns for assignment."""
     async with pool.acquire() as conn:
+        # Service accounts are excluded alongside clients: this list populates the
+        # CRM assignment dropdown, and a client must never be assignable to an
+        # unattended machine.
         rows = await conn.fetch(
-            """
+            f"""
             SELECT email, full_name, role, avatar_url
             FROM team_members
-            WHERE active = true AND role != 'client'
+            WHERE active = true AND role NOT IN ({NON_HUMAN_ROLES_SQL})
             ORDER BY full_name
             """
         )

--- a/apps/backend-rag/backend/app/utils/service_accounts.py
+++ b/apps/backend-rag/backend/app/utils/service_accounts.py
@@ -1,0 +1,83 @@
+"""Which `team_members` rows are people, and which are machines.
+
+Several call sites partition "team" from "client" by testing the role against
+the literal string ``client``. That test answers *"is this not a client"*,
+which is not the same question as *"is this a person"*. A service account — an
+unattended probe, a bot — is neither. The two questions returned the same
+answer only for as long as no service account carried a non-client role.
+
+Anything that produces a human-facing artifact must exclude
+:data:`SERVICE_ROLES` as well as clients:
+
+* an attendance record (``team_timesheet``) — a probe must never clock in;
+* a headcount — a probe is not a colleague;
+* an assignment dropdown — a client must never be assignable to a machine.
+
+Checks that merely gate *access* are deliberately left alone: they ask "is this
+caller allowed here", and for those a service account genuinely is a
+non-client. See the module-level note in ``services/whatsapp_identity.py`` for
+one such case that is correct as written.
+
+This module imports nothing, so it cannot participate in an import cycle.
+"""
+
+from __future__ import annotations
+
+#: Roles whose holder is an end customer, reached through the client portal.
+CLIENT_ROLES = frozenset({"client"})
+
+#: Roles held by unattended machines that authenticate like team members.
+#: ``monitoring`` is the login-healthcheck probe, which authenticates against
+#: kita every 5 minutes to prove the operator door is open.
+SERVICE_ROLES = frozenset({"monitoring"})
+
+#: Everything that must be excluded from people-shaped artifacts.
+NON_HUMAN_ROLES = CLIENT_ROLES | SERVICE_ROLES
+
+
+def normalize_role(role: str | None) -> str:
+    """Return a role in the canonical form the comparisons below expect."""
+    return (role or "").strip().lower()
+
+
+def is_human_team_member(role: str | None) -> bool:
+    """True when the role belongs to a person on the team.
+
+    Neither clients nor service accounts qualify.
+    """
+    return normalize_role(role) not in NON_HUMAN_ROLES
+
+
+def non_human_roles_sql_array() -> list[str]:
+    """The exclusion set as a sorted list, for ``role <> ALL($n::text[])``.
+
+    Sorted so a query plan and a test assertion both see a stable order.
+    """
+    return sorted(NON_HUMAN_ROLES)
+
+
+def _sql_literal_list(roles: frozenset[str]) -> str:
+    """Render roles as a SQL ``IN`` list, refusing anything not a bare token.
+
+    These roles are compile-time constants declared in this module, never user
+    input, so interpolating them carries no injection risk — but a future
+    contributor could add a role with a quote in it, so the guard is asserted
+    rather than assumed.
+
+    Two mechanisms exist because the call sites differ: this literal serves the
+    queries that take no positional parameters, while
+    :func:`non_human_roles_sql_array` serves the ones that already do, where a
+    bind parameter is both idiomatic and avoids turning a multi-CTE query
+    containing braces into an f-string.
+    """
+    for role in roles:
+        if not role or not all(ch.isalpha() or ch == "_" for ch in role):
+            raise ValueError(
+                f"role {role!r} is not a bare token and cannot be inlined into SQL; "
+                "use a bind parameter for it instead"
+            )
+    return ", ".join(f"'{role}'" for role in sorted(roles))
+
+
+#: Ready-to-interpolate SQL fragment: ``WHERE role NOT IN (NON_HUMAN_ROLES_SQL)``.
+NON_HUMAN_ROLES_SQL = _sql_literal_list(NON_HUMAN_ROLES)

--- a/apps/backend-rag/backend/tests/unit/routers/test_auth_auto_clockin.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_auth_auto_clockin.py
@@ -116,6 +116,51 @@ class TestAutoClockInIfNeeded:
         conn.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_auto_clockin_skips_service_accounts(self) -> None:
+        """A service account is not a person — an unattended probe never clocks in.
+
+        The login-healthcheck probe authenticates against kita every 5 minutes on
+        a @balizero.com address, so the email guard below does not catch it: only
+        the role does. Without this, the probe files one attendance record per day,
+        forever, into the table that feeds HR.
+        """
+        from backend.app.routers.auth import _auto_clockin_if_needed
+
+        pool, conn = _make_pool(fetchval_result=0)
+
+        result = await _auto_clockin_if_needed(
+            pool=pool,
+            user_id="probe-001",
+            email="healthcheck@balizero.com",
+            role="monitoring",
+        )
+
+        assert result is False
+        conn.fetchval.assert_not_awaited()
+        conn.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_clockin_still_fires_for_a_real_team_role(self) -> None:
+        """Innocence: excluding service accounts must not exclude colleagues.
+
+        Guards the fix above against being written as "skip everything unusual".
+        'Tax Lead' is a real role held by real people in this system.
+        """
+        from backend.app.routers.auth import _auto_clockin_if_needed
+
+        pool, conn = _make_pool(fetchval_result=0)
+
+        result = await _auto_clockin_if_needed(
+            pool=pool,
+            user_id="user-777",
+            email="someone@balizero.com",
+            role="Tax Lead",
+        )
+
+        assert result is True
+        conn.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_auto_clockin_skips_non_balizero_email(self) -> None:
         """Non-@balizero.com emails (external accounts) are skipped."""
         from backend.app.routers.auth import _auto_clockin_if_needed

--- a/apps/backend-rag/backend/tests/unit/utils/test_service_accounts.py
+++ b/apps/backend-rag/backend/tests/unit/utils/test_service_accounts.py
@@ -1,0 +1,112 @@
+"""A service account is not a colleague — and every people-shaped query knows it.
+
+Guilt and innocence for `backend/app/utils/service_accounts.py`, plus a
+class-audit test: the point of the module is that the exclusion set lives in ONE
+place, so a test that only checked the helper would pass while a call site
+quietly kept its own hand-written `NOT IN ('client')`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from backend.app.utils.service_accounts import (
+    CLIENT_ROLES,
+    NON_HUMAN_ROLES,
+    NON_HUMAN_ROLES_SQL,
+    SERVICE_ROLES,
+    _sql_literal_list,
+    is_human_team_member,
+    non_human_roles_sql_array,
+)
+
+ROUTERS = Path(__file__).resolve().parents[3] / "app" / "routers"
+
+
+class TestIsHumanTeamMember:
+    @pytest.mark.parametrize("role", sorted(NON_HUMAN_ROLES))
+    def test_clients_and_service_accounts_are_not_people(self, role: str) -> None:
+        assert is_human_team_member(role) is False
+
+    @pytest.mark.parametrize(
+        "role",
+        ["Tax Lead", "admin", "Founder", "Reception", "member", "Specialist Advisor"],
+    )
+    def test_real_roles_still_count_as_people(self, role: str) -> None:
+        """Innocence: this must not degenerate into 'exclude anything unfamiliar'.
+
+        Every role here is held by a real person in the live team_members table.
+        """
+        assert is_human_team_member(role) is True
+
+    def test_role_matching_ignores_case_and_padding(self) -> None:
+        assert is_human_team_member("  MONITORING  ") is False
+        assert is_human_team_member("Client") is False
+
+    def test_the_two_sets_are_disjoint(self) -> None:
+        assert not (CLIENT_ROLES & SERVICE_ROLES)
+        assert NON_HUMAN_ROLES == CLIENT_ROLES | SERVICE_ROLES
+
+
+class TestSqlRendering:
+    def test_literal_is_sorted_and_quoted(self) -> None:
+        assert NON_HUMAN_ROLES_SQL == "'client', 'monitoring'"
+
+    def test_array_is_sorted(self) -> None:
+        assert non_human_roles_sql_array() == sorted(NON_HUMAN_ROLES)
+
+    def test_a_role_that_cannot_be_inlined_is_refused_not_escaped(self) -> None:
+        """The guard must raise rather than silently produce injectable SQL."""
+        with pytest.raises(ValueError, match="bare token"):
+            _sql_literal_list(frozenset({"we're not a token"}))
+
+    def test_rejects_a_role_carrying_a_sql_comment(self) -> None:
+        with pytest.raises(ValueError, match="bare token"):
+            _sql_literal_list(frozenset({"client'--"}))
+
+
+class TestNoCallSiteKeepsItsOwnCopy:
+    """Class-audit: the exclusion set must not be re-hardcoded anywhere.
+
+    This is the test that would have failed BEFORE the fix, when four routers
+    each carried their own `role NOT IN ('client')`. It is here so the fifth
+    call site cannot be added by hand.
+    """
+
+    HARDCODED = re.compile(
+        r"""role\s*(?:!=|<>)\s*'client'|role\s+NOT\s+IN\s*\(\s*'client'\s*\)""",
+        re.IGNORECASE,
+    )
+
+    def test_no_router_hardcodes_the_client_only_exclusion(self) -> None:
+        offenders: list[str] = []
+        for path in sorted(ROUTERS.glob("*.py")):
+            text = path.read_text(encoding="utf-8")
+            for match in self.HARDCODED.finditer(text):
+                line_no = text.count("\n", 0, match.start()) + 1
+                offenders.append(f"{path.name}:{line_no}: {match.group(0)}")
+
+        assert not offenders, (
+            "these queries partition team-vs-client by hand instead of using "
+            "service_accounts.NON_HUMAN_ROLES, so a service account would be "
+            "counted as a colleague:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_the_probe_finds_the_pattern_it_is_looking_for(self) -> None:
+        """Innocence for the probe itself: a regex that matches nothing proves nothing.
+
+        Without this, deleting the routers directory would make the test above
+        pass (W107 — the probe that measures its own poverty).
+        """
+        assert self.HARDCODED.search("WHERE role != 'client'")
+        assert self.HARDCODED.search("WHERE tm.role NOT IN ('client')")
+        assert not self.HARDCODED.search("WHERE role <> ALL($2::text[])")
+
+    def test_the_routers_directory_was_actually_scanned(self) -> None:
+        assert len(list(ROUTERS.glob("*.py"))) > 10, (
+            f"expected the routers package at {ROUTERS}, found almost nothing — "
+            "the audit above would pass vacuously"
+        )


### PR DESCRIPTION
## What

Several queries partition *team* from *client* by testing the role against the literal string `client`. That answers **"is this not a client"**, which is not the same question as **"is this a person"** — a service account is neither. The two questions returned the same answer only for as long as no service account carried a non-client role.

One is about to. The `login-healthcheck` probe (`~/scripts/login-healthcheck.sh`, launchd every 5 min) authenticates as `role=client`, which is why it has been answered `403` continuously since **2026-08-09** — `auth.py` has exactly one 403 path, and it is `role == "client" AND (not portal_access OR linked_client_id IS NULL)`. Moving it to a team role fixes the probe; done naively it also makes the robot a colleague.

## Why this change first

Measured against prod (read-only) before touching anything. With a non-client role and no other change, the probe would every day:

- **file an attendance record** into `team_timesheet` — the table behind the HR pages (`_auto_clockin_if_needed` skips clients, and the probe's `@balizero.com` address defeats the email guard, so only the role can stop it);
- **appear in the CRM assignment dropdown** (`/api/team/members`, comment: *"Used by CRM dropdowns for assignment"*) — where a real client could be assigned to an unattended machine;
- **inflate the headcount** and the two team-activity listings.

## How

`backend/app/utils/service_accounts.py` becomes the single place that knows which roles are not people. It imports nothing, so it cannot join an import cycle. The four call sites that produce human-facing artifacts read from it:

| Site | Was |
|---|---|
| `auth.py` `_auto_clockin_if_needed` | `role in _CLIENT_ROLES` |
| `team_members.py` roster | `role != 'client'` |
| `admin_team_activity.py` headcount | `NOT IN ('client')` |
| `admin_team_activity.py` ×2 activity listings | `tm.role NOT IN ('client')` |

Two rendering helpers exist because the sites differ: a validated SQL literal where the query takes no positional parameters, a bind array where it already does (one of those queries contains braces, so an f-string would break it). The literal builder **raises** on any role that is not a bare token rather than escaping it.

## Deliberately not changed

The sites that gate **access** rather than produce an artifact: `lkpm.py`, `portal.py`'s superuser branch, `services/whatsapp_identity.py`. There *"is this not a client"* is the right question, and `whatsapp_identity.py` carries a module note explaining why its own form is correct — read, not overwritten.

## Verification

- The new clock-in test was **red before the fix**: `assert True is False` — the probe does clock in today.
- `25 passed` — new corpus + clock-in suite.
- `1395 passed` — `backend/tests/unit/routers/` (1 pre-existing unrelated LangChain deprecation warning).
- Import chain: `from backend.app.dependencies import get_current_user` OK.
- Class-audit test asserts no router hand-rolls the exclusion again, and carries its own **innocence** check so it cannot pass vacuously (it also asserts the routers directory was really scanned — 158 files).

## Follow-up (not in this PR)

The role flip itself, probe hardening (it must exit non-zero when its own alarm channel is unarmed — all 61 alarms it raised died on `telegram: missing creds`), and promoting the script into the repo + `declared-pairs.json`, where the HOME-fork lint can finally see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)