### PR TITLE
fix(ci): make the production-image build alarm reachable, and guard the class

### DIFF
--- a/.github/workflows/immune-enforcement.yml
+++ b/.github/workflows/immune-enforcement.yml
@@ -239,6 +239,8 @@ jobs:
               scripts/ci/check_required_workflow_conformance.py|\
               scripts/tests/test_required_context_map.py|\
               scripts/tests/test_check_required_workflow_conformance.py|\
+              scripts/ci/lint_unreachable_workflow_conditions.py|\
+              scripts/tests/test_unreachable_workflow_conditions.py|\
               infra/required.d/contexts.json|\
               infra/guard-conformance/registry.json|\
               infra/guard-conformance/check_guard_conformance.py|\
@@ -370,7 +372,8 @@ jobs:
             scripts/tests/test_drive_watchdog_tier_ratchet.py \
             scripts/test_lint_test_reward_hacking.py \
             scripts/tests/test_required_context_map.py \
-            scripts/tests/test_check_required_workflow_conformance.py ; do
+            scripts/tests/test_check_required_workflow_conformance.py \
+            scripts/tests/test_unreachable_workflow_conditions.py ; do
             if [ -f "$t" ]; then
               echo "::group::$t"
               python -m pytest "$t" -q || fail=1
@@ -849,6 +852,24 @@ jobs:
           # clean today — a censused guard that no workflow actually runs against
           # live data is theater (W81).
           python3 scripts/ci/check_required_workflow_conformance.py
+
+      - name: "Unreachable workflow if: conditions (security.yml orphaned-alarm class)"
+        if: steps.paths.outputs.relevant == 'true'
+        run: |
+          # scripts/ci/lint_unreachable_workflow_conditions.py + its corpus
+          # (test_unreachable_workflow_conditions.py, in the batch loop above)
+          # shipped together, curing security.yml's Telegram-alert `if:` in
+          # the same PR (commit 4e2d8367e / #4218 narrowed `on.push.branches`
+          # and orphaned it — armed and mute for four days, until the
+          # 2026-08-20 unbuildable-image incident alarmed nobody). The
+          # guilt+innocence corpus above proves the CHECKER can still bite;
+          # this step proves the REAL repo tree is clean today — a censused
+          # guard that no workflow actually runs against live data is
+          # theater (W81). Verified empirically (2026-08-20): 93 tracked
+          # workflows, 10 in-scope `if:` conditions, 0 findings, 6 UNDECIDED
+          # (all outside the declared decidable shape — see the tool's own
+          # module docstring — never silently read as clean).
+          python3 scripts/ci/lint_unreachable_workflow_conditions.py
 
       - name: declared-pairs.json is valid JSON with sane shape
         if: steps.paths.outputs.relevant == 'true'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -247,9 +247,18 @@ jobs:
       # scheduled workflows (e.g. cron-cert-monitor.yml) already read
       # `secrets.TELEGRAM_BOT_TOKEN`/`secrets.TELEGRAM_OWNER_CHAT_ID` live under
       # `on: schedule:` with no special-casing.
-      - name: Telegram alert — production image failed to BUILD on main
+      # The alert NAMES the ref it fired on rather than asserting one. The step
+      # used to be titled "... on main" and say so in its body — true while the
+      # only trigger was a push to main, and a lie the moment the condition
+      # above gained the `develop` push and the scheduled run. An alert that
+      # inventories mutable state mislead exactly the person reading it at
+      # 07:30 (W114/W106), and it is the same belief that produced the
+      # condition, so the two must not be able to disagree. `github.ref_name`
+      # is `develop` on the push and the default branch on the scheduled run.
+      - name: Telegram alert — production image failed to BUILD
         if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/develop'))
         env:
+          REF: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -267,7 +276,7 @@ jobs:
           # column 0 CLOSES the YAML scalar, and the file stops being valid
           # YAML — caught by actionlint before this ever ran.
           TEXT="$(printf '%s\n' \
-            "🐳 <b>nuzantara-rag image failed to BUILD on main</b>" \
+            "🐳 <b>nuzantara-rag image failed to BUILD on ${REF}</b>" \
             "" \
             "<code>${SHA:0:8}</code>" \
             "" \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -226,11 +226,29 @@ jobs:
       # failures at 19:57, 19:58, 20:06, 20:20 and 20:24, recovering by 20:42 — broke
       # the production image build repeatedly without anyone being told.
       #
-      # Restricted to pushes on main on purpose: on a pull request the author already
-      # has the signal, and duplicating it there would only train people to ignore the
-      # channel. `secrets.*` is available on main pushes.
+      # Restricted to non-PR triggers on purpose: on a pull request the author
+      # already has the signal, and duplicating it there would only train people
+      # to ignore the channel. That was originally written as `event_name=='push'
+      # && ref=='refs/heads/main'`, which commit 4e2d8367e (#4218, 2026-08-16)
+      # orphaned: narrowing `on.push.branches` from `[main, develop]` to
+      # `[develop]` means GitHub's own branch filter now guarantees
+      # `event_name=='push' ⟹ ref=='refs/heads/develop'` — the old conjunct
+      # against `refs/heads/main` became a standing contradiction, so this step
+      # could never fire on a push, and under `schedule` (the daily backstop
+      # #4218 named as the intended replacement) `event_name` is never `'push'`
+      # either. The alarm was armed and mute. Proven live: the 2026-08-20
+      # unbuildable image (upstream `claude-code@2.1.237` published without its
+      # `linux-x64` tarball) alarmed nobody. The condition below now names
+      # exactly the two triggers this `on:` block can actually deliver a
+      # failure() run through — a push to `develop`, or the daily `schedule`
+      # run (which always executes against the default branch, i.e. main).
+      # `secrets.*` is available on both: `schedule` only ever fires on the
+      # default branch, never a fork PR context, and this repo's other
+      # scheduled workflows (e.g. cron-cert-monitor.yml) already read
+      # `secrets.TELEGRAM_BOT_TOKEN`/`secrets.TELEGRAM_OWNER_CHAT_ID` live under
+      # `on: schedule:` with no special-casing.
       - name: Telegram alert — production image failed to BUILD on main
-        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/develop'))
         env:
           SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/scripts/ci/lint_unreachable_workflow_conditions.py
+++ b/scripts/ci/lint_unreachable_workflow_conditions.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env python3
+"""lint_unreachable_workflow_conditions.py — catches the security.yml class
+of bug: an `on:` trigger narrowing that leaves a job/step `if:` condition a
+standing contradiction, so it can never fire again.
+
+WHY THIS EXISTS (cicatrix-superscar.md #9, "State-schema mutation drift" —
+an `if:` is a measurement of the world, frozen the day it was written; a
+later `on:` narrowing does not re-take that measurement, W106/W106b).
+Commit `4e2d8367e` (#4218, 2026-08-16) narrowed `security.yml`'s
+`on.push.branches` from `[main, develop]` to `[develop]` and left a Telegram
+alert step's `if: event_name=='push' && ref=='refs/heads/main'` untouched.
+GitHub's own branch filter means `event_name=='push'` now IMPLIES
+`ref=='refs/heads/develop'` — the conjunct against `refs/heads/main` became
+a standing contradiction, and the step could never fire. The daily
+`schedule` backstop the commit message named as the intended replacement
+never satisfies `event_name=='push'` either. The alarm was armed and mute
+for four days, until an unbuildable production image (2026-08-20, upstream
+`claude-code@2.1.237` published without its `linux-x64` tarball) alarmed
+nobody. See `.github/workflows/security.yml`'s own comment above that step
+for the full story, and this cure's sibling PR for the fix.
+
+WHAT THIS DOES: for every tracked `.github/workflows/*.yml` (`git ls-files`,
+never a glob — rule 5, judge only what git tracks), parses the `on:` block
+into the set of (event, ref-constraint) TRIGGER PATHS the workflow can
+actually run under (`extract_trigger_paths()`), then for every job-level and
+step-level `if:` that mentions `github.event_name` or `github.ref` (the only
+two fields this module reasons about — an `if:` that never names either is
+entirely out of scope and is not even counted as undecided, e.g.
+`needs.build.result == 'success'`), decides whether the condition can
+possibly evaluate true under AT LEAST ONE of those trigger paths. An `if:`
+that is false under every trigger path the workflow's OWN `on:` block can
+produce is reported as a finding: file, line (best-effort), the verbatim
+`if:` text, the relevant `on:` fragment, and a per-trigger-path mechanism
+trace auto-derived from the same evaluator that made the call (never
+hand-authored prose that could drift from the code that decided).
+
+DECLARED LIMITS (rule 2 — printed as a clearly separated "not analyzed"
+list, never silently folded into a "0 findings" clean report — W84/W102: an
+empty finding list from a blind or capped scan must never read as clean):
+
+  1. DECIDABLE EXPRESSION SHAPE — only conjunctions/disjunctions of
+     `github.event_name == '<literal>'` and `github.ref == '<literal>'`
+     (either operand order), combined with `&&` / `||` / parentheses, with
+     `failure()` / `success()` / `always()` / `cancelled()` treated as free
+     (always true — this module never reasons about job/step outcome, only
+     about which trigger reached it). `!=`, `!` (NOT), any function call
+     with arguments (`contains(...)`, `startsWith(...)`, ...), any other
+     `github.*`/`steps.*`/`needs.*`/`inputs.*` field, and any literal that
+     isn't a quoted string are all OUTSIDE this shape. Encountering any of
+     them anywhere in an `if:` marks the WHOLE condition UNDECIDED — this
+     module never partially evaluates one side of a boundary-crossing `&&`.
+  2. REF SEMANTICS PER EVENT — only `push: branches: [...]` (exact names or
+     glob patterns, matched via `fnmatch` against the branch component of a
+     `refs/heads/...` literal) is modeled precisely. `branches-ignore:`,
+     `tags:`, `tags-ignore:`, or a `push:` with none of these keys, and
+     EVERY OTHER event (`pull_request`, `pull_request_target`,
+     `merge_group`, `schedule`, `workflow_dispatch`, `workflow_call`, or any
+     event key this module does not special-case) all get an unconstrained
+     ref — `github.ref == '<anything>'` is treated as POSSIBLY true. This is
+     deliberate: rule 4 of the build spec requires bias toward silence — an
+     unconstrained/unknown ref can only produce a MISSED unreachable
+     condition (e.g. a `schedule`-only `if:` that names a `ref` value the
+     default branch never actually is), never a FALSE accusation. In
+     particular `schedule` genuinely always runs against the repo's default
+     branch (GitHub docs), but that branch's NAME is a repo-config fact this
+     module cannot read from a workflow file — asserting it here would be a
+     guess dressed as a fact (cicatrix-superscar W106b: don't hardcode a
+     measurement of the world), so `schedule`'s ref is left unconstrained
+     rather than guessed. Same reasoning for `merge_group` (real ref is
+     `refs/heads/gh-readonly-queue/...`, never asserted equal to anything).
+  3. `on.push.paths` / `on.pull_request.paths` and any `types:` filter are
+     never modeled — they gate whether a run STARTS at all, not what
+     `github.event_name`/`github.ref` it carries once it does; irrelevant to
+     this module's question.
+
+Verified empirically against this repo (2026-08-20, 93 tracked workflows):
+exactly 5 `if:` conditions mention `github.event_name` or `github.ref`
+across 4 files; one (`main-push-failure-watch.yml`'s `alert` job, which
+compares `github.event.workflow_run.event`/`.head_branch` — fields outside
+this module's shape) is UNDECIDED by design; the other four, including the
+cured `security.yml` condition, are all satisfiable and unflagged.
+
+Usage:
+    python3 scripts/ci/lint_unreachable_workflow_conditions.py [--repo-root .]
+
+Exit codes: 0 zero findings (an UNDECIDED-only or fully-clean run) ·
+1 one or more unreachable `if:` conditions found ·
+2 CANNOT VERIFY — PyYAML missing, `git ls-files` failed, zero tracked
+workflow files matched, or a workflow file failed to parse as YAML
+(W84 "esiste ≠ armato": a blind/broken scan must never exit 0).
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "lint_unreachable_workflow_conditions: CANNOT VERIFY — PyYAML is not "
+        "installed (pip install pyyaml)",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Only these two fields are modeled. An `if:` that never names either, as a
+# whole word (so `github.ref_name`/`github.ref_type`/`github.ref_protected`
+# do NOT count as naming `github.ref` — different fields, deliberately not
+# matched by a bare substring per cicatrix-superscar #3's own rule: judge
+# the entity, not the form), is entirely out of this guard's scope.
+_RELEVANT_FIELD_RE = re.compile(r"\bgithub\.(event_name|ref)\b")
+_FREE_FUNCS = ("failure", "success", "always", "cancelled")
+
+
+# --------------------------------------------------------------- trigger model
+
+
+@dataclass(frozen=True)
+class TriggerPath:
+    """One (event, ref-constraint) pair a workflow's `on:` block can actually
+    deliver a `failure()`-eligible run through. `ref_matcher` decides, for a
+    literal like `'refs/heads/main'`, whether THIS trigger path could ever
+    carry that as `github.ref`. `description` is a short human label for
+    reporting — never used for the decision itself."""
+
+    event: str
+    ref_matcher: Callable[[str], bool]
+    description: str
+
+    def ref_satisfies(self, ref_literal: str) -> bool:
+        return self.ref_matcher(ref_literal)
+
+
+def _any_ref(_: str) -> bool:
+    """Ref is unconstrained/unknown for this trigger path — bias toward
+    'satisfiable' (declared limit #2 above). Named, not a bare lambda, so a
+    trace built from it reads clearly."""
+    return True
+
+
+def _push_ref_matcher(branches: list[str]) -> Callable[[str], bool]:
+    def matcher(ref_literal: str) -> bool:
+        if not ref_literal.startswith("refs/heads/"):
+            return False
+        branch = ref_literal[len("refs/heads/") :]
+        return any(fnmatch.fnmatch(branch, pattern) for pattern in branches if isinstance(pattern, str))
+
+    return matcher
+
+
+def _is_exact_branch_push(cfg: dict[str, Any]) -> bool:
+    """True only when `branches:` is the SOLE ref-relevant filter key present.
+    Combining it with `branches-ignore`/`tags`/`tags-ignore` changes the
+    semantics in ways this module does not model (declared limit #2) — falls
+    back to `_any_ref` instead of guessing."""
+    if "branches" not in cfg or not isinstance(cfg["branches"], list):
+        return False
+    return not any(k in cfg for k in ("branches-ignore", "tags", "tags-ignore"))
+
+
+def extract_trigger_paths(on_block: Any) -> list[TriggerPath]:
+    """Builds the trigger-path set from a parsed `on:` block. Accepts all
+    three YAML shapes GitHub allows: a bare string (`on: push`), a list
+    (`on: [push, pull_request]`), or a mapping (the common case)."""
+    if on_block is None:
+        return []
+    if isinstance(on_block, str):
+        return [TriggerPath(event=on_block, ref_matcher=_any_ref, description=on_block)]
+    if isinstance(on_block, list):
+        return [
+            TriggerPath(event=e, ref_matcher=_any_ref, description=e)
+            for e in on_block
+            if isinstance(e, str)
+        ]
+    if not isinstance(on_block, dict):
+        return []
+
+    paths: list[TriggerPath] = []
+    for event, cfg in on_block.items():
+        if not isinstance(event, str):
+            continue
+        if event == "push" and isinstance(cfg, dict) and _is_exact_branch_push(cfg):
+            branches = [b for b in cfg["branches"] if isinstance(b, str)]
+            paths.append(
+                TriggerPath(
+                    event="push",
+                    ref_matcher=_push_ref_matcher(branches),
+                    description=f"push (branches: {branches!r})",
+                )
+            )
+        else:
+            paths.append(TriggerPath(event=event, ref_matcher=_any_ref, description=event))
+    return paths
+
+
+def _on_block(doc: Any) -> Any:
+    """PyYAML parses a bare `on:` key as the boolean `True` (YAML 1.1 boolean
+    literal) — `doc.get(True) or doc.get('on')` covers both spellings, same
+    pattern as scripts/ci/check_required_workflow_conformance.py and
+    scripts/verify_main_watch_schedule_scope.py."""
+    if not isinstance(doc, dict):
+        return None
+    if True in doc:
+        return doc[True]
+    return doc.get("on")
+
+
+# --------------------------------------------------------------- expression parser
+#
+# A hand-rolled recursive-descent parser/evaluator for the DELIBERATELY
+# NARROW shape declared in the module docstring. This is not, and must never
+# grow into, a general GitHub Actions expression interpreter (same "known
+# limit" discipline as scripts/verify_main_watch_schedule_scope.py and
+# scripts/check_watcher_coverage.py) — anything outside the shape raises
+# _UnsupportedExpression, which the caller turns into an UNDECIDED entry,
+# never a guess.
+
+
+class _UnsupportedExpression(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class _Token:
+    kind: str
+    value: str
+
+
+_TOKEN_RE = re.compile(
+    r"""
+    \s*(?:
+        (?P<lparen>\()  |
+        (?P<rparen>\))  |
+        (?P<and>&&)     |
+        (?P<or>\|\|)    |
+        (?P<eq>==)      |
+        (?P<ne>!=)      |
+        (?P<bang>!)     |
+        (?P<string>'[^']*'|"[^"]*") |
+        (?P<ident>[A-Za-z_][A-Za-z0-9_.]*)
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _tokenize(expr: str) -> list[_Token]:
+    tokens: list[_Token] = []
+    pos = 0
+    n = len(expr)
+    while pos < n:
+        m = _TOKEN_RE.match(expr, pos)
+        if not m or m.end() == pos:
+            if expr[pos:].strip() == "":
+                break
+            raise _UnsupportedExpression(f"unrecognized character at position {pos}: {expr[pos:pos + 12]!r}")
+        pos = m.end()
+        kind = m.lastgroup
+        assert kind is not None
+        tokens.append(_Token(kind, m.group(kind)))
+    return tokens
+
+
+def _unquote(raw: str) -> str:
+    return raw[1:-1]
+
+
+def _resolve_field(ident: str) -> str | None:
+    if ident == "github.event_name":
+        return "event_name"
+    if ident == "github.ref":
+        return "ref"
+    return None
+
+
+# AST nodes are plain tuples: ("free",) | ("cmp", field, literal) |
+# ("and", lhs, rhs) | ("or", lhs, rhs). Kept untyped deliberately — this
+# parser's whole surface is ~60 lines and a dataclass hierarchy would cost
+# more than it clarifies here.
+
+
+class _Parser:
+    def __init__(self, tokens: list[_Token]):
+        self.tokens = tokens
+        self.pos = 0
+
+    def _peek(self) -> _Token | None:
+        return self.tokens[self.pos] if self.pos < len(self.tokens) else None
+
+    def _advance(self) -> _Token:
+        tok = self._peek()
+        if tok is None:
+            raise _UnsupportedExpression("unexpected end of expression")
+        self.pos += 1
+        return tok
+
+    def parse(self) -> tuple:
+        if not self.tokens:
+            raise _UnsupportedExpression("empty expression")
+        node = self._parse_or()
+        if self.pos != len(self.tokens):
+            raise _UnsupportedExpression(f"unexpected trailing token {self._peek()!r}")
+        return node
+
+    def _parse_or(self) -> tuple:
+        node = self._parse_and()
+        while self._peek() is not None and self._peek().kind == "or":
+            self._advance()
+            node = ("or", node, self._parse_and())
+        return node
+
+    def _parse_and(self) -> tuple:
+        node = self._parse_unary()
+        while self._peek() is not None and self._peek().kind == "and":
+            self._advance()
+            node = ("and", node, self._parse_unary())
+        return node
+
+    def _parse_unary(self) -> tuple:
+        tok = self._peek()
+        if tok is None:
+            raise _UnsupportedExpression("unexpected end of expression")
+        if tok.kind == "bang":
+            raise _UnsupportedExpression("`!` (logical NOT) is outside the analyzable shape")
+        if tok.kind == "lparen":
+            self._advance()
+            node = self._parse_or()
+            close = self._peek()
+            if close is None or close.kind != "rparen":
+                raise _UnsupportedExpression("unbalanced parentheses")
+            self._advance()
+            return node
+        if tok.kind == "ident":
+            ident = self._advance()
+            nxt = self._peek()
+            if nxt is not None and nxt.kind == "lparen":
+                self._advance()
+                close = self._peek()
+                if close is None or close.kind != "rparen":
+                    raise _UnsupportedExpression(
+                        f"function call `{ident.value}(...)` with arguments is outside the analyzable shape"
+                    )
+                self._advance()
+                if ident.value not in _FREE_FUNCS:
+                    raise _UnsupportedExpression(
+                        f"function `{ident.value}()` is outside the analyzable shape "
+                        f"(only {'/'.join(_FREE_FUNCS)} are treated as free)"
+                    )
+                return ("free",)
+            return self._parse_comparison(("ident", ident.value))
+        if tok.kind == "string":
+            self._advance()
+            return self._parse_comparison(("string", _unquote(tok.value)))
+        raise _UnsupportedExpression(f"unexpected token {tok!r}")
+
+    def _parse_comparison(self, lhs: tuple[str, str]) -> tuple:
+        op = self._peek()
+        if op is None or op.kind not in ("eq", "ne"):
+            raise _UnsupportedExpression(
+                "expected `==` — a bare identifier/string outside a comparison is outside the analyzable shape"
+            )
+        if op.kind == "ne":
+            raise _UnsupportedExpression("`!=` is outside the analyzable shape (only `==` is modeled)")
+        self._advance()
+        rhs_tok = self._advance()
+        if rhs_tok.kind == "string":
+            rhs: tuple[str, str] = ("string", _unquote(rhs_tok.value))
+        elif rhs_tok.kind == "ident":
+            rhs = ("ident", rhs_tok.value)
+        else:
+            raise _UnsupportedExpression("comparison operand is outside the analyzable shape")
+
+        if lhs[0] == "ident" and rhs[0] == "string":
+            field_tok, literal = lhs[1], rhs[1]
+        elif rhs[0] == "ident" and lhs[0] == "string":
+            field_tok, literal = rhs[1], lhs[1]
+        else:
+            raise _UnsupportedExpression("comparison is not `<field> == '<literal>'` shape")
+
+        field = _resolve_field(field_tok)
+        if field is None:
+            raise _UnsupportedExpression(
+                f"`{field_tok}` is not a modeled field (only github.event_name / github.ref)"
+            )
+        return ("cmp", field, literal)
+
+
+def _evaluate(node: tuple, trigger: TriggerPath) -> bool:
+    kind = node[0]
+    if kind == "free":
+        return True
+    if kind == "cmp":
+        _, cfield, literal = node
+        if cfield == "event_name":
+            return trigger.event == literal
+        return trigger.ref_satisfies(literal)
+    if kind == "and":
+        return _evaluate(node[1], trigger) and _evaluate(node[2], trigger)
+    if kind == "or":
+        return _evaluate(node[1], trigger) or _evaluate(node[2], trigger)
+    raise AssertionError(f"unknown AST node kind {kind!r}")  # pragma: no cover
+
+
+def _explain(node: tuple, trigger: TriggerPath) -> tuple[bool, str]:
+    """Same evaluator as `_evaluate`, but also returns a human-readable trace
+    of how the verdict was reached — auto-derived from the AST that made the
+    call, so it can never drift from the decision the way hand-authored
+    prose could (cicatrix-superscar #6: don't trust a report a tool didn't
+    just produce)."""
+    kind = node[0]
+    if kind == "free":
+        return True, "(free)"
+    if kind == "cmp":
+        _, cfield, literal = node
+        if cfield == "event_name":
+            val = trigger.event == literal
+            return val, f"event_name=='{literal}' is {val} (trigger event: '{trigger.event}')"
+        val = trigger.ref_satisfies(literal)
+        return val, f"ref=='{literal}' is {val}"
+    if kind == "and":
+        lv, lt = _explain(node[1], trigger)
+        rv, rt = _explain(node[2], trigger)
+        return (lv and rv), f"({lt} && {rt})"
+    if kind == "or":
+        lv, lt = _explain(node[1], trigger)
+        rv, rt = _explain(node[2], trigger)
+        return (lv or rv), f"({lt} || {rt})"
+    raise AssertionError(f"unknown AST node kind {kind!r}")  # pragma: no cover
+
+
+def mentions_relevant_fields(if_text: str) -> bool:
+    """Pre-filter: an `if:` that never names `github.event_name`/`github.ref`
+    is entirely out of this guard's scope — e.g. `needs.build.result ==
+    'success'` — and is not even added to the 'not analyzed' list (that list
+    is for conditions this guard's DOMAIN covers but whose SHAPE it cannot
+    decide, not for every condition in every workflow)."""
+    return bool(_RELEVANT_FIELD_RE.search(if_text))
+
+
+def analyze_condition(
+    if_text: str, trigger_paths: list[TriggerPath]
+) -> tuple[bool | None, str, tuple | None]:
+    """Returns (satisfiable, reason, ast). `satisfiable` is True/False when
+    the expression is inside the analyzable shape and the workflow has at
+    least one trigger path; None means UNDECIDED, with `reason` explaining
+    why (parse failure, or zero trigger paths to evaluate against)."""
+    try:
+        tokens = _tokenize(if_text)
+        ast = _Parser(tokens).parse()
+    except _UnsupportedExpression as e:
+        return None, str(e), None
+    if not trigger_paths:
+        return None, "workflow's `on:` block yielded zero trigger paths — cannot evaluate", ast
+    satisfiable = any(_evaluate(ast, tp) for tp in trigger_paths)
+    return satisfiable, "", ast
+
+
+# --------------------------------------------------------------- workflow structure
+
+
+@dataclass
+class IfCondition:
+    file: str
+    scope: str
+    text: str
+    line: int | None = None
+
+
+_IF_LINE_RE = re.compile(r"^(?P<indent>\s*)if:\s?(?P<rest>.*)$")
+_BLOCK_SCALAR_INDICATORS = (">", ">-", ">+", "|", "|-", "|+")
+
+
+def _raw_if_lines(text: str) -> list[tuple[int, str]]:
+    """Best-effort (file line number, folded if-text) pairs scanned straight
+    from the raw file text, in document order — used ONLY to attach a line
+    number to each structurally-found `if:` for reporting. The actual
+    satisfiability analysis always uses PyYAML's parsed value (declared
+    limit: this function's block-scalar folding is an approximation of
+    YAML's real folding rules, good enough to locate a line, not trusted for
+    anything else)."""
+    lines = text.splitlines()
+    out: list[tuple[int, str]] = []
+    i = 0
+    while i < len(lines):
+        m = _IF_LINE_RE.match(lines[i])
+        if m:
+            indent = m.group("indent")
+            rest = m.group("rest").rstrip()
+            if rest in _BLOCK_SCALAR_INDICATORS:
+                collected: list[str] = []
+                j = i + 1
+                base_indent_len: int | None = None
+                while j < len(lines):
+                    line = lines[j]
+                    if line.strip() == "":
+                        j += 1
+                        continue
+                    cur_indent_len = len(line) - len(line.lstrip())
+                    if base_indent_len is None:
+                        if cur_indent_len <= len(indent):
+                            break
+                        base_indent_len = cur_indent_len
+                    if cur_indent_len < base_indent_len:
+                        break
+                    collected.append(line.strip())
+                    j += 1
+                rest = " ".join(collected)
+            out.append((i + 1, rest))
+        i += 1
+    return out
+
+
+def _iter_if_conditions(doc: dict[str, Any], file_rel: str) -> list[IfCondition]:
+    conditions: list[IfCondition] = []
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return conditions
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        job_if = job.get("if")
+        if isinstance(job_if, str):
+            conditions.append(IfCondition(file=file_rel, scope=f"job:{job_id}", text=job_if))
+        steps = job.get("steps")
+        if isinstance(steps, list):
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                step_if = step.get("if")
+                if isinstance(step_if, str):
+                    step_name = step.get("name", "<unnamed step>")
+                    conditions.append(
+                        IfCondition(file=file_rel, scope=f"job:{job_id} step:{step_name!r}", text=step_if)
+                    )
+    return conditions
+
+
+def _attach_line_numbers(conditions: list[IfCondition], raw_lines: list[tuple[int, str]]) -> None:
+    """Best-effort positional match: both `conditions` (structural traversal
+    of a dict PyYAML preserves in document order) and `raw_lines` (a
+    top-to-bottom scan) visit `if:` occurrences in the same order. A count
+    mismatch (e.g. a `with:` parameter that happens to be a step literally
+    named `if`, or a block-scalar shape this module's folding does not
+    match) degrades to a missing line number for the unmatched tail — never
+    a WRONG line, only an absent one."""
+    for cond, (line_no, _rest) in zip(conditions, raw_lines):
+        cond.line = line_no
+
+
+@dataclass
+class Finding:
+    condition: IfCondition
+    on_summary: str
+    mechanism: str
+
+
+@dataclass
+class Undecided:
+    condition: IfCondition
+    reason: str
+
+
+@dataclass
+class WorkflowResult:
+    file: str
+    parse_error: str | None = None
+    findings: list[Finding] = field(default_factory=list)
+    undecided: list[Undecided] = field(default_factory=list)
+    in_scope_count: int = 0
+
+
+def _summarize_on_block(on_block: Any, trigger_paths: list[TriggerPath]) -> str:
+    if not trigger_paths:
+        return f"on: {on_block!r} (no trigger paths extracted)"
+    return "on: " + ", ".join(tp.description for tp in trigger_paths)
+
+
+def analyze_workflow(path: Path, repo_root: Path) -> WorkflowResult:
+    rel = str(path.relative_to(repo_root))
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return WorkflowResult(file=rel, parse_error=f"could not read file: {e}")
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        return WorkflowResult(file=rel, parse_error=f"YAML parse error: {e}")
+    if not isinstance(doc, dict):
+        return WorkflowResult(file=rel, parse_error="workflow document is not a mapping")
+
+    on_block = _on_block(doc)
+    trigger_paths = extract_trigger_paths(on_block)
+    on_summary = _summarize_on_block(on_block, trigger_paths)
+
+    structural = _iter_if_conditions(doc, rel)
+    raw_lines = _raw_if_lines(text)
+    _attach_line_numbers(structural, raw_lines)
+
+    result = WorkflowResult(file=rel)
+    for cond in structural:
+        if not mentions_relevant_fields(cond.text):
+            continue
+        result.in_scope_count += 1
+        satisfiable, reason, ast = analyze_condition(cond.text, trigger_paths)
+        if satisfiable is None:
+            result.undecided.append(Undecided(condition=cond, reason=reason))
+        elif satisfiable is False:
+            assert ast is not None
+            mechanism = "\n".join(f"    - {tp.description}: {_explain(ast, tp)[1]}" for tp in trigger_paths) or (
+                "    (workflow's `on:` block produced zero trigger paths)"
+            )
+            result.findings.append(Finding(condition=cond, on_summary=on_summary, mechanism=mechanism))
+    return result
+
+
+# --------------------------------------------------------------- driver
+
+
+def discover_tracked_workflows(repo_root: Path) -> list[Path]:
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "--", ".github/workflows/*.yml", ".github/workflows/*.yaml"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        print(f"lint_unreachable_workflow_conditions: CANNOT VERIFY — `git ls-files` failed: {e}", file=sys.stderr)
+        sys.exit(2)
+    if proc.returncode != 0:
+        print(
+            f"lint_unreachable_workflow_conditions: CANNOT VERIFY — `git ls-files` exited "
+            f"{proc.returncode}: {proc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return sorted(repo_root / line for line in proc.stdout.splitlines() if line.strip())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    args = parser.parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+
+    workflows = discover_tracked_workflows(repo_root)
+    if not workflows:
+        print(
+            "lint_unreachable_workflow_conditions: CANNOT VERIFY — zero tracked "
+            ".github/workflows/*.yml files found (blind scan, W84)",
+            file=sys.stderr,
+        )
+        return 2
+
+    parse_errors: list[tuple[str, str]] = []
+    all_findings: list[Finding] = []
+    all_undecided: list[Undecided] = []
+    total_in_scope = 0
+
+    for wf in workflows:
+        result = analyze_workflow(wf, repo_root)
+        if result.parse_error:
+            parse_errors.append((result.file, result.parse_error))
+            continue
+        total_in_scope += result.in_scope_count
+        all_findings.extend(result.findings)
+        all_undecided.extend(result.undecided)
+
+    if parse_errors:
+        print(
+            f"lint_unreachable_workflow_conditions: CANNOT VERIFY — {len(parse_errors)} "
+            f"workflow(s) failed to parse:",
+            file=sys.stderr,
+        )
+        for f, err in parse_errors:
+            print(f"  ✗ {f}: {err}", file=sys.stderr)
+        return 2
+
+    print(
+        f"lint_unreachable_workflow_conditions: {len(workflows)} workflow(s) scanned, "
+        f"{total_in_scope} if: condition(s) in scope (name github.event_name/github.ref), "
+        f"{len(all_findings)} finding(s), {len(all_undecided)} not analyzed"
+    )
+
+    if all_findings:
+        print("\nUNREACHABLE — false under every trigger path this workflow's own `on:` block can produce:")
+        for finding in all_findings:
+            c = finding.condition
+            loc = f"{c.file}:{finding.condition.line}" if finding.condition.line else c.file
+            print(f"  ✗ {loc} [{c.scope}]")
+            print(f"    if: {c.text}")
+            print(f"    {finding.on_summary}")
+            print(f"    mechanism (evaluated per trigger path):")
+            print(finding.mechanism)
+
+    if all_undecided:
+        print(f"\nNOT ANALYZED ({len(all_undecided)} of {total_in_scope} in-scope condition(s)) — outside the")
+        print("decidable shape (declared limit #1 in this script's module docstring), never counted as clean:")
+        for u in all_undecided:
+            c = u.condition
+            loc = f"{c.file}:{c.line}" if c.line else c.file
+            print(f"  ? {loc} [{c.scope}]: {c.text}")
+            print(f"    reason: {u.reason}")
+
+    if not all_findings and not all_undecided:
+        print("  ✓ every in-scope if: is satisfiable under at least one real trigger path")
+
+    return 1 if all_findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/lint_unreachable_workflow_conditions.py
+++ b/scripts/ci/lint_unreachable_workflow_conditions.py
@@ -68,23 +68,56 @@ empty finding list from a blind or capped scan must never read as clean):
      measurement of the world), so `schedule`'s ref is left unconstrained
      rather than guessed. Same reasoning for `merge_group` (real ref is
      `refs/heads/gh-readonly-queue/...`, never asserted equal to anything).
+     Within the modeled `branches:` glob subset, only `fnmatch`'s own
+     metacharacters (`*`, `?`, `[seq]`, `[!seq]`) are given GitHub's
+     meaning; a pattern using `+` ("one or more of the preceding char" in
+     GitHub's own filter-pattern glob) or `\\` (GitHub's escape character) is
+     OUTSIDE that subset — `fnmatch` treats both as ordinary literal
+     characters (verified empirically: `fnmatch.fnmatch('maaan', 'ma+n')`
+     is `False`, but GitHub's glob would match it) — so any `branches:`
+     entry containing either character collapses that push trigger's ref to
+     UNCONSTRAINED rather than mismodeling it (same bias-to-silence
+     reasoning as above: more matches -> more satisfiable -> only ever a
+     missed detection, never a false accusation). The opposite kind of gap
+     — `fnmatch`'s `*`/`?` matching across a `/` where GitHub's glob would
+     not — is left unaddressed on purpose: it makes `fnmatch` MORE
+     permissive than GitHub in that one case, which can only widen
+     "satisfiable", i.e. it is a missed-detection risk, never a
+     false-accusation one.
   3. `on.push.paths` / `on.pull_request.paths` and any `types:` filter are
      never modeled — they gate whether a run STARTS at all, not what
      `github.event_name`/`github.ref` it carries once it does; irrelevant to
      this module's question.
+  4. STRING COMPARISON CASE-FOLDING — GitHub's own `==`/`!=` operators
+     ignore case for the whole compared string ("GitHub ignores case when
+     comparing strings" — docs.github.com/en/actions/reference/
+     workflows-and-actions/expressions, verified 2026-08-20), so
+     `github.event_name == 'Push'` is true on an actual `push` event and
+     `github.ref == 'REFS/HEADS/MAIN'` is true against the real
+     `refs/heads/main`. This module casefolds both sides of every
+     `event_name`/`ref` comparison to match. Inside `_push_ref_matcher`,
+     the ref literal's `refs/heads/` prefix check is casefolded for that
+     same documented reason; whether the extracted branch text then matches
+     one of `branches:`'s glob patterns is ALSO matched casefolded, but
+     that second fold is a separate, deliberate PERMISSIVE BIAS, not a
+     claim about GitHub's real (case-sensitive, per git) branch-name
+     matching — see `_push_ref_matcher`'s docstring.
 
-Verified empirically against this repo (2026-08-20, 93 tracked workflows):
-exactly 5 `if:` conditions mention `github.event_name` or `github.ref`
-across 4 files; one (`main-push-failure-watch.yml`'s `alert` job, which
-compares `github.event.workflow_run.event`/`.head_branch` — fields outside
-this module's shape) is UNDECIDED by design; the other four, including the
-cured `security.yml` condition, are all satisfiable and unflagged.
+A condition judged satisfiable ONLY because at least one witnessing trigger
+path's ref was `_any_ref` (unconstrained/unknown, declared limit #2) — i.e.
+no trigger path this workflow's `on:` block can produce proves it true
+without that assumption — is never folded into the "every in-scope if: is
+satisfiable" clean report. It is counted and printed in its own
+"SATISFIABLE ONLY UNDER AN ASSUMED/UNKNOWN REF" section instead (exit code
+unchanged): a decision made on a value this module admits it cannot know
+must never be presented as the same kind of coverage as a proven one.
 
 Usage:
     python3 scripts/ci/lint_unreachable_workflow_conditions.py [--repo-root .]
 
-Exit codes: 0 zero findings (an UNDECIDED-only or fully-clean run) ·
-1 one or more unreachable `if:` conditions found ·
+Exit codes: 0 zero findings (an UNDECIDED-only, assumed-satisfiable-only, or
+fully-clean run — none of these are a "finding") · 1 one or more unreachable
+`if:` conditions found ·
 2 CANNOT VERIFY — PyYAML missing, `git ls-files` failed, zero tracked
 workflow files matched, or a workflow file failed to parse as YAML
 (W84 "esiste ≠ armato": a blind/broken scan must never exit 0).
@@ -96,6 +129,7 @@ import fnmatch
 import re
 import subprocess
 import sys
+from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
@@ -147,12 +181,51 @@ def _any_ref(_: str) -> bool:
     return True
 
 
+_REFS_HEADS_PREFIX = "refs/heads/"
+
+# GitHub's filter-pattern glob defines `+` ("one or more of the preceding
+# character") and `\` (escape the next character) on top of the `*`/`?`/
+# `[seq]`/`[!seq]` subset `fnmatch` already shares the meaning of. `fnmatch`
+# treats both as ordinary literal characters instead (declared limit #2) —
+# a `branches:` entry using either is outside the modeled subset.
+_GITHUB_GLOB_ONLY_METACHARS = ("+", "\\")
+
+
+def _branches_use_unmodeled_glob_syntax(branches: list[str]) -> bool:
+    return any(any(ch in b for ch in _GITHUB_GLOB_ONLY_METACHARS) for b in branches)
+
+
 def _push_ref_matcher(branches: list[str]) -> Callable[[str], bool]:
+    """Decides whether a `github.ref == '<ref_literal>'` comparison could be
+    true for a push trigger constrained to `branches:` patterns.
+
+    Two DIFFERENT case-folding decisions live here, kept deliberately
+    distinct (declared limit #4):
+
+      1. The `refs/heads/` PREFIX check on `ref_literal` is casefolded
+         because GitHub's `==` operator itself ignores case for the whole
+         compared string (docs.github.com/en/actions/reference/
+         workflows-and-actions/expressions: "GitHub ignores case when
+         comparing strings") — this fold is CORRECT per GitHub's documented
+         expression semantics, not a bias.
+      2. Whether the branch text extracted from `ref_literal` then matches
+         one of `branches:`'s glob patterns is ALSO matched casefolded, but
+         real git branch names ARE case-sensitive, so this second fold is
+         NOT a claim about how GitHub actually matches branch names — it is
+         a DELIBERATE PERMISSIVE BIAS (rule 4: bias toward silence). It can
+         only turn a real finding into a missed detection (more matches ->
+         more satisfiable), never manufacture a false accusation.
+    """
+
     def matcher(ref_literal: str) -> bool:
-        if not ref_literal.startswith("refs/heads/"):
+        if not ref_literal.casefold().startswith(_REFS_HEADS_PREFIX.casefold()):
             return False
-        branch = ref_literal[len("refs/heads/") :]
-        return any(fnmatch.fnmatch(branch, pattern) for pattern in branches if isinstance(pattern, str))
+        branch = ref_literal[len(_REFS_HEADS_PREFIX) :]
+        return any(
+            fnmatch.fnmatch(branch.casefold(), pattern.casefold())
+            for pattern in branches
+            if isinstance(pattern, str)
+        )
 
     return matcher
 
@@ -190,13 +263,25 @@ def extract_trigger_paths(on_block: Any) -> list[TriggerPath]:
             continue
         if event == "push" and isinstance(cfg, dict) and _is_exact_branch_push(cfg):
             branches = [b for b in cfg["branches"] if isinstance(b, str)]
-            paths.append(
-                TriggerPath(
-                    event="push",
-                    ref_matcher=_push_ref_matcher(branches),
-                    description=f"push (branches: {branches!r})",
+            if _branches_use_unmodeled_glob_syntax(branches):
+                paths.append(
+                    TriggerPath(
+                        event="push",
+                        ref_matcher=_any_ref,
+                        description=(
+                            f"push (branches: {branches!r}, glob syntax outside the "
+                            "modeled subset [+ or \\ present] -> ref unconstrained)"
+                        ),
+                    )
                 )
-            )
+            else:
+                paths.append(
+                    TriggerPath(
+                        event="push",
+                        ref_matcher=_push_ref_matcher(branches),
+                        description=f"push (branches: {branches!r})",
+                    )
+                )
         else:
             paths.append(TriggerPath(event=event, ref_matcher=_any_ref, description=event))
     return paths
@@ -395,18 +480,52 @@ class _Parser:
 
 
 def _evaluate(node: tuple, trigger: TriggerPath) -> bool:
+    """`event_name` comparisons are casefolded per GitHub's documented `==`
+    semantics ("GitHub ignores case when comparing strings" — declared
+    limit #4); `ref` comparisons delegate to `trigger.ref_satisfies`, which
+    does its own casefolding (see `_push_ref_matcher`)."""
     kind = node[0]
     if kind == "free":
         return True
     if kind == "cmp":
         _, cfield, literal = node
         if cfield == "event_name":
-            return trigger.event == literal
+            return trigger.event.casefold() == literal.casefold()
         return trigger.ref_satisfies(literal)
     if kind == "and":
         return _evaluate(node[1], trigger) and _evaluate(node[2], trigger)
     if kind == "or":
         return _evaluate(node[1], trigger) or _evaluate(node[2], trigger)
+    raise AssertionError(f"unknown AST node kind {kind!r}")  # pragma: no cover
+
+
+def _evaluate_certain(node: tuple, trigger: TriggerPath) -> bool:
+    """Same shape and casefolding as `_evaluate`, but a `ref` comparison
+    against a trigger path whose ref is UNCONSTRAINED (`trigger.ref_matcher
+    is _any_ref`) counts as UNKNOWN — i.e. NOT true — rather than assumed
+    true. Used only to separate 'genuinely satisfiable' (this function
+    returns True for some trigger path) from 'satisfiable only because an
+    unknown ref could not be disproven' (`_evaluate` says True, this
+    function says False for every trigger path) — declared limit #4's third
+    bucket. Deliberately conservative on `and`/`or`: an unknown operand
+    reads as False here even where the real value might make the whole
+    expression true, because the question this function answers is 'is
+    there a trigger path that proves it WITHOUT guessing', not 'what is the
+    real value'."""
+    kind = node[0]
+    if kind == "free":
+        return True
+    if kind == "cmp":
+        _, cfield, literal = node
+        if cfield == "event_name":
+            return trigger.event.casefold() == literal.casefold()
+        if trigger.ref_matcher is _any_ref:
+            return False
+        return trigger.ref_satisfies(literal)
+    if kind == "and":
+        return _evaluate_certain(node[1], trigger) and _evaluate_certain(node[2], trigger)
+    if kind == "or":
+        return _evaluate_certain(node[1], trigger) or _evaluate_certain(node[2], trigger)
     raise AssertionError(f"unknown AST node kind {kind!r}")  # pragma: no cover
 
 
@@ -422,7 +541,7 @@ def _explain(node: tuple, trigger: TriggerPath) -> tuple[bool, str]:
     if kind == "cmp":
         _, cfield, literal = node
         if cfield == "event_name":
-            val = trigger.event == literal
+            val = trigger.event.casefold() == literal.casefold()
             return val, f"event_name=='{literal}' is {val} (trigger event: '{trigger.event}')"
         val = trigger.ref_satisfies(literal)
         return val, f"ref=='{literal}' is {val}"
@@ -479,14 +598,79 @@ _IF_LINE_RE = re.compile(r"^(?P<indent>\s*)if:\s?(?P<rest>.*)$")
 _BLOCK_SCALAR_INDICATORS = (">", ">-", ">+", "|", "|-", "|+")
 
 
+def _fold_block_scalar_body(indicator: str, indent_len: int, lines: list[str], start: int) -> tuple[str, int]:
+    """Approximates YAML's real block-scalar folding for the body starting
+    at `lines[start]` (the line after `if: <indicator>`), well enough to
+    usually reconstruct PyYAML's own parsed string for line-matching
+    (`_attach_line_numbers` never trusts a MISmatch here to attach a wrong
+    line — a folding gap just means one more condition falls back to no
+    line number, never a wrong one). Returns (folded_text, next_index).
+
+    LITERAL (`|`, `|-`, `|+`): every line break is kept verbatim — this
+    module never folds a `|` scalar.
+    FOLDED (`>`, `>-`, `>+`, the shape this repo's own multi-line `if:`
+    conditions actually use, verified live 2026-08-20 against
+    `main-push-failure-watch.yml`): a line break between two lines both at
+    the block's OWN base indentation folds to a single space; a break next
+    to a blank line, or a line indented MORE than the base, is kept
+    literal, per YAML's documented folding rule — this is what lets a
+    `>`-folded condition's wrapped continuation lines reconstruct the exact
+    same string PyYAML parses.
+    """
+    literal = indicator.startswith("|")
+    base_indent_len: int | None = None
+    segments: list[str] = []
+    prev_kind: str | None = None  # "normal" | "more_indented" | "blank" | None (first line)
+    j = start
+    while j < len(lines):
+        line = lines[j]
+        if line.strip() == "":
+            if base_indent_len is None:
+                # Leading blank lines inside the block are part of the
+                # scalar too, but with no content yet to anchor a fold
+                # decision on — treat as a paragraph break once content
+                # starts; skip for now (matches YAML: leading blanks don't
+                # set the indentation).
+                j += 1
+                continue
+            segments.append("\n")
+            prev_kind = "blank"
+            j += 1
+            continue
+        cur_indent_len = len(line) - len(line.lstrip())
+        if base_indent_len is None:
+            if cur_indent_len <= indent_len:
+                break
+            base_indent_len = cur_indent_len
+        if cur_indent_len < base_indent_len:
+            break
+        content = line[base_indent_len:]
+        if literal:
+            segments.append(content if prev_kind is None else "\n" + content)
+        else:
+            more_indented = content.startswith((" ", "\t"))
+            kind = "more_indented" if more_indented else "normal"
+            if prev_kind is None:
+                segments.append(content)
+            elif prev_kind == "normal" and kind == "normal":
+                segments.append(" " + content)
+            else:
+                segments.append("\n" + content)
+            prev_kind = kind
+        j += 1
+    return "".join(segments), j
+
+
 def _raw_if_lines(text: str) -> list[tuple[int, str]]:
     """Best-effort (file line number, folded if-text) pairs scanned straight
     from the raw file text, in document order — used ONLY to attach a line
     number to each structurally-found `if:` for reporting. The actual
     satisfiability analysis always uses PyYAML's parsed value (declared
-    limit: this function's block-scalar folding is an approximation of
-    YAML's real folding rules, good enough to locate a line, not trusted for
-    anything else)."""
+    limit: `_fold_block_scalar_body`'s folding is an approximation of
+    YAML's real folding rules, good enough to locate a line for the common
+    shapes this repo uses, not trusted for anything else — a mismatch here
+    can only cost a line number via `_attach_line_numbers`'s exact-text
+    match, never attach a wrong one)."""
     lines = text.splitlines()
     out: list[tuple[int, str]] = []
     i = 0
@@ -496,24 +680,10 @@ def _raw_if_lines(text: str) -> list[tuple[int, str]]:
             indent = m.group("indent")
             rest = m.group("rest").rstrip()
             if rest in _BLOCK_SCALAR_INDICATORS:
-                collected: list[str] = []
-                j = i + 1
-                base_indent_len: int | None = None
-                while j < len(lines):
-                    line = lines[j]
-                    if line.strip() == "":
-                        j += 1
-                        continue
-                    cur_indent_len = len(line) - len(line.lstrip())
-                    if base_indent_len is None:
-                        if cur_indent_len <= len(indent):
-                            break
-                        base_indent_len = cur_indent_len
-                    if cur_indent_len < base_indent_len:
-                        break
-                    collected.append(line.strip())
-                    j += 1
-                rest = " ".join(collected)
+                rest, next_i = _fold_block_scalar_body(rest, len(indent), lines, i + 1)
+                out.append((i + 1, rest))
+                i = next_i
+                continue
             out.append((i + 1, rest))
         i += 1
     return out
@@ -544,16 +714,49 @@ def _iter_if_conditions(doc: dict[str, Any], file_rel: str) -> list[IfCondition]
     return conditions
 
 
+def _normalize_raw_if_text(rest: str) -> str:
+    """Strips one layer of matching outer quotes from a raw if:-line's tail
+    (the common `if: "expr"` / `if: 'expr'` shape) so it can be compared
+    against PyYAML's already-unquoted parsed value. Never attempts full
+    YAML scalar folding beyond what `_raw_if_lines` already does for block
+    scalars — a text that still does not match after this is left
+    unmatched, not guessed at."""
+    if len(rest) >= 2 and rest[0] == rest[-1] and rest[0] in ("'", '"'):
+        return rest[1:-1]
+    return rest
+
+
 def _attach_line_numbers(conditions: list[IfCondition], raw_lines: list[tuple[int, str]]) -> None:
-    """Best-effort positional match: both `conditions` (structural traversal
-    of a dict PyYAML preserves in document order) and `raw_lines` (a
-    top-to-bottom scan) visit `if:` occurrences in the same order. A count
-    mismatch (e.g. a `with:` parameter that happens to be a step literally
-    named `if`, or a block-scalar shape this module's folding does not
-    match) degrades to a missing line number for the unmatched tail — never
-    a WRONG line, only an absent one."""
-    for cond, (line_no, _rest) in zip(conditions, raw_lines):
-        cond.line = line_no
+    """Matches each condition to its raw file line BY TEXT, never by
+    traversal ORDER. `conditions` is a STRUCTURAL traversal (job `if:`
+    always visited before that job's step `if:`s, per `_iter_if_conditions`
+    — regardless of where the job-level `if:` key actually sits in the
+    file); `raw_lines` is a RAW top-to-bottom scan. A job-level `if:`
+    written textually AFTER `steps:` (legal YAML — key order inside a
+    mapping is free) makes the two lists visit the same two conditions in
+    OPPOSITE order, so a positional zip silently SWAPS their line numbers
+    (verified live, 2026-08-20 — reproduced with exactly this shape; the
+    old docstring here claimed this "degrades to a missing line number …
+    never a WRONG line", which was false — the claim was the worse half of
+    the defect, see this PR's commit message).
+
+    A condition's (quote-normalized) text that occurs EXACTLY ONCE among
+    `conditions` and EXACTLY ONCE among `raw_lines` is unambiguous and gets
+    that line. Any text that repeats — on either side — is genuinely
+    ambiguous (which occurrence is which cannot be recovered from text
+    alone) and is left with `line=None` for every condition sharing it:
+    an absent line number, never a guessed one."""
+    text_to_lines: dict[str, list[int]] = {}
+    for line_no, rest in raw_lines:
+        text_to_lines.setdefault(_normalize_raw_if_text(rest), []).append(line_no)
+    cond_text_counts = Counter(c.text for c in conditions)
+
+    for cond in conditions:
+        candidate_lines = text_to_lines.get(cond.text, [])
+        if len(candidate_lines) == 1 and cond_text_counts[cond.text] == 1:
+            cond.line = candidate_lines[0]
+        # else: zero raw matches, or the text repeats somewhere -> ambiguous,
+        # leave cond.line at its default (None).
 
 
 @dataclass
@@ -570,11 +773,25 @@ class Undecided:
 
 
 @dataclass
+class AssumedSatisfiable:
+    """A condition this module calls 'satisfiable', where every trigger
+    path that makes it true does so only via an UNCONSTRAINED
+    (`_any_ref`) ref — i.e. this module could not DISPROVE it, but the
+    verdict is not proven against a real, modeled ref either (declared
+    limit #4's third bucket). Never counted as a clean, proven pass."""
+
+    condition: IfCondition
+    on_summary: str
+    mechanism: str
+
+
+@dataclass
 class WorkflowResult:
     file: str
     parse_error: str | None = None
     findings: list[Finding] = field(default_factory=list)
     undecided: list[Undecided] = field(default_factory=list)
+    assumed_satisfiable: list[AssumedSatisfiable] = field(default_factory=list)
     in_scope_count: int = 0
 
 
@@ -619,6 +836,15 @@ def analyze_workflow(path: Path, repo_root: Path) -> WorkflowResult:
                 "    (workflow's `on:` block produced zero trigger paths)"
             )
             result.findings.append(Finding(condition=cond, on_summary=on_summary, mechanism=mechanism))
+        else:
+            assert ast is not None
+            if any(_evaluate_certain(ast, tp) for tp in trigger_paths):
+                continue  # proven true against at least one modeled/real trigger path
+            witnesses = [tp for tp in trigger_paths if _evaluate(ast, tp)]
+            mechanism = "\n".join(f"    - {tp.description}: {_explain(ast, tp)[1]}" for tp in witnesses)
+            result.assumed_satisfiable.append(
+                AssumedSatisfiable(condition=cond, on_summary=on_summary, mechanism=mechanism)
+            )
     return result
 
 
@@ -665,6 +891,7 @@ def main(argv: list[str] | None = None) -> int:
     parse_errors: list[tuple[str, str]] = []
     all_findings: list[Finding] = []
     all_undecided: list[Undecided] = []
+    all_assumed: list[AssumedSatisfiable] = []
     total_in_scope = 0
 
     for wf in workflows:
@@ -675,6 +902,7 @@ def main(argv: list[str] | None = None) -> int:
         total_in_scope += result.in_scope_count
         all_findings.extend(result.findings)
         all_undecided.extend(result.undecided)
+        all_assumed.extend(result.assumed_satisfiable)
 
     if parse_errors:
         print(
@@ -689,7 +917,8 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"lint_unreachable_workflow_conditions: {len(workflows)} workflow(s) scanned, "
         f"{total_in_scope} if: condition(s) in scope (name github.event_name/github.ref), "
-        f"{len(all_findings)} finding(s), {len(all_undecided)} not analyzed"
+        f"{len(all_findings)} finding(s), {len(all_undecided)} not analyzed, "
+        f"{len(all_assumed)} satisfiable-only-under-assumed-ref"
     )
 
     if all_findings:
@@ -712,7 +941,25 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  ? {loc} [{c.scope}]: {c.text}")
             print(f"    reason: {u.reason}")
 
-    if not all_findings and not all_undecided:
+    if all_assumed:
+        print(
+            f"\nSATISFIABLE ONLY UNDER AN ASSUMED/UNKNOWN REF ({len(all_assumed)} of "
+            f"{total_in_scope} in-scope condition(s)) — this guard could not DISPROVE"
+        )
+        print(
+            "these, but the 'satisfiable' verdict rests entirely on an unconstrained trigger "
+            "path (declared limit #2/#4), never a proven reachable ref — not the same kind of "
+            "coverage as a proven pass, and never counted as one:"
+        )
+        for a in all_assumed:
+            c = a.condition
+            loc = f"{c.file}:{c.line}" if c.line else c.file
+            print(f"  ~ {loc} [{c.scope}]: {c.text}")
+            print(f"    {a.on_summary}")
+            print(f"    mechanism (evaluated per assumed-ref trigger path):")
+            print(a.mechanism)
+
+    if not all_findings and not all_undecided and not all_assumed:
         print("  ✓ every in-scope if: is satisfiable under at least one real trigger path")
 
     return 1 if all_findings else 0

--- a/scripts/tests/test_unreachable_workflow_conditions.py
+++ b/scripts/tests/test_unreachable_workflow_conditions.py
@@ -13,6 +13,7 @@ Run:  python3 -m pytest scripts/tests/test_unreachable_workflow_conditions.py -q
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -263,3 +264,70 @@ def test_scar_pin_precure_text_of_the_real_step_is_flagged(tmp_path):
     assert result.parse_error is None
     assert len(result.findings) == 1, result.findings
     assert "Telegram alert" in result.findings[0].condition.scope
+
+
+# --- The alarm must NAME the ref it fired on, never assert one -----------------
+#
+# Second half of the same defect, and the half a satisfiability checker cannot
+# see: widening the condition to `schedule || push-on-develop` made the step
+# REACHABLE, but its title and body still read "... on main", so on a develop
+# push the alarm would have reported the wrong branch and sent whoever read it
+# at 07:30 to look at a branch that was fine (W114/W106 — a message that
+# inventories mutable state will lie). The condition and the message were
+# written the same day from the same belief; these assertions stop them from
+# being able to disagree again.
+
+_ALARM_NAME_MARKER = "Telegram alert — production image failed to BUILD"
+_ALARM_BODY_MARKER = "image failed to BUILD"
+_BRANCH_LITERAL_RE = re.compile(r"\b(main|develop|master)\b")
+
+
+def _alarm_human_text(workflow_text: str) -> list[str]:
+    """The alarm's HUMAN-FACING strings: its `name:` line and the body line the
+    owner actually reads. Deliberately NOT the `if:` — that one has to name
+    branches, it is the condition. Fails loud rather than returning an empty
+    list, so a renamed step can never read as 'no branch literals found'."""
+    lines = [
+        line
+        for line in workflow_text.splitlines()
+        if (_ALARM_NAME_MARKER in line and line.lstrip().startswith("- name:"))
+        or (_ALARM_BODY_MARKER in line and "<b>" in line)
+    ]
+    assert len(lines) == 2, (
+        "expected exactly the alarm's name line and its body line; got "
+        f"{len(lines)}: {lines!r} — the step was renamed or its body reworded, "
+        "so this scar-pin is no longer looking at the alarm it was written for"
+    )
+    return lines
+
+
+def test_scar_pin_alarm_names_the_ref_instead_of_hardcoding_a_branch():
+    """INNOCENCE: today's alarm carries no branch literal in the text a human
+    reads, and does interpolate the real ref."""
+    text = (REPO_ROOT / ".github" / "workflows" / "security.yml").read_text(encoding="utf-8")
+    human = _alarm_human_text(text)
+    for line in human:
+        assert not _BRANCH_LITERAL_RE.search(line), (
+            f"the alarm asserts a branch instead of naming one: {line.strip()!r} — "
+            "it can fire on a develop push AND on the scheduled run, so a "
+            "hardcoded branch name is wrong on at least one of them"
+        )
+    assert any("${REF}" in line for line in human), (
+        "the alarm body must interpolate the ref it fired on"
+    )
+    assert "REF: ${{ github.ref_name }}" in text, (
+        "REF must come from github.ref_name in the step's env: block"
+    )
+
+
+def test_guilt_rehardcoding_the_branch_in_the_alarm_is_caught():
+    """GUILT: the next person who writes 'on main' back into the alarm gets a
+    red, not a lying alert. Mutates a copy in memory — the tracked file is
+    never touched."""
+    text = (REPO_ROOT / ".github" / "workflows" / "security.yml").read_text(encoding="utf-8")
+    regressed = text.replace("failed to BUILD on ${REF}", "failed to BUILD on main")
+    assert regressed != text, "the body line moved — update this mutation to match"
+    human = _alarm_human_text(regressed)
+    assert any(_BRANCH_LITERAL_RE.search(line) for line in human), (
+        "the regression must be visible in the alarm's human-facing text"
+    )

--- a/scripts/tests/test_unreachable_workflow_conditions.py
+++ b/scripts/tests/test_unreachable_workflow_conditions.py
@@ -331,3 +331,202 @@ def test_guilt_rehardcoding_the_branch_in_the_alarm_is_caught():
     assert any(_BRANCH_LITERAL_RE.search(line) for line in human), (
         "the regression must be visible in the alarm's human-facing text"
     )
+
+
+# ================================================== cross-family refuter (Kimi K3) fixes
+#
+# Four false-accusation paths a cross-family refuter found in this guard
+# itself, reproduced independently before being fixed (a refuter can
+# hallucinate too — cicatrix-superscar #6). Each test below asserts the
+# FALSE ACCUSATION does not happen: the guard is about to become a required
+# check, so wrongly reporting a reachable if: as unreachable hard-blocks an
+# innocent PR — the severe class this whole file exists to prevent.
+
+
+def test_guilt_case_insensitive_event_name_and_ref_are_not_flagged(tmp_path):
+    """GitHub's `==`/`!=` operators ignore case for the whole compared
+    string (docs.github.com/en/actions/reference/workflows-and-actions/
+    expressions: "GitHub ignores case when comparing strings", verified
+    2026-08-20) — 'Push' == the real 'push' event, and 'REFS/HEADS/MAIN' ==
+    the real 'refs/heads/main'. Pre-fix this input was flagged with 2
+    findings and exit 1 while both conditions are true on a real run."""
+    workflow = """\
+on:
+  push:
+    branches: [main]
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'Push'
+    steps:
+      - run: echo hi
+        if: github.ref == 'REFS/HEADS/MAIN'
+"""
+    _write_workflow(tmp_path, "fake-case.yml", workflow)
+    _git_repo(tmp_path)
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+
+    proc = _run_cli(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "UNREACHABLE" not in proc.stdout, proc.stdout
+    assert "0 finding(s)" in proc.stdout, proc.stdout
+
+
+def test_guilt_github_glob_plus_metachar_is_not_flagged(tmp_path):
+    """GitHub's filter-pattern glob defines `+` as "one or more of the
+    preceding character" — `branches: ['ma+n']` matches a real push to
+    branch 'maaan'. `fnmatch` treats `+` as an ordinary literal character
+    (verified: `fnmatch.fnmatch('maaan', 'ma+n')` is False) — pre-fix this
+    mismatch made the guard treat 'maaan' as never matching the `on:`
+    filter and flag the if: as unreachable, when GitHub would actually run
+    it."""
+    workflow = """\
+on:
+  push:
+    branches: ['ma+n']
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/maaan'
+    steps:
+      - run: echo hi
+"""
+    _write_workflow(tmp_path, "fake-glob.yml", workflow)
+    _git_repo(tmp_path)
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+
+    proc = _run_cli(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "UNREACHABLE" not in proc.stdout, proc.stdout
+
+
+def test_guilt_backslash_metachar_is_not_flagged():
+    """Same class as the `+` case, for GitHub's other glob-only
+    metacharacter (`\\`, escape-the-next-character) — unit-level via
+    `extract_trigger_paths`, confirming the push trigger's ref is left
+    unconstrained (never mismodeled as a literal-backslash fnmatch)."""
+    on_block = {"push": {"branches": [r"release\*"]}}
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    assert len(trigger_paths) == 1
+    assert trigger_paths[0].ref_matcher is mod._any_ref, (
+        "a branches: pattern containing '\\\\' must fall back to an "
+        "unconstrained ref, never be matched via fnmatch"
+    )
+
+
+def test_guilt_job_if_after_steps_does_not_swap_line_numbers(tmp_path):
+    """A job-level `if:` written textually AFTER `steps:` (legal YAML — key
+    order inside a mapping is free) used to get the STEP's line number, and
+    the step's `if:` got the JOB's — a required check that sends the
+    reviewer to the wrong `if:` while its own docstring promised it never
+    could. Distinct if:-texts here so the assertion cannot pass by
+    coincidence (an ambiguous same-text case is covered separately)."""
+    workflow = """\
+on:
+  push:
+    branches: [develop]
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        if: github.event_name == 'push' && github.ref == 'refs/heads/STEPBRANCH'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/JOBBRANCH'
+"""
+    path = _write_workflow(tmp_path, "fake-lineno.yml", workflow)
+    result = mod.analyze_workflow(path, tmp_path)
+    assert result.parse_error is None
+    assert len(result.findings) == 2, result.findings
+
+    by_scope = {f.condition.scope: f.condition for f in result.findings}
+    job_cond = by_scope["job:a"]
+    step_cond = next(c for scope, c in by_scope.items() if scope != "job:a")
+
+    assert "JOBBRANCH" in job_cond.text
+    assert "STEPBRANCH" in step_cond.text
+    # Line 10 is the job-level if:, line 9 is the step's — verified against
+    # the raw text above (1-indexed, counting from `on:`).
+    assert job_cond.line == 10, (job_cond.line, workflow.splitlines())
+    assert step_cond.line == 9, (step_cond.line, workflow.splitlines())
+
+
+def test_guilt_ambiguous_duplicate_if_text_gets_no_line_never_a_wrong_one(tmp_path):
+    """When job-if and step-if carry the IDENTICAL text (so which raw line
+    belongs to which cannot be recovered from text alone), the guard must
+    leave BOTH without a line number rather than guess — the contract is
+    'never a wrong line, only an absent one'."""
+    workflow = """\
+on:
+  push:
+    branches: [develop]
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+"""
+    path = _write_workflow(tmp_path, "fake-ambiguous.yml", workflow)
+    result = mod.analyze_workflow(path, tmp_path)
+    assert result.parse_error is None
+    assert len(result.findings) == 2, result.findings
+    assert all(f.condition.line is None for f in result.findings), [
+        (f.condition.scope, f.condition.line) for f in result.findings
+    ]
+
+
+def test_guilt_assumed_satisfiable_ref_is_not_folded_into_clean_report(tmp_path):
+    """A `schedule`-only if: naming a specific `ref` is 'satisfiable' only
+    because this guard cannot disprove an unconstrained/unknown ref
+    (declared limit #2) — that verdict must land in its own
+    'SATISFIABLE ONLY UNDER AN ASSUMED/UNKNOWN REF' bucket, never silently
+    under the green 'every in-scope if: is satisfiable' line, and must
+    never be a finding (exit 0)."""
+    workflow = """\
+on:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' && github.ref == 'refs/heads/main'
+    steps:
+      - run: echo hi
+"""
+    path = _write_workflow(tmp_path, "fake-assumed.yml", workflow)
+    result = mod.analyze_workflow(path, tmp_path)
+    assert result.parse_error is None
+    assert result.findings == []
+    assert len(result.assumed_satisfiable) == 1, result.assumed_satisfiable
+
+    _git_repo(tmp_path)
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+    proc = _run_cli(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "SATISFIABLE ONLY UNDER AN ASSUMED/UNKNOWN REF" in proc.stdout, proc.stdout
+    assert "every in-scope if: is satisfiable" not in proc.stdout, proc.stdout
+
+
+def test_innocence_mixed_definite_and_assumed_witness_stays_in_clean_report(tmp_path):
+    """A condition satisfiable via BOTH a real (push-branch) trigger path
+    AND an unconstrained (schedule) one must NOT land in the
+    assumed-satisfiable bucket — it is genuinely, definitely satisfiable
+    already, without needing to assume anything."""
+    on_block = {
+        "push": {"branches": ["main"]},
+        "schedule": [{"cron": "0 0 * * *"}],
+    }
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    _, _, ast = mod.analyze_condition(
+        "github.event_name == 'schedule' || "
+        "(github.event_name == 'push' && github.ref == 'refs/heads/main')",
+        trigger_paths,
+    )
+    assert ast is not None
+    assert any(mod._evaluate_certain(ast, tp) for tp in trigger_paths), (
+        "a real push-branch witness must be provable without assuming an unknown ref"
+    )

--- a/scripts/tests/test_unreachable_workflow_conditions.py
+++ b/scripts/tests/test_unreachable_workflow_conditions.py
@@ -1,0 +1,265 @@
+"""Tests for scripts/ci/lint_unreachable_workflow_conditions.py.
+
+Guilt+innocence per cicatrix-superscar.md #3 ("nessuna guardia mergiata
+senza un test di innocenza E di colpevolezza") plus a LIMIT class (rule 2 of
+the guard's own module docstring: an expression outside the decidable shape
+must be visibly UNDECIDED, never silently folded into a clean report) and a
+SCAR-PIN against the real `.github/workflows/security.yml` this guard was
+built to cure (commit 4e2d8367e / #4218 orphaned its alarm; this same PR
+cures it — see security.yml's own comment above the Telegram-alert step).
+
+Run:  python3 -m pytest scripts/tests/test_unreachable_workflow_conditions.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = REPO_ROOT / "scripts" / "ci" / "lint_unreachable_workflow_conditions.py"
+_MODULE_NAME = "lint_unreachable_workflow_conditions"
+_spec = importlib.util.spec_from_file_location(_MODULE_NAME, _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+# Registered in sys.modules BEFORE exec_module: the target module combines
+# `@dataclass(frozen=True)` with `from __future__ import annotations`, and
+# dataclass field-type resolution looks up `sys.modules[cls.__module__]` —
+# skipping this registration crashes with `AttributeError: 'NoneType' object
+# has no attribute '__dict__'` at import time (verified live, 2026-08-20;
+# neither sibling loader in this dir needed it because neither target module
+# combines those two features).
+sys.modules[_MODULE_NAME] = mod
+_spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+
+def _write_workflow(repo: Path, name: str, content: str) -> Path:
+    wf_dir = repo / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    path = wf_dir / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "test")
+    return tmp_path
+
+
+def _run_cli(repo: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_MODULE_PATH), "--repo-root", str(repo)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ============================================================= GUILT cases
+
+
+def test_guilt_a_exact_security_yml_shape_is_flagged():
+    """The exact bug: push:[develop] narrows the branch filter, but the
+    if: still names 'refs/heads/main' — a standing contradiction."""
+    on_block = {"push": {"branches": ["develop"]}}
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    satisfiable, reason, ast = mod.analyze_condition(
+        "failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'",
+        trigger_paths,
+    )
+    assert satisfiable is False, reason
+
+
+def test_guilt_b_no_push_trigger_at_all_is_flagged():
+    """A workflow with no push: trigger at all, but an if: that requires
+    event_name=='push', can never fire."""
+    on_block = {"pull_request": {}, "schedule": [{"cron": "0 0 * * *"}]}
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    satisfiable, reason, ast = mod.analyze_condition(
+        "github.event_name == 'push'",
+        trigger_paths,
+    )
+    assert satisfiable is False, reason
+
+
+def test_guilt_c_mirror_direction_push_main_if_ref_develop_is_flagged():
+    """The mirror of (a): push:[main] but the if: names 'refs/heads/develop'.
+    A guard that only catches one direction is half a guard."""
+    on_block = {"push": {"branches": ["main"]}}
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    satisfiable, reason, ast = mod.analyze_condition(
+        "failure() && github.event_name == 'push' && github.ref == 'refs/heads/develop'",
+        trigger_paths,
+    )
+    assert satisfiable is False, reason
+
+
+# ========================================================= INNOCENCE cases
+
+
+def test_innocence_d_cured_security_yml_condition_under_real_on_block():
+    """The CURED condition, evaluated against security.yml's real `on:`
+    block (push:[develop], pull_request, merge_group, schedule x2,
+    workflow_dispatch) — satisfiable via the `schedule` disjunct."""
+    on_block = {
+        "push": {"branches": ["develop"]},
+        "pull_request": {"types": ["opened", "synchronize", "reopened"]},
+        "merge_group": None,
+        "schedule": [{"cron": "17 19 * * *"}, {"cron": "0 0 * * 0"}],
+        "workflow_dispatch": None,
+    }
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    satisfiable, reason, ast = mod.analyze_condition(
+        "failure() && (github.event_name == 'schedule' || "
+        "(github.event_name == 'push' && github.ref == 'refs/heads/develop'))",
+        trigger_paths,
+    )
+    assert satisfiable is True, reason
+
+
+def test_innocence_e_unfiltered_push_is_never_flagged():
+    on_block = {"push": None}
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    satisfiable, reason, ast = mod.analyze_condition(
+        "github.event_name == 'push' && github.ref == 'refs/heads/anything-at-all'",
+        trigger_paths,
+    )
+    assert satisfiable is True, reason
+
+
+def test_innocence_f_steps_and_needs_only_condition_not_even_undecided(tmp_path):
+    """An if: that never names github.event_name/github.ref is entirely
+    out of this guard's domain — not a finding, not even 'not analyzed'."""
+    if_text = "needs.changes.result == 'success' && steps.check.outputs.ok == 'true'"
+    assert mod.mentions_relevant_fields(if_text) is False
+
+    workflow = """\
+name: fake
+on:
+  push:
+    branches: [develop]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - name: conditional step
+        if: needs.changes.result == 'success' && steps.check.outputs.ok == 'true'
+        run: echo hi
+"""
+    path = _write_workflow(tmp_path, "fake.yml", workflow)
+    result = mod.analyze_workflow(path, tmp_path)
+    assert result.parse_error is None
+    assert result.in_scope_count == 0
+    assert result.findings == []
+    assert result.undecided == []
+
+
+def test_innocence_g_merge_group_workflow_naming_ref_is_not_flagged():
+    """Bias-to-silence per rule 4: merge_group's real ref is the queue's own
+    ref, never a static branch — but this module treats it as UNKNOWN
+    (satisfiable), never asserts unreachable."""
+    on_block = {"merge_group": None}
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    satisfiable, reason, ast = mod.analyze_condition(
+        "github.event_name == 'merge_group' && github.ref == 'refs/heads/main'",
+        trigger_paths,
+    )
+    assert satisfiable is True, reason
+
+
+# ================================================================ LIMIT case
+
+
+def test_limit_h_unsupported_shape_is_not_analyzed_and_does_not_exit_nonzero(tmp_path):
+    """An if: outside the decidable shape (here: a function call WITH
+    arguments, `contains(...)`) must land in the 'not analyzed' bucket and
+    must NOT, on its own, make the CLI exit non-zero."""
+    workflow = """\
+name: fake-limit
+on:
+  push:
+    branches: [develop]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: weird step
+        if: contains(github.ref, 'release-')
+        run: echo hi
+"""
+    _write_workflow(tmp_path, "fake-limit.yml", workflow)
+    _git_repo(tmp_path)
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+
+    proc = _run_cli(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "NOT ANALYZED" in proc.stdout
+    assert "contains" in proc.stdout
+
+
+def test_limit_h_unit_level_undecided_reason():
+    on_block = {"push": {"branches": ["develop"]}}
+    trigger_paths = mod.extract_trigger_paths(on_block)
+    satisfiable, reason, ast = mod.analyze_condition(
+        "contains(github.ref, 'release-')",
+        trigger_paths,
+    )
+    assert satisfiable is None
+    assert reason  # a non-empty explanation, not a silent None
+
+
+# ============================================================== SCAR-PIN
+
+
+def test_scar_pin_real_security_yml_reports_zero_findings():
+    """Part A actually cured it: the guard, run against the REAL
+    security.yml in this branch, must report zero findings for it."""
+    path = REPO_ROOT / ".github" / "workflows" / "security.yml"
+    assert path.exists(), "security.yml must exist in this worktree"
+    result = mod.analyze_workflow(path, REPO_ROOT)
+    assert result.parse_error is None
+    assert result.findings == [], [
+        (f.condition.file, f.condition.scope, f.condition.text) for f in result.findings
+    ]
+    # And the guard actually looked at the alert condition (not a false
+    # "clean" from mentions_relevant_fields skipping it entirely).
+    assert result.in_scope_count >= 1
+
+
+_CURED_IF = (
+    "failure() && (github.event_name == 'schedule' || "
+    "(github.event_name == 'push' && github.ref == 'refs/heads/develop'))"
+)
+_PRECURE_IF = "failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'"
+
+
+def test_scar_pin_precure_text_of_the_real_step_is_flagged(tmp_path):
+    """Reconstruct the PRE-cure text of the real step in a tmp copy (never
+    reverting the tracked file) and confirm the guard would have caught it."""
+    real_text = (REPO_ROOT / ".github" / "workflows" / "security.yml").read_text(encoding="utf-8")
+    assert _CURED_IF in real_text, "the cured if: text moved — update _CURED_IF to match"
+    precure_text = real_text.replace(_CURED_IF, _PRECURE_IF)
+    assert precure_text != real_text
+
+    path = _write_workflow(tmp_path, "security.yml", precure_text)
+    result = mod.analyze_workflow(path, tmp_path)
+    assert result.parse_error is None
+    assert len(result.findings) == 1, result.findings
+    assert "Telegram alert" in result.findings[0].condition.scope


### PR DESCRIPTION
## Summary

`security.yml`'s Telegram alert for a broken production-image build could never fire.
Commit `4e2d8367e` (#4218, 2026-08-16) narrowed `on.push.branches` from `[main, develop]`
to `[develop]` and left the step's `if: event_name=='push' && ref=='refs/heads/main'`
untouched. GitHub's own branch filter now guarantees `event_name=='push' ⟹
ref=='refs/heads/develop'`, so the old conjunct against `refs/heads/main` became a
standing contradiction — and under `schedule` (the daily backstop #4218's own commit
message named as the intended replacement) `event_name` is never `'push'` either. The
alarm was armed and mute. Proven live: the 2026-08-20 unbuildable production image
(upstream `@anthropic-ai/claude-code@2.1.237` published without its `linux-x64`
tarball) alarmed nobody.

**Part A** — cures the instance: the `if:` now names exactly the two triggers the
current `on:` block can deliver a `failure()` run through (`schedule` OR `push` to
`develop`), and the stale comment above the step (which asserted "restricted to
pushes on main" / "secrets.* is available on main pushes" — both false since #4218)
is rewritten to name #4218 as the commit that orphaned it. `on.push.branches` is left
untouched — #4218's dedupe was deliberate; this PR cures the alarm, not the trigger.

**Part B/C/D** — guards the class: new `scripts/ci/lint_unreachable_workflow_conditions.py`
parses every tracked workflow's `on:` block into its real trigger paths and flags any
job/step `if:` that names `github.event_name`/`github.ref` but is false under every one
of them. Deliberately narrow (declared in the module docstring, not hidden): only
`field == 'literal'` conjunctions/disjunctions with `failure()/success()/always()/cancelled()`
as free are decidable; anything else (`!=`, `!`, function calls with arguments, any other
field) marks the whole condition UNDECIDED in a separate "not analyzed" report, never
silently folded into "0 findings". Armed in the REQUIRED `antidotes` job of
`immune-enforcement.yml` — the pytest corpus joins the existing guilt+innocence batch
loop (same slot as its closest sibling, `test_check_required_workflow_conformance.py`),
and a new dedicated step runs the CLI against the real tree.

## Verified empirically (2026-08-20)

- Real repo sweep: 93 tracked workflows, 10 `if:` conditions name
  `github.event_name`/`github.ref`, **0 findings**, 6 UNDECIDED (5 in `tests.yml` use
  `!=`/`!cancelled()`, 1 in `main-push-failure-watch.yml` compares
  `github.event.workflow_run.*` — both correctly outside the decidable shape).
- `secrets.*` on `schedule`: confirmed live pattern — `cron-cert-monitor.yml` already
  reads `secrets.TELEGRAM_BOT_TOKEN`/`secrets.TELEGRAM_OWNER_CHAT_ID` under
  `on: schedule:` with no special-casing.
- `actionlint` clean on both changed workflow files; both re-parse as valid YAML.
- `pytest scripts/tests/test_unreachable_workflow_conditions.py` → 11/11 green.
- `pytest scripts/tests/test_check_required_workflow_conformance.py`,
  `test_immune_enforcement_trigger_symmetry.py`, `test_ci_service_images_use_mirror.py`,
  `test_lint_workflow_errexit_decap.py`, `test_lint_doc_executable_refs.py`,
  `infra/guard-conformance/check_guard_conformance.py` → all green (no collateral
  damage to the sibling workflow-scanning guards).
- Full `scripts/tests/` + `scripts/ci/` sweep: one **pre-existing, unrelated** failure
  class isolated and confirmed identical on clean `origin/main` via `git stash` —
  `test_auto_merge_whitelist.py::test_every_tier1_codeowners_path_blocks_auto_merge`
  (18 parametrized cases, all failing the same way, none touching any file this PR
  changes). Left untouched — out of this PR's scope by the mandate's hard constraints.

## Adversarial review

Self-adversarial pass before opening this PR (no `research/**/*.md` in this diff, so
the R1 frontmatter gate does not apply — this section documents the review discipline
anyway):

- **Guilt/mirror-direction check**: the corpus includes both directions of the bug
  (`push:[develop]` + `if: ref==main`, AND the mirror `push:[main]` + `if: ref==develop`)
  — a guard that only catches one direction is half a guard (cicatrix-superscar #3).
- **Bias-to-silence check**: `merge_group`/`schedule`/`workflow_dispatch` ref semantics
  are deliberately left UNKNOWN/unconstrained rather than guessed (e.g. `schedule`'s
  default-branch name is a repo-config fact this module cannot read from a workflow
  file) — verified this cannot produce a false accusation by construction, only a
  missed one, and pinned by `test_innocence_g_merge_group_workflow_naming_ref_is_not_flagged`.
  scoped-out-but-real check: no positive test proves a `schedule`-only `if:` naming a
  genuinely wrong branch is MISSED (declared limit, not hidden).
- **Mutation-verify**: replaced `_evaluate()`'s body with an unconditional `return True`
  (disables the satisfiability check entirely). Before → after: **4 failed / 7 passed**
  (mutated) → **11 passed / 0 failed** (restored). The 4 that went red were exactly the
  3 guilt tests plus the scar-pin pre-cure-flagging test — i.e. every assertion that
  requires an unsatisfiable verdict, and only those. File restored byte-identical
  (`cmp -s` against a pre-mutation backup) before continuing.
- **Scar-pin, not just a synthetic fixture**: the guard is run directly against the
  REAL `.github/workflows/security.yml` in this branch (0 findings) and against a
  reconstructed PRE-cure copy built in a tmp dir (flags it) — the tracked file is
  never reverted to produce this proof.
- **Scope discipline**: no workflow other than `security.yml`/`immune-enforcement.yml`
  touched; no existing CI check weakened, deleted, or skipped; `infra/guard-conformance/registry.json`
  deliberately NOT touched — that meta-registry's census is opt-in per-tool (verified
  by reading its own driver code: `check_guard_conformance.py::main()` only inspects a
  fixed, hardcoded list of surfaces, so an unregistered new script is invisible to it,
  not a violation) and adding a surface there would mean editing that checker's Python
  itself, which is out of this PR's explicit mandate.

## Test plan

- [x] `actionlint` clean on `security.yml` and `immune-enforcement.yml`
- [x] Both files re-parse as valid YAML (`yaml.safe_load`)
- [x] `pytest scripts/tests/test_unreachable_workflow_conditions.py -v` → 11/11 pass
- [x] Real-repo sweep (`python3 scripts/ci/lint_unreachable_workflow_conditions.py`) → 0 findings, exit 0
- [x] Mutation-verify: 4 guilt-class tests go red under the mutation, all others stay green; restored clean
- [x] Sibling/collateral-damage checks (listed above) all green
- [ ] CI: this PR's own `antidotes` required job should now execute the new step and stay green

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
