### PR TITLE
fix(portal): clear superuser impersonation state on logout/token-expiry

### DIFF
--- a/apps/mouth/src/contexts/AdminImpersonationContext.tsx
+++ b/apps/mouth/src/contexts/AdminImpersonationContext.tsx
@@ -20,6 +20,7 @@ import React, {
   useCallback,
 } from "react";
 import { api } from "@/lib/api";
+import { PORTAL_IMPERSONATION_STORAGE_KEY } from "@/lib/api/client";
 
 type ImpersonationTarget = {
   id: number;
@@ -34,7 +35,10 @@ type Ctx = {
   loading: boolean;
 };
 
-const STORAGE_KEY = "bz_portal_impersonation_v1";
+// Single source of truth for the storage key lives in lib/api/client.ts
+// (the module that also reads it on construction and clears it on
+// clearToken()) — imported here, never re-typed, so the two sides cannot
+// drift apart. See the constant's own doc comment for why that matters.
 
 const AdminImpersonationContext = createContext<Ctx>({
   isSuperuser: false,
@@ -55,7 +59,7 @@ export function AdminImpersonationProvider({
   // Restore from localStorage on mount
   useEffect(() => {
     try {
-      const raw = localStorage.getItem(STORAGE_KEY);
+      const raw = localStorage.getItem(PORTAL_IMPERSONATION_STORAGE_KEY);
       if (raw) {
         const parsed = JSON.parse(raw) as ImpersonationTarget;
         if (parsed && typeof parsed.id === "number") {
@@ -102,10 +106,10 @@ export function AdminImpersonationProvider({
   const setTarget = useCallback((t: ImpersonationTarget | null) => {
     setTargetState(t);
     if (t) {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(t));
+      localStorage.setItem(PORTAL_IMPERSONATION_STORAGE_KEY, JSON.stringify(t));
       api.setPortalImpersonation?.(t.id);
     } else {
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(PORTAL_IMPERSONATION_STORAGE_KEY);
       api.setPortalImpersonation?.(null);
     }
   }, []);

--- a/apps/mouth/src/lib/api/client.test.ts
+++ b/apps/mouth/src/lib/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ApiClientBase } from "./client";
+import { ApiClientBase, PORTAL_IMPERSONATION_STORAGE_KEY } from "./client";
 import { UserProfile } from "@/types";
 
 // Mock localStorage
@@ -99,7 +99,9 @@ describe("ApiClientBase", () => {
   });
 
   describe("Portal Impersonation (cross-operator inheritance regression)", () => {
-    const IMPERSONATION_KEY = "bz_portal_impersonation_v1";
+    // Storage key comes from the imported PORTAL_IMPERSONATION_STORAGE_KEY
+    // constant (see import above) — no local literal, single source of truth
+    // with client.ts.
 
     beforeEach(() => {
       global.fetch = vi.fn().mockResolvedValue({
@@ -116,7 +118,7 @@ describe("ApiClientBase", () => {
       // and pushes it into the live api client's in-memory field.
       client.setPortalImpersonation(42);
       localStorageMock.setItem(
-        IMPERSONATION_KEY,
+        PORTAL_IMPERSONATION_STORAGE_KEY,
         JSON.stringify({ id: 42, email: "client@example.com", fullName: null }),
       );
       expect(client.getPortalImpersonation()).toBe(42);
@@ -127,9 +129,11 @@ describe("ApiClientBase", () => {
       // 1. The persisted key must be gone — a fresh page/context mount must
       //    have nothing to rehydrate from.
       expect(localStorageMock.removeItem).toHaveBeenCalledWith(
-        IMPERSONATION_KEY,
+        PORTAL_IMPERSONATION_STORAGE_KEY,
       );
-      expect(localStorageMock.getItem(IMPERSONATION_KEY)).toBeNull();
+      expect(
+        localStorageMock.getItem(PORTAL_IMPERSONATION_STORAGE_KEY),
+      ).toBeNull();
 
       // 2. The in-memory id must be reset too — this is what actually rides
       //    on the next request, independent of storage.
@@ -153,7 +157,9 @@ describe("ApiClientBase", () => {
       expect(client.getPortalImpersonation()).toBeNull();
       // No impersonation key ever existed — removeItem is safe to call
       // regardless (storage.removeItem on a missing key is a no-op).
-      expect(localStorageMock.getItem(IMPERSONATION_KEY)).toBeNull();
+      expect(
+        localStorageMock.getItem(PORTAL_IMPERSONATION_STORAGE_KEY),
+      ).toBeNull();
     });
 
     it("a plain page reload while still logged in legitimately re-seeds impersonation from storage (must NOT regress)", () => {
@@ -163,7 +169,7 @@ describe("ApiClientBase", () => {
       // very first portal fetch after reload still carries as_client.
       localStorageMock.setItem("auth_token", "still-logged-in-token");
       localStorageMock.setItem(
-        IMPERSONATION_KEY,
+        PORTAL_IMPERSONATION_STORAGE_KEY,
         JSON.stringify({ id: 7, email: "other@example.com", fullName: null }),
       );
 

--- a/apps/mouth/src/lib/api/client.test.ts
+++ b/apps/mouth/src/lib/api/client.test.ts
@@ -98,6 +98,82 @@ describe("ApiClientBase", () => {
     });
   });
 
+  describe("Portal Impersonation (cross-operator inheritance regression)", () => {
+    const IMPERSONATION_KEY = "bz_portal_impersonation_v1";
+
+    beforeEach(() => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        json: async () => ({}),
+      });
+    });
+
+    it("clearToken() removes the impersonation key from storage AND stops injecting as_client into subsequent requests", async () => {
+      // Simulate a superuser (zero@) who is viewing as client 42 — the
+      // AdminImpersonationContext both persists the target to localStorage
+      // and pushes it into the live api client's in-memory field.
+      client.setPortalImpersonation(42);
+      localStorageMock.setItem(
+        IMPERSONATION_KEY,
+        JSON.stringify({ id: 42, email: "client@example.com", fullName: null }),
+      );
+      expect(client.getPortalImpersonation()).toBe(42);
+
+      // logout() -> clearToken()
+      client.clearToken();
+
+      // 1. The persisted key must be gone — a fresh page/context mount must
+      //    have nothing to rehydrate from.
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        IMPERSONATION_KEY,
+      );
+      expect(localStorageMock.getItem(IMPERSONATION_KEY)).toBeNull();
+
+      // 2. The in-memory id must be reset too — this is what actually rides
+      //    on the next request, independent of storage.
+      expect(client.getPortalImpersonation()).toBeNull();
+
+      // 3. The real property under test: a DIFFERENT superuser logging in
+      //    right after must NOT have as_client silently attached to their
+      //    portal calls.
+      await (client as any).request("/api/portal/clients");
+      const callArgs = (global.fetch as any).mock.calls[0];
+      const requestedUrl = callArgs[0] as string;
+      expect(requestedUrl).not.toContain("as_client=");
+    });
+
+    it("clearToken() does not throw and still clears the ordinary session when no impersonation was ever set", () => {
+      // Innocence: a regular client/employee logging out (never impersonating)
+      // must not be affected by the impersonation-clearing logic.
+      client.setToken("plain-token");
+      expect(() => client.clearToken()).not.toThrow();
+      expect(client.getToken()).toBeNull();
+      expect(client.getPortalImpersonation()).toBeNull();
+      // No impersonation key ever existed — removeItem is safe to call
+      // regardless (storage.removeItem on a missing key is a no-op).
+      expect(localStorageMock.getItem(IMPERSONATION_KEY)).toBeNull();
+    });
+
+    it("a plain page reload while still logged in legitimately re-seeds impersonation from storage (must NOT regress)", () => {
+      // This is the moment impersonation SHOULD persist: the operator never
+      // logged out, they just refreshed the tab. ApiClientBase's constructor
+      // seeds portalImpersonationClientId from localStorage precisely so the
+      // very first portal fetch after reload still carries as_client.
+      localStorageMock.setItem("auth_token", "still-logged-in-token");
+      localStorageMock.setItem(
+        IMPERSONATION_KEY,
+        JSON.stringify({ id: 7, email: "other@example.com", fullName: null }),
+      );
+
+      // clearToken() is never called on a reload — only the constructor runs.
+      const reloadedClient = new ApiClientBase(baseUrl);
+
+      expect(reloadedClient.getPortalImpersonation()).toBe(7);
+    });
+  });
+
   describe("User Profile Management", () => {
     it("should set and get user profile", () => {
       const profile: UserProfile = {

--- a/apps/mouth/src/lib/api/client.ts
+++ b/apps/mouth/src/lib/api/client.ts
@@ -102,9 +102,21 @@ export class ApiClientBase implements IApiClient {
     this.token = null;
     this.csrfToken = null;
     this.userProfile = null;
+    // Reset superuser impersonation together with the session. Without this,
+    // logging out (or a token-expiry 401, below) leaves the in-memory
+    // portalImpersonationClientId set AND the localStorage key that
+    // AdminImpersonationContext restores on mount — so the very next login
+    // in this browser, even by a DIFFERENT superuser, silently inherits the
+    // previous operator's impersonation target on every portal request.
+    this.portalImpersonationClientId = null;
     if (typeof window !== "undefined") {
       safeStorage.removeItem("auth_token");
       safeStorage.removeItem("user_profile");
+      try {
+        localStorage.removeItem("bz_portal_impersonation_v1");
+      } catch {
+        // ignore — impersonation storage is optional, same as the read path
+      }
     }
   }
 

--- a/apps/mouth/src/lib/api/client.ts
+++ b/apps/mouth/src/lib/api/client.ts
@@ -13,6 +13,20 @@ interface FastAPIValidationError {
 }
 
 /**
+ * localStorage key for superuser portal impersonation ("view as client X").
+ * Single source of truth — this module owns the key because it is also the
+ * one that reads/consumes it (constructor seed + request() injection +
+ * clearToken() teardown, below). AdminImpersonationContext
+ * (contexts/AdminImpersonationContext.tsx) imports this constant rather than
+ * re-typing the literal: the two sides MUST agree on the exact key, and a
+ * future rename/version-bump (_v1 -> _v2) done in only one place would leave
+ * the context writing/restoring a key clearToken() no longer clears —
+ * silently reviving the cross-operator impersonation-inheritance bug this
+ * key exists to guard against.
+ */
+export const PORTAL_IMPERSONATION_STORAGE_KEY = "bz_portal_impersonation_v1";
+
+/**
  * Base API client with token management and request handling.
  * This is the core class that all domain-specific API modules extend or use.
  * Implements IApiClient interface for type-safe dependency injection.
@@ -47,7 +61,7 @@ export class ApiClientBase implements IApiClient {
       // Seed impersonation from localStorage so the very first portal fetch
       // on page reload already carries as_client.
       try {
-        const rawImp = localStorage.getItem("bz_portal_impersonation_v1");
+        const rawImp = localStorage.getItem(PORTAL_IMPERSONATION_STORAGE_KEY);
         if (rawImp) {
           const parsed = JSON.parse(rawImp) as { id?: number };
           if (typeof parsed.id === "number") {
@@ -113,7 +127,7 @@ export class ApiClientBase implements IApiClient {
       safeStorage.removeItem("auth_token");
       safeStorage.removeItem("user_profile");
       try {
-        localStorage.removeItem("bz_portal_impersonation_v1");
+        localStorage.removeItem(PORTAL_IMPERSONATION_STORAGE_KEY);
       } catch {
         // ignore — impersonation storage is optional, same as the read path
       }


### PR DESCRIPTION
## What this fixes

`ApiClientBase.clearToken()` (`apps/mouth/src/lib/api/client.ts`) nulled the auth token, CSRF token,
and user profile — but never reset `portalImpersonationClientId` (the in-memory field injected as
`?as_client=<id>` into every `/api/portal` and `/api/v1/lkpm` request) and never removed the
`bz_portal_impersonation_v1` localStorage key. `clearToken()` is the single choke point for:

- `AuthApi.logout()` (normal logout)
- `SecuritySettings`'s "revoke all sessions"
- the 401 token-expiry path (`ApiClientBase.getToken()` / `request()`)

**What the bug allowed:** a superuser (`zero@`/admin) who was impersonating a client
("view as client X") could log out, and the impersonation target survived — both in memory and in
localStorage. `AdminImpersonationContext` restores the target from that same localStorage key on
mount, so the next time *any* superuser logged in on that browser (including a **different**
superuser who never chose to impersonate anyone), every portal/LKPM API call they made silently
carried `as_client=<previous operator's target>`. Cross-operator inheritance of an impersonation
target, invisible to the person now driving the session.

## Fix

`clearToken()` now also:
1. Sets `this.portalImpersonationClientId = null`
2. Removes `bz_portal_impersonation_v1` from `localStorage` (wrapped in try/catch, matching the
   existing tolerance for blocked storage — Safari Private Browsing — on the read path)

Grepped the whole `apps/mouth/src` tree for `bz_portal_impersonation_v1` — only two files touch the
key: `client.ts` (read in constructor, now also cleared in `clearToken()`) and
`AdminImpersonationContext.tsx` (read/write/mount-restore). Both are covered: the context only ever
rehydrates from a key `clearToken()` now deletes.

## What the test proves

New `describe("Portal Impersonation (cross-operator inheritance regression)")` block in
`client.test.ts`:

1. **Real-property test** (the actual regression): sets impersonation via both `setPortalImpersonation()`
   and the localStorage key (mirroring what `AdminImpersonationContext` does live), calls
   `clearToken()`, then asserts — not that `clearToken()` "didn't throw" — but that (a) the storage
   key is gone, (b) the in-memory id is `null`, and (c) a subsequent `/api/portal/...` request no
   longer carries `as_client=` in the URL.
2. **Innocence test A**: `clearToken()` on a plain (never-impersonating) session still clears
   normally and doesn't throw.
3. **Innocence test B**: a plain page reload while still logged in (no `clearToken()` call —
   only the constructor runs) still re-seeds impersonation from storage, proving the fix didn't
   regress the legitimate "refresh keeps your impersonation target" behavior.

## Adversarial review

- **Grep sweep, not just the two named files**: searched the entire `apps/mouth/src` tree for the
  literal storage key to make sure there wasn't a third reader/writer outside `client.ts` and
  `AdminImpersonationContext.tsx`. There isn't.
- **Mutation-tested the cure**: reverted just the `client.ts` fix (kept the new test), re-ran —
  the new test failed with the exact original bug signature (`removeItem` called with `auth_token`/
  `user_profile` but never `bz_portal_impersonation_v1`). Restored the fix — green again. Proves the
  test is not decorative.
- **Checked the innocence boundary I was told to find or disprove**: is there a legitimate moment
  where impersonation should survive a "reset"? Yes — a plain page reload while still authenticated.
  `clearToken()` is never called on reload (only the constructor, which already seeds from storage);
  wrote a test asserting that path is untouched by this change, rather than asserting a boundary that
  doesn't exist.
- **Checked all `clearToken()` call sites**, not just `AuthApi.logout()`: also `SecuritySettings`
  ("revoke all sessions") and the 401 token-expiry branch inside `client.ts` itself — all three route
  through the same fixed method, so all three are covered by one change.
- **Full regression run**: `apps/mouth` full vitest suite — 393 test files / 3770 tests, all green.
  `tsc --noEmit` clean. `eslint` clean on the touched file.

## Explicitly out of scope (per mandate)

Not touched here — separate owner decision: writes still carry the impersonated client's identity,
the audit trail for impersonated actions is write-only, and there is no write-block during
impersonation. Frontend-only change; `apps/backend-rag` untouched.

## Verification

```
apps/mouth$ npx vitest run src/lib/api/client.test.ts src/lib/api/auth/auth.api.test.ts \
  src/lib/api/public-auth.test.ts src/lib/api/__tests__/api-client-base.test.ts \
  src/lib/api/unit/api-client.unit.test.ts src/lib/api/integration/api-client.integration.test.ts \
  src/components/portal/SuperuserImpersonationBar.test.tsx
 Test Files  7 passed (7)
      Tests  148 passed (148)

apps/mouth$ npx vitest run   # full suite
 Test Files  393 passed (393)
      Tests  3770 passed (3770)

apps/mouth$ npx tsc --noEmit   # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
