### PR TITLE
docs(research): correct three claims in the upsert-by-phone note

### DIFF
--- a/research/operations/2026-08-19-crm-upsert-by-phone-duplicate-advisory.md
+++ b/research/operations/2026-08-19-crm-upsert-by-phone-duplicate-advisory.md
@@ -208,7 +208,7 @@ refuters killed it. It surfaces one layer up, at `crm_delivery.py:391-397`, as
 `"phone-upsert could not resolve an UNAMBIGUOUS Fly client id"` — to *every* cause.
 
 There are seven of them (`_ensure_client_on_fly` spans 132-221; a third draft of this paragraph said
-five, and a second seat produced the two it had missed):
+five, and a third seat — GLM, Round 4 — produced the two it had missed):
 
 | exit | cause | preceding line of its own |
 |---|---|---|
@@ -222,8 +222,8 @@ five, and a second seat produced the two it had missed):
 
 **The shared phone lands on `:192`, the silent one.** That is the whole point: because the endpoint
 answers `client_id: None`, the refusal arrives at the caller as an unremarkable "no id" and exits
-without a word, while the warning written to name it sits two exits further down (`:214`, guarded at
-`:209`) waiting for a response shape this caller can never receive.
+without a word, while the warning written to name it sits two exits further down (`:209-213`, guarded
+at `:204`, returning at `:214`) waiting for a response shape this caller can never receive.
 
 So a shared-phone refusal produces exactly **one** line in the entire system, and it is the line
 seven causes share. Both warnings written to name this cause are unreachable: the server's `N
@@ -277,8 +277,15 @@ the original error but the over-confident repair of it.
    client. "Duplicate" may be the wrong word for many of them, and a merge would destroy a real
    distinction.
 2. Should `wa-mirror-auto-promote-leads.py` adopt `crm_push.py`'s posture? That is the smallest
-   change with the largest effect, but it converts ~849 silent writes into refusals — a
-   behaviour change on a live lead pipeline, not a bug fix.
+   change with the largest effect: up to ~849 collision groups would stop being acted on and
+   start being refused. Two corrections to an earlier draft of this line, which called them
+   "~849 silent writes" — they are neither necessarily silent nor necessarily writes. The
+   advisory does fire on every one of them (it simply did not say *what* it had done, which is
+   what #4387 fixed), and the refusal side is logged one layer up as
+   `intake.delivery.identity_unresolved`; and an unknown share of those groups resolve to
+   `skipped_no_change`, where nothing is written at all. Still a behaviour change on a live lead
+   pipeline, not a bug fix — but the count is of *collision groups*, not of writes prevented,
+   and that number has not been measured.
 3. Is resurrecting an archived card ever the intent on the auto-promote path? `crm_push.py` says
    no, in writing, for identity resolution. Whether the lead-promotion path has a different and
    legitimate answer is a business call, not a code call.
@@ -357,7 +364,7 @@ correction that went too far. The seat also caught the function-span figure (`13
 trailing blank lines; the last statement is at 1552) and a loose claim that the log identifies the
 *caller* when it can only identify the *flag value*.
 
-### Round 4 — a second seat on the numbers (GLM)
+### Round 4 — a third seat on the numbers (GLM)
 
 GLM was dispatched independently on the `crm_push` half and **refuted the taxonomy**: the function
 has **seven** `return None` sites, not five — `:156` (phone digits outside 6-20, reachable because


### PR DESCRIPTION
Consistency review by a cross-family seat (Kimi K3) on the note as merged in #4384. **Three defects, none of them in the finding** — all three in the prose that describes how the finding was reached, which is the part nobody re-reads.

| # | was | is | why it matters |
|---|---|---|---|
| 1 | line 211 "a **second** seat produced the two it had missed"; Round 4 heading "a second seat on the numbers" | "a **third** seat — GLM, Round 4" in both | the same note says "three seats" at line 270 and "a third seat" at line 359. GLM is the third (Codex, Kimi, GLM). A document that cannot count its own reviewers undercuts the one thing it is arguing for |
| 2 | "(`:214`, guarded at `:209`)" | "(`:209-213`, guarded at `:204`, returning at `:214`)" | roles reversed. In `crm_push.py`, `:204` is the guard, `:209-213` the warning, `:214` the return. As written it sends a reader to grep `:209` for a guard and find a log line |
| 3 | "it converts ~849 **silent writes** into refusals" | "up to ~849 **collision groups** would stop being acted on and start being refused", with both wrong halves named | wrong twice, in the section a human reads to make a business call |

On #3 specifically — the two errors, since this is the one that could have changed a decision:

- **Not silent.** The advisory fires on every one of those groups; it simply did not say *what* it had done, which is exactly what #4387 fixed. The refusal side is logged one layer up as `intake.delivery.identity_unresolved`.
- **Not all writes.** An unknown share resolve to `skipped_no_change`, where nothing is written at all — the very branch this whole investigation turned on.

849 counts **collision groups**. The number of writes actually prevented has not been measured, and the line now says that rather than implying a measurement it never had.

## What this does not change

No finding, no `file:line` evidence, no conclusion, no frontmatter. The R1 token stays `kimi-k3` — a single vocabulary token, per the gate's contract.

## Verification

- `scripts/lint_retracted_claims.py --selftest` → rc 0, then `--all` → `OK — 2421 file(s) scanned, no un-annotated retracted claim`
- `git diff --stat` → one file, +13/-6
- Every corrected line re-derived against the source in this session: `crm_push.py` guard/warning/return positions read on disk, not recalled

## Lineage

Third and fourth strata of the lesson this note is itself about: **a correction is a new claim**, and the description of a finding decays even when the finding holds. #4374 → #4384 (retraction) → #4387 (the cure) → this.