### PR TITLE
fix(clients): surface stats-fetch failure instead of rendering 0

### DIFF
--- a/apps/mouth/src/app/(workspace)/clients/page.tsx
+++ b/apps/mouth/src/app/(workspace)/clients/page.tsx
@@ -352,7 +352,7 @@ function ClientsListContent() {
   });
 
   // Stats hook
-  const { data: stats } = useCrmStats();
+  const { data: stats, isError: statsError } = useCrmStats();
 
   // Load team assignees from API (not just from loaded clients)
   const { data: assigneesData } = useQuery({
@@ -564,6 +564,14 @@ function ClientsListContent() {
             {stats && (
               <span className="ml-2 text-xs">• {stats.totalClients} total</span>
             )}
+            {statsError && (
+              <span
+                className="ml-2 text-xs"
+                style={{ color: "var(--state-danger)" }}
+              >
+                • stats unavailable
+              </span>
+            )}
           </>
         }
         actions={
@@ -643,6 +651,11 @@ function ClientsListContent() {
       />
 
       {/* Revenue Stats Ribbon */}
+      {statsError && isMounted && (
+        <p className="text-xs" style={{ color: "var(--state-danger)" }}>
+          Stats unavailable — retry to reload counts.
+        </p>
+      )}
       {stats && isMounted && (
         <StatChips
           className="flex flex-wrap gap-3 text-xs"

--- a/apps/mouth/src/hooks/useCrmClients.test.tsx
+++ b/apps/mouth/src/hooks/useCrmClients.test.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/api";
+import { useCrmStats } from "./useCrmClients";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    crm: {
+      request: vi.fn(),
+      getPracticeStats: vi.fn(),
+      getInteractionStats: vi.fn(),
+    },
+  },
+}));
+vi.mock("@/lib/logger");
+
+const practiceStatsFixture = {
+  total_practices: 0,
+  active_practices: 0,
+  by_status: {},
+  by_type: [],
+  revenue: { total_revenue: 0, paid_revenue: 0, outstanding_revenue: 0 },
+};
+
+const interactionStatsFixture = {
+  total_interactions: 0,
+  last_7_days: 0,
+  by_type: {},
+  by_sentiment: {},
+  by_team_member: [],
+};
+
+const createClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+const wrapperFor =
+  (queryClient: QueryClient) =>
+  ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+const mockedRequest = vi.mocked(api.crm.request);
+const mockedGetPracticeStats = vi.mocked(api.crm.getPracticeStats);
+const mockedGetInteractionStats = vi.mocked(api.crm.getInteractionStats);
+
+describe("useCrmStats — client-stats failure vs genuine zero", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetPracticeStats.mockResolvedValue(practiceStatsFixture);
+    mockedGetInteractionStats.mockResolvedValue(interactionStatsFixture);
+  });
+
+  // GUILT: the client-stats endpoint fails (e.g. a 503 while the rag process
+  // is down). Before the fix, Promise.allSettled swallowed this into
+  // `totalClients: 0` — a real outage rendered identically to an empty book.
+  // clients/page.tsx has no isError guard of its own for this value; it
+  // renders "N total" only when `stats` (the query's `data`) is truthy. The
+  // only way the page can avoid ever showing "0 total" on a failure is for
+  // this query to actually reject, so `data` stays `undefined`.
+  it("does not resolve totalClients=0 when the client-stats fetch rejects", async () => {
+    mockedRequest.mockRejectedValue(new Error("503 Service Unavailable"));
+
+    const queryClient = createClient();
+    const { result } = renderHook(() => useCrmStats(), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isError).toBe(true);
+  });
+
+  // INNOCENCE: the client-stats endpoint succeeds and genuinely reports zero
+  // clients (a real empty book). This must still resolve normally — the fix
+  // must not turn a legitimate 0 into an error state.
+  it("resolves totalClients=0 with no error when the fetch succeeds with a real zero", async () => {
+    mockedRequest.mockResolvedValue({
+      total: 0,
+      by_status: {},
+      by_team_member: [],
+      passport_expired: 0,
+      passport_expiring_soon: 0,
+      silent_30d: 0,
+    });
+
+    const queryClient = createClient();
+    const { result } = renderHook(() => useCrmStats(), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.totalClients).toBe(0);
+    expect(result.current.isError).toBe(false);
+  });
+});

--- a/apps/mouth/src/hooks/useCrmClients.ts
+++ b/apps/mouth/src/hooks/useCrmClients.ts
@@ -277,8 +277,17 @@ export function useCrmStats() {
           api.crm.getInteractionStats(),
         ]);
 
-      const clientStats =
-        clientResult.status === "fulfilled" ? clientResult.value : null;
+      // clientStats backs totalClients, the count clients/page.tsx renders as
+      // "N total" with no isError guard of its own — it relies on this
+      // query's isError instead. A failed fetch here must surface as a query
+      // error, not silently coalesce into 0 (a stats-endpoint 503 was
+      // rendering as a legitimate empty book). practice/interaction stats
+      // keep degrading independently below — that tolerance is a separate,
+      // unrelated concern.
+      if (clientResult.status === "rejected") {
+        throw clientResult.reason;
+      }
+      const clientStats = clientResult.value;
       const practiceStats =
         practiceResult.status === "fulfilled" ? practiceResult.value : null;
       const interactionStats =
@@ -287,18 +296,18 @@ export function useCrmStats() {
           : null;
 
       return {
-        totalClients: clientStats?.total ?? 0,
+        totalClients: clientStats.total,
         activePractices: practiceStats?.active_practices ?? 0,
         revenue: {
           total: practiceStats?.revenue?.total_revenue ?? 0,
           paid: practiceStats?.revenue?.paid_revenue ?? 0,
           outstanding: practiceStats?.revenue?.outstanding_revenue ?? 0,
         },
-        byStatus: clientStats?.by_status ?? {},
+        byStatus: clientStats.by_status ?? {},
         interactions: interactionStats ?? null,
-        passportExpired: clientStats?.passport_expired ?? 0,
-        passportExpiringSoon: clientStats?.passport_expiring_soon ?? 0,
-        silent30d: clientStats?.silent_30d ?? 0,
+        passportExpired: clientStats.passport_expired ?? 0,
+        passportExpiringSoon: clientStats.passport_expiring_soon ?? 0,
+        silent30d: clientStats.silent_30d ?? 0,
       };
     },
     staleTime: 5 * 60 * 1000, // 5 minutes


### PR DESCRIPTION
## 1. Insight

SCOPE — clients: distinguish stats failure from a genuine zero

1. GOAL        : When /api/crm/clients/stats/overview fails, /clients no longer renders "0 total" as if it were measured; it states the figure is unavailable.
2. NON-GOAL    : Does not touch packages/core. Does not touch apps/backend-rag. Does not touch the existing isError guard for the client list at apps/mouth/src/app/(workspace)/clients/page.tsx:522 — that one is already correct. Does not change practice/interaction stats degradation.
3. FILES       : apps/mouth/src/hooks/useCrmClients.ts · apps/mouth/src/app/(workspace)/clients/page.tsx · apps/mouth/src/hooks/useCrmClients.test.tsx (new)
4. MEASURED BY : npx vitest run src/hooks/useCrmClients.test.tsx — two cases, guilt and innocence.
5. ROLLBACK    : gh pr revert <N>. No migration, no DB, no config.
6. DONE WHEN   : State 4 — PR open, CI green, stopped at gh pr ready. State 6 is not reachable today: production is behind origin/main and promote is operator territory.

## 2. Studio

WHAT changes for the user, on /clients only:

- Before: when the stats endpoint failed, the header showed "• 0 total" and the StatChips ribbon disappeared with no explanation. A failed fetch was indistinguishable from an empty client book.
- After: the header shows "• stats unavailable" and the ribbon area shows "Stats unavailable — retry to reload counts." Both in var(--state-danger).
- Unchanged: a successful response carrying total: 0 still renders "• 0 total" with no error marker. The client list's own error and empty states are untouched.

WHERE:

- apps/mouth/src/hooks/useCrmClients.ts:277-312 — useCrmStats — VERDE
- apps/mouth/src/app/(workspace)/clients/page.tsx:355, :567-574, :654-658 — ClientsListContent — VERDE
- apps/mouth/src/hooks/useCrmClients.test.tsx — new file — VERDE

Two surfaces are marked deliberately, not by duplication: the header replaces the "• N total" count, the ribbon replaces the StatChips block. Marking only one would leave the other silently blank — the same failure mode this PR closes.

## 3. Source

Todoist: PR /clients — bedakan "kosong" dari "tidak bisa tahu" (GO sudah turun, pola #2183).
Written GO from Antonello, email 18 Aug 2026.
Origin incident: 18 Aug 2026, Fly process-group `rag` stopped by user, `api` alive, /health green, UI reporting an empty client book.

Branch cut from origin/main at 548b3ab3e.

## 4. Methodology

Three read-only phases before any edit, each stopping for review:

- Phase 1  — map the /clients surface and its zone boundary.
- Phase 1B — trace the render path for the empty state.
- Phase 1C — read the backend to determine what it actually returns when a dependency is down.

Only after Phase 1C established which failure class was unguarded was any file changed. Every command was run with explicit --exclude-dir=node_modules --exclude-dir=coverage; ripgrep is absent on this machine.

## 5. Raw Observations

Measured this session, on branch sancho/clients-empty-vs-unknown at 548b3ab3e:

- `grep -rn "useCrmStats" apps/mouth/src --exclude-dir=node_modules --exclude-dir=coverage` → 8 lines across 4 files. One consumer page: apps/mouth/src/app/(workspace)/clients/page.tsx (lines 57 and 355). No other page consumes this hook, so the behaviour change has no blast radius beyond /clients.
- `git diff --stat` → 2 files changed, 30 insertions, 8 deletions. Plus 1 new test file.
- `npx tsc --noEmit` → rc=0, 0 lines of output.
- `npm run build` → rc=0. 1763/1763 static pages generated. /clients and /clients/[id] generated normally. assert-public-login-bundle.mjs passed.
- `npx vitest run src/hooks/useCrmClients.test.tsx` → rc=0, 2 files… 2 tests passed.
- `npm run lint` → rc=2. NOT MEASURABLE on this machine, see Risk.
- apps/mouth/public/llms-full.txt was regenerated by the build step and discarded with `git checkout --` before staging.

Backend read, not owned — the paths that made the diagnosis possible:

- apps/backend-rag/backend/app/routers/crm_clients.py:757 — GET handler, response_model=list[ClientResponse], a bare array with no envelope.
- apps/backend-rag/backend/app/routers/crm_clients.py:967-970 — every exception re-raised; no branch returns an empty list.
- rag_proxy.py:296-313 — ConnectError → 503, TimeoutException → 504.
- deps/database.py:42-49 — missing pool → 503.

## 6. Reasoning Path

The task described the bug as "No clients found" shown when the fetch had failed. That premise turned out to be wrong, and the correction is the substance of this PR.

Phase 1B found that the client list already separates the two states: page.tsx:522 early-returns on isError with "Error loading clients", so the ternary that renders "No clients found" at :1355 is only reachable when the fetch genuinely succeeded. That guard is correct and was left alone.

My follow-up hypothesis — that the backend answers 200 with an empty array when a dependency is down — was also wrong. Phase 1C traced four layers and every failure path produces a non-2xx.

The unguarded path was elsewhere. useCrmStats wraps three fetches in Promise.allSettled and coalesced a rejected client-stats fetch to `totalClients: clientStats?.total ?? 0`. A rejected promise inside allSettled still resolves the outer query, so isError stayed false permanently and the UI rendered 0 as a measured figure. That is the same class as the incident: a surface saying "nothing" when the truth is "I cannot know".

The fix rethrows only the client-stats rejection. practice and interaction stats keep their independent tolerance — that is a separate concern, recorded as its own Todoist item rather than absorbed here.

## 7. Risk

- `npm run lint` is NOT MEASURABLE on this machine. ESLint 10.3.0 crashes with `TypeError: scopeManager.addGlobals is not a function` before reading any file; the stack originates in eslint/lib/languages/js/source-code/source-code.js:221. This is neither "lint clean" nor "lint failing" — the lint gate rests entirely on CI for this PR.
- Behaviour change: useCrmStats now reports isError when client-stats fails, where it previously always resolved. Measured blast radius: one consumer page (see Raw Observations). tsc and build both pass with no consumer changes.
- practice/interaction stats retain the silent-degradation pattern. Deliberately out of scope; separate item.
- Not verified live. Production is behind origin/main and promote is operator territory, so state 6 cannot be reached from this PR today.

## 8. Implication

A guard that only covers the throwing failure class does not cover the coalescing one. The client list had a correct guard and the stats bar, on the same page and fed by the same outage, had none — and no coverage report would have flagged it, because the surface was never blank.

The general form: `?? 0` on a value that originates in a network call converts an unknown into a plausible number. Every remaining `?? 0` fed by a fetch in this codebase is a candidate for the same defect.

## 9. Recommendation

Rekomendasi: Tinggi — merge as is.

The change is small, VERDE-only, covered by both a guilt and an innocence test, and closes a failure class that was live during the 18 Aug incident. The lint gate is unmeasurable locally and must be read from CI before merging.

## 10. Next Action

Mine: stop here at gh pr ready, per the auto-merge suspension of 13 Aug 2026. No arming, no merge, no promote. Separate Todoist item opened for the practice/interaction stats degradation.

Yours: review, arm, merge, and prove live — including confirming the lint check passed on CI, since it could not be measured locally.
