### PR TITLE
fix(crm): make the shared-phone advisory name the action it took

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_clients.py
+++ b/apps/backend-rag/backend/app/routers/crm_clients.py
@@ -1542,11 +1542,22 @@ async def upsert_client_by_phone(
 
     if result.get("matched_count", 0) > 1:
         # Do NOT log the phone (PII / UU PDP + log-injection: it's user-supplied).
-        # client_id + matched_count are non-PII DB integers and fully identify the row.
+        # client_id + matched_count are non-PII DB integers and fully identify the
+        # row; `action` is a fixed enum this endpoint sets itself, never user input.
+        #
+        # `action` is load-bearing, not decoration. This line used to read
+        # "acted on id=%s", which is FALSE for `skipped_no_change`: an empty
+        # `set_parts` above skips the UPDATE entirely, yet `result` is still bound
+        # and reaches this guard, so the advisory claimed a write for a row nothing
+        # was written to — on the caller that takes the defaults (the wa-mirror
+        # promoter), where re-promoting an unchanged lead is the common case.
+        # Naming the action is what makes the sentence checkable.
+        # Reference: research/operations/2026-08-19-crm-upsert-by-phone-duplicate-advisory.md
         logger.warning(
-            "upsert-by-phone: %s clients share a phone (acted on id=%s) — "
+            "upsert-by-phone: %s clients share a phone (action=%s id=%s) — "
             "review for possible duplicate-client merge",
             result["matched_count"],
+            result["action"],
             result["client_id"],
         )
     return result

--- a/apps/backend-rag/backend/tests/routers/test_crm_clients_upsert_by_phone.py
+++ b/apps/backend-rag/backend/tests/routers/test_crm_clients_upsert_by_phone.py
@@ -7,6 +7,7 @@ reporting, and update-only mode (create_if_missing=False).
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -346,3 +347,121 @@ def test_update_only_mode_skips_when_not_found(
     assert body["action"] == "skipped_not_found"
     assert body["client_id"] is None
     assert conn.fetchval.await_count == 0  # never inserted
+
+
+_ADVISORY = "clients share a phone"
+_LOGGER = "backend.app.routers.crm_clients"
+
+
+def _advisory_lines(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if _ADVISORY in r.getMessage()]
+
+
+def test_shared_phone_advisory_names_a_noop_as_such(
+    client: TestClient, write_enabled: None, mock_db_pool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """GUILT for the sentence itself: two rows share the phone and there is
+    NOTHING to write (recap is human-owned, no name/notes change), so no UPDATE
+    runs — the advisory must say `action=skipped_no_change`, never claim a write.
+
+    This is the case the merged advisory note got wrong: `result` is bound at the
+    enrich branch even when `set_parts` is empty, so the guard is reached with a
+    real matched_count for a row nothing happened to. On the caller that takes the
+    model defaults (the wa-mirror promoter) this is the COMMON case, not a corner.
+    """
+    _pool, conn = mock_db_pool
+    row = {
+        "id": 7,
+        "full_name": "Real Human",
+        "notes": "",
+        "deleted_at": None,
+        "strategic_recap_source": "manual",  # human edit wins -> no recap write
+        "updated_at": None,
+    }
+    conn.fetch.return_value = [row, {**row, "id": 9}]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        resp = client.post(
+            "/api/crm/clients/upsert-by-phone",
+            json={
+                "phone_normalized": "6281234567",
+                "strategic_recap": "auto-generated summary",
+            },
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["action"] == "skipped_no_change"
+    assert body["matched_count"] == 2
+    # Nothing was written: only the advisory locks executed, no UPDATE.
+    assert not [c for c in conn.execute.await_args_list if "UPDATE" in str(c.args[0])]
+
+    lines = _advisory_lines(caplog)
+    assert len(lines) == 1, lines
+    assert "action=skipped_no_change" in lines[0]
+    assert "id=7" in lines[0]
+    # The retracted wording claimed a write on every firing.
+    assert "acted on" not in lines[0]
+
+
+def test_shared_phone_advisory_names_a_real_write_as_such(
+    client: TestClient, write_enabled: None, mock_db_pool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """INNOCENCE: the same guard, same two-row collision, but with something to
+    write. The advisory must report the acting outcome — the fix must not make
+    every firing look like a no-op."""
+    _pool, conn = mock_db_pool
+    conn.fetch.return_value = [
+        {"id": 1, "full_name": "Spouse A", "notes": "", "deleted_at": None,
+         "strategic_recap_source": None, "updated_at": None},
+        {"id": 2, "full_name": "Spouse B", "notes": "", "deleted_at": None,
+         "strategic_recap_source": None, "updated_at": None},
+    ]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        resp = client.post(
+            "/api/crm/clients/upsert-by-phone",
+            json={"phone_normalized": "6281234567", "notes_append": "x"},
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["action"] == "enriched"
+
+    lines = _advisory_lines(caplog)
+    assert len(lines) == 1, lines
+    assert "action=enriched" in lines[0]
+    assert "id=1" in lines[0]
+
+
+def test_sole_match_writes_no_advisory_at_all(
+    client: TestClient, write_enabled: None, mock_db_pool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """INNOCENCE: one match is not a collision — the guard is `> 1`, so a
+    no-op on a SINGLE row must stay silent rather than gain a new alarm."""
+    _pool, conn = mock_db_pool
+    conn.fetch.return_value = [
+        {
+            "id": 7,
+            "full_name": "Real Human",
+            "notes": "",
+            "deleted_at": None,
+            "strategic_recap_source": "manual",
+            "updated_at": None,
+        }
+    ]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        resp = client.post(
+            "/api/crm/clients/upsert-by-phone",
+            json={
+                "phone_normalized": "6281234567",
+                "strategic_recap": "auto-generated summary",
+            },
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["action"] == "skipped_no_change"
+    assert _advisory_lines(caplog) == []


### PR DESCRIPTION
The cure for the finding corrected in #4384. One line, three tests.

## The defect

`crm_clients.py` logged `(acted on id=%s)` on **every** firing of the duplicate-phone advisory.
That is false for `skipped_no_change`: an empty `set_parts` at `:1461` skips the UPDATE entirely,
yet `result` is still bound at `:1477` with the real `matched_count`, so the guard at `:1543` passes
and the line claims a write for a row nothing was written to.

Not a corner case. The caller running in production (`scripts/wa-mirror-auto-promote-leads.py`)
omits `reject_ambiguous`, and re-promoting an already-promoted lead — same name, notes not stale, no
recap — is exactly how `set_parts` comes out empty. Measured live on 2026-08-19: the advisory fired
4 times in ~40s during a bulk upsert stream, and nothing in the line says how many of those wrote
anything.

## The fix

`(action=%s id=%s)` with `result["action"]` — the one field that separates a write from a no-op.
`action` is a fixed enum this endpoint sets itself, never user input, so the PII / log-injection
reasoning in the comment above it is unchanged. The comment now records why the field is
load-bearing, so a future tidy-up does not drop it again.

## Tests (3 added; the file now defines 17)

| test | role |
|---|---|
| `test_shared_phone_advisory_names_a_noop_as_such` | **guilt** — two rows share the phone, nothing to write: body says `skipped_no_change`, **zero** UPDATE statements executed, advisory says `action=skipped_no_change` and does **not** say `acted on` |
| `test_shared_phone_advisory_names_a_real_write_as_such` | **innocence** — same collision, something to write: `action=enriched`. The fix must not make every firing look like a no-op |
| `test_sole_match_writes_no_advisory_at_all` | **innocence** — one match is not a collision (`> 1`); a no-op on a single row must stay silent rather than gain a new alarm |

## Verification

- `backend/tests/routers/test_crm_clients_upsert_by_phone.py` → exit 0
- whole `backend/tests/routers/` → exit 0
- `python -c "from backend.app.dependencies import get_current_user"` → OK
- `scripts/lint_test_reward_hacking.py` on the test file → clean
- **Mutation-checked**: with the old `(acted on id=%s)` wording restored and the `action` argument
  removed, exactly the two advisory-wording tests fail and the sole-match innocence test stays
  green — i.e. the new tests bite the thing they claim to. The file was restored byte-identical
  afterwards (`cmp -s` against a pre-mutation copy) and `git status` shows only the two intended
  files.

## Scope

Logging only — no behaviour change, no schema change, no new field in the response body (`action`
was already returned to callers; it was simply never logged). The two adjacent findings from the
same investigation — the unreachable `intake.crm_push.upsert_ambiguous` warning, and the single
`detail` string shared by all seven `return None` causes of `_ensure_client_on_fly` — are **not**
touched here; they are separate concerns with their own blast radius.

Background: `research/operations/2026-08-19-crm-upsert-by-phone-duplicate-advisory.md`, corrected in
#4374 → #4384.