### PR TITLE
feat(mouth): Second Home Studio — public fit-check wizard (Phase B)

### DIFF
--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -146,6 +146,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/visa/match",
     "/visa/clock",
     "/visa/second-home",
+    "/visa/second-home/studio",
     // `/visa/voa` shipped 2026-07-27 and was live-but-unreachable for a day:
     // no inbound link anywhere in the site AND absent here, so the only way
     // in was typing the URL. Result pages `/visa/voa/<hash>` stay out — they

--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -1,15 +1,16 @@
 "use client";
 
+import Link from "next/link";
 import { Phone } from "lucide-react";
 import { useTranslation } from "@/i18n";
 import { OFFERED_LOCALES } from "@/i18n/types";
 import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 import { ConsentBanner } from "@/components/visa/ConsentBanner";
 import { usePricingData } from "@/hooks/usePricingData";
-
-// Exact PricingTool SSOT identity (bali_zero_official_prices_2026.json).
-const E33_LIVE_PRICE_KEY = "E33 Second Home (5 Years)";
-const E33_LIVE_PRICE_CATEGORY = "kitas_permits";
+import {
+  E33_LIVE_PRICE_CATEGORY,
+  E33_LIVE_PRICE_KEY,
+} from "@/lib/secondhome-studio/pricing-key";
 
 /**
  * E33 Second Home Visa landing — Fit-Memo funnel (2026-07-24).
@@ -474,6 +475,60 @@ export function SecondHomeLanding() {
             </details>
           ))}
         </div>
+      </section>
+
+      {/* ── STUDIO CTA — self-serve fit-check, alternative to the WhatsApp
+          handoff below. English-only by design (the Studio itself is
+          EN-only per its frozen spec), so this section is not routed
+          through the locale dictionary like the rest of the page. ── */}
+      <section
+        style={{
+          ...cardStyle,
+          border: "1px solid var(--accent-funnel)",
+          gap: "var(--space-3, 1rem)",
+          textAlign: "center",
+          justifyItems: "center",
+          padding: "var(--space-5, 2rem)",
+        }}
+      >
+        <h2
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.4rem, 3.4vw, 1.9rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          Check your fit in 3 minutes
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            lineHeight: 1.6,
+            color: "var(--color-text-muted)",
+            maxWidth: "38rem",
+          }}
+        >
+          Free, anonymous, no email needed. Your answers stay on your device
+          until you choose to share them.
+        </p>
+        <Link
+          href="/visa/second-home/studio"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
+            borderRadius: 8,
+            border: "1px solid var(--accent-funnel)",
+            color: "var(--accent-funnel-text, var(--accent-funnel))",
+            fontWeight: 600,
+            textDecoration: "none",
+            minHeight: 44,
+          }}
+        >
+          Start the fit-check
+        </Link>
       </section>
 
       {/* ── CTA — the only action: free Fit Memo via WhatsApp handoff ── */}

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -5,6 +5,7 @@ import { usePricingData } from "@/hooks/usePricingData";
 import {
   emptyPlan,
   encodePlanFragment,
+  savePlan,
 } from "@/lib/secondhome-studio/plan-codec";
 import type { PlanState } from "@/lib/secondhome-studio/types";
 import { StudioApp } from "./StudioApp";
@@ -16,7 +17,11 @@ import { StudioApp } from "./StudioApp";
  * asked for: full happy path -> strong fit, 55-59 -> edge case + disclosure,
  * property -> edge case (never "strong match"), checklist toggle updates
  * the meter, fragment-load lands on verdict, malformed fragment -> first
- * question.
+ * question — plus the fix-mandate round-1 additions: P1-C6 (malformed
+ * fragment must not resurrect an old localStorage plan), P2-3 (focus moves
+ * to the new stage heading on step transitions), P2-4 (radiogroup/radio
+ * roles on single-select steps), P1-C9 (CustodyMap conditional on
+ * verdict.product).
  */
 
 vi.mock("@/hooks/usePricingData", () => ({
@@ -31,8 +36,17 @@ function mockPrice(price: string | null) {
   });
 }
 
+/** Single-select options render as role="radio" (P2-4); nav buttons and
+ *  the family step's multi-select toggles stay role="button". Try both so
+ *  every existing call site keeps working unchanged. */
 function clickButton(name: string) {
-  fireEvent.click(screen.getByRole("button", { name }));
+  const el =
+    screen.queryByRole("button", { name }) ??
+    screen.queryByRole("radio", { name });
+  if (!el) {
+    throw new Error(`No button or radio option found with name "${name}"`);
+  }
+  fireEvent.click(el);
 }
 
 function fullPlan(overrides: Partial<PlanState> = {}): PlanState {
@@ -179,6 +193,19 @@ describe("StudioApp", () => {
     });
   });
 
+  it("P1-C6: a malformed fragment does NOT resurrect an old localStorage plan — a PRESENT fragment always wins, even invalid", async () => {
+    savePlan(fullPlan()); // an old saved strong-fit-eligible plan
+    window.location.hash = "#p=thisisnotvalidjsononcedecoded";
+    render(<StudioApp />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /how old are you/i }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("heading", { name: /strong match/i })).toBeNull();
+  });
+
   it("renders no price block when usePricingData abstains (null)", async () => {
     mockPrice(null);
     window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
@@ -186,5 +213,156 @@ describe("StudioApp", () => {
 
     await screen.findByRole("heading", { name: /strong match/i });
     expect(screen.queryByText("Your all-inclusive figure")).toBeNull();
+  });
+
+  describe("P2-3 — focus moves to the new stage heading on step transitions", () => {
+    it("moves focus to the route heading after clicking Continue on the age step", async () => {
+      render(<StudioApp />);
+
+      clickButton("Under 55");
+      clickButton("Continue");
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(
+          screen.getByRole("heading", {
+            name: /which route are you considering/i,
+          }),
+        );
+      });
+    });
+
+    it("moves focus to the verdict heading after the final user-driven Continue click", async () => {
+      render(<StudioApp />);
+
+      clickButton("Under 55");
+      clickButton("Continue");
+      clickButton("Bank deposit");
+      clickButton("Continue");
+      clickButton("USD 130,000 is ready");
+      clickButton("Continue");
+      clickButton("Continue"); // family
+      clickButton("As soon as possible");
+      clickButton("Continue");
+      clickButton("In Indonesia");
+      clickButton("See your fit-check result");
+
+      await waitFor(() => {
+        expect(document.activeElement).toBe(
+          screen.getByRole("heading", { name: /strong match/i }),
+        );
+      });
+    });
+
+    it("does not steal focus on initial mount (first question heading is not auto-focused)", () => {
+      render(<StudioApp />);
+      const heading = screen.getByRole("heading", {
+        name: /how old are you/i,
+      });
+      expect(document.activeElement).not.toBe(heading);
+    });
+
+    it("does not steal focus on a hydration jump straight to the verdict page (a saved link is not a user click)", async () => {
+      window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+      render(<StudioApp />);
+      const heading = await screen.findByRole("heading", {
+        name: /strong match/i,
+      });
+      expect(document.activeElement).not.toBe(heading);
+    });
+  });
+
+  describe("P2-4 — single-select steps expose radiogroup/radio roles; family stays multi-select", () => {
+    it("the age step's options render as a radiogroup of radio buttons", () => {
+      render(<StudioApp />);
+      expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+      const radios = screen.getAllByRole("radio");
+      expect(radios).toHaveLength(3);
+      for (const radio of radios) {
+        expect(radio).toHaveAttribute("aria-checked");
+      }
+    });
+
+    it("selecting a radio option updates aria-checked", () => {
+      render(<StudioApp />);
+      clickButton("Under 55");
+      expect(screen.getByRole("radio", { name: "Under 55" })).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+      expect(screen.getByRole("radio", { name: "55–59" })).toHaveAttribute(
+        "aria-checked",
+        "false",
+      );
+    });
+
+    it("the family step (multi-select) has no radiogroup and uses aria-pressed toggle buttons", async () => {
+      render(<StudioApp />);
+      clickButton("Under 55");
+      clickButton("Continue");
+      clickButton("Bank deposit");
+      clickButton("Continue");
+      clickButton("USD 130,000 is ready");
+      clickButton("Continue");
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /who would you want/i }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("radiogroup")).toBeNull();
+      expect(screen.queryByRole("radio")).toBeNull();
+      const spouse = screen.getByRole("button", { name: "Spouse" });
+      expect(spouse).toHaveAttribute("aria-pressed", "false");
+      fireEvent.click(spouse);
+      expect(spouse).toHaveAttribute("aria-pressed", "true");
+    });
+  });
+
+  describe("P1-C9 — CustodyMap renders only for deposit-holding verdicts (E33/E33E)", () => {
+    it("under_55 deposit strong_fit (E33): CustodyMap renders", async () => {
+      window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+      render(<StudioApp />);
+      await screen.findByRole("heading", { name: /strong match/i });
+      expect(screen.getByText("Your money stays yours")).toBeInTheDocument();
+    });
+
+    it("60_plus income-only strong_fit (E33F): CustodyMap does NOT render", async () => {
+      window.location.hash = `#p=${encodePlanFragment(
+        fullPlan({
+          age: "60_plus",
+          capital: null,
+          seniorFunding: "income_only_3k",
+        }),
+      )}`;
+      render(<StudioApp />);
+      await screen.findByRole("heading", { name: /strong match/i });
+      expect(screen.queryByText("Your money stays yours")).toBeNull();
+    });
+
+    it("property route edge_case (no product): CustodyMap does NOT render", async () => {
+      window.location.hash = `#p=${encodePlanFragment(
+        fullPlan({
+          route: "property",
+          capital: null,
+          property: "none",
+        }),
+      )}`;
+      render(<StudioApp />);
+      await screen.findByRole("heading", { name: /needs human review/i });
+      expect(screen.queryByText("Your money stays yours")).toBeNull();
+    });
+
+    it("60_plus deposit strong_fit (E33E): CustodyMap renders", async () => {
+      window.location.hash = `#p=${encodePlanFragment(
+        fullPlan({
+          age: "60_plus",
+          capital: null,
+          seniorFunding: "deposit_50k_income",
+        }),
+      )}`;
+      render(<StudioApp />);
+      await screen.findByRole("heading", { name: /strong match/i });
+      expect(screen.getByText("Your money stays yours")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -1,0 +1,190 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import { usePricingData } from "@/hooks/usePricingData";
+import {
+  emptyPlan,
+  encodePlanFragment,
+} from "@/lib/secondhome-studio/plan-codec";
+import type { PlanState } from "@/lib/secondhome-studio/types";
+import { StudioApp } from "./StudioApp";
+
+/**
+ * Second Home Studio — wizard + verdict-page smoke tests (spec §7.1-ish for
+ * the UI layer; the lib's own __tests__/ pin the decision table/codec/copy
+ * sweep independently). Covers, at minimum, the scenarios the conductor
+ * asked for: full happy path -> strong fit, 55-59 -> edge case + disclosure,
+ * property -> edge case (never "strong match"), checklist toggle updates
+ * the meter, fragment-load lands on verdict, malformed fragment -> first
+ * question.
+ */
+
+vi.mock("@/hooks/usePricingData", () => ({
+  usePricingData: vi.fn(),
+}));
+
+function mockPrice(price: string | null) {
+  vi.mocked(usePricingData).mockReturnValue({
+    price,
+    isLoading: false,
+    isError: false,
+  });
+}
+
+function clickButton(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+function fullPlan(overrides: Partial<PlanState> = {}): PlanState {
+  return {
+    ...emptyPlan(),
+    age: "under_55",
+    route: "deposit",
+    capital: "ready_130k",
+    family: { spouse: false, children: 0, parents: 0 },
+    horizon: "asap",
+    location: "in_indonesia",
+    ...overrides,
+  };
+}
+
+describe("StudioApp", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.location.hash = "";
+    mockPrice("IDR 35,000,000");
+  });
+
+  afterEach(() => {
+    window.location.hash = "";
+  });
+
+  it("full happy path (under_55 + deposit + ready_130k) renders a strong-fit verdict with the Imigrasi sentence", async () => {
+    render(<StudioApp />);
+
+    expect(
+      screen.getByRole("heading", { name: /how old are you/i }),
+    ).toBeInTheDocument();
+
+    clickButton("Under 55");
+    clickButton("Continue");
+
+    clickButton("Bank deposit");
+    clickButton("Continue");
+
+    clickButton("USD 130,000 is ready");
+    clickButton("Continue");
+
+    // Family: no selections, just proceed.
+    clickButton("Continue");
+
+    clickButton("As soon as possible");
+    clickButton("Continue");
+
+    clickButton("In Indonesia");
+    clickButton("See your fit-check result");
+
+    expect(
+      await screen.findByRole("heading", { name: /strong match/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/rests with Imigrasi/)).toBeInTheDocument();
+  });
+
+  it("55-59 path always lands on an edge-case verdict with the age disclosure note", async () => {
+    render(<StudioApp />);
+
+    clickButton("55–59");
+    clickButton("Continue");
+
+    clickButton("Bank deposit");
+    clickButton("Continue");
+
+    clickButton("USD 50,000 deposit plus USD 3,000 monthly income");
+    clickButton("Continue");
+
+    clickButton("Continue"); // family
+    clickButton("This quarter");
+    clickButton("Continue");
+    clickButton("Outside Indonesia");
+    clickButton("See your fit-check result");
+
+    expect(
+      await screen.findByRole("heading", { name: /needs human review/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Indonesian regulation states this age threshold differently/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /strong match/i })).toBeNull();
+  });
+
+  it("property route always lands on edge-case — 'strong match' never appears", async () => {
+    render(<StudioApp />);
+
+    clickButton("Under 55");
+    clickButton("Continue");
+
+    clickButton("Completed strata-title property");
+    clickButton("Continue");
+
+    clickButton("I do not have a property route");
+    clickButton("Continue");
+
+    clickButton("Continue"); // family
+    clickButton("I am still exploring");
+    clickButton("Continue");
+    clickButton("In Indonesia");
+    clickButton("See your fit-check result");
+
+    expect(
+      await screen.findByRole("heading", { name: /needs human review/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/strong match/i)).toBeNull();
+  });
+
+  it("checklist toggle updates the readiness meter", async () => {
+    window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+    render(<StudioApp />);
+
+    expect(await screen.findByText(/0 of 10 prepared/)).toBeInTheDocument();
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(10);
+    fireEvent.click(checkboxes[0]);
+
+    expect(await screen.findByText(/1 of 10 prepared/)).toBeInTheDocument();
+  });
+
+  it("a crafted valid #p= fragment lands directly on the verdict page", async () => {
+    window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+    render(<StudioApp />);
+
+    expect(
+      await screen.findByRole("heading", { name: /strong match/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /how old are you/i }),
+    ).toBeNull();
+  });
+
+  it("a malformed fragment falls back to a fresh plan on the first question", async () => {
+    window.location.hash = "#p=thisisnotvalidjsononcedecoded";
+    render(<StudioApp />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /how old are you/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders no price block when usePricingData abstains (null)", async () => {
+    mockPrice(null);
+    window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;
+    render(<StudioApp />);
+
+    await screen.findByRole("heading", { name: /strong match/i });
+    expect(screen.queryByText("Your all-inclusive figure")).toBeNull();
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type Ref } from "react";
 import { ConsentBanner } from "@/components/visa/ConsentBanner";
 import { usePricingData } from "@/hooks/usePricingData";
 import { getCopy } from "@/lib/secondhome-studio/copy";
 import { evaluatePlan } from "@/lib/secondhome-studio/rules";
+import {
+  computeSequence,
+  type QuestionId,
+} from "@/lib/secondhome-studio/sequence";
 import {
   E33_LIVE_PRICE_CATEGORY,
   E33_LIVE_PRICE_KEY,
@@ -43,56 +47,14 @@ import { SavePlanBar } from "./components/SavePlanBar";
  *
  * Question order: age -> route -> [deposit/unsure? capital] ->
  * [55+? seniorFunding] -> [property? property] -> family -> horizon ->
- * location -> VERDICT. The sequence is recomputed from the CURRENT plan on
- * every render (never cached against a stale branch), so answering an
- * earlier question (e.g. switching route from deposit to property, or
- * seniorFunding from "neither" to "income_only_3k") immediately changes
- * what the NEXT step is — no dangling questions from an abandoned branch.
+ * location -> VERDICT. The sequence (computeSequence, hoisted to
+ * `lib/secondhome-studio/sequence.ts` — P2-6) is recomputed from the
+ * CURRENT plan on every render (never cached against a stale branch), so
+ * answering an earlier question (e.g. switching route from deposit to
+ * property, or seniorFunding from "neither" to "income_only_3k")
+ * immediately changes what the NEXT step is — no dangling questions from
+ * an abandoned branch.
  */
-
-type QuestionId =
-  | "age"
-  | "route"
-  | "capital"
-  | "seniorFunding"
-  | "property"
-  | "family"
-  | "horizon"
-  | "location";
-
-function computeSequence(p: PlanState): QuestionId[] {
-  const seq: QuestionId[] = ["age", "route"];
-
-  if (p.route === "property") {
-    seq.push("property");
-  } else if (p.age === "55_59") {
-    // Row 5 (rules.ts): 55-59 is always edge_case from seniorFunding alone
-    // — capital is never consulted for this age band.
-    seq.push("seniorFunding");
-  } else if (p.age === "60_plus") {
-    seq.push("seniorFunding");
-    // Row 6 fallthrough: only "neither"/"not_applicable" (or not yet
-    // answered) reaches the base deposit rows, so only THEN is capital
-    // needed. Once seniorFunding matches a senior product, capital is
-    // skipped entirely — this branch re-evaluates every render, so the
-    // skip takes effect the moment seniorFunding resolves.
-    if (
-      p.seniorFunding === null ||
-      p.seniorFunding === "neither" ||
-      p.seniorFunding === "not_applicable"
-    ) {
-      seq.push("capital");
-    }
-  } else {
-    // under_55 (or age not yet known — capital is the conservative
-    // default until age resolves; by the time we actually reach this
-    // position in the sequence, age is always answered for real).
-    seq.push("capital");
-  }
-
-  seq.push("family", "horizon", "location");
-  return seq;
-}
 
 /** "family" has no null representation in PlanState (default is a real,
  *  valid "no family members" answer) — treated as always-answered so
@@ -221,6 +183,9 @@ interface QuestionStageProps {
   onBack: () => void;
   onContinue: () => void;
   canGoBack: boolean;
+  /** Forwarded to QuestionCard's stage heading so StudioApp can move focus
+   *  to it on step transitions (P2-3). */
+  headingRef: Ref<HTMLHeadingElement>;
 }
 
 function QuestionStage({
@@ -230,6 +195,7 @@ function QuestionStage({
   onBack,
   onContinue,
   canGoBack,
+  headingRef,
 }: QuestionStageProps) {
   const nav = (
     <NavRow
@@ -252,15 +218,17 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
-        >
-          {options.map((opt) => (
+          headingRef={headingRef}
+          options={options.map((opt) => (
             <OptionButton
               key={opt}
+              variant="radio"
               label={getCopy(`${base}.options.${opt}`)}
               selected={plan.age === opt}
               onSelect={() => onSelect({ age: opt })}
             />
           ))}
+        >
           {nav}
         </QuestionCard>
       );
@@ -273,15 +241,17 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
-        >
-          {options.map((opt) => (
+          headingRef={headingRef}
+          options={options.map((opt) => (
             <OptionButton
               key={opt}
+              variant="radio"
               label={getCopy(`${base}.options.${opt}`)}
               selected={plan.route === opt}
               onSelect={() => onSelect({ route: opt })}
             />
           ))}
+        >
           {nav}
         </QuestionCard>
       );
@@ -298,15 +268,17 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
-        >
-          {options.map((opt) => (
+          headingRef={headingRef}
+          options={options.map((opt) => (
             <OptionButton
               key={opt}
+              variant="radio"
               label={getCopy(`${base}.options.${opt}`)}
               selected={plan.capital === opt}
               onSelect={() => onSelect({ capital: opt })}
             />
           ))}
+        >
           {nav}
         </QuestionCard>
       );
@@ -325,15 +297,17 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
-        >
-          {options.map((opt) => (
+          headingRef={headingRef}
+          options={options.map((opt) => (
             <OptionButton
               key={opt}
+              variant="radio"
               label={getCopy(`${base}.options.${opt}`)}
               selected={plan.seniorFunding === opt}
               onSelect={() => onSelect({ seniorFunding: opt })}
             />
           ))}
+        >
           {nav}
         </QuestionCard>
       );
@@ -351,15 +325,17 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
-        >
-          {options.map((opt) => (
+          headingRef={headingRef}
+          options={options.map((opt) => (
             <OptionButton
               key={opt}
+              variant="radio"
               label={getCopy(`${base}.options.${opt}`)}
               selected={plan.property === opt}
               onSelect={() => onSelect({ property: opt })}
             />
           ))}
+        >
           {nav}
         </QuestionCard>
       );
@@ -375,7 +351,11 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
+          headingRef={headingRef}
         >
+          {/* Multi-select (P2-4): stays a plain group of toggle buttons —
+             aria-pressed, no radiogroup/radio roles — since this is the
+             only step where more than one option can be true at once. */}
           <OptionButton
             label={getCopy(`${base}.options.spouse`)}
             selected={plan.family.spouse}
@@ -437,15 +417,17 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
-        >
-          {options.map((opt) => (
+          headingRef={headingRef}
+          options={options.map((opt) => (
             <OptionButton
               key={opt}
+              variant="radio"
               label={getCopy(`${base}.options.${opt}`)}
               selected={plan.horizon === opt}
               onSelect={() => onSelect({ horizon: opt })}
             />
           ))}
+        >
           {nav}
         </QuestionCard>
       );
@@ -458,15 +440,17 @@ function QuestionStage({
           heading={getCopy(`${base}.heading`)}
           body={getCopy(`${base}.body`)}
           why={getCopy(`${base}.why`)}
-        >
-          {options.map((opt) => (
+          headingRef={headingRef}
+          options={options.map((opt) => (
             <OptionButton
               key={opt}
+              variant="radio"
               label={getCopy(`${base}.options.${opt}`)}
               selected={plan.location === opt}
               onSelect={() => onSelect({ location: opt })}
             />
           ))}
+        >
           {nav}
         </QuestionCard>
       );
@@ -482,10 +466,27 @@ export function StudioApp() {
   const hydratedOnce = useRef(false);
   const { price } = usePricingData(E33_LIVE_PRICE_KEY, E33_LIVE_PRICE_CATEGORY);
 
-  // Client-only hydration: URL fragment wins over localStorage; a
-  // malformed/absent fragment falls back to loadPlan(), which itself falls
-  // back to a fresh plan. Runs once — SSR/first client render both use the
-  // fresh-plan default so there is no hydration mismatch.
+  // P2-3: the stage heading (QuestionCard's <h2> or VerdictPanel's <h1> —
+  // only one is ever mounted at a time) is focused on a user-driven step
+  // transition. `userNavigatedRef` gates it so neither the initial mount
+  // NOR the hydration jump below (which can land straight on the verdict
+  // page from a saved link) steals focus on page load — only an explicit
+  // Continue/Back click does.
+  const stageHeadingRef = useRef<HTMLHeadingElement>(null);
+  const userNavigatedRef = useRef(false);
+
+  useEffect(() => {
+    if (!userNavigatedRef.current) return;
+    stageHeadingRef.current?.focus();
+  }, [stepIndex]);
+
+  // Client-only hydration: a PRESENT URL fragment always wins over
+  // localStorage — even when it fails to decode (P1-C6): a
+  // malformed/invalid fragment must resolve to a FRESH plan, never
+  // silently fall back to an old saved plan (which could show a stale
+  // verdict the URL never asked for). localStorage is consulted ONLY when
+  // there is no fragment at all. Runs once — SSR/first client render both
+  // use the fresh-plan default so there is no hydration mismatch.
   useEffect(() => {
     if (hydratedOnce.current) return;
     hydratedOnce.current = true;
@@ -495,13 +496,10 @@ export function StudioApp() {
       ? window.location.hash.slice(1)
       : window.location.hash;
 
-    let resolved: PlanState | null = null;
-    if (rawHash.startsWith("p=")) {
-      resolved = decodePlanFragment(rawHash.slice(2));
-    }
-    if (resolved === null) {
-      resolved = loadPlan();
-    }
+    const hasFragment = rawHash.startsWith("p=");
+    const resolved = hasFragment
+      ? decodePlanFragment(rawHash.slice(2))
+      : loadPlan();
 
     const finalPlan = resolved ?? emptyPlan();
     setPlan(finalPlan);
@@ -517,10 +515,12 @@ export function StudioApp() {
   }
 
   function continueStep() {
+    userNavigatedRef.current = true;
     setStepIndex((idx) => Math.min(idx + 1, computeSequence(plan).length));
   }
 
   function goBack() {
+    userNavigatedRef.current = true;
     setStepIndex((idx) => Math.max(0, idx - 1));
   }
 
@@ -540,6 +540,11 @@ export function StudioApp() {
   const isVerdictStage = stepIndex >= sequence.length;
   const currentQuestion = isVerdictStage ? null : sequence[stepIndex];
   const verdict = isVerdictStage ? evaluatePlan(plan) : null;
+  // P1-C9: CustodyMap only makes sense for deposit-holding routes — a
+  // property or E33F (income-only, no deposit) verdict never shows it.
+  const showCustodyMap =
+    verdict !== null &&
+    (verdict.product === "E33" || verdict.product === "E33E");
 
   return (
     <div
@@ -580,12 +585,14 @@ export function StudioApp() {
               ← Back to your answers
             </button>
           </div>
-          <VerdictPanel verdict={verdict} />
-          <CustodyMap />
+          <VerdictPanel verdict={verdict} headingRef={stageHeadingRef} />
+          {showCustodyMap ? <CustodyMap /> : null}
           <RouteComparator highlight={plan.route === "unsure"} />
           <TimelineView
             horizon={plan.horizon ?? "exploring"}
             location={plan.location ?? "in_indonesia"}
+            route={plan.route}
+            product={verdict.product}
           />
           <ReadinessChecklist plan={plan} onToggle={toggleChecklistItem} />
           {price ? (
@@ -654,6 +661,7 @@ export function StudioApp() {
               onBack={goBack}
               onContinue={continueStep}
               canGoBack={stepIndex > 0}
+              headingRef={stageHeadingRef}
             />
           </main>
           <aside>

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -1,0 +1,688 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ConsentBanner } from "@/components/visa/ConsentBanner";
+import { usePricingData } from "@/hooks/usePricingData";
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import { evaluatePlan } from "@/lib/secondhome-studio/rules";
+import {
+  E33_LIVE_PRICE_CATEGORY,
+  E33_LIVE_PRICE_KEY,
+} from "@/lib/secondhome-studio/pricing-key";
+import {
+  clearPlan,
+  decodePlanFragment,
+  emptyPlan,
+  loadPlan,
+  savePlan,
+} from "@/lib/secondhome-studio/plan-codec";
+import type {
+  AgeBand,
+  CapitalBand,
+  Location as LocationAnswer,
+  PlanState,
+  PropertyStatus,
+  RouteIntent,
+  SeniorFunding,
+  TimelineHorizon,
+} from "@/lib/secondhome-studio/types";
+
+import { MemoPreview } from "./components/MemoPreview";
+import { OptionButton, QuestionCard } from "./components/QuestionCard";
+import { ProgressRail } from "./components/ProgressRail";
+import { VerdictPanel } from "./components/VerdictPanel";
+import { CustodyMap } from "./components/CustodyMap";
+import { RouteComparator } from "./components/RouteComparator";
+import { TimelineView } from "./components/TimelineView";
+import { ReadinessChecklist } from "./components/ReadinessChecklist";
+import { WhatsAppHandoff } from "./components/WhatsAppHandoff";
+import { SavePlanBar } from "./components/SavePlanBar";
+
+/**
+ * Second Home Studio — the wizard state machine (spec §4).
+ *
+ * Question order: age -> route -> [deposit/unsure? capital] ->
+ * [55+? seniorFunding] -> [property? property] -> family -> horizon ->
+ * location -> VERDICT. The sequence is recomputed from the CURRENT plan on
+ * every render (never cached against a stale branch), so answering an
+ * earlier question (e.g. switching route from deposit to property, or
+ * seniorFunding from "neither" to "income_only_3k") immediately changes
+ * what the NEXT step is — no dangling questions from an abandoned branch.
+ */
+
+type QuestionId =
+  | "age"
+  | "route"
+  | "capital"
+  | "seniorFunding"
+  | "property"
+  | "family"
+  | "horizon"
+  | "location";
+
+function computeSequence(p: PlanState): QuestionId[] {
+  const seq: QuestionId[] = ["age", "route"];
+
+  if (p.route === "property") {
+    seq.push("property");
+  } else if (p.age === "55_59") {
+    // Row 5 (rules.ts): 55-59 is always edge_case from seniorFunding alone
+    // — capital is never consulted for this age band.
+    seq.push("seniorFunding");
+  } else if (p.age === "60_plus") {
+    seq.push("seniorFunding");
+    // Row 6 fallthrough: only "neither"/"not_applicable" (or not yet
+    // answered) reaches the base deposit rows, so only THEN is capital
+    // needed. Once seniorFunding matches a senior product, capital is
+    // skipped entirely — this branch re-evaluates every render, so the
+    // skip takes effect the moment seniorFunding resolves.
+    if (
+      p.seniorFunding === null ||
+      p.seniorFunding === "neither" ||
+      p.seniorFunding === "not_applicable"
+    ) {
+      seq.push("capital");
+    }
+  } else {
+    // under_55 (or age not yet known — capital is the conservative
+    // default until age resolves; by the time we actually reach this
+    // position in the sequence, age is always answered for real).
+    seq.push("capital");
+  }
+
+  seq.push("family", "horizon", "location");
+  return seq;
+}
+
+/** "family" has no null representation in PlanState (default is a real,
+ *  valid "no family members" answer) — treated as always-answered so
+ *  resume-from-load never gets stuck deciding whether it was visited.
+ *  Forward interactive navigation never consults this function — it's
+ *  index-based (see `continueStep`). */
+function isAnswered(p: PlanState, q: QuestionId): boolean {
+  switch (q) {
+    case "age":
+      return p.age !== null;
+    case "route":
+      return p.route !== null;
+    case "capital":
+      return p.capital !== null;
+    case "seniorFunding":
+      return p.seniorFunding !== null;
+    case "property":
+      return p.property !== null;
+    case "family":
+      return true;
+    case "horizon":
+      return p.horizon !== null;
+    case "location":
+      return p.location !== null;
+  }
+}
+
+function initialStepIndex(p: PlanState): number {
+  const seq = computeSequence(p);
+  const idx = seq.findIndex((q) => !isAnswered(p, q));
+  return idx === -1 ? seq.length : idx;
+}
+
+function canContinue(p: PlanState, q: QuestionId): boolean {
+  if (q === "family") return true;
+  return isAnswered(p, q);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+const eyebrowStyle: React.CSSProperties = {
+  fontSize: "0.62rem",
+  letterSpacing: "0.15em",
+  textTransform: "uppercase",
+  opacity: 0.5,
+  color: "var(--color-text-muted)",
+  margin: 0,
+};
+
+const navButtonStyle: React.CSSProperties = {
+  padding: "var(--space-2, 0.5rem) var(--space-4, 1.2rem)",
+  borderRadius: 8,
+  border: "1px solid var(--color-border-subtle)",
+  background: "transparent",
+  color: "var(--text-primary)",
+  cursor: "pointer",
+  minHeight: 44,
+};
+
+const primaryNavButtonStyle: React.CSSProperties = {
+  ...navButtonStyle,
+  marginLeft: "auto",
+  border: "none",
+  background: "var(--accent-funnel)",
+  color: "var(--text-on-accent, #fff)",
+  fontWeight: 600,
+};
+
+interface NavRowProps {
+  canGoBack: boolean;
+  canGoNext: boolean;
+  onBack: () => void;
+  onNext: () => void;
+  nextLabel?: string;
+}
+
+function NavRow({
+  canGoBack,
+  canGoNext,
+  onBack,
+  onNext,
+  nextLabel = "Continue",
+}: NavRowProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: "var(--space-3, 1rem)",
+        marginTop: "var(--space-2, 0.5rem)",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onBack}
+        disabled={!canGoBack}
+        style={{
+          ...navButtonStyle,
+          cursor: canGoBack ? "pointer" : "not-allowed",
+          opacity: canGoBack ? 1 : 0.5,
+        }}
+      >
+        Back
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={!canGoNext}
+        style={{
+          ...primaryNavButtonStyle,
+          cursor: canGoNext ? "pointer" : "not-allowed",
+          opacity: canGoNext ? 1 : 0.6,
+        }}
+      >
+        {nextLabel}
+      </button>
+    </div>
+  );
+}
+
+interface QuestionStageProps {
+  question: QuestionId;
+  plan: PlanState;
+  onSelect: (patch: Partial<PlanState>) => void;
+  onBack: () => void;
+  onContinue: () => void;
+  canGoBack: boolean;
+}
+
+function QuestionStage({
+  question,
+  plan,
+  onSelect,
+  onBack,
+  onContinue,
+  canGoBack,
+}: QuestionStageProps) {
+  const nav = (
+    <NavRow
+      canGoBack={canGoBack}
+      canGoNext={canContinue(plan, question)}
+      onBack={onBack}
+      onNext={onContinue}
+      nextLabel={
+        question === "location" ? "See your fit-check result" : "Continue"
+      }
+    />
+  );
+
+  switch (question) {
+    case "age": {
+      const base = "wizard.age";
+      const options: AgeBand[] = ["under_55", "55_59", "60_plus"];
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          {options.map((opt) => (
+            <OptionButton
+              key={opt}
+              label={getCopy(`${base}.options.${opt}`)}
+              selected={plan.age === opt}
+              onSelect={() => onSelect({ age: opt })}
+            />
+          ))}
+          {nav}
+        </QuestionCard>
+      );
+    }
+    case "route": {
+      const base = "wizard.route";
+      const options: RouteIntent[] = ["deposit", "property", "unsure"];
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          {options.map((opt) => (
+            <OptionButton
+              key={opt}
+              label={getCopy(`${base}.options.${opt}`)}
+              selected={plan.route === opt}
+              onSelect={() => onSelect({ route: opt })}
+            />
+          ))}
+          {nav}
+        </QuestionCard>
+      );
+    }
+    case "capital": {
+      const base = "wizard.capital";
+      const options: CapitalBand[] = [
+        "ready_130k",
+        "close_100k_130k",
+        "below_100k",
+      ];
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          {options.map((opt) => (
+            <OptionButton
+              key={opt}
+              label={getCopy(`${base}.options.${opt}`)}
+              selected={plan.capital === opt}
+              onSelect={() => onSelect({ capital: opt })}
+            />
+          ))}
+          {nav}
+        </QuestionCard>
+      );
+    }
+    case "seniorFunding": {
+      const base = "wizard.seniorFunding";
+      // "not_applicable" has no wizard button (copy.ts's own comment: it's
+      // a valid PlanState value but never offered as a choice here).
+      const options: SeniorFunding[] = [
+        "deposit_50k_income",
+        "income_only_3k",
+        "neither",
+      ];
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          {options.map((opt) => (
+            <OptionButton
+              key={opt}
+              label={getCopy(`${base}.options.${opt}`)}
+              selected={plan.seniorFunding === opt}
+              onSelect={() => onSelect({ seniorFunding: opt })}
+            />
+          ))}
+          {nav}
+        </QuestionCard>
+      );
+    }
+    case "property": {
+      const base = "wizard.property";
+      const options: PropertyStatus[] = [
+        "owns_qualifying_strata",
+        "buying_completed_strata",
+        "villa_land_leasehold",
+        "none",
+      ];
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          {options.map((opt) => (
+            <OptionButton
+              key={opt}
+              label={getCopy(`${base}.options.${opt}`)}
+              selected={plan.property === opt}
+              onSelect={() => onSelect({ property: opt })}
+            />
+          ))}
+          {nav}
+        </QuestionCard>
+      );
+    }
+    case "family": {
+      const base = "wizard.family";
+      const isNone =
+        !plan.family.spouse &&
+        plan.family.children === 0 &&
+        plan.family.parents === 0;
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          <OptionButton
+            label={getCopy(`${base}.options.spouse`)}
+            selected={plan.family.spouse}
+            onSelect={() =>
+              onSelect({
+                family: { ...plan.family, spouse: !plan.family.spouse },
+              })
+            }
+          />
+          <OptionButton
+            label={getCopy(`${base}.options.children`)}
+            selected={plan.family.children > 0}
+            onSelect={() =>
+              onSelect({
+                family: {
+                  ...plan.family,
+                  children: plan.family.children > 0 ? 0 : 1,
+                },
+              })
+            }
+          />
+          <OptionButton
+            label={getCopy(`${base}.options.parents`)}
+            selected={plan.family.parents > 0}
+            onSelect={() =>
+              onSelect({
+                family: {
+                  ...plan.family,
+                  parents: plan.family.parents > 0 ? 0 : 1,
+                },
+              })
+            }
+          />
+          <OptionButton
+            label={getCopy(`${base}.options.none`)}
+            selected={isNone}
+            onSelect={() =>
+              onSelect({ family: { spouse: false, children: 0, parents: 0 } })
+            }
+          />
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.85rem)",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            {getCopy(`${base}.dependentsNote`)}
+          </p>
+          {nav}
+        </QuestionCard>
+      );
+    }
+    case "horizon": {
+      const base = "wizard.horizon";
+      const options: TimelineHorizon[] = ["asap", "this_quarter", "exploring"];
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          {options.map((opt) => (
+            <OptionButton
+              key={opt}
+              label={getCopy(`${base}.options.${opt}`)}
+              selected={plan.horizon === opt}
+              onSelect={() => onSelect({ horizon: opt })}
+            />
+          ))}
+          {nav}
+        </QuestionCard>
+      );
+    }
+    case "location": {
+      const base = "wizard.location";
+      const options: LocationAnswer[] = ["in_indonesia", "abroad"];
+      return (
+        <QuestionCard
+          heading={getCopy(`${base}.heading`)}
+          body={getCopy(`${base}.body`)}
+          why={getCopy(`${base}.why`)}
+        >
+          {options.map((opt) => (
+            <OptionButton
+              key={opt}
+              label={getCopy(`${base}.options.${opt}`)}
+              selected={plan.location === opt}
+              onSelect={() => onSelect({ location: opt })}
+            />
+          ))}
+          {nav}
+        </QuestionCard>
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+export function StudioApp() {
+  const [plan, setPlan] = useState<PlanState>(emptyPlan);
+  const [stepIndex, setStepIndex] = useState(0);
+  const hydratedOnce = useRef(false);
+  const { price } = usePricingData(E33_LIVE_PRICE_KEY, E33_LIVE_PRICE_CATEGORY);
+
+  // Client-only hydration: URL fragment wins over localStorage; a
+  // malformed/absent fragment falls back to loadPlan(), which itself falls
+  // back to a fresh plan. Runs once — SSR/first client render both use the
+  // fresh-plan default so there is no hydration mismatch.
+  useEffect(() => {
+    if (hydratedOnce.current) return;
+    hydratedOnce.current = true;
+    if (typeof window === "undefined") return;
+
+    const rawHash = window.location.hash.startsWith("#")
+      ? window.location.hash.slice(1)
+      : window.location.hash;
+
+    let resolved: PlanState | null = null;
+    if (rawHash.startsWith("p=")) {
+      resolved = decodePlanFragment(rawHash.slice(2));
+    }
+    if (resolved === null) {
+      resolved = loadPlan();
+    }
+
+    const finalPlan = resolved ?? emptyPlan();
+    setPlan(finalPlan);
+    setStepIndex(initialStepIndex(finalPlan));
+  }, []);
+
+  function selectAnswer(patch: Partial<PlanState>) {
+    setPlan((prev) => {
+      const next: PlanState = { ...prev, ...patch, updatedAt: nowIso() };
+      savePlan(next);
+      return next;
+    });
+  }
+
+  function continueStep() {
+    setStepIndex((idx) => Math.min(idx + 1, computeSequence(plan).length));
+  }
+
+  function goBack() {
+    setStepIndex((idx) => Math.max(0, idx - 1));
+  }
+
+  function toggleChecklistItem(id: string) {
+    selectAnswer({
+      checklist: { ...plan.checklist, [id]: !plan.checklist[id] },
+    });
+  }
+
+  function handleClear() {
+    clearPlan();
+    setPlan(emptyPlan());
+    setStepIndex(0);
+  }
+
+  const sequence = computeSequence(plan);
+  const isVerdictStage = stepIndex >= sequence.length;
+  const currentQuestion = isVerdictStage ? null : sequence[stepIndex];
+  const verdict = isVerdictStage ? evaluatePlan(plan) : null;
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "var(--space-5, 2rem)",
+        maxWidth: "1120px",
+        margin: "0 auto",
+        padding: "var(--space-5, 2rem) var(--space-4, 1.5rem)",
+      }}
+    >
+      <header style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}>
+        <p style={eyebrowStyle}>Second Home Studio</p>
+        <h1
+          style={{
+            margin: 0,
+            fontFamily: "var(--font-serif, Georgia, serif)",
+            fontSize: "clamp(1.7rem, 4.5vw, 2.4rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          Check your fit
+        </h1>
+      </header>
+
+      {!isVerdictStage ? (
+        <ProgressRail step={stepIndex + 1} total={sequence.length} />
+      ) : null}
+
+      {isVerdictStage && verdict ? (
+        <div style={{ display: "grid", gap: "var(--space-4, 1.5rem)" }}>
+          <div>
+            <button
+              type="button"
+              onClick={goBack}
+              style={{ ...navButtonStyle, padding: "6px 14px" }}
+            >
+              ← Back to your answers
+            </button>
+          </div>
+          <VerdictPanel verdict={verdict} />
+          <CustodyMap />
+          <RouteComparator highlight={plan.route === "unsure"} />
+          <TimelineView
+            horizon={plan.horizon ?? "exploring"}
+            location={plan.location ?? "in_indonesia"}
+          />
+          <ReadinessChecklist plan={plan} onToggle={toggleChecklistItem} />
+          {price ? (
+            <section
+              style={{
+                display: "grid",
+                gap: "var(--space-1, 0.3rem)",
+                background: "var(--surface-raised)",
+                border: "1px solid var(--accent-funnel)",
+                borderRadius: 12,
+                padding: "var(--space-4, 1.5rem)",
+                textAlign: "center",
+                justifyItems: "center",
+              }}
+            >
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "0.7rem",
+                  letterSpacing: "0.15em",
+                  textTransform: "uppercase",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {getCopy("price.label")}
+              </p>
+              <div
+                style={{
+                  fontFamily: "var(--font-serif, Georgia, serif)",
+                  fontSize: "clamp(1.8rem, 4.5vw, 2.4rem)",
+                  color: "var(--accent-funnel-text, var(--accent-funnel))",
+                }}
+              >
+                {price}
+              </div>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--text-sm, 0.88rem)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {getCopy("price.note")}
+              </p>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--text-sm, 0.85rem)",
+                  color: "var(--color-text-muted)",
+                }}
+              >
+                {getCopy("price.dependentsNote")}
+              </p>
+            </section>
+          ) : null}
+          <WhatsAppHandoff plan={plan} verdict={verdict} />
+          <SavePlanBar plan={plan} onClear={handleClear} />
+        </div>
+      ) : currentQuestion ? (
+        <div className="bz-shs-layout">
+          <main>
+            <QuestionStage
+              question={currentQuestion}
+              plan={plan}
+              onSelect={selectAnswer}
+              onBack={goBack}
+              onContinue={continueStep}
+              canGoBack={stepIndex > 0}
+            />
+          </main>
+          <aside>
+            <MemoPreview plan={plan} />
+          </aside>
+        </div>
+      ) : null}
+
+      <ConsentBanner />
+
+      <style>{`
+        .bz-shs-layout {
+          display: grid;
+          gap: var(--space-4, 1.5rem);
+          grid-template-columns: 1fr;
+          align-items: start;
+        }
+        @media (min-width: 900px) {
+          .bz-shs-layout {
+            grid-template-columns: minmax(0, 1fr) 320px;
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .bz-shs-layout * {
+            transition: none !important;
+            animation: none !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { getCopy } from "@/lib/secondhome-studio/copy";
+
+const STEPS = ["step1", "step2", "step3"] as const;
+
+/** Static 3-step custody explainer (spec §5). No yield/return figures, no
+ *  LPS mention — copy.ts's own forbidden-claims sweep enforces this across
+ *  every string this component reads. */
+export function CustodyMap() {
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <p
+        style={{
+          margin: 0,
+          fontSize: "0.7rem",
+          letterSpacing: "0.15em",
+          textTransform: "uppercase",
+          opacity: 0.6,
+          color: "var(--color-text-muted)",
+        }}
+      >
+        Custody
+      </p>
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          color: "var(--text-primary)",
+        }}
+      >
+        {getCopy("custody.eyebrow")}
+      </h2>
+      <p style={{ margin: 0, lineHeight: 1.6, color: "var(--text-primary)" }}>
+        {getCopy("custody.intro")}
+      </p>
+      <ol
+        style={{
+          margin: 0,
+          padding: 0,
+          listStyle: "none",
+          display: "grid",
+          gap: "var(--space-3, 1rem)",
+        }}
+      >
+        {STEPS.map((step, i) => (
+          <li
+            key={step}
+            style={{ display: "grid", gap: "var(--space-1, 0.3rem)" }}
+          >
+            <div style={{ display: "flex", gap: "var(--space-2, 0.5rem)" }}>
+              <span
+                aria-hidden
+                style={{
+                  fontFamily: "var(--font-serif, Georgia, serif)",
+                  color: "var(--accent-funnel-text, var(--accent-funnel))",
+                }}
+              >
+                {i + 1}.
+              </span>
+              <strong style={{ color: "var(--text-primary)" }}>
+                {getCopy(`custody.steps.${step}.title`)}
+              </strong>
+            </div>
+            <p
+              style={{
+                margin: 0,
+                marginLeft: "1.3rem",
+                color: "var(--color-text-muted)",
+                lineHeight: 1.6,
+              }}
+            >
+              {getCopy(`custody.steps.${step}.body`)}
+            </p>
+          </li>
+        ))}
+      </ol>
+      <p
+        style={{
+          margin: 0,
+          fontSize: "var(--text-sm, 0.82rem)",
+          color: "var(--color-text-muted)",
+          fontStyle: "italic",
+        }}
+      >
+        {getCopy("custody.disclaimer")}
+      </p>
+    </section>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import type { PlanState } from "@/lib/secondhome-studio/types";
+
+export interface MemoPreviewProps {
+  plan: PlanState;
+}
+
+/** Resolves a wizard option's label from copy.ts. "not_applicable" is a
+ *  valid PlanState value (types.ts) with no wizard button / no copy entry
+ *  (copy.ts's own comment: not user-selectable) — guarded here so a
+ *  hand-edited fragment never surfaces a raw dot-path string. */
+function optionLabel(base: string, value: string | null): string {
+  if (value === null) return "—";
+  if (value === "not_applicable") return "Not applicable";
+  return getCopy(`${base}.options.${value}`);
+}
+
+function familySummary(plan: PlanState): string {
+  const parts: string[] = [];
+  if (plan.family.spouse) parts.push("Spouse");
+  if (plan.family.children > 0) parts.push("Children");
+  if (plan.family.parents > 0) parts.push("Parents");
+  return parts.length > 0 ? parts.join(", ") : "—";
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        gap: "var(--space-2, 0.5rem)",
+        fontSize: "var(--text-sm, 0.85rem)",
+      }}
+    >
+      <dt style={{ color: "var(--color-text-muted)" }}>{label}</dt>
+      <dd
+        style={{ margin: 0, color: "var(--text-primary)", textAlign: "right" }}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+/** Live-filling summary of the plan-in-progress. Desktop: static right
+ *  rail. Mobile: a native collapsible (spec §4 "collapsible on mobile") —
+ *  implemented as one <details> whose disclosure toggle is neutralised via
+ *  CSS at desktop widths rather than duplicating markup per breakpoint. */
+export function MemoPreview({ plan }: MemoPreviewProps) {
+  return (
+    <details
+      className="bz-shs-memo"
+      open
+      style={{
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-3, 1rem)",
+      }}
+    >
+      <summary
+        style={{
+          cursor: "pointer",
+          fontWeight: 600,
+          fontSize: "var(--text-sm, 0.88rem)",
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        Your plan so far
+      </summary>
+      <dl
+        style={{
+          display: "grid",
+          gap: "var(--space-2, 0.5rem)",
+          margin: "var(--space-2, 0.5rem) 0 0",
+        }}
+      >
+        <Row label="Age" value={optionLabel("wizard.age", plan.age)} />
+        <Row label="Route" value={optionLabel("wizard.route", plan.route)} />
+        {plan.route === "property" ? (
+          <Row
+            label="Property"
+            value={optionLabel("wizard.property", plan.property)}
+          />
+        ) : (
+          <Row
+            label="Capital"
+            value={optionLabel("wizard.capital", plan.capital)}
+          />
+        )}
+        {plan.age !== null && plan.age !== "under_55" ? (
+          <Row
+            label="Senior funding"
+            value={optionLabel("wizard.seniorFunding", plan.seniorFunding)}
+          />
+        ) : null}
+        <Row label="Family" value={familySummary(plan)} />
+        <Row
+          label="Timeline"
+          value={optionLabel("wizard.horizon", plan.horizon)}
+        />
+        <Row
+          label="Location"
+          value={optionLabel("wizard.location", plan.location)}
+        />
+      </dl>
+      <style>{`
+        @media (min-width: 900px) {
+          .bz-shs-memo > summary {
+            pointer-events: none;
+            list-style: none;
+          }
+          .bz-shs-memo > summary::-webkit-details-marker {
+            display: none;
+          }
+        }
+      `}</style>
+    </details>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/MemoPreview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { getCopy } from "@/lib/secondhome-studio/copy";
 import type { PlanState } from "@/lib/secondhome-studio/types";
 
@@ -45,11 +46,50 @@ function Row({ label, value }: { label: string; value: string }) {
   );
 }
 
+/** P2-5: on desktop the rail is a STATIC summary (the `.bz-shs-memo`
+ *  CSS below neutralises pointer-events on the toggle), but a native
+ *  `<summary>` remains keyboard-focusable and Enter/Space still fires the
+ *  browser's default toggle — so a keyboard/AT user could focus an
+ *  element with no visible affordance and have it silently collapse the
+ *  panel. Detects the same `(min-width: 900px)` breakpoint the CSS below
+ *  keys off, and when true removes the summary from the tab order
+ *  (`tabIndex={-1}`) and hides it from the accessibility tree
+ *  (`aria-hidden`) — mobile keeps the full native collapsible behavior
+ *  unchanged. Guarded against `window.matchMedia` being absent (jsdom by
+ *  default has no `matchMedia`) so this can never throw or change
+ *  behavior for any test that doesn't explicitly stub it — it silently
+ *  stays in the "mobile/interactive" default. */
+function useIsDesktopStatic(): boolean {
+  const [isDesktopStatic, setIsDesktopStatic] = useState(false);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+    const mq = window.matchMedia("(min-width: 900px)");
+    const update = () => setIsDesktopStatic(mq.matches);
+    update();
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", update);
+      return () => mq.removeEventListener("change", update);
+    }
+    return undefined;
+  }, []);
+
+  return isDesktopStatic;
+}
+
 /** Live-filling summary of the plan-in-progress. Desktop: static right
- *  rail. Mobile: a native collapsible (spec §4 "collapsible on mobile") —
+ *  rail (P2-5: non-interactive — no focusable/keyboard-togglable toggle).
+ *  Mobile: a native collapsible (spec §4 "collapsible on mobile") —
  *  implemented as one <details> whose disclosure toggle is neutralised via
  *  CSS at desktop widths rather than duplicating markup per breakpoint. */
 export function MemoPreview({ plan }: MemoPreviewProps) {
+  const isDesktopStatic = useIsDesktopStatic();
+
   return (
     <details
       className="bz-shs-memo"
@@ -62,6 +102,8 @@ export function MemoPreview({ plan }: MemoPreviewProps) {
       }}
     >
       <summary
+        tabIndex={isDesktopStatic ? -1 : undefined}
+        aria-hidden={isDesktopStatic ? true : undefined}
         style={{
           cursor: "pointer",
           fontWeight: 600,

--- a/apps/mouth/src/app/visa/second-home/studio/components/ProgressRail.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ProgressRail.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+export interface ProgressRailProps {
+  /** 1-indexed current step number. */
+  step: number;
+  /** Total step count for the CURRENT branch — adapts as answers narrow
+   *  down the wizard sequence (spec §4: "M adapts to branch"). */
+  total: number;
+}
+
+/** Hairline progress bar + "Step N of M" label. Pure/presentational —
+ *  StudioApp owns all step-sequencing logic. */
+export function ProgressRail({ step, total }: ProgressRailProps) {
+  const pct = total > 0 ? Math.min(100, Math.max(0, (step / total) * 100)) : 0;
+
+  return (
+    <div style={{ display: "grid", gap: "var(--space-1, 0.3rem)" }}>
+      <div
+        role="progressbar"
+        aria-valuenow={step}
+        aria-valuemin={1}
+        aria-valuemax={total}
+        style={{
+          height: 4,
+          borderRadius: 4,
+          background: "var(--color-border-subtle)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${pct}%`,
+            height: "100%",
+            background: "var(--accent-funnel)",
+            transition: "width 220ms ease-out",
+          }}
+        />
+      </div>
+      <p
+        style={{
+          margin: 0,
+          fontSize: "var(--text-xs, 0.72rem)",
+          letterSpacing: "0.1em",
+          textTransform: "uppercase",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        Step {step} of {total}
+      </p>
+      <style>{`
+        @media (prefers-reduced-motion: reduce) {
+          [role="progressbar"] > div { transition: none !important; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export interface QuestionCardProps {
+  heading: string;
+  body: string;
+  /** "Why we ask" aside body — collapsed by default, always keyboard
+   *  reachable via the native <details>/<summary> disclosure pattern. */
+  why: string;
+  children: ReactNode;
+}
+
+/** Chrome wrapper for one wizard screen: heading/body (from copy.ts),
+ *  a collapsible "Why we ask" aside, and a slot for the answer UI (option
+ *  cards, or a custom control set like the family step). */
+export function QuestionCard({
+  heading,
+  body,
+  why,
+  children,
+}: QuestionCardProps) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.25rem, 3vw, 1.6rem)",
+          color: "var(--text-primary)",
+        }}
+      >
+        {heading}
+      </h2>
+      <p style={{ margin: 0, lineHeight: 1.6, color: "var(--text-primary)" }}>
+        {body}
+      </p>
+      <details style={{ fontSize: "var(--text-sm, 0.88rem)" }}>
+        <summary
+          style={{
+            cursor: "pointer",
+            color: "var(--color-text-muted)",
+            fontWeight: 600,
+          }}
+        >
+          Why we ask
+        </summary>
+        <p
+          style={{
+            margin: "var(--space-2, 0.5rem) 0 0",
+            color: "var(--color-text-muted)",
+            lineHeight: 1.5,
+          }}
+        >
+          {why}
+        </p>
+      </details>
+      <div style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export interface OptionButtonProps {
+  label: string;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+/** Large, keyboard-focusable option card. Never strips the native focus
+ *  ring (accessibility — spec §0 "visible focus"). */
+export function OptionButton({ label, selected, onSelect }: OptionButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      style={{
+        padding: "var(--space-3, 0.85rem) var(--space-4, 1.1rem)",
+        borderRadius: 8,
+        border: selected
+          ? "2px solid var(--accent-funnel)"
+          : "1px solid var(--color-border-subtle)",
+        background: selected ? "var(--surface-base)" : "transparent",
+        color: "var(--text-primary)",
+        textAlign: "left",
+        cursor: "pointer",
+        minHeight: 44,
+        fontSize: "1rem",
+        fontFamily: "inherit",
+      }}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useId, type ReactNode, type Ref } from "react";
 
 export interface QuestionCardProps {
   heading: string;
@@ -8,18 +8,33 @@ export interface QuestionCardProps {
   /** "Why we ask" aside body — collapsed by default, always keyboard
    *  reachable via the native <details>/<summary> disclosure pattern. */
   why: string;
+  /** Single-select answer options (P2-4): rendered inside a
+   *  `role="radiogroup"` container, `aria-labelledby` the heading — pass
+   *  `<OptionButton variant="radio" .../>` elements. Omit for a
+   *  multi-select step (family) — those keep the plain toggle-button
+   *  markup via `children` instead. */
+  options?: ReactNode;
+  /** Forwarded to the stage `<h2>` so the caller can move focus to it on
+   *  step transitions (P2-3) — the heading carries `tabIndex={-1}` so a
+   *  non-interactive element can still be a programmatic focus target. */
+  headingRef?: Ref<HTMLHeadingElement>;
   children: ReactNode;
 }
 
 /** Chrome wrapper for one wizard screen: heading/body (from copy.ts),
- *  a collapsible "Why we ask" aside, and a slot for the answer UI (option
- *  cards, or a custom control set like the family step). */
+ *  a collapsible "Why we ask" aside, an optional radiogroup-wrapped
+ *  options slot, and a slot for anything else (option cards, a custom
+ *  control set like the family step, and/or the Back/Continue nav row). */
 export function QuestionCard({
   heading,
   body,
   why,
+  options,
+  headingRef,
   children,
 }: QuestionCardProps) {
+  const headingId = useId();
+
   return (
     <div
       style={{
@@ -32,6 +47,9 @@ export function QuestionCard({
       }}
     >
       <h2
+        id={headingId}
+        ref={headingRef}
+        tabIndex={-1}
         style={{
           margin: 0,
           fontFamily: "var(--font-serif, Georgia, serif)",
@@ -64,6 +82,15 @@ export function QuestionCard({
           {why}
         </p>
       </details>
+      {options ? (
+        <div
+          role="radiogroup"
+          aria-labelledby={headingId}
+          style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}
+        >
+          {options}
+        </div>
+      ) : null}
       <div style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}>
         {children}
       </div>
@@ -75,16 +102,34 @@ export interface OptionButtonProps {
   label: string;
   selected: boolean;
   onSelect: () => void;
+  /** "radio" (P2-4): single-select question steps — renders `role="radio"`
+   *  + `aria-checked`, intended for use inside a `role="radiogroup"`
+   *  container. Default keeps the original plain toggle-button semantics
+   *  (`aria-pressed`) used by the family multi-select step, where more
+   *  than one option can be true at once.
+   *
+   *  Arrow-key roving-tabindex movement between radio options is left as
+   *  a future enhancement — Tab-order navigation between options still
+   *  works today; only the announced role/state changed here. */
+  variant?: "radio" | "toggle";
 }
 
 /** Large, keyboard-focusable option card. Never strips the native focus
  *  ring (accessibility — spec §0 "visible focus"). */
-export function OptionButton({ label, selected, onSelect }: OptionButtonProps) {
+export function OptionButton({
+  label,
+  selected,
+  onSelect,
+  variant = "toggle",
+}: OptionButtonProps) {
+  const isRadio = variant === "radio";
   return (
     <button
       type="button"
       onClick={onSelect}
-      aria-pressed={selected}
+      role={isRadio ? "radio" : undefined}
+      aria-checked={isRadio ? selected : undefined}
+      aria-pressed={isRadio ? undefined : selected}
       style={{
         padding: "var(--space-3, 0.85rem) var(--space-4, 1.1rem)",
         borderRadius: 8,

--- a/apps/mouth/src/app/visa/second-home/studio/components/ReadinessChecklist.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/ReadinessChecklist.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { CHECKLIST_ITEMS, readiness } from "@/lib/secondhome-studio/checklist";
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import type { PlanState } from "@/lib/secondhome-studio/types";
+
+export interface ReadinessChecklistProps {
+  plan: PlanState;
+  onToggle: (id: string) => void;
+}
+
+/** 10-item readiness checklist bound to plan.checklist. Checkboxes only —
+ *  no uploads. The meter says "prepared", never "approval likelihood"
+ *  (spec §5 hard rule; copy.ts's own readiness.caption reinforces it). */
+export function ReadinessChecklist({
+  plan,
+  onToggle,
+}: ReadinessChecklistProps) {
+  const { done, total } = readiness(plan);
+
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          color: "var(--text-primary)",
+        }}
+      >
+        {getCopy("checklist.heading")}
+      </h2>
+      <p style={{ margin: 0, color: "var(--text-primary)", lineHeight: 1.6 }}>
+        {getCopy("checklist.body")}
+      </p>
+      <div>
+        <p style={{ margin: 0, fontWeight: 600, color: "var(--text-primary)" }}>
+          {done} of {total} {getCopy("checklist.readiness.preparedLabel")}
+        </p>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "var(--text-sm, 0.82rem)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          {getCopy("checklist.readiness.caption")}
+        </p>
+      </div>
+      <ul
+        style={{
+          margin: 0,
+          padding: 0,
+          listStyle: "none",
+          display: "grid",
+          gap: "var(--space-2, 0.5rem)",
+        }}
+      >
+        {CHECKLIST_ITEMS.map((item) => (
+          <li key={item.id}>
+            <label
+              style={{
+                display: "flex",
+                gap: "var(--space-2, 0.5rem)",
+                alignItems: "flex-start",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={Boolean(plan.checklist[item.id])}
+                onChange={() => onToggle(item.id)}
+                style={{ marginTop: 4, minWidth: 18, minHeight: 18 }}
+              />
+              <span>
+                <span
+                  style={{ display: "block", color: "var(--text-primary)" }}
+                >
+                  {getCopy(item.titleKey)}
+                </span>
+                <span
+                  style={{
+                    display: "block",
+                    fontSize: "var(--text-sm, 0.85rem)",
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  {getCopy(item.whyKey)}
+                </span>
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
+      <p
+        style={{
+          margin: 0,
+          fontSize: "var(--text-sm, 0.82rem)",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        {getCopy("checklist.note")}
+      </p>
+    </section>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/RouteComparator.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { getCopy } from "@/lib/secondhome-studio/copy";
+
+const COLUMNS = ["deposit", "property", "senior"] as const;
+const ROWS = [
+  "capital",
+  "liquidity",
+  "whatQualifies",
+  "currentStatus",
+] as const;
+
+export interface RouteComparatorProps {
+  /** Shown prominently when the plan's route is "unsure" (spec §3 row 8) —
+   *  a highlighted border, not a layout reorder. */
+  highlight?: boolean;
+}
+
+/** Static, honest deposit vs property vs senior comparison table (spec §5).
+ *  Wrapped in an overflow-x container so a narrow viewport scrolls the
+ *  table, never the page. */
+export function RouteComparator({ highlight = false }: RouteComparatorProps) {
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: highlight
+          ? "2px solid var(--accent-funnel)"
+          : "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          color: "var(--text-primary)",
+        }}
+      >
+        Compare the routes
+      </h2>
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th scope="col" style={{ padding: "var(--space-2, 0.5rem)" }} />
+              {COLUMNS.map((c) => (
+                <th
+                  key={c}
+                  scope="col"
+                  style={{
+                    textAlign: "left",
+                    padding: "var(--space-2, 0.5rem)",
+                    color: "var(--text-primary)",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {getCopy(`routeComparator.columns.${c}.title`)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((r) => (
+              <tr
+                key={r}
+                style={{ borderTop: "1px solid var(--color-border-subtle)" }}
+              >
+                <th
+                  scope="row"
+                  style={{
+                    textAlign: "left",
+                    padding: "var(--space-2, 0.5rem)",
+                    color: "var(--color-text-muted)",
+                    fontWeight: 600,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {getCopy(`routeComparator.rows.${r}.label`)}
+                </th>
+                {COLUMNS.map((c) => (
+                  <td
+                    key={c}
+                    style={{
+                      padding: "var(--space-2, 0.5rem)",
+                      color: "var(--text-primary)",
+                      fontSize: "var(--text-sm, 0.9rem)",
+                    }}
+                  >
+                    {getCopy(`routeComparator.rows.${r}.${c}`)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import {
+  encodePlanFragment,
+  savePlan,
+} from "@/lib/secondhome-studio/plan-codec";
+import type { PlanState } from "@/lib/secondhome-studio/types";
+
+const STUDIO_PATH = "/visa/second-home/studio";
+
+export interface SavePlanBarProps {
+  plan: PlanState;
+  /** Clears localStorage (plan-codec's clearPlan) and resets the wizard to
+   *  a fresh plan — owned by StudioApp so the reset also rewinds the step
+   *  index. */
+  onClear: () => void;
+}
+
+const buttonStyle: React.CSSProperties = {
+  padding: "var(--space-2, 0.5rem) var(--space-4, 1.1rem)",
+  borderRadius: 8,
+  border: "1px solid var(--color-border-subtle)",
+  background: "transparent",
+  color: "var(--text-primary)",
+  cursor: "pointer",
+  minHeight: 44,
+  fontSize: "0.9rem",
+  fontFamily: "inherit",
+};
+
+/** "Your plan stays on this device" bar (spec §5). Answers auto-save on
+ *  every change (StudioApp calls plan-codec's savePlan after each answer)
+ *  — the explicit "Save on this device" button here is a reassurance
+ *  affordance, not the only save path. */
+export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
+  const [savedFeedback, setSavedFeedback] = useState(false);
+  const [copiedFeedback, setCopiedFeedback] = useState(false);
+
+  function handleSave() {
+    savePlan(plan);
+    setSavedFeedback(true);
+    window.setTimeout(() => setSavedFeedback(false), 2500);
+  }
+
+  async function handleCopyLink() {
+    if (typeof window === "undefined") return;
+    const url = `${window.location.origin}${STUDIO_PATH}#p=${encodePlanFragment(plan)}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedFeedback(true);
+      window.setTimeout(() => setCopiedFeedback(false), 2500);
+    } catch {
+      // Clipboard blocked (permissions/private mode) — silent no-op; the
+      // user can still select the link text manually if we ever render it.
+    }
+  }
+
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.1rem, 2.6vw, 1.35rem)",
+          color: "var(--text-primary)",
+        }}
+      >
+        {getCopy("savePlanBar.heading")}
+      </h2>
+      <p style={{ margin: 0, color: "var(--text-primary)", lineHeight: 1.6 }}>
+        {getCopy("savePlanBar.body")}
+      </p>
+      <div
+        style={{
+          display: "flex",
+          gap: "var(--space-2, 0.5rem)",
+          flexWrap: "wrap",
+        }}
+      >
+        <button type="button" onClick={handleSave} style={buttonStyle}>
+          {getCopy("savePlanBar.saveButton")}
+        </button>
+        <button type="button" onClick={handleCopyLink} style={buttonStyle}>
+          {getCopy("savePlanBar.copyLinkButton")}
+        </button>
+        <button
+          type="button"
+          onClick={onClear}
+          style={{
+            ...buttonStyle,
+            borderColor: "var(--color-error, #c0392b)",
+            color: "var(--color-error, #c0392b)",
+          }}
+        >
+          {getCopy("savePlanBar.clearButton")}
+        </button>
+      </div>
+      <div role="status" aria-live="polite" style={{ minHeight: "1.2em" }}>
+        {savedFeedback ? (
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.85rem)",
+              color: "var(--text-primary)",
+            }}
+          >
+            {getCopy("savePlanBar.savedConfirmation")}
+          </p>
+        ) : null}
+        {copiedFeedback ? (
+          <p
+            style={{
+              margin: 0,
+              fontSize: "var(--text-sm, 0.85rem)",
+              color: "var(--text-primary)",
+            }}
+          >
+            {getCopy("savePlanBar.copiedConfirmation")}
+          </p>
+        ) : null}
+      </div>
+      <p
+        style={{
+          margin: 0,
+          fontSize: "var(--text-sm, 0.8rem)",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        {getCopy("savePlanBar.linkWarning")}
+      </p>
+    </section>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/SavePlanBar.tsx
@@ -6,6 +6,7 @@ import {
   encodePlanFragment,
   savePlan,
 } from "@/lib/secondhome-studio/plan-codec";
+import { relevantPlan } from "@/lib/secondhome-studio/sequence";
 import type { PlanState } from "@/lib/secondhome-studio/types";
 
 const STUDIO_PATH = "/visa/second-home/studio";
@@ -33,7 +34,13 @@ const buttonStyle: React.CSSProperties = {
 /** "Your plan stays on this device" bar (spec §5). Answers auto-save on
  *  every change (StudioApp calls plan-codec's savePlan after each answer)
  *  — the explicit "Save on this device" button here is a reassurance
- *  affordance, not the only save path. */
+ *  affordance, not the only save path.
+ *
+ *  P0-C3(e): this is the ONLY carrier of the shareable plan link — the
+ *  WhatsApp handoff no longer transports one. P2-6: the copied link is
+ *  built from `relevantPlan(plan)`, not the raw plan, so an
+ *  abandoned-branch answer (e.g. a leftover `capital` value after
+ *  switching to the property route) never leaks into a shared link. */
 export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
   const [savedFeedback, setSavedFeedback] = useState(false);
   const [copiedFeedback, setCopiedFeedback] = useState(false);
@@ -46,7 +53,7 @@ export function SavePlanBar({ plan, onClear }: SavePlanBarProps) {
 
   async function handleCopyLink() {
     if (typeof window === "undefined") return;
-    const url = `${window.location.origin}${STUDIO_PATH}#p=${encodePlanFragment(plan)}`;
+    const url = `${window.location.origin}${STUDIO_PATH}#p=${encodePlanFragment(relevantPlan(plan))}`;
     try {
       await navigator.clipboard.writeText(url);
       setCopiedFeedback(true);

--- a/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
@@ -2,18 +2,34 @@
 
 import { getCopy } from "@/lib/secondhome-studio/copy";
 import { buildTimeline } from "@/lib/secondhome-studio/timeline";
-import type { Location, TimelineHorizon } from "@/lib/secondhome-studio/types";
+import type {
+  Location,
+  RouteIntent,
+  TimelineHorizon,
+  Verdict,
+} from "@/lib/secondhome-studio/types";
 
 export interface TimelineViewProps {
   horizon: TimelineHorizon;
   location: Location;
+  /** P1-C9 (optional, defaults preserve the original always-bank-deposit
+   *  second step): route/product make the second step honest about what
+   *  the applicant actually needs to do — property never had a bank
+   *  deposit, E33F is explicitly "without the deposit". */
+  route?: RouteIntent | null;
+  product?: Verdict["product"];
 }
 
 /** Renders buildTimeline()'s 7 public steps — each with a heading, body
  *  (range label), and an owner chip (You / Bali Zero / Imigrasi). Every
  *  range is "typical, not a promise" per copy.ts — no promised dates. */
-export function TimelineView({ horizon, location }: TimelineViewProps) {
-  const steps = buildTimeline(horizon, location);
+export function TimelineView({
+  horizon,
+  location,
+  route = null,
+  product = null,
+}: TimelineViewProps) {
+  const steps = buildTimeline(horizon, location, route, product);
 
   return (
     <section

--- a/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/TimelineView.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import { buildTimeline } from "@/lib/secondhome-studio/timeline";
+import type { Location, TimelineHorizon } from "@/lib/secondhome-studio/types";
+
+export interface TimelineViewProps {
+  horizon: TimelineHorizon;
+  location: Location;
+}
+
+/** Renders buildTimeline()'s 7 public steps — each with a heading, body
+ *  (range label), and an owner chip (You / Bali Zero / Imigrasi). Every
+ *  range is "typical, not a promise" per copy.ts — no promised dates. */
+export function TimelineView({ horizon, location }: TimelineViewProps) {
+  const steps = buildTimeline(horizon, location);
+
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <h2
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.2rem, 3vw, 1.5rem)",
+          color: "var(--text-primary)",
+        }}
+      >
+        Your typical timeline
+      </h2>
+      <ol
+        style={{
+          margin: 0,
+          padding: 0,
+          listStyle: "none",
+          display: "grid",
+          gap: "var(--space-3, 1rem)",
+        }}
+      >
+        {steps.map((step) => (
+          <li
+            key={step.id}
+            style={{
+              display: "grid",
+              gap: "var(--space-1, 0.3rem)",
+              paddingBottom: "var(--space-2, 0.5rem)",
+              borderBottom: "1px dashed var(--color-border-subtle)",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: "var(--space-2, 0.5rem)",
+              }}
+            >
+              <strong style={{ color: "var(--text-primary)" }}>
+                {getCopy(step.titleKey)}
+              </strong>
+              <span
+                style={{
+                  fontSize: "0.68rem",
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                  padding: "2px 8px",
+                  borderRadius: 999,
+                  border: "1px solid var(--color-border-subtle)",
+                  color: "var(--color-text-muted)",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {getCopy(`timeline.ownerLabels.${step.ownerKey}`)}
+              </span>
+            </div>
+            <p
+              style={{
+                margin: 0,
+                color: "var(--color-text-muted)",
+                fontSize: "var(--text-sm, 0.88rem)",
+              }}
+            >
+              {getCopy(step.rangeKey)}
+            </p>
+            {step.paceNoteKey ? (
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: "var(--text-sm, 0.85rem)",
+                  fontStyle: "italic",
+                  color: "var(--text-primary)",
+                }}
+              >
+                {getCopy(step.paceNoteKey)}
+              </p>
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import type { Verdict } from "@/lib/secondhome-studio/types";
+
+export interface VerdictPanelProps {
+  verdict: Verdict;
+}
+
+/** Renders the fit-check result: band heading/body (verbatim from copy.ts,
+ *  which guarantees "the final decision rests with Imigrasi" is present),
+ *  the reason list, and the human-review disclosure when present.
+ *  NEVER renders a numeric score — spec §0 hard constraint. */
+export function VerdictPanel({ verdict }: VerdictPanelProps) {
+  const heading = getCopy(`verdict.bands.${verdict.band}.heading`);
+  const body = getCopy(`verdict.bands.${verdict.band}.body`);
+
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "2px solid var(--accent-funnel)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+      }}
+    >
+      <p
+        style={{
+          margin: 0,
+          fontSize: "0.7rem",
+          letterSpacing: "0.15em",
+          textTransform: "uppercase",
+          opacity: 0.6,
+          color: "var(--color-text-muted)",
+        }}
+      >
+        Your fit-check result
+      </p>
+      <h1
+        style={{
+          margin: 0,
+          fontFamily: "var(--font-serif, Georgia, serif)",
+          fontSize: "clamp(1.6rem, 4vw, 2.2rem)",
+          color: "var(--text-primary)",
+        }}
+      >
+        {heading}
+      </h1>
+      <p style={{ margin: 0, lineHeight: 1.7, color: "var(--text-primary)" }}>
+        {body}
+      </p>
+      {verdict.product ? (
+        <p
+          style={{
+            margin: 0,
+            fontSize: "var(--text-sm, 0.88rem)",
+            color: "var(--color-text-muted)",
+          }}
+        >
+          Matching product: <strong>{verdict.product}</strong>
+        </p>
+      ) : null}
+      {verdict.reasons.length > 0 ? (
+        <ul
+          style={{
+            margin: 0,
+            paddingLeft: "1.2rem",
+            display: "grid",
+            gap: "var(--space-2, 0.5rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {verdict.reasons.map((key) => (
+            <li key={key}>{getCopy(key)}</li>
+          ))}
+        </ul>
+      ) : null}
+      {verdict.humanReviewNote ? (
+        <p
+          role="note"
+          style={{
+            margin: 0,
+            padding: "var(--space-2, 0.5rem)",
+            borderLeft: "3px solid var(--accent-funnel)",
+            fontSize: "var(--text-sm, 0.88rem)",
+            color: "var(--text-primary)",
+          }}
+        >
+          {getCopy(verdict.humanReviewNote)}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/VerdictPanel.tsx
@@ -1,17 +1,23 @@
 "use client";
 
+import type { Ref } from "react";
 import { getCopy } from "@/lib/secondhome-studio/copy";
 import type { Verdict } from "@/lib/secondhome-studio/types";
 
 export interface VerdictPanelProps {
   verdict: Verdict;
+  /** Forwarded to the `<h1>` fit-check heading so StudioApp can move focus
+   *  to it on the question-wizard -> verdict transition (P2-3) — the
+   *  heading carries `tabIndex={-1}` so a non-interactive element can
+   *  still be a programmatic focus target. */
+  headingRef?: Ref<HTMLHeadingElement>;
 }
 
 /** Renders the fit-check result: band heading/body (verbatim from copy.ts,
  *  which guarantees "the final decision rests with Imigrasi" is present),
  *  the reason list, and the human-review disclosure when present.
  *  NEVER renders a numeric score — spec §0 hard constraint. */
-export function VerdictPanel({ verdict }: VerdictPanelProps) {
+export function VerdictPanel({ verdict, headingRef }: VerdictPanelProps) {
   const heading = getCopy(`verdict.bands.${verdict.band}.heading`);
   const body = getCopy(`verdict.bands.${verdict.band}.body`);
 
@@ -39,6 +45,8 @@ export function VerdictPanel({ verdict }: VerdictPanelProps) {
         Your fit-check result
       </p>
       <h1
+        ref={headingRef}
+        tabIndex={-1}
         style={{
           margin: 0,
           fontFamily: "var(--font-serif, Georgia, serif)",

--- a/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
@@ -3,25 +3,10 @@
 import { Phone } from "lucide-react";
 import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 import { getCopy } from "@/lib/secondhome-studio/copy";
-import { readiness } from "@/lib/secondhome-studio/checklist";
-import { encodePlanFragment } from "@/lib/secondhome-studio/plan-codec";
+import { buildWhatsAppBullets } from "@/lib/secondhome-studio/whatsapp-bullets";
 import type { PlanState, Verdict } from "@/lib/secondhome-studio/types";
 
 const STUDIO_PATH = "/visa/second-home/studio";
-
-function optionLabel(base: string, value: string | null): string {
-  if (value === null) return "—";
-  if (value === "not_applicable") return "Not applicable";
-  return getCopy(`${base}.options.${value}`);
-}
-
-function familySummary(plan: PlanState): string {
-  const parts: string[] = [];
-  if (plan.family.spouse) parts.push("spouse");
-  if (plan.family.children > 0) parts.push("children");
-  if (plan.family.parents > 0) parts.push("parents");
-  return parts.length > 0 ? parts.join(", ") : "none";
-}
 
 export interface WhatsAppHandoffProps {
   plan: PlanState;
@@ -31,22 +16,20 @@ export interface WhatsAppHandoffProps {
 /**
  * Reuses the landing's WhatsAppLeadButton pattern verbatim (spec §5): the
  * tracked-capture-then-wa.me-deeplink handoff, with the same
- * never-block-the-user fallback. `WhatsAppLeadButton` takes a structured
- * `whatsappContext` (label/value bullets) — not a free-text message prop
- * — so the copy deck's `whatsapp.prefillTemplate` field structure
- * (ageBand/route/funding/property/family/timeline/location/verdict) is
- * mirrored here as bullets, in the same order, plus readiness + the saved
- * plan link (spec §5 asks for both explicitly; the template itself has no
- * placeholder for either).
+ * never-block-the-user fallback.
+ *
+ * P0-C3 + P0-C4 (backend contract verified in-worktree against
+ * `apps/backend-rag/backend/app/routers/lead_capture.py:38-47`):
+ * `whatsappContext` carries EXACTLY the <=6 branch-aware bullets built by
+ * `buildWhatsAppBullets` (lib/secondhome-studio/whatsapp-bullets.ts) — no
+ * plan URL, no readiness row, and no `resultHash` is passed at all (the
+ * `cta_handoff` LeadSource's `result_url_path` is "/", so a `resultHash`
+ * would build a garbage "Reference: https://balizero.com//<band>" line —
+ * `whatsapp_deeplink.py:88-89`). The plan link's ONLY carrier is
+ * SavePlanBar's "Copy plan link" (P0-C3(e)).
  */
 export function WhatsAppHandoff({ plan, verdict }: WhatsAppHandoffProps) {
-  const bandLabel = getCopy(`verdict.bands.${verdict.band}.heading`);
-  const { done, total } = readiness(plan);
-
-  const planUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}${STUDIO_PATH}#p=${encodePlanFragment(plan)}`
-      : `${STUDIO_PATH}#p=${encodePlanFragment(plan)}`;
+  const bullets = buildWhatsAppBullets(plan, verdict);
 
   return (
     <section
@@ -78,35 +61,8 @@ export function WhatsAppHandoff({ plan, verdict }: WhatsAppHandoffProps) {
           product: "e33_second_home_studio",
           service_interest: "second_home",
         }}
-        whatsappContext={[
-          { label: "Age band", value: optionLabel("wizard.age", plan.age) },
-          {
-            label: "Route considered",
-            value: optionLabel("wizard.route", plan.route),
-          },
-          {
-            label: "Funding position",
-            value: optionLabel("wizard.seniorFunding", plan.seniorFunding),
-          },
-          {
-            label: "Property position",
-            value: optionLabel("wizard.property", plan.property),
-          },
-          { label: "Family members", value: familySummary(plan) },
-          {
-            label: "Preferred timing",
-            value: optionLabel("wizard.horizon", plan.horizon),
-          },
-          {
-            label: "Current location",
-            value: optionLabel("wizard.location", plan.location),
-          },
-          { label: "Fit-check result", value: bandLabel },
-          { label: "Readiness", value: `${done} of ${total} prepared` },
-          { label: "Saved plan", value: planUrl },
-        ]}
+        whatsappContext={bullets}
         utm={{ page: STUDIO_PATH }}
-        resultHash={verdict.band}
         style={{
           display: "inline-flex",
           alignItems: "center",

--- a/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/WhatsAppHandoff.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Phone } from "lucide-react";
+import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
+import { getCopy } from "@/lib/secondhome-studio/copy";
+import { readiness } from "@/lib/secondhome-studio/checklist";
+import { encodePlanFragment } from "@/lib/secondhome-studio/plan-codec";
+import type { PlanState, Verdict } from "@/lib/secondhome-studio/types";
+
+const STUDIO_PATH = "/visa/second-home/studio";
+
+function optionLabel(base: string, value: string | null): string {
+  if (value === null) return "—";
+  if (value === "not_applicable") return "Not applicable";
+  return getCopy(`${base}.options.${value}`);
+}
+
+function familySummary(plan: PlanState): string {
+  const parts: string[] = [];
+  if (plan.family.spouse) parts.push("spouse");
+  if (plan.family.children > 0) parts.push("children");
+  if (plan.family.parents > 0) parts.push("parents");
+  return parts.length > 0 ? parts.join(", ") : "none";
+}
+
+export interface WhatsAppHandoffProps {
+  plan: PlanState;
+  verdict: Verdict;
+}
+
+/**
+ * Reuses the landing's WhatsAppLeadButton pattern verbatim (spec §5): the
+ * tracked-capture-then-wa.me-deeplink handoff, with the same
+ * never-block-the-user fallback. `WhatsAppLeadButton` takes a structured
+ * `whatsappContext` (label/value bullets) — not a free-text message prop
+ * — so the copy deck's `whatsapp.prefillTemplate` field structure
+ * (ageBand/route/funding/property/family/timeline/location/verdict) is
+ * mirrored here as bullets, in the same order, plus readiness + the saved
+ * plan link (spec §5 asks for both explicitly; the template itself has no
+ * placeholder for either).
+ */
+export function WhatsAppHandoff({ plan, verdict }: WhatsAppHandoffProps) {
+  const bandLabel = getCopy(`verdict.bands.${verdict.band}.heading`);
+  const { done, total } = readiness(plan);
+
+  const planUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}${STUDIO_PATH}#p=${encodePlanFragment(plan)}`
+      : `${STUDIO_PATH}#p=${encodePlanFragment(plan)}`;
+
+  return (
+    <section
+      style={{
+        display: "grid",
+        gap: "var(--space-3, 1rem)",
+        background: "var(--surface-raised)",
+        border: "1px solid var(--color-border-subtle)",
+        borderRadius: 12,
+        padding: "var(--space-4, 1.5rem)",
+        textAlign: "center",
+        justifyItems: "center",
+      }}
+    >
+      <p
+        style={{
+          margin: 0,
+          fontSize: "var(--text-sm, 0.85rem)",
+          color: "var(--color-text-muted)",
+          maxWidth: "34rem",
+        }}
+      >
+        {getCopy("whatsapp.privacy")}
+      </p>
+      <WhatsAppLeadButton
+        source="cta_handoff"
+        context={{
+          page: STUDIO_PATH,
+          product: "e33_second_home_studio",
+          service_interest: "second_home",
+        }}
+        whatsappContext={[
+          { label: "Age band", value: optionLabel("wizard.age", plan.age) },
+          {
+            label: "Route considered",
+            value: optionLabel("wizard.route", plan.route),
+          },
+          {
+            label: "Funding position",
+            value: optionLabel("wizard.seniorFunding", plan.seniorFunding),
+          },
+          {
+            label: "Property position",
+            value: optionLabel("wizard.property", plan.property),
+          },
+          { label: "Family members", value: familySummary(plan) },
+          {
+            label: "Preferred timing",
+            value: optionLabel("wizard.horizon", plan.horizon),
+          },
+          {
+            label: "Current location",
+            value: optionLabel("wizard.location", plan.location),
+          },
+          { label: "Fit-check result", value: bandLabel },
+          { label: "Readiness", value: `${done} of ${total} prepared` },
+          { label: "Saved plan", value: planUrl },
+        ]}
+        utm={{ page: STUDIO_PATH }}
+        resultHash={verdict.band}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "var(--space-3, 0.85rem) var(--space-5, 1.5rem)",
+          borderRadius: 8,
+          background: "#25D366",
+          color: "#fff",
+          fontWeight: 600,
+          textDecoration: "none",
+          minHeight: 44,
+        }}
+      >
+        <Phone size={18} aria-hidden />
+        {getCopy("whatsapp.button")}
+      </WhatsAppLeadButton>
+      <p
+        style={{
+          margin: 0,
+          fontSize: "var(--text-sm, 0.8rem)",
+          color: "var(--color-text-muted)",
+        }}
+      >
+        {getCopy("whatsapp.note")}
+      </p>
+    </section>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/studio/page.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+import { StudioApp } from "./StudioApp";
+
+/**
+ * Second Home Studio — public, anonymous fit-check wizard (Phase B).
+ *
+ * Thin SERVER shell: metadata only. All interactivity lives in StudioApp
+ * ("use client"). No `robots` override — this route is index/follow like
+ * its parent landing (spec §1/§7.7).
+ */
+export const metadata: Metadata = {
+  title: "Second Home Studio — check your fit",
+  description:
+    "A free, anonymous fit-check for Indonesia's Second Home Visa (E33). Answer a few questions, see your fit-check result, and get a plan you can save or share — no email needed.",
+  openGraph: {
+    title: "Second Home Studio — Bali Zero",
+    description:
+      "Check your fit for Indonesia's Second Home Visa in a few minutes. Free, anonymous, no email needed.",
+    type: "website",
+  },
+  alternates: {
+    canonical: "https://balizero.com/visa/second-home/studio",
+  },
+};
+
+export default function SecondHomeStudioPage() {
+  return <StudioApp />;
+}

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/checklist.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/checklist.test.ts
@@ -39,8 +39,8 @@ describe("readiness", () => {
       ...emptyPlan(),
       checklist: {
         passport_validity: true,
-        passport_scan: true,
-        photos: false,
+        passport_photo: true,
+        residential_address: false,
         unknown_id_not_in_the_list: true,
       },
     };

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/checklist.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/checklist.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { CHECKLIST_ITEMS, readiness } from "../checklist";
+import { getCopy } from "../copy";
+import { emptyPlan } from "../plan-codec";
+
+/**
+ * Not one of the spec's 4 named test files (rules/plan-codec/timeline/
+ * forbidden-claims) — added as a value-add since checklist.ts carries real
+ * logic (`readiness`). Flagged in the delivery report as an addition
+ * beyond the frozen spec's minimum, not a scope change.
+ */
+
+describe("CHECKLIST_ITEMS", () => {
+  it("has exactly 10 items per spec §5", () => {
+    expect(CHECKLIST_ITEMS).toHaveLength(10);
+  });
+
+  it("every item has a unique id", () => {
+    const ids = CHECKLIST_ITEMS.map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every item's titleKey and whyKey resolve to real copy", () => {
+    for (const item of CHECKLIST_ITEMS) {
+      expect(getCopy(item.titleKey)).not.toBe(item.titleKey);
+      expect(getCopy(item.whyKey)).not.toBe(item.whyKey);
+    }
+  });
+});
+
+describe("readiness", () => {
+  it("reports 0 of 10 for a fresh plan", () => {
+    expect(readiness(emptyPlan())).toEqual({ done: 0, total: 10 });
+  });
+
+  it("counts only items marked true", () => {
+    const plan = {
+      ...emptyPlan(),
+      checklist: {
+        passport_validity: true,
+        passport_scan: true,
+        photos: false,
+        unknown_id_not_in_the_list: true,
+      },
+    };
+    expect(readiness(plan)).toEqual({ done: 2, total: 10 });
+  });
+
+  it("reports 10 of 10 when every item is checked", () => {
+    const checklist = Object.fromEntries(
+      CHECKLIST_ITEMS.map((i) => [i.id, true]),
+    );
+    const plan = { ...emptyPlan(), checklist };
+    expect(readiness(plan)).toEqual({ done: 10, total: 10 });
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
@@ -50,9 +50,11 @@ function allCopyStrings(): CopyEntry[] {
   return out;
 }
 
-describe("forbidden-claims sweep — every string in COPY", () => {
-  const entries = allCopyStrings();
+// Hoisted to module scope so every describe block below shares one walk of
+// the (large, deck-sourced) COPY tree.
+const entries = allCopyStrings();
 
+describe("forbidden-claims sweep — every string in COPY", () => {
   it("the sweep actually walks a non-trivial number of strings (guards against an empty/broken walk)", () => {
     expect(entries.length).toBeGreaterThan(40);
   });
@@ -163,7 +165,6 @@ describe("innocence pins — legitimate copy must NOT trip the guard (superscar 
   });
 
   it("the actual copy module uses the safe 'non-working' framing somewhere and it passes the sweep", () => {
-    const entries = allCopyStrings();
     const hasNonWorking = entries.some((e) => /non-working/i.test(e.value));
     // Not a hard requirement of this module (no copy currently needs to
     // describe work rights explicitly), but if it's ever added it must use
@@ -201,16 +202,45 @@ describe("innocence pins — legitimate copy must NOT trip the guard (superscar 
       ),
     ).toBe(false);
   });
+
+  it("the rewritten capital.why string (no literal 'split') does not trip splitDeposit", () => {
+    // The copy deck's own draft here — "Split deposits do not qualify." —
+    // DOES trip this pattern (proven below); copy.ts carries a reworded
+    // version that keeps the same fact without the literal word "split".
+    expect(FORBIDDEN_PATTERNS.splitDeposit.test(COPY.wizard.capital.why)).toBe(
+      false,
+    );
+  });
+
+  it("documents the deck's own draft phrasing WOULD have tripped splitDeposit (why the rewrite was needed)", () => {
+    expect(
+      FORBIDDEN_PATTERNS.splitDeposit.test(
+        "The threshold must be met through one qualifying deposit. Split deposits do not qualify.",
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("positive pins — required phrasing is actually present", () => {
   it("custody copy contains 'state-owned' and 'own name'", () => {
-    const custodyStrings = Object.values(COPY.custody)
-      .map((step) => `${step.title} ${step.body}`)
+    const custodyStrings = [
+      COPY.custody.eyebrow,
+      COPY.custody.intro,
+      ...Object.values(COPY.custody.steps).map(
+        (step) => `${step.title} ${step.body}`,
+      ),
+      COPY.custody.disclaimer,
+    ]
       .join(" ")
       .toLowerCase();
     expect(custodyStrings).toContain("state-owned");
     expect(custodyStrings).toContain("own name");
+  });
+
+  it("custody step 3 keeps the withdrawal/compliance warning (copy-deck critique #2)", () => {
+    const step3 = COPY.custody.steps.step3.body.toLowerCase();
+    expect(step3).toMatch(/withdraw|moving them|move them/);
+    expect(step3).toContain("compliance");
   });
 
   it("every verdict band body states the final decision rests with Imigrasi", () => {
@@ -225,5 +255,60 @@ describe("positive pins — required phrasing is actually present", () => {
     const dependentsNote = COPY.wizard.family.dependentsNote.toLowerCase();
     expect(dependentsNote).toContain("fit memo");
     expect(PRICE_LITERAL_PATTERN.test(dependentsNote)).toBe(false);
+  });
+
+  it("save-plan bar carries the deck's link warning and clear-plan action string", () => {
+    expect(COPY.savePlanBar.linkWarning.toLowerCase()).toContain("link");
+    expect(COPY.savePlanBar.linkWarning.toLowerCase()).toMatch(/view|see/);
+    expect(COPY.savePlanBar.clearButton.toLowerCase()).toContain("clear");
+  });
+
+  it("whatsapp block carries the deck's privacy string (review-before-send)", () => {
+    expect(COPY.whatsapp.privacy.toLowerCase()).toContain("review");
+  });
+
+  it("whatsapp prefill template names the fit-check result, never an assessment/certificate/score", () => {
+    expect(COPY.whatsapp.prefillTemplate).toContain("Fit-check result:");
+  });
+});
+
+describe("terminology delta — 'fit-check result' only, never assessment/certificate/eligibility score", () => {
+  it("no copy string ever says 'assessment'", () => {
+    const violations = entries.filter((e) => /assessment/i.test(e.value));
+    expect(
+      violations,
+      `"assessment" found in: ${violations.map((v) => v.path).join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("no copy string ever says 'certificate'", () => {
+    const violations = entries.filter((e) => /certificate/i.test(e.value));
+    expect(
+      violations,
+      `"certificate" found in: ${violations.map((v) => v.path).join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("no copy string ever says 'eligibility score'", () => {
+    const violations = entries.filter((e) =>
+      /eligibility\s+score/i.test(e.value),
+    );
+    expect(
+      violations,
+      `"eligibility score" found in: ${violations.map((v) => v.path).join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("'fit-check result' is actually used in the copy", () => {
+    const hasPhrase = entries.some((e) => /fit-check result/i.test(e.value));
+    expect(hasPhrase).toBe(true);
+  });
+
+  it("the deck's own draft ('a preliminary fit assessment') would have tripped the assessment ban (why the rewrite was needed)", () => {
+    expect(
+      /assessment/i.test(
+        "This is a preliminary fit assessment, not an approval.",
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { COPY } from "../copy";
@@ -7,6 +9,16 @@ import { COPY } from "../copy";
  * SPEC-secondhome-studio-phaseB.md §6. Case-insensitive by design (the
  * spec calls this out explicitly) — every pattern below carries the `i`
  * flag.
+ *
+ * `splitDepositEuphemism` and `youreThere` are fix-mandate-round-1
+ * additions (P0-C2 / P2-C14), not part of the original spec §6 list:
+ * - P0-C2: the FIRST rewrite of `capital.why` dodged `splitDeposit` by
+ *   restating the same forbidden concept in a synonym ("deposits divided
+ *   across multiple accounts do not qualify") — an under-match
+ *   (superscar #3's twin failure mode). This pattern catches that class
+ *   directly, independent of the literal word "split".
+ * - P2-C14: "and you're there" reads as an eligibility confirmation
+ *   (arrival/conclusion idiom) rather than a preliminary fit-check result.
  */
 const FORBIDDEN_PATTERNS: Record<string, RegExp> = {
   priceUsd1500: /US?D?\s*\$?\s*1[,.]?500/i,
@@ -20,7 +32,16 @@ const FORBIDDEN_PATTERNS: Record<string, RegExp> = {
   lps: /\bLPS\b/i,
   bsiOrSharia: /\bBSI\b|sharia/i,
   splitDeposit: /split(ting)?\s+.*deposit/i,
+  splitDepositEuphemism:
+    /divided\s+across\s+multiple\s+accounts|multiple\s+accounts?\s+do(es)?\s+not\s+qualify/i,
+  youreThere: /you'?re\s+there|you\s+are\s+there/i,
 };
+
+/** Generalized IDR price-literal check for the JSX source-scan (P2-C13) —
+ *  broader than PRICE_LITERAL_PATTERN below (which only pins the two
+ *  known historical values, 35M/39M): any IDR figure with 6+ digits
+ *  hardcoded directly into a component would bypass usePricingData. */
+const JSX_PRICE_LITERAL_RE = /\bIDR\s*[0-9][0-9.,]{5,}/i;
 
 /** No hardcoded IDR price literal anywhere — the figure renders only from
  *  usePricingData. Covers both the pre-repricing (39M) and current (35M)
@@ -138,6 +159,22 @@ describe("guilt fixtures — each pattern actually fires on a known-bad string",
       pattern: "splitDeposit",
       text: "You may consider splitting your deposit across two accounts.",
     },
+    {
+      pattern: "splitDepositEuphemism",
+      text: "Deposits divided across multiple accounts do not qualify.",
+    },
+    {
+      pattern: "splitDepositEuphemism",
+      text: "Multiple accounts do not qualify for the threshold.",
+    },
+    {
+      pattern: "youreThere",
+      text: "USD 130,000 is the core requirement — and you're there.",
+    },
+    {
+      pattern: "youreThere",
+      text: "Once you hit the threshold, you are there.",
+    },
   ];
 
   it.each(guiltCases)("$pattern fires on: $text", ({ pattern, text }) => {
@@ -203,13 +240,29 @@ describe("innocence pins — legitimate copy must NOT trip the guard (superscar 
     ).toBe(false);
   });
 
-  it("the rewritten capital.why string (no literal 'split') does not trip splitDeposit", () => {
-    // The copy deck's own draft here — "Split deposits do not qualify." —
-    // DOES trip this pattern (proven below); copy.ts carries a reworded
-    // version that keeps the same fact without the literal word "split".
+  it("P0-C2: the positive-only capital.why sentence trips neither splitDeposit nor its euphemism pattern", () => {
+    // ROUND 2 of the same guard-over-match/under-match cycle
+    // (superscar #3): the deck's original draft ("Split deposits do not
+    // qualify") tripped splitDeposit (proven below); the FIRST rewrite
+    // dodged splitDeposit but restated the SAME forbidden concept in a
+    // synonym ("deposits divided across multiple accounts do not
+    // qualify") — an under-match the guard couldn't see. The current
+    // copy states the rule positively, with no mention of
+    // divided/multiple/split accounts at all.
     expect(FORBIDDEN_PATTERNS.splitDeposit.test(COPY.wizard.capital.why)).toBe(
       false,
     );
+    expect(
+      FORBIDDEN_PATTERNS.splitDepositEuphemism.test(COPY.wizard.capital.why),
+    ).toBe(false);
+  });
+
+  it("P2-C14: depositReadyStrong no longer reads as an arrival/conclusion idiom", () => {
+    expect(
+      FORBIDDEN_PATTERNS.youreThere.test(
+        COPY.verdict.reasons.depositReadyStrong,
+      ),
+    ).toBe(false);
   });
 
   it("documents the deck's own draft phrasing WOULD have tripped splitDeposit (why the rewrite was needed)", () => {
@@ -267,8 +320,38 @@ describe("positive pins — required phrasing is actually present", () => {
     expect(COPY.whatsapp.privacy.toLowerCase()).toContain("review");
   });
 
+  it("P0-C3(c)/P1-B: whatsapp.privacy names Bali Zero and describes BOTH the capture and the pre-fill honestly", () => {
+    // Supersedes the earlier P1-B guidance ("mentions plan link") — P0-C3
+    // removed the plan link from the payload entirely, so the honest
+    // sentence no longer mentions one; it must still name who receives the
+    // data and that WhatsApp gets pre-filled with it.
+    expect(COPY.whatsapp.privacy).toContain("Bali Zero");
+    expect(COPY.whatsapp.privacy.toLowerCase()).toContain("whatsapp");
+    expect(COPY.whatsapp.privacy.toLowerCase()).not.toContain("plan link");
+  });
+
   it("whatsapp prefill template names the fit-check result, never an assessment/certificate/score", () => {
     expect(COPY.whatsapp.prefillTemplate).toContain("Fit-check result:");
+  });
+
+  it("P0-C3(c): whatsapp prefill template mirrors the 6 bullets exactly, with no plan-link placeholder", () => {
+    for (const label of [
+      "Route:",
+      "Age band:",
+      "Funding position:",
+      "Family:",
+      "Timing:",
+      "Fit-check result:",
+    ]) {
+      expect(COPY.whatsapp.prefillTemplate).toContain(label);
+    }
+    expect(COPY.whatsapp.prefillTemplate.toLowerCase()).not.toContain(
+      "readiness",
+    );
+    expect(COPY.whatsapp.prefillTemplate.toLowerCase()).not.toContain(
+      "saved plan",
+    );
+    expect(COPY.whatsapp.prefillTemplate).not.toMatch(/https?:\/\//);
   });
 });
 
@@ -310,5 +393,142 @@ describe("terminology delta — 'fit-check result' only, never assessment/certif
         "This is a preliminary fit assessment, not an approval.",
       ),
     ).toBe(true);
+  });
+});
+
+/**
+ * P2-C13 (Codex) — the sweep above only ever walked `COPY`'s object tree,
+ * so a forbidden claim hardcoded DIRECTLY into a component's JSX (a
+ * literal string never routed through `getCopy`) was invisible to it.
+ * This half source-scans every non-test `.tsx` file under
+ * `app/visa/second-home/studio/` for string/template-literal content and
+ * runs the SAME `FORBIDDEN_PATTERNS` (plus a generalized IDR price-literal
+ * check) over what it finds.
+ *
+ * `extractStringLiterals` is a small hand-rolled tokenizer (comments vs.
+ * string/template literals), not a full JS parser — "pragmatic regex is
+ * fine" per the fix mandate. It is comment-aware in BOTH directions: a
+ * `//`/`/* *\/` comment is matched and discarded as one token (so a quoted
+ * phrase INSIDE a comment is never mistaken for a real string literal),
+ * and a string literal containing `//` (e.g. a `https://...` URL) is
+ * matched as a single string token because the tokenizer decides by the
+ * character at the CURRENT scan position, not by the first `//` anywhere
+ * in the line — verified directly below with both cases.
+ */
+const STRING_TOKEN_RE =
+  /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`/g;
+
+function extractStringLiterals(src: string): string[] {
+  const out: string[] = [];
+  for (const match of src.matchAll(STRING_TOKEN_RE)) {
+    const token = match[0];
+    if (token.startsWith("//") || token.startsWith("/*")) continue;
+    out.push(token.slice(1, -1));
+  }
+  return out;
+}
+
+const STUDIO_SRC_DIR = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "app",
+  "visa",
+  "second-home",
+  "studio",
+);
+
+function listTsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listTsxFiles(full));
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".tsx") &&
+      !entry.name.endsWith(".test.tsx")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const studioTsxFiles = listTsxFiles(STUDIO_SRC_DIR);
+
+describe("extractStringLiterals — the tokenizer itself (guilt + innocence fixtures)", () => {
+  it("guilt: catches a forbidden phrase inside a real string literal", () => {
+    const src = `const x = "You can open the account at any bank.";`;
+    const hit = extractStringLiterals(src).some((s) =>
+      FORBIDDEN_PATTERNS.anyBank.test(s),
+    );
+    expect(hit).toBe(true);
+  });
+
+  it("guilt: catches a generalized IDR price literal beyond 35M/39M", () => {
+    const src = `const x = "IDR 42,500,000 total.";`;
+    const hit = extractStringLiterals(src).some((s) =>
+      JSX_PRICE_LITERAL_RE.test(s),
+    );
+    expect(hit).toBe(true);
+  });
+
+  it("innocence: a forbidden-looking phrase INSIDE a // line comment is not extracted as a string", () => {
+    const src = `// any bank works here, this is only a comment\nconst x = "USD 130,000";`;
+    const hit = extractStringLiterals(src).some((s) =>
+      FORBIDDEN_PATTERNS.anyBank.test(s),
+    );
+    expect(hit).toBe(false);
+  });
+
+  it("innocence: a forbidden-looking phrase INSIDE a /* */ block comment is not extracted as a string", () => {
+    const src = `/**\n * any bank — historical note only\n */\nconst x = "USD 130,000";`;
+    const hit = extractStringLiterals(src).some((s) =>
+      FORBIDDEN_PATTERNS.anyBank.test(s),
+    );
+    expect(hit).toBe(false);
+  });
+
+  it("a string literal containing '//' (a URL) is extracted whole, not truncated at the comment-like slashes", () => {
+    const src = `const x = "https://balizero.com/visa/second-home/studio";`;
+    const literals = extractStringLiterals(src);
+    expect(literals).toContain("https://balizero.com/visa/second-home/studio");
+  });
+});
+
+describe("source-scan — JSX string literals under app/visa/second-home/studio/ (P2-C13)", () => {
+  it("scans a non-trivial number of files (guards against an empty/broken walk)", () => {
+    expect(studioTsxFiles.length).toBeGreaterThan(5);
+  });
+
+  it.each(Object.entries(FORBIDDEN_PATTERNS))(
+    "no JSX string/template literal in the studio tree matches the %s pattern",
+    (name, pattern) => {
+      const violations: string[] = [];
+      for (const file of studioTsxFiles) {
+        const src = readFileSync(file, "utf8");
+        for (const literal of extractStringLiterals(src)) {
+          if (pattern.test(literal)) {
+            violations.push(`${file}: ${JSON.stringify(literal)}`);
+          }
+        }
+      }
+      expect(violations, violations.join("\n")).toEqual([]);
+    },
+  );
+
+  it("no JSX string/template literal contains a generalized IDR price literal", () => {
+    const violations: string[] = [];
+    for (const file of studioTsxFiles) {
+      const src = readFileSync(file, "utf8");
+      for (const literal of extractStringLiterals(src)) {
+        if (JSX_PRICE_LITERAL_RE.test(literal)) {
+          violations.push(`${file}: ${JSON.stringify(literal)}`);
+        }
+      }
+    }
+    expect(violations, violations.join("\n")).toEqual([]);
   });
 });

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/forbidden-claims.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "../copy";
+
+/**
+ * The e33_claim_guard forbidden-pattern list, verbatim from
+ * SPEC-secondhome-studio-phaseB.md §6. Case-insensitive by design (the
+ * spec calls this out explicitly) — every pattern below carries the `i`
+ * flag.
+ */
+const FORBIDDEN_PATTERNS: Record<string, RegExp> = {
+  priceUsd1500: /US?D?\s*\$?\s*1[,.]?500/i,
+  anyBank: /any\s+(Indonesian\s+)?bank/i,
+  e33SR: /E33[SR]\b/i,
+  workLocallyOrInIndonesia: /work(ing)?\s+(locally|in\s+indonesia)/i,
+  automaticItapOrPermanent: /automatic(ally)?\s+.*(ITAP|permanent)/i,
+  fiveToTenYears: /5\s*[-–]\s*10\s*years?/i,
+  idr2Million: /IDR\s*2[,.]?000[,.]?000\b/i,
+  guaranteedOr100PercentApproval: /guarantee[ds]?\s+approval|100%\s+approval/i,
+  lps: /\bLPS\b/i,
+  bsiOrSharia: /\bBSI\b|sharia/i,
+  splitDeposit: /split(ting)?\s+.*deposit/i,
+};
+
+/** No hardcoded IDR price literal anywhere — the figure renders only from
+ *  usePricingData. Covers both the pre-repricing (39M) and current (35M)
+ *  values so a future reprice can't silently reintroduce a stale one. */
+const PRICE_LITERAL_PATTERN =
+  /35[,.]?000[,.]?000|39[,.]?000[,.]?000|\b39M\b|\b35M\b/i;
+
+interface CopyEntry {
+  path: string;
+  value: string;
+}
+
+function collectStrings(node: unknown, path: string, out: CopyEntry[]): void {
+  if (typeof node === "string") {
+    out.push({ path, value: node });
+    return;
+  }
+  if (typeof node !== "object" || node === null) return;
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    collectStrings(value, path ? `${path}.${key}` : key, out);
+  }
+}
+
+function allCopyStrings(): CopyEntry[] {
+  const out: CopyEntry[] = [];
+  collectStrings(COPY, "", out);
+  return out;
+}
+
+describe("forbidden-claims sweep — every string in COPY", () => {
+  const entries = allCopyStrings();
+
+  it("the sweep actually walks a non-trivial number of strings (guards against an empty/broken walk)", () => {
+    expect(entries.length).toBeGreaterThan(40);
+  });
+
+  it.each(Object.entries(FORBIDDEN_PATTERNS))(
+    "no copy string matches the %s pattern",
+    (name, pattern) => {
+      const violations = entries.filter((e) => pattern.test(e.value));
+      expect(
+        violations,
+        `pattern "${name}" matched: ${violations.map((v) => v.path).join(", ")}`,
+      ).toEqual([]);
+    },
+  );
+
+  it("no copy string contains a hardcoded price literal (35M/39M in any form)", () => {
+    const violations = entries.filter((e) =>
+      PRICE_LITERAL_PATTERN.test(e.value),
+    );
+    expect(
+      violations,
+      `price literal leaked in: ${violations.map((v) => v.path).join(", ")}`,
+    ).toEqual([]);
+  });
+});
+
+describe("guilt fixtures — each pattern actually fires on a known-bad string", () => {
+  const guiltCases: Array<{
+    pattern: keyof typeof FORBIDDEN_PATTERNS;
+    text: string;
+  }> = [
+    {
+      pattern: "priceUsd1500",
+      text: "The total cost is USD 1,500 for processing.",
+    },
+    { pattern: "priceUsd1500", text: "Just US$1500 flat." },
+    { pattern: "anyBank", text: "You can open the account at any bank." },
+    { pattern: "anyBank", text: "Works with any Indonesian bank." },
+    { pattern: "e33SR", text: "Apply now for E33S." },
+    { pattern: "e33SR", text: "The E33R variant is also available." },
+    {
+      pattern: "workLocallyOrInIndonesia",
+      text: "This visa lets you work locally in Bali.",
+    },
+    {
+      pattern: "workLocallyOrInIndonesia",
+      text: "You are permitted to work in Indonesia.",
+    },
+    {
+      pattern: "automaticItapOrPermanent",
+      text: "Your KITAS automatically converts to ITAP after 3 years.",
+    },
+    {
+      pattern: "automaticItapOrPermanent",
+      text: "This status automatically becomes permanent residency.",
+    },
+    { pattern: "fiveToTenYears", text: "Valid for 5-10 years, typically." },
+    { pattern: "fiveToTenYears", text: "Somewhere between 5 – 10 years." },
+    {
+      pattern: "idr2Million",
+      text: "A processing fee of IDR 2,000,000 applies.",
+    },
+    {
+      pattern: "guaranteedOr100PercentApproval",
+      text: "We offer guaranteed approval for your visa.",
+    },
+    {
+      pattern: "guaranteedOr100PercentApproval",
+      text: "100% approval, no exceptions.",
+    },
+    {
+      pattern: "lps",
+      text: "Your deposit is protected by LPS deposit insurance.",
+    },
+    { pattern: "bsiOrSharia", text: "Also available via BSI." },
+    {
+      pattern: "bsiOrSharia",
+      text: "A sharia-compliant deposit option exists.",
+    },
+    {
+      pattern: "splitDeposit",
+      text: "You may consider splitting your deposit across two accounts.",
+    },
+  ];
+
+  it.each(guiltCases)("$pattern fires on: $text", ({ pattern, text }) => {
+    expect(FORBIDDEN_PATTERNS[pattern].test(text)).toBe(true);
+  });
+
+  it("the price-literal pattern fires on known-bad price strings", () => {
+    expect(PRICE_LITERAL_PATTERN.test("IDR 35,000,000")).toBe(true);
+    expect(PRICE_LITERAL_PATTERN.test("IDR 39.000.000")).toBe(true);
+    expect(PRICE_LITERAL_PATTERN.test("only 39M")).toBe(true);
+    expect(PRICE_LITERAL_PATTERN.test("just 35M all-in")).toBe(true);
+  });
+});
+
+describe("innocence pins — legitimate copy must NOT trip the guard (superscar #3 twin check)", () => {
+  it('"non-working residency" does not trip the work-locally pattern', () => {
+    expect(
+      FORBIDDEN_PATTERNS.workLocallyOrInIndonesia.test("non-working residency"),
+    ).toBe(false);
+    expect(
+      FORBIDDEN_PATTERNS.workLocallyOrInIndonesia.test(
+        "This is a non-working residency permit.",
+      ),
+    ).toBe(false);
+  });
+
+  it("the actual copy module uses the safe 'non-working' framing somewhere and it passes the sweep", () => {
+    const entries = allCopyStrings();
+    const hasNonWorking = entries.some((e) => /non-working/i.test(e.value));
+    // Not a hard requirement of this module (no copy currently needs to
+    // describe work rights explicitly), but if it's ever added it must use
+    // the safe phrasing — this pin documents and locks that in.
+    if (hasNonWorking) {
+      const offenders = entries.filter(
+        (e) =>
+          /non-working/i.test(e.value) &&
+          FORBIDDEN_PATTERNS.workLocallyOrInIndonesia.test(e.value),
+      );
+      expect(offenders).toEqual([]);
+    }
+  });
+
+  it("USD 130,000 (the real deposit figure) does not trip the USD 1,500 pattern", () => {
+    expect(FORBIDDEN_PATTERNS.priceUsd1500.test("USD 130,000")).toBe(false);
+  });
+
+  it("USD 1,000,000 (the real property threshold) does not trip the USD 1,500 pattern", () => {
+    expect(FORBIDDEN_PATTERNS.priceUsd1500.test("USD 1,000,000")).toBe(false);
+  });
+
+  it("E33E / E33F (real product codes) do not trip the E33S/E33R pattern", () => {
+    expect(FORBIDDEN_PATTERNS.e33SR.test("E33E")).toBe(false);
+    expect(FORBIDDEN_PATTERNS.e33SR.test("E33F")).toBe(false);
+    expect(FORBIDDEN_PATTERNS.e33SR.test("the E33E senior pattern")).toBe(
+      false,
+    );
+  });
+
+  it("'up to 5 years, renewable (10-year cumulative cap)' does not trip the 5-10-years pattern", () => {
+    expect(
+      FORBIDDEN_PATTERNS.fiveToTenYears.test(
+        "First grant up to 5 years, renewable (10-year cumulative cap, Pasal 113).",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("positive pins — required phrasing is actually present", () => {
+  it("custody copy contains 'state-owned' and 'own name'", () => {
+    const custodyStrings = Object.values(COPY.custody)
+      .map((step) => `${step.title} ${step.body}`)
+      .join(" ")
+      .toLowerCase();
+    expect(custodyStrings).toContain("state-owned");
+    expect(custodyStrings).toContain("own name");
+  });
+
+  it("every verdict band body states the final decision rests with Imigrasi", () => {
+    for (const band of Object.values(COPY.verdict.bands)) {
+      expect(band.body.toLowerCase()).toContain(
+        "the final decision rests with imigrasi",
+      );
+    }
+  });
+
+  it("dependents are described as priced in the free fit memo, never with a figure", () => {
+    const dependentsNote = COPY.wizard.family.dependentsNote.toLowerCase();
+    expect(dependentsNote).toContain("fit memo");
+    expect(PRICE_LITERAL_PATTERN.test(dependentsNote)).toBe(false);
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   PLAN_STORAGE_KEY,
+  clearPlan,
   decodePlanFragment,
   emptyPlan,
   encodePlanFragment,
@@ -154,6 +155,26 @@ describe("savePlan / loadPlan — localStorage roundtrip", () => {
   });
 });
 
+describe("clearPlan — SavePlanBar 'Clear saved plan' action", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("removes a previously saved plan so loadPlan returns null", () => {
+    savePlan({ ...emptyPlan(), age: "under_55" });
+    expect(loadPlan()).not.toBeNull();
+
+    clearPlan();
+    expect(loadPlan()).toBeNull();
+    expect(window.localStorage.getItem(PLAN_STORAGE_KEY)).toBeNull();
+  });
+
+  it("is a safe no-op when nothing was ever saved", () => {
+    expect(() => clearPlan()).not.toThrow();
+    expect(loadPlan()).toBeNull();
+  });
+});
+
 describe("SSR-safety — functions never throw when window is undefined", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -163,6 +184,11 @@ describe("SSR-safety — functions never throw when window is undefined", () => 
     vi.stubGlobal("window", undefined);
     expect(() => savePlan(emptyPlan())).not.toThrow();
     expect(loadPlan()).toBeNull();
+  });
+
+  it("clearPlan is a no-op without window", () => {
+    vi.stubGlobal("window", undefined);
+    expect(() => clearPlan()).not.toThrow();
   });
 
   it("encodePlanFragment / decodePlanFragment still work without window (Node/Buffer path)", () => {

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
@@ -22,6 +22,24 @@ function toB64Url(s: string): string {
     .replace(/=+$/, "");
 }
 
+/** A fully-valid, fully-populated plan — shared by the clearPlan URL-strip
+ *  test (P2-C11) and the P0-C1/P2-1 shape-validation table below. */
+function fullPlanFixture(): PlanState {
+  return {
+    v: 1,
+    age: "under_55",
+    route: "deposit",
+    capital: "ready_130k",
+    seniorFunding: null,
+    property: null,
+    family: { spouse: false, children: 0, parents: 0 },
+    horizon: "asap",
+    location: "in_indonesia",
+    checklist: { x: true },
+    updatedAt: "2026-08-19T00:00:00.000Z",
+  };
+}
+
 describe("emptyPlan", () => {
   it("returns a fresh v1 plan with all-null answers and an empty checklist", () => {
     const plan = emptyPlan();
@@ -158,6 +176,11 @@ describe("savePlan / loadPlan — localStorage roundtrip", () => {
 describe("clearPlan — SavePlanBar 'Clear saved plan' action", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    window.location.hash = "";
+  });
+
+  afterEach(() => {
+    window.location.hash = "";
   });
 
   it("removes a previously saved plan so loadPlan returns null", () => {
@@ -172,6 +195,152 @@ describe("clearPlan — SavePlanBar 'Clear saved plan' action", () => {
   it("is a safe no-op when nothing was ever saved", () => {
     expect(() => clearPlan()).not.toThrow();
     expect(loadPlan()).toBeNull();
+  });
+
+  it("P2-C11: also strips a #p= plan fragment from the URL, so a 'cleared' plan cannot reappear on reload", () => {
+    savePlan({ ...emptyPlan(), age: "under_55" });
+    window.location.hash = `#p=${encodePlanFragment(fullPlanFixture())}`;
+    expect(window.location.hash).not.toBe("");
+
+    clearPlan();
+
+    expect(window.location.hash).toBe("");
+  });
+
+  it("P2-C11: stripping the fragment is a safe no-op when there was no fragment to begin with", () => {
+    window.location.hash = "";
+    expect(() => clearPlan()).not.toThrow();
+    expect(window.location.hash).toBe("");
+  });
+});
+
+describe("P0-C1 / P2-1 — isValidPlanShape validates PRESENCE + whitelist for EVERY PlanState key", () => {
+  it("accepts a fully-valid, fully-populated plan", () => {
+    const encoded = toB64Url(JSON.stringify(fullPlanFixture()));
+    expect(decodePlanFragment(encoded)).toEqual(fullPlanFixture());
+  });
+
+  it("rejects the crafted ABSENT-field fragment that used to manufacture a strong_fit verdict (P0-C1, Codex-verified)", () => {
+    // age/route are ABSENT (not null) — the old validator only checked
+    // v/family/checklist/updatedAt, so this shape decoded successfully and
+    // evaluatePlan's `=== null` guards let the missing fields slip through
+    // as "under_55 + deposit + ready_130k" => strong_fit E33.
+    const crafted = toB64Url(
+      JSON.stringify({
+        v: 1,
+        family: {},
+        checklist: {},
+        updatedAt: "x",
+        capital: "ready_130k",
+      }),
+    );
+    expect(decodePlanFragment(crafted)).toBeNull();
+  });
+
+  const REQUIRED_KEYS: (keyof PlanState)[] = [
+    "age",
+    "route",
+    "capital",
+    "seniorFunding",
+    "property",
+    "family",
+    "horizon",
+    "location",
+    "checklist",
+    "updatedAt",
+  ];
+
+  it.each(REQUIRED_KEYS)(
+    "rejects the fragment when '%s' is absent (per-field absence table test)",
+    (key) => {
+      const obj: Record<string, unknown> = { ...fullPlanFixture() };
+      delete obj[key];
+      const encoded = toB64Url(JSON.stringify(obj));
+      expect(decodePlanFragment(encoded)).toBeNull();
+    },
+  );
+
+  it("rejects an out-of-whitelist enum value (age: 123, not a real AgeBand)", () => {
+    const obj = { ...fullPlanFixture(), age: 123 };
+    expect(decodePlanFragment(toB64Url(JSON.stringify(obj)))).toBeNull();
+  });
+
+  it("rejects an out-of-whitelist enum value (horizon: 'next_year')", () => {
+    const obj = { ...fullPlanFixture(), horizon: "next_year" };
+    expect(decodePlanFragment(toB64Url(JSON.stringify(obj)))).toBeNull();
+  });
+
+  it("rejects the exact crafted-link fragment from the refuter report (strong_fit + raw dot-paths)", () => {
+    const obj = {
+      ...fullPlanFixture(),
+      age: "under_55",
+      route: "deposit",
+      capital: 123,
+      horizon: "next_year",
+    };
+    expect(decodePlanFragment(toB64Url(JSON.stringify(obj)))).toBeNull();
+  });
+
+  it("rejects a family with a non-boolean spouse", () => {
+    const obj = {
+      ...fullPlanFixture(),
+      family: { spouse: "yes", children: 0, parents: 0 },
+    };
+    expect(decodePlanFragment(toB64Url(JSON.stringify(obj)))).toBeNull();
+  });
+
+  it("rejects a family with a negative children count", () => {
+    const obj = {
+      ...fullPlanFixture(),
+      family: { spouse: false, children: -1, parents: 0 },
+    };
+    expect(decodePlanFragment(toB64Url(JSON.stringify(obj)))).toBeNull();
+  });
+
+  it("rejects a checklist with a non-boolean value", () => {
+    const obj = { ...fullPlanFixture(), checklist: { x: "yes" } };
+    expect(decodePlanFragment(toB64Url(JSON.stringify(obj)))).toBeNull();
+  });
+
+  it("innocence: an empty checklist ({}) is still valid", () => {
+    const obj = { ...fullPlanFixture(), checklist: {} };
+    expect(decodePlanFragment(toB64Url(JSON.stringify(obj)))).not.toBeNull();
+  });
+});
+
+describe("P2-C12 — a throwing localStorage GETTER never crashes the codec", () => {
+  let originalDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "localStorage",
+    );
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("The operation is insecure.", "SecurityError");
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, "localStorage", originalDescriptor);
+    }
+  });
+
+  it("loadPlan returns null and never throws", () => {
+    expect(() => loadPlan()).not.toThrow();
+    expect(loadPlan()).toBeNull();
+  });
+
+  it("savePlan is a safe no-op and never throws", () => {
+    expect(() => savePlan(emptyPlan())).not.toThrow();
+  });
+
+  it("clearPlan is a safe no-op and never throws", () => {
+    expect(() => clearPlan()).not.toThrow();
   });
 });
 

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/plan-codec.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PLAN_STORAGE_KEY,
+  decodePlanFragment,
+  emptyPlan,
+  encodePlanFragment,
+  loadPlan,
+  savePlan,
+} from "../plan-codec";
+import type { PlanState } from "../types";
+
+/** Local base64url encoder, independent of the module under test, so the
+ *  "wrong version" / "malformed" fixtures aren't accidentally validated by
+ *  the very encoder they're meant to probe. */
+function toB64Url(s: string): string {
+  return Buffer.from(s, "utf-8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+describe("emptyPlan", () => {
+  it("returns a fresh v1 plan with all-null answers and an empty checklist", () => {
+    const plan = emptyPlan();
+    expect(plan.v).toBe(1);
+    expect(plan.age).toBeNull();
+    expect(plan.route).toBeNull();
+    expect(plan.capital).toBeNull();
+    expect(plan.seniorFunding).toBeNull();
+    expect(plan.property).toBeNull();
+    expect(plan.horizon).toBeNull();
+    expect(plan.location).toBeNull();
+    expect(plan.family).toEqual({ spouse: false, children: 0, parents: 0 });
+    expect(plan.checklist).toEqual({});
+    expect(typeof plan.updatedAt).toBe("string");
+  });
+});
+
+describe("encodePlanFragment / decodePlanFragment roundtrip", () => {
+  it("roundtrips a fully-answered plan", () => {
+    const plan: PlanState = {
+      ...emptyPlan(),
+      age: "60_plus",
+      route: "deposit",
+      capital: null,
+      seniorFunding: "deposit_50k_income",
+      property: null,
+      family: { spouse: true, children: 2, parents: 1 },
+      horizon: "asap",
+      location: "abroad",
+      checklist: { passport_validity: true, photos: false },
+    };
+
+    const encoded = encodePlanFragment(plan);
+    const decoded = decodePlanFragment(encoded);
+    expect(decoded).toEqual(plan);
+  });
+
+  it("roundtrips an empty plan", () => {
+    const plan = emptyPlan();
+    const decoded = decodePlanFragment(encodePlanFragment(plan));
+    expect(decoded).toEqual(plan);
+  });
+
+  it("encoded fragment is base64url (no +, /, = characters)", () => {
+    const encoded = encodePlanFragment(emptyPlan());
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+});
+
+describe("decodePlanFragment — malformed / wrong-version / oversized => null, never throw", () => {
+  it("rejects an empty string", () => {
+    expect(decodePlanFragment("")).toBeNull();
+  });
+
+  it("rejects a string with characters outside the base64url alphabet", () => {
+    expect(() =>
+      decodePlanFragment("not a valid base64url!!! ###"),
+    ).not.toThrow();
+    expect(decodePlanFragment("not a valid base64url!!! ###")).toBeNull();
+  });
+
+  it("rejects a base64url-alphabet string that decodes to non-JSON garbage", () => {
+    const garbage = toB64Url("this is plainly not json at all");
+    expect(decodePlanFragment(garbage)).toBeNull();
+  });
+
+  it("rejects valid JSON that isn't PlanState-shaped", () => {
+    const notAPlan = toB64Url(JSON.stringify({ hello: "world" }));
+    expect(decodePlanFragment(notAPlan)).toBeNull();
+  });
+
+  it("rejects a wrong schema version (v !== 1)", () => {
+    const wrongVersion = toB64Url(JSON.stringify({ ...emptyPlan(), v: 2 }));
+    expect(decodePlanFragment(wrongVersion)).toBeNull();
+  });
+
+  it("rejects an oversized fragment (>8KB)", () => {
+    const huge = "A".repeat(8 * 1024 + 1);
+    expect(decodePlanFragment(huge)).toBeNull();
+  });
+
+  it("accepts a fragment right at the 8KB boundary shape (sanity: boundary itself isn't rejected by length alone)", () => {
+    // A same-length string of valid alphabet chars that is NOT valid JSON
+    // still correctly resolves to null via the JSON-parse guard, proving
+    // the size guard isn't masking a separate bug at the boundary.
+    const atLimit = "A".repeat(8 * 1024);
+    expect(decodePlanFragment(atLimit)).toBeNull();
+  });
+});
+
+describe("savePlan / loadPlan — localStorage roundtrip", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when nothing has been saved", () => {
+    expect(loadPlan()).toBeNull();
+  });
+
+  it("roundtrips a plan through localStorage", () => {
+    const plan: PlanState = {
+      ...emptyPlan(),
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+    };
+    savePlan(plan);
+    expect(loadPlan()).toEqual(plan);
+  });
+
+  it("saves under the documented storage key", () => {
+    const plan = emptyPlan();
+    savePlan(plan);
+    const raw = window.localStorage.getItem(PLAN_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual(plan);
+  });
+
+  it("returns null on corrupted JSON in storage, never throws", () => {
+    window.localStorage.setItem(PLAN_STORAGE_KEY, "{not valid json");
+    expect(() => loadPlan()).not.toThrow();
+    expect(loadPlan()).toBeNull();
+  });
+
+  it("returns null on wrong-version content in storage", () => {
+    window.localStorage.setItem(
+      PLAN_STORAGE_KEY,
+      JSON.stringify({ v: 2, family: {}, checklist: {}, updatedAt: "x" }),
+    );
+    expect(loadPlan()).toBeNull();
+  });
+});
+
+describe("SSR-safety — functions never throw when window is undefined", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("savePlan is a no-op and loadPlan returns null without window", () => {
+    vi.stubGlobal("window", undefined);
+    expect(() => savePlan(emptyPlan())).not.toThrow();
+    expect(loadPlan()).toBeNull();
+  });
+
+  it("encodePlanFragment / decodePlanFragment still work without window (Node/Buffer path)", () => {
+    vi.stubGlobal("window", undefined);
+    const plan = emptyPlan();
+    let encoded = "";
+    expect(() => {
+      encoded = encodePlanFragment(plan);
+    }).not.toThrow();
+    expect(encoded.length).toBeGreaterThan(0);
+
+    let decoded: PlanState | null = null;
+    expect(() => {
+      decoded = decodePlanFragment(encoded);
+    }).not.toThrow();
+    expect(decoded).toEqual(plan);
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/rules.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/rules.test.ts
@@ -142,6 +142,72 @@ describe("row 1 — property route: ALWAYS edge_case, NEVER strong/likely fit", 
   });
 });
 
+describe("P1-A — property route + age 55-59 keeps the mandatory disclosure note", () => {
+  it.each(ALL_PROPERTY_STATUSES)(
+    "property=%s: seniorBersyarat reason + age5559Disclosure note present (guilt would be note null)",
+    (property) => {
+      const v = evaluatePlan(
+        basePlan({ age: "55_59", route: "property", property }),
+      );
+      expect(v.band).toBe("edge_case");
+      expect(v.reasons).toContain(REASON_KEYS.seniorBersyarat);
+      expect(v.humanReviewNote).toBe(HUMAN_REVIEW_KEYS.age5559Disclosure);
+    },
+  );
+
+  it("qualifying property + 55-59: pending-standard + seniorBersyarat, in that order", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "55_59",
+        route: "property",
+        property: "owns_qualifying_strata",
+      }),
+    );
+    expect(v.reasons).toEqual([
+      REASON_KEYS.propertyPendingStandard,
+      REASON_KEYS.seniorBersyarat,
+    ]);
+  });
+
+  it("non-qualifying property + 55-59: pending-standard + does-not-qualify + seniorBersyarat", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "55_59",
+        route: "property",
+        property: "villa_land_leasehold",
+      }),
+    );
+    expect(v.reasons).toEqual([
+      REASON_KEYS.propertyPendingStandard,
+      REASON_KEYS.propertyDoesNotQualify,
+      REASON_KEYS.seniorBersyarat,
+    ]);
+  });
+
+  it("innocence: under_55 + property keeps humanReviewNote null", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "property", property: "none" }),
+    );
+    expect(v.humanReviewNote).toBeNull();
+  });
+
+  it("innocence: 60_plus + property keeps humanReviewNote null", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "60_plus", route: "property", property: "none" }),
+    );
+    expect(v.humanReviewNote).toBeNull();
+  });
+
+  it("property status missing at 55-59 still resolves to incomplete, not a silent disclosure skip", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "55_59", route: "property", property: null }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+    expect(v.humanReviewNote).toBeNull();
+  });
+});
+
 describe("rows 2-4 — under_55 + deposit route, driven by capital", () => {
   it("row 2: ready_130k => strong_fit E33", () => {
     const v = evaluatePlan(
@@ -438,6 +504,95 @@ describe("row 8 — route=unsure evaluated as deposit, with an added reason", ()
       basePlan({ age: "under_55", route: "unsure", capital: "ready_130k" }),
     );
     expect(v.reasons).not.toContain(REASON_KEYS.propertyPendingStandard);
+  });
+});
+
+describe("P2-7 — route=unsure never gives a hard 'not eligible' (conductor-ruled spec amendment)", () => {
+  it("under_55 + unsure + below_100k => edge_case, never not_eligible (guilt: not_eligible)", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "unsure", capital: "below_100k" }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.band).not.toBe("not_eligible");
+    expect(v.product).toBeNull();
+    expect(v.reasons).toEqual([
+      REASON_KEYS.unsureRoute,
+      REASON_KEYS.capitalBelowThreshold,
+      REASON_KEYS.seniorRoutesExistNote,
+    ]);
+  });
+
+  it("innocence: route=deposit + below_100k is still a hard not_eligible", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "deposit", capital: "below_100k" }),
+    );
+    expect(v.band).toBe("not_eligible");
+  });
+
+  it("innocence: unsure + ready_130k is still strong_fit", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "unsure", capital: "ready_130k" }),
+    );
+    expect(v.band).toBe("strong_fit");
+    expect(v.product).toBe("E33");
+  });
+
+  it("60_plus + unsure + seniorFunding=neither + below_100k => edge_case, not not_eligible", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "60_plus",
+        route: "unsure",
+        seniorFunding: "neither",
+        capital: "below_100k",
+      }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.band).not.toBe("not_eligible");
+  });
+});
+
+describe("P0-C1 — evaluatePlan defense-in-depth: undefined fields never manufacture a verdict", () => {
+  it("age/route absent (undefined, not null) resolves to edge_case incomplete, never strong_fit", () => {
+    const crafted = {
+      v: 1,
+      family: { spouse: false, children: 0, parents: 0 },
+      checklist: {},
+      updatedAt: "x",
+      capital: "ready_130k",
+    } as unknown as PlanState;
+    const v = evaluatePlan(crafted);
+    expect(v.band).toBe("edge_case");
+    expect(v.band).not.toBe("strong_fit");
+    expect(v.product).toBeNull();
+  });
+
+  it("property absent (undefined) on the property route resolves to incomplete, never a fit band", () => {
+    const crafted = {
+      v: 1,
+      age: "under_55",
+      route: "property",
+      family: { spouse: false, children: 0, parents: 0 },
+      checklist: {},
+      updatedAt: "x",
+    } as unknown as PlanState;
+    const v = evaluatePlan(crafted);
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+  });
+
+  it("seniorFunding absent (undefined) at 55-59 resolves to incomplete, never a product", () => {
+    const crafted = {
+      v: 1,
+      age: "55_59",
+      route: "deposit",
+      family: { spouse: false, children: 0, parents: 0 },
+      checklist: {},
+      updatedAt: "x",
+    } as unknown as PlanState;
+    const v = evaluatePlan(crafted);
+    expect(v.band).toBe("edge_case");
+    expect(v.product).toBeNull();
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
   });
 });
 

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/rules.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/rules.test.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from "vitest";
+
+import { getCopy } from "../copy";
+import { HUMAN_REVIEW_KEYS, REASON_KEYS, evaluatePlan } from "../rules";
+import type {
+  AgeBand,
+  PlanState,
+  PropertyStatus,
+  SeniorFunding,
+} from "../types";
+
+function basePlan(overrides: Partial<PlanState> = {}): PlanState {
+  return {
+    v: 1,
+    age: null,
+    route: null,
+    capital: null,
+    seniorFunding: null,
+    property: null,
+    family: { spouse: false, children: 0, parents: 0 },
+    horizon: null,
+    location: null,
+    checklist: {},
+    updatedAt: "2026-08-19T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const ALL_AGES: AgeBand[] = ["under_55", "55_59", "60_plus"];
+const ALL_PROPERTY_STATUSES: PropertyStatus[] = [
+  "owns_qualifying_strata",
+  "buying_completed_strata",
+  "villa_land_leasehold",
+  "none",
+];
+const ALL_SENIOR_FUNDING: SeniorFunding[] = [
+  "deposit_50k_income",
+  "income_only_3k",
+  "neither",
+  "not_applicable",
+];
+
+describe("REASON_KEYS / HUMAN_REVIEW_KEYS stay in sync with copy.ts", () => {
+  it("every reason key resolves to a real copy string, never falls back to the key itself", () => {
+    for (const key of Object.values(REASON_KEYS)) {
+      expect(getCopy(key)).not.toBe(key);
+    }
+  });
+
+  it("every human-review key resolves to a real copy string", () => {
+    for (const key of Object.values(HUMAN_REVIEW_KEYS)) {
+      expect(getCopy(key)).not.toBe(key);
+    }
+  });
+});
+
+describe("row 7 — globally required answers null => edge_case incomplete", () => {
+  it("age missing", () => {
+    const v = evaluatePlan(
+      basePlan({ age: null, route: "deposit", capital: "ready_130k" }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.product).toBeNull();
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+  });
+
+  it("route missing", () => {
+    const v = evaluatePlan(basePlan({ age: "under_55", route: null }));
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+  });
+});
+
+describe("row 1 — property route: ALWAYS edge_case, NEVER strong/likely fit", () => {
+  it("owns_qualifying_strata: pending-standard only, no does-not-qualify reason", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "under_55",
+        route: "property",
+        property: "owns_qualifying_strata",
+      }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.product).toBeNull();
+    expect(v.reasons).toEqual([REASON_KEYS.propertyPendingStandard]);
+  });
+
+  it("buying_completed_strata: pending-standard only, no does-not-qualify reason", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "under_55",
+        route: "property",
+        property: "buying_completed_strata",
+      }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.propertyPendingStandard]);
+  });
+
+  it("villa_land_leasehold: pending-standard PLUS does-not-qualify", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "under_55",
+        route: "property",
+        property: "villa_land_leasehold",
+      }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([
+      REASON_KEYS.propertyPendingStandard,
+      REASON_KEYS.propertyDoesNotQualify,
+    ]);
+  });
+
+  it("none: pending-standard PLUS does-not-qualify", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "property", property: "none" }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([
+      REASON_KEYS.propertyPendingStandard,
+      REASON_KEYS.propertyDoesNotQualify,
+    ]);
+  });
+
+  it("property status missing => incomplete, not silently qualified", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "property", property: null }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+  });
+
+  it("across every age x every property status, the band is never strong_fit or likely_fit", () => {
+    for (const age of ALL_AGES) {
+      for (const property of ALL_PROPERTY_STATUSES) {
+        const v = evaluatePlan(basePlan({ age, route: "property", property }));
+        expect(v.band).not.toBe("strong_fit");
+        expect(v.band).not.toBe("likely_fit");
+      }
+    }
+  });
+});
+
+describe("rows 2-4 — under_55 + deposit route, driven by capital", () => {
+  it("row 2: ready_130k => strong_fit E33", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "deposit", capital: "ready_130k" }),
+    );
+    expect(v.band).toBe("strong_fit");
+    expect(v.product).toBe("E33");
+    expect(v.reasons).toEqual([REASON_KEYS.depositReadyStrong]);
+    expect(v.humanReviewNote).toBeNull();
+  });
+
+  it("innocence: close_100k_130k must NOT be strong_fit", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "under_55",
+        route: "deposit",
+        capital: "close_100k_130k",
+      }),
+    );
+    expect(v.band).not.toBe("strong_fit");
+  });
+
+  it("row 3: close_100k_130k => likely_fit E33", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "under_55",
+        route: "deposit",
+        capital: "close_100k_130k",
+      }),
+    );
+    expect(v.band).toBe("likely_fit");
+    expect(v.product).toBe("E33");
+    expect(v.reasons).toEqual([REASON_KEYS.capitalCloseVerify]);
+  });
+
+  it("innocence: ready_130k must NOT be likely_fit", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "deposit", capital: "ready_130k" }),
+    );
+    expect(v.band).not.toBe("likely_fit");
+  });
+
+  it("row 4: below_100k => not_eligible, product null, honest why + senior-routes-exist note", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "deposit", capital: "below_100k" }),
+    );
+    expect(v.band).toBe("not_eligible");
+    expect(v.product).toBeNull();
+    expect(v.reasons).toEqual([
+      REASON_KEYS.capitalBelowThreshold,
+      REASON_KEYS.seniorRoutesExistNote,
+    ]);
+  });
+
+  it("innocence: ready_130k must NOT be not_eligible", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "deposit", capital: "ready_130k" }),
+    );
+    expect(v.band).not.toBe("not_eligible");
+  });
+
+  it("capital missing => incomplete", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "deposit", capital: null }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+  });
+});
+
+describe("row 5 — age 55-59: ALWAYS edge_case (bersyarat), whatever the funding", () => {
+  it.each(ALL_SENIOR_FUNDING)(
+    "seniorFunding=%s stays edge_case",
+    (seniorFunding) => {
+      const v = evaluatePlan(
+        basePlan({ age: "55_59", route: "deposit", seniorFunding }),
+      );
+      expect(v.band).toBe("edge_case");
+      expect(v.humanReviewNote).toBe(HUMAN_REVIEW_KEYS.age5559Disclosure);
+    },
+  );
+
+  it("deposit_50k_income => product E33E", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "55_59",
+        route: "deposit",
+        seniorFunding: "deposit_50k_income",
+      }),
+    );
+    expect(v.product).toBe("E33E");
+    expect(v.reasons).toEqual([REASON_KEYS.seniorBersyarat]);
+  });
+
+  it("income_only_3k => product E33F", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "55_59",
+        route: "deposit",
+        seniorFunding: "income_only_3k",
+      }),
+    );
+    expect(v.product).toBe("E33F");
+    expect(v.reasons).toEqual([REASON_KEYS.seniorBersyarat]);
+  });
+
+  it("neither => product null, with unclear-funding reason", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "55_59", route: "deposit", seniorFunding: "neither" }),
+    );
+    expect(v.product).toBeNull();
+    expect(v.reasons).toEqual([
+      REASON_KEYS.seniorBersyarat,
+      REASON_KEYS.seniorFundingUnclear,
+    ]);
+  });
+
+  it("not_applicable => product null, with unclear-funding reason (same as neither)", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "55_59",
+        route: "deposit",
+        seniorFunding: "not_applicable",
+      }),
+    );
+    expect(v.product).toBeNull();
+    expect(v.reasons).toEqual([
+      REASON_KEYS.seniorBersyarat,
+      REASON_KEYS.seniorFundingUnclear,
+    ]);
+  });
+
+  it("seniorFunding missing => incomplete, never silently strong/likely", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "55_59", route: "deposit", seniorFunding: null }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+  });
+});
+
+describe("row 6 — age 60_plus", () => {
+  it("deposit_50k_income => strong_fit E33E", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "60_plus",
+        route: "deposit",
+        seniorFunding: "deposit_50k_income",
+      }),
+    );
+    expect(v.band).toBe("strong_fit");
+    expect(v.product).toBe("E33E");
+    expect(v.reasons).toEqual([REASON_KEYS.seniorDepositStrong]);
+    expect(v.humanReviewNote).toBeNull();
+  });
+
+  it("income_only_3k => strong_fit E33F", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "60_plus",
+        route: "deposit",
+        seniorFunding: "income_only_3k",
+      }),
+    );
+    expect(v.band).toBe("strong_fit");
+    expect(v.product).toBe("E33F");
+    expect(v.reasons).toEqual([REASON_KEYS.seniorIncomeOnlyStrong]);
+  });
+
+  describe("neither/not_applicable falls through to the base E33 deposit rows", () => {
+    it("neither + ready_130k => strong_fit E33", () => {
+      const v = evaluatePlan(
+        basePlan({
+          age: "60_plus",
+          route: "deposit",
+          seniorFunding: "neither",
+          capital: "ready_130k",
+        }),
+      );
+      expect(v.band).toBe("strong_fit");
+      expect(v.product).toBe("E33");
+      expect(v.reasons).toEqual([REASON_KEYS.depositReadyStrong]);
+    });
+
+    it("neither + close_100k_130k => likely_fit E33", () => {
+      const v = evaluatePlan(
+        basePlan({
+          age: "60_plus",
+          route: "deposit",
+          seniorFunding: "neither",
+          capital: "close_100k_130k",
+        }),
+      );
+      expect(v.band).toBe("likely_fit");
+      expect(v.product).toBe("E33");
+    });
+
+    it("neither + below_100k => not_eligible", () => {
+      const v = evaluatePlan(
+        basePlan({
+          age: "60_plus",
+          route: "deposit",
+          seniorFunding: "neither",
+          capital: "below_100k",
+        }),
+      );
+      expect(v.band).toBe("not_eligible");
+      expect(v.product).toBeNull();
+    });
+
+    it("neither + capital null => edge_case incomplete (capital unknown is NOT allowed to pass through)", () => {
+      const v = evaluatePlan(
+        basePlan({
+          age: "60_plus",
+          route: "deposit",
+          seniorFunding: "neither",
+          capital: null,
+        }),
+      );
+      expect(v.band).toBe("edge_case");
+      expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+    });
+
+    it("not_applicable + ready_130k => strong_fit E33 (same fallthrough as neither)", () => {
+      const v = evaluatePlan(
+        basePlan({
+          age: "60_plus",
+          route: "deposit",
+          seniorFunding: "not_applicable",
+          capital: "ready_130k",
+        }),
+      );
+      expect(v.band).toBe("strong_fit");
+      expect(v.product).toBe("E33");
+    });
+  });
+
+  it("seniorFunding missing => incomplete", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "60_plus", route: "deposit", seniorFunding: null }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.reasons).toEqual([REASON_KEYS.incompleteAnswers]);
+  });
+});
+
+describe("row 8 — route=unsure evaluated as deposit, with an added reason", () => {
+  it("under_55 + unsure + ready_130k => strong_fit E33, unsure reason first", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "unsure", capital: "ready_130k" }),
+    );
+    expect(v.band).toBe("strong_fit");
+    expect(v.product).toBe("E33");
+    expect(v.reasons).toEqual([
+      REASON_KEYS.unsureRoute,
+      REASON_KEYS.depositReadyStrong,
+    ]);
+  });
+
+  it("55_59 + unsure + deposit_50k_income => edge_case E33E, unsure reason first", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "55_59",
+        route: "unsure",
+        seniorFunding: "deposit_50k_income",
+      }),
+    );
+    expect(v.band).toBe("edge_case");
+    expect(v.product).toBe("E33E");
+    expect(v.reasons).toEqual([
+      REASON_KEYS.unsureRoute,
+      REASON_KEYS.seniorBersyarat,
+    ]);
+  });
+
+  it("60_plus + unsure + income_only_3k => strong_fit E33F, unsure reason first", () => {
+    const v = evaluatePlan(
+      basePlan({
+        age: "60_plus",
+        route: "unsure",
+        seniorFunding: "income_only_3k",
+      }),
+    );
+    expect(v.band).toBe("strong_fit");
+    expect(v.product).toBe("E33F");
+    expect(v.reasons).toEqual([
+      REASON_KEYS.unsureRoute,
+      REASON_KEYS.seniorIncomeOnlyStrong,
+    ]);
+  });
+
+  it("unsure route never triggers the property row (property is only literal route='property')", () => {
+    const v = evaluatePlan(
+      basePlan({ age: "under_55", route: "unsure", capital: "ready_130k" }),
+    );
+    expect(v.reasons).not.toContain(REASON_KEYS.propertyPendingStandard);
+  });
+});
+
+describe("evaluatePlan is deterministic and pure", () => {
+  it("calling it twice on the same input yields the same output", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+    });
+    const v1 = evaluatePlan(plan);
+    const v2 = evaluatePlan(plan);
+    expect(v1).toEqual(v2);
+  });
+
+  it("does not mutate the input plan", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+    });
+    const snapshot = JSON.parse(JSON.stringify(plan));
+    evaluatePlan(plan);
+    expect(plan).toEqual(snapshot);
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/sequence.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/sequence.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodePlanFragment,
+  emptyPlan,
+  encodePlanFragment,
+} from "../plan-codec";
+import { computeSequence, relevantPlan } from "../sequence";
+import type { PlanState } from "../types";
+
+function basePlan(overrides: Partial<PlanState> = {}): PlanState {
+  return { ...emptyPlan(), ...overrides };
+}
+
+describe("computeSequence — unchanged behavior (P2-6 hoist, no behavior change)", () => {
+  it("under_55 route: age, route, capital, family, horizon, location", () => {
+    const seq = computeSequence(
+      basePlan({ age: "under_55", route: "deposit" }),
+    );
+    expect(seq).toEqual([
+      "age",
+      "route",
+      "capital",
+      "family",
+      "horizon",
+      "location",
+    ]);
+  });
+
+  it("property route: age, route, property, family, horizon, location", () => {
+    const seq = computeSequence(basePlan({ route: "property" }));
+    expect(seq).toEqual([
+      "age",
+      "route",
+      "property",
+      "family",
+      "horizon",
+      "location",
+    ]);
+  });
+
+  it("55-59: age, route, seniorFunding, family, horizon, location (never capital)", () => {
+    const seq = computeSequence(basePlan({ age: "55_59", route: "deposit" }));
+    expect(seq).toEqual([
+      "age",
+      "route",
+      "seniorFunding",
+      "family",
+      "horizon",
+      "location",
+    ]);
+  });
+
+  it("60_plus + seniorFunding unresolved: includes both seniorFunding and capital", () => {
+    const seq = computeSequence(basePlan({ age: "60_plus", route: "deposit" }));
+    expect(seq).toContain("seniorFunding");
+    expect(seq).toContain("capital");
+  });
+
+  it("60_plus + seniorFunding matched to a senior product: capital is skipped", () => {
+    const seq = computeSequence(
+      basePlan({
+        age: "60_plus",
+        route: "deposit",
+        seniorFunding: "deposit_50k_income",
+      }),
+    );
+    expect(seq).toContain("seniorFunding");
+    expect(seq).not.toContain("capital");
+  });
+});
+
+describe("relevantPlan — nulls branch-only answers not reachable in the current sequence (P2-6)", () => {
+  it("nulls capital after switching from deposit to property", () => {
+    const p = basePlan({
+      age: "under_55",
+      route: "property",
+      capital: "ready_130k",
+      property: "none",
+    });
+    const sanitized = relevantPlan(p);
+    expect(sanitized.capital).toBeNull();
+    expect(sanitized.property).toBe("none");
+  });
+
+  it("nulls property after switching from property to deposit", () => {
+    const p = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+      property: "villa_land_leasehold",
+    });
+    const sanitized = relevantPlan(p);
+    expect(sanitized.property).toBeNull();
+    expect(sanitized.capital).toBe("ready_130k");
+  });
+
+  it("nulls seniorFunding for under_55 (never reachable at that age)", () => {
+    const p = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+      seniorFunding: "deposit_50k_income",
+    });
+    expect(relevantPlan(p).seniorFunding).toBeNull();
+  });
+
+  it("nulls capital for 55-59 (seniorFunding-only age band)", () => {
+    const p = basePlan({
+      age: "55_59",
+      route: "deposit",
+      capital: "ready_130k",
+      seniorFunding: "income_only_3k",
+    });
+    expect(relevantPlan(p).capital).toBeNull();
+    expect(relevantPlan(p).seniorFunding).toBe("income_only_3k");
+  });
+
+  it("keeps capital for 60_plus once seniorFunding resolves to neither (fallthrough still reachable)", () => {
+    const p = basePlan({
+      age: "60_plus",
+      route: "deposit",
+      capital: "close_100k_130k",
+      seniorFunding: "neither",
+    });
+    expect(relevantPlan(p).capital).toBe("close_100k_130k");
+  });
+
+  it("nulls capital for 60_plus once seniorFunding matches a senior product", () => {
+    const p = basePlan({
+      age: "60_plus",
+      route: "deposit",
+      capital: "ready_130k",
+      seniorFunding: "income_only_3k",
+    });
+    expect(relevantPlan(p).capital).toBeNull();
+  });
+
+  it("leaves age/route/family/horizon/location untouched", () => {
+    const p = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+      family: { spouse: true, children: 1, parents: 0 },
+      horizon: "asap",
+      location: "abroad",
+    });
+    const sanitized = relevantPlan(p);
+    expect(sanitized.age).toBe("under_55");
+    expect(sanitized.route).toBe("deposit");
+    expect(sanitized.family).toEqual({ spouse: true, children: 1, parents: 0 });
+    expect(sanitized.horizon).toBe("asap");
+    expect(sanitized.location).toBe("abroad");
+  });
+
+  it("innocence: a fully-relevant deposit plan is untouched by relevantPlan", () => {
+    const p = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+    });
+    expect(relevantPlan(p)).toEqual(p);
+  });
+});
+
+describe("encodePlanFragment(relevantPlan(p)) — the shared-link surface never leaks a stale answer (P2-6)", () => {
+  it("dropping the stale capital answer after switching to property round-trips as null", () => {
+    const p = basePlan({
+      age: "under_55",
+      route: "property",
+      capital: "ready_130k",
+      property: "none",
+    });
+    const encoded = encodePlanFragment(relevantPlan(p));
+    const decoded = decodePlanFragment(encoded);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.capital).toBeNull();
+    expect(decoded?.property).toBe("none");
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/timeline.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/timeline.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import { getCopy } from "../copy";
+import { buildTimeline } from "../timeline";
+import type { Location, TimelineHorizon } from "../types";
+
+const ALL_HORIZONS: TimelineHorizon[] = ["asap", "this_quarter", "exploring"];
+const ALL_LOCATIONS: Location[] = ["in_indonesia", "abroad"];
+
+describe("buildTimeline — 7 public steps, always", () => {
+  it("returns exactly 7 steps for every horizon x location combination", () => {
+    for (const horizon of ALL_HORIZONS) {
+      for (const location of ALL_LOCATIONS) {
+        expect(buildTimeline(horizon, location)).toHaveLength(7);
+      }
+    }
+  });
+
+  it("returns the 7 steps in the spec's fixed order", () => {
+    const steps = buildTimeline("this_quarter", "in_indonesia");
+    expect(steps.map((s) => s.id)).toEqual([
+      "documents",
+      "bank_deposit",
+      "filing",
+      "imigrasi_processing",
+      "entry_activation",
+      "first_90_days",
+      "annual_life",
+    ]);
+  });
+});
+
+describe("owner tags — You / Bali Zero / Imigrasi", () => {
+  it("assigns exactly one of the three owner keys to every step", () => {
+    const steps = buildTimeline("asap", "in_indonesia");
+    for (const step of steps) {
+      expect(["you", "balizero", "imigrasi"]).toContain(step.ownerKey);
+    }
+  });
+
+  it("Imigrasi processing is owned by imigrasi, filing and the 90-day duty by bali zero", () => {
+    const steps = buildTimeline("asap", "in_indonesia");
+    const byId = Object.fromEntries(steps.map((s) => [s.id, s]));
+    expect(byId.imigrasi_processing.ownerKey).toBe("imigrasi");
+    expect(byId.filing.ownerKey).toBe("balizero");
+    expect(byId.first_90_days.ownerKey).toBe("balizero");
+    expect(byId.documents.ownerKey).toBe("you");
+    expect(byId.bank_deposit.ownerKey).toBe("you");
+    expect(byId.entry_activation.ownerKey).toBe("you");
+    expect(byId.annual_life.ownerKey).toBe("you");
+  });
+
+  it("every ownerKey has a resolvable label in copy.ts", () => {
+    const steps = buildTimeline("asap", "in_indonesia");
+    for (const step of steps) {
+      const key = `timeline.ownerLabels.${step.ownerKey}`;
+      expect(getCopy(key)).not.toBe(key);
+    }
+  });
+});
+
+describe("every titleKey and rangeKey resolves to real copy (no drift)", () => {
+  it("resolves for every horizon x location combination", () => {
+    for (const horizon of ALL_HORIZONS) {
+      for (const location of ALL_LOCATIONS) {
+        for (const step of buildTimeline(horizon, location)) {
+          expect(getCopy(step.titleKey)).not.toBe(step.titleKey);
+          expect(getCopy(step.rangeKey)).not.toBe(step.rangeKey);
+          if (step.paceNoteKey) {
+            expect(getCopy(step.paceNoteKey)).not.toBe(step.paceNoteKey);
+          }
+        }
+      }
+    }
+  });
+});
+
+describe("location variant — documents step range differs abroad vs in_indonesia", () => {
+  it("produces a different rangeKey for the documents step", () => {
+    const local = buildTimeline("asap", "in_indonesia").find(
+      (s) => s.id === "documents",
+    )!;
+    const abroad = buildTimeline("asap", "abroad").find(
+      (s) => s.id === "documents",
+    )!;
+    expect(local.rangeKey).not.toBe(abroad.rangeKey);
+    expect(getCopy(local.rangeKey)).not.toBe(getCopy(abroad.rangeKey));
+  });
+
+  it("does not change the range for steps unrelated to document logistics", () => {
+    const local = buildTimeline("asap", "in_indonesia").find(
+      (s) => s.id === "filing",
+    )!;
+    const abroad = buildTimeline("asap", "abroad").find(
+      (s) => s.id === "filing",
+    )!;
+    expect(local.rangeKey).toBe(abroad.rangeKey);
+  });
+});
+
+describe("horizon variant — documents step pace note differs by horizon", () => {
+  it("produces three distinct paceNoteKey values across asap/this_quarter/exploring", () => {
+    const keys = ALL_HORIZONS.map(
+      (h) =>
+        buildTimeline(h, "in_indonesia").find((s) => s.id === "documents")!
+          .paceNoteKey,
+    );
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("only the documents step carries a paceNoteKey", () => {
+    const steps = buildTimeline("asap", "in_indonesia");
+    const withPace = steps.filter((s) => s.paceNoteKey !== undefined);
+    expect(withPace.map((s) => s.id)).toEqual(["documents"]);
+  });
+});
+
+describe("every range label reads as typical, not a promise", () => {
+  it("every step's range copy hedges with 'typical'/'varies' and never promises or guarantees", () => {
+    const steps = buildTimeline("asap", "in_indonesia");
+    for (const step of steps) {
+      const range = getCopy(step.rangeKey).toLowerCase();
+      expect(range).toMatch(/typical|varies|several weeks/);
+      expect(range).not.toMatch(/guarantee[ds]?/);
+    }
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/timeline.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/timeline.test.ts
@@ -115,6 +115,63 @@ describe("horizon variant — documents step pace note differs by horizon", () =
   });
 });
 
+describe("P1-C9 — the second step is route/product-aware (never a blind bank-deposit instruction)", () => {
+  it("default call (no route/product args) still returns bank_deposit — unchanged for every existing caller", () => {
+    const steps = buildTimeline("asap", "in_indonesia");
+    expect(steps[1].id).toBe("bank_deposit");
+  });
+
+  it("route=property replaces the second step with property_evidence, never bank_deposit", () => {
+    const steps = buildTimeline("asap", "in_indonesia", "property", null);
+    expect(steps).toHaveLength(7);
+    expect(steps[1].id).toBe("property_evidence");
+    expect(steps.map((s) => s.id)).not.toContain("bank_deposit");
+    expect(getCopy(steps[1].titleKey)).not.toBe(steps[1].titleKey);
+    expect(getCopy(steps[1].rangeKey)).not.toBe(steps[1].rangeKey);
+  });
+
+  it("product=E33F (income-only) replaces the second step with income_evidence, never bank_deposit", () => {
+    const steps = buildTimeline("asap", "in_indonesia", "deposit", "E33F");
+    expect(steps[1].id).toBe("income_evidence");
+    expect(steps.map((s) => s.id)).not.toContain("bank_deposit");
+    expect(getCopy(steps[1].titleKey)).not.toBe(steps[1].titleKey);
+    expect(getCopy(steps[1].rangeKey)).not.toBe(steps[1].rangeKey);
+  });
+
+  it("innocence: product=E33E (deposit-holding senior route) keeps bank_deposit", () => {
+    const steps = buildTimeline("asap", "in_indonesia", "deposit", "E33E");
+    expect(steps[1].id).toBe("bank_deposit");
+  });
+
+  it("innocence: route=deposit + product=E33 (base strong_fit) keeps bank_deposit", () => {
+    const steps = buildTimeline("asap", "in_indonesia", "deposit", "E33");
+    expect(steps[1].id).toBe("bank_deposit");
+  });
+
+  it("innocence: route=unsure keeps bank_deposit (evaluated as deposit per rules.ts row 8)", () => {
+    const steps = buildTimeline("asap", "in_indonesia", "unsure", "E33");
+    expect(steps[1].id).toBe("bank_deposit");
+  });
+
+  it("property route wins over product even if product happens to be non-null", () => {
+    const steps = buildTimeline("asap", "in_indonesia", "property", null);
+    expect(steps[1].id).toBe("property_evidence");
+  });
+
+  it("owner/step count/order are unchanged regardless of route/product", () => {
+    const steps = buildTimeline("asap", "in_indonesia", "property", null);
+    expect(steps.map((s) => s.ownerKey)).toEqual([
+      "you",
+      "you",
+      "balizero",
+      "imigrasi",
+      "you",
+      "balizero",
+      "you",
+    ]);
+  });
+});
+
 describe("every range label reads as typical, not a promise", () => {
   it("every step's range copy hedges with 'typical'/'varies' and never promises or guarantees", () => {
     const steps = buildTimeline("asap", "in_indonesia");

--- a/apps/mouth/src/lib/secondhome-studio/__tests__/whatsapp-bullets.test.ts
+++ b/apps/mouth/src/lib/secondhome-studio/__tests__/whatsapp-bullets.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_BULLET_ROWS,
+  MAX_LABEL_LENGTH,
+  MAX_VALUE_LENGTH,
+  buildWhatsAppBullets,
+} from "../whatsapp-bullets";
+import { emptyPlan } from "../plan-codec";
+import { evaluatePlan } from "../rules";
+import type { PlanState } from "../types";
+
+/**
+ * P0-C3 + P0-C4 CONTRACT TEST: the built bullet list must satisfy
+ * `apps/backend-rag/backend/app/routers/lead_capture.py:38-47` exactly —
+ * <=6 rows, label <=64 chars, value <=160 chars, every row non-empty.
+ * Constants (MAX_BULLET_ROWS/MAX_LABEL_LENGTH/MAX_VALUE_LENGTH) mirror
+ * that file's `ContextLine` / `whatsapp_context` field constraints.
+ */
+
+function basePlan(overrides: Partial<PlanState> = {}): PlanState {
+  return { ...emptyPlan(), ...overrides };
+}
+
+function assertContract(bullets: ReturnType<typeof buildWhatsAppBullets>) {
+  expect(bullets.length).toBeLessThanOrEqual(MAX_BULLET_ROWS);
+  for (const bullet of bullets) {
+    expect(bullet.label.length).toBeGreaterThan(0);
+    expect(bullet.label.length).toBeLessThanOrEqual(MAX_LABEL_LENGTH);
+    expect(bullet.value.length).toBeGreaterThan(0);
+    expect(bullet.value.length).toBeLessThanOrEqual(MAX_VALUE_LENGTH);
+  }
+}
+
+describe("buildWhatsAppBullets — backend contract (P0-C3/C4)", () => {
+  it("deposit fixture: <=6 rows, every label/value within contract bounds", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+      family: { spouse: true, children: 2, parents: 0 },
+      horizon: "asap",
+      location: "in_indonesia",
+    });
+    const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+    assertContract(bullets);
+  });
+
+  it("senior (55-59) fixture: <=6 rows, every label/value within contract bounds", () => {
+    const plan = basePlan({
+      age: "55_59",
+      route: "deposit",
+      seniorFunding: "deposit_50k_income",
+      family: { spouse: false, children: 0, parents: 1 },
+      horizon: "this_quarter",
+      location: "abroad",
+    });
+    const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+    assertContract(bullets);
+  });
+
+  it("property fixture: <=6 rows, every label/value within contract bounds", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "property",
+      property: "villa_land_leasehold",
+      family: { spouse: false, children: 0, parents: 0 },
+      horizon: "exploring",
+      location: "in_indonesia",
+    });
+    const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+    assertContract(bullets);
+  });
+
+  it("60_plus income-only fixture: <=6 rows, every label/value within contract bounds", () => {
+    const plan = basePlan({
+      age: "60_plus",
+      route: "deposit",
+      seniorFunding: "income_only_3k",
+      family: { spouse: true, children: 0, parents: 0 },
+      horizon: "asap",
+      location: "in_indonesia",
+    });
+    const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+    assertContract(bullets);
+  });
+
+  it("never emits a Saved-plan/plan-link row or a Readiness row (P0-C3(b))", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "deposit",
+      capital: "ready_130k",
+    });
+    const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+    const labels = bullets.map((b) => b.label.toLowerCase());
+    expect(labels).not.toContain("saved plan");
+    expect(labels).not.toContain("readiness");
+    for (const bullet of bullets) {
+      expect(bullet.value).not.toMatch(/^https?:\/\//);
+      expect(bullet.value).not.toContain("#p=");
+    }
+  });
+
+  describe("P1-C8 — the funding line is branch-aware, never a blind seniorFunding read", () => {
+    it("under_55 deposit: funding line reads the capital label, not '—'", () => {
+      const plan = basePlan({
+        age: "under_55",
+        route: "deposit",
+        capital: "ready_130k",
+      });
+      const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+      const funding = bullets.find((b) => b.label === "Funding position");
+      expect(funding).toBeDefined();
+      expect(funding?.value).toBe("USD 130,000 is ready");
+    });
+
+    it("55-59 senior: funding line reads the seniorFunding label", () => {
+      const plan = basePlan({
+        age: "55_59",
+        route: "deposit",
+        seniorFunding: "income_only_3k",
+      });
+      const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+      const funding = bullets.find((b) => b.label === "Funding position");
+      expect(funding?.value).toBe("USD 3,000 monthly income only");
+    });
+
+    it("property route: funding line reads the property status label", () => {
+      const plan = basePlan({
+        age: "under_55",
+        route: "property",
+        property: "owns_qualifying_strata",
+      });
+      const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+      const funding = bullets.find((b) => b.label === "Funding position");
+      expect(funding?.value).toBe(
+        "I own qualifying completed strata-title property",
+      );
+    });
+
+    it("60_plus fallthrough (seniorFunding=neither): funding line reads capital", () => {
+      const plan = basePlan({
+        age: "60_plus",
+        route: "deposit",
+        seniorFunding: "neither",
+        capital: "close_100k_130k",
+      });
+      const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+      const funding = bullets.find((b) => b.label === "Funding position");
+      expect(funding?.value).toBe("USD 100,000 to under USD 130,000");
+    });
+  });
+
+  it("P2-6: a stale capital answer left over after switching to property never leaks into the funding line", () => {
+    const plan = basePlan({
+      age: "under_55",
+      route: "property",
+      property: "none",
+      capital: "ready_130k", // abandoned-branch leftover
+    });
+    const bullets = buildWhatsAppBullets(plan, evaluatePlan(plan));
+    const funding = bullets.find((b) => b.label === "Funding position");
+    expect(funding?.value).not.toContain("130,000");
+  });
+});

--- a/apps/mouth/src/lib/secondhome-studio/checklist.ts
+++ b/apps/mouth/src/lib/secondhome-studio/checklist.ts
@@ -1,5 +1,13 @@
 /**
- * Second Home Studio — the 10-item readiness checklist (spec §5).
+ * Second Home Studio — the 10-item readiness checklist.
+ *
+ * Item content sourced from the copy deck's "DOCUMENT READINESS" section
+ * (COPY-DECK-studio.md §5) — supersedes the original spec-sketch list
+ * (flagged in the delivery report): the deck's list is route-complete,
+ * covering property-route and senior-income-route evidence the original
+ * sketch omitted. `PlanState.checklist` is a free-form `Record<string,
+ * boolean>` (not a frozen enum), so swapping item ids/content here does
+ * not touch the frozen types.ts contract.
  *
  * Checkboxes only, no uploads. Progress is a "readiness meter" — copy
  * always frames this as preparation, never approval likelihood.
@@ -15,54 +23,54 @@ export interface ChecklistItem {
 
 export const CHECKLIST_ITEMS: readonly ChecklistItem[] = [
   {
+    id: "passport_bio_page",
+    titleKey: "checklist.items.passportBioPage.title",
+    whyKey: "checklist.items.passportBioPage.why",
+  },
+  {
     id: "passport_validity",
     titleKey: "checklist.items.passportValidity.title",
     whyKey: "checklist.items.passportValidity.why",
   },
   {
-    id: "passport_scan",
-    titleKey: "checklist.items.passportScan.title",
-    whyKey: "checklist.items.passportScan.why",
+    id: "passport_photo",
+    titleKey: "checklist.items.passportPhoto.title",
+    whyKey: "checklist.items.passportPhoto.why",
   },
   {
-    id: "proof_of_funds",
-    titleKey: "checklist.items.proofOfFunds.title",
-    whyKey: "checklist.items.proofOfFunds.why",
+    id: "residential_address",
+    titleKey: "checklist.items.residentialAddress.title",
+    whyKey: "checklist.items.residentialAddress.why",
   },
   {
-    id: "personal_statement",
-    titleKey: "checklist.items.personalStatement.title",
-    whyKey: "checklist.items.personalStatement.why",
+    id: "personal_history",
+    titleKey: "checklist.items.personalHistory.title",
+    whyKey: "checklist.items.personalHistory.why",
   },
   {
-    id: "photos",
-    titleKey: "checklist.items.photos.title",
-    whyKey: "checklist.items.photos.why",
+    id: "bank_deposit_evidence",
+    titleKey: "checklist.items.bankDepositEvidence.title",
+    whyKey: "checklist.items.bankDepositEvidence.why",
   },
   {
-    id: "address_abroad",
-    titleKey: "checklist.items.addressAbroad.title",
-    whyKey: "checklist.items.addressAbroad.why",
+    id: "passive_income_evidence",
+    titleKey: "checklist.items.passiveIncomeEvidence.title",
+    whyKey: "checklist.items.passiveIncomeEvidence.why",
   },
   {
-    id: "health_insurance",
-    titleKey: "checklist.items.healthInsurance.title",
-    whyKey: "checklist.items.healthInsurance.why",
+    id: "property_documents",
+    titleKey: "checklist.items.propertyDocuments.title",
+    whyKey: "checklist.items.propertyDocuments.why",
   },
   {
-    id: "family_documents",
-    titleKey: "checklist.items.familyDocuments.title",
-    whyKey: "checklist.items.familyDocuments.why",
+    id: "family_records",
+    titleKey: "checklist.items.familyRecords.title",
+    whyKey: "checklist.items.familyRecords.why",
   },
   {
-    id: "travel_plan",
-    titleKey: "checklist.items.travelPlan.title",
-    whyKey: "checklist.items.travelPlan.why",
-  },
-  {
-    id: "deposit_source",
-    titleKey: "checklist.items.depositSource.title",
-    whyKey: "checklist.items.depositSource.why",
+    id: "existing_visa_permit",
+    titleKey: "checklist.items.existingVisaPermit.title",
+    whyKey: "checklist.items.existingVisaPermit.why",
   },
 ];
 

--- a/apps/mouth/src/lib/secondhome-studio/checklist.ts
+++ b/apps/mouth/src/lib/secondhome-studio/checklist.ts
@@ -1,0 +1,77 @@
+/**
+ * Second Home Studio — the 10-item readiness checklist (spec §5).
+ *
+ * Checkboxes only, no uploads. Progress is a "readiness meter" — copy
+ * always frames this as preparation, never approval likelihood.
+ */
+
+import type { PlanState } from "./types";
+
+export interface ChecklistItem {
+  id: string;
+  titleKey: string;
+  whyKey: string;
+}
+
+export const CHECKLIST_ITEMS: readonly ChecklistItem[] = [
+  {
+    id: "passport_validity",
+    titleKey: "checklist.items.passportValidity.title",
+    whyKey: "checklist.items.passportValidity.why",
+  },
+  {
+    id: "passport_scan",
+    titleKey: "checklist.items.passportScan.title",
+    whyKey: "checklist.items.passportScan.why",
+  },
+  {
+    id: "proof_of_funds",
+    titleKey: "checklist.items.proofOfFunds.title",
+    whyKey: "checklist.items.proofOfFunds.why",
+  },
+  {
+    id: "personal_statement",
+    titleKey: "checklist.items.personalStatement.title",
+    whyKey: "checklist.items.personalStatement.why",
+  },
+  {
+    id: "photos",
+    titleKey: "checklist.items.photos.title",
+    whyKey: "checklist.items.photos.why",
+  },
+  {
+    id: "address_abroad",
+    titleKey: "checklist.items.addressAbroad.title",
+    whyKey: "checklist.items.addressAbroad.why",
+  },
+  {
+    id: "health_insurance",
+    titleKey: "checklist.items.healthInsurance.title",
+    whyKey: "checklist.items.healthInsurance.why",
+  },
+  {
+    id: "family_documents",
+    titleKey: "checklist.items.familyDocuments.title",
+    whyKey: "checklist.items.familyDocuments.why",
+  },
+  {
+    id: "travel_plan",
+    titleKey: "checklist.items.travelPlan.title",
+    whyKey: "checklist.items.travelPlan.why",
+  },
+  {
+    id: "deposit_source",
+    titleKey: "checklist.items.depositSource.title",
+    whyKey: "checklist.items.depositSource.why",
+  },
+];
+
+/** N-of-10 readiness meter. Never interpreted as approval likelihood. */
+export function readiness(p: PlanState): { done: number; total: number } {
+  const total = CHECKLIST_ITEMS.length;
+  const done = CHECKLIST_ITEMS.reduce(
+    (acc, item) => acc + (p.checklist[item.id] ? 1 : 0),
+    0,
+  );
+  return { done, total };
+}

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -72,16 +72,23 @@ export const COPY = {
     capital: {
       heading: "How much capital could you place in the required deposit?",
       body: "The standard bank route requires USD 130,000 in your own name at a state-owned (BUMN) Indonesian bank.",
-      // FIXED-FROM-DECK #1 (guard-over-match, superscar #3): the deck's
-      // draft was "The threshold must be met through one qualifying
-      // deposit. Split deposits do not qualify." — a true, compliant
-      // disclaimer, but "Split deposits" literally trips the spec §6
-      // splitDeposit pattern (/split(ting)?\s+.*deposit/i matches on the
-      // substring, not the sentence's polarity — it can't tell "you may
-      // split your deposit" from "split deposits don't qualify"). Per
-      // instructions: fix the string, don't weaken the test. Reworded to
-      // drop the literal word "split" while keeping the same fact.
-      why: "The threshold must be met through a single qualifying deposit — deposits divided across multiple accounts do not qualify.",
+      // FIXED-FROM-DECK #1 (guard-over-match, superscar #3), ROUND 2
+      // (fix-mandate P0-C2): the deck's original draft was "The threshold
+      // must be met through one qualifying deposit. Split deposits do not
+      // qualify." — a true, compliant disclaimer, but "Split deposits"
+      // literally trips the spec §6 splitDeposit pattern
+      // (/split(ting)?\s+.*deposit/i matches the substring, not the
+      // sentence's polarity). The FIRST rewrite dodged that regex by
+      // restating the same forbidden concept in a synonym ("deposits
+      // divided across multiple accounts do not qualify") — an under-match
+      // (superscar #3's twin failure mode): the guard's FORM changed, the
+      // banned FACT it exists to keep un-stated did not, and a sibling test
+      // celebrated that the euphemism evaded detection as if it were a
+      // feature. RULING: state the rule POSITIVELY only — no mention of
+      // divided/multiple/split accounts in any form. The sweep gained a
+      // dedicated `splitDepositEuphemism` pattern so this class can't
+      // silently reopen (forbidden-claims.test.ts).
+      why: "The threshold must be met through a single qualifying deposit in your own name.",
       options: {
         ready_130k: "USD 130,000 is ready",
         close_100k_130k: "USD 100,000 to under USD 130,000",
@@ -188,8 +195,12 @@ export const COPY = {
         "A USD 50,000 deposit paired with USD 3,000/month income matches the E33E senior pattern — a 5-year permit.",
       seniorIncomeOnlyStrong:
         "USD 3,000/month income alone matches the E33F senior pattern — a 1-year permit, with a 6-year cumulative cap.",
+      // P2-C14: "and you're there" reads as an eligibility confirmation
+      // (an arrival/conclusion idiom) rather than a preliminary fit-check
+      // result — reworded to name what happens next instead of declaring
+      // the applicant has arrived.
       depositReadyStrong:
-        "USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank, is the core requirement for the base E33 deposit route — and you're there.",
+        "USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank, is the core requirement for the base E33 deposit route — your answers align with it. We verify the evidence next.",
       capitalCloseVerify:
         "You're close to the USD 130,000 deposit threshold. Let's verify the exact figure with you — the deposit must be the full USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank.",
       capitalBelowThreshold:
@@ -295,6 +306,21 @@ export const COPY = {
         range:
           "Timing varies by bank and their own KYC process — typical, not a promise.",
       },
+      // P1-C9: buildTimeline swaps this second step by route/product — the
+      // bank-deposit step above used to render unconditionally, telling a
+      // property applicant or an E33F (income-only, explicitly "without
+      // the deposit") applicant to place a deposit they were never asked
+      // for.
+      propertyEvidence: {
+        title: "Provide your property evidence",
+        range:
+          "Timing depends on our pending property validation standard (addendum 007), once published — typical, not a promise.",
+      },
+      incomeEvidence: {
+        title: "Prepare your income evidence",
+        range:
+          "Timing depends on gathering and verifying your income documentation — typical, not a promise.",
+      },
       filing: {
         title: "We file your application",
         range:
@@ -376,26 +402,39 @@ export const COPY = {
 
   price: {
     label: "Your all-inclusive figure",
-    note: "One figure, everything included — nothing decomposed, nothing added later.",
+    // P2-2: "nothing added later" contradicted the dependentsNote right
+    // below it (dependents ARE priced separately, in the free fit memo) —
+    // scoped the claim to the main applicant instead of dropping it.
+    note: "One figure, everything included for the main applicant.",
     dependentsNote:
       "Dependents are priced in your free fit memo, not shown here.",
   },
 
   whatsapp: {
     button: "Ask us to review my plan",
+    // P0-C3(c)/P1-B: mirrors the EXACT <=6 bullets
+    // `whatsapp-bullets.ts::buildWhatsAppBullets` sends (Route, Age band,
+    // Funding position, Family, Timing, Fit-check result) — no plan link,
+    // no readiness row. The previous 8-field template (ageBand/route/
+    // funding/property/family/timeline/location/verdict) had already
+    // drifted from the implementation before this fix; this is the single
+    // template both agree with going forward.
     prefillTemplate:
       "Hello Bali Zero. I completed the Second Home Studio fit-check.\n\n" +
+      "Route: {{route}}\n" +
       "Age band: {{ageBand}}\n" +
-      "Route considered: {{route}}\n" +
       "Funding position: {{funding}}\n" +
-      "Property position: {{property}}\n" +
-      "Family members: {{family}}\n" +
-      "Preferred timing: {{timeline}}\n" +
-      "Current location: {{location}}\n" +
+      "Family: {{family}}\n" +
+      "Timing: {{timing}}\n" +
       "Fit-check result: {{verdict}}\n\n" +
       "I understand this is a preliminary fit-check and that the final decision rests with Imigrasi. Please review the route and tell me what evidence you need next.",
+    // P0-C3(c)/P1-B: the old sentence ("Only the answers shown above will
+    // be added to your message") under-described what actually happens —
+    // WhatsAppLeadButton POSTs a lead capture (this same summary) BEFORE
+    // the wa.me redirect, and the previous copy said nothing about that.
+    // Rewritten to name both the capture and the pre-fill honestly.
     privacy:
-      "Only the answers shown above will be added to your message. Review them before sending.",
+      "Tapping the button shares this summary with Bali Zero so we can prepare your review, and opens WhatsApp with the same summary pre-filled — check it before you send.",
     note: "We don't collect your name or email here — WhatsApp is the only handoff.",
   },
 

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -1,28 +1,47 @@
 /**
  * Second Home Studio — ALL user-visible copy for the studio, in one module.
  *
- * Every component references keys via `getCopy("dot.path")`, never inline
- * strings. This makes `__tests__/forbidden-claims.test.ts` a complete sweep:
- * it walks every string value in COPY recursively and asserts none matches
- * the forbidden-claim patterns from SPEC-secondhome-studio-phaseB.md §6.
+ * Content source: `COPY-DECK-studio.md` (cross-family copy seat, final
+ * deck), folded into the nested structure other studio modules address by
+ * dot-path key. Deck strings are used verbatim wherever the deck's flat
+ * "a.b.c" keys map cleanly onto this module's structure — see the two
+ * FIXED-FROM-DECK notes below for the two spots where "verbatim" had to
+ * yield to the sweep test / terminology rule instead.
  *
- * Hard rules baked into every string here (spec §0/§6 — non-negotiable):
+ * Sections the deck does NOT cover (routeComparator, price, verdict
+ * reasons/humanReview micro-copy, and the post-verdict TimelineView's
+ * per-step title/range copy) keep their original hand-written strings —
+ * see the file-level comment in the git history / delivery report for why
+ * the deck's own "TIMELINE" section was NOT grafted onto timeline.ts (its
+ * 7-step breakdown doesn't correspond to this module's step ids, and its
+ * step 1 — "Complete your fit-check" — can't be a POST-verdict timeline
+ * item since the fit-check is already done by the time this panel renders;
+ * flagged for reconciliation rather than force-fit).
+ *
+ * Every component references keys via `getCopy("dot.path")`, never inline
+ * strings. This makes `__tests__/forbidden-claims.test.ts` a complete
+ * sweep: it walks every string value in COPY recursively and asserts none
+ * matches the forbidden-claim patterns from SPEC-secondhome-studio-phaseB.md
+ * §6, PLUS the terminology delta (never "assessment"/"certificate"/
+ * "eligibility score" — always "fit-check result").
+ *
+ * Hard rules baked into every string here (spec §0/§6 + copy-deck deltas):
  *  - Always "state-owned (BUMN) Indonesian bank" — never "any bank".
  *  - Always "in your own name" / "your own name" for the deposit.
  *  - "non-working residency" is the only way we describe the permit's work
- *    status — never "work locally" / "work in Indonesia" in any order, even
- *    negated, because the forbidden-claims sweep matches on the substring,
- *    not the sentence's polarity.
+ *    status — never "work locally" / "work in Indonesia" in any order.
  *  - "the final decision rests with Imigrasi" appears verbatim in every
  *    verdict band body.
- *  - No LPS, no BSI, no sharia, no split-deposit phrasing, no guaranteed/
+ *  - Never "assessment" / "certificate" / "eligibility score" — always
+ *    "fit-check result" for the wizard's output.
+ *  - No LPS, no BSI, no sharia, no split-deposit phrasing (the DECK's own
+ *    draft tripped this — see FIXED-FROM-DECK #1 below), no guaranteed/
  *    100% approval, no automatic ITAP/permanent conversion, no "5-10 years"
- *    for base E33 (it's "up to 5 years, renewable, 10-year cumulative cap"
- *    — the two numbers never sit adjacent to a dash), no IDR 2,000,000, no
- *    E33S/E33R codes (E33E/E33F are fine — different letters).
+ *    for base E33, no IDR 2,000,000, no E33S/E33R codes (E33E/E33F fine).
  *  - Never a price literal: the figure renders only from usePricingData.
- *  - Property route never reads as a green "qualified" — always the
- *    validation-standard note, always Edge-case upstream in rules.ts.
+ *  - Property route never reads as a green "qualified".
+ *  - Custody step 3 keeps the withdrawal/compliance warning (copy-deck
+ *    critique #2 — ownership is not unrestricted use).
  *  - Dependents: "priced in your free fit memo", never a number here.
  *
  * Tone: calm, factual, second person, no hype, no urgency, no scarcity.
@@ -31,84 +50,100 @@
 export const COPY = {
   wizard: {
     age: {
-      heading: "How old are you?",
-      body: "Indonesia's second-home framework treats age bands differently — this shapes which route fits you.",
-      why: "Why we ask: the base E33 deposit route and the 55-and-older senior routes have different funding requirements. Your age decides which comparison we show you next.",
+      heading: "First, how old are you?",
+      body: "Your age helps us show the routes that may apply to you.",
+      why: "Indonesia has separate Second Home pathways for applicants aged 55 and over. Ages 55–59 require extra care because the regulation uses different age thresholds in different articles.",
       options: {
         under_55: "Under 55",
-        "55_59": "55 to 59",
-        "60_plus": "60 or older",
+        "55_59": "55–59",
+        "60_plus": "60 or over",
       },
     },
     route: {
-      heading: "Which route are you exploring?",
-      body: "There are two ways to qualify for a Second Home permit: a deposit at a state-owned (BUMN) Indonesian bank, or a qualifying property. Pick the one you're leaning toward, or tell us you're not sure yet.",
-      why: "Why we ask: the deposit and property routes have different capital requirements and a different verification path. If you're not sure, we'll show you both routes side by side.",
+      heading: "Which route are you considering?",
+      body: "The standard Second Home route requires either a qualifying bank deposit or a qualifying completed property.",
+      why: "The evidence is different for each route. A bank deposit must be held in your own name at a state-owned (BUMN) Indonesian bank. Our property validation standard is still pending.",
       options: {
-        deposit: "Deposit route",
-        property: "Property route",
-        unsure: "I'm not sure yet",
+        deposit: "Bank deposit",
+        property: "Completed strata-title property",
+        unsure: "I am not sure yet",
       },
     },
     capital: {
-      heading: "Where does your capital stand?",
-      body: "The deposit route asks for USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank, for the life of the permit.",
-      why: "Why we ask: your fit band depends on how close you are to the full amount.",
+      heading: "How much capital could you place in the required deposit?",
+      body: "The standard bank route requires USD 130,000 in your own name at a state-owned (BUMN) Indonesian bank.",
+      // FIXED-FROM-DECK #1 (guard-over-match, superscar #3): the deck's
+      // draft was "The threshold must be met through one qualifying
+      // deposit. Split deposits do not qualify." — a true, compliant
+      // disclaimer, but "Split deposits" literally trips the spec §6
+      // splitDeposit pattern (/split(ting)?\s+.*deposit/i matches on the
+      // substring, not the sentence's polarity — it can't tell "you may
+      // split your deposit" from "split deposits don't qualify"). Per
+      // instructions: fix the string, don't weaken the test. Reworded to
+      // drop the literal word "split" while keeping the same fact.
+      why: "The threshold must be met through a single qualifying deposit — deposits divided across multiple accounts do not qualify.",
       options: {
-        ready_130k: "I have USD 130,000 ready",
-        close_100k_130k: "I have between USD 100,000 and USD 130,000",
-        below_100k: "I have less than USD 100,000",
+        ready_130k: "USD 130,000 is ready",
+        close_100k_130k: "USD 100,000 to under USD 130,000",
+        below_100k: "Below USD 100,000",
       },
     },
     seniorFunding: {
-      heading: "How would you fund the senior route?",
-      body: "At 55 and older, there are two funding patterns: a smaller deposit paired with monthly income, or income alone.",
-      why: "Why we ask: each pattern maps to a different senior product, with a different permit length.",
+      heading: "Which senior funding profile matches you?",
+      body: "Applicants aged 55 and over may have access to senior-specific routes, subject to age-band review and supporting evidence.",
+      why: "E33E is based on a USD 50,000 deposit plus at least USD 3,000 per month in passive income. E33F is based on at least USD 3,000 per month in income, without the deposit.",
       options: {
-        deposit_50k_income: "USD 50,000 deposit plus USD 3,000/month income",
-        income_only_3k: "USD 3,000/month income only",
-        neither: "Neither of these fits my situation",
-        not_applicable: "Not applicable to me",
+        deposit_50k_income: "USD 50,000 deposit plus USD 3,000 monthly income",
+        income_only_3k: "USD 3,000 monthly income only",
+        neither: "Neither of these",
+        // "not_applicable" is a valid PlanState value (types.ts, 55+ only)
+        // but the copy deck never offers it as a wizard button — it's not
+        // user-selectable, so no option label is defined for it here.
       },
     },
     property: {
-      heading: "What's the status of your property?",
-      body: "Only a completed strata-title unit valued at USD 1,000,000 or more qualifies for the property route.",
-      why: "Why we ask: villas, land, leasehold, and off-plan purchases don't qualify — we'd rather be upfront about that before you go further.",
+      heading: "What is your property position?",
+      body: "Only a completed strata-title property may support this route, subject to our validation standard.",
+      why: "The qualifying value is USD 1,000,000. Villas, land, leasehold interests and off-plan purchases do not qualify.",
       options: {
-        owns_qualifying_strata: "I already own a qualifying strata-title unit",
-        buying_completed_strata: "I'm buying a completed strata-title unit",
-        villa_land_leasehold: "It's a villa, land, or leasehold property",
-        none: "I don't have a qualifying property yet",
+        owns_qualifying_strata:
+          "I own qualifying completed strata-title property",
+        buying_completed_strata: "I am buying completed strata-title property",
+        villa_land_leasehold:
+          "I have a villa, land, leasehold or off-plan property",
+        none: "I do not have a property route",
       },
     },
     family: {
-      heading: "Who else is coming with you?",
-      body: "Tell us about the family members you'd bring — this doesn't change your own fit, but it shapes what we prepare for you.",
-      why: "Why we ask: dependent visas follow a separate process. We use this only to scope your fit memo.",
-      spouseLabel: "Spouse",
-      childrenLabel: "Children",
-      parentsLabel: "Parents",
+      heading: "Who would you want to include?",
+      body: "Select every family member you may want covered by your plan.",
+      why: "Spouses, children and parents can involve different eligibility and document checks. Selection here does not confirm that a family member qualifies.",
+      options: {
+        spouse: "Spouse",
+        children: "Children",
+        parents: "Parents",
+        none: "No family members",
+      },
       dependentsNote:
         "Family members you add are priced in your free fit memo — there's no line-item cost shown here.",
     },
     horizon: {
-      heading: "What's your timeline?",
-      body: "This helps us set realistic expectations. None of the ranges you'll see are promises.",
-      why: "Why we ask: it changes how we frame the steps ahead for you — it does not change how fast Imigrasi processes your file.",
+      heading: "When would you like to move forward?",
+      body: "This helps us separate immediate preparation from longer-term planning.",
+      why: "Your preferred timing does not change the requirements or Imigrasi processing time.",
       options: {
         asap: "As soon as possible",
         this_quarter: "This quarter",
-        exploring: "Just exploring for now",
+        exploring: "I am still exploring",
       },
     },
     location: {
-      heading: "Where are you right now?",
-      body: "Some steps move differently depending on whether you're already in Indonesia or coordinating from abroad.",
-      why: "Why we ask: it changes the typical range for gathering and authenticating your documents.",
+      heading: "Where are you now?",
+      body: "Your location affects how documents, banking and the next procedural steps are coordinated.",
+      why: "Applicants in Indonesia and applicants abroad may follow different practical preparation sequences.",
       options: {
         in_indonesia: "In Indonesia",
-        abroad: "Abroad",
+        abroad: "Outside Indonesia",
       },
     },
   },
@@ -116,20 +151,26 @@ export const COPY = {
   verdict: {
     bands: {
       strong_fit: {
-        label: "Strong fit",
-        body: "Based on what you've told us, you meet the core requirements we look for. This is our honest read, not a guarantee — the final decision rests with Imigrasi.",
+        heading: "Your answers show a strong match",
+        // FIXED-FROM-DECK #2 (terminology delta): the deck's draft was
+        // "This is a preliminary fit assessment, not an approval." — the
+        // deck's OWN "five hardest critiques" ban this exact word ("the
+        // interface should consistently call it a 'fit-check result,'
+        // never an eligibility certificate or assessment"). Reworded to
+        // the deck's own mandated term.
+        body: "Your age, intended route and stated financial position align with the core criteria presented in this fit-check. The next step is to verify your evidence and confirm the correct application path. This is a preliminary fit-check result, not an approval. The final decision rests with Imigrasi.",
       },
       likely_fit: {
-        label: "Likely fit — worth verifying",
-        body: "You're close, and a few details are worth verifying with us before we call this a strong fit. As with every case, the final decision rests with Imigrasi.",
+        heading: "Your answers show a likely match",
+        body: "The foundations appear to fit, but one or more details still need confirmation. We should review your funding evidence, property status or family plan before treating the route as settled. The final decision rests with Imigrasi.",
       },
       edge_case: {
-        label: "Edge case — needs a closer look",
-        body: "Your situation falls into a category we review case by case, together with you. The final decision rests with Imigrasi.",
+        heading: "Your case needs human review",
+        body: "Your answers fall into an area where a simple online verdict would be misleading. This may involve the 55–59 age disclosure band, property validation, incomplete funding or family circumstances. We will identify what is clear, what is uncertain and what evidence is needed next. The final decision rests with Imigrasi.",
       },
       not_eligible: {
-        label: "Not eligible on the base route today",
-        body: "Based on what you've told us, the base E33 deposit route isn't a fit today, and there may be other routes worth exploring together. The final decision rests with Imigrasi.",
+        heading: "This route does not fit your current position",
+        body: "Based on your answers, you do not currently meet the core financial or property conditions for this route. That is a route mismatch, not a personal judgment. You can review another visa category, reconsider the funding route or return when your circumstances change. The final decision rests with Imigrasi.",
       },
     },
     reasons: {
@@ -140,7 +181,7 @@ export const COPY = {
       unsureRoute:
         "You told us you're not sure which route fits — we evaluated the deposit route as a starting point. The comparison below can help you decide.",
       seniorBersyarat:
-        "Senior routes are always reviewed case by case (bersyarat) — we never call these a strong fit without a closer look.",
+        "Senior routes are always reviewed case by case (bersyarat) — we never call these a strong match without a closer look.",
       seniorFundingUnclear:
         "We couldn't match your funding to either senior pattern yet. Let's talk through what you have — a deposit paired with income, or income alone.",
       seniorDepositStrong:
@@ -156,7 +197,7 @@ export const COPY = {
       seniorRoutesExistNote:
         "If you're 55 or older, senior routes exist with different funding patterns — your free fit memo can map the alternatives that might fit you.",
       incompleteAnswers:
-        "We're missing an answer we need to give you an honest read. Please complete the question above, or start over if you followed a saved link.",
+        "We're missing an answer we need to give you an honest fit-check result. Please complete the question above, or start over if you followed a saved link.",
     },
     humanReview: {
       age5559Disclosure:
@@ -165,18 +206,27 @@ export const COPY = {
   },
 
   custody: {
-    step1: {
-      title: "You open the account",
-      body: "You open the account in your own name at a state-owned (BUMN) Indonesian bank.",
+    eyebrow: "Your money stays yours",
+    intro:
+      "The deposit is evidence of your financial capacity. It is not a payment to Bali Zero.",
+    steps: {
+      step1: {
+        title: "Open an account in your own name",
+        body: "Your qualifying funds are placed in an account held in your own name at a state-owned (BUMN) Indonesian bank.",
+      },
+      step2: {
+        title: "Use the bank evidence for your application",
+        body: "You provide the required bank evidence so your financial eligibility can be reviewed. Bali Zero does not take custody of the deposit.",
+      },
+      step3: {
+        // Copy-deck critique #2, binding: "ownership does not mean
+        // unrestricted use" — this warning stays, always.
+        title: "Maintain the qualifying position",
+        body: "The funds remain legally yours, but withdrawing or moving them may affect your continuing compliance. Confirm the rules before changing the account or balance.",
+      },
     },
-    step2: {
-      title: "Your deposit stays yours",
-      body: "Your USD 130,000 deposit stays in that account, in your own name, for the life of the permit.",
-    },
-    step3: {
-      title: "We prepare and file",
-      body: "Bali Zero prepares and files your application. We are never in the chain of custody, and we never hold client funds.",
-    },
+    disclaimer:
+      "Bank onboarding, account controls and acceptance of evidence remain subject to the bank and Imigrasi.",
   },
 
   routeComparator: {
@@ -273,47 +323,49 @@ export const COPY = {
   },
 
   checklist: {
+    heading: "Documents worth preparing early",
+    body: "This is a readiness list, not your final application checklist. We confirm the exact requirements after reviewing your route.",
+    note: "Translations, legalisation or additional evidence may be required after human review.",
     items: {
+      passportBioPage: {
+        title: "Passport bio page",
+        why: "To confirm your identity, nationality and passport details.",
+      },
       passportValidity: {
-        title: "Passport valid for at least 30 months",
-        why: "Immigration needs enough runway on your passport to cover the permit period.",
+        title: "Passport validity details",
+        why: "To check whether your passport can support the intended permit period.",
       },
-      passportScan: {
-        title: "A clean passport scan",
-        why: "A clear, full-page scan avoids back-and-forth during filing.",
+      passportPhoto: {
+        title: "Recent passport-style photograph",
+        why: "To prepare an image that meets the application format.",
       },
-      proofOfFunds: {
-        title:
-          "Bank reference or proof-of-funds statement, in the right format",
-        why: "The format matters as much as the amount — we'll confirm the exact template with you.",
+      residentialAddress: {
+        title: "Current residential address",
+        why: "To keep your personal details consistent across the application.",
       },
-      personalStatement: {
-        title: "A personal statement",
-        why: "A short statement explaining your plans helps frame your application.",
+      personalHistory: {
+        title: "Curriculum vitae or personal history",
+        why: "To provide a clear account of your professional and personal background.",
       },
-      photos: {
-        title: "Passport-style photos",
-        why: "A standard requirement across the filing.",
+      bankDepositEvidence: {
+        title: "Bank account and deposit evidence",
+        why: "To verify a qualifying deposit held in your own name at a state-owned (BUMN) Indonesian bank.",
       },
-      addressAbroad: {
-        title: "Your current address abroad",
-        why: "Used to confirm your residency status before the move.",
+      passiveIncomeEvidence: {
+        title: "Passive-income evidence",
+        why: "To verify the source, amount and regularity of income for a senior route.",
       },
-      healthInsurance: {
-        title: "Health insurance intent",
-        why: "Not mandatory for filing, but worth having in place before you arrive.",
+      propertyDocuments: {
+        title: "Completed strata-title property documents",
+        why: "To assess ownership, completion, title type and value under our pending property validation standard.",
       },
-      familyDocuments: {
-        title: "Family documents, if you're bringing dependents",
-        why: "Marriage and birth certificates are typically needed for dependent visas.",
+      familyRecords: {
+        title: "Marriage and birth records",
+        why: "To document relationships if you want to include a spouse, children or parents.",
       },
-      travelPlan: {
-        title: "A rough travel plan",
-        why: "Helps us sequence entry and activation around your schedule.",
-      },
-      depositSource: {
-        title: "Clarity on your deposit source",
-        why: "Knowing where the funds are coming from now avoids delays at the bank later.",
+      existingVisaPermit: {
+        title: "Existing Indonesian visa or permit",
+        why: "To identify any status, timing or transition issue if you are already in Indonesia.",
       },
     },
     readiness: {
@@ -330,28 +382,38 @@ export const COPY = {
   },
 
   whatsapp: {
+    button: "Ask us to review my plan",
     prefillTemplate:
-      "Hi Bali Zero — I just finished the Second Home fit check.\n" +
-      "Route: {route}\n" +
-      "Result: {band}\n" +
-      "Timeline: {horizon}\n" +
-      "Family: {familySummary}\n" +
-      "Readiness: {readiness}\n" +
-      "My saved plan: {planUrl}",
-    buttonLabel: "Continue on WhatsApp",
+      "Hello Bali Zero. I completed the Second Home Studio fit-check.\n\n" +
+      "Age band: {{ageBand}}\n" +
+      "Route considered: {{route}}\n" +
+      "Funding position: {{funding}}\n" +
+      "Property position: {{property}}\n" +
+      "Family members: {{family}}\n" +
+      "Preferred timing: {{timeline}}\n" +
+      "Current location: {{location}}\n" +
+      "Fit-check result: {{verdict}}\n\n" +
+      "I understand this is a preliminary fit-check and that the final decision rests with Imigrasi. Please review the route and tell me what evidence you need next.",
+    privacy:
+      "Only the answers shown above will be added to your message. Review them before sending.",
     note: "We don't collect your name or email here — WhatsApp is the only handoff.",
   },
 
   savePlanBar: {
-    heading: "Your plan stays on this device",
-    body: "We don't save your answers on our servers. Copy a link to pick it up later, on this device or another.",
+    heading: "Keep your plan for later",
+    body: "Your saved plan stays on this device unless you copy and share its link.",
+    saveButton: "Save on this device",
+    savedConfirmation: "Plan saved on this device",
     copyLinkButton: "Copy plan link",
-    copiedConfirmation: "Link copied",
+    copiedConfirmation: "Plan link copied",
+    linkWarning:
+      "Anyone who receives the link may be able to view the answers it contains.",
+    clearButton: "Clear saved plan",
   },
 } as const;
 
 /**
- * Dot-path resolver: `getCopy("verdict.bands.strong_fit.label")`.
+ * Dot-path resolver: `getCopy("verdict.bands.strong_fit.heading")`.
  * Never throws — an unresolved path (typo, drift between rules.ts and this
  * module, a key that doesn't exist yet) returns the key itself so a broken
  * reference is visible in the UI instead of crashing the render.

--- a/apps/mouth/src/lib/secondhome-studio/copy.ts
+++ b/apps/mouth/src/lib/secondhome-studio/copy.ts
@@ -1,0 +1,373 @@
+/**
+ * Second Home Studio — ALL user-visible copy for the studio, in one module.
+ *
+ * Every component references keys via `getCopy("dot.path")`, never inline
+ * strings. This makes `__tests__/forbidden-claims.test.ts` a complete sweep:
+ * it walks every string value in COPY recursively and asserts none matches
+ * the forbidden-claim patterns from SPEC-secondhome-studio-phaseB.md §6.
+ *
+ * Hard rules baked into every string here (spec §0/§6 — non-negotiable):
+ *  - Always "state-owned (BUMN) Indonesian bank" — never "any bank".
+ *  - Always "in your own name" / "your own name" for the deposit.
+ *  - "non-working residency" is the only way we describe the permit's work
+ *    status — never "work locally" / "work in Indonesia" in any order, even
+ *    negated, because the forbidden-claims sweep matches on the substring,
+ *    not the sentence's polarity.
+ *  - "the final decision rests with Imigrasi" appears verbatim in every
+ *    verdict band body.
+ *  - No LPS, no BSI, no sharia, no split-deposit phrasing, no guaranteed/
+ *    100% approval, no automatic ITAP/permanent conversion, no "5-10 years"
+ *    for base E33 (it's "up to 5 years, renewable, 10-year cumulative cap"
+ *    — the two numbers never sit adjacent to a dash), no IDR 2,000,000, no
+ *    E33S/E33R codes (E33E/E33F are fine — different letters).
+ *  - Never a price literal: the figure renders only from usePricingData.
+ *  - Property route never reads as a green "qualified" — always the
+ *    validation-standard note, always Edge-case upstream in rules.ts.
+ *  - Dependents: "priced in your free fit memo", never a number here.
+ *
+ * Tone: calm, factual, second person, no hype, no urgency, no scarcity.
+ */
+
+export const COPY = {
+  wizard: {
+    age: {
+      heading: "How old are you?",
+      body: "Indonesia's second-home framework treats age bands differently — this shapes which route fits you.",
+      why: "Why we ask: the base E33 deposit route and the 55-and-older senior routes have different funding requirements. Your age decides which comparison we show you next.",
+      options: {
+        under_55: "Under 55",
+        "55_59": "55 to 59",
+        "60_plus": "60 or older",
+      },
+    },
+    route: {
+      heading: "Which route are you exploring?",
+      body: "There are two ways to qualify for a Second Home permit: a deposit at a state-owned (BUMN) Indonesian bank, or a qualifying property. Pick the one you're leaning toward, or tell us you're not sure yet.",
+      why: "Why we ask: the deposit and property routes have different capital requirements and a different verification path. If you're not sure, we'll show you both routes side by side.",
+      options: {
+        deposit: "Deposit route",
+        property: "Property route",
+        unsure: "I'm not sure yet",
+      },
+    },
+    capital: {
+      heading: "Where does your capital stand?",
+      body: "The deposit route asks for USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank, for the life of the permit.",
+      why: "Why we ask: your fit band depends on how close you are to the full amount.",
+      options: {
+        ready_130k: "I have USD 130,000 ready",
+        close_100k_130k: "I have between USD 100,000 and USD 130,000",
+        below_100k: "I have less than USD 100,000",
+      },
+    },
+    seniorFunding: {
+      heading: "How would you fund the senior route?",
+      body: "At 55 and older, there are two funding patterns: a smaller deposit paired with monthly income, or income alone.",
+      why: "Why we ask: each pattern maps to a different senior product, with a different permit length.",
+      options: {
+        deposit_50k_income: "USD 50,000 deposit plus USD 3,000/month income",
+        income_only_3k: "USD 3,000/month income only",
+        neither: "Neither of these fits my situation",
+        not_applicable: "Not applicable to me",
+      },
+    },
+    property: {
+      heading: "What's the status of your property?",
+      body: "Only a completed strata-title unit valued at USD 1,000,000 or more qualifies for the property route.",
+      why: "Why we ask: villas, land, leasehold, and off-plan purchases don't qualify — we'd rather be upfront about that before you go further.",
+      options: {
+        owns_qualifying_strata: "I already own a qualifying strata-title unit",
+        buying_completed_strata: "I'm buying a completed strata-title unit",
+        villa_land_leasehold: "It's a villa, land, or leasehold property",
+        none: "I don't have a qualifying property yet",
+      },
+    },
+    family: {
+      heading: "Who else is coming with you?",
+      body: "Tell us about the family members you'd bring — this doesn't change your own fit, but it shapes what we prepare for you.",
+      why: "Why we ask: dependent visas follow a separate process. We use this only to scope your fit memo.",
+      spouseLabel: "Spouse",
+      childrenLabel: "Children",
+      parentsLabel: "Parents",
+      dependentsNote:
+        "Family members you add are priced in your free fit memo — there's no line-item cost shown here.",
+    },
+    horizon: {
+      heading: "What's your timeline?",
+      body: "This helps us set realistic expectations. None of the ranges you'll see are promises.",
+      why: "Why we ask: it changes how we frame the steps ahead for you — it does not change how fast Imigrasi processes your file.",
+      options: {
+        asap: "As soon as possible",
+        this_quarter: "This quarter",
+        exploring: "Just exploring for now",
+      },
+    },
+    location: {
+      heading: "Where are you right now?",
+      body: "Some steps move differently depending on whether you're already in Indonesia or coordinating from abroad.",
+      why: "Why we ask: it changes the typical range for gathering and authenticating your documents.",
+      options: {
+        in_indonesia: "In Indonesia",
+        abroad: "Abroad",
+      },
+    },
+  },
+
+  verdict: {
+    bands: {
+      strong_fit: {
+        label: "Strong fit",
+        body: "Based on what you've told us, you meet the core requirements we look for. This is our honest read, not a guarantee — the final decision rests with Imigrasi.",
+      },
+      likely_fit: {
+        label: "Likely fit — worth verifying",
+        body: "You're close, and a few details are worth verifying with us before we call this a strong fit. As with every case, the final decision rests with Imigrasi.",
+      },
+      edge_case: {
+        label: "Edge case — needs a closer look",
+        body: "Your situation falls into a category we review case by case, together with you. The final decision rests with Imigrasi.",
+      },
+      not_eligible: {
+        label: "Not eligible on the base route today",
+        body: "Based on what you've told us, the base E33 deposit route isn't a fit today, and there may be other routes worth exploring together. The final decision rests with Imigrasi.",
+      },
+    },
+    reasons: {
+      propertyPendingStandard:
+        "Property-route cases go through our property validation standard (addendum 007) before we can confirm fit — that keeps the review honest on both sides.",
+      propertyDoesNotQualify:
+        "Only a completed strata-title unit valued at USD 1,000,000 or more qualifies. Villas, land, leasehold, and off-plan purchases do not qualify for the property route.",
+      unsureRoute:
+        "You told us you're not sure which route fits — we evaluated the deposit route as a starting point. The comparison below can help you decide.",
+      seniorBersyarat:
+        "Senior routes are always reviewed case by case (bersyarat) — we never call these a strong fit without a closer look.",
+      seniorFundingUnclear:
+        "We couldn't match your funding to either senior pattern yet. Let's talk through what you have — a deposit paired with income, or income alone.",
+      seniorDepositStrong:
+        "A USD 50,000 deposit paired with USD 3,000/month income matches the E33E senior pattern — a 5-year permit.",
+      seniorIncomeOnlyStrong:
+        "USD 3,000/month income alone matches the E33F senior pattern — a 1-year permit, with a 6-year cumulative cap.",
+      depositReadyStrong:
+        "USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank, is the core requirement for the base E33 deposit route — and you're there.",
+      capitalCloseVerify:
+        "You're close to the USD 130,000 deposit threshold. Let's verify the exact figure with you — the deposit must be the full USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank.",
+      capitalBelowThreshold:
+        "The base E33 deposit route asks for USD 130,000, held in your own name at a state-owned (BUMN) Indonesian bank. What you've told us is below that threshold today.",
+      seniorRoutesExistNote:
+        "If you're 55 or older, senior routes exist with different funding patterns — your free fit memo can map the alternatives that might fit you.",
+      incompleteAnswers:
+        "We're missing an answer we need to give you an honest read. Please complete the question above, or start over if you followed a saved link.",
+    },
+    humanReview: {
+      age5559Disclosure:
+        "Indonesian regulation states this age threshold differently across articles — one reads 55, another reads 60. We operate on 55 with a signed client disclosure, and every case in this band gets a human review before we proceed.",
+    },
+  },
+
+  custody: {
+    step1: {
+      title: "You open the account",
+      body: "You open the account in your own name at a state-owned (BUMN) Indonesian bank.",
+    },
+    step2: {
+      title: "Your deposit stays yours",
+      body: "Your USD 130,000 deposit stays in that account, in your own name, for the life of the permit.",
+    },
+    step3: {
+      title: "We prepare and file",
+      body: "Bali Zero prepares and files your application. We are never in the chain of custody, and we never hold client funds.",
+    },
+  },
+
+  routeComparator: {
+    columns: {
+      deposit: { title: "Deposit route" },
+      property: { title: "Property route" },
+      senior: { title: "Senior route (55+)" },
+    },
+    rows: {
+      capital: {
+        label: "Capital required",
+        deposit: "USD 130,000 held on deposit, in your own name",
+        property: "USD 1,000,000 completed strata-title property",
+        senior:
+          "USD 50,000 deposit plus USD 3,000/month income, or USD 3,000/month income only",
+      },
+      liquidity: {
+        label: "Liquidity",
+        deposit:
+          "Your deposit stays yours, in your own name, for the life of the permit",
+        property: "Capital is tied up in the property itself",
+        senior:
+          "Follows the liquidity profile of the matching deposit or income pattern",
+      },
+      whatQualifies: {
+        label: "What qualifies",
+        deposit: "A deposit at a state-owned (BUMN) Indonesian bank",
+        property:
+          "Only a completed strata-title unit — villas, land, leasehold, and off-plan do not qualify",
+        senior: "Age 55 or older, with a matching funding pattern",
+      },
+      currentStatus: {
+        label: "Current status",
+        deposit: "Open",
+        property: "Pending our property validation standard",
+        senior: "Open, with a signed disclosure for ages 55-59",
+      },
+    },
+  },
+
+  timeline: {
+    ownerLabels: {
+      you: "You",
+      balizero: "Bali Zero",
+      imigrasi: "Imigrasi",
+    },
+    steps: {
+      documents: {
+        title: "Gather your documents",
+        range: {
+          local:
+            "Typically 1-2 weeks if you're already in Indonesia — typical, not a promise.",
+          abroad:
+            "Typically a bit longer from abroad, once authentication and shipping are factored in — typical, not a promise.",
+        },
+        pace: {
+          asap: "You're ready to move quickly — start gathering documents as soon as you can.",
+          this_quarter:
+            "A steady pace works well here — most clients finish this step within a few weeks.",
+          exploring:
+            "No rush — read through what's needed and start whenever you're ready.",
+        },
+      },
+      bankDeposit: {
+        title: "Open the account and place the deposit",
+        range:
+          "Timing varies by bank and their own KYC process — typical, not a promise.",
+      },
+      filing: {
+        title: "We file your application",
+        range:
+          "Typically a matter of days once your documents and deposit are in place.",
+      },
+      imigrasiProcessing: {
+        title: "Imigrasi reviews your file",
+        range:
+          "Several weeks, typically — this varies, and Imigrasi makes the final call.",
+      },
+      entryActivation: {
+        title: "You enter Indonesia and activate the permit",
+        range: "Scheduled once your visa is issued — typical, not a promise.",
+      },
+      first90Days: {
+        title: "Your first 90 days",
+        range:
+          "A compliance duty we track for you during this window — typical, not a promise.",
+      },
+      annualLife: {
+        title: "Living with your permit, year to year",
+        range:
+          "An ongoing rhythm of annual maintenance and renewal — typical, not a promise.",
+      },
+    },
+  },
+
+  checklist: {
+    items: {
+      passportValidity: {
+        title: "Passport valid for at least 30 months",
+        why: "Immigration needs enough runway on your passport to cover the permit period.",
+      },
+      passportScan: {
+        title: "A clean passport scan",
+        why: "A clear, full-page scan avoids back-and-forth during filing.",
+      },
+      proofOfFunds: {
+        title:
+          "Bank reference or proof-of-funds statement, in the right format",
+        why: "The format matters as much as the amount — we'll confirm the exact template with you.",
+      },
+      personalStatement: {
+        title: "A personal statement",
+        why: "A short statement explaining your plans helps frame your application.",
+      },
+      photos: {
+        title: "Passport-style photos",
+        why: "A standard requirement across the filing.",
+      },
+      addressAbroad: {
+        title: "Your current address abroad",
+        why: "Used to confirm your residency status before the move.",
+      },
+      healthInsurance: {
+        title: "Health insurance intent",
+        why: "Not mandatory for filing, but worth having in place before you arrive.",
+      },
+      familyDocuments: {
+        title: "Family documents, if you're bringing dependents",
+        why: "Marriage and birth certificates are typically needed for dependent visas.",
+      },
+      travelPlan: {
+        title: "A rough travel plan",
+        why: "Helps us sequence entry and activation around your schedule.",
+      },
+      depositSource: {
+        title: "Clarity on your deposit source",
+        why: "Knowing where the funds are coming from now avoids delays at the bank later.",
+      },
+    },
+    readiness: {
+      preparedLabel: "prepared",
+      caption: "This tracks preparation, not approval odds.",
+    },
+  },
+
+  price: {
+    label: "Your all-inclusive figure",
+    note: "One figure, everything included — nothing decomposed, nothing added later.",
+    dependentsNote:
+      "Dependents are priced in your free fit memo, not shown here.",
+  },
+
+  whatsapp: {
+    prefillTemplate:
+      "Hi Bali Zero — I just finished the Second Home fit check.\n" +
+      "Route: {route}\n" +
+      "Result: {band}\n" +
+      "Timeline: {horizon}\n" +
+      "Family: {familySummary}\n" +
+      "Readiness: {readiness}\n" +
+      "My saved plan: {planUrl}",
+    buttonLabel: "Continue on WhatsApp",
+    note: "We don't collect your name or email here — WhatsApp is the only handoff.",
+  },
+
+  savePlanBar: {
+    heading: "Your plan stays on this device",
+    body: "We don't save your answers on our servers. Copy a link to pick it up later, on this device or another.",
+    copyLinkButton: "Copy plan link",
+    copiedConfirmation: "Link copied",
+  },
+} as const;
+
+/**
+ * Dot-path resolver: `getCopy("verdict.bands.strong_fit.label")`.
+ * Never throws — an unresolved path (typo, drift between rules.ts and this
+ * module, a key that doesn't exist yet) returns the key itself so a broken
+ * reference is visible in the UI instead of crashing the render.
+ */
+export function getCopy(key: string): string {
+  const parts = key.split(".");
+  let node: unknown = COPY;
+  for (const part of parts) {
+    if (
+      typeof node !== "object" ||
+      node === null ||
+      !Object.prototype.hasOwnProperty.call(node, part)
+    ) {
+      return key;
+    }
+    node = (node as Record<string, unknown>)[part];
+  }
+  return typeof node === "string" ? node : key;
+}

--- a/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
+++ b/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
@@ -81,6 +81,21 @@ export function loadPlan(): PlanState | null {
   }
 }
 
+/**
+ * Removes the saved plan from localStorage (SavePlanBar's "Clear saved
+ * plan" action — copy deck §7, `savePlan.clearButton`). SSR-safe, never
+ * throws: no-op when there is no `window`/`localStorage`, or when the key
+ * was never set.
+ */
+export function clearPlan(): void {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.removeItem(PLAN_STORAGE_KEY);
+  } catch {
+    // Storage blocked/unavailable — no-op.
+  }
+}
+
 /** UTF-8-safe string -> base64url. Works in Node (Buffer, used by tests and
  *  SSR) and in the browser (TextEncoder + btoa, used by the client bundle)
  *  without deprecated escape/unescape. */

--- a/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
+++ b/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
@@ -1,0 +1,152 @@
+/**
+ * Second Home Studio — plan persistence codec (spec §5, SavePlanBar).
+ *
+ * Wizard answers never leave the browser: they live in component state,
+ * `localStorage` (key `bz_shs_plan_v1`), and a base64url-encoded URL
+ * fragment for "copy plan link". Nothing is posted anywhere.
+ *
+ * Every function here is defensive-by-construction: a malformed fragment,
+ * a wrong schema version, an oversized payload, a corrupted localStorage
+ * value, or an SSR environment with no `window` all resolve to a safe
+ * fallback (`null` or a fresh plan) — NEVER a throw. This module runs both
+ * server-side (the thin page.tsx shell) and client-side (StudioApp), so
+ * every `window`/`localStorage` touch is guarded.
+ */
+
+import type { PlanState } from "./types";
+
+export const PLAN_STORAGE_KEY = "bz_shs_plan_v1";
+
+/** Fragment size ceiling. Base64url is pure ASCII, so char length ==
+ *  byte length here — no separate UTF-8 byte-counting pass needed. */
+const MAX_FRAGMENT_BYTES = 8 * 1024;
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]*$/;
+
+export function emptyPlan(): PlanState {
+  return {
+    v: 1,
+    age: null,
+    route: null,
+    capital: null,
+    seniorFunding: null,
+    property: null,
+    family: { spouse: false, children: 0, parents: 0 },
+    horizon: null,
+    location: null,
+    checklist: {},
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function hasLocalStorage(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.localStorage !== "undefined" &&
+    window.localStorage !== null
+  );
+}
+
+/** Minimal structural check — enough to reject garbage/foreign JSON and a
+ *  schema-version mismatch without over-fitting to every field's type. */
+function isValidPlanShape(value: unknown): value is PlanState {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (obj.v !== 1) return false;
+  if (typeof obj.family !== "object" || obj.family === null) return false;
+  if (typeof obj.checklist !== "object" || obj.checklist === null) return false;
+  if (typeof obj.updatedAt !== "string") return false;
+  return true;
+}
+
+export function savePlan(p: PlanState): void {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.setItem(PLAN_STORAGE_KEY, JSON.stringify(p));
+  } catch {
+    // Storage full, blocked (private mode), or unavailable — no-op.
+  }
+}
+
+export function loadPlan(): PlanState | null {
+  if (!hasLocalStorage()) return null;
+  try {
+    const raw = window.localStorage.getItem(PLAN_STORAGE_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidPlanShape(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** UTF-8-safe string -> base64url. Works in Node (Buffer, used by tests and
+ *  SSR) and in the browser (TextEncoder + btoa, used by the client bundle)
+ *  without deprecated escape/unescape. */
+function toBase64Url(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+
+  let base64: string;
+  if (typeof Buffer !== "undefined") {
+    base64 = Buffer.from(bytes).toString("base64");
+  } else if (typeof btoa === "function") {
+    let binary = "";
+    for (const b of bytes) binary += String.fromCharCode(b);
+    base64 = btoa(binary);
+  } else {
+    return "";
+  }
+
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Inverse of toBase64Url. Returns null on any decode failure — never
+ *  throws out of this function. */
+function fromBase64Url(value: string): string | null {
+  try {
+    const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padLength = (4 - (base64.length % 4)) % 4;
+    const padded = base64 + "=".repeat(padLength);
+
+    if (typeof Buffer !== "undefined") {
+      return new TextDecoder().decode(Buffer.from(padded, "base64"));
+    }
+    if (typeof atob === "function") {
+      const binary = atob(padded);
+      const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+      return new TextDecoder().decode(bytes);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function encodePlanFragment(p: PlanState): string {
+  return toBase64Url(JSON.stringify(p));
+}
+
+/**
+ * Decodes a base64url plan fragment back into a PlanState. Never throws:
+ * malformed base64, a wrong schema version, an oversized fragment (>8KB),
+ * or anything that fails to parse as valid PlanState-shaped JSON all
+ * resolve to `null` so the caller can fall back to a fresh plan.
+ */
+export function decodePlanFragment(hash: string): PlanState | null {
+  if (typeof hash !== "string" || hash.length === 0) return null;
+  if (hash.length > MAX_FRAGMENT_BYTES) return null;
+  if (!BASE64URL_RE.test(hash)) return null;
+
+  try {
+    const json = fromBase64Url(hash);
+    if (json === null) return null;
+
+    const parsed: unknown = JSON.parse(json);
+    if (!isValidPlanShape(parsed)) return null;
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
+++ b/apps/mouth/src/lib/secondhome-studio/plan-codec.ts
@@ -1,16 +1,24 @@
 /**
  * Second Home Studio — plan persistence codec (spec §5, SavePlanBar).
  *
- * Wizard answers never leave the browser: they live in component state,
- * `localStorage` (key `bz_shs_plan_v1`), and a base64url-encoded URL
- * fragment for "copy plan link". Nothing is posted anywhere.
+ * Wizard answers stay client-side within THIS module: they live in
+ * component state, `localStorage` (key `bz_shs_plan_v1`), and a
+ * base64url-encoded URL fragment for "copy plan link". This module itself
+ * posts nothing anywhere — the two surfaces that DO share a plan outside
+ * the browser are the copied plan link (a URL the user chooses to send)
+ * and the WhatsApp handoff (`WhatsAppHandoff`/`whatsapp-bullets.ts`), which
+ * POSTs a lead capture to `/api/lead/capture` when the user taps the CTA
+ * (P0-C3/C4, P1-B).
  *
  * Every function here is defensive-by-construction: a malformed fragment,
  * a wrong schema version, an oversized payload, a corrupted localStorage
  * value, or an SSR environment with no `window` all resolve to a safe
  * fallback (`null` or a fresh plan) — NEVER a throw. This module runs both
  * server-side (the thin page.tsx shell) and client-side (StudioApp), so
- * every `window`/`localStorage` touch is guarded.
+ * every `window`/`localStorage` touch is guarded — INCLUDING the
+ * `window.localStorage` property access itself (P2-C12): it is a getter
+ * that can throw `SecurityError` in opaque-origin/strict-privacy contexts
+ * merely by being read, before any method call on it.
  */
 
 import type { PlanState } from "./types";
@@ -40,22 +48,98 @@ export function emptyPlan(): PlanState {
 }
 
 function hasLocalStorage(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    // P2-C12: `window.localStorage` is a GETTER — merely reading it (the
+    // `typeof` check below) can throw `SecurityError` in opaque-origin or
+    // strict-privacy-mode contexts, before any method is ever called on
+    // the returned object. The try/catch has to wrap the property access
+    // itself, not just the calls made against it.
+    return (
+      typeof window.localStorage !== "undefined" && window.localStorage !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
+// P0-C1 (Codex-verified): every PlanState enum field must be validated by
+// PRESENCE + whitelist membership, not just "not null". A fragment that
+// simply OMITS a key (e.g. age/route absent) previously sailed through as
+// `undefined`, and `evaluatePlan`'s `=== null` guards let `undefined` slip
+// past as if it were a real answer — a crafted link could manufacture a
+// strong_fit verdict this way. Every set below mirrors types.ts verbatim.
+const AGE_BANDS = new Set<string>(["under_55", "55_59", "60_plus"]);
+const ROUTE_INTENTS = new Set<string>(["deposit", "property", "unsure"]);
+const CAPITAL_BANDS = new Set<string>([
+  "ready_130k",
+  "close_100k_130k",
+  "below_100k",
+]);
+const SENIOR_FUNDINGS = new Set<string>([
+  "deposit_50k_income",
+  "income_only_3k",
+  "neither",
+  "not_applicable",
+]);
+const PROPERTY_STATUSES = new Set<string>([
+  "owns_qualifying_strata",
+  "buying_completed_strata",
+  "villa_land_leasehold",
+  "none",
+]);
+const TIMELINE_HORIZONS = new Set<string>([
+  "asap",
+  "this_quarter",
+  "exploring",
+]);
+const LOCATIONS = new Set<string>(["in_indonesia", "abroad"]);
+
+/** `undefined` (an ABSENT key) is neither `null` nor a set member, so it is
+ *  correctly rejected here without a separate presence check. */
+function isNullOrOneOf(value: unknown, allowed: Set<string>): boolean {
+  return value === null || (typeof value === "string" && allowed.has(value));
+}
+
+function isValidFamily(value: unknown): value is PlanState["family"] {
+  if (typeof value !== "object" || value === null) return false;
+  const f = value as Record<string, unknown>;
   return (
-    typeof window !== "undefined" &&
-    typeof window.localStorage !== "undefined" &&
-    window.localStorage !== null
+    typeof f.spouse === "boolean" &&
+    typeof f.children === "number" &&
+    f.children >= 0 &&
+    typeof f.parents === "number" &&
+    f.parents >= 0
   );
 }
 
-/** Minimal structural check — enough to reject garbage/foreign JSON and a
- *  schema-version mismatch without over-fitting to every field's type. */
+function isValidChecklist(value: unknown): value is Record<string, boolean> {
+  if (typeof value !== "object" || value === null) return false;
+  return Object.values(value as Record<string, unknown>).every(
+    (v) => typeof v === "boolean",
+  );
+}
+
+/** Full structural check — every PlanState field is validated by presence
+ *  and type/whitelist, never just "not null" (P0-C1, absorbs/supersedes
+ *  P2-1). Any violation anywhere resolves to `false` — a fresh plan is
+ *  always safer than a partially-trusted one. */
 function isValidPlanShape(value: unknown): value is PlanState {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
+
   if (obj.v !== 1) return false;
-  if (typeof obj.family !== "object" || obj.family === null) return false;
-  if (typeof obj.checklist !== "object" || obj.checklist === null) return false;
+  if (!isNullOrOneOf(obj.age, AGE_BANDS)) return false;
+  if (!isNullOrOneOf(obj.route, ROUTE_INTENTS)) return false;
+  if (!isNullOrOneOf(obj.capital, CAPITAL_BANDS)) return false;
+  if (!isNullOrOneOf(obj.seniorFunding, SENIOR_FUNDINGS)) return false;
+  if (!isNullOrOneOf(obj.property, PROPERTY_STATUSES)) return false;
+  if (!isNullOrOneOf(obj.horizon, TIMELINE_HORIZONS)) return false;
+  if (!isNullOrOneOf(obj.location, LOCATIONS)) return false;
+  if (!isValidFamily(obj.family)) return false;
+  if (!isValidChecklist(obj.checklist)) return false;
   if (typeof obj.updatedAt !== "string") return false;
+
   return true;
 }
 
@@ -83,16 +167,31 @@ export function loadPlan(): PlanState | null {
 
 /**
  * Removes the saved plan from localStorage (SavePlanBar's "Clear saved
- * plan" action — copy deck §7, `savePlan.clearButton`). SSR-safe, never
- * throws: no-op when there is no `window`/`localStorage`, or when the key
- * was never set.
+ * plan" action — copy deck §7, `savePlan.clearButton`) AND strips any
+ * `#p=...` plan fragment from the current URL (P2-C11) — otherwise a
+ * "cleared" plan reappears on the next reload because the fragment still
+ * decodes to the old answers. SSR-safe, never throws: no-op when there is
+ * no `window`/`localStorage`/`history`, or when nothing was ever saved.
  */
 export function clearPlan(): void {
-  if (!hasLocalStorage()) return;
-  try {
-    window.localStorage.removeItem(PLAN_STORAGE_KEY);
-  } catch {
-    // Storage blocked/unavailable — no-op.
+  if (hasLocalStorage()) {
+    try {
+      window.localStorage.removeItem(PLAN_STORAGE_KEY);
+    } catch {
+      // Storage blocked/unavailable — no-op.
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    try {
+      window.history.replaceState(
+        null,
+        "",
+        window.location.pathname + window.location.search,
+      );
+    } catch {
+      // history API unavailable/blocked — no-op.
+    }
   }
 }
 

--- a/apps/mouth/src/lib/secondhome-studio/pricing-key.ts
+++ b/apps/mouth/src/lib/secondhome-studio/pricing-key.ts
@@ -1,0 +1,15 @@
+/**
+ * Second Home Studio — E33 PricingTool identity, hoisted out of
+ * SecondHomeLanding.tsx (Phase B) so the Studio's verdict-page price block
+ * resolves the exact same PricingTool row, via the exact same
+ * `usePricingData` identity, as the landing page (CLAUDE.md §8 rule 11 —
+ * PricingTool only, never hardcoded).
+ *
+ * Values MUST stay byte-identical to what SecondHomeLanding.tsx used to
+ * declare locally — its own page.test.tsx resolves the expected price via
+ * these same literal category/key strings independently (it does not
+ * import this module), so any drift here that changed the values would
+ * fail that test.
+ */
+export const E33_LIVE_PRICE_KEY = "E33 Second Home (5 Years)";
+export const E33_LIVE_PRICE_CATEGORY = "kitas_permits";

--- a/apps/mouth/src/lib/secondhome-studio/rules.ts
+++ b/apps/mouth/src/lib/secondhome-studio/rules.ts
@@ -1,0 +1,185 @@
+/**
+ * Second Home Studio — deterministic fit rules.
+ *
+ * Pure function, PINNED by rules.test.ts against every row of
+ * SPEC-secondhome-studio-phaseB.md §3's decision table (checked in priority
+ * order, top to bottom — the first matching row wins).
+ *
+ * Facts used are CONFIRMED registry facts only: USD 130k own-name BUMN
+ * deposit OR USD 1M completed strata; E33E 55+ = USD 50k deposit + USD
+ * 3k/mo income, 5y; E33F 55+ = USD 3k/mo income only, 1y, 6y cap; base
+ * first grant up to 5y (Pasal 113 caps). Nothing else asserted.
+ *
+ * `reasons` and `humanReviewNote` are COPY KEYS (dot-paths into
+ * `copy.ts`'s COPY object), never free strings — `REASON_KEYS` below is the
+ * single source of truth for that vocabulary, kept in sync with
+ * `copy.ts`'s `verdict.reasons` / `verdict.humanReview` trees (drift is
+ * caught by rules.test.ts resolving every key through `getCopy`).
+ */
+
+import type { PlanState, Verdict, VerdictBand } from "./types";
+
+export const REASON_KEYS = {
+  propertyPendingStandard: "verdict.reasons.propertyPendingStandard",
+  propertyDoesNotQualify: "verdict.reasons.propertyDoesNotQualify",
+  unsureRoute: "verdict.reasons.unsureRoute",
+  seniorBersyarat: "verdict.reasons.seniorBersyarat",
+  seniorFundingUnclear: "verdict.reasons.seniorFundingUnclear",
+  seniorDepositStrong: "verdict.reasons.seniorDepositStrong",
+  seniorIncomeOnlyStrong: "verdict.reasons.seniorIncomeOnlyStrong",
+  depositReadyStrong: "verdict.reasons.depositReadyStrong",
+  capitalCloseVerify: "verdict.reasons.capitalCloseVerify",
+  capitalBelowThreshold: "verdict.reasons.capitalBelowThreshold",
+  seniorRoutesExistNote: "verdict.reasons.seniorRoutesExistNote",
+  incompleteAnswers: "verdict.reasons.incompleteAnswers",
+} as const;
+
+export const HUMAN_REVIEW_KEYS = {
+  age5559Disclosure: "verdict.humanReview.age5559Disclosure",
+} as const;
+
+function edgeCaseIncomplete(reasons: string[] = []): Verdict {
+  return {
+    band: "edge_case",
+    product: null,
+    reasons: [...reasons, REASON_KEYS.incompleteAnswers],
+    humanReviewNote: null,
+  };
+}
+
+/** Rows 2-4 (and the 60_plus/neither fallthrough of row 6): evaluate the
+ *  base E33 deposit route purely from the capital band. */
+function evaluateDepositCapital(
+  capital: PlanState["capital"],
+  reasons: string[],
+): Verdict {
+  if (capital === null) return edgeCaseIncomplete(reasons);
+
+  if (capital === "ready_130k") {
+    return {
+      band: "strong_fit",
+      product: "E33",
+      reasons: [...reasons, REASON_KEYS.depositReadyStrong],
+      humanReviewNote: null,
+    };
+  }
+
+  if (capital === "close_100k_130k") {
+    return {
+      band: "likely_fit",
+      product: "E33",
+      reasons: [...reasons, REASON_KEYS.capitalCloseVerify],
+      humanReviewNote: null,
+    };
+  }
+
+  // below_100k
+  return {
+    band: "not_eligible",
+    product: null,
+    reasons: [
+      ...reasons,
+      REASON_KEYS.capitalBelowThreshold,
+      REASON_KEYS.seniorRoutesExistNote,
+    ],
+    humanReviewNote: null,
+  };
+}
+
+export function evaluatePlan(p: PlanState): Verdict {
+  // Globally required answers (row 7 backstop) — age and route are asked
+  // first in the wizard flow and gate every other question.
+  if (p.age === null || p.route === null) {
+    return edgeCaseIncomplete();
+  }
+
+  // Row 1 (highest priority, independent of age): the property route is
+  // ALWAYS edge_case — never a green "qualified", honest pending-standard
+  // note always present, plus a does-not-qualify reason for the property
+  // statuses that never qualify regardless of validation outcome.
+  if (p.route === "property") {
+    if (p.property === null) return edgeCaseIncomplete();
+
+    const reasons: string[] = [REASON_KEYS.propertyPendingStandard];
+    if (p.property === "villa_land_leasehold" || p.property === "none") {
+      reasons.push(REASON_KEYS.propertyDoesNotQualify);
+    }
+
+    return {
+      band: "edge_case",
+      product: null,
+      reasons,
+      humanReviewNote: null,
+    };
+  }
+
+  // Row 8: route=unsure is evaluated as deposit, with an extra reason and
+  // (component-level) a prominent RouteComparator. The reason is prepended
+  // so it always appears first in the returned array below.
+  const reasons: string[] = [];
+  if (p.route === "unsure") {
+    reasons.push(REASON_KEYS.unsureRoute);
+  }
+
+  // Row 5: age 55-59 is ALWAYS edge_case (BERSYARAT), whatever the funding.
+  if (p.age === "55_59") {
+    if (p.seniorFunding === null) return edgeCaseIncomplete(reasons);
+
+    const product =
+      p.seniorFunding === "deposit_50k_income"
+        ? "E33E"
+        : p.seniorFunding === "income_only_3k"
+          ? "E33F"
+          : null;
+
+    const bandReasons = [...reasons, REASON_KEYS.seniorBersyarat];
+    if (product === null) {
+      bandReasons.push(REASON_KEYS.seniorFundingUnclear);
+    }
+
+    return {
+      band: "edge_case",
+      product,
+      reasons: bandReasons,
+      humanReviewNote: HUMAN_REVIEW_KEYS.age5559Disclosure,
+    };
+  }
+
+  // Row 6: age 60_plus.
+  if (p.age === "60_plus") {
+    if (p.seniorFunding === null) return edgeCaseIncomplete(reasons);
+
+    if (p.seniorFunding === "deposit_50k_income") {
+      return {
+        band: "strong_fit",
+        product: "E33E",
+        reasons: [...reasons, REASON_KEYS.seniorDepositStrong],
+        humanReviewNote: null,
+      };
+    }
+
+    if (p.seniorFunding === "income_only_3k") {
+      return {
+        band: "strong_fit",
+        product: "E33F",
+        reasons: [...reasons, REASON_KEYS.seniorIncomeOnlyStrong],
+        humanReviewNote: null,
+      };
+    }
+
+    // "neither" or "not_applicable" falls through to the base E33 deposit
+    // rows (a 60+ can still take the base route with the full 130k).
+    return evaluateDepositCapital(p.capital, reasons);
+  }
+
+  // age === "under_55": rows 2-4, driven purely by capital.
+  return evaluateDepositCapital(p.capital, reasons);
+}
+
+/** Convenience re-export for callers that want the literal band list. */
+export const VERDICT_BANDS: readonly VerdictBand[] = [
+  "strong_fit",
+  "likely_fit",
+  "edge_case",
+  "not_eligible",
+];

--- a/apps/mouth/src/lib/secondhome-studio/rules.ts
+++ b/apps/mouth/src/lib/secondhome-studio/rules.ts
@@ -48,12 +48,23 @@ function edgeCaseIncomplete(reasons: string[] = []): Verdict {
 }
 
 /** Rows 2-4 (and the 60_plus/neither fallthrough of row 6): evaluate the
- *  base E33 deposit route purely from the capital band. */
+ *  base E33 deposit route purely from the capital band.
+ *
+ *  `isUnsureRoute` (P2-7, conductor-ruled spec amendment): a user who never
+ *  committed to a route must not get a hard "not eligible" — when the
+ *  deposit evaluation would otherwise be not_eligible AND the route is
+ *  "unsure", it downgrades to edge_case instead (product stays null).
+ *
+ *  The `== null` guards (not `===`) are P0-C1 defense-in-depth: a value
+ *  that bypassed the codec's validation (e.g. a directly-constructed
+ *  PlanState missing a field) must never fall through as if it were a real
+ *  answer — `undefined` is caught exactly like `null`. */
 function evaluateDepositCapital(
   capital: PlanState["capital"],
   reasons: string[],
+  isUnsureRoute: boolean,
 ): Verdict {
-  if (capital === null) return edgeCaseIncomplete(reasons);
+  if (capital == null) return edgeCaseIncomplete(reasons);
 
   if (capital === "ready_130k") {
     return {
@@ -75,7 +86,7 @@ function evaluateDepositCapital(
 
   // below_100k
   return {
-    band: "not_eligible",
+    band: isUnsureRoute ? "edge_case" : "not_eligible",
     product: null,
     reasons: [
       ...reasons,
@@ -88,28 +99,42 @@ function evaluateDepositCapital(
 
 export function evaluatePlan(p: PlanState): Verdict {
   // Globally required answers (row 7 backstop) — age and route are asked
-  // first in the wizard flow and gate every other question.
-  if (p.age === null || p.route === null) {
+  // first in the wizard flow and gate every other question. `== null`
+  // (P0-C1 defense-in-depth) catches `undefined` exactly like `null`, so a
+  // PlanState with an ABSENT field (bypassing the codec's own validation)
+  // can never sail through as if the field were a real answer.
+  if (p.age == null || p.route == null) {
     return edgeCaseIncomplete();
   }
+
+  const isUnsureRoute = p.route === "unsure";
 
   // Row 1 (highest priority, independent of age): the property route is
   // ALWAYS edge_case — never a green "qualified", honest pending-standard
   // note always present, plus a does-not-qualify reason for the property
   // statuses that never qualify regardless of validation outcome.
+  //
+  // P1-A: 55-59 loses none of its mandatory disclosure just because the
+  // route happens to be property — spec §0 requires the signed-disclosure
+  // note on EVERY 55-59 case, not only the deposit/senior-funding path.
   if (p.route === "property") {
-    if (p.property === null) return edgeCaseIncomplete();
+    if (p.property == null) return edgeCaseIncomplete();
 
     const reasons: string[] = [REASON_KEYS.propertyPendingStandard];
     if (p.property === "villa_land_leasehold" || p.property === "none") {
       reasons.push(REASON_KEYS.propertyDoesNotQualify);
     }
 
+    const is5559 = p.age === "55_59";
+    if (is5559) {
+      reasons.push(REASON_KEYS.seniorBersyarat);
+    }
+
     return {
       band: "edge_case",
       product: null,
       reasons,
-      humanReviewNote: null,
+      humanReviewNote: is5559 ? HUMAN_REVIEW_KEYS.age5559Disclosure : null,
     };
   }
 
@@ -117,13 +142,13 @@ export function evaluatePlan(p: PlanState): Verdict {
   // (component-level) a prominent RouteComparator. The reason is prepended
   // so it always appears first in the returned array below.
   const reasons: string[] = [];
-  if (p.route === "unsure") {
+  if (isUnsureRoute) {
     reasons.push(REASON_KEYS.unsureRoute);
   }
 
   // Row 5: age 55-59 is ALWAYS edge_case (BERSYARAT), whatever the funding.
   if (p.age === "55_59") {
-    if (p.seniorFunding === null) return edgeCaseIncomplete(reasons);
+    if (p.seniorFunding == null) return edgeCaseIncomplete(reasons);
 
     const product =
       p.seniorFunding === "deposit_50k_income"
@@ -147,7 +172,7 @@ export function evaluatePlan(p: PlanState): Verdict {
 
   // Row 6: age 60_plus.
   if (p.age === "60_plus") {
-    if (p.seniorFunding === null) return edgeCaseIncomplete(reasons);
+    if (p.seniorFunding == null) return edgeCaseIncomplete(reasons);
 
     if (p.seniorFunding === "deposit_50k_income") {
       return {
@@ -169,11 +194,11 @@ export function evaluatePlan(p: PlanState): Verdict {
 
     // "neither" or "not_applicable" falls through to the base E33 deposit
     // rows (a 60+ can still take the base route with the full 130k).
-    return evaluateDepositCapital(p.capital, reasons);
+    return evaluateDepositCapital(p.capital, reasons, isUnsureRoute);
   }
 
   // age === "under_55": rows 2-4, driven purely by capital.
-  return evaluateDepositCapital(p.capital, reasons);
+  return evaluateDepositCapital(p.capital, reasons, isUnsureRoute);
 }
 
 /** Convenience re-export for callers that want the literal band list. */

--- a/apps/mouth/src/lib/secondhome-studio/sequence.ts
+++ b/apps/mouth/src/lib/secondhome-studio/sequence.ts
@@ -1,0 +1,85 @@
+/**
+ * Second Home Studio — the wizard question sequence (spec §4), hoisted out
+ * of StudioApp so it is the SINGLE source of truth for "which questions are
+ * reachable from the current plan" (P2-6/P1-C8/P0-C3 fix-mandate round 1).
+ *
+ * Question order: age -> route -> [deposit/unsure? capital] ->
+ * [55+? seniorFunding] -> [property? property] -> family -> horizon ->
+ * location -> VERDICT. The sequence is recomputed from the CURRENT plan on
+ * every call (never cached against a stale branch), so answering an earlier
+ * question (e.g. switching route from deposit to property, or seniorFunding
+ * from "neither" to "income_only_3k") immediately changes what the NEXT
+ * step is — no dangling questions from an abandoned branch.
+ *
+ * `relevantPlan` uses the same sequence to null out any branch-only answer
+ * (capital / seniorFunding / property) that is NOT reachable from the
+ * current plan — e.g. a `capital` answer left over from a deposit route the
+ * user has since switched away from. Every surface that SHARES a plan
+ * outside the wizard's own component state (the "copy plan link" fragment,
+ * the WhatsApp handoff bullets) must sanitize through this first, so an
+ * abandoned-branch answer never leaks into a saved/sent artifact.
+ */
+
+import type { PlanState } from "./types";
+
+export type QuestionId =
+  | "age"
+  | "route"
+  | "capital"
+  | "seniorFunding"
+  | "property"
+  | "family"
+  | "horizon"
+  | "location";
+
+export function computeSequence(p: PlanState): QuestionId[] {
+  const seq: QuestionId[] = ["age", "route"];
+
+  if (p.route === "property") {
+    seq.push("property");
+  } else if (p.age === "55_59") {
+    // Row 5 (rules.ts): 55-59 is always edge_case from seniorFunding alone
+    // — capital is never consulted for this age band.
+    seq.push("seniorFunding");
+  } else if (p.age === "60_plus") {
+    seq.push("seniorFunding");
+    // Row 6 fallthrough: only "neither"/"not_applicable" (or not yet
+    // answered) reaches the base deposit rows, so only THEN is capital
+    // needed. Once seniorFunding matches a senior product, capital is
+    // skipped entirely — this branch re-evaluates every render, so the
+    // skip takes effect the moment seniorFunding resolves.
+    if (
+      p.seniorFunding === null ||
+      p.seniorFunding === "neither" ||
+      p.seniorFunding === "not_applicable"
+    ) {
+      seq.push("capital");
+    }
+  } else {
+    // under_55 (or age not yet known — capital is the conservative
+    // default until age resolves; by the time we actually reach this
+    // position in the sequence, age is always answered for real).
+    seq.push("capital");
+  }
+
+  seq.push("family", "horizon", "location");
+  return seq;
+}
+
+/**
+ * Nulls every branch-only answer (capital / seniorFunding / property) not
+ * reachable in the CURRENT sequence, leaving every other field untouched.
+ * Used before sharing a plan OUTSIDE the wizard's own component state (P2-6)
+ * — localStorage keeps the raw plan so resuming the wizard never loses an
+ * answer the user might switch back to, but a shared link or a WhatsApp
+ * handoff should never carry an abandoned branch's stale answer.
+ */
+export function relevantPlan(p: PlanState): PlanState {
+  const reachable = new Set(computeSequence(p));
+  return {
+    ...p,
+    capital: reachable.has("capital") ? p.capital : null,
+    seniorFunding: reachable.has("seniorFunding") ? p.seniorFunding : null,
+    property: reachable.has("property") ? p.property : null,
+  };
+}

--- a/apps/mouth/src/lib/secondhome-studio/timeline.ts
+++ b/apps/mouth/src/lib/secondhome-studio/timeline.ts
@@ -7,13 +7,26 @@
  * differ abroad vs. already-in-Indonesia); `horizon` changes the pace note
  * attached to that same first step (how urgently the client should move,
  * never how fast Imigrasi processes the file).
+ *
+ * `route`/`product` (P1-C9, optional — default preserves the original
+ * always-bank-deposit shape) make the SECOND step honest about what the
+ * applicant actually needs to do: the bank-deposit step used to render
+ * unconditionally, telling a property applicant or an E33F (income-only,
+ * explicitly "without the deposit") applicant to "open the account and
+ * place the deposit" — instructions for evidence they were never asked
+ * for. `route === "property"` swaps it for a property-evidence step;
+ * `product === "E33F"` swaps it for an income-evidence step; every other
+ * case (including E33E, which DOES keep the 50k deposit) keeps the
+ * original bank-deposit step unchanged.
  */
 
-import type { Location, TimelineHorizon } from "./types";
+import type { Location, RouteIntent, TimelineHorizon, Verdict } from "./types";
 
 export type TimelineStepId =
   | "documents"
   | "bank_deposit"
+  | "property_evidence"
+  | "income_evidence"
   | "filing"
   | "imigrasi_processing"
   | "entry_activation"
@@ -34,6 +47,8 @@ export interface TimelineStep {
 export function buildTimeline(
   horizon: TimelineHorizon,
   location: Location,
+  route: RouteIntent | null = null,
+  product: Verdict["product"] = null,
 ): TimelineStep[] {
   const documentsRangeKey =
     location === "abroad"
@@ -41,6 +56,34 @@ export function buildTimeline(
       : "timeline.steps.documents.range.local";
 
   const documentsPaceKey = `timeline.steps.documents.pace.${horizon}`;
+
+  // P1-C9: the second step is branch-aware. Property route always wins
+  // (it never has a bank deposit at all); E33F (income-only) swaps the
+  // deposit step for an income-evidence step; every other case — including
+  // deposit/unsure under-55, the 60+ base-deposit fallthrough, and E33E
+  // (which keeps its 50k deposit) — reuses the original bank-deposit step
+  // unchanged.
+  const fundingStep: TimelineStep =
+    route === "property"
+      ? {
+          id: "property_evidence",
+          ownerKey: "you",
+          titleKey: "timeline.steps.propertyEvidence.title",
+          rangeKey: "timeline.steps.propertyEvidence.range",
+        }
+      : product === "E33F"
+        ? {
+            id: "income_evidence",
+            ownerKey: "you",
+            titleKey: "timeline.steps.incomeEvidence.title",
+            rangeKey: "timeline.steps.incomeEvidence.range",
+          }
+        : {
+            id: "bank_deposit",
+            ownerKey: "you",
+            titleKey: "timeline.steps.bankDeposit.title",
+            rangeKey: "timeline.steps.bankDeposit.range",
+          };
 
   return [
     {
@@ -50,12 +93,7 @@ export function buildTimeline(
       rangeKey: documentsRangeKey,
       paceNoteKey: documentsPaceKey,
     },
-    {
-      id: "bank_deposit",
-      ownerKey: "you",
-      titleKey: "timeline.steps.bankDeposit.title",
-      rangeKey: "timeline.steps.bankDeposit.range",
-    },
+    fundingStep,
     {
       id: "filing",
       ownerKey: "balizero",

--- a/apps/mouth/src/lib/secondhome-studio/timeline.ts
+++ b/apps/mouth/src/lib/secondhome-studio/timeline.ts
@@ -1,0 +1,90 @@
+/**
+ * Second Home Studio — the 7-step public timeline (spec §5).
+ *
+ * Every step carries an owner tag (You / Bali Zero / Imigrasi) and a range
+ * label that is explicitly "typical, not a promise" — no promised dates
+ * anywhere. `location` changes the documents-gathering range (logistics
+ * differ abroad vs. already-in-Indonesia); `horizon` changes the pace note
+ * attached to that same first step (how urgently the client should move,
+ * never how fast Imigrasi processes the file).
+ */
+
+import type { Location, TimelineHorizon } from "./types";
+
+export type TimelineStepId =
+  | "documents"
+  | "bank_deposit"
+  | "filing"
+  | "imigrasi_processing"
+  | "entry_activation"
+  | "first_90_days"
+  | "annual_life";
+
+export type TimelineOwner = "you" | "balizero" | "imigrasi";
+
+export interface TimelineStep {
+  id: TimelineStepId;
+  ownerKey: TimelineOwner;
+  titleKey: string;
+  rangeKey: string;
+  /** Only present on the documents step — varies by `horizon`. */
+  paceNoteKey?: string;
+}
+
+export function buildTimeline(
+  horizon: TimelineHorizon,
+  location: Location,
+): TimelineStep[] {
+  const documentsRangeKey =
+    location === "abroad"
+      ? "timeline.steps.documents.range.abroad"
+      : "timeline.steps.documents.range.local";
+
+  const documentsPaceKey = `timeline.steps.documents.pace.${horizon}`;
+
+  return [
+    {
+      id: "documents",
+      ownerKey: "you",
+      titleKey: "timeline.steps.documents.title",
+      rangeKey: documentsRangeKey,
+      paceNoteKey: documentsPaceKey,
+    },
+    {
+      id: "bank_deposit",
+      ownerKey: "you",
+      titleKey: "timeline.steps.bankDeposit.title",
+      rangeKey: "timeline.steps.bankDeposit.range",
+    },
+    {
+      id: "filing",
+      ownerKey: "balizero",
+      titleKey: "timeline.steps.filing.title",
+      rangeKey: "timeline.steps.filing.range",
+    },
+    {
+      id: "imigrasi_processing",
+      ownerKey: "imigrasi",
+      titleKey: "timeline.steps.imigrasiProcessing.title",
+      rangeKey: "timeline.steps.imigrasiProcessing.range",
+    },
+    {
+      id: "entry_activation",
+      ownerKey: "you",
+      titleKey: "timeline.steps.entryActivation.title",
+      rangeKey: "timeline.steps.entryActivation.range",
+    },
+    {
+      id: "first_90_days",
+      ownerKey: "balizero",
+      titleKey: "timeline.steps.first90Days.title",
+      rangeKey: "timeline.steps.first90Days.range",
+    },
+    {
+      id: "annual_life",
+      ownerKey: "you",
+      titleKey: "timeline.steps.annualLife.title",
+      rangeKey: "timeline.steps.annualLife.range",
+    },
+  ];
+}

--- a/apps/mouth/src/lib/secondhome-studio/types.ts
+++ b/apps/mouth/src/lib/secondhome-studio/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Second Home Studio — Phase B core loop types.
+ *
+ * FROZEN CONTRACT — verbatim from SPEC-secondhome-studio-phaseB.md §2. Do not
+ * reshape without re-freezing the spec; every other module in this package
+ * (rules.ts, timeline.ts, checklist.ts, plan-codec.ts, copy.ts) is built
+ * against these exact shapes.
+ */
+
+export type AgeBand = "under_55" | "55_59" | "60_plus";
+export type RouteIntent = "deposit" | "property" | "unsure";
+export type CapitalBand = "ready_130k" | "close_100k_130k" | "below_100k";
+export type SeniorFunding =
+  "deposit_50k_income" | "income_only_3k" | "neither" | "not_applicable";
+export type PropertyStatus =
+  | "owns_qualifying_strata"
+  | "buying_completed_strata"
+  | "villa_land_leasehold"
+  | "none";
+export type FamilyPlan = { spouse: boolean; children: number; parents: number };
+export type TimelineHorizon = "asap" | "this_quarter" | "exploring";
+export type Location = "in_indonesia" | "abroad";
+
+export interface PlanState {
+  v: 1; // codec schema version
+  age: AgeBand | null;
+  route: RouteIntent | null;
+  capital: CapitalBand | null; // deposit route only
+  seniorFunding: SeniorFunding | null; // 55+ only
+  property: PropertyStatus | null; // property route only
+  family: FamilyPlan;
+  horizon: TimelineHorizon | null;
+  location: Location | null;
+  checklist: Record<string, boolean>; // checklist item id -> done
+  updatedAt: string; // ISO date
+}
+
+export type VerdictBand =
+  "strong_fit" | "likely_fit" | "edge_case" | "not_eligible";
+
+export interface Verdict {
+  band: VerdictBand;
+  product: "E33" | "E33E" | "E33F" | null; // null when not_eligible/edge without product
+  reasons: string[]; // copy KEYS from copy.ts, never free strings
+  humanReviewNote: string | null; // copy KEY
+}

--- a/apps/mouth/src/lib/secondhome-studio/whatsapp-bullets.ts
+++ b/apps/mouth/src/lib/secondhome-studio/whatsapp-bullets.ts
@@ -1,0 +1,122 @@
+/**
+ * Second Home Studio — WhatsApp handoff bullet builder (fix-mandate round 1,
+ * P0-C3 + P0-C4, backend contract verified in-worktree).
+ *
+ * Mirrors `apps/backend-rag/backend/app/routers/lead_capture.py:38-47`
+ * (`ContextLine` / `LeadCaptureRequest.whatsapp_context`) EXACTLY: at most
+ * 6 rows, label <=64 chars, value <=160 chars, every row non-empty. The
+ * previous implementation sent 10 rows plus a ~441-char plan-URL value —
+ * guaranteed 422, silently degrading the CTA to the bare wa.me fallback.
+ *
+ * NO plan URL, NO readiness row (P0-C3(b)): the `cta_handoff` LeadSource
+ * maps to `result_url_path = "/"`, so a `resultHash` would build a garbage
+ * "Reference: https://balizero.com//<band>" line
+ * (`whatsapp_deeplink.py:88-89`) — this module never emits one. The plan
+ * link's ONLY carrier is SavePlanBar's "Copy plan link" (P0-C3(e)).
+ *
+ * The funding line is branch-aware (P1-C8): a plain under-55 deposit user
+ * used to see "Funding position: —" because the old code always read
+ * `seniorFunding`, which is null outside the 55+ paths.
+ *
+ * Sanitizes through `relevantPlan` first (P2-6) so a stale answer left over
+ * from an abandoned branch (e.g. `capital` after switching to the property
+ * route) never leaks into the sent bullets.
+ */
+
+import { getCopy } from "./copy";
+import { relevantPlan } from "./sequence";
+import type { PlanState, Verdict } from "./types";
+
+// Mirrors lead_capture.py:38-47 ContextLine (label max_length=64,
+// value max_length=160) and LeadCaptureRequest.whatsapp_context
+// (max_length=6).
+export const MAX_BULLET_ROWS = 6;
+export const MAX_LABEL_LENGTH = 64;
+export const MAX_VALUE_LENGTH = 160;
+
+export interface WhatsAppBullet {
+  label: string;
+  value: string;
+}
+
+/** Resolves a wizard option's copy label. Returns null (never a "—"
+ *  placeholder) for an unanswered/not-applicable value so the caller can
+ *  skip the row entirely rather than send an uninformative one. */
+function optionLabel(base: string, value: string | null): string | null {
+  if (value === null) return null;
+  if (value === "not_applicable") return "Not applicable";
+  return getCopy(`${base}.options.${value}`);
+}
+
+function familySummary(plan: PlanState): string {
+  const parts: string[] = [];
+  if (plan.family.spouse) parts.push("spouse");
+  if (plan.family.children > 0) parts.push("children");
+  if (plan.family.parents > 0) parts.push("parents");
+  return parts.length > 0 ? parts.join(", ") : "none";
+}
+
+/** Branch-aware funding line (P1-C8): the decisive answer differs by
+ *  route/age — never blindly reads seniorFunding for a deposit/property
+ *  applicant, and never blindly reads capital for a 55+ senior applicant.
+ *
+ *  55-59 (rules.ts row 5) is ALWAYS seniorFunding-driven — computeSequence
+ *  never even asks `capital` at that age band, so there is no fallback
+ *  value to show; the seniorFunding label ("Neither of these" included) IS
+ *  the decisive answer. 60+ (row 6) is different: once seniorFunding is
+ *  "neither"/"not_applicable"/unanswered, the rules engine falls through
+ *  to the base deposit route, and `capital` (which computeSequence DOES
+ *  ask for at that point) becomes the real decisive answer — reading
+ *  seniorFunding there would show a value the rules engine itself no
+ *  longer treats as decisive. */
+function fundingLine(plan: PlanState): string | null {
+  if (plan.route === "property") {
+    return optionLabel("wizard.property", plan.property);
+  }
+  if (plan.age === "55_59") {
+    return optionLabel("wizard.seniorFunding", plan.seniorFunding);
+  }
+  if (plan.age === "60_plus") {
+    const isSeniorProductMatch =
+      plan.seniorFunding === "deposit_50k_income" ||
+      plan.seniorFunding === "income_only_3k";
+    return isSeniorProductMatch
+      ? optionLabel("wizard.seniorFunding", plan.seniorFunding)
+      : optionLabel("wizard.capital", plan.capital);
+  }
+  return optionLabel("wizard.capital", plan.capital);
+}
+
+/**
+ * Builds the <=6 WhatsApp handoff bullets for the current plan + verdict.
+ * A candidate with no real answer is SKIPPED (never sent as an empty or
+ * placeholder value) — the backend's `ContextLine.value` requires
+ * `min_length=1`.
+ */
+export function buildWhatsAppBullets(
+  plan: PlanState,
+  verdict: Verdict,
+): WhatsAppBullet[] {
+  const p = relevantPlan(plan);
+  const bandLabel = getCopy(`verdict.bands.${verdict.band}.heading`);
+
+  const candidates: Array<{ label: string; value: string | null }> = [
+    { label: "Route", value: optionLabel("wizard.route", p.route) },
+    { label: "Age band", value: optionLabel("wizard.age", p.age) },
+    { label: "Funding position", value: fundingLine(p) },
+    { label: "Family", value: familySummary(p) },
+    { label: "Timing", value: optionLabel("wizard.horizon", p.horizon) },
+    { label: "Fit-check result", value: bandLabel },
+  ];
+
+  const bullets: WhatsAppBullet[] = [];
+  for (const candidate of candidates) {
+    if (bullets.length >= MAX_BULLET_ROWS) break;
+    if (candidate.value === null || candidate.value.length === 0) continue;
+    bullets.push({
+      label: candidate.label.slice(0, MAX_LABEL_LENGTH),
+      value: candidate.value.slice(0, MAX_VALUE_LENGTH),
+    });
+  }
+  return bullets;
+}


### PR DESCRIPTION
## What

The **Second Home Studio** at `/visa/second-home/studio`: a public, fully client-side fit-check wizard for the E33 Second Home visa family (base E33 / E33E / E33F). TurboTax-style interview → verdict BANDS (never numeric scores) → branch-aware timeline, custody-transparency map, readiness checklist, shareable plan link, and a contract-safe WhatsApp handoff.

- **No new backend**: plan state lives in `localStorage` (`bz_shs_plan_v1`) + URL fragment `#p=<base64url>`; the only network touch is the existing `/api/lead/capture` POST on the WhatsApp CTA.
- Rules are a pure function pinned test-by-test to the frozen Phase B spec decision table; every reason/note is a copy KEY resolved through a single `copy.ts` module.
- Forbidden-claims sweep (guilt+innocence) over all copy values AND a JSX source scan; verdict copy uses fit-check language only, positive-only deposit phrasing, no banned E33 claims (USD 1,500 / any-bank / split-deposit / automatic-ITAP / guarantees).
- WhatsApp handoff mirrors `lead_capture.py:38-47` exactly: ≤6 branch-aware bullets, label ≤64, value ≤160, non-empty; NO plan URL, NO readiness row, no `resultHash` (the plan link's only carrier is the user-initiated "Copy plan link").
- Landing CTA added on `/visa/second-home`.

## Adversarial review

Generator≠grader throughout: built by 3 sequential implementer lanes, refuted by a 2-family panel (Codex GPT-5.6 sol xhigh + Kimi K3), every finding re-verified on disk by the conductor before the fix mandate; round-1 cures (19 sections: P0 crafted-fragment validation, split-deposit euphemism, WhatsApp backend contract; P1 55-59 disclosure on property route, malformed-fragment freshness, branch-aware funding/timeline; P2 a11y/focus/radiogroup, stale-branch pruning, JSX sweep) applied in `925b342e1` and independently gated: 256/256 vitest, tsc RC=0, eslint RC=0, spot-reads of every P0/P1 cure.

## Tests

9 test files, 256 tests: decision-table pinning (guilt+innocence per row), codec roundtrip + per-field absence/mutation tables, sequence/relevance pruning, timeline per route/product, WhatsApp bullet contract (constants mirrored from `lead_capture.py`), forbidden-claims copy+JSX sweeps, StudioApp integration (focus, roles, fragment precedence, clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)