### PR TITLE
fix(docker): pin @anthropic-ai/claude-code to 2.1.236 — 2.1.237 breaks in-image install

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -104,7 +104,11 @@ jobs:
 
       - name: Install Claude CLI
         if: steps.guard.outputs.has_token == 'true' && steps.input.outputs.diff_bytes != '0'
-        run: npm install -g @anthropic-ai/claude-code
+        # Pinned 2026-08-20: @anthropic-ai/claude-code@2.1.237 (2026-08-19T23:57Z) fails
+        # `claude --version` with "Error: claude native binary not installed." — same
+        # class-audit as apps/backend-rag/Dockerfile. 2.1.236 is last verified-good.
+        # Bump deliberately after verifying the install flow, never back to floating latest.
+        run: npm install -g @anthropic-ai/claude-code@2.1.236
 
       - name: Run advisory review
         id: review

--- a/apps/backend-rag/Dockerfile
+++ b/apps/backend-rag/Dockerfile
@@ -152,10 +152,15 @@ COPY --from=node22 /usr/local/lib/node_modules /usr/local/lib/node_modules
 # first draft used `grep -Eq '^v(2[2-9]|[3-9][0-9])\.'`, which reads correctly and
 # would have rejected node v100 — a range written as a pattern is a form standing in
 # for a quantity, and it goes wrong at exactly the boundary nobody tests.
+# Pinned 2026-08-20: @anthropic-ai/claude-code@2.1.237 (published 2026-08-19T23:57Z) fails
+# `claude --version` IN-IMAGE with "Error: claude native binary not installed." — the
+# native-binary install flow this Dockerfile relies on is not satisfied by that release.
+# 2.1.236 (2026-08-18T18:45Z) is the last verified-good version. Bump deliberately after
+# verifying the install flow in a real build — never back to floating latest.
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && node --version && npm --version \
     && [ "$(node -p 'process.versions.node.split(".")[0]')" -ge 22 ] \
-    && npm install -g @anthropic-ai/claude-code \
+    && npm install -g @anthropic-ai/claude-code@2.1.236 \
     && npm cache clean --force \
     && rm -rf /root/.npm \
     && node --version && which claude && claude --version


### PR DESCRIPTION
## Summary
- `@anthropic-ai/claude-code@2.1.237` (published 2026-08-19T23:57Z) fails `claude --version` in-image with `Error: claude native binary not installed.` — the native-binary install flow this Dockerfile's RUN step relies on is not satisfied by that release.
- Every PR since ~01:05Z today has failed the "Snyk Docker Security" job's Build-Docker-image step identically (evidence: #4386, #4388, unrelated docs/frontend PRs, both fail at stage-2 step 5/20). Main's last green run (19:43Z yesterday) exercised 2.1.236 (published 18:45Z) — that's the innocence proof for the pin target.
- Pins to `2.1.236`, the last verified-good version, with a dated comment explaining why and instructing future bumps to verify the install flow first rather than floating back to `latest`.
- Class-audit (W107): grepped the whole repo for other `npm install -g @anthropic-ai/claude-code` occurrences. Found and pinned identically one other active build-path occurrence: `.github/workflows/ai-pr-review.yml`'s "Install Claude CLI" step (same install command, same failure class, part of `.github/workflows/`). Found but deliberately NOT touched (not a build path): a comment-only mention in `vendor/evoskill/Dockerfile` (Docker mode is disabled there, no active install), prose references in `docs/superpowers/plans/2026-05-04-subhi-tutor-implementation.md` and `docs/superpowers/sessions/2026-04-17-strategic-8/DOCKER-CLAUDE-CLI.md`, and `scripts/ruslana-node/install.sh` (a manual one-time provisioning script run on a physical Mac, not a CI/build path, already has graceful `|| warn` degradation).

## Test plan
- [x] `git diff` shows only the intended two-file, minimal-line change (version pin + dated comment on each).
- [x] Dockerfile RUN backslash-continuation chain verified intact line-by-line.
- [x] `.github/workflows/ai-pr-review.yml` re-parsed with `yaml.safe_load` — valid YAML.
- [x] Repo-wide grep for other `npm install -g @anthropic-ai/claude-code` occurrences in Dockerfiles/CI — none left unpinned.
- [ ] CI: this PR's own "Snyk Docker Security" / Build-Docker-image job should go green with the pin, unblocking the repo-wide stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)