### PR TITLE
fix(mouth): 301 second-home-e33 → second-home; honor ?lang= on first load

### DIFF
--- a/apps/mouth/next.config.ts
+++ b/apps/mouth/next.config.ts
@@ -347,6 +347,14 @@ const nextConfig: NextConfig = {
       },
       // Note: /chat redirect to zantara.balizero.com is handled by middleware
       // (cannot be here — next.config redirects would conflict with middleware rewrites)
+      // Wrong-page fix (2026-08-20): /visa/second-home-e33 was served 200 by the
+      // (blog)/[category]/[slug] catch-all with ZERO second-home content — the
+      // canonical E33 landing is /visa/second-home. See .claude/skills/secondhome §4bis.
+      {
+        source: "/visa/second-home-e33",
+        destination: "/visa/second-home",
+        permanent: true,
+      },
     ];
   },
 

--- a/apps/mouth/src/i18n/index.tsx
+++ b/apps/mouth/src/i18n/index.tsx
@@ -69,6 +69,20 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
   const [locale, setLocaleState] = React.useState<Locale>(DEFAULT_LOCALE);
 
   React.useEffect(() => {
+    // `?lang=<locale>` lets a shared link set the UI-chrome language for THIS
+    // VISIT only (2026-08-20). Strict whitelist — this is a user-controlled
+    // input (searchParams), so it is validated against LOCALES and never
+    // written anywhere but React state + `<html lang>` (guarded exactly like
+    // the localStorage path below). It takes precedence over a saved
+    // preference but is deliberately NOT persisted to localStorage: a link
+    // must not overwrite a visitor's explicit saved choice for future visits.
+    const urlLang = new URLSearchParams(window.location.search).get("lang");
+    if (urlLang && LOCALES.includes(urlLang as Locale)) {
+      setLocaleState(urlLang as Locale);
+      if (!pageOwnsLang()) document.documentElement.lang = urlLang;
+      return;
+    }
+
     const saved = localStorage.getItem("blog-language");
     if (saved && LOCALES.includes(saved as Locale)) {
       setLocaleState(saved as Locale);

--- a/apps/mouth/src/i18n/lang-query-param.test.tsx
+++ b/apps/mouth/src/i18n/lang-query-param.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { I18nProvider, useTranslation } from "@/i18n";
+import { LANG_OWNER_ATTR, LANG_OWNER_CONTENT } from "@/i18n/content-locale";
+
+/**
+ * `?lang=<locale>` (2026-08-20).
+ *
+ * A shared link (`?lang=it`) did nothing on first load: the provider only
+ * ever initialized from the saved `blog-language` preference, so a
+ * first-time visitor following a localized link got the default locale
+ * regardless of what the URL asked for, even though full translations
+ * exist. The fix reads the query param once on mount and, if it is on the
+ * LOCALES whitelist, lets it win for THIS VISIT — without ever persisting
+ * it to localStorage, so it can never clobber an explicit saved choice.
+ *
+ * GUILT     — a valid `?lang` overrides the (absent or present) saved value.
+ * INNOCENCE — an invalid `?lang` is ignored; no `?lang` is unaffected;
+ *             a page that owns `<html lang>` keeps its own value.
+ */
+
+function LocaleProbe() {
+  const { locale } = useTranslation();
+  return <span data-testid="locale">{locale}</span>;
+}
+
+function renderProvider() {
+  return render(
+    <I18nProvider>
+      <LocaleProbe />
+    </I18nProvider>,
+  );
+}
+
+describe("I18nProvider honors ?lang= on first load", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute(LANG_OWNER_ATTR);
+    document.documentElement.lang = "en";
+    window.history.replaceState({}, "", "/");
+  });
+
+  // ── GUILT ────────────────────────────────────────────────────────────────
+  it("?lang=it becomes the provider locale without touching localStorage", () => {
+    window.history.replaceState({}, "", "/?lang=it");
+
+    renderProvider();
+
+    expect(screen.getByTestId("locale").textContent).toBe("it");
+    expect(localStorage.getItem("blog-language")).toBeNull();
+    expect(document.documentElement.lang).toBe("it");
+  });
+
+  it("?lang=it takes precedence over an existing saved preference, still without persisting it", () => {
+    localStorage.setItem("blog-language", "en");
+    window.history.replaceState({}, "", "/?lang=it");
+
+    renderProvider();
+
+    expect(screen.getByTestId("locale").textContent).toBe("it");
+    // The saved preference is untouched — a link must not overwrite it.
+    expect(localStorage.getItem("blog-language")).toBe("en");
+  });
+
+  // ── INNOCENCE ────────────────────────────────────────────────────────────
+  it("an unknown ?lang=zz falls back to the saved localStorage preference", () => {
+    localStorage.setItem("blog-language", "id");
+    window.history.replaceState({}, "", "/?lang=zz");
+
+    renderProvider();
+
+    expect(screen.getByTestId("locale").textContent).toBe("id");
+    expect(localStorage.getItem("blog-language")).toBe("id");
+  });
+
+  it("an unknown ?lang=zz with no saved preference stays on the default locale", () => {
+    window.history.replaceState({}, "", "/?lang=zz");
+
+    renderProvider();
+
+    expect(screen.getByTestId("locale").textContent).toBe("en");
+  });
+
+  it("no ?lang param — existing localStorage-only behavior is unchanged", () => {
+    localStorage.setItem("blog-language", "fr");
+    window.history.replaceState({}, "", "/");
+
+    renderProvider();
+
+    expect(screen.getByTestId("locale").textContent).toBe("fr");
+  });
+
+  it("?lang=it with a page owning lang does not overwrite documentElement.lang", () => {
+    document.documentElement.setAttribute(LANG_OWNER_ATTR, LANG_OWNER_CONTENT);
+    document.documentElement.lang = "en";
+    window.history.replaceState({}, "", "/?lang=it");
+
+    renderProvider();
+
+    // The UI-chrome locale still switches (translations/picker follow it)...
+    expect(screen.getByTestId("locale").textContent).toBe("it");
+    // ...but the page's declared content language is not clobbered.
+    expect(document.documentElement.lang).toBe("en");
+  });
+});


### PR DESCRIPTION
## Summary
- 301 `/visa/second-home-e33` → `/visa/second-home`: the wrong-page URL was being served 200 by the blog `(blog)/[category]/[slug]` catch-all with zero second-home content (measured live, see `.claude/skills/secondhome` §4bis).
- `I18nProvider` now honors `?lang=<locale>` on first load: a shared link like `?lang=it` sets the UI-chrome locale for that visit only (strict `LOCALES` whitelist), without ever persisting it to `localStorage` — an explicit saved preference is never overwritten by a link. Falls through to the existing `localStorage` path when the param is absent/invalid, and still yields to a page that owns `<html lang>` (`LANG_OWNER_ATTR`).

## Test plan
- [x] `npx vitest run src/i18n --root .` — 26/26 passed (RC=0), incl. 6 new guilt/innocence cases in `lang-query-param.test.tsx`
- [x] `npx tsc --noEmit -p .` — RC=0
- [x] `npx eslint src/i18n next.config.ts` — RC=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)