### PR TITLE
feat(visa-engine): RulePack seq-11 — pricing_key for E30A/E30B

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq11.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq11.py
@@ -1,0 +1,399 @@
+"""fold_pack_seq11.py — assemble RulePack seq-11 from seq-10 + a single,
+minimal payload change: give products E30A and E30B a ``pricing_key``.
+
+One concern, nothing else changes:
+
+1. **Pricing-key assignment.** E30A ("Primary/Secondary Education Visa")
+   and E30B ("Higher Education Visa") ship on seq-10 with
+   ``pricing_key: null`` — the E30 family was authored (2026-07-24, W2)
+   before the education-visa price list existed. This fold assigns the
+   base 1-year variant to each, matching the house convention set by
+   E28A → the base "Investor KITAS 2 Years (Offshore)" single key
+   (no altus/onshore/extend tier split at the RulePack layer — that
+   lives in the pricing catalog, not the product's ``pricing_key``):
+
+   - E30A → ``{"category": "kitas_permits", "item_key": "E30A Education
+     Visa (1 Year)"}``
+   - E30B → ``{"category": "kitas_permits", "item_key": "E30B Higher
+     Education (1 Year)"}``
+
+   E30, E30E, E30F are deliberately left ``null`` — no per-product price
+   has been authored for the SEZ / student-exchange / generic-E30
+   variants yet (the "Data Belum Tersedia" honesty pin).
+
+**PRICING-RESOLUTION GATE (deliberate blocker).** Both new item_keys are
+asserted to resolve against a non-empty ``price`` row in
+``backend/data/bali_zero_official_prices_2026.json`` BEFORE the payload is
+mutated. As of this fold's authoring, PR #4383 (which adds the E30A/E30B
+price-list entries) has not merged to main — running this module today
+aborts loud on that gate. This is intentional: the fold becomes runnable
+the moment #4383 lands, with no further code change.
+
+Every input is read from disk at run time. The chain hash is read LIVE from
+``rulepack-prod-010.signed.json`` and asserted against the expected anchor;
+the seq-10 source bytes are additionally re-hashed (RFC 8785 JCS) and must
+equal that same value — a source/signed mismatch aborts the fold.
+Ledger-drift guards assert each touched product's CURRENT ``pricing_key`` is
+``null`` before overwriting it. Deterministic: fixed timestamps, no
+``datetime.now()`` — re-running is byte-identical.
+
+Usage::
+
+    PYTHONPATH=. python -m backend.scripts.visa_engine.fold_pack_seq11
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+from backend.services.visa_engine.bundle import canonicalize_json
+from backend.services.visa_engine.models import RulePackPayload
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_THIS_FILE = Path(__file__).resolve()
+_BACKEND_ROOT = _THIS_FILE.parents[2]  # apps/backend-rag/backend
+_REPO_ROOT = _THIS_FILE.parents[5]
+
+_PACKS_DIR = _BACKEND_ROOT / "services" / "visa_engine" / "contracts" / "packs"
+_SEQ10_SOURCE = _PACKS_DIR / "rulepack-prod-010.source.json"
+_SEQ10_SIGNED = _PACKS_DIR / "rulepack-prod-010.signed.json"
+_SEQ11_SOURCE = _PACKS_DIR / "rulepack-prod-011.source.json"
+
+_PRICES_FILE = _BACKEND_ROOT / "data" / "bali_zero_official_prices_2026.json"
+
+_PRETTIER_BIN = _REPO_ROOT / "node_modules" / ".bin" / "prettier"
+
+# ---------------------------------------------------------------------------
+# seq-11 identity (the uuid5 anchor is verified, never assumed)
+# ---------------------------------------------------------------------------
+
+_SEQ11_SEQUENCE = 11
+_SEQ11_VERSION = "2026.8.20"
+_SEQ11_RULE_PACK_ID_URL = (
+    "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/11"
+)
+_EXPECTED_SEQ11_RULE_PACK_ID = uuid.UUID("5c3974ab-bb15-5a73-b74f-f9f0af88a4a7")
+
+# The signed seq-10 payload hash this pack must chain to. Read LIVE from the
+# signed file at run time AND asserted equal to this anchor AND equal to the
+# recomputed canonical hash of the seq-10 SOURCE bytes — three independent
+# derivations of one value, any mismatch aborts.
+_EXPECTED_SEQ10_PAYLOAD_SHA256 = (
+    "188442baee0af899e464a696b883d2158e6e362c29d75b61eec5769ba24b9aac"
+)
+
+# Fixed (not datetime.now()) so re-running this script is byte-identical.
+_SEQ11_CREATED_AT = "2026-08-20T01:00:00Z"
+_SEQ11_CREATED_BY = "agent.air-m5.backend-rag.visa-seq11-pricing.fold-2026-08-20"
+
+# ---------------------------------------------------------------------------
+# Phase constants — the two touched products and their new pricing_key.
+# ---------------------------------------------------------------------------
+
+_E30A_PRICING_KEY: dict[str, str] = {
+    "category": "kitas_permits",
+    "item_key": "E30A Education Visa (1 Year)",
+}
+_E30B_PRICING_KEY: dict[str, str] = {
+    "category": "kitas_permits",
+    "item_key": "E30B Higher Education (1 Year)",
+}
+_NEW_PRICING_KEYS: dict[str, dict[str, str]] = {
+    "E30A": _E30A_PRICING_KEY,
+    "E30B": _E30B_PRICING_KEY,
+}
+_TOUCHED_PRODUCT_CODES = ("E30A", "E30B")
+
+# Cross-check on the fold's own assumption about seq-10's baseline split —
+# if this drifts, the seq-10 bytes (or the touched-product set) changed
+# under this fold without the fold being updated to match.
+_EXPECTED_NON_NULL_PRICING_KEYS_AFTER = 26
+_EXPECTED_NULL_PRICING_KEYS_AFTER = 12
+
+
+class FoldPackError(RuntimeError):
+    """A fail-loud gate inside the fold tripped — never silently degrade."""
+
+
+class PricingResolutionError(FoldPackError):
+    """A newly-assigned pricing_key does not resolve to a priced catalog
+    row. DELIBERATE until the price-list PR (#4383) lands on main — this
+    is the gate that makes the fold unrunnable until then."""
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# Identity + chain
+# ---------------------------------------------------------------------------
+
+
+def _verify_rule_pack_id() -> uuid.UUID:
+    computed = uuid.uuid5(uuid.NAMESPACE_URL, _SEQ11_RULE_PACK_ID_URL)
+    if computed != _EXPECTED_SEQ11_RULE_PACK_ID:
+        raise FoldPackError(
+            f"seq-11 rule_pack_id convention drifted: uuid5(NAMESPACE_URL, "
+            f"{_SEQ11_RULE_PACK_ID_URL!r}) = {computed}, expected "
+            f"{_EXPECTED_SEQ11_RULE_PACK_ID} — do not hand-adjust either side"
+        )
+    return computed
+
+
+def _chain_hash(seq10_source: dict[str, Any]) -> str:
+    signed = _load_json(_SEQ10_SIGNED)
+    declared = signed.get("payload_sha256")
+    if declared != _EXPECTED_SEQ10_PAYLOAD_SHA256:
+        raise FoldPackError(
+            f"{_SEQ10_SIGNED} declares payload_sha256={declared!r}, expected "
+            f"{_EXPECTED_SEQ10_PAYLOAD_SHA256!r} — the signed seq-10 on disk is "
+            "not the one this fold was authored against"
+        )
+    recomputed = hashlib.sha256(canonicalize_json(seq10_source)).hexdigest()
+    if recomputed != declared:
+        raise FoldPackError(
+            f"seq-10 SOURCE bytes re-hash to {recomputed}, but the signed file "
+            f"declares {declared} — source/signed mismatch, refusing to chain"
+        )
+    return declared
+
+
+def _apply_identity(payload: dict[str, Any], seq10_source: dict[str, Any]) -> None:
+    payload["sequence"] = _SEQ11_SEQUENCE
+    payload["version"] = _SEQ11_VERSION
+    payload["rule_pack_id"] = str(_verify_rule_pack_id())
+    payload["previous_payload_sha256"] = _chain_hash(seq10_source)
+    payload["created_at"] = _SEQ11_CREATED_AT
+    payload["created_by"] = _SEQ11_CREATED_BY
+    # rollback_of_payload_sha256 stays null; top-level valid_period untouched
+    # (seq-10's fold precedent: it is not in _IDENTITY_KEYS, so the
+    # byte-invariance sweep below asserts it equals seq-10's).
+
+
+# ---------------------------------------------------------------------------
+# Pricing-resolution gate — deliberate blocker until PR #4383 lands
+# ---------------------------------------------------------------------------
+
+
+def _assert_price_resolves(
+    prices_payload: Any, pricing_key: dict[str, str], *, product_code: str
+) -> None:
+    services = prices_payload.get("services") if isinstance(prices_payload, dict) else None
+    if not isinstance(services, dict):
+        raise PricingResolutionError(
+            f"{_PRICES_FILE} has no top-level 'services' object — cannot resolve "
+            f"{product_code}'s pricing_key {pricing_key!r}"
+        )
+    category = services.get(pricing_key["category"])
+    if not isinstance(category, dict):
+        raise PricingResolutionError(
+            f"{product_code}: pricing category {pricing_key['category']!r} does not "
+            f"exist in {_PRICES_FILE.name} — PR #4383 (E30A/E30B price-list entries) "
+            "has not landed on main yet"
+        )
+    entry = category.get(pricing_key["item_key"])
+    if not isinstance(entry, dict):
+        raise PricingResolutionError(
+            f"{product_code}: pricing item_key {pricing_key['item_key']!r} not found "
+            f"under category {pricing_key['category']!r} in {_PRICES_FILE.name} — "
+            "PR #4383 (E30A/E30B price-list entries) has not landed on main yet"
+        )
+    price = entry.get("price")
+    if not isinstance(price, str) or not price.strip():
+        raise PricingResolutionError(
+            f"{product_code}: pricing row {pricing_key['item_key']!r} exists under "
+            f"{pricing_key['category']!r} but has no non-empty 'price' — PR #4383 has "
+            "not fully landed"
+        )
+
+
+def _pricing_resolution_gate() -> None:
+    if not _PRICES_FILE.exists():
+        raise PricingResolutionError(f"pricing catalog not found at {_PRICES_FILE}")
+    prices_payload = _load_json(_PRICES_FILE)
+    for code, key in _NEW_PRICING_KEYS.items():
+        _assert_price_resolves(prices_payload, key, product_code=code)
+
+
+# ---------------------------------------------------------------------------
+# Payload edit — E30A/E30B pricing_key: null -> {category, item_key}
+# ---------------------------------------------------------------------------
+
+
+def _apply_pricing_keys(payload: dict[str, Any]) -> None:
+    products_by_code = {p["product_code"]: p for p in payload["products"]}
+    for code in _TOUCHED_PRODUCT_CODES:
+        product = products_by_code.get(code)
+        if product is None:
+            raise FoldPackError(f"product {code!r} not found — cannot set pricing_key")
+        current = product.get("pricing_key")
+        if current is not None:
+            raise FoldPackError(
+                f"product {code!r} pricing_key is {current!r} on seq-10, expected "
+                "null — ledger drift, refusing to overwrite blind"
+            )
+        product["pricing_key"] = copy.deepcopy(_NEW_PRICING_KEYS[code])
+
+    non_null = sum(1 for p in payload["products"] if p.get("pricing_key") is not None)
+    null = len(payload["products"]) - non_null
+    if (
+        non_null != _EXPECTED_NON_NULL_PRICING_KEYS_AFTER
+        or null != _EXPECTED_NULL_PRICING_KEYS_AFTER
+    ):
+        raise FoldPackError(
+            f"post-fold pricing_key split is {non_null} non-null / {null} null, "
+            f"expected {_EXPECTED_NON_NULL_PRICING_KEYS_AFTER} non-null / "
+            f"{_EXPECTED_NULL_PRICING_KEYS_AFTER} null — the seq-10 bytes or the "
+            "touched-product set drifted from what this fold was authored against"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Byte-invariance sweep — everything not declared touched must match seq-10
+# ---------------------------------------------------------------------------
+
+#: Top-level payload keys this fold is ALLOWED to differ from seq-10 on.
+_IDENTITY_KEYS = frozenset(
+    {"sequence", "version", "rule_pack_id", "previous_payload_sha256", "created_at", "created_by"}
+)
+
+
+def _assert_untouched(payload: dict[str, Any], seq10: dict[str, Any]) -> None:
+    for key in set(seq10) | set(payload):
+        if key in _IDENTITY_KEYS or key == "products":
+            continue
+        if _canon(payload.get(key)) != _canon(seq10.get(key)):
+            raise FoldPackError(
+                f"top-level payload key {key!r} drifted from seq-10 — this fold "
+                "declares no edit there"
+            )
+
+    # rules and source_records: this fold declares ZERO edits anywhere in
+    # either collection — whole-collection canonical equality, not a
+    # per-item sweep with a carve-out (there is no carve-out to make).
+    if _canon(payload["rules"]) != _canon(seq10["rules"]):
+        raise FoldPackError("rules drifted from seq-10 — this fold declares no rule edits")
+    if _canon(payload["source_records"]) != _canon(seq10["source_records"]):
+        raise FoldPackError(
+            "source_records drifted from seq-10 — this fold declares no source_record edits"
+        )
+
+    seq10_products = {p["product_code"]: p for p in seq10["products"]}
+    new_products = {p["product_code"]: p for p in payload["products"]}
+    if set(new_products) != set(seq10_products):
+        raise FoldPackError(
+            "product set (by product_code) drifted from seq-10 — this fold declares "
+            "no product add/remove"
+        )
+    for code, product in new_products.items():
+        baseline = seq10_products[code]
+        if code in _TOUCHED_PRODUCT_CODES:
+            b, c = dict(baseline), dict(product)
+            b.pop("pricing_key"), c.pop("pricing_key")
+            if _canon(b) != _canon(c):
+                raise FoldPackError(f"product {code!r} changed beyond pricing_key")
+        elif _canon(product) != _canon(baseline):
+            raise FoldPackError(
+                f"product {code!r} drifted from seq-10 outside the declared "
+                "pricing_key edit set"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Write (atomic + prettier — fold_pack.py's Codex-finding-7 shape)
+# ---------------------------------------------------------------------------
+
+
+def _write_pack(payload: dict[str, Any], out_path: Path) -> None:
+    if not _PRETTIER_BIN.exists():
+        raise FoldPackError(
+            f"prettier binary not found at {_PRETTIER_BIN} — run `npm install` at repo root"
+        )
+
+    text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f"{out_path.stem}.tmp.", suffix=out_path.suffix, dir=str(out_path.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with open(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        result = subprocess.run(
+            [str(_PRETTIER_BIN), "--write", str(tmp_path)],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise FoldPackError(
+                f"prettier --write {tmp_path} failed (rc={result.returncode}):\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        tmp_path.replace(out_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def assemble_payload() -> dict[str, Any]:
+    seq10_original = _load_json(_SEQ10_SOURCE)
+    payload = copy.deepcopy(seq10_original)
+
+    _apply_identity(payload, seq10_original)
+    # The pricing gate is a pure read against the catalog file — it does not
+    # depend on payload state, so it runs before any mutation: fail fastest,
+    # fail loudest, and never leave the payload half-edited on a gate abort.
+    _pricing_resolution_gate()
+    _apply_pricing_keys(payload)
+    _assert_untouched(payload, seq10_original)
+
+    try:
+        RulePackPayload.model_validate(payload)
+    except Exception as exc:  # re-raised loud with context
+        raise FoldPackError(
+            f"assembled seq-11 payload failed RulePackPayload validation: {exc}"
+        ) from exc
+
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # no CLI flags — deterministic single-purpose script
+    try:
+        payload = assemble_payload()
+    except FoldPackError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    _write_pack(payload, _SEQ11_SOURCE)
+    print(
+        f"wrote {_SEQ11_SOURCE} — {len(payload['rules'])} rule(s), "
+        f"{len(payload['products'])} product(s), {len(payload['source_records'])} source_record(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-011.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-011.source.json
@@ -1,0 +1,9066 @@
+{
+  "created_at": "2026-08-20T01:00:00Z",
+  "created_by": "agent.air-m5.backend-rag.visa-seq11-pricing.fold-2026-08-20",
+  "decision_domain": "IMMIGRATION_VISA",
+  "engine_contract_version": "1.0.0",
+  "engine_max_version": "1.0.0",
+  "engine_min_version": "1.0.0",
+  "environment": "PRODUCTION",
+  "hit_policy": {
+    "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+    "hard_filter": "COLLECT_ALL",
+    "human_review": "COLLECT_ALL",
+    "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+  },
+  "jurisdiction": "ID",
+  "previous_payload_sha256": "188442baee0af899e464a696b883d2158e6e362c29d75b61eec5769ba24b9aac",
+  "rollback_of_payload_sha256": null,
+  "products": [
+    {
+      "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+      "product_code": "E28A",
+      "legacy_codes": ["B211"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Visa (E28A)",
+        "id": "Visa Investor (E28A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": [
+        "operational_work_beyond_management_and_ownership"
+      ],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 730,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 100,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Investor KITAS 2 Years (Offshore)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+      "product_code": "E28B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Company Establishment (E28B)",
+        "id": "Visa Investor Pendirian Perusahaan (E28B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+      "product_code": "E28C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Capital Market (E28C)",
+        "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work", "corporate_establishment"],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+      "product_code": "E28D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Branch or Subsidiary (E28D)",
+        "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work_outside_managing_subsidiary"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+      "product_code": "E28F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — New Capital (IKN) Subsidiary (E28F)",
+        "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+      "product_code": "E33",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa (E33)",
+        "id": "Visa Rumah Kedua (E33)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["SECOND_HOME", "TOURISM"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "guarantee_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33 Second Home (5 Years)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+      "product_code": "E33A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Special-Expertise Government Invitation (E33A)",
+        "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+      "product_code": "E33B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Special-Expertise Collaboration (E33B)",
+        "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "EMPLOYMENT",
+        "BUSINESS_MEETINGS",
+        "INVESTMENT",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+      "product_code": "E33C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — World-Figure Government Invitation (E33C)",
+        "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "INVESTMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+      "product_code": "E33E",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Elderly 5-Year (E33E)",
+        "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "deposit_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Retirement (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+      "product_code": "E33F",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Elderly 1-Year (E33F)",
+        "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "RETIREMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33F Second Home Senior (1 Year, Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+      "product_code": "E33G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Remote Worker (E33G)",
+        "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "work_for_indonesian_entity",
+        "indonesian_source_compensation_including_in_kind",
+        "indonesian_company_ownership",
+        "sale_of_goods_or_services_beyond_remote_work"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33G Remote Worker (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+      "product_code": "A1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa-Free Tourism Visit (A1)",
+        "id": "Bebas Visa Kunjungan Wisata (A1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "TRANSIT"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "A1 Visa-Free Tourism"
+      },
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+      "product_code": "B1",
+      "legacy_codes": ["B213"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa on Arrival — Tourism (B1)",
+        "id": "Visa Saat Kedatangan Wisata (B1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 30,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "B1 Visa on Arrival (VOA)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+      "product_code": "C1",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Tourist Visit Visa (C1)",
+        "id": "Visa Kunjungan Wisata (C1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C1 Tourism"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+      "product_code": "C2",
+      "legacy_codes": ["B211B", "B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Business Visit Visa (C2)",
+        "id": "Visa Kunjungan Bisnis (C2)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C2 Business"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+      "product_code": "C6",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Social Activity Visit Visa (C6)",
+        "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": ["paid_employment", "business_meetings"],
+      "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C6 Social Activity"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+      "product_code": "BRIDGING",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Bridging Visa — Transitional Stay Permit",
+        "id": "Izin Tinggal Peralihan"
+      },
+      "category": "OTHER",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": [
+        "employment_relationship",
+        "exit_terminates_permit"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "NOT_APPLICABLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": null,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "Bridging Visa"
+      },
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+      "product_code": "E23",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa (E23)",
+        "id": "Visa Kerja (E23)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": [
+        "work_for_non_sponsor_entity",
+        "hr_personnel_positions",
+        "passive_investment_management"
+      ],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Working KITAS (Offshore)"
+      },
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+      "product_code": "E23U",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Foreign Diplomat House Assistant (E23U)",
+        "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_non_diplomat_employer"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+      "product_code": "E23V",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Trade and Economic Office (E23V)",
+        "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_standard_corporate_employers"],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+      "product_code": "E31A",
+      "legacy_codes": ["C317"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of Indonesian Citizen (E31A)",
+        "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": [],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Spouse 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+      "product_code": "E31B",
+      "legacy_codes": ["C318"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of ITAS/ITAP Holder (E31B)",
+        "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+      "product_code": "E31C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Legal Mixed Marriage (E31C)",
+        "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+      "product_code": "E31D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+        "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+      "product_code": "E31E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of ITAS/ITAP Holder (E31E)",
+        "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+      "product_code": "E31F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Indonesian Citizen Parent (E31F)",
+        "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+      "product_code": "E31G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Indonesian Citizen Child (E31G)",
+        "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+      "product_code": "E31H",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Child ITAS/ITAP Holder (E31H)",
+        "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+      "product_code": "E31J",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child Joining Sibling ITAS/ITAP Holder (E31J)",
+        "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+      "product_code": "D1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Tourism — Multiple Entry (D1)",
+        "id": "Visa Kunjungan Wisata — Beberapa Kali Perjalanan (D1)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D1 Tourism (1 Year)"
+      },
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+      "product_code": "D2",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Business — Multiple Entry (D2)",
+        "id": "Visa Kunjungan Bisnis (D2)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "continuous_supervision_production_sales"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D2 Business (1 Year)"
+      },
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+      "product_code": "D12",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Pre-Investment — Multiple Entry (D12)",
+        "id": "Visa Kunjungan Pra-Investasi (D12)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 180,
+        "maximum_days": 180
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 180,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D12 Business Investigation (1 Year)"
+      },
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+      "product_code": "E30",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Education Visa (E30)",
+        "id": "Visa Pendidikan (E30)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+      "product_code": "E30A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Primary/Secondary Education Visa (E30A)",
+        "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30A Education Visa (1 Year)"
+      },
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+      "product_code": "E30B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Higher Education Visa (E30B)",
+        "id": "Visa Pendidikan Tinggi (E30B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 1460
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30B Higher Education (1 Year)"
+      },
+      "source_refs": [
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "31850f85-8d19-58df-bb66-b04968c9aff0"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+      "product_code": "E30E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "SEZ Education Visa (E30E)",
+        "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+      "product_code": "E30F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Student Exchange Visa (E30F)",
+        "id": "Visa Pertukaran Pelajar (E30F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hf.citizen",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "derived.has_indonesian_citizenship",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.has_indonesian_citizenship"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.citizen",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.overstay-exceeds-60-days",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 60
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "OVERSTAY_EXCEEDS_60_DAYS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.overstay-exceeds-60-days",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.calling-visa",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "intersects",
+        "fact": "person.nationalities",
+        "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CALLING_VISA_REVIEW"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+      "explanation_key": "explain.review.calling-visa",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.active-overstay",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 0
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ACTIVE_OVERSTAY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.review.active-overstay",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.a1.not-bvk-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "BN",
+            "MY",
+            "TH",
+            "SG",
+            "PH",
+            "KH",
+            "LA",
+            "MM",
+            "VN",
+            "TL",
+            "SR",
+            "CO",
+            "HK",
+            "TR",
+            "BR",
+            "PE",
+            "MO",
+            "KZ",
+            "BY"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BVK_NATIONALITY_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.hf.a1.not-bvk-nationality",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.a1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "TRANSIT"]
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "A1_BVK_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "TRANSIT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.el.a1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.b1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "B1_VOA_ELIGIBLE",
+        "covered_purposes": ["TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+      ],
+      "explanation_key": "explain.el.b1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "el.c1.tourism-family",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "FAMILY"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C1_VISIT_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c1.tourism-family",
+      "safety_critical": false,
+      "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"]
+    },
+    {
+      "rule_id": "el.c2.business",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C2_BUSINESS_ELIGIBLE",
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c2.business",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "el.c6.social",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C6_SOCIAL_ELIGIBLE",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c6.social",
+      "safety_critical": false,
+      "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"]
+    },
+    {
+      "rule_id": "hf.e28a.paid-capital-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.paid_up_capital_idr",
+        "value": 2500000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.paid_up_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "hf.e28a.total-investment-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.investment_capital_idr",
+        "value": 10000000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.investment_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.total-investment-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "el.e28a.investment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "investment.proposed_role",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          },
+          {
+            "op": "gte",
+            "fact": "investment.paid_up_capital_idr",
+            "value": 2500000000
+          },
+          {
+            "op": "gte",
+            "fact": "investment.investment_capital_idr",
+            "value": 10000000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.investment_capital_idr",
+        "investment.paid_up_capital_idr",
+        "investment.proposed_role",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.e28a.investment",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "review.e28b.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28b.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"]
+    },
+    {
+      "rule_id": "review.e28c.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28c.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"]
+    },
+    {
+      "rule_id": "review.e28d.usd-threshold-turnover-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28D"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"]
+    },
+    {
+      "rule_id": "review.e28f.ikn-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28F"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"]
+    },
+    {
+      "rule_id": "el.e33.deposit-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.bank_deposit_usd",
+            "value": 130000
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_at_state_bank",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_in_own_name",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.deposit-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-qualification",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.qualifying_property_value_usd",
+                "value": 1000000
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.guarantee-maintenance",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "any",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.guarantee-maintenance",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.work-rangkap-kegiatan",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33a.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33A"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33a.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "review.e33b.expertise-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33b.expertise-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "review.e33c.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33c.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "hf.e33e.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33e.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.age-55-59-disputed-band",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "between",
+                "fact": "derived.age_years",
+                "lower": 55,
+                "upper": 59
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "gte",
+                "fact": "derived.age_years",
+                "value": 55
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 50000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.passive_monthly_income_usd",
+                "value": 3000
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_AGE_55_59_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY", "RETIREMENT", "SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 50000
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_at_state_bank",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_in_own_name",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "hf.e33f.sponsor-required",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "family.sponsor_confirmed",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "SPONSOR_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["family.sponsor_confirmed"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e33f.sponsor-required",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "el.e33f.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33f.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-employer",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.employer_is_indonesian_entity",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.employer_is_indonesian_entity"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-employer",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-source-compensation",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.indonesia_source_compensation",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.indonesia_source_compensation"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-market",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-market",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-company-ownership",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-company-ownership",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e33g.remote-work",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REMOTE_WORK_ELIGIBLE",
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.e33g.remote-work",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.bridging.offshore",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.currently_in_indonesia",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_ONSHORE_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.currently_in_indonesia"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.offshore",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.from-visit-itk",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "in",
+        "fact": "immigration.current_status_code",
+        "values": [
+          "ITK_FROM_BVK",
+          "ITK_FROM_VISIT_C",
+          "ITK_FROM_VISIT_D",
+          "A1",
+          "C1",
+          "C2",
+          "C6"
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+      ],
+      "explanation_key": "explain.hf.bridging.from-visit-itk",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.to-bridging",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.current_status_code",
+        "value": "ITK_PERALIHAN"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.to-bridging",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.t3-window-manual",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.t3-window-manual",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.overstay-shield-payment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.overstay-shield-payment",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.source-status-verify",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_code"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_code",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.source-status-verify",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.adverse-history",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "intersects",
+            "fact": "immigration.violation_history",
+            "values": [
+              "OVERSTAY",
+              "DEPORTATION",
+              "BLACKLIST",
+              "IMMIGRATION_INVESTIGATION"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_ADVERSE_HISTORY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": [
+        "immigration.currently_in_indonesia",
+        "immigration.violation_history"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.adverse-history",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.destination-stated",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "neq",
+            "fact": "intent.requested_product_code",
+            "value": "BRIDGING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_DESTINATION_STATED",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.destination-stated",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.e23-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.employer_is_indonesian_entity",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e23-operational-work-boundary",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "investment.proposed_role",
+                "op": "in",
+                "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "work.employer_is_indonesian_entity",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "work.indonesian_work_sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.proposed_role",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-operational-work-boundary",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e31a-spouse-wni-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "family.marriage_registered"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-spouse-wni-support",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-funds-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_FUNDS_2000",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-funds-2000",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-spousal-work-article-61",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-spousal-work-article-61",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-kitap-prerequisites",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "process.wants_onshore_conversion",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes",
+        "process.wants_onshore_conversion"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-kitap-prerequisites",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-spouse-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31b-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31c-mixed-marriage-parents",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-mixed-marriage-parents",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31d-stepchild-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-stepchild-support",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-step-parent-relation",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_STEP_PARENT_RELATION",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-step-parent-relation",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-sponsor-mixed-marriage",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-sponsor-mixed-marriage",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hf.e31e-adult-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "derived.age_years",
+        "op": "gte",
+        "value": 18
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNDER_18"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-adult-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hf.e31e-married-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "person.marital_status",
+        "op": "neq",
+        "value": "SINGLE"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNMARRIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.marital_status"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-married-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31e-child-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "lt",
+                "value": 18
+              },
+              {
+                "fact": "person.marital_status",
+                "op": "eq",
+                "value": "SINGLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+      ],
+      "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31f-child-wni-parent-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31f-child-wni-parent-support",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31f-adult-age-review",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8"
+      ],
+      "explanation_key": "explain.el.e31f-adult-age-review",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31g-parent-wni-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31g-parent-wni-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"]
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-parent-itas-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31h-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sibling-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-dependency-age",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-dependency-age",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.d1-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "intent.entry_pattern"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D1",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d2-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D2",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d12-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-funds-usd-5000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D12",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-funds-usd-5000",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hf.d12-onshore-conversion-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "D12_NOT_CONVERTIBLE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.e30-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-student-support",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+      ]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.e30a-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["PRIMARY", "SECONDARY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DASMEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30a-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hf.e30b-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DIKTI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30b-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30b-izin-belajar",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "STUDY_PERMIT_KEMDIKBUD",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30b-izin-belajar",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.b1.not-voa-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "ZA",
+            "AL",
+            "US",
+            "AD",
+            "SA",
+            "AR",
+            "AM",
+            "AU",
+            "AT",
+            "AZ",
+            "BH",
+            "NL",
+            "BY",
+            "BE",
+            "BR",
+            "BN",
+            "BA",
+            "BG",
+            "CZ",
+            "CL",
+            "DK",
+            "EC",
+            "EE",
+            "PH",
+            "FI",
+            "GT",
+            "HK",
+            "HU",
+            "IN",
+            "GB",
+            "IE",
+            "IT",
+            "IS",
+            "JP",
+            "DE",
+            "KH",
+            "CA",
+            "KZ",
+            "KE",
+            "CO",
+            "KR",
+            "HR",
+            "KW",
+            "LA",
+            "LV",
+            "LI",
+            "LT",
+            "LU",
+            "MV",
+            "MY",
+            "MT",
+            "MA",
+            "MU",
+            "MX",
+            "EG",
+            "MC",
+            "MN",
+            "MZ",
+            "MM",
+            "NO",
+            "OM",
+            "PS",
+            "PG",
+            "FR",
+            "PE",
+            "PL",
+            "PT",
+            "QA",
+            "RO",
+            "RU",
+            "RW",
+            "NZ",
+            "RS",
+            "SC",
+            "SG",
+            "CY",
+            "SK",
+            "SI",
+            "ES",
+            "SR",
+            "SE",
+            "CH",
+            "TW",
+            "TZ",
+            "TH",
+            "TL",
+            "CN",
+            "TN",
+            "TR",
+            "AE",
+            "UZ",
+            "UA",
+            "VA",
+            "VE",
+            "VN",
+            "JO",
+            "GR"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "VOA_NATIONALITY_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+      "explanation_key": "explain.hf.b1.not-voa-nationality",
+      "safety_critical": true,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "review.citizenship-conflict",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "any",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "ZA",
+                  "AL",
+                  "US",
+                  "AD",
+                  "SA",
+                  "AR",
+                  "AM",
+                  "AU",
+                  "AT",
+                  "AZ",
+                  "BH",
+                  "NL",
+                  "BY",
+                  "BE",
+                  "BR",
+                  "BN",
+                  "BA",
+                  "BG",
+                  "CZ",
+                  "CL",
+                  "DK",
+                  "EC",
+                  "EE",
+                  "PH",
+                  "FI",
+                  "GT",
+                  "HK",
+                  "HU",
+                  "IN",
+                  "GB",
+                  "IE",
+                  "IT",
+                  "IS",
+                  "JP",
+                  "DE",
+                  "KH",
+                  "CA",
+                  "KZ",
+                  "KE",
+                  "CO",
+                  "KR",
+                  "HR",
+                  "KW",
+                  "LA",
+                  "LV",
+                  "LI",
+                  "LT",
+                  "LU",
+                  "MV",
+                  "MY",
+                  "MT",
+                  "MA",
+                  "MU",
+                  "MX",
+                  "EG",
+                  "MC",
+                  "MN",
+                  "MZ",
+                  "MM",
+                  "NO",
+                  "OM",
+                  "PS",
+                  "PG",
+                  "FR",
+                  "PE",
+                  "PL",
+                  "PT",
+                  "QA",
+                  "RO",
+                  "RU",
+                  "RW",
+                  "NZ",
+                  "RS",
+                  "SC",
+                  "SG",
+                  "CY",
+                  "SK",
+                  "SI",
+                  "ES",
+                  "SR",
+                  "SE",
+                  "CH",
+                  "TW",
+                  "TZ",
+                  "TH",
+                  "TL",
+                  "CN",
+                  "TN",
+                  "TR",
+                  "AE",
+                  "UZ",
+                  "UA",
+                  "VA",
+                  "VE",
+                  "VN",
+                  "JO",
+                  "GR"
+                ]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AF",
+                  "AG",
+                  "AI",
+                  "AO",
+                  "AQ",
+                  "AS",
+                  "AW",
+                  "AX",
+                  "BB",
+                  "BD",
+                  "BF",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BO",
+                  "BQ",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BZ",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CI",
+                  "CK",
+                  "CM",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "DJ",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EH",
+                  "ER",
+                  "ET",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "GA",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GS",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HM",
+                  "HN",
+                  "HT",
+                  "ID",
+                  "IL",
+                  "IM",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "JE",
+                  "JM",
+                  "KG",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KP",
+                  "KY",
+                  "LB",
+                  "LC",
+                  "LK",
+                  "LR",
+                  "LS",
+                  "LY",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MW",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NG",
+                  "NI",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "PA",
+                  "PF",
+                  "PK",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PW",
+                  "PY",
+                  "RE",
+                  "SB",
+                  "SD",
+                  "SH",
+                  "SJ",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SO",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TJ",
+                  "TK",
+                  "TM",
+                  "TO",
+                  "TT",
+                  "TV",
+                  "UG",
+                  "UM",
+                  "UY",
+                  "VC",
+                  "VG",
+                  "VI",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AD",
+                  "AE",
+                  "AG",
+                  "AI",
+                  "AL",
+                  "AM",
+                  "AO",
+                  "AQ",
+                  "AR",
+                  "AS",
+                  "AT",
+                  "AU",
+                  "AW",
+                  "AX",
+                  "AZ",
+                  "BA",
+                  "BB",
+                  "BD",
+                  "BE",
+                  "BF",
+                  "BG",
+                  "BH",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BN",
+                  "BO",
+                  "BQ",
+                  "BR",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BY",
+                  "BZ",
+                  "CA",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CH",
+                  "CI",
+                  "CK",
+                  "CL",
+                  "CM",
+                  "CN",
+                  "CO",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "CY",
+                  "CZ",
+                  "DE",
+                  "DJ",
+                  "DK",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EC",
+                  "EE",
+                  "EG",
+                  "EH",
+                  "ER",
+                  "ES",
+                  "ET",
+                  "FI",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "FR",
+                  "GA",
+                  "GB",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GR",
+                  "GS",
+                  "GT",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HK",
+                  "HM",
+                  "HN",
+                  "HR",
+                  "HT",
+                  "HU",
+                  "ID",
+                  "IE",
+                  "IM",
+                  "IN",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "IS",
+                  "IT",
+                  "JE",
+                  "JM",
+                  "JO",
+                  "JP",
+                  "KE",
+                  "KG",
+                  "KH",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KR",
+                  "KW",
+                  "KY",
+                  "KZ",
+                  "LA",
+                  "LB",
+                  "LC",
+                  "LI",
+                  "LK",
+                  "LS",
+                  "LT",
+                  "LU",
+                  "LV",
+                  "LY",
+                  "MA",
+                  "MC",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MM",
+                  "MN",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MT",
+                  "MU",
+                  "MV",
+                  "MW",
+                  "MX",
+                  "MY",
+                  "MZ",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NI",
+                  "NL",
+                  "NO",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "NZ",
+                  "OM",
+                  "PA",
+                  "PE",
+                  "PF",
+                  "PG",
+                  "PH",
+                  "PK",
+                  "PL",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PS",
+                  "PT",
+                  "PW",
+                  "PY",
+                  "QA",
+                  "RE",
+                  "RO",
+                  "RS",
+                  "RU",
+                  "RW",
+                  "SA",
+                  "SB",
+                  "SC",
+                  "SD",
+                  "SE",
+                  "SG",
+                  "SH",
+                  "SI",
+                  "SJ",
+                  "SK",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SR",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TH",
+                  "TJ",
+                  "TK",
+                  "TL",
+                  "TM",
+                  "TN",
+                  "TO",
+                  "TR",
+                  "TT",
+                  "TV",
+                  "TW",
+                  "TZ",
+                  "UA",
+                  "UG",
+                  "UM",
+                  "US",
+                  "UY",
+                  "UZ",
+                  "VA",
+                  "VC",
+                  "VE",
+                  "VG",
+                  "VI",
+                  "VN",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZA",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CITIZENSHIP_LIST_DIVERGENCE"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": [
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+      ],
+      "explanation_key": "explain.review.citizenship-conflict",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.minor-without-guardian",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-09T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "derived.is_minor",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "explanation_key": "explain.review.minor-without-guardian",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.e33f.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33f.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "review.e33g.income-evidence",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_INCOME_EVIDENCE_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.review.e33g.income-evidence",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e30e-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "values": ["EDUCATION", "INDIVIDUAL"],
+            "op": "in"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e30e-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"]
+    },
+    {
+      "rule_id": "el.e30f-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "value": "EDUCATION",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30f-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"]
+    },
+    {
+      "rule_id": "hf.e33a.sponsor-not-government",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "value": "GOVERNMENT",
+        "op": "neq"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33A_SPONSOR_NOT_GOVERNMENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33a.sponsor-not-government",
+      "safety_critical": true,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "hf.e33b.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33B_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "hf.e33c.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33C_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "review.e23u.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23U",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23u.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "review.e23v.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23V",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23V_TRADE_OFFICE_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23v.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hf.e31c-marriage-not-registered",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["FAMILY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT",
+            "op": "eq"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "value": false,
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENTS_MARRIAGE_REGISTERED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.hf.e31c-marriage-not-registered",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    }
+  ],
+  "rule_pack_id": "5c3974ab-bb15-5a73-b74f-f9f0af88a4a7",
+  "sequence": 11,
+  "version": "2026.8.20",
+  "valid_period": {
+    "from": "2026-07-25T00:00:00Z",
+    "to": null
+  },
+  "source_records": [
+    {
+      "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+      "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Kepmen M.IP-08.GR.01.01/2025 — Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+      "language": "id",
+      "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28D"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33E"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33G"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/B1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C2"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C6"
+        }
+      ],
+      "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+      "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 — Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+      "language": "id",
+      "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33(2)(j)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 62"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 63"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 86A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94B"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 185"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 39"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 40"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 57"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 58"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 59"
+        }
+      ],
+      "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+      "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 10/2026 — Daftar Negara Bebas Visa Kunjungan (BVK)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+      "language": "id",
+      "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+      "locators": [],
+      "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+      "legal_period": {
+        "from": "2026-07-09T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+      "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian — kewarganegaraan dan ketentuan overstay",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+      "language": "id",
+      "document_number": "UU 6/2011 jo. UU 63/2024",
+      "locators": [],
+      "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Calling Visa — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Calling Visa country list; national Ditjen Imigrasi display"
+        }
+      ],
+      "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:20:35Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 — Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+      "legal_period": {
+        "from": "2024-04-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:20:35Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+      "source_key": "permen-imipas-5-2025-penjamin-revocation",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 5/2025 — Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+      "language": "id",
+      "document_number": "Permen Imipas 5/2025",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 1"
+        }
+      ],
+      "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+      "legal_period": {
+        "from": "2025-02-07T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Layanan Alih Status — Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:20:35Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+      "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+      "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+      "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+      "language": "id",
+      "document_number": "M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Lampiran"
+        }
+      ],
+      "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+      "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+      "language": "id",
+      "document_number": "22/2023",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 42"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33"
+        }
+      ],
+      "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+      "legal_period": {
+        "from": "2023-08-22T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+      "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+      "language": "id",
+      "document_number": "11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105 ayat (7)"
+        }
+      ],
+      "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "5a0d367b-bf64-535d-83e4-f40c45de2008",
+      "source_key": "peraturan.bpk.go.id.uu-6-2011-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Pasal 60 ayat (2) dan Pasal 61",
+      "publisher": "Badan Pemeriksa Keuangan Republik Indonesia",
+      "canonical_url": "https://peraturan.bpk.go.id/Home/Download/28550/UU%206%20Tahun%202011.pdf",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 60 ayat (2)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "63708ca9b50ac067834a50c395385fdc6abda22e6e51def88983cd1ad685edc4",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-10T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-10T00:00:00Z",
+      "verified_at": "2026-08-10T00:00:00Z",
+      "verified_by": "agent.air-m5.visa-seq6-semantics",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+      "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri WNI (E31A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:20:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:21:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:22:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:20:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-18T21:41:23Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq9-implementer-b.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:20:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:20:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:21:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:31:03Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-orchestrator.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:21:51Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Bisnis (D2) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:21:51Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Pra-Investasi (D12) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:21:51Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Dasar dan Menengah (E30A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:21:51Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Tinggi (E30B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-19T04:21:51Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "source_key": "imigrasi-voa-country-list",
+      "version": 1,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Subjek Visa on Arrival (VoA) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+        }
+      ],
+      "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-08T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-08T00:00:00Z",
+      "verified_at": "2026-08-19T04:20:35Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    }
+  ]
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq11_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq11_pack.py
@@ -1,0 +1,283 @@
+"""seq-11 pricing increment — gates for the assembled
+``rulepack-prod-011.source.json`` (see
+``backend.scripts.visa_engine.fold_pack_seq11``).
+
+This module SKIPS cleanly (not error, not red) while
+``rulepack-prod-011.source.json`` does not exist on disk — the fold is
+deliberately unrunnable until PR #4383 (the E30A/E30B price-list entries)
+lands on main, per the fold's own pricing-resolution gate. Once the fold has
+run and the file exists, five checks run, each verified against the real
+files on disk:
+
+(a) chain gate — seq-11's ``previous_payload_sha256`` equals the
+    RECOMPUTED SHA256(JCS(...)) of seq-10's own source payload (never a
+    declared-field-vs-declared-field comparison — the house pattern from
+    ``test_seq10_pack.py``'s ``TestChainGate``, one generation later in
+    the chain).
+(b) identity — ``sequence == 11``, ``rule_pack_id`` matches the uuid5
+    convention recomputed in-test (never imported from the fold module as
+    a trusted constant).
+(c) pricing-key parity — exactly 26 products carry a non-null
+    ``pricing_key`` and 12 carry ``null``; E30A/E30B's keys deep-equal the
+    expected dicts; every one of the 26 non-null keys resolves against
+    ``bali_zero_official_prices_2026.json`` to a catalog row with a
+    non-empty ``price`` — with a positive control proving the resolver can
+    fail (a fabricated item_key must NOT resolve).
+(d) byte-invariance — every rule and every source_record is canonically
+    identical to seq-10's (this fold declares ZERO edits in either
+    collection); every product except E30A/E30B is canonically identical
+    to its seq-10 counterpart.
+(e) the 5 E30-family products minus E30A/E30B (E30, E30E, E30F) still
+    carry ``pricing_key: null`` — the "Data Belum Tersedia" honesty pin
+    this fold does not touch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.services.visa_engine.bundle import canonicalize_json
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_PACKS_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "backend-rag"
+    / "backend"
+    / "services"
+    / "visa_engine"
+    / "contracts"
+    / "packs"
+)
+_SEQ10_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-010.source.json"
+_SEQ10_SIGNED_PATH = _PACKS_DIR / "rulepack-prod-010.signed.json"
+_SEQ11_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-011.source.json"
+
+_PRICES_PATH = (
+    _REPO_ROOT / "apps" / "backend-rag" / "backend" / "data" / "bali_zero_official_prices_2026.json"
+)
+
+_E30A_PRICING_KEY = {"category": "kitas_permits", "item_key": "E30A Education Visa (1 Year)"}
+_E30B_PRICING_KEY = {"category": "kitas_permits", "item_key": "E30B Higher Education (1 Year)"}
+_UNTOUCHED_E30_FAMILY = ("E30", "E30E", "E30F")
+
+_EXPECTED_NON_NULL_COUNT = 26
+_EXPECTED_NULL_COUNT = 12
+
+pytestmark = pytest.mark.skipif(
+    not _SEQ11_SOURCE_PATH.exists(),
+    reason=(
+        "rulepack-prod-011.source.json does not exist yet — the seq-11 fold "
+        "(backend.scripts.visa_engine.fold_pack_seq11) is deliberately blocked "
+        "on its own pricing-resolution gate until PR #4383 (E30A/E30B price-list "
+        "entries) lands on main. This module SKIPS, not reds, until then."
+    ),
+)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+@pytest.fixture(scope="module")
+def seq10_source() -> dict[str, Any]:
+    return _read_json(_SEQ10_SOURCE_PATH)
+
+
+@pytest.fixture(scope="module")
+def seq11_source() -> dict[str, Any]:
+    return _read_json(_SEQ11_SOURCE_PATH)
+
+
+@pytest.fixture(scope="module")
+def prices() -> dict[str, Any]:
+    return _read_json(_PRICES_PATH)
+
+
+def _resolves(prices_payload: dict[str, Any], pricing_key: dict[str, str]) -> bool:
+    """Independent re-implementation of the resolve check (deliberately not
+    imported from the fold module — a test that reuses the code it is
+    grading is not evidence, per W100)."""
+
+    services = prices_payload.get("services")
+    if not isinstance(services, dict):
+        return False
+    category = services.get(pricing_key["category"])
+    if not isinstance(category, dict):
+        return False
+    entry = category.get(pricing_key["item_key"])
+    if not isinstance(entry, dict):
+        return False
+    price = entry.get("price")
+    return isinstance(price, str) and bool(price.strip())
+
+
+# ---------------------------------------------------------------------------
+# (a) chain + identity
+# ---------------------------------------------------------------------------
+
+
+class TestChainGate:
+    def test_previous_payload_sha256_chains_to_recomputed_seq10(
+        self, seq10_source: dict[str, Any], seq11_source: dict[str, Any]
+    ) -> None:
+        recomputed = hashlib.sha256(canonicalize_json(seq10_source)).hexdigest()
+        seq10_signed = _read_json(_SEQ10_SIGNED_PATH)
+        assert recomputed == seq10_signed["payload_sha256"]
+        assert seq11_source["previous_payload_sha256"] == recomputed
+
+    def test_sequence_is_11(self, seq11_source: dict[str, Any]) -> None:
+        assert seq11_source["sequence"] == 11
+
+    def test_rule_pack_id_matches_uuid5_convention(self, seq11_source: dict[str, Any]) -> None:
+        expected = uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/11",
+        )
+        assert seq11_source["rule_pack_id"] == str(expected)
+        # Formula sanity: the same convention reproduces seq-10's id.
+        seq10_expected = uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/10",
+        )
+        assert str(seq10_expected) == "d390c8eb-926d-5c37-9bbb-83e4a8601195"
+
+
+# ---------------------------------------------------------------------------
+# (c) pricing-key parity + real-catalog resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPricingKeyParity:
+    def test_exactly_26_non_null_12_null(self, seq11_source: dict[str, Any]) -> None:
+        non_null = [p for p in seq11_source["products"] if p.get("pricing_key") is not None]
+        null = [p for p in seq11_source["products"] if p.get("pricing_key") is None]
+        assert len(non_null) == _EXPECTED_NON_NULL_COUNT
+        assert len(null) == _EXPECTED_NULL_COUNT
+        assert len(non_null) + len(null) == len(seq11_source["products"])
+
+    def test_e30a_pricing_key(self, seq11_source: dict[str, Any]) -> None:
+        product = next(p for p in seq11_source["products"] if p["product_code"] == "E30A")
+        assert product["pricing_key"] == _E30A_PRICING_KEY
+
+    def test_e30b_pricing_key(self, seq11_source: dict[str, Any]) -> None:
+        product = next(p for p in seq11_source["products"] if p["product_code"] == "E30B")
+        assert product["pricing_key"] == _E30B_PRICING_KEY
+
+    def test_all_26_non_null_keys_resolve_in_real_catalog(
+        self, seq11_source: dict[str, Any], prices: dict[str, Any]
+    ) -> None:
+        unresolved = []
+        checked = 0
+        for product in seq11_source["products"]:
+            pricing_key = product.get("pricing_key")
+            if pricing_key is None:
+                continue
+            checked += 1
+            if not _resolves(prices, pricing_key):
+                unresolved.append((product["product_code"], pricing_key))
+        assert checked == _EXPECTED_NON_NULL_COUNT
+        assert unresolved == []
+
+    def test_positive_control_fake_key_does_not_resolve(self, prices: dict[str, Any]) -> None:
+        fake = {
+            "category": "kitas_permits",
+            "item_key": "E30A Education Visa (1 Year) DOES-NOT-EXIST-FAKE",
+        }
+        assert _resolves(prices, fake) is False
+
+    def test_positive_control_fake_category_does_not_resolve(self, prices: dict[str, Any]) -> None:
+        fake = {"category": "not_a_real_category", "item_key": "E30A Education Visa (1 Year)"}
+        assert _resolves(prices, fake) is False
+
+
+# ---------------------------------------------------------------------------
+# (e) untouched E30-family siblings stay null
+# ---------------------------------------------------------------------------
+
+
+class TestUntouchedE30FamilyStaysNull:
+    def test_e30_e30e_e30f_pricing_key_still_null(self, seq11_source: dict[str, Any]) -> None:
+        by_code = {p["product_code"]: p for p in seq11_source["products"]}
+        for code in _UNTOUCHED_E30_FAMILY:
+            assert by_code[code]["pricing_key"] is None, f"{code} should still be null"
+
+
+# ---------------------------------------------------------------------------
+# (d) byte-invariance — rules, source_records, and every other product
+# ---------------------------------------------------------------------------
+
+
+class TestByteInvariance:
+    def test_rules_canonically_identical_to_seq10(
+        self, seq10_source: dict[str, Any], seq11_source: dict[str, Any]
+    ) -> None:
+        assert len(seq11_source["rules"]) == len(seq10_source["rules"])
+        assert _canon(seq11_source["rules"]) == _canon(seq10_source["rules"])
+
+    def test_source_records_canonically_identical_to_seq10(
+        self, seq10_source: dict[str, Any], seq11_source: dict[str, Any]
+    ) -> None:
+        assert len(seq11_source["source_records"]) == len(seq10_source["source_records"])
+        assert _canon(seq11_source["source_records"]) == _canon(seq10_source["source_records"])
+
+    def test_product_set_unchanged(
+        self, seq10_source: dict[str, Any], seq11_source: dict[str, Any]
+    ) -> None:
+        seq10_codes = {p["product_code"] for p in seq10_source["products"]}
+        seq11_codes = {p["product_code"] for p in seq11_source["products"]}
+        assert seq10_codes == seq11_codes
+        assert len(seq11_source["products"]) == len(seq10_source["products"])
+
+    def test_every_product_except_e30a_e30b_canonically_identical(
+        self, seq10_source: dict[str, Any], seq11_source: dict[str, Any]
+    ) -> None:
+        seq10_by_code = {p["product_code"]: p for p in seq10_source["products"]}
+        drifted = []
+        for product in seq11_source["products"]:
+            code = product["product_code"]
+            if code in ("E30A", "E30B"):
+                continue
+            if _canon(product) != _canon(seq10_by_code[code]):
+                drifted.append(code)
+        assert drifted == []
+
+    def test_e30a_e30b_changed_only_pricing_key(
+        self, seq10_source: dict[str, Any], seq11_source: dict[str, Any]
+    ) -> None:
+        seq10_by_code = {p["product_code"]: p for p in seq10_source["products"]}
+        seq11_by_code = {p["product_code"]: p for p in seq11_source["products"]}
+        for code in ("E30A", "E30B"):
+            baseline = dict(seq10_by_code[code])
+            candidate = dict(seq11_by_code[code])
+            baseline.pop("pricing_key")
+            candidate.pop("pricing_key")
+            assert _canon(baseline) == _canon(candidate), f"{code} changed beyond pricing_key"
+
+    def test_top_level_keys_other_than_identity_unchanged(
+        self, seq10_source: dict[str, Any], seq11_source: dict[str, Any]
+    ) -> None:
+        identity_keys = {
+            "sequence",
+            "version",
+            "rule_pack_id",
+            "previous_payload_sha256",
+            "created_at",
+            "created_by",
+        }
+        for key in set(seq10_source) | set(seq11_source):
+            if key in identity_keys or key == "products":
+                continue
+            assert _canon(seq11_source.get(key)) == _canon(seq10_source.get(key)), (
+                f"top-level key {key!r} drifted from seq-10"
+            )

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -320,6 +320,30 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
         "the public signed seq-9 RulePack payload, triple-derived at run "
         "time; exact value pinned, never a credential",
     ),
+    # fold_pack_seq11.py: _EXPECTED_SEQ10_PAYLOAD_SHA256 is the chain anchor —
+    # the content-derived sha256 of the PUBLIC signed seq-10 RulePack payload
+    # (same value class as the contracts/packs/rulepack-*.json rule in
+    # AUTO_APPROVE_RULES: hashes of public legal documents, never
+    # credentials). The fold script pins it so the seq-11 chain link is
+    # triple-derived at run time (declared == anchor == recomputed from the
+    # seq-10 source bytes) and any mismatch aborts the fold.
+    #
+    # Content-keyed and pinned to the EXACT anchor value, not a hex shape:
+    # this is production code with an open surface for future edits — a real
+    # credential pasted anywhere else in the file (or even another 64-hex
+    # value on this line) stays flagged. The approved line is the bare
+    # continuation-string line of the parenthesized assignment, end-anchored.
+    (
+        re.compile(
+            r"^apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq11\.py$"
+        ),
+        re.compile(
+            r'^\s*"188442baee0af899e464a696b883d2158e6e362c29d75b61eec5769ba24b9aac"\s*$'
+        ),
+        "fold_pack_seq11.py: seq-10 chain anchor — content-derived sha256 of "
+        "the public signed seq-10 RulePack payload, triple-derived at run "
+        "time; exact value pinned, never a credential",
+    ),
 ]
 
 # Each rule is (pattern, reason). The pattern matches the file path

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -217,12 +217,13 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     """Sanity: the KBLI gold-set rule is path-scoped to kbli-gold-all.json
     only — not the other KBLI files, which stay on the closed-writer-set
     path rules in AUTO_APPROVE_RULES."""
-    assert len(CONTENT_KEYED_RULES) == 10  # +1: infra/llm-credentials/declared.json sha256_16 (2026-08-12)
+    assert len(CONTENT_KEYED_RULES) == 11  # +1: infra/llm-credentials/declared.json sha256_16 (2026-08-12)
     # +1: apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py public_key (2026-08-13)
     # +1: research/visa/2026-08-12-gold-replay-live-report.json payload_sha256 (2026-08-13)
     # +1: scripts/lint_telegram_tokens.py KNOWN_COMPROMISED sha256[:16] key (2026-08-14)
     # +1: traffic-source fail-closed proof identity/integrity anchors (2026-08-15)
     # +1: fold_pack_seq10.py seq-9 chain anchor exact-value pin (2026-08-19)
+    # +1: fold_pack_seq11.py seq-10 chain anchor exact-value pin (2026-08-20)
     path_pat, _content_pat, reason = CONTENT_KEYED_RULES[1]
     assert path_pat.search(KBLI_GOLD_ALL)
     assert not path_pat.search("apps/mouth/data/KBLI_2025_FINAL_CLEAN.json")
@@ -1015,4 +1016,87 @@ def test_innocence_fold_seq10_keyed_assignment_not_approved() -> None:
     parenthesized assignment, never a `"key": "value"` shape."""
     _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[9]
     keyed_line = f'    "payload_sha256": "{FOLD_PACK_SEQ10_ANCHOR}",'
+    assert content_pat.match(keyed_line) is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 11: fold_pack_seq11.py — the seq-10 chain anchor, pinned to the exact
+# public payload sha256 of the signed seq-10 RulePack. Same value class and
+# same discipline as rule 10 above (the seq-9 anchor in fold_pack_seq10.py):
+# the fold script pins the PRIOR pack's payload hash so the chain link is
+# triple-derived at run time (declared == anchor == recomputed) and any
+# mismatch aborts the fold.
+#
+# Content-keyed and pinned to the EXACT anchor value, not a hex shape: this
+# is production code with an open surface for future edits — a real
+# credential pasted anywhere else in the file (or even another 64-hex value
+# on this line) stays flagged. The approved line is the bare
+# continuation-string line of the parenthesized assignment, end-anchored.
+
+FOLD_PACK_SEQ11 = "apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq11.py"
+FOLD_PACK_SEQ11_ANCHOR = (
+    "188442baee0af899e464a696b883d2158e6e362c29d75b61eec5769ba24b9aac"
+)
+
+
+def test_fold_seq11_rule_registered_and_scoped_to_exactly_one_file() -> None:
+    path_pat, _content_pat, reason = CONTENT_KEYED_RULES[10]
+    assert path_pat.search(FOLD_PACK_SEQ11)
+    assert not path_pat.search(FOLD_PACK_SEQ10)
+    assert not path_pat.search(
+        "apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py"
+    )
+    assert not path_pat.search("scripts/fold_pack_seq11.py")
+    assert "credential" in reason
+
+
+def test_guilt_fold_seq11_real_finding_approved() -> None:
+    """The exact real line 93 in the fold script must be approved — read live
+    off disk, so this fails if the file and rule ever drift, not merely if
+    someone edits a string literal in this test."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[10]
+    lines = Path(FOLD_PACK_SEQ11).read_text(encoding="utf-8").splitlines()
+    real_line = lines[92]  # line 93, 1-indexed
+    assert real_line == f'    "{FOLD_PACK_SEQ11_ANCHOR}"'
+    assert content_pat.match(real_line), f"should be approved: {real_line!r}"
+
+
+def test_innocence_fold_seq11_other_hex_value_not_approved() -> None:
+    """A DIFFERENT 64-hex bare string line must not be approved — proves the
+    rule is pinned to the exact anchor value, not merely to the shape.
+    The seq-9 anchor (rule 10's value) doubles as the nearest-neighbour
+    innocent: a REAL sibling anchor must still not launder through THIS rule."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[10]
+    other_hex_line = '    "' + "a" * 64 + '"'
+    assert content_pat.match(other_hex_line) is None
+    sibling_anchor_line = f'    "{FOLD_PACK_SEQ10_ANCHOR}"'
+    assert content_pat.match(sibling_anchor_line) is None
+
+
+def test_innocence_fold_seq11_uppercase_not_approved() -> None:
+    """The same value uppercased must not be approved — the anchor is
+    lowercase hex, matching hashlib.hexdigest's own output."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[10]
+    uppercase_line = f'    "{FOLD_PACK_SEQ11_ANCHOR.upper()}"'
+    assert content_pat.match(uppercase_line) is None
+
+
+def test_innocence_fold_seq11_ride_along_statement_not_approved() -> None:
+    """The value followed by a second statement or token on the same line
+    must not launder the ride-along — end-anchored, same discipline as every
+    other rule in this list."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[10]
+    for compound in (
+        f'    "{FOLD_PACK_SEQ11_ANCHOR}"; import os',
+        f'    "{FOLD_PACK_SEQ11_ANCHOR}" "second_token"',
+    ):
+        assert content_pat.match(compound) is None, f"must NOT be approved: {compound!r}"
+
+
+def test_innocence_fold_seq11_keyed_assignment_not_approved() -> None:
+    """A JSON-style keyed line carrying the same value must not be approved —
+    the rule approves only the bare continuation-string shape of the
+    parenthesized assignment, never a `"key": "value"` shape."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[10]
+    keyed_line = f'    "payload_sha256": "{FOLD_PACK_SEQ11_ANCHOR}",'
     assert content_pat.match(keyed_line) is None


### PR DESCRIPTION
## RulePack seq-11 — pricing_key for E30A/E30B (one concern)

Follows #4383 (E30A/E30B price entries, owner rule PNBP + 3jt, live-grounded). This pack
increment does ONE thing: `pricing_key` null → set for E30A (`E30A Education Visa (1 Year)`)
and E30B (`E30B Higher Education (1 Year)`), base-variant convention (E28A precedent).
E30/E30E/E30F stay null (portal: "Data Belum Tersedia" — honesty pin, tested).

- Chain: `previous_payload_sha256` triple-derived → signed seq-10 payload (`188442ba…`);
  `rule_pack_id` uuid5 `5c3974ab-bb15-5a73-b74f-f9f0af88a4a7`; version `2026.8.20`.
- Fold (`fold_pack_seq11.py`): pricing-resolution gate BEFORE mutation (both keys must
  resolve to a non-empty price in the real catalog); byte-invariance — rules +
  source_records whole-collection canonical-identical to seq-10, all other products
  identical, the two touched change `pricing_key` only; idempotent (two runs
  byte-identical, sha `32e548aa…`); `compile_pack` RC 0.
- Tests 34/34: `test_seq11_pack.py` 16 (chain recomputed from bytes, identity, 26/12
  pricing parity with ALL 26 keys resolving + positive controls, byte-invariance,
  E30-family null pin) + `test_seq10_pack.py` 18 (no regression).

After merge (same session): sign on M5 (`--sequence 11`, kid `prod-2026-07-1`) → bundle
PR → two-login activation 10→11 → live smoke (verdict cites seq-11). SHADOW only —
ENFORCE untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
