### PR TITLE
feat(pricing): E30A/E30B Education KITAS prices (owner rule PNBP + 3jt)

### DIFF
--- a/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
+++ b/apps/backend-rag/backend/data/bali_zero_official_prices_2026.json
@@ -408,6 +408,56 @@
         "description_en": "Onshore annual extension of an existing E33F Second Home senior permit. USD 3,000/month passive income proof is re-validated at each extension.",
         "icon_id": "kitas-investor"
       },
+      "E30A Education Visa (1 Year)": {
+        "name": "E30A Education Visa (1 Year)",
+        "price": "9.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "1 year",
+        "notes": "All-inclusive price.",
+        "description_en": "Education Visa / KITAS (E30A) for foreign students enrolled at an Indonesian primary or secondary school (pendidikan dasar/menengah). Valid 1 year, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30A Education Visa (2 Years)": {
+        "name": "E30A Education Visa (2 Years)",
+        "price": "11.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "2 years",
+        "notes": "All-inclusive price.",
+        "description_en": "Education Visa / KITAS (E30A) for foreign students enrolled at an Indonesian primary or secondary school (pendidikan dasar/menengah). Valid 2 years, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30B Higher Education (1 Year)": {
+        "name": "E30B Higher Education (1 Year)",
+        "price": "9.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "1 year",
+        "notes": "All-inclusive price.",
+        "description_en": "Higher Education Visa / KITAS (E30B) for foreign students enrolled at an Indonesian university or higher-education institution (pendidikan tinggi). Valid 1 year, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30B Higher Education (2 Years)": {
+        "name": "E30B Higher Education (2 Years)",
+        "price": "11.500.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "2 years",
+        "notes": "All-inclusive price.",
+        "description_en": "Higher Education Visa / KITAS (E30B) for foreign students enrolled at an Indonesian university or higher-education institution (pendidikan tinggi). Valid 2 years, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30B Higher Education (4 Years)": {
+        "name": "E30B Higher Education (4 Years)",
+        "price": "15.000.000 IDR",
+        "tier_range": null,
+        "duration": "",
+        "validity": "4 years",
+        "notes": "All-inclusive price.",
+        "description_en": "Higher Education Visa / KITAS (E30B) for foreign students enrolled at an Indonesian university or higher-education institution (pendidikan tinggi). Valid 4 years, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
       "Spouse 1 Year (Altus/Onshore)": {
         "name": "Spouse 1 Year (Altus/Onshore)",
         "price": "13.500.000 IDR",

--- a/apps/mouth/data/bali-zero-prices.json
+++ b/apps/mouth/data/bali-zero-prices.json
@@ -453,6 +453,61 @@
         "description_en": "Onshore annual extension of an existing E33F Second Home senior permit. USD 3,000/month passive income proof is re-validated at each extension.",
         "icon_id": "kitas-investor"
       },
+      "E30A Education Visa (1 Year)": {
+        "category": "kitas_permits",
+        "key": "E30A Education Visa (1 Year)",
+        "name": "E30A Education Visa (1 Year)",
+        "price": "9.000.000 IDR",
+        "duration": "",
+        "validity": "1 year",
+        "notes": "All-inclusive price.",
+        "description_en": "Education Visa / KITAS (E30A) for foreign students enrolled at an Indonesian primary or secondary school (pendidikan dasar/menengah). Valid 1 year, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30A Education Visa (2 Years)": {
+        "category": "kitas_permits",
+        "key": "E30A Education Visa (2 Years)",
+        "name": "E30A Education Visa (2 Years)",
+        "price": "11.500.000 IDR",
+        "duration": "",
+        "validity": "2 years",
+        "notes": "All-inclusive price.",
+        "description_en": "Education Visa / KITAS (E30A) for foreign students enrolled at an Indonesian primary or secondary school (pendidikan dasar/menengah). Valid 2 years, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30B Higher Education (1 Year)": {
+        "category": "kitas_permits",
+        "key": "E30B Higher Education (1 Year)",
+        "name": "E30B Higher Education (1 Year)",
+        "price": "9.000.000 IDR",
+        "duration": "",
+        "validity": "1 year",
+        "notes": "All-inclusive price.",
+        "description_en": "Higher Education Visa / KITAS (E30B) for foreign students enrolled at an Indonesian university or higher-education institution (pendidikan tinggi). Valid 1 year, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30B Higher Education (2 Years)": {
+        "category": "kitas_permits",
+        "key": "E30B Higher Education (2 Years)",
+        "name": "E30B Higher Education (2 Years)",
+        "price": "11.500.000 IDR",
+        "duration": "",
+        "validity": "2 years",
+        "notes": "All-inclusive price.",
+        "description_en": "Higher Education Visa / KITAS (E30B) for foreign students enrolled at an Indonesian university or higher-education institution (pendidikan tinggi). Valid 2 years, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
+      "E30B Higher Education (4 Years)": {
+        "category": "kitas_permits",
+        "key": "E30B Higher Education (4 Years)",
+        "name": "E30B Higher Education (4 Years)",
+        "price": "15.000.000 IDR",
+        "duration": "",
+        "validity": "4 years",
+        "notes": "All-inclusive price.",
+        "description_en": "Higher Education Visa / KITAS (E30B) for foreign students enrolled at an Indonesian university or higher-education institution (pendidikan tinggi). Valid 4 years, renewable; non-working residency tied to active enrollment.",
+        "icon_id": "kitas-investor"
+      },
       "Spouse 1 Year (Altus/Onshore)": {
         "category": "kitas_permits",
         "key": "Spouse 1 Year (Altus/Onshore)",

--- a/apps/mouth/src/lib/pricing-snapshot.test.ts
+++ b/apps/mouth/src/lib/pricing-snapshot.test.ts
@@ -109,7 +109,7 @@ describe("generated PricingTool snapshot", () => {
         (count, rows) => count + Object.keys(rows).length,
         0,
       ),
-    ).toBe(109);
+    ).toBe(114);
   });
 
   it.each(selectedRows)("keeps %s:%s in parity", (category, key) => {


### PR DESCRIPTION
## E30A/E30B Education KITAS prices — owner rule PNBP + 3jt

Executes Zero's standing pricing rule for the Education family (2026-08-19: "+3jt sul PNBP").

**Grounding (live, QW-5, quoted verbatim twice from the official pages, component sums cross-checked):**
- [E30A](https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A) "Biaya (PNBP)": 1y Rp 6.000.000 · 2y Rp 8.500.000
- [E30B](https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B): 1y 6.000.000 · 2y 8.500.000 · 4y 12.000.000

**Composed all-inclusive entries** (kitas_permits, schema mirrors neighbors; client-facing single price, never a PNBP/fee split): E30A 9.0M / 11.5M — E30B 9.0M / 11.5M / 15.0M.

**Deliberately NOT priced:** E30 (generic), E30E, E30F — their portal pages read "Data Belum Tersedia"; no grounded PNBP, no invented price (they stay contact-required).

Mouth snapshot regenerated via `scripts/sync_frontend_prices.py` (the mouth file is a SYNCED COPY — the correct pattern is edit-canonical-then-sync, not the hand-edit-both that #4349's diff visually suggested). Parity guard count 109 → 114.

Suites green (re-run by the gate, not just the implementer): data-invariant tripwires + pricing router (RC 0), `pricing-snapshot` + `bali-zero-prices` vitest 15/15.

Remaining (ledger row, seq-11 lane): pack `pricing_key` for E30A/E30B in the next signed sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
