### PR TITLE
test(ci): kill surviving mutant in npm_audit_gate carrier via filter

### DIFF
--- a/scripts/ci/test_npm_audit_gate.py
+++ b/scripts/ci/test_npm_audit_gate.py
@@ -179,6 +179,23 @@ def test_a_carrier_below_the_threshold_is_still_ignored():
     assert evaluate({"vulnerabilities": {"prisma": carrier(severity="moderate")}}, WAIVE) == []
 
 
+def test_a_carrier_ignores_non_string_via_entries():
+    """Kills a surviving mutant: `carries` filters `via` with `isinstance(x, str)`,
+    but nothing in the corpus gave it a `via` entry that is neither a string (a
+    carrier name) nor a dict (an advisory object — which routes the vuln away
+    from this branch entirely, via `advisory_ids`). Without the filter, a
+    non-string/non-dict junk element (e.g. `None`, from a malformed/older npm
+    audit shape) leaks into the human-readable message as the literal 'None'.
+    """
+    bad = evaluate(
+        {"vulnerabilities": {"prisma": carrier(via=("deepmerge-ts", None, "prisma"))}},
+        WAIVE,
+    )
+    assert len(bad) == 1, bad
+    assert "None" not in bad[0][3], bad
+    assert "deepmerge-ts" in bad[0][3] and "prisma" in bad[0][3], bad
+
+
 def test_a_real_advisory_still_reads_not_waived():
     """Innocence: the new branch must not swallow the ordinary unwaived case."""
     bad = evaluate({"vulnerabilities": {"lodash": vuln(ids=("GHSA-unknown",))}}, WAIVE)


### PR DESCRIPTION
## Summary
- Adds a guilt-case test for `npm_audit_gate.py`'s `carries` filter: a non-string/non-dict `via` entry (e.g. `None`, from a malformed/older npm-audit shape) must not leak the literal `"None"` into the human-readable gate message.
- Production code already filters with `isinstance(x, str)` — this closes a mutation-testing gap in the existing corpus, no behavior change.

## Test plan
- [x] `python3 scripts/ci/test_npm_audit_gate.py` → 19/19 passed locally
- [x] Pre-commit anti-reward-hacking lint clean
- [ ] CI required checks green

🤖 Healer tick (Mini) — resuming a same-day interrupted worktree, finished + verified before shipping.