### PR TITLE
fix(portal): archived clients get the same 404 from profile and dashboard-summary as everywhere else

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -1127,12 +1127,19 @@ async def get_profile(
                     tm.avatar as assigned_to_avatar
                 FROM clients c
                 LEFT JOIN team_members tm ON c.assigned_to = tm.email
-                WHERE c.id = $1
+                WHERE c.id = $1 AND c.deleted_at IS NULL
                 """,
                 client["client_id"],
             )
 
             if not row:
+                # Row missing OR soft-deleted (deleted_at IS NULL above) -> not
+                # found, not a 500. Every other client-scoped portal endpoint
+                # resolves the client through PortalService, which filters
+                # `... WHERE id = $1 AND deleted_at IS NULL` and 404s the same
+                # way (see get_dashboard's "BUG C" comment) — this raw-SQL
+                # handler now matches that gate instead of serving an archived
+                # client's passport/DOB/address (2026-08-20).
                 raise HTTPException(status_code=404, detail="Profile not found")
 
             return {

--- a/apps/backend-rag/backend/app/routers/portal_dashboard.py
+++ b/apps/backend-rag/backend/app/routers/portal_dashboard.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 import asyncpg
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from backend.app.dependencies import get_database_pool
 from backend.app.routers.portal import get_current_client
@@ -154,6 +154,23 @@ async def summary(
     """Return 3-hero-card data + AI recap in a single round-trip."""
     client_id = client["client_id"]
     async with pool.acquire() as conn:
+        # Verify client exists and is not archived. Every other client-scoped
+        # portal endpoint resolves the client through PortalService, which
+        # filters `... WHERE id = $1 AND deleted_at IS NULL` and 404s
+        # (portal.py get_dashboard's "BUG C"); this router talks to the pool
+        # directly and had no equivalent check, so an archived client's
+        # visa/passport expiry still leaked into "upcoming deadlines" below.
+        # Deliberately NOT wrapped in the graceful-degrade try/except used
+        # for the three data sources — this is an identity check, not an
+        # optional data source, and an unexpected DB error here should 500
+        # like it does for the sibling endpoints, not degrade silently.
+        client_row = await conn.fetchrow(
+            "SELECT id FROM clients WHERE id = $1 AND deleted_at IS NULL",
+            client_id,
+        )
+        if not client_row:
+            raise HTTPException(status_code=404, detail="Client not found")
+
         open_actions = await _fetch_open_actions(conn, client_id)
         deadlines = await _fetch_deadlines(conn, client_id)
         unread = await _fetch_unread_count(conn, client_id)

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -670,6 +670,65 @@ class TestProfile:
         response = client.get("/api/portal/profile")
         assert response.status_code == 404
 
+    def test_get_profile_archived_client_returns_404(self, client, mock_db_pool):
+        """
+        2026-08-20 class-fix: an archived client (clients.deleted_at set) must
+        get the same 404 every other portal endpoint gives — get_profile was
+        one of two raw-SQL handlers that bypassed the deleted_at IS NULL gate
+        every sibling resolves through PortalService. In production the
+        WHERE clause filters the row out, so asyncpg's fetchrow returns None
+        exactly like the not-found case above.
+        """
+        conn = mock_db_pool._mock_conn
+        conn.fetchrow.return_value = None
+
+        response = client.get("/api/portal/profile")
+
+        assert response.status_code == 404
+        # GUILT, mutation-sensitive: the 404 above is only proof the row was
+        # absent — this proves it is absent *because the query excludes
+        # soft-deleted rows*, not merely because the mock defaults to None.
+        # Removing "AND c.deleted_at IS NULL" from the router's SQL turns
+        # this assertion red even though the 404 assertion above stays green.
+        sql = conn.fetchrow.call_args.args[0]
+        assert "deleted_at IS NULL" in sql, (
+            "GET /api/portal/profile no longer filters deleted_at — an "
+            "archived client's passport/DOB/address would be served again"
+        )
+
+    def test_get_profile_success_query_still_scoped_to_client_id(self, client, mock_db_pool):
+        """
+        INNOCENCE: a live client (not archived) still gets 200 with their
+        data — the deleted_at gate must not turn into a blanket 404.
+        """
+        conn = mock_db_pool._mock_conn
+        conn.fetchrow.return_value = {
+            "id": 42,
+            "full_name": "Jane Live",
+            "email": "jane@example.com",
+            "phone": "+62812000000",
+            "whatsapp": "+62812000000",
+            "nationality": "IT",
+            "passport_number": "Z99999999",
+            "passport_expiry": datetime(2029, 1, 1).date(),
+            "date_of_birth": datetime(1990, 5, 5).date(),
+            "gender": "F",
+            "address": "Jl. Test Rd, Bali",
+            "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "assigned_to": "agent@balizero.com",
+            "assigned_to_name": "Agent Smith",
+            "assigned_to_avatar": None,
+        }
+
+        response = client.get("/api/portal/profile")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["data"]["full_name"] == "Jane Live"
+        sql = conn.fetchrow.call_args.args[0]
+        assert "WHERE c.id = $1" in sql
+        assert "deleted_at IS NULL" in sql
+
     def test_update_profile_success(self, client, mock_portal_service):
         """Update profile fields."""
         mock_portal_service.update_profile.return_value = {

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal_dashboard.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal_dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -90,9 +91,22 @@ async def test_unread_count_graceful_on_missing_table() -> None:
     assert await _fetch_unread_count(mock_conn, 42) == 0
 
 
+def _live_client_fetchrow_side_effect(sql: str, *args: object) -> dict[str, Any] | None:
+    """
+    Route a shared AsyncMock's `.fetchrow` by query shape so the top-level
+    liveness gate (`SELECT id FROM clients WHERE id = $1 AND deleted_at IS
+    NULL`) sees a row while `_fetch_deadlines`'s own unrelated
+    `SELECT id, visa_expiry, passport_expiry FROM clients WHERE id = $1`
+    still exercises its own (independently tested) None branch.
+    """
+    if "deleted_at IS NULL" in sql:
+        return {"id": 42}
+    return None
+
+
 @pytest.mark.asyncio
 async def test_dashboard_summary_has_three_sections(monkeypatch) -> None:
-    """Integration-ish: verify summary endpoint returns 3 required keys."""
+    """Integration-ish: a LIVE client gets 200 with the 3 required keys."""
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -105,7 +119,7 @@ async def test_dashboard_summary_has_three_sections(monkeypatch) -> None:
 
     mock_conn = AsyncMock()
     mock_conn.fetch.return_value = []
-    mock_conn.fetchrow.return_value = None
+    mock_conn.fetchrow.side_effect = _live_client_fetchrow_side_effect
     mock_conn.fetchval.return_value = 0
 
     class _PoolCtx:
@@ -132,3 +146,61 @@ async def test_dashboard_summary_has_three_sections(monkeypatch) -> None:
     assert isinstance(body["open_actions"], list)
     assert isinstance(body["upcoming_deadlines"], list)
     assert isinstance(body["unread_messages"], int)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_summary_archived_client_returns_404(monkeypatch) -> None:
+    """
+    2026-08-20 class-fix: archived clients (clients.deleted_at set) must get
+    the same 404 every other portal endpoint gives. `/dashboard/summary` was
+    one of two handlers that bypassed the deleted_at IS NULL gate every
+    sibling resolves through PortalService — instead it served the archived
+    client's visa/passport expiry as "upcoming deadlines" (see
+    _fetch_deadlines's own SELECT, which never filtered deleted_at).
+
+    GUILT: with no client row surviving the liveness query (soft-deleted or
+    plain missing — the predicate can't tell them apart, matching every
+    sibling), the endpoint must 404 before touching the 3 data sources.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from backend.app.dependencies import get_database_pool
+    from backend.app.routers.portal import get_current_client
+    from backend.app.routers.portal_dashboard import router
+
+    app = FastAPI()
+    app.include_router(router)
+
+    mock_conn = AsyncMock()
+    mock_conn.fetch.return_value = []
+    mock_conn.fetchrow.return_value = None  # liveness gate finds nothing
+    mock_conn.fetchval.return_value = 0
+
+    class _PoolCtx:
+        async def __aenter__(self):
+            return mock_conn
+
+        async def __aexit__(self, *a):
+            return False
+
+    class _Pool:
+        def acquire(self):
+            return _PoolCtx()
+
+    app.dependency_overrides[get_current_client] = lambda: {"client_id": 42}
+    app.dependency_overrides[get_database_pool] = lambda: _Pool()
+
+    client = TestClient(app)
+    r = client.get("/api/portal/dashboard/summary")
+    assert r.status_code == 404
+
+    # Mutation-sensitive: proves the 404 comes from a deleted_at-filtered
+    # query, not merely from the mock defaulting to None for any query.
+    first_call_sql = mock_conn.fetchrow.call_args_list[0].args[0]
+    assert "FROM clients" in first_call_sql
+    assert "deleted_at IS NULL" in first_call_sql
+
+    # Data sources must never be reached once the client fails the gate.
+    mock_conn.fetch.assert_not_called()
+    mock_conn.fetchval.assert_not_called()


### PR DESCRIPTION
## What

The client portal (`my.balizero.com`) answered "is an archived client still served?" **two different ways depending on which URL you hit.**

Ten portal endpoints resolve the client through `PortalService`, whose methods filter `... WHERE id = $1 AND deleted_at IS NULL` and raise `ValueError("Client N not found")`, which the router turns into **404**: `get_dashboard`, `get_visa_status`, `get_companies`/`get_company_detail`, `get_tax_overview`, `get_documents`, `upload_document`, `get_messages`/`send_message`/`mark_message_read`, `get_preferences`/`update_preferences`, `get_timeline`, `update_profile`.

**Two endpoints bypassed that gate** because they run raw SQL directly in the router, with no `deleted_at` predicate at all:

1. `GET /api/portal/profile` (`portal.py::get_profile`) — served `passport_number`, `passport_expiry`, `date_of_birth`, `gender`, `address`, phone, whatsapp, nationality, member-since, and the assigned team member for an archived client.
2. `GET /api/portal/dashboard/summary` (`portal_dashboard.py::summary`, via `_fetch_deadlines`) — served an archived client's `visa_expiry`/`passport_expiry` from `clients` as "upcoming deadlines".

## Fix

Both queries now filter `deleted_at IS NULL`, matching the sibling pattern exactly:

- **`portal.py`**: added `AND c.deleted_at IS NULL` to `get_profile`'s `WHERE` clause. The existing `if not row: raise HTTPException(404, ...)` already does the right thing once the row is filtered out — no new control flow needed.
- **`portal_dashboard.py`**: `summary()` had no client-liveness check at all — its 3 data sources (`_fetch_open_actions`, `_fetch_deadlines`, `_fetch_unread_count`) each degrade gracefully on a missing table/column by design (see module docstring). Added an explicit `SELECT id FROM clients WHERE id = $1 AND deleted_at IS NULL` gate before those 3 fetches, raising `HTTPException(404, "Client not found")`. Deliberately **not** wrapped in the same try/except-degrade used for the data sources — this is an identity check, not an optional data source, and an unexpected DB error here should 500 like every sibling endpoint, not silently serve a partial dashboard.

I looked for an existing `PortalService` method to reuse first (`_get_profile_data` in `_mixins/billing.py` returns nearly the same field set and already filters `deleted_at`), but it's a private helper with different not-found semantics (`{}` vs raising) and different date serialization (`str()` vs `.isoformat()`) — reusing it would have meant either changing `/profile`'s response format or adding glue code, so I added the predicate directly instead, per the task's explicit fallback.

## Tests

`test_portal.py::TestProfile` and `test_portal_dashboard.py`:

- **Guilt**: archived/missing client → 404 from both endpoints. Each assertion is anchored to the *captured SQL text* passed to the mock (`conn.fetchrow.call_args`), not just the mock returning `None` by coincidence — mutation-sensitive.
- **Innocence**: a live client still gets 200 with their data from both endpoints.
- Updated the pre-existing `test_dashboard_summary_has_three_sections`, which previously exercised a bare "client row missing" case that the new gate now correctly 404s — it now uses a query-routed mock so it exercises a genuine live-client path; the new archived-client test covers the 404 path explicitly.

**Mutation-verify** (by hand, not left in the tree): stripped `deleted_at IS NULL` from both queries → the 4 new/updated guilt tests went red (43 passed / 4 failed). Restored → 47/47 green.

```
cd apps/backend-rag && source .venv/bin/activate
PYTHONPATH=. pytest backend/tests/unit/routers/test_portal.py backend/tests/unit/routers/test_portal_dashboard.py -v
# 47 passed
```

Also ran the wider portal test suite (404-class guard test, company-detail-404, client-safe, admin-search-deleted, billing, profile-update, service unit tests): **217 passed, 0 failed**.

## Explicitly NOT changed here — owner's decision (Legge 5)

- **Whether archiving a client should revoke portal login at all.** `DELETE /api/crm/clients/{client_id}` (`crm_clients.py`) only sets `clients.deleted_at`; it never touches `team_members`, so an archived client's account can still authenticate (`get_current_client` resolves identity from `team_members`, not `clients`). This PR makes every *data* endpoint agree the client is archived once they're past login — it does not touch whether they can log in at all.
- **Deactivating `team_members` on CRM archival** — same reason, that's the policy change this fix intentionally does not make.
- The superuser email-fallback at `portal.py:163-167`.
- Anything about the shared-phone / `upsert-by-phone` code path.

`crm_clients.py` was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
