### PR TITLE
feat(infra): recurring 6h sweep for the one-shot secrets-perms cure

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: e11245a037596cf5ea58dc1873607bad171fc8d0d18dc5bb14d65f72706ad55f
+checksum: 2db42b7730eba415f51571ca1afa40e72bbb4f44c93505f711731f4b23bd7614
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -2480,5 +2480,25 @@ organs:
   bridge_source:
     type: state_file
     path: ~/.organism/last_seen/pro.wa_mirror_freshness_liveness.json
+    timestamp_field: ts
+    status_field: status
+- id: mini.secrets_perms_sweep
+  runtime: mini_launchd
+  type: cron
+  expected_hb_seconds: 21600
+  owner_module: infra/launchagents/wrappers/mini-secrets-perms-sweep.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: mini
+    label: com.nuzantara.secrets-perms-sweep
+  severity_on_silence: warning
+  notes: 'recurring sweep+fix of group/other-readable secret-named files (memory notes,
+    tokens, keys) via secrets_permissions_audit.py --fix — closes the one-shot debt
+    from PR #3621 (born via organ_birth.py, genes imprinted 2026+)'
+  cicatrix_refs: []
+  bridge_source:
+    type: state_file
+    path: ~/.organism/last_seen/mini.secrets_perms_sweep.json
     timestamp_field: ts
     status_field: status

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -810,6 +810,16 @@
       "repo": "infra/launchagents/wrappers/wa-codex-broker-wrapper.sh",
       "machines": ["pro"],
       "_note": "WA codex broker daemon wrapper (BOT-V4 S2 PR-6), installed root-owned by scripts/provision_zantara_codex.sh. System-domain LaunchDaemon payload under the registry's absolute-prefix exception (fw-guard precedent 2026-08-14): the daemon runs AS the login-less zantara-codex user, and a root-owned payload outside any user-writable $HOME denies a compromised zantara-codex identity persistence across restarts. World-readable, so the lint can verify this pair as any user. Re-run provisioning after changing the repo twin: the merge alone never updates the live copy (W107 delivery gotcha)."
+    },
+    {
+      "live": "~/scripts/mini-secrets-perms-sweep.sh",
+      "repo": "infra/launchagents/wrappers/mini-secrets-perms-sweep.sh",
+      "machines": ["mini"]
+    },
+    {
+      "live": "~/Library/LaunchAgents/com.nuzantara.secrets-perms-sweep.plist",
+      "repo": "infra/launchagents/com.nuzantara.secrets-perms-sweep.plist",
+      "machines": ["mini"]
     }
   ],
   "allow": [

--- a/infra/launchagents/com.nuzantara.secrets-perms-sweep.plist
+++ b/infra/launchagents/com.nuzantara.secrets-perms-sweep.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>com.nuzantara.secrets-perms-sweep</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/nuzantara/scripts/mini-secrets-perms-sweep.sh</string>
+    </array>
+    <key>StartInterval</key><integer>21600</integer>
+    <key>RunAtLoad</key><false/>
+    <key>StandardOutPath</key><string>/tmp/com.nuzantara.secrets-perms-sweep.out</string>
+    <key>StandardErrorPath</key><string>/tmp/com.nuzantara.secrets-perms-sweep.err</string>
+</dict>
+</plist>

--- a/infra/launchagents/wrappers/mini-secrets-perms-sweep.sh
+++ b/infra/launchagents/wrappers/mini-secrets-perms-sweep.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# mini.secrets_perms_sweep — recurring sweep+fix of group/other-readable secret-named files (memory notes, tokens, keys) via secrets_permissions_audit.py --fix — closes the one-shot debt from PR #3621
+# Born via scripts/organ_birth.py (DNA/GENOME 2026-07-06): genes imprinted at birth.
+# Canon: infra/launchagents/wrappers/mini-secrets-perms-sweep.sh
+# Live:  ~/scripts/mini-secrets-perms-sweep.sh (declared pair, node=mini)
+
+set -u   # G9_fail_visible: unset vars crash, they do not expand empty
+
+ORGAN_ID="mini.secrets_perms_sweep"
+LOG_DIR="$HOME/logs/mini-secrets_perms_sweep"
+LOG="$LOG_DIR/run.log"
+mkdir -p "$LOG_DIR"
+SIDECAR_DIR="$HOME/.organism/last_seen"
+PIDFILE="/tmp/nuzantara-mini-secrets_perms_sweep.pid"
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+# G2_heartbeat — sidecar EVERY exit path (Esiste≠Armato: prove life, every run)
+heartbeat() { # $1 status, $2 note
+    mkdir -p "$SIDECAR_DIR"
+    printf '{"ts":"%s","status":"%s","note":"%s"}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" > "$SIDECAR_DIR/$ORGAN_ID.json"
+}
+
+# G4_node_guard — wrong node exits VISIBLY (heartbeat), never silently (#10)
+if [ "$(hostname -s | tr '[:upper:]' '[:lower:]')" != "mini-pro2" ]; then
+    log "node guard: $(hostname -s) != mini-pro2 — not my node, exiting"
+    heartbeat "disabled" "wrong-node $(hostname -s)"
+    exit 0
+fi
+
+# G5_kill_switch — operator stop without uninstall; disabled heartbeat keeps
+# the healer from resurrecting an intentionally-stopped organ
+if [ "${MINI_SECRETS_PERMS_SWEEP_ENABLED:-true}" = "false" ]; then
+    log "kill switch MINI_SECRETS_PERMS_SWEEP_ENABLED=false — exiting"
+    heartbeat "disabled" "kill switch"
+    exit 0
+fi
+
+# G10_single_instance — pidfile + liveness probe + trap cleanup
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+    log "previous run still alive (pid $(cat "$PIDFILE")) — skipping"
+    heartbeat "ok" "skipped: previous run alive"
+    exit 0
+fi
+echo $$ > "$PIDFILE"
+trap 'rm -f "$PIDFILE"' EXIT
+
+# ---- payload (cron one-shot; G8_keepalive_sane: plist uses StartInterval, no KeepAlive)
+log "run start"
+/usr/bin/python3 "$HOME/nuzantara/scripts/secrets_permissions_audit.py" --fix >> "$LOG" 2>&1
+RC=$?
+
+if [ $RC -eq 0 ]; then
+    heartbeat "ok" "run done"
+else
+    heartbeat "error" "rc=$RC"   # G9: failure is VISIBLE in the sidecar too
+fi
+log "run done rc=$RC"
+exit 0


### PR DESCRIPTION
## Summary
- PR #3621 (2026-08-05, Mini healer tick) chmod'd 16 world/group-readable secret-named memory files to 0600 — a one-shot cure with nothing re-running it, so the class silently re-populates (ledger line opened 2026-08-08).
- Births `mini.secrets_perms_sweep` via `organ_birth.py` (StartInterval 21600s / 6h, no KeepAlive) wired to `secrets_permissions_audit.py --fix`, with the standard wrapper genome (node guard, kill switch, single-instance pidfile, heartbeat sidecar on every exit path).
- Declares the wrapper + plist as a Mini-only home-fork pair and registers the organ in `organs_registry.yaml` for heartbeat liveness tracking.

## Test plan
- [x] `apps/organism/organism/tools/validate_organs_registry.py` passes (schema + checksum)
- [x] Manual end-to-end run of the finished wrapper: exit 0, `FINDINGS: 0` (fleet currently clean), fresh `ok` heartbeat sidecar written
- [ ] CI required checks green
- [ ] Post-merge: install the live plist+wrapper pair on Mini and `launchctl load`, verify first real heartbeat

Closes PENDING-ARMS: "the memory-file permissions cure is ONE-SHOT, and the class re-populated within a day — nothing re-runs it" (opened 2026-08-08).

🤖 Healer tick (Mini) — resuming a same-day interrupted worktree, finished + verified before shipping.