### PR TITLE
test(crm): give the sole-match advisory test an internal positive control

### DIFF
--- a/apps/backend-rag/backend/tests/routers/test_crm_clients_upsert_by_phone.py
+++ b/apps/backend-rag/backend/tests/routers/test_crm_clients_upsert_by_phone.py
@@ -439,8 +439,48 @@ def test_sole_match_writes_no_advisory_at_all(
     client: TestClient, write_enabled: None, mock_db_pool, caplog: pytest.LogCaptureFixture
 ) -> None:
     """INNOCENCE: one match is not a collision — the guard is `> 1`, so a
-    no-op on a SINGLE row must stay silent rather than gain a new alarm."""
+    no-op on a SINGLE row must stay silent rather than gain a new alarm.
+
+    `_advisory_lines(caplog) == []` is vacuous on its own: it passes just as
+    well if caplog capture is misconfigured, the logger name/propagation is
+    off, or `_advisory_lines`'s match string stops matching the real
+    advisory format — any of those makes the list empty for the WRONG
+    reason. So before trusting silence, this test first proves — through
+    this exact fixture/caplog/logger wiring, in THIS test — that the
+    capture chain CAN see an advisory: it drives the same production code
+    path through a genuine duplicate-match write (the fixture reused from
+    test_shared_phone_advisory_names_a_real_write_as_such) and asserts that
+    DOES produce a line. Only then does it clear caplog and assert silence
+    on the sole-match case below.
+    """
     _pool, conn = mock_db_pool
+
+    # --- positive control: a genuine duplicate-match write must be visible
+    # through this same caplog/logger wiring, via the real advisory code path.
+    conn.fetch.return_value = [
+        {"id": 1, "full_name": "Spouse A", "notes": "", "deleted_at": None,
+         "strategic_recap_source": None, "updated_at": None},
+        {"id": 2, "full_name": "Spouse B", "notes": "", "deleted_at": None,
+         "strategic_recap_source": None, "updated_at": None},
+    ]
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        control_resp = client.post(
+            "/api/crm/clients/upsert-by-phone",
+            json={"phone_normalized": "6281234567", "notes_append": "x"},
+            headers=HEADERS,
+        )
+    assert control_resp.status_code == 200, control_resp.text
+    assert control_resp.json()["action"] == "enriched"
+    control_lines = _advisory_lines(caplog)
+    assert len(control_lines) == 1, (
+        "positive control saw no advisory line for a genuine duplicate-match "
+        "write — caplog capture, logger propagation, or _advisory_lines's "
+        "match string is broken here, so the silence assertion below would "
+        "be meaningless"
+    )
+    caplog.clear()
+
+    # --- case under test: a single match is not a collision, must stay silent.
     conn.fetch.return_value = [
         {
             "id": 7,


### PR DESCRIPTION
## The defect

`test_sole_match_writes_no_advisory_at_all` asserted only:

```python
assert _advisory_lines(caplog) == []
```

That is vacuous **standalone**: the list comes out empty just the same if caplog capture is misconfigured, the logger name/propagation is off, or `_advisory_lines`'s match string stops matching the real advisory format — any of those makes it pass while asserting nothing. It only had meaning because a sibling test in the same file (`test_shared_phone_advisory_names_a_real_write_as_such`) proved capture works — nothing *inside this test* said so.

## The cure — internal positive control

Before asserting silence, the test now drives the same production advisory code path through a genuine duplicate-match write (the exact two-row fixture reused verbatim from `test_shared_phone_advisory_names_a_real_write_as_such`) and asserts that control produces exactly one advisory line, through this test's own `caplog`/logger wiring. Only then does it `caplog.clear()` and run the original sole-match assertion.

No new scaffolding — reuses the existing `_advisory_lines` helper and `_LOGGER` constant already defined in the file. The control goes through the same production code (`POST /api/crm/clients/upsert-by-phone` → the real advisory `logger.warning` call), not a hand-emitted log line — a hand-emitted line would only prove caplog itself works, not that *this module's* advisory path is observable.

## Mutation verification (empirical, not asserted)

Mutation applied: `_ADVISORY = "clients share a phone"` → `_ADVISORY = "clients share a phone MUTATED-NO-MATCH"` (breaks `_advisory_lines`'s substring match against the real, unchanged log line).

| state | result |
|---|---|
| hardened test + mutation | **FAILS** — on the positive control's own assertion (`len(control_lines) == 1`), with the captured log showing the real WARNING line *was* emitted (`... 2 clients share a phone (action=enriched id=1) ...`) but no longer matched — exactly the "logger works, matcher broke" failure mode the control exists to catch |
| **old** (pre-cure) test body + same mutation | **PASSES** vacuously — confirmed empirically by swapping in the original function body from `main` (`226340a8b`) while keeping the mutation in place, then re-running just that test |
| hardened test, mutation reverted | **PASSES** (green) |

Both the mutation and the temporary body-swap were fully reverted before committing. `git diff` against `origin/main` shows only the intended control added — no leftover mutation artifacts.

## Verification

- Full file: `PYTHONPATH=. pytest backend/tests/routers/test_crm_clients_upsert_by_phone.py -q` → 17/17 green, exit 0
- `python -c "from backend.app.dependencies import get_current_user"` → OK
- `scripts/lint_test_reward_hacking.py` on the file → clean
- Pre-commit + pre-push hooks: all passed

## Scope

Test file only — no production code touched. If the cure had needed a production-code change I was instructed to stop and report instead; it didn't.

Not auto-merging this — leaving armed for review per the requester's instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>