### PR TITLE
feat(intake): add company projection refresh

### DIFF
--- a/apps/backend-rag/backend/tests/scripts/test_intake_company_projection.py
+++ b/apps/backend-rag/backend/tests/scripts/test_intake_company_projection.py
@@ -1,0 +1,3363 @@
+"""Contract tests for the bounded PROD -> dev company projection.
+
+All rows are synthetic and every database/subprocess boundary is faked.  These
+tests must never contact Postgres, start the Fly proxy, or mutate an intake
+table.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import decimal
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import uuid
+from collections.abc import Callable, Mapping
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "intake_company_projection.py"
+
+EXPECTED_COMPANY_COLUMNS = (
+    "id",
+    "uuid",
+    "company_name",
+    "company_type",
+    "brand_name",
+    "kbli_code",
+    "kbli_description",
+    "nib",
+    "npwp_company",
+    "akta_pendirian_no",
+    "akta_pendirian_date",
+    "akta_perubahan_no",
+    "akta_perubahan_date",
+    "sk_menhumkam_no",
+    "sk_menhumkam_date",
+    "registered_address",
+    "office_address",
+    "city",
+    "province",
+    "postal_code",
+    "company_phone",
+    "company_email",
+    "status",
+    "setup_progress",
+    "google_drive_folder_id",
+    "custom_fields",
+    "created_at",
+    "updated_at",
+    "created_by",
+    "updated_by",
+)
+
+EXPECTED_LINK_COLUMNS = (
+    "id",
+    "client_id",
+    "company_id",
+    "role",
+    "is_primary",
+    "ownership_percentage",
+    "shares_count",
+    "share_nominal_value",
+    "start_date",
+    "end_date",
+    "status",
+    "notes",
+    "created_at",
+    "updated_at",
+)
+
+_PROJECTION_DIGEST_DOMAIN = "nuzantara:intake-company-projection"
+_PROJECTION_DIGEST_VERSION = "1"
+EXPECTED_PROTECTED_TABLES = (
+    "clients",
+    "intake_queue",
+    "document_instances",
+    "document_routing_proposal",
+    "intake_commit_audit",
+)
+
+
+def _independent_digest_value(value: Any) -> Any:
+    if value is None:
+        return ["null"]
+    if isinstance(value, bool):
+        return ["bool", value]
+    if isinstance(value, int):
+        return ["int", str(value)]
+    if isinstance(value, decimal.Decimal):
+        return ["decimal", str(value)]
+    if isinstance(value, float):
+        raise TypeError("float is not lossless")
+    if isinstance(value, str):
+        return ["string", value]
+    if isinstance(value, Mapping):
+        return [
+            "object",
+            [
+                [key, _independent_digest_value(value[key])]
+                for key in sorted(value)
+            ],
+        ]
+    if isinstance(value, (list, tuple)):
+        return ["array", [_independent_digest_value(item) for item in value]]
+    raise TypeError(f"unsupported canonical value type: {type(value).__name__}")
+
+
+def _independent_projection_bytes(
+    *,
+    companies: tuple[Mapping[str, Any], ...],
+    eligible_links: tuple[Mapping[str, Any], ...],
+    company_columns: tuple[str, ...] = EXPECTED_COMPANY_COLUMNS,
+    link_columns: tuple[str, ...] = EXPECTED_LINK_COLUMNS,
+) -> bytes:
+    records: list[Any] = [
+        [
+            "header",
+            _PROJECTION_DIGEST_DOMAIN,
+            _PROJECTION_DIGEST_VERSION,
+            list(company_columns),
+            list(link_columns),
+        ]
+    ]
+    records.extend(
+        ["company", [_independent_digest_value(row[column]) for column in company_columns]]
+        for row in sorted(companies, key=lambda row: int(row["id"]))
+    )
+    records.extend(
+        ["link", [_independent_digest_value(row[column]) for column in link_columns]]
+        for row in sorted(eligible_links, key=lambda row: int(row["id"]))
+    )
+    return b"\n".join(
+        json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode()
+        for record in records
+    ) + b"\n"
+
+
+def _independent_projection_digest(
+    *,
+    companies: tuple[Mapping[str, Any], ...],
+    eligible_links: tuple[Mapping[str, Any], ...],
+    company_columns: tuple[str, ...] = EXPECTED_COMPANY_COLUMNS,
+    link_columns: tuple[str, ...] = EXPECTED_LINK_COLUMNS,
+) -> str:
+    return hashlib.sha256(
+        _independent_projection_bytes(
+            companies=companies,
+            eligible_links=eligible_links,
+            company_columns=company_columns,
+            link_columns=link_columns,
+        )
+    ).hexdigest()
+
+
+def _load() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "intake_company_projection_under_test", _SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _company(company_id: int, *, marker: str = "SYNTHETIC COMPANY") -> dict[str, Any]:
+    row = dict.fromkeys(EXPECTED_COMPANY_COLUMNS)
+    row.update(
+        {
+            "id": company_id,
+            "uuid": f"00000000-0000-4000-8000-{company_id:012d}",
+            "company_name": marker,
+            "company_type": "PT PMA",
+            "status": "active",
+            "setup_progress": 0,
+            "custom_fields": {},
+            "created_at": "2026-08-01T00:00:00+00:00",
+            "updated_at": "2026-08-02T00:00:00+00:00",
+        }
+    )
+    return row
+
+
+def _link(link_id: int, client_id: int, company_id: int) -> dict[str, Any]:
+    row = dict.fromkeys(EXPECTED_LINK_COLUMNS)
+    row.update(
+        {
+            "id": link_id,
+            "client_id": client_id,
+            "company_id": company_id,
+            "role": "shareholder",
+            "is_primary": True,
+            "status": "active",
+            "created_at": "2026-08-01T00:00:00+00:00",
+            "updated_at": "2026-08-02T00:00:00+00:00",
+        }
+    )
+    return row
+
+
+def _snapshot_stdout(
+    companies: list[dict[str, Any]],
+    links: list[dict[str, Any]],
+    *,
+    meta_overrides: Mapping[str, Any] | None = None,
+) -> bytes:
+    meta: dict[str, Any] = {
+        "kind": "meta",
+        "database": "nuzantara_rag",
+        "role": "nuzantara_readonly",
+        "transaction_read_only": "on",
+        "snapshot_at": "2026-08-19T01:02:03+00:00",
+        "companies_count": len(companies),
+        "links_count": len(links),
+        "companies_max_updated_at": "2026-08-02T00:00:00+00:00",
+        "links_max_updated_at": "2026-08-02T00:00:00+00:00",
+    }
+    meta.update(meta_overrides or {})
+    records = [meta]
+    records.extend({"kind": "company", "row": row} for row in companies)
+    records.extend({"kind": "link", "row": row} for row in links)
+    return ("\n".join(json.dumps(record) for record in records) + "\n").encode()
+
+
+class _Runner:
+    def __init__(self, stdout: bytes, *, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = b"SYNTHETIC STDERR MUST NOT BE ECHOED"
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        self.calls.append((args, kwargs))
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=self.returncode,
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+
+
+def test_schema_allowlists_are_exact_and_source_only_columns_are_excluded() -> None:
+    mod = _load()
+    assert mod.COMPANY_COLUMNS == EXPECTED_COMPANY_COLUMNS
+    assert mod.LINK_COLUMNS == EXPECTED_LINK_COLUMNS
+    assert set(mod.SOURCE_ONLY_COMPANY_COLUMNS) == {
+        "geo_point",
+        "rdtr_zone_code",
+        "geocoded_at",
+        "geocode_source",
+        "tax_dept_folder_id",
+    }
+    assert set(mod.COMPANY_COLUMNS).isdisjoint(mod.SOURCE_ONLY_COMPANY_COLUMNS)
+
+
+def test_script_help_runs_and_defaults_to_dry_run() -> None:
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": str(_REPO_ROOT / "apps" / "backend-rag"),
+    }
+    result = subprocess.run(
+        [sys.executable, str(_SCRIPT_PATH), "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--apply" in result.stdout
+    assert "--expected-content-digest" in result.stdout
+    assert "dry-run" in result.stdout.lower()
+
+
+def test_actual_main_default_dry_run_never_connects_to_target_or_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(_snapshot_stdout([_company(101)], []))
+    target_connects = 0
+    writes = 0
+
+    async def forbidden_target_connect(*args: Any, **kwargs: Any) -> Any:
+        nonlocal target_connects
+        target_connects += 1
+        raise AssertionError("default dry-run connected to target")
+
+    async def forbidden_apply(*args: Any, **kwargs: Any) -> Any:
+        nonlocal writes
+        writes += 1
+        raise AssertionError("default dry-run attempted a write")
+
+    monkeypatch.setattr(mod, "fetch_source_snapshot", lambda **kwargs: snapshot)
+    monkeypatch.setattr(mod.asyncpg, "connect", forbidden_target_connect)
+    monkeypatch.setattr(mod, "apply_projection", forbidden_apply)
+
+    assert mod.main([]) == 0
+    captured = capsys.readouterr()
+    report = json.loads(captured.out)
+    assert captured.err == ""
+    assert report["mode"] == "dry-run"
+    assert report["write_attempted"] is False
+    assert target_connects == 0
+    assert writes == 0
+
+
+def test_prod_snapshot_uses_one_pg_sh_read_only_json_stream() -> None:
+    mod = _load()
+    company = _company(101)
+    company["geo_point"] = "SOURCE_ONLY"
+    company["unexpected_source_field"] = "DROP_ME"
+    runner = _Runner(_snapshot_stdout([company], [_link(201, 301, 101)]))
+
+    snapshot = mod.fetch_source_snapshot(run=runner)
+
+    assert len(runner.calls) == 1
+    positional, kwargs = runner.calls[0]
+    command = positional[0]
+    assert command[:2] == ["bash", str(_REPO_ROOT / "scripts" / "pg.sh")]
+    assert "-q" in command and "-tA" in command and "ON_ERROR_STOP=1" in command
+    sql = kwargs["input"]
+    assert isinstance(sql, bytes)
+    decoded_sql = sql.decode()
+    assert "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY" in decoded_sql
+    assert decoded_sql.count("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY") == 1
+    assert decoded_sql.count("COMMIT") == 1
+    assert "current_database()" in decoded_sql
+    assert "current_user" in decoded_sql
+    assert "current_setting('transaction_read_only')" in decoded_sql
+    assert "FROM public.companies" in decoded_sql
+    assert "FROM public.client_company_links" in decoded_sql
+    assert decoded_sql.count("ORDER BY id") == 2
+    for verb in ("INSERT", "UPDATE", "DELETE", "TRUNCATE", "DROP", "ALTER"):
+        assert not re.search(rf"\b{verb}\b", decoded_sql.upper())
+    assert snapshot.companies[0]["company_name"] == "SYNTHETIC COMPANY"
+    assert set(snapshot.companies[0]) == set(EXPECTED_COMPANY_COLUMNS)
+    assert "geo_point" not in snapshot.companies[0]
+    assert "unexpected_source_field" not in snapshot.companies[0]
+    exact_row_bytes = b"\n".join(runner.stdout.splitlines()[1:]) + b"\n"
+    assert snapshot.canonical_row_bytes == exact_row_bytes
+
+
+def test_content_digest_binds_domain_version_ordered_columns_and_exact_row_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mod = _load()
+    raw = _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    baseline = mod.parse_source_snapshot(raw)
+    original_domain = mod.CONTENT_DIGEST_DOMAIN
+    original_version = mod.CONTENT_DIGEST_VERSION
+    assert isinstance(mod.CONTENT_DIGEST_DOMAIN, str) and mod.CONTENT_DIGEST_DOMAIN
+    assert isinstance(mod.CONTENT_DIGEST_VERSION, str) and mod.CONTENT_DIGEST_VERSION
+    assert baseline.content_digest == mod.compute_content_digest(
+        canonical_row_bytes=baseline.canonical_row_bytes,
+        domain=mod.CONTENT_DIGEST_DOMAIN,
+        version=mod.CONTENT_DIGEST_VERSION,
+        company_columns=EXPECTED_COMPANY_COLUMNS,
+        link_columns=EXPECTED_LINK_COLUMNS,
+    )
+
+    monkeypatch.setattr(mod, "CONTENT_DIGEST_DOMAIN", "mutated-domain")
+    assert mod.parse_source_snapshot(raw).content_digest != baseline.content_digest
+    monkeypatch.setattr(mod, "CONTENT_DIGEST_DOMAIN", original_domain)
+    monkeypatch.setattr(mod, "CONTENT_DIGEST_VERSION", "mutated-version")
+    assert mod.parse_source_snapshot(raw).content_digest != baseline.content_digest
+    monkeypatch.setattr(mod, "CONTENT_DIGEST_VERSION", original_version)
+
+    reordered = (EXPECTED_COMPANY_COLUMNS[1], EXPECTED_COMPANY_COLUMNS[0], *EXPECTED_COMPANY_COLUMNS[2:])
+    assert mod.compute_content_digest(
+        canonical_row_bytes=baseline.canonical_row_bytes,
+        domain="contract-domain",
+        version="contract-version",
+        company_columns=reordered,
+        link_columns=EXPECTED_LINK_COLUMNS,
+    ) != mod.compute_content_digest(
+        canonical_row_bytes=baseline.canonical_row_bytes,
+        domain="contract-domain",
+        version="contract-version",
+        company_columns=EXPECTED_COMPANY_COLUMNS,
+        link_columns=EXPECTED_LINK_COLUMNS,
+    )
+
+    reordered_links = (EXPECTED_LINK_COLUMNS[1], EXPECTED_LINK_COLUMNS[0], *EXPECTED_LINK_COLUMNS[2:])
+    assert mod.compute_content_digest(
+        canonical_row_bytes=baseline.canonical_row_bytes,
+        domain="contract-domain",
+        version="contract-version",
+        company_columns=EXPECTED_COMPANY_COLUMNS,
+        link_columns=reordered_links,
+    ) != mod.compute_content_digest(
+        canonical_row_bytes=baseline.canonical_row_bytes,
+        domain="contract-domain",
+        version="contract-version",
+        company_columns=EXPECTED_COMPANY_COLUMNS,
+        link_columns=EXPECTED_LINK_COLUMNS,
+    )
+
+
+def test_numeric_values_are_lossless_and_never_roundtrip_through_float() -> None:
+    mod = _load()
+    company = _company(101)
+    company["setup_progress"] = decimal.Decimal("0.123456789012345678901234567890")
+    base = _snapshot_stdout([_company(101)], [])
+    line = base.splitlines()[1].decode()
+    line = line.replace('"setup_progress": 0', '"setup_progress": 0.123456789012345678901234567890')
+    raw = base.splitlines()[0] + b"\n" + line.encode() + b"\n"
+
+    snapshot = mod.parse_source_snapshot(raw)
+
+    value = snapshot.companies[0]["setup_progress"]
+    assert not isinstance(value, float)
+    assert decimal.Decimal(str(value)) == company["setup_progress"]
+    assert b"0.123456789012345678901234567890" in snapshot.canonical_row_bytes
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_fragment"),
+    [
+        ({"database": "not_prod"}, "source database attestation failed"),
+        ({"role": "write_role"}, "source role attestation failed"),
+        ({"transaction_read_only": "off"}, "source read-only attestation failed"),
+        ({"companies_count": 99}, "source company count mismatch"),
+    ],
+)
+def test_prod_snapshot_attestation_fails_closed(
+    overrides: Mapping[str, Any], expected_fragment: str
+) -> None:
+    mod = _load()
+    stdout = _snapshot_stdout([_company(101)], [], meta_overrides=overrides)
+    with pytest.raises(mod.SourceSnapshotError, match=expected_fragment):
+        mod.parse_source_snapshot(stdout)
+
+
+def test_malformed_source_json_error_never_echoes_payload_or_stderr() -> None:
+    mod = _load()
+    private_marker = "SYNTHETIC_PRIVATE_MARKER"
+    malformed = _snapshot_stdout([_company(101)], []) + f'{{"{private_marker}":'.encode()
+    runner = _Runner(malformed)
+
+    with pytest.raises(mod.SourceSnapshotError) as exc_info:
+        mod.fetch_source_snapshot(run=runner)
+
+    message = str(exc_info.value)
+    assert "output line" in message
+    assert private_marker not in message
+    assert "SYNTHETIC STDERR" not in message
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda records: [records[0], records[0], *records[1:]],
+        lambda records: [*records, {"kind": "unknown", "row": {}}],
+        lambda records: [*records, records[1]],
+        lambda records: [*records, records[2]],
+    ],
+    ids=("duplicate-meta", "unknown-record", "duplicate-company", "duplicate-link"),
+)
+def test_source_stream_rejects_duplicate_unknown_or_trailing_records(mutate) -> None:
+    mod = _load()
+    original = _snapshot_stdout(
+        [_company(101)], [_link(201, 301, 101)]
+    ).decode().splitlines()
+    records = [json.loads(line) for line in original]
+    poisoned = ("\n".join(json.dumps(record) for record in mutate(records)) + "\n").encode()
+
+    with pytest.raises(mod.SourceSnapshotError):
+        mod.parse_source_snapshot(poisoned)
+
+
+def test_source_stream_rejects_trailing_non_json_bytes_without_echoing_them() -> None:
+    mod = _load()
+    poison = b"SYNTHETIC_TRAILING_PRIVATE_BYTES"
+    raw = _snapshot_stdout([_company(101)], []) + poison
+    with pytest.raises(mod.SourceSnapshotError) as exc_info:
+        mod.parse_source_snapshot(raw)
+    assert poison.decode() not in str(exc_info.value)
+
+
+def test_projection_keeps_all_companies_and_only_links_with_local_clients() -> None:
+    mod = _load()
+    stdout = _snapshot_stdout(
+        [_company(101), _company(102)],
+        [_link(201, 301, 101), _link(202, 999, 102)],
+    )
+    snapshot = mod.parse_source_snapshot(stdout)
+
+    plan = mod.build_projection_plan(snapshot, local_client_ids={301})
+
+    assert len(plan.companies) == 2
+    assert [row["id"] for row in plan.eligible_links] == [201]
+    assert plan.rejected_missing_local_client == 1
+    assert not hasattr(plan, "synthesized_clients")
+
+
+def test_projection_digest_is_lossless_and_excludes_rejected_links() -> None:
+    mod = _load()
+    eligible = _link(201, 301, 101)
+    rejected_a = _link(202, 999, 101)
+    rejected_b = dict(rejected_a, notes="SYNTHETIC REJECTED CONTENT MUTANT")
+    first = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [eligible, rejected_a])
+    )
+    second = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [eligible, rejected_b])
+    )
+    first_plan = mod.build_projection_plan(first, local_client_ids={301})
+    second_plan = mod.build_projection_plan(second, local_client_ids={301})
+    assert first.content_digest != second.content_digest
+    assert first_plan.projection_digest == second_plan.projection_digest
+
+    eligible_mutant = dict(eligible, ownership_percentage="0.12345678901234567890")
+    third = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [eligible_mutant, rejected_a])
+    )
+    third_plan = mod.build_projection_plan(third, local_client_ids={301})
+    assert third_plan.projection_digest != first_plan.projection_digest
+    assert third_plan.projection_digest == _independent_projection_digest(
+        companies=third_plan.companies,
+        eligible_links=third_plan.eligible_links,
+    )
+
+
+def test_projection_digest_independent_oracle_covers_every_ordered_column() -> None:
+    mod = _load()
+    assert mod.PROJECTION_DIGEST_DOMAIN == _PROJECTION_DIGEST_DOMAIN
+    assert mod.PROJECTION_DIGEST_VERSION == _PROJECTION_DIGEST_VERSION
+    assert mod.COMPANY_COLUMNS == EXPECTED_COMPANY_COLUMNS
+    assert mod.LINK_COLUMNS == EXPECTED_LINK_COLUMNS
+
+    company = _company(101)
+    company["setup_progress"] = decimal.Decimal(
+        "0.123456789012345678901234567890"
+    )
+    company["custom_fields"] = {"nested": ["SYNTHETIC", decimal.Decimal("1.01")]}
+    link = _link(201, 301, 101)
+    link["ownership_percentage"] = decimal.Decimal("99.999999999999999999")
+    link["share_nominal_value"] = decimal.Decimal("1000000.000000000001")
+    companies = (company,)
+    links = (link,)
+    expected = _independent_projection_digest(
+        companies=companies, eligible_links=links
+    )
+    assert mod.compute_projection_digest(
+        companies=companies, eligible_links=links
+    ) == expected
+    canonical_bytes = _independent_projection_bytes(
+        companies=companies, eligible_links=links
+    )
+    assert b"0.123456789012345678901234567890" in canonical_bytes
+    assert b"99.999999999999999999" in canonical_bytes
+    assert b"1000000.000000000001" in canonical_bytes
+
+    for index, column in enumerate(EXPECTED_COMPANY_COLUMNS, start=1):
+        mutant = copy.deepcopy(company)
+        if column == "id":
+            mutant[column] = 1000 + index
+        elif column == "setup_progress":
+            mutant[column] = decimal.Decimal(f"0.{index:030d}")
+        elif column == "custom_fields":
+            mutant[column] = {"poison": f"SYNTHETIC_COMPANY_COLUMN_{index}"}
+        else:
+            mutant[column] = f"SYNTHETIC_COMPANY_COLUMN_{index}_{column}"
+        oracle = _independent_projection_digest(
+            companies=(mutant,), eligible_links=links
+        )
+        assert oracle != expected, column
+        assert mod.compute_projection_digest(
+            companies=(mutant,), eligible_links=links
+        ) == oracle
+
+    for index, column in enumerate(EXPECTED_LINK_COLUMNS, start=1):
+        mutant = copy.deepcopy(link)
+        if column in {"id", "client_id", "company_id", "shares_count"}:
+            mutant[column] = 2000 + index
+        elif column == "is_primary":
+            mutant[column] = not link[column]
+        elif column in {"ownership_percentage", "share_nominal_value"}:
+            mutant[column] = decimal.Decimal(f"{index}.{'7' * 30}")
+        else:
+            mutant[column] = f"SYNTHETIC_LINK_COLUMN_{index}_{column}"
+        oracle = _independent_projection_digest(
+            companies=companies, eligible_links=(mutant,)
+        )
+        assert oracle != expected, column
+        assert mod.compute_projection_digest(
+            companies=companies, eligible_links=(mutant,)
+        ) == oracle
+
+    reordered = _independent_projection_digest(
+        companies=companies,
+        eligible_links=links,
+        company_columns=(EXPECTED_COMPANY_COLUMNS[1], EXPECTED_COMPANY_COLUMNS[0], *EXPECTED_COMPANY_COLUMNS[2:]),
+    )
+    assert reordered != expected
+    float_company = copy.deepcopy(company)
+    float_company["setup_progress"] = 0.1
+    with pytest.raises(TypeError, match="float"):
+        mod.compute_projection_digest(
+            companies=(float_company,), eligible_links=links
+        )
+
+
+def test_shape_digest_excludes_company_content() -> None:
+    mod = _load()
+    first = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101, marker="SYNTHETIC A")], [_link(201, 301, 101)])
+    )
+    second = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101, marker="SYNTHETIC B")], [_link(201, 301, 101)])
+    )
+    assert mod.source_shape_digest(first) == mod.source_shape_digest(second)
+
+
+@pytest.mark.parametrize(
+    "dsn",
+    [
+        "postgresql://nuzantara@db.internal:5432/nuzantara_dev",
+        "postgresql://nuzantara@127.0.0.1:5432/nuzantara_rag",
+        "postgresql://nuzantara@127.0.0.1:5432/postgres",
+    ],
+)
+def test_target_dsn_rejects_remote_or_non_dev_database(dsn: str) -> None:
+    mod = _load()
+    with pytest.raises(mod.ApplyGateError):
+        mod.validate_target_dsn(dsn)
+
+
+def test_apply_requires_flag_environment_gate_and_exact_local_target() -> None:
+    mod = _load()
+    dsn = "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+    digest = "a" * 64
+    mod.validate_target_dsn(dsn)
+
+    with pytest.raises(mod.ApplyGateError, match="--apply"):
+        mod.validate_apply_request(
+            apply=False,
+            dsn=dsn,
+            environ={},
+            expected_content_digest=None,
+            actual_content_digest=digest,
+        )
+    with pytest.raises(mod.ApplyGateError, match=mod.WRITE_ENABLE_ENV):
+        mod.validate_apply_request(
+            apply=True,
+            dsn=dsn,
+            environ={},
+            expected_content_digest=digest,
+            actual_content_digest=digest,
+        )
+    with pytest.raises(mod.ApplyGateError, match="expected content digest"):
+        mod.validate_apply_request(
+            apply=True,
+            dsn=dsn,
+            environ={mod.WRITE_ENABLE_ENV: "true"},
+            expected_content_digest=None,
+            actual_content_digest=digest,
+        )
+    with pytest.raises(mod.ApplyGateError, match="content digest mismatch"):
+        mod.validate_apply_request(
+            apply=True,
+            dsn=dsn,
+            environ={mod.WRITE_ENABLE_ENV: "true"},
+            expected_content_digest="b" * 64,
+            actual_content_digest=digest,
+        )
+    mod.validate_apply_request(
+        apply=True,
+        dsn=dsn,
+        environ={mod.WRITE_ENABLE_ENV: "true"},
+        expected_content_digest=digest,
+        actual_content_digest=digest,
+    )
+
+
+def test_target_contract_requires_allowlisted_columns_and_both_link_fks() -> None:
+    mod = _load()
+    columns = {
+        "companies": {*EXPECTED_COMPANY_COLUMNS, "future_target_only_column"},
+        "client_company_links": {*EXPECTED_LINK_COLUMNS, "future_link_only_column"},
+    }
+    constraints = {
+        "companies": ("PRIMARY KEY (id)",),
+        "client_company_links": (
+            "PRIMARY KEY (id)",
+            "UNIQUE (client_id, company_id)",
+            "FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE",
+            "FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE",
+        ),
+    }
+    mod.validate_target_contract(columns, constraints)
+
+    missing_fk = dict(constraints)
+    missing_fk["client_company_links"] = constraints["client_company_links"][:-1]
+    with pytest.raises(mod.TargetContractError, match="company_id foreign key"):
+        mod.validate_target_contract(columns, missing_fk)
+
+
+def test_target_attestation_contract_is_exact_and_rejects_socket_fallback() -> None:
+    mod = _load()
+    required_aliases = {
+        "database",
+        "role",
+        "server_address",
+        "server_port",
+        "transaction_read_only",
+        "search_path",
+        "public_schema_oid",
+        "companies_relation",
+        "companies_relation_oid",
+        "companies_regclass_oid",
+        "companies_namespace_oid",
+        "companies_namespace",
+        "companies_relname",
+        "companies_relkind",
+        "links_relation",
+        "links_relation_oid",
+        "links_regclass_oid",
+        "links_namespace_oid",
+        "links_namespace",
+        "links_relname",
+        "links_relkind",
+    }
+    for alias in required_aliases:
+        assert re.search(rf"\bAS\s+{alias}\b", mod.TARGET_ATTEST_SQL, re.IGNORECASE)
+    assert "current_setting('search_path')" in mod.TARGET_ATTEST_SQL
+    assert "to_regnamespace('public')" in mod.TARGET_ATTEST_SQL
+    assert "to_regclass('public.companies')" in mod.TARGET_ATTEST_SQL
+    assert "to_regclass('public.client_company_links')" in mod.TARGET_ATTEST_SQL
+    assert re.search(
+        r"company_relation\.oid\s+AS\s+companies_relation_oid",
+        mod.TARGET_ATTEST_SQL,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"to_regclass\('public\.companies'\)::oid\s+AS\s+companies_regclass_oid",
+        mod.TARGET_ATTEST_SQL,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"company_namespace\.oid\s+AS\s+companies_namespace_oid",
+        mod.TARGET_ATTEST_SQL,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"link_relation\.oid\s+AS\s+links_relation_oid",
+        mod.TARGET_ATTEST_SQL,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"to_regclass\('public\.client_company_links'\)::oid\s+AS\s+links_regclass_oid",
+        mod.TARGET_ATTEST_SQL,
+        re.IGNORECASE,
+    )
+    assert re.search(
+        r"link_namespace\.oid\s+AS\s+links_namespace_oid",
+        mod.TARGET_ATTEST_SQL,
+        re.IGNORECASE,
+    )
+
+
+class _AttestConnection:
+    def __init__(self, mod: Any, values: Mapping[str, Any]) -> None:
+        self.mod = mod
+        self.values = dict(values)
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        assert sql == self.mod.TARGET_ATTEST_SQL
+        return dict(self.values)
+
+
+def _valid_target_attestation() -> dict[str, Any]:
+    return {
+        "database": "nuzantara_dev",
+        "role": "nuzantara",
+        "server_address": "127.0.0.1",
+        "server_port": 5432,
+        "transaction_read_only": "off",
+        "search_path": "public",
+        "public_schema_oid": 2200,
+        # PostgreSQL renders visible regclass values without schema qualification
+        # when search_path is exactly public.  Identity comes from the catalog OIDs,
+        # namespace, relation name, and relkind below, not this display string.
+        "companies_relation": "companies",
+        "companies_relation_oid": 41001,
+        "companies_regclass_oid": 41001,
+        "companies_namespace_oid": 2200,
+        "companies_namespace": "public",
+        "companies_relname": "companies",
+        "companies_relkind": "r",
+        "links_relation": "client_company_links",
+        "links_relation_oid": 41002,
+        "links_regclass_oid": 41002,
+        "links_namespace_oid": 2200,
+        "links_namespace": "public",
+        "links_relname": "client_company_links",
+        "links_relkind": "r",
+    }
+
+
+async def test_target_attestation_accepts_pg_visible_unqualified_regclass_text() -> None:
+    """A real search_path=public regclass rendering must not fail attestation."""
+    mod = _load()
+
+    await mod.attest_target(
+        _AttestConnection(mod, _valid_target_attestation()),
+        expect_read_only=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "mutant"),
+    [
+        ("database", "postgres"),
+        ("role", "write_role"),
+        ("server_address", None),
+        ("server_address", "10.0.0.9"),
+        ("server_port", 15432),
+        ("transaction_read_only", "on"),
+        ("search_path", '"$user", public'),
+        ("public_schema_oid", None),
+        ("companies_relation", "shadow.companies"),
+        ("links_relation", "shadow.client_company_links"),
+    ],
+)
+async def test_target_attestation_rejects_every_value_mutant(
+    field: str, mutant: Any
+) -> None:
+    mod = _load()
+    values = _valid_target_attestation()
+    values[field] = mutant
+    with pytest.raises(mod.TargetContractError):
+        await mod.attest_target(
+            _AttestConnection(mod, values), expect_read_only=False
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "mutant"),
+    [
+        ("companies_relation_oid", 41999),
+        ("companies_regclass_oid", 41999),
+        ("companies_namespace_oid", 2299),
+        ("links_relation_oid", 42999),
+        ("links_regclass_oid", 42999),
+        ("links_namespace_oid", 2299),
+    ],
+)
+async def test_target_attestation_rejects_catalog_oid_identity_mismatch(
+    field: str, mutant: int
+) -> None:
+    """Catalog identity remains causal even if legacy display text looks valid."""
+    mod = _load()
+    values = _valid_target_attestation()
+    values.update(
+        {
+            "companies_relation": "public.companies",
+            "links_relation": "public.client_company_links",
+            field: mutant,
+        }
+    )
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.attest_target(
+            _AttestConnection(mod, values), expect_read_only=False
+        )
+
+
+def test_target_contract_queries_fk_validation_and_exact_sequence_ownership() -> None:
+    mod = _load()
+    constraint_sql = mod.TARGET_CONSTRAINTS_SQL.lower()
+    assert "convalidated" in constraint_sql
+    assert "public" in constraint_sql
+    sequence_sql = mod.SEQUENCE_ATTEST_SQL.lower()
+    for exact_name in (
+        "public.companies_id_seq",
+        "public.client_company_links_id_seq",
+        "public.companies",
+        "public.client_company_links",
+    ):
+        assert exact_name in sequence_sql
+    assert "pg_depend" in sequence_sql
+    assert "attnum" in sequence_sql or "pg_attribute" in sequence_sql
+
+
+def test_protected_table_set_and_digest_sql_cover_actual_rows_and_columns() -> None:
+    mod = _load()
+    assert mod.PROTECTED_TABLES == (
+        "clients",
+        "intake_queue",
+        "document_instances",
+        "document_routing_proposal",
+        "intake_commit_audit",
+    )
+    assert len(mod.PROTECTED_INVARIANT_SQL) == len(mod.PROTECTED_TABLES)
+    for table, sql in zip(
+        mod.PROTECTED_TABLES, mod.PROTECTED_INVARIANT_SQL, strict=True
+    ):
+        assert f"public.{table}" in sql
+        assert "information_schema.columns" in sql
+        assert "ordinal_position" in sql
+        assert "to_jsonb" in sql
+        assert "ORDER BY row_hash" in sql
+        assert "schema_digest" in sql and "row_digest" in sql
+
+
+class _SharedProjectionState:
+    def __init__(self) -> None:
+        self.companies: dict[int, dict[str, Any]] = {}
+        self.links: dict[int, dict[str, Any]] = {}
+        self.sequences: dict[str, tuple[int, bool]] = {
+            "public.companies_id_seq": (1000, True),
+            "public.client_company_links_id_seq": (2000, True),
+        }
+        self.advisory_lock = asyncio.Lock()
+        self.second_lock_waiting = asyncio.Event()
+        self.first_writer_entered = asyncio.Event()
+        self.release_first_writer = asyncio.Event()
+        self.active_writers = 0
+        self.max_active_writers = 0
+
+
+class _FakeTransaction:
+    def __init__(self, conn: _StatefulConnection, options: dict[str, Any]) -> None:
+        self.conn = conn
+        self.options = options
+        self.saved_companies: dict[int, dict[str, Any]] = {}
+        self.saved_links: dict[int, dict[str, Any]] = {}
+        self.saved_sequences: dict[str, tuple[int, bool]] = {}
+
+    async def __aenter__(self) -> _FakeTransaction:
+        assert not self.conn.in_transaction
+        self.conn.in_transaction = True
+        self.conn.transaction_options.append(self.options)
+        self.saved_companies = copy.deepcopy(self.conn.state.companies)
+        self.saved_links = copy.deepcopy(self.conn.state.links)
+        self.saved_sequences = copy.deepcopy(self.conn.state.sequences)
+        self.conn.events.append("begin")
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool:
+        if exc_type is not None:
+            self.conn.state.companies = self.saved_companies
+            self.conn.state.links = self.saved_links
+            self.conn.state.sequences = self.saved_sequences
+            self.conn.events.append("rollback")
+        else:
+            self.conn.events.append("commit")
+        if self.conn.holds_advisory_lock:
+            self.conn.state.active_writers -= 1
+            self.conn.state.advisory_lock.release()
+            self.conn.holds_advisory_lock = False
+        self.conn.in_transaction = False
+        return False
+
+
+class _StatefulConnection:
+    def __init__(
+        self,
+        mod: Any,
+        *,
+        state: _SharedProjectionState | None = None,
+        fail_links: bool = False,
+        drift_invariants: bool = False,
+        hold_first_writer: bool = False,
+        fail_after_alter: int | None = None,
+        sequence_attest_mutant: Mapping[str, Any] | None = None,
+        constraint_mutant: Mapping[str, Any] | None = None,
+        drift_schema: bool = False,
+    ) -> None:
+        self.mod = mod
+        self.state = state or _SharedProjectionState()
+        self.fail_links = fail_links
+        self.drift_invariants = drift_invariants
+        self.hold_first_writer = hold_first_writer
+        self.fail_after_alter = fail_after_alter
+        self.sequence_attest_mutant = dict(sequence_attest_mutant or {})
+        self.constraint_mutant = dict(constraint_mutant or {})
+        self.drift_schema = drift_schema
+        self.events: list[str] = []
+        self.transaction_options: list[dict[str, Any]] = []
+        self.in_transaction = False
+        self.holds_advisory_lock = False
+        self.invariant_reads = 0
+        self.company_payloads: list[tuple[str]] = []
+        self.link_payloads: list[tuple[str]] = []
+        self.alter_count = 0
+
+    def transaction(self, **kwargs: Any) -> _FakeTransaction:
+        return _FakeTransaction(self, kwargs)
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        assert self.in_transaction
+        if sql == self.mod.TARGET_COLUMNS_SQL:
+            self.events.append("schema_columns")
+            return [
+                {"table_name": "companies", "column_name": column}
+                for column in EXPECTED_COMPANY_COLUMNS
+            ] + [
+                {"table_name": "client_company_links", "column_name": column}
+                for column in EXPECTED_LINK_COLUMNS
+            ]
+        if sql == self.mod.TARGET_CONSTRAINTS_SQL:
+            self.events.append("schema_constraints")
+            rows = [
+                {"table_name": "companies", "definition": "PRIMARY KEY (id)"},
+                {
+                    "table_name": "client_company_links",
+                    "definition": "PRIMARY KEY (id)",
+                    "convalidated": True,
+                },
+                {
+                    "table_name": "client_company_links",
+                    "definition": "UNIQUE (client_id, company_id)",
+                    "convalidated": True,
+                },
+                {
+                    "table_name": "client_company_links",
+                    "definition": (
+                        "FOREIGN KEY (client_id) REFERENCES clients(id) "
+                        "ON DELETE CASCADE"
+                    ),
+                    "convalidated": True,
+                },
+                {
+                    "table_name": "client_company_links",
+                    "definition": (
+                        "FOREIGN KEY (company_id) REFERENCES companies(id) "
+                        "ON DELETE CASCADE"
+                    ),
+                    "convalidated": True,
+                },
+            ]
+            if self.constraint_mutant:
+                fragment = self.constraint_mutant["definition_contains"]
+                row = next(item for item in rows if fragment in item["definition"])
+                row.update(self.constraint_mutant["values"])
+            return rows
+        if sql == self.mod.TARGET_COMPANIES_SQL:
+            self.events.append("target_companies")
+            return [
+                self.state.companies[key] for key in sorted(self.state.companies)
+            ]
+        if sql == self.mod.TARGET_LINKS_SQL:
+            self.events.append("target_links")
+            return [self.state.links[key] for key in sorted(self.state.links)]
+        assert sql == self.mod.LOCAL_CLIENT_IDS_SQL
+        self.events.append("local_clients")
+        return [{"id": 301}]
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        assert self.in_transaction
+        if sql == self.mod.TARGET_ATTEST_SQL:
+            self.events.append("attest")
+            return _valid_target_attestation()
+        if sql == self.mod.SEQUENCE_ATTEST_SQL:
+            self.events.append("sequence_preflight")
+            company_sequence = self.state.sequences["public.companies_id_seq"]
+            link_sequence = self.state.sequences[
+                "public.client_company_links_id_seq"
+            ]
+            row = {
+                "companies_sequence": "public.companies_id_seq",
+                "companies_owned_by": "public.companies.id",
+                "companies_last_value": company_sequence[0],
+                "companies_is_called": company_sequence[1],
+                "companies_increment_by": 1,
+                "companies_cycle": False,
+                "links_sequence": "public.client_company_links_id_seq",
+                "links_owned_by": "public.client_company_links.id",
+                "links_last_value": link_sequence[0],
+                "links_is_called": link_sequence[1],
+                "links_increment_by": 1,
+                "links_cycle": False,
+            }
+            row.update(self.sequence_attest_mutant)
+            return row
+        if sql == self.mod.TARGET_COUNTS_SQL:
+            self.events.append("counts")
+            return {
+                "companies": len(self.state.companies),
+                "client_company_links": len(self.state.links),
+            }
+        assert "information_schema.columns" in sql
+        assert "to_jsonb" in sql and "ORDER BY row_hash" in sql
+        self.invariant_reads += 1
+        phase = "after" if self.invariant_reads % 10 > 5 or self.invariant_reads % 10 == 0 else "before"
+        self.events.append(f"invariant:{phase}")
+        digest = "changed" if self.drift_invariants and phase == "after" else "stable"
+        schema_digest = (
+            "schema-changed"
+            if self.drift_schema and phase == "after"
+            else "schema-stable"
+        )
+        return {
+            "row_count": 7,
+            "schema_digest": schema_digest,
+            "row_digest": digest,
+        }
+
+    async def execute(self, sql: str, *args: Any) -> str:
+        assert self.in_transaction
+        fixed_events = {
+            self.mod.SET_LOCAL_SEARCH_PATH_SQL: "set_search_path",
+            self.mod.SET_LOCAL_LOCK_TIMEOUT_SQL: "set_lock_timeout",
+            self.mod.SET_LOCAL_STATEMENT_TIMEOUT_SQL: "set_statement_timeout",
+            _CLIENTS_SHARE_LOCK_SQL: "clients_share_lock",
+            self.mod.TARGET_TABLE_LOCK_SQL: "target_table_lock",
+        }
+        if sql in fixed_events:
+            self.events.append(fixed_events[sql])
+            return "OK"
+        if sql == self.mod.ADVISORY_XACT_LOCK_SQL:
+            self.events.append("advisory_lock_attempt")
+            if self.state.advisory_lock.locked():
+                self.state.second_lock_waiting.set()
+            await self.state.advisory_lock.acquire()
+            self.holds_advisory_lock = True
+            self.state.active_writers += 1
+            self.state.max_active_writers = max(
+                self.state.max_active_writers, self.state.active_writers
+            )
+            self.events.append("advisory_lock_acquired")
+            return "SELECT 1"
+        match = re.fullmatch(
+            r"ALTER SEQUENCE (public\.(?:companies_id_seq|client_company_links_id_seq)) "
+            r"RESTART WITH ([1-9][0-9]*)",
+            sql,
+        )
+        assert match is not None, f"unapproved SQL: {sql}"
+        sequence_name, raw_value = match.groups()
+        self.state.sequences[sequence_name] = (int(raw_value), False)
+        self.alter_count += 1
+        self.events.append(f"alter:{sequence_name}")
+        if self.fail_after_alter == self.alter_count:
+            raise RuntimeError(f"synthetic failure after alter {self.alter_count}")
+        return "ALTER SEQUENCE"
+
+    async def executemany(self, sql: str, args: list[tuple[str]]) -> None:
+        assert self.in_transaction and self.holds_advisory_lock
+        if sql == self.mod.COMPANY_INSERT_SQL:
+            self.events.append("companies")
+            self.company_payloads = args
+            for payload, in args:
+                row = json.loads(payload, parse_float=decimal.Decimal)
+                if row["id"] in self.state.companies:
+                    raise RuntimeError("synthetic duplicate company id")
+                self.state.companies[row["id"]] = row
+            if self.hold_first_writer:
+                self.state.first_writer_entered.set()
+                await self.state.release_first_writer.wait()
+            return
+        assert sql == self.mod.LINK_INSERT_SQL
+        self.events.append("links")
+        if self.fail_links:
+            raise RuntimeError("synthetic link failure")
+        self.link_payloads = args
+        for payload, in args:
+            row = json.loads(payload, parse_float=decimal.Decimal)
+            if row["id"] in self.state.links:
+                raise RuntimeError("synthetic duplicate link id")
+            if row["client_id"] != 301 or row["company_id"] not in self.state.companies:
+                raise RuntimeError("synthetic foreign key failure")
+            self.state.links[row["id"]] = row
+
+
+async def test_apply_attests_and_reads_clients_inside_one_locked_transaction() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _StatefulConnection(mod)
+
+    result = await mod.apply_projection(
+        conn,
+        snapshot,
+        expected_content_digest=snapshot.content_digest,
+    )
+
+    assert conn.transaction_options == [
+        {"isolation": "serializable", "readonly": False}
+    ]
+    assert conn.events[0:9] == [
+        "begin",
+        "set_search_path",
+        "set_lock_timeout",
+        "set_statement_timeout",
+        "clients_share_lock",
+        "target_table_lock",
+        "advisory_lock_attempt",
+        "advisory_lock_acquired",
+        "attest",
+    ]
+    assert conn.events.index("local_clients") < conn.events.index("companies")
+    assert conn.events.index("sequence_preflight") < conn.events.index("companies")
+    assert conn.events.index("companies") < conn.events.index("links")
+    assert conn.events.index("links") < conn.events.index("alter:public.companies_id_seq")
+    assert conn.events.index("alter:public.companies_id_seq") < conn.events.index(
+        "alter:public.client_company_links_id_seq"
+    )
+    assert conn.events.index("alter:public.client_company_links_id_seq") < max(
+        index
+        for index, event in enumerate(conn.events)
+        if event == "target_companies"
+    )
+    assert conn.events.count("target_companies") == 2
+    assert conn.events.count("target_links") == 2
+    assert [event for event in conn.events if event.startswith("alter:")] == [
+        "alter:public.companies_id_seq",
+        "alter:public.client_company_links_id_seq",
+    ]
+    assert conn.events[-1] == "commit"
+    assert result.companies_inserted == 1
+    assert result.links_inserted == 1
+    assert result.no_op is False
+    assert set(json.loads(conn.company_payloads[0][0])) == set(EXPECTED_COMPANY_COLUMNS)
+    assert set(json.loads(conn.link_payloads[0][0])) == set(EXPECTED_LINK_COLUMNS)
+
+
+async def test_apply_twice_is_idempotent_in_stateful_transaction_harness() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    state = _SharedProjectionState()
+    conn = _StatefulConnection(mod, state=state)
+
+    first = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+    first_state = (copy.deepcopy(state.companies), copy.deepcopy(state.links))
+    first_sequences = copy.deepcopy(state.sequences)
+    second_event_start = len(conn.events)
+    second = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+
+    assert (state.companies, state.links) == first_state
+    assert state.sequences == first_sequences
+    assert len(state.companies) == 1 and len(state.links) == 1
+    assert first.companies_inserted == first.links_inserted == 1
+    assert first.no_op is False
+    assert second.companies_inserted == second.links_inserted == 0
+    assert second.no_op is True
+    second_events = conn.events[second_event_start:]
+    assert "companies" not in second_events and "links" not in second_events
+    assert not any(event.startswith("alter:") for event in second_events)
+    assert second_events[-1] == "commit"
+
+
+@pytest.mark.parametrize("target_kind", ["partial", "mismatch"])
+async def test_apply_refuses_nonempty_nonmatching_target_without_writes(
+    target_kind: str,
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    state = _SharedProjectionState()
+    state.companies[101] = copy.deepcopy(_company(101))
+    if target_kind == "mismatch":
+        state.companies[101]["company_name"] = "SYNTHETIC DIFFERENT COMPANY"
+        state.links[201] = copy.deepcopy(_link(201, 301, 101))
+    before = copy.deepcopy((state.companies, state.links, state.sequences))
+    conn = _StatefulConnection(mod, state=state)
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert (state.companies, state.links, state.sequences) == before
+    assert "companies" not in conn.events and "links" not in conn.events
+    assert not any(event.startswith("alter:") for event in conn.events)
+    assert conn.events[-1] == "rollback"
+
+
+async def test_apply_rolls_back_on_link_foreign_key_failure() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _StatefulConnection(mod, fail_links=True)
+
+    with pytest.raises(RuntimeError, match="synthetic link failure"):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.events[-1] == "rollback"
+    assert conn.state.companies == {} and conn.state.links == {}
+
+
+async def test_apply_rolls_back_if_protected_rows_or_columns_digest_changes() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _StatefulConnection(mod, drift_invariants=True)
+
+    with pytest.raises(mod.ProjectionInvariantError, match="protected table"):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.events[-1] == "rollback"
+    assert conn.state.companies == {} and conn.state.links == {}
+
+
+async def test_apply_rolls_back_on_protected_schema_digest_only_drift() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _StatefulConnection(mod, drift_schema=True)
+
+    with pytest.raises(mod.ProjectionInvariantError, match="protected table"):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.events[-1] == "rollback"
+    assert conn.state.companies == {} and conn.state.links == {}
+
+
+@pytest.mark.parametrize(
+    "sequence_attest_mutant",
+    [
+        {"companies_owned_by": "public.other_table.id"},
+        {"links_owned_by": "public.other_table.id"},
+        {"companies_sequence": "shadow.companies_id_seq"},
+        {"links_sequence": "public.wrong_links_id_seq"},
+    ],
+    ids=(
+        "company-sequence-owner",
+        "link-sequence-owner",
+        "company-sequence-name",
+        "link-sequence-name",
+    ),
+)
+async def test_returned_sequence_identity_mutants_refuse_without_writes(
+    sequence_attest_mutant: Mapping[str, Any],
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _StatefulConnection(
+        mod, sequence_attest_mutant=sequence_attest_mutant
+    )
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert "companies" not in conn.events and "links" not in conn.events
+    assert not any(event.startswith("alter:") for event in conn.events)
+    assert conn.events[-1] == "rollback"
+
+
+@pytest.mark.parametrize(
+    "definition_contains",
+    ["FOREIGN KEY (client_id)", "FOREIGN KEY (company_id)"],
+    ids=("client-fk", "company-fk"),
+)
+async def test_returned_unvalidated_fk_mutants_refuse_without_writes(
+    definition_contains: str,
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _StatefulConnection(
+        mod,
+        constraint_mutant={
+            "definition_contains": definition_contains,
+            "values": {"convalidated": False},
+        },
+    )
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert "companies" not in conn.events and "links" not in conn.events
+    assert not any(event.startswith("alter:") for event in conn.events)
+    assert conn.events[-1] == "rollback"
+
+
+@pytest.mark.parametrize("fail_after_alter", [1, 2])
+async def test_apply_rolls_back_rows_and_sequence_state_after_each_alter_failure(
+    fail_after_alter: int,
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _StatefulConnection(mod, fail_after_alter=fail_after_alter)
+    before = copy.deepcopy(
+        (conn.state.companies, conn.state.links, conn.state.sequences)
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic failure after alter"):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert (conn.state.companies, conn.state.links, conn.state.sequences) == before
+    assert conn.alter_count == fail_after_alter
+    assert conn.events[-1] == "rollback"
+
+
+@pytest.mark.parametrize(
+    "sequence_name",
+    ["public.companies_id_seq", "public.client_company_links_id_seq"],
+)
+@pytest.mark.parametrize(
+    ("last_value", "is_called", "source_max_id", "expected_restart"),
+    [
+        (500, False, 100, 500),  # uncalled: last_value is already the effective next
+        (500, True, 100, 501),  # called: effective next is last_value + 1
+        (101, False, 100, 101),  # equality boundary, uncalled
+        (100, True, 100, 101),  # equality boundary, called
+        (50, False, 100, 101),  # source max + 1 is higher, uncalled
+        (50, True, 100, 101),  # source max + 1 is higher, called
+    ],
+)
+def test_sequence_restart_boundaries_are_lossless_and_hardcoded(
+    sequence_name: str,
+    last_value: int,
+    is_called: bool,
+    source_max_id: int,
+    expected_restart: int,
+) -> None:
+    mod = _load()
+    restart = mod.sequence_restart_value(
+        last_value=last_value,
+        is_called=is_called,
+        source_max_id=source_max_id,
+    )
+    assert restart == expected_restart
+    assert mod.sequence_restart_sql(sequence_name, restart) == (
+        f"ALTER SEQUENCE {sequence_name} RESTART WITH {expected_restart}"
+    )
+
+
+@pytest.mark.parametrize(
+    "sequence_name",
+    [
+        "public.unapproved_id_seq",
+        "shadow.companies_id_seq",
+        "public.companies_id_seq; DROP TABLE public.clients",
+        'public."companies_id_seq"',
+    ],
+)
+def test_sequence_restart_rejects_every_nonexact_or_injected_name(
+    sequence_name: str,
+) -> None:
+    mod = _load()
+    with pytest.raises((mod.TargetContractError, ValueError)):
+        mod.sequence_restart_sql(sequence_name, 101)
+
+
+@pytest.mark.parametrize("restart", [0, -1, True, 1.5, "101", 9223372036854775808])
+def test_sequence_restart_rejects_non_positive_non_integer_or_out_of_range_value(
+    restart: Any,
+) -> None:
+    mod = _load()
+    with pytest.raises((mod.TargetContractError, ValueError, TypeError)):
+        mod.sequence_restart_sql("public.companies_id_seq", restart)
+
+
+def test_target_initial_state_is_empty_or_exact_digest_noop_only() -> None:
+    mod = _load()
+    desired = "a" * 64
+    assert mod.classify_target_state(
+        companies_count=0,
+        links_count=0,
+        actual_digest=mod.EMPTY_TARGET_DIGEST,
+        desired_digest=desired,
+    ) == "empty"
+    assert mod.classify_target_state(
+        companies_count=2,
+        links_count=1,
+        actual_digest=desired,
+        desired_digest=desired,
+    ) == "exact-noop"
+    for counts, digest in [((2, 1), "b" * 64)]:
+        with pytest.raises(mod.TargetContractError):
+            mod.classify_target_state(
+                companies_count=counts[0],
+                links_count=counts[1],
+                actual_digest=digest,
+                desired_digest=desired,
+            )
+
+
+async def test_advisory_transaction_lock_serializes_concurrent_applies() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    state = _SharedProjectionState()
+    first_conn = _StatefulConnection(mod, state=state, hold_first_writer=True)
+    second_conn = _StatefulConnection(mod, state=state)
+
+    first_task = asyncio.create_task(
+        mod.apply_projection(
+            first_conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+    )
+    await asyncio.wait_for(state.first_writer_entered.wait(), timeout=1.0)
+    second_task = asyncio.create_task(
+        mod.apply_projection(
+            second_conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+    )
+    await asyncio.wait_for(state.second_lock_waiting.wait(), timeout=1.0)
+    assert state.max_active_writers == 1
+    state.release_first_writer.set()
+    await asyncio.wait_for(asyncio.gather(first_task, second_task), timeout=1.0)
+
+    assert state.max_active_writers == 1
+
+
+def test_sql_surface_is_insert_only_except_two_exact_sequence_restarts() -> None:
+    mod = _load()
+    sql_surface = "\n".join(mod.ALL_LOCAL_SQL).upper()
+    for verb in ("DELETE", "TRUNCATE", "DROP", "UPDATE"):
+        assert not re.search(rf"\b{verb}\b", sql_surface)
+    assert "SETVAL" not in sql_surface
+    assert "NEXTVAL" not in sql_surface
+    assert "PG_ADVISORY_XACT_LOCK" in mod.ADVISORY_XACT_LOCK_SQL.upper()
+    assert "LAST_VALUE" in mod.SEQUENCE_ATTEST_SQL.upper()
+    assert "IS_CALLED" in mod.SEQUENCE_ATTEST_SQL.upper()
+    assert "ON CONFLICT" not in sql_surface
+    assert re.search(r"\bINSERT\s+INTO\s+PUBLIC\.COMPANIES\s*\(", mod.COMPANY_INSERT_SQL.upper())
+    assert re.search(
+        r"\bINSERT\s+INTO\s+PUBLIC\.CLIENT_COMPANY_LINKS\s*\(",
+        mod.LINK_INSERT_SQL.upper(),
+    )
+    assert "ON CONFLICT" not in mod.COMPANY_INSERT_SQL.upper()
+    assert "ON CONFLICT" not in mod.LINK_INSERT_SQL.upper()
+    assert not re.search(r"\bINSERT\s+INTO\s+CLIENTS\b", sql_surface)
+    assert not re.search(r"\bUPDATE\s+CLIENTS\b", sql_surface)
+    for table in mod.PROTECTED_TABLES:
+        assert not re.search(
+            rf"\b(?:INSERT\s+INTO|UPDATE)\s+{re.escape(table.upper())}\b",
+            sql_surface,
+        )
+
+
+def test_apply_transaction_setup_and_target_acquisition_are_fixed() -> None:
+    mod = _load()
+    assert mod.SET_LOCAL_SEARCH_PATH_SQL == "SET LOCAL search_path = public"
+    assert re.fullmatch(
+        r"SET LOCAL lock_timeout = '[1-9][0-9]*ms'",
+        mod.SET_LOCAL_LOCK_TIMEOUT_SQL,
+    )
+    assert re.fullmatch(
+        r"SET LOCAL statement_timeout = '[1-9][0-9]*ms'",
+        mod.SET_LOCAL_STATEMENT_TIMEOUT_SQL,
+    )
+    assert mod.TARGET_TABLE_LOCK_SQL == (
+        "LOCK TABLE public.companies, public.client_company_links "
+        "IN SHARE ROW EXCLUSIVE MODE"
+    )
+    assert _CLIENTS_SHARE_LOCK_SQL in mod.ALL_LOCAL_SQL
+    assert "pg_advisory_xact_lock" in mod.ADVISORY_XACT_LOCK_SQL
+    assert "from public.companies" in mod.TARGET_COMPANIES_SQL.lower()
+    assert "from public.client_company_links" in mod.TARGET_LINKS_SQL.lower()
+
+
+def test_report_is_aggregate_only_and_never_contains_row_payloads() -> None:
+    mod = _load()
+    private_markers = {
+        column: f"SYNTHETIC_PRIVATE_{column.upper()}"
+        for column in (
+            "company_name",
+            "brand_name",
+            "nib",
+            "npwp_company",
+            "registered_address",
+            "office_address",
+            "company_phone",
+            "company_email",
+            "google_drive_folder_id",
+            "created_by",
+            "updated_by",
+        )
+    }
+    company = _company(101, marker=private_markers["company_name"])
+    company.update(private_markers)
+    link = _link(201, 301, 101)
+    link["notes"] = "SYNTHETIC_PRIVATE_LINK_NOTES"
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([company], [link])
+    )
+    plan = mod.build_projection_plan(snapshot, local_client_ids={301})
+
+    report = mod.build_report(
+        snapshot=snapshot,
+        plan=plan,
+        mode="dry-run",
+        target_before={"companies": 0, "client_company_links": 0},
+        target_after=None,
+        invariant_digest="shape-only-digest",
+        sequence_status={
+            "companies": {
+                "last_value": 1000,
+                "is_called": True,
+                "next_value": 1001,
+                "source_max_id": 101,
+                "safe": True,
+            },
+            "client_company_links": {
+                "last_value": 2000,
+                "is_called": True,
+                "next_value": 2001,
+                "source_max_id": 201,
+                "safe": True,
+            },
+        },
+    )
+
+    serialized = json.dumps(report, sort_keys=True)
+    for private_marker in (*private_markers.values(), link["notes"]):
+        assert private_marker not in serialized
+    assert "company_name" not in serialized
+    assert "row" not in report
+    assert set(report) == {
+        "status",
+        "mode",
+        "write_attempted",
+        "source",
+        "projection",
+        "target_before",
+        "target_after",
+        "sequence_preflight",
+        "protected_type_digest",
+    }
+    assert set(report["source"]) == {
+        "authority",
+        "snapshot_at",
+        "companies_max_updated_at",
+        "links_max_updated_at",
+        "companies",
+        "links",
+        "content_digest",
+        "type_identity_digest",
+    }
+    assert set(report["target_before"]) == {
+        "companies",
+        "client_company_links",
+    }
+    assert report["write_attempted"] is False
+    assert report["projection"]["companies"] == 1
+    assert report["projection"]["eligible_links"] == 1
+
+
+def test_report_rejects_unallowlisted_recursive_keys() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(_snapshot_stdout([_company(101)], []))
+    plan = mod.build_projection_plan(snapshot, local_client_ids=set())
+    with pytest.raises(mod.TargetContractError, match="report target counts"):
+        mod.build_report(
+            snapshot=snapshot,
+            plan=plan,
+            mode="dry-run",
+            target_before={
+                "companies": 0,
+                "client_company_links": 0,
+                "private_unallowlisted_key": 1,
+            },
+            target_after=None,
+            invariant_digest="shape-only-digest",
+            sequence_status={},
+        )
+
+
+@pytest.mark.parametrize(
+    "sequence_status",
+    [
+        {"private_unallowlisted_key": "SYNTHETIC_PRIVATE_REPORT_POISON"},
+        {
+            "companies": {
+                "last_value": 1000,
+                "is_called": True,
+                "next_value": 1001,
+                "source_max_id": 101,
+                "safe": True,
+                "private_nested_key": "SYNTHETIC_PRIVATE_REPORT_POISON",
+            }
+        },
+        {
+            "companies": {
+                "last_value": 1000,
+                "is_called": True,
+                "next_value": 1001,
+                "source_max_id": 101,
+                "safe": True,
+                "failures": ["SYNTHETIC_PRIVATE_REPORT_POISON"],
+            }
+        },
+    ],
+    ids=("sequence-top-level", "sequence-nested", "sequence-failures"),
+)
+def test_report_rejects_recursive_sequence_status_pii(
+    sequence_status: Mapping[str, Any],
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(_snapshot_stdout([_company(101)], []))
+    plan = mod.build_projection_plan(snapshot, local_client_ids=set())
+    poison = "SYNTHETIC_PRIVATE_REPORT_POISON"
+
+    with pytest.raises(mod.TargetContractError) as exc_info:
+        mod.build_report(
+            snapshot=snapshot,
+            plan=plan,
+            mode="dry-run",
+            target_before={"companies": 0, "client_company_links": 0},
+            target_after=None,
+            invariant_digest="shape-only-digest",
+            sequence_status=sequence_status,
+        )
+
+    assert poison not in str(exc_info.value)
+
+
+def test_every_cli_failure_path_suppresses_poisoned_exception_content() -> None:
+    mod = _load()
+    poison = "SYNTHETIC_PRIVATE_FAILURE_PAYLOAD"
+    error_types = (
+        RuntimeError,
+        mod.ProjectionError,
+        mod.SourceSnapshotError,
+        mod.ApplyGateError,
+        mod.TargetContractError,
+        mod.ProjectionInvariantError,
+    )
+    for error_type in error_types:
+        exc = error_type(poison)
+        serialized = json.dumps(mod._safe_error(exc), sort_keys=True)
+        assert poison not in serialized
+
+    runner = _Runner(poison.encode(), returncode=9)
+    runner.stderr = poison.encode()
+    with pytest.raises(mod.SourceSnapshotError) as exc_info:
+        mod.fetch_source_snapshot(run=runner)
+    assert poison not in str(exc_info.value)
+
+
+def test_main_suppresses_every_projection_failure_from_stdout_and_stderr(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = _load()
+    poison = "SYNTHETIC_PRIVATE_CLI_FAILURE"
+    error_types = (
+        mod.ProjectionError,
+        mod.SourceSnapshotError,
+        mod.ApplyGateError,
+        mod.TargetContractError,
+        mod.ProjectionInvariantError,
+    )
+
+    for error_type in error_types:
+        async def fail_projection(
+            *, _error_type: type[BaseException] = error_type, **kwargs: Any
+        ) -> dict[str, Any]:
+            raise _error_type(poison)
+
+        monkeypatch.setattr(mod, "run_projection", fail_projection)
+        assert mod.main([]) == 2
+        captured = capsys.readouterr()
+        assert poison not in captured.out
+        assert poison not in captured.err
+        failure = json.loads(captured.err)
+        assert set(failure) == {"status", "error_type", "reason"}
+
+
+class _AcquiredTargetConnection:
+    """Target double which returns rows only through production acquisition SQL."""
+
+    def __init__(
+        self,
+        mod: Any,
+        *,
+        companies: tuple[Mapping[str, Any], ...],
+        links: tuple[Mapping[str, Any], ...],
+    ) -> None:
+        self.mod = mod
+        self.companies = tuple(copy.deepcopy(row) for row in companies)
+        self.links = tuple(copy.deepcopy(row) for row in links)
+        self.fetch_calls: list[str] = []
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls.append(sql)
+        if sql == self.mod.TARGET_COMPANIES_SQL:
+            return [copy.deepcopy(row) for row in self.companies]
+        if sql == self.mod.TARGET_LINKS_SQL:
+            return [copy.deepcopy(row) for row in self.links]
+        raise AssertionError(f"unexpected target acquisition SQL: {sql}")
+
+
+def _require_target_acquisition_contract(mod: Any) -> None:
+    assert hasattr(mod, "TARGET_COMPANIES_SQL")
+    assert hasattr(mod, "TARGET_LINKS_SQL")
+    assert hasattr(mod, "read_target_projection")
+
+
+def _assert_exact_target_acquisition_sql(sql: str, columns: tuple[str, ...], table: str) -> None:
+    normalized = " ".join(sql.lower().split())
+    assert re.search(rf"\bfrom\s+public\.{table}\b", normalized)
+    assert re.search(r"\border\s+by\s+id\b", normalized)
+    selected = re.search(r"\bselect\s+(.+?)\s+\bfrom\b", normalized)
+    assert selected is not None
+    assert tuple(part.strip() for part in selected.group(1).split(",")) == columns
+
+
+@pytest.mark.parametrize(
+    ("companies", "links", "desired_digest", "expected_state"),
+    [
+        ((), (), None, "empty"),
+        (( _company(101),), (_link(201, 301, 101),), "oracle", "exact-noop"),
+        (
+            (_company(101, marker="SYNTHETIC CONTENT MUTANT"),),
+            (_link(201, 301, 101),),
+            "different",
+            "refuse",
+        ),
+        (( _company(101), _company(102)), (_link(201, 301, 101),), "oracle", "post-insert"),
+    ],
+    ids=("empty", "exact-noop", "same-count-content-mutant", "post-insert"),
+)
+async def test_target_projection_is_acquired_from_exact_rows_and_python_digest(
+    companies: tuple[Mapping[str, Any], ...],
+    links: tuple[Mapping[str, Any], ...],
+    desired_digest: str | None,
+    expected_state: str,
+) -> None:
+    mod = _load()
+    _require_target_acquisition_contract(mod)
+    _assert_exact_target_acquisition_sql(
+        mod.TARGET_COMPANIES_SQL, EXPECTED_COMPANY_COLUMNS, "companies"
+    )
+    _assert_exact_target_acquisition_sql(
+        mod.TARGET_LINKS_SQL, EXPECTED_LINK_COLUMNS, "client_company_links"
+    )
+    conn = _AcquiredTargetConnection(mod, companies=companies, links=links)
+    target = await mod.read_target_projection(conn)
+    oracle = _independent_projection_digest(
+        companies=companies, eligible_links=links
+    )
+
+    assert conn.fetch_calls == [mod.TARGET_COMPANIES_SQL, mod.TARGET_LINKS_SQL]
+    assert target.companies == companies
+    assert target.links == links
+    assert target.digest == oracle
+    if expected_state == "empty":
+        assert mod.classify_target_state(
+            companies_count=len(companies),
+            links_count=len(links),
+            actual_digest=target.digest,
+            desired_digest="a" * 64,
+        ) == "empty"
+    elif expected_state == "exact-noop":
+        assert mod.classify_target_state(
+            companies_count=len(companies),
+            links_count=len(links),
+            actual_digest=target.digest,
+            desired_digest=oracle,
+        ) == "exact-noop"
+    elif expected_state == "post-insert":
+        assert target.digest == _independent_projection_digest(
+            companies=companies, eligible_links=links
+        )
+    else:
+        with pytest.raises(mod.TargetContractError):
+            mod.classify_target_state(
+                companies_count=len(companies),
+                links_count=len(links),
+                actual_digest=target.digest,
+                desired_digest=("b" * 64 if desired_digest == "different" else oracle),
+            )
+
+
+def test_legacy_target_digest_queries_are_absent() -> None:
+    mod = _load()
+    assert not hasattr(mod, "TARGET_STATE_SQL")
+    assert not hasattr(mod, "FINAL_ACCEPTANCE_SQL")
+
+
+class _ExclusiveTargetAcquisitionConnection(_StatefulConnection):
+    """Apply double: target rows are available only through the new SQL pair."""
+
+    def __init__(self, mod: Any, *, state: _SharedProjectionState) -> None:
+        super().__init__(mod, state=state)
+        self.acquisition_fetches: list[str] = []
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        if sql == self.mod.TARGET_COMPANIES_SQL:
+            self.acquisition_fetches.append(sql)
+            return [
+                copy.deepcopy(self.state.companies[company_id])
+                for company_id in sorted(self.state.companies)
+            ]
+        if sql == self.mod.TARGET_LINKS_SQL:
+            self.acquisition_fetches.append(sql)
+            return [
+                copy.deepcopy(self.state.links[link_id])
+                for link_id in sorted(self.state.links)
+            ]
+        return await super().fetch(sql, *args)
+
+async def test_apply_exclusively_acquires_target_rows_prewrite_and_precommit(
+) -> None:
+    mod = _load()
+    _require_target_acquisition_contract(mod)
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    state = _SharedProjectionState()
+    conn = _ExclusiveTargetAcquisitionConnection(mod, state=state)
+
+    first = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+
+    assert first.no_op is False
+    assert conn.acquisition_fetches == [
+        mod.TARGET_COMPANIES_SQL,
+        mod.TARGET_LINKS_SQL,
+        mod.TARGET_COMPANIES_SQL,
+        mod.TARGET_LINKS_SQL,
+    ]
+    exact_event_start = len(conn.events)
+    exact = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+    assert exact.no_op is True
+    assert "companies" not in conn.events[exact_event_start:]
+    assert "links" not in conn.events[exact_event_start:]
+
+    state.companies[101]["company_name"] = "SYNTHETIC SAME-COUNT MUTANT"
+    before = copy.deepcopy((state.companies, state.links, state.sequences))
+    mutant_conn = _ExclusiveTargetAcquisitionConnection(mod, state=state)
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            mutant_conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+    assert mutant_conn.acquisition_fetches == [
+        mod.TARGET_COMPANIES_SQL,
+        mod.TARGET_LINKS_SQL,
+    ]
+    assert "companies" not in mutant_conn.events and "links" not in mutant_conn.events
+    assert (state.companies, state.links, state.sequences) == before
+
+
+class _ConstraintPhaseMutantConnection(_StatefulConnection):
+    def __init__(
+        self,
+        mod: Any,
+        *,
+        constraint_mutator: Callable[[list[dict[str, Any]]], None],
+        mutate_on_constraint_read: int,
+    ) -> None:
+        super().__init__(mod)
+        self.constraint_mutator = constraint_mutator
+        self.mutate_on_constraint_read = mutate_on_constraint_read
+        self.constraint_reads = 0
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        rows = await super().fetch(sql, *args)
+        if sql == self.mod.TARGET_CONSTRAINTS_SQL:
+            self.constraint_reads += 1
+            if self.constraint_reads >= self.mutate_on_constraint_read:
+                self.constraint_mutator(rows)
+        return rows
+
+
+def _mutate_fk_row(
+    rows: list[dict[str, Any]], *, fk_column: str, kind: str
+) -> None:
+    fk_index = next(
+        index
+        for index, row in enumerate(rows)
+        if row["definition"].startswith(f"FOREIGN KEY ({fk_column})")
+    )
+    if kind == "missing":
+        rows.pop(fk_index)
+    elif kind == "wrong-target":
+        target_table = "shadow_clients" if fk_column == "client_id" else "shadow_companies"
+        rows[fk_index]["definition"] = (
+            f"FOREIGN KEY ({fk_column}) REFERENCES public.{target_table}(id)"
+        )
+    elif kind == "wrong-source":
+        target_table = "clients" if fk_column == "client_id" else "companies"
+        rows[fk_index]["definition"] = (
+            f"FOREIGN KEY (other_{fk_column}) REFERENCES public.{target_table}(id)"
+        )
+    elif kind == "unrelated-validated":
+        rows[fk_index]["definition"] = (
+            "FOREIGN KEY (unrelated_id) REFERENCES public.unrelated(id)"
+        )
+        rows[fk_index]["convalidated"] = True
+    elif kind == "unvalidated":
+        rows[fk_index]["convalidated"] = False
+    else:
+        raise AssertionError(f"unknown FK mutation: {kind}")
+
+
+@pytest.mark.parametrize(
+    "mutation_kind",
+    ("missing", "wrong-target", "wrong-source", "unrelated-validated", "unvalidated"),
+)
+@pytest.mark.parametrize("fk_column", ("client_id", "company_id"))
+@pytest.mark.parametrize(
+    ("phase", "constraint_read"),
+    (("prewrite", 1), ("final", 2)),
+)
+async def test_exact_validated_link_fks_are_rechecked_prewrite_and_before_commit(
+    mutation_kind: str,
+    fk_column: str,
+    phase: str,
+    constraint_read: int,
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _ConstraintPhaseMutantConnection(
+        mod,
+        constraint_mutator=lambda rows: _mutate_fk_row(
+            rows, fk_column=fk_column, kind=mutation_kind
+        ),
+        mutate_on_constraint_read=constraint_read,
+    )
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.events[-1] == "rollback"
+    if phase == "prewrite":
+        assert "companies" not in conn.events and "links" not in conn.events
+    else:
+        assert "companies" in conn.events
+        assert conn.constraint_reads >= 2
+    assert conn.state.companies == {} and conn.state.links == {}
+
+
+class _ProtectedDigestDriftConnection(_StatefulConnection):
+    def __init__(self, mod: Any, *, drift_table: str, drift_field: str) -> None:
+        super().__init__(mod)
+        self.drift_table = drift_table
+        self.drift_field = drift_field
+        self.invariant_reads_by_table: dict[str, int] = {}
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        if sql in self.mod.PROTECTED_INVARIANT_SQL:
+            table = self.mod.PROTECTED_TABLES[
+                self.mod.PROTECTED_INVARIANT_SQL.index(sql)
+            ]
+            count = self.invariant_reads_by_table.get(table, 0) + 1
+            self.invariant_reads_by_table[table] = count
+            row = await super().fetchrow(sql, *args)
+            if table == self.drift_table and count == 2:
+                row[self.drift_field] = f"synthetic-{self.drift_field}-drift"
+            return row
+        return await super().fetchrow(sql, *args)
+
+
+@pytest.mark.parametrize("protected_table", EXPECTED_PROTECTED_TABLES)
+@pytest.mark.parametrize("drift_field", ("row_digest", "schema_digest"))
+async def test_each_protected_table_digest_drift_rolls_back(
+    protected_table: str,
+    drift_field: str,
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _ProtectedDigestDriftConnection(
+        mod, drift_table=protected_table, drift_field=drift_field
+    )
+
+    with pytest.raises(mod.ProjectionInvariantError, match="protected table"):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.invariant_reads_by_table == dict.fromkeys(mod.PROTECTED_TABLES, 2)
+    assert conn.events[-1] == "rollback"
+    assert conn.state.companies == {} and conn.state.links == {}
+
+
+def test_target_state_classifier_handles_empty_and_zero_link_noops_exactly() -> None:
+    mod = _load()
+    desired = "a" * 64
+    assert mod.classify_target_state(
+        companies_count=0,
+        links_count=0,
+        actual_digest="f" * 64,
+        desired_digest=desired,
+    ) == "empty"
+    assert mod.classify_target_state(
+        companies_count=2,
+        links_count=0,
+        actual_digest=desired,
+        desired_digest=desired,
+    ) == "exact-noop"
+
+
+async def test_company_only_projection_applies_once_then_is_exact_noop() -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(_snapshot_stdout([_company(101)], []))
+    conn = _StatefulConnection(mod)
+
+    first = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+    second_event_start = len(conn.events)
+    second = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+
+    assert first.companies_inserted == 1 and first.links_inserted == 0
+    assert second.companies_inserted == second.links_inserted == 0
+    assert second.no_op is True
+    second_events = conn.events[second_event_start:]
+    assert "companies" not in second_events and "links" not in second_events
+    assert not any(event.startswith("alter:") for event in second_events)
+
+
+async def test_dry_run_never_connects_or_writes_and_reports_unknown_eligibility(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mod = _load()
+    connect_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    write_attempts: list[bool] = []
+
+    async def forbidden_connect(*args: Any, **kwargs: Any) -> Any:
+        connect_calls.append((args, kwargs))
+        raise AssertionError("dry-run must not connect to the target")
+
+    async def forbidden_apply(*args: Any, **kwargs: Any) -> Any:
+        write_attempts.append(True)
+        raise AssertionError("dry-run must not write to the target")
+
+    monkeypatch.setattr(mod, "apply_projection", forbidden_apply)
+
+    runner = _Runner(_snapshot_stdout([_company(101)], [_link(201, 301, 101)]))
+    report = await mod.run_projection(
+        apply=False,
+        dsn=mod.DEFAULT_TARGET_DSN,
+        environ={},
+        run_subprocess=runner,
+        connect=forbidden_connect,
+    )
+    assert connect_calls == []
+    assert report["projection"]["target_eligibility"] == "not_evaluated"
+    assert report["projection"]["eligible_links"] == "unknown"
+    assert report["projection"]["rejected_links_missing_local_client"] == "unknown"
+    assert report["source"]["companies"] == 1
+    assert report["source"]["links"] == 1
+    assert report["target_before"] is None
+    assert report["target_after"] is None
+    assert report["projection"].get("projection_digest") in (None, "unknown")
+    assert report.get("protected_type_digest") in (None, "unknown")
+    assert report.get("sequence_preflight") in (None, "unknown")
+    assert write_attempts == []
+
+    actual_run_projection = mod.run_projection
+
+    async def main_run_projection(**kwargs: Any) -> dict[str, Any]:
+        return await actual_run_projection(
+            **kwargs,
+            run_subprocess=runner,
+            connect=forbidden_connect,
+        )
+
+    monkeypatch.setattr(mod, "run_projection", main_run_projection)
+    assert mod.main([]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["mode"] == "dry-run"
+    assert output["write_attempted"] is False
+    assert output["projection"]["target_eligibility"] == "not_evaluated"
+    assert output["projection"]["eligible_links"] == "unknown"
+    assert output["projection"]["rejected_links_missing_local_client"] == "unknown"
+    assert connect_calls == []
+    assert write_attempts == []
+
+
+def _asyncpg_shaped_target_row(
+    row: Mapping[str, Any], *, table: str
+) -> dict[str, Any]:
+    """Model asyncpg typed scalars and JSONB text at the target boundary."""
+    shaped = copy.deepcopy(dict(row))
+    if table == "companies":
+        shaped["uuid"] = uuid.UUID(str(shaped["uuid"]))
+        date_columns = (
+            "akta_pendirian_date",
+            "akta_perubahan_date",
+            "sk_menhumkam_date",
+        )
+        shaped["custom_fields"] = json.dumps(
+            shaped["custom_fields"], ensure_ascii=False, separators=(",", ":")
+        )
+    else:
+        date_columns = ("start_date", "end_date")
+    for column in date_columns:
+        if shaped[column] is not None:
+            shaped[column] = date.fromisoformat(str(shaped[column]))
+    for column in ("created_at", "updated_at"):
+        if shaped[column] is not None:
+            shaped[column] = datetime.fromisoformat(str(shaped[column]))
+    return shaped
+
+
+def _independent_source_shape(row: Mapping[str, Any], *, table: str) -> dict[str, Any]:
+    """Independent logical representation for a source JSON versus target row check."""
+    normalized = dict(row)
+    if table == "companies":
+        normalized["uuid"] = str(normalized["uuid"])
+        normalized["custom_fields"] = json.loads(str(normalized["custom_fields"]))
+        date_columns = (
+            "akta_pendirian_date",
+            "akta_perubahan_date",
+            "sk_menhumkam_date",
+        )
+    else:
+        date_columns = ("start_date", "end_date")
+    for column in date_columns:
+        if normalized[column] is not None:
+            normalized[column] = normalized[column].isoformat()
+    for column in ("created_at", "updated_at"):
+        if normalized[column] is not None:
+            normalized[column] = normalized[column].isoformat()
+    return normalized
+
+
+class _AsyncpgProjectionConnection(_StatefulConnection):
+    def __init__(
+        self,
+        mod: Any,
+        *,
+        target_mutation: tuple[str, str, Any] | None = None,
+    ) -> None:
+        super().__init__(mod)
+        self.target_mutation = target_mutation
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        rows = await super().fetch(sql, *args)
+        if sql not in (self.mod.TARGET_COMPANIES_SQL, self.mod.TARGET_LINKS_SQL):
+            return rows
+        table = "companies" if sql == self.mod.TARGET_COMPANIES_SQL else "links"
+        shaped = [_asyncpg_shaped_target_row(row, table=table) for row in rows]
+        if shaped and self.target_mutation is not None:
+            mutation_table, column, value = self.target_mutation
+            if mutation_table == table:
+                shaped[0][column] = value
+        return shaped
+
+
+def _typed_source_snapshot(mod: Any) -> Any:
+    company = _company(101)
+    company.update(
+        {
+            "uuid": "00000000-0000-4000-8000-000000000101",
+            "akta_pendirian_date": "2024-02-29",
+            "akta_perubahan_date": "2025-01-02",
+            "created_at": "2026-08-01T00:00:00",
+            "updated_at": "2026-08-02T00:00:00+00:00",
+            "custom_fields": {"sensitive": {"tier": 3}, "registered": True},
+        }
+    )
+    link = _link(201, 301, 101)
+    link.update(
+        {
+            "ownership_percentage": 12.5,
+            "share_nominal_value": 123.45,
+            "start_date": "2024-02-29",
+            "end_date": "2026-08-01",
+            "created_at": "2026-08-01T00:00:00+00:00",
+            "updated_at": "2026-08-02T00:00:00",
+        }
+    )
+    return mod.parse_source_snapshot(_snapshot_stdout([company], [link]))
+
+
+async def test_asyncpg_target_scalars_match_source_json_in_final_acceptance() -> None:
+    mod = _load()
+    snapshot = _typed_source_snapshot(mod)
+    expected = _independent_projection_digest(
+        companies=snapshot.companies, eligible_links=snapshot.links
+    )
+    typed_companies = tuple(
+        _independent_source_shape(
+            _asyncpg_shaped_target_row(row, table="companies"), table="companies"
+        )
+        for row in snapshot.companies
+    )
+    typed_links = tuple(
+        _independent_source_shape(
+            _asyncpg_shaped_target_row(row, table="links"), table="links"
+        )
+        for row in snapshot.links
+    )
+    assert _independent_projection_digest(
+        companies=typed_companies, eligible_links=typed_links
+    ) == expected
+
+    conn = _AsyncpgProjectionConnection(mod)
+    result = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+    assert result.projection_digest == expected
+    assert conn.events[-1] == "commit"
+
+
+@pytest.mark.parametrize(
+    ("table", "column", "mutant"),
+    [
+        ("companies", "uuid", uuid.UUID("00000000-0000-4000-8000-000000000999")),
+        ("companies", "akta_pendirian_date", date(2030, 1, 1)),
+        ("companies", "created_at", datetime(2030, 1, 1, 0, 0)),
+        ("companies", "updated_at", datetime(2030, 1, 1, tzinfo=timezone.utc)),
+        ("links", "ownership_percentage", decimal.Decimal("12.6")),
+        ("companies", "custom_fields", '{"sensitive":"mutant"}'),
+    ],
+    ids=("uuid", "date", "naive-datetime", "aware-datetime", "decimal", "jsonb"),
+)
+async def test_asyncpg_sensitive_target_mutants_fail_final_acceptance(
+    table: str, column: str, mutant: Any
+) -> None:
+    mod = _load()
+    snapshot = _typed_source_snapshot(mod)
+    conn = _AsyncpgProjectionConnection(
+        mod, target_mutation=(table, column, mutant)
+    )
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.events[-1] == "rollback"
+    assert conn.state.companies == {} and conn.state.links == {}
+
+
+def _noop_sequence_state(
+    *, source_max_id: int, is_called: bool, safe: bool
+) -> tuple[int, bool]:
+    if safe:
+        return (source_max_id if is_called else source_max_id + 1, is_called)
+    return (source_max_id - 1 if is_called else source_max_id, is_called)
+
+
+@pytest.mark.parametrize(
+    ("sequence_name", "source_max_id"),
+    [
+        ("public.companies_id_seq", 101),
+        ("public.client_company_links_id_seq", 201),
+    ],
+)
+@pytest.mark.parametrize("is_called", (False, True))
+@pytest.mark.parametrize("safe", (False, True))
+async def test_exact_noop_requires_safe_sequence_preflight(
+    sequence_name: str, source_max_id: int, is_called: bool, safe: bool
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    state = _SharedProjectionState()
+    state.companies = {101: copy.deepcopy(snapshot.companies[0])}
+    state.links = {201: copy.deepcopy(snapshot.links[0])}
+    state.sequences[sequence_name] = _noop_sequence_state(
+        source_max_id=source_max_id, is_called=is_called, safe=safe
+    )
+    conn = _StatefulConnection(mod, state=state)
+
+    if safe:
+        result = await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+        assert result.no_op is True
+        assert conn.events[-1] == "commit"
+    else:
+        with pytest.raises(mod.TargetContractError):
+            await mod.apply_projection(
+                conn, snapshot, expected_content_digest=snapshot.content_digest
+            )
+        assert conn.events[-1] == "rollback"
+
+    assert "companies" not in conn.events and "links" not in conn.events
+    assert not any(event.startswith("alter:") for event in conn.events)
+
+
+class _CatalogAttestationConnection(_StatefulConnection):
+    def __init__(
+        self, mod: Any, *, relation_mutation: Mapping[str, Any] | None = None
+    ) -> None:
+        super().__init__(mod)
+        self.relation_mutation = dict(relation_mutation or {})
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        row = await super().fetchrow(sql, *args)
+        if sql == self.mod.TARGET_ATTEST_SQL:
+            row.update(self.relation_mutation)
+        return row
+
+
+def test_target_attestation_uses_real_public_pg_catalog_relations() -> None:
+    mod = _load()
+    sql = mod.TARGET_ATTEST_SQL
+    assert "pg_catalog.pg_class" in sql
+    assert "pg_catalog.pg_namespace" in sql
+    assert "companies_namespace" in sql and "links_namespace" in sql
+    assert "companies_relname" in sql and "links_relname" in sql
+    assert "companies_relkind" in sql and "links_relkind" in sql
+
+
+@pytest.mark.parametrize(
+    "relation_mutation",
+    [
+        {"companies_namespace": "shadow"},
+        {"companies_relname": "companies_shadow"},
+        {"companies_relkind": "v"},
+        {"links_namespace": "shadow"},
+        {"links_relname": "client_company_links_shadow"},
+        {"links_relkind": "m"},
+    ],
+    ids=(
+        "companies-namespace",
+        "companies-name",
+        "companies-kind",
+        "links-namespace",
+        "links-name",
+        "links-kind",
+    ),
+)
+async def test_catalog_relation_attestation_mutants_rollback_before_writes(
+    relation_mutation: Mapping[str, Any],
+) -> None:
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _CatalogAttestationConnection(mod, relation_mutation=relation_mutation)
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.events[-1] == "rollback"
+    assert "companies" not in conn.events and "links" not in conn.events
+    assert not any(event.startswith("alter:") for event in conn.events)
+
+
+def _nested_fractional_snapshot(mod: Any) -> Any:
+    company = _company(101)
+    company["custom_fields"] = {
+        "nested": {"fraction": 12.5},
+        "array": [0.125, {"fraction": 7.25}],
+    }
+    return mod.parse_source_snapshot(_snapshot_stdout([company], []))
+
+
+def _nested_fractional_target(
+    source_row: Mapping[str, Any],
+    *,
+    fraction: float = 12.5,
+    array_fraction: float = 0.125,
+) -> dict[str, Any]:
+    target = copy.deepcopy(dict(source_row))
+    target["custom_fields"] = json.dumps(
+        {
+            "nested": {"fraction": fraction},
+            "array": [array_fraction, {"fraction": 7.25}],
+        },
+        separators=(",", ":"),
+    )
+    return target
+
+
+def test_jsonb_text_nested_fractionals_match_independent_decimal_oracle() -> None:
+    mod = _load()
+    snapshot = _nested_fractional_snapshot(mod)
+    target = _nested_fractional_target(snapshot.companies[0], fraction=12.5)
+    oracle_target = dict(target)
+    oracle_target["custom_fields"] = json.loads(
+        target["custom_fields"], parse_float=decimal.Decimal
+    )
+    expected = _independent_projection_digest(
+        companies=snapshot.companies, eligible_links=()
+    )
+
+    assert _independent_projection_digest(
+        companies=(oracle_target,), eligible_links=()
+    ) == expected
+    assert mod.compute_projection_digest(
+        companies=(target,), eligible_links=()
+    ) == expected
+
+
+@pytest.mark.parametrize("fraction", (12.25, 12.75))
+def test_jsonb_text_nested_fractional_mutants_change_projection_digest(
+    fraction: float,
+) -> None:
+    mod = _load()
+    snapshot = _nested_fractional_snapshot(mod)
+    target = _nested_fractional_target(snapshot.companies[0], fraction=fraction)
+    expected = mod.compute_projection_digest(
+        companies=snapshot.companies, eligible_links=()
+    )
+
+    assert mod.compute_projection_digest(
+        companies=(target,), eligible_links=()
+    ) != expected
+
+
+@pytest.mark.parametrize(
+    ("array_fraction", "matches_source"),
+    ((0.125, True), (0.0625, False), (0.375, False)),
+)
+def test_jsonb_text_fractional_array_matches_independent_oracle_and_detects_mutation(
+    array_fraction: float,
+    matches_source: bool,
+) -> None:
+    mod = _load()
+    snapshot = _nested_fractional_snapshot(mod)
+    target = _nested_fractional_target(
+        snapshot.companies[0], array_fraction=array_fraction
+    )
+    oracle_target = dict(target)
+    oracle_target["custom_fields"] = json.loads(
+        target["custom_fields"], parse_float=decimal.Decimal
+    )
+    expected = _independent_projection_digest(
+        companies=snapshot.companies, eligible_links=()
+    )
+    mutant_oracle = _independent_projection_digest(
+        companies=(oracle_target,), eligible_links=()
+    )
+
+    assert (mutant_oracle == expected) is matches_source
+    assert mod.compute_projection_digest(
+        companies=(target,), eligible_links=()
+    ) == mutant_oracle
+
+
+class _SequenceDefinitionConnection(_StatefulConnection):
+    def __init__(
+        self, mod: Any, *, sequence_mutation: Mapping[str, Any]
+    ) -> None:
+        super().__init__(mod)
+        self.sequence_mutation = dict(sequence_mutation)
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        row = await super().fetchrow(sql, *args)
+        if sql == self.mod.SEQUENCE_ATTEST_SQL:
+            row.update(self.sequence_mutation)
+        return row
+
+
+def test_sequence_attestation_requires_increment_one_and_cycle_false() -> None:
+    mod = _load()
+    sql = mod.SEQUENCE_ATTEST_SQL
+    for field in (
+        "companies_increment_by",
+        "companies_cycle",
+        "links_increment_by",
+        "links_cycle",
+    ):
+        assert field in sql
+
+
+@pytest.mark.parametrize("phase", ("initial-empty", "exact-noop"))
+@pytest.mark.parametrize(
+    ("sequence_mutation", "label"),
+    [
+        ({"companies_increment_by": -1}, "companies-increment-negative"),
+        ({"companies_increment_by": 2}, "companies-increment-two"),
+        ({"companies_cycle": True}, "companies-cycle"),
+        ({"links_increment_by": -1}, "links-increment-negative"),
+        ({"links_increment_by": 2}, "links-increment-two"),
+        ({"links_cycle": True}, "links-cycle"),
+    ],
+)
+async def test_sequence_definition_mutants_refuse_before_write_or_alter(
+    phase: str,
+    sequence_mutation: Mapping[str, Any],
+    label: str,
+) -> None:
+    del label
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    conn = _SequenceDefinitionConnection(
+        mod, sequence_mutation=sequence_mutation
+    )
+    if phase == "exact-noop":
+        conn.state.companies = {101: copy.deepcopy(snapshot.companies[0])}
+        conn.state.links = {201: copy.deepcopy(snapshot.links[0])}
+
+    with pytest.raises(mod.TargetContractError):
+        await mod.apply_projection(
+            conn, snapshot, expected_content_digest=snapshot.content_digest
+        )
+
+    assert conn.events[-1] == "rollback"
+    assert "companies" not in conn.events and "links" not in conn.events
+    assert not any(event.startswith("alter:") for event in conn.events)
+
+
+_CLIENTS_SHARE_LOCK_SQL = "LOCK TABLE public.clients IN SHARE MODE"
+_TARGET_WRITE_LOCK_SQL = (
+    "LOCK TABLE public.companies, public.client_company_links "
+    "IN SHARE ROW EXCLUSIVE MODE"
+)
+
+
+class _ClientLockOrderState(_SharedProjectionState):
+    def __init__(self) -> None:
+        super().__init__()
+        self.clients_write_lock = asyncio.Lock()
+        self.client_writer_waiting = asyncio.Event()
+        self.client_writer_acquired = asyncio.Event()
+
+
+class _ClientLockOrderTransaction(_FakeTransaction):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool:
+        result = await super().__aexit__(exc_type, exc, traceback)
+        if self.conn.holds_clients_share_lock:
+            self.conn.state.clients_write_lock.release()
+            self.conn.holds_clients_share_lock = False
+        return result
+
+
+class _ClientLockOrderConnection(_StatefulConnection):
+    state: _ClientLockOrderState
+
+    def __init__(
+        self, mod: Any, *, state: _ClientLockOrderState, hold_first_writer: bool
+    ) -> None:
+        super().__init__(mod, state=state, hold_first_writer=hold_first_writer)
+        self.holds_clients_share_lock = False
+        self.holds_target_write_lock = False
+
+    def transaction(self, **kwargs: Any) -> _ClientLockOrderTransaction:
+        return _ClientLockOrderTransaction(self, kwargs)
+
+    async def execute(self, sql: str, *args: Any) -> str:
+        if sql == _CLIENTS_SHARE_LOCK_SQL:
+            assert self.events[-1] == "set_statement_timeout"
+            await self.state.clients_write_lock.acquire()
+            self.holds_clients_share_lock = True
+            self.events.append("clients_share_lock")
+            return "LOCK TABLE"
+        if sql == _TARGET_WRITE_LOCK_SQL:
+            assert self.holds_clients_share_lock
+            self.holds_target_write_lock = True
+            self.events.append("target_table_lock")
+            return "LOCK TABLE"
+        if sql == self.mod.ADVISORY_XACT_LOCK_SQL:
+            assert self.holds_clients_share_lock and self.holds_target_write_lock
+        return await super().execute(sql, *args)
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        assert self.holds_clients_share_lock and self.holds_target_write_lock
+        return await super().fetch(sql, *args)
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        assert self.holds_clients_share_lock and self.holds_target_write_lock
+        return await super().fetchrow(sql, *args)
+
+    async def write_client_row(self) -> None:
+        self.state.client_writer_waiting.set()
+        await self.state.clients_write_lock.acquire()
+        self.state.client_writer_acquired.set()
+        self.state.clients_write_lock.release()
+
+
+async def test_client_lock_order_precedes_advisory_and_blocks_client_writer() -> None:
+    """The clients SHARE lock is a transaction-wide barrier for client writers."""
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    state = _ClientLockOrderState()
+    apply_conn = _ClientLockOrderConnection(
+        mod, state=state, hold_first_writer=True
+    )
+    writer_conn = _ClientLockOrderConnection(
+        mod, state=state, hold_first_writer=False
+    )
+
+    apply_task = asyncio.create_task(
+        mod.apply_projection(
+            apply_conn,
+            snapshot,
+            expected_content_digest=snapshot.content_digest,
+        )
+    )
+    try:
+        await asyncio.wait_for(state.first_writer_entered.wait(), timeout=1.0)
+    except TimeoutError:
+        await asyncio.gather(apply_task, return_exceptions=True)
+        raise
+
+    writer_task = asyncio.create_task(writer_conn.write_client_row())
+    await asyncio.wait_for(state.client_writer_waiting.wait(), timeout=1.0)
+    await asyncio.sleep(0)
+    assert not state.client_writer_acquired.is_set()
+
+    state.release_first_writer.set()
+    await asyncio.wait_for(asyncio.gather(apply_task, writer_task), timeout=1.0)
+
+    assert state.client_writer_acquired.is_set()
+    assert apply_conn.events[0:7] == [
+        "begin",
+        "set_search_path",
+        "set_lock_timeout",
+        "set_statement_timeout",
+        "clients_share_lock",
+        "target_table_lock",
+        "advisory_lock_attempt",
+    ]
+
+
+class _QualifiedRegclassCompatibilityConnection(_StatefulConnection):
+    """Isolate result immutability from the legacy regclass-rendering failure."""
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        row = await super().fetchrow(sql, *args)
+        if sql == self.mod.TARGET_ATTEST_SQL:
+            row.update(
+                {
+                    "companies_relation": "public.companies",
+                    "links_relation": "public.client_company_links",
+                }
+            )
+        return row
+
+
+def _expected_sequence_status() -> dict[str, dict[str, int | bool]]:
+    return {
+        "companies": {
+            "last_value": 1000,
+            "is_called": True,
+            "next_value": 1001,
+            "source_max_id": 101,
+            "safe": True,
+        },
+        "client_company_links": {
+            "last_value": 2000,
+            "is_called": True,
+            "next_value": 2001,
+            "source_max_id": 201,
+            "safe": True,
+        },
+    }
+
+
+def _expected_protected_facts(mod: Any) -> dict[str, Any]:
+    return {
+        table: mod.InvariantState(
+            row_count=7,
+            schema_digest="schema-stable",
+            row_digest="stable",
+        )
+        for table in mod.PROTECTED_TABLES
+    }
+
+
+def _detached_result_value(value: Any) -> Any:
+    """Snapshot returned API values without retaining any mutable reference."""
+    if isinstance(value, Mapping):
+        return {
+            key: _detached_result_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return tuple(_detached_result_value(item) for item in value)
+    if all(
+        hasattr(value, attribute)
+        for attribute in ("row_count", "schema_digest", "row_digest")
+    ):
+        return (
+            value.row_count,
+            value.schema_digest,
+            value.row_digest,
+        )
+    return value
+
+
+def _observe_apply_result(result: Any) -> dict[str, Any]:
+    """Read every fact carried by ApplyResult through its public attributes."""
+    return {
+        "accepted_plan": {
+            "companies": _detached_result_value(result.accepted_plan.companies),
+            "eligible_links": _detached_result_value(
+                result.accepted_plan.eligible_links
+            ),
+            "rejected_missing_local_client": (
+                result.accepted_plan.rejected_missing_local_client
+            ),
+            "projection_digest": result.accepted_plan.projection_digest,
+        },
+        "source_content_digest": result.source_content_digest,
+        "target_before_counts": _detached_result_value(
+            result.target_before_counts
+        ),
+        "target_after_counts": _detached_result_value(result.target_after_counts),
+        "sequence_status": _detached_result_value(result.sequence_status),
+        "protected_before": _detached_result_value(result.protected_before),
+        "protected_after": _detached_result_value(result.protected_after),
+        "companies_inserted": result.companies_inserted,
+        "links_inserted": result.links_inserted,
+        "invariant_digest": result.invariant_digest,
+        "projection_digest": result.projection_digest,
+        "no_op": result.no_op,
+    }
+
+
+def _assign_item(container: Any, key: Any, value: Any) -> None:
+    container[key] = value
+
+
+def _append_item(container: Any, value: Any) -> None:
+    container.append(value)
+
+
+def _assign_attribute(instance: Any, name: str, value: Any) -> None:
+    setattr(instance, name, value)
+
+
+async def _returned_apply_result_with_aliases(
+    mod: Any, *, phase: str
+) -> tuple[Any, dict[str, Any]]:
+    company = _company(101)
+    company["custom_fields"] = {
+        "nested": {"fraction": 12.5, "label": "original"},
+        "array": [0.125, {"fraction": 7.25}],
+    }
+    link = _link(201, 301, 101)
+    link["notes"] = "ORIGINAL LINK"
+    snapshot = mod.parse_source_snapshot(_snapshot_stdout([company], [link]))
+    state = _SharedProjectionState()
+    if phase == "exact-noop":
+        state.companies = {101: copy.deepcopy(snapshot.companies[0])}
+        state.links = {201: copy.deepcopy(snapshot.links[0])}
+    conn = _QualifiedRegclassCompatibilityConnection(mod, state=state)
+    result = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+    source_company = snapshot.companies[0]
+    source_link = snapshot.links[0]
+    state_company = state.companies[101]
+    state_link = state.links[201]
+    aliases = {
+        "snapshot": snapshot,
+        "source_company": source_company,
+        "source_link": source_link,
+        "source_custom_fields": source_company["custom_fields"],
+        "source_nested_object": source_company["custom_fields"]["nested"],
+        "source_array": source_company["custom_fields"]["array"],
+        "source_array_object": source_company["custom_fields"]["array"][1],
+        "state_companies": state.companies,
+        "state_links": state.links,
+        "state_sequences": state.sequences,
+        "state_company": state_company,
+        "state_link": state_link,
+        "state_custom_fields": state_company["custom_fields"],
+        "state_nested_object": state_company["custom_fields"]["nested"],
+        "state_array": state_company["custom_fields"]["array"],
+        "state_array_object": state_company["custom_fields"]["array"][1],
+    }
+    return result, aliases
+
+
+async def _returned_apply_result(mod: Any, *, phase: str) -> Any:
+    result, _aliases = await _returned_apply_result_with_aliases(
+        mod, phase=phase
+    )
+    return result
+
+
+def _apply_result_mutations() -> tuple[tuple[str, Callable[[Any], None]], ...]:
+    return (
+        (
+            "accepted company row",
+            lambda result: _assign_item(
+                result.accepted_plan.companies[0], "company_name", "MUTATED"
+            ),
+        ),
+        (
+            "accepted company custom_fields",
+            lambda result: _assign_item(
+                result.accepted_plan.companies[0]["custom_fields"],
+                "extra",
+                "MUTATED",
+            ),
+        ),
+        (
+            "accepted company nested object",
+            lambda result: _assign_item(
+                result.accepted_plan.companies[0]["custom_fields"]["nested"],
+                "label",
+                "MUTATED",
+            ),
+        ),
+        (
+            "accepted company nested array item",
+            lambda result: _assign_item(
+                result.accepted_plan.companies[0]["custom_fields"]["array"],
+                0,
+                decimal.Decimal("9.875"),
+            ),
+        ),
+        (
+            "accepted company nested array append",
+            lambda result: _append_item(
+                result.accepted_plan.companies[0]["custom_fields"]["array"],
+                {"mutant": True},
+            ),
+        ),
+        (
+            "accepted link row",
+            lambda result: _assign_item(
+                result.accepted_plan.eligible_links[0], "notes", "MUTATED"
+            ),
+        ),
+        (
+            "accepted companies tuple",
+            lambda result: _assign_item(result.accepted_plan.companies, 0, {}),
+        ),
+        (
+            "accepted plan attribute",
+            lambda result: _assign_attribute(
+                result.accepted_plan, "rejected_missing_local_client", 99
+            ),
+        ),
+        (
+            "target before counts",
+            lambda result: _assign_item(
+                result.target_before_counts, "companies", 999
+            ),
+        ),
+        (
+            "target after counts",
+            lambda result: _assign_item(
+                result.target_after_counts, "client_company_links", 999
+            ),
+        ),
+        (
+            "sequence status outer map",
+            lambda result: _assign_item(result.sequence_status, "mutant", {}),
+        ),
+        (
+            "sequence status nested map",
+            lambda result: _assign_item(
+                result.sequence_status["companies"], "last_value", 999
+            ),
+        ),
+        (
+            "protected before map",
+            lambda result: _assign_item(result.protected_before, "clients", None),
+        ),
+        (
+            "protected before value",
+            lambda result: _assign_attribute(
+                result.protected_before["clients"], "row_count", 999
+            ),
+        ),
+        (
+            "protected after map",
+            lambda result: _assign_item(
+                result.protected_after, "intake_queue", None
+            ),
+        ),
+        (
+            "apply result attribute",
+            lambda result: _assign_attribute(result, "source_content_digest", "x"),
+        ),
+    )
+
+
+def _clear_mapping(mapping: Any) -> None:
+    mapping.clear()
+
+
+def _apply_result_backing_alias_mutations() -> tuple[
+    tuple[str, Callable[[Mapping[str, Any]], None]], ...
+]:
+    return (
+        (
+            "source company row alias",
+            lambda aliases: _assign_item(
+                aliases["source_company"], "company_name", "MUTATED SOURCE"
+            ),
+        ),
+        (
+            "source link row alias",
+            lambda aliases: _assign_item(
+                aliases["source_link"], "notes", "MUTATED SOURCE LINK"
+            ),
+        ),
+        (
+            "source custom_fields alias",
+            lambda aliases: _assign_item(
+                aliases["source_custom_fields"], "extra", "MUTATED SOURCE"
+            ),
+        ),
+        (
+            "source nested object alias",
+            lambda aliases: _assign_item(
+                aliases["source_nested_object"], "label", "MUTATED SOURCE"
+            ),
+        ),
+        (
+            "source array item alias",
+            lambda aliases: _assign_item(
+                aliases["source_array"], 0, decimal.Decimal("6.875")
+            ),
+        ),
+        (
+            "source array append alias",
+            lambda aliases: _append_item(
+                aliases["source_array"], {"source_mutant": True}
+            ),
+        ),
+        (
+            "source array object alias",
+            lambda aliases: _assign_item(
+                aliases["source_array_object"],
+                "fraction",
+                decimal.Decimal("8.75"),
+            ),
+        ),
+        (
+            "state companies backing map",
+            lambda aliases: _clear_mapping(aliases["state_companies"]),
+        ),
+        (
+            "state links backing map",
+            lambda aliases: _clear_mapping(aliases["state_links"]),
+        ),
+        (
+            "state company row alias",
+            lambda aliases: _assign_item(
+                aliases["state_company"], "company_name", "MUTATED STATE"
+            ),
+        ),
+        (
+            "state link row alias",
+            lambda aliases: _assign_item(
+                aliases["state_link"], "notes", "MUTATED STATE LINK"
+            ),
+        ),
+        (
+            "state custom_fields alias",
+            lambda aliases: _assign_item(
+                aliases["state_custom_fields"], "extra", "MUTATED STATE"
+            ),
+        ),
+        (
+            "state nested object alias",
+            lambda aliases: _assign_item(
+                aliases["state_nested_object"], "label", "MUTATED STATE"
+            ),
+        ),
+        (
+            "state array item alias",
+            lambda aliases: _assign_item(
+                aliases["state_array"], 0, decimal.Decimal("6.875")
+            ),
+        ),
+        (
+            "state array append alias",
+            lambda aliases: _append_item(
+                aliases["state_array"], {"state_mutant": True}
+            ),
+        ),
+        (
+            "state array object alias",
+            lambda aliases: _assign_item(
+                aliases["state_array_object"],
+                "fraction",
+                decimal.Decimal("8.75"),
+            ),
+        ),
+        (
+            "state sequence backing map",
+            lambda aliases: _clear_mapping(aliases["state_sequences"]),
+        ),
+    )
+
+
+@pytest.mark.parametrize("phase", ("apply", "exact-noop"))
+async def test_apply_result_is_deeply_immutable_for_every_carried_fact(
+    phase: str,
+) -> None:
+    """Every returned mapping and nested source row rejects mutation."""
+    mod = _load()
+    baseline_result = await _returned_apply_result(mod, phase=phase)
+    baseline = _observe_apply_result(baseline_result)
+    assert baseline["accepted_plan"]["companies"][0]["custom_fields"] == {
+        "array": (decimal.Decimal("0.125"), {"fraction": decimal.Decimal("7.25")}),
+        "nested": {
+            "fraction": decimal.Decimal("12.5"),
+            "label": "original",
+        },
+    }
+    assert baseline["accepted_plan"]["eligible_links"][0]["notes"] == (
+        "ORIGINAL LINK"
+    )
+
+    violations: list[str] = []
+    for label, mutate in _apply_result_mutations():
+        result = await _returned_apply_result(mod, phase=phase)
+        if _observe_apply_result(result) != baseline:
+            violations.append(f"{label}: pre-mutation facts differ")
+            continue
+        try:
+            mutate(result)
+        except (TypeError, AttributeError):
+            pass
+        except Exception as exc:  # pragma: no cover - diagnostic contract
+            violations.append(f"{label}: raised {type(exc).__name__}")
+        else:
+            violations.append(f"{label}: mutation succeeded")
+        if _observe_apply_result(result) != baseline:
+            violations.append(f"{label}: original facts changed")
+
+    assert violations == []
+
+
+@pytest.mark.parametrize("phase", ("apply", "exact-noop"))
+async def test_apply_result_is_detached_from_every_mutable_input_alias(
+    phase: str,
+) -> None:
+    """A read-only proxy over caller-owned backing dictionaries is insufficient."""
+    mod = _load()
+    baseline_result, baseline_aliases = await _returned_apply_result_with_aliases(
+        mod, phase=phase
+    )
+    baseline = _observe_apply_result(baseline_result)
+    assert baseline_aliases["snapshot"].companies[0] is (
+        baseline_aliases["source_company"]
+    )
+    assert baseline_aliases["snapshot"].links[0] is baseline_aliases["source_link"]
+    assert baseline_aliases["source_company"]["custom_fields"] is (
+        baseline_aliases["source_custom_fields"]
+    )
+    assert baseline_aliases["source_custom_fields"]["nested"] is (
+        baseline_aliases["source_nested_object"]
+    )
+    assert baseline_aliases["source_custom_fields"]["array"] is (
+        baseline_aliases["source_array"]
+    )
+    assert baseline_aliases["source_array"][1] is (
+        baseline_aliases["source_array_object"]
+    )
+    assert baseline_aliases["state_companies"][101] is (
+        baseline_aliases["state_company"]
+    )
+    assert baseline_aliases["state_links"][201] is baseline_aliases["state_link"]
+    assert baseline_aliases["state_company"]["custom_fields"] is (
+        baseline_aliases["state_custom_fields"]
+    )
+    assert baseline_aliases["state_custom_fields"]["nested"] is (
+        baseline_aliases["state_nested_object"]
+    )
+    assert baseline_aliases["state_custom_fields"]["array"] is (
+        baseline_aliases["state_array"]
+    )
+    assert baseline_aliases["state_array"][1] is (
+        baseline_aliases["state_array_object"]
+    )
+
+    violations: list[str] = []
+    for label, mutate_alias in _apply_result_backing_alias_mutations():
+        result, aliases = await _returned_apply_result_with_aliases(
+            mod, phase=phase
+        )
+        if _observe_apply_result(result) != baseline:
+            violations.append(f"{label}: pre-mutation facts differ")
+            continue
+        mutate_alias(aliases)
+        if _observe_apply_result(result) != baseline:
+            violations.append(f"{label}: accepted facts followed mutable alias")
+
+    assert violations == []
+
+
+@pytest.mark.parametrize("phase", ("apply", "exact-noop"))
+async def test_apply_result_carries_all_transaction_accepted_report_facts(
+    phase: str,
+) -> None:
+    """The report must be derived from immutable facts accepted before commit."""
+    mod = _load()
+    snapshot = mod.parse_source_snapshot(
+        _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    )
+    state = _SharedProjectionState()
+    if phase == "exact-noop":
+        state.companies = {101: copy.deepcopy(snapshot.companies[0])}
+        state.links = {201: copy.deepcopy(snapshot.links[0])}
+    conn = _StatefulConnection(mod, state=state)
+
+    result = await mod.apply_projection(
+        conn, snapshot, expected_content_digest=snapshot.content_digest
+    )
+
+    assert result.accepted_plan == mod.build_projection_plan(
+        snapshot, local_client_ids={301}
+    )
+    assert result.source_content_digest == snapshot.content_digest
+    assert result.target_before_counts == {
+        "companies": 1 if phase == "exact-noop" else 0,
+        "client_company_links": 1 if phase == "exact-noop" else 0,
+    }
+    assert result.target_after_counts == {
+        "companies": 1,
+        "client_company_links": 1,
+    }
+    assert result.sequence_status == _expected_sequence_status()
+    expected_protected = _expected_protected_facts(mod)
+    assert result.protected_before == expected_protected
+    assert result.protected_after == expected_protected
+    assert result.invariant_digest == mod.protected_shape_digest(expected_protected)
+    assert result.projection_digest == result.accepted_plan.projection_digest
+    assert result.companies_inserted == (0 if phase == "exact-noop" else 1)
+    assert result.links_inserted == (0 if phase == "exact-noop" else 1)
+    assert result.no_op is (phase == "exact-noop")
+
+
+class _PostCommitMutationTransaction(_FakeTransaction):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool:
+        result = await super().__aexit__(exc_type, exc, traceback)
+        if exc_type is None:
+            self.conn.post_commit_mutated = True
+            self.conn.state.companies.clear()
+            self.conn.state.links.clear()
+            self.conn.state.sequences["public.companies_id_seq"] = (1, False)
+            self.conn.state.sequences["public.client_company_links_id_seq"] = (
+                1,
+                False,
+            )
+        return result
+
+
+class _PostCommitMutationConnection(_StatefulConnection):
+    def __init__(
+        self, mod: Any, *, state: _SharedProjectionState | None = None
+    ) -> None:
+        super().__init__(mod, state=state)
+        self.post_commit_mutated = False
+        self.post_transaction_reads: list[str] = []
+        self.closed = False
+
+    def transaction(self, **kwargs: Any) -> _PostCommitMutationTransaction:
+        return _PostCommitMutationTransaction(self, kwargs)
+
+    async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        if not self.in_transaction:
+            self.post_transaction_reads.append(sql)
+            raise AssertionError("report must not fetch after the transaction")
+        return await super().fetch(sql, *args)
+
+    async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any]:
+        if not self.in_transaction:
+            self.post_transaction_reads.append(sql)
+            raise AssertionError("report must not fetch after the transaction")
+        return await super().fetchrow(sql, *args)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.parametrize("phase", ("apply", "exact-noop"))
+async def test_run_projection_reports_only_transaction_accepted_facts(
+    phase: str,
+) -> None:
+    mod = _load()
+    snapshot_stdout = _snapshot_stdout([_company(101)], [_link(201, 301, 101)])
+    snapshot = mod.parse_source_snapshot(snapshot_stdout)
+    state = _SharedProjectionState()
+    if phase == "exact-noop":
+        state.companies = {101: copy.deepcopy(snapshot.companies[0])}
+        state.links = {201: copy.deepcopy(snapshot.links[0])}
+    conn = _PostCommitMutationConnection(mod, state=state)
+
+    async def connect(*args: Any, **kwargs: Any) -> _PostCommitMutationConnection:
+        del args, kwargs
+        return conn
+
+    report = await mod.run_projection(
+        apply=True,
+        dsn=mod.DEFAULT_TARGET_DSN,
+        environ={mod.WRITE_ENABLE_ENV: "true"},
+        run_subprocess=_Runner(snapshot_stdout),
+        connect=connect,
+        expected_content_digest=snapshot.content_digest,
+    )
+
+    assert conn.post_commit_mutated and conn.closed
+    assert conn.post_transaction_reads == []
+    assert conn.state.companies == {} and conn.state.links == {}
+    assert report["target_before"] == {
+        "companies": 1 if phase == "exact-noop" else 0,
+        "client_company_links": 1 if phase == "exact-noop" else 0,
+    }
+    assert report["target_after"] == {
+        "companies": 1,
+        "client_company_links": 1,
+    }
+    assert report["projection"] == {
+        "companies": 1,
+        "eligible_links": 1,
+        "rejected_links_missing_local_client": 0,
+        "projection_digest": mod.compute_projection_digest(
+            companies=snapshot.companies, eligible_links=snapshot.links
+        ),
+    }
+    assert report["sequence_preflight"] == _expected_sequence_status()
+    assert report["protected_type_digest"] == mod.protected_shape_digest(
+        _expected_protected_facts(mod)
+    )

--- a/scripts/intake_company_projection.py
+++ b/scripts/intake_company_projection.py
@@ -1,0 +1,1805 @@
+#!/usr/bin/env python3
+"""Project the canonical PROD company graph into local ``nuzantara_dev``.
+
+The command is deliberately narrow:
+
+* PROD is read once through ``scripts/pg.sh`` in one read-only,
+  repeatable-read snapshot.  Rows travel as an in-memory JSON-lines stream and
+  are never printed or logged.
+* The target is exactly the loopback ``nuzantara_dev`` database.  Dry-run is
+  the default.  Writes require both ``--apply`` and
+  ``INTAKE_COMPANY_PROJECTION_WRITE_ENABLED=true``.
+* Apply uses one local transaction in companies -> eligible links -> sequence
+  order.  Links whose client does not already exist locally are counted and
+  skipped; clients are never synthesized.
+* No delete, truncate, intake mutation, reroute, or service restart exists in
+  this script.  User-visible output is aggregate JSON plus type-only digests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Protocol, TypeAlias, cast
+from urllib.parse import urlparse
+from uuid import UUID
+
+import asyncpg
+
+PG_SH = Path(__file__).resolve().with_name("pg.sh")
+
+EXPECTED_SOURCE_DATABASE = "nuzantara_rag"
+EXPECTED_SOURCE_ROLE = "nuzantara_readonly"
+EXPECTED_TARGET_DATABASE = "nuzantara_dev"
+EXPECTED_TARGET_ROLE = "nuzantara"
+
+DEFAULT_TARGET_DSN = (
+    "postgresql://nuzantara@127.0.0.1:5432/nuzantara_dev"
+)
+TARGET_DSN_ENV = "INTAKE_COMPANY_PROJECTION_DATABASE_URL"
+WRITE_ENABLE_ENV = "INTAKE_COMPANY_PROJECTION_WRITE_ENABLED"
+CONTENT_DIGEST_DOMAIN = "nuzantara:intake-company-source-snapshot"
+CONTENT_DIGEST_VERSION = "1"
+PROJECTION_DIGEST_DOMAIN = "nuzantara:intake-company-projection"
+PROJECTION_DIGEST_VERSION = "1"
+
+COMPANY_COLUMNS = (
+    "id",
+    "uuid",
+    "company_name",
+    "company_type",
+    "brand_name",
+    "kbli_code",
+    "kbli_description",
+    "nib",
+    "npwp_company",
+    "akta_pendirian_no",
+    "akta_pendirian_date",
+    "akta_perubahan_no",
+    "akta_perubahan_date",
+    "sk_menhumkam_no",
+    "sk_menhumkam_date",
+    "registered_address",
+    "office_address",
+    "city",
+    "province",
+    "postal_code",
+    "company_phone",
+    "company_email",
+    "status",
+    "setup_progress",
+    "google_drive_folder_id",
+    "custom_fields",
+    "created_at",
+    "updated_at",
+    "created_by",
+    "updated_by",
+)
+
+SOURCE_ONLY_COMPANY_COLUMNS = (
+    "geo_point",
+    "rdtr_zone_code",
+    "geocoded_at",
+    "geocode_source",
+    "tax_dept_folder_id",
+)
+
+LINK_COLUMNS = (
+    "id",
+    "client_id",
+    "company_id",
+    "role",
+    "is_primary",
+    "ownership_percentage",
+    "shares_count",
+    "share_nominal_value",
+    "start_date",
+    "end_date",
+    "status",
+    "notes",
+    "created_at",
+    "updated_at",
+)
+
+PROTECTED_TABLES = (
+    "clients",
+    "intake_queue",
+    "document_instances",
+    "document_routing_proposal",
+    "intake_commit_audit",
+)
+
+
+class ProjectionError(RuntimeError):
+    """Base class for deliberately sanitized projection failures."""
+
+
+class SourceSnapshotError(ProjectionError):
+    """The PROD snapshot failed transport, attestation, or validation."""
+
+
+class ApplyGateError(ProjectionError):
+    """A target or operator write gate was not satisfied."""
+
+
+class TargetContractError(ProjectionError):
+    """The local database does not expose the expected schema/FK contract."""
+
+
+class ProjectionInvariantError(ProjectionError):
+    """A protected local table changed during the projection transaction."""
+
+
+@dataclass(frozen=True)
+class SourceMetadata:
+    snapshot_at: str
+    companies_count: int
+    links_count: int
+    companies_max_updated_at: str | None
+    links_max_updated_at: str | None
+
+
+JsonRow: TypeAlias = Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class SourceSnapshot:
+    metadata: SourceMetadata
+    companies: tuple[JsonRow, ...]
+    links: tuple[JsonRow, ...]
+    canonical_row_bytes: bytes
+    content_digest: str
+
+
+@dataclass(frozen=True)
+class ProjectionPlan:
+    companies: tuple[JsonRow, ...]
+    eligible_links: tuple[JsonRow, ...]
+    rejected_missing_local_client: int
+    projection_digest: str
+
+
+@dataclass(frozen=True)
+class TargetProjection:
+    """Canonical, local target rows acquired through the narrow allowlists."""
+
+    companies: tuple[JsonRow, ...]
+    links: tuple[JsonRow, ...]
+    digest: str
+
+
+@dataclass(frozen=True)
+class InvariantState:
+    row_count: int
+    schema_digest: str
+    row_digest: str
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    accepted_source: SourceSnapshot
+    accepted_plan: ProjectionPlan
+    source_content_digest: str
+    target_before_counts: Mapping[str, int]
+    target_after_counts: Mapping[str, int]
+    sequence_status: Mapping[str, Mapping[str, int | bool]]
+    protected_before: Mapping[str, InvariantState]
+    protected_after: Mapping[str, InvariantState]
+    companies_inserted: int
+    links_inserted: int
+    invariant_digest: str
+    projection_digest: str
+    no_op: bool
+
+
+def _immutable_value_copy(value: Any) -> Any:
+    """Recursively detach and freeze a value accepted from a source row."""
+
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("accepted mapping keys must be strings")
+            frozen[key] = _immutable_value_copy(item)
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_immutable_value_copy(item) for item in value)
+    if value is None or isinstance(
+        value, (str, int, Decimal, UUID, datetime, date, bytes)
+    ):
+        return value
+    raise TypeError("unsupported accepted value type")
+
+
+def _immutable_rows_copy(rows: Sequence[Mapping[str, Any]]) -> tuple[JsonRow, ...]:
+    return tuple(cast(JsonRow, _immutable_value_copy(row)) for row in rows)
+
+
+def _immutable_source_copy(snapshot: SourceSnapshot) -> SourceSnapshot:
+    metadata = snapshot.metadata
+    return SourceSnapshot(
+        metadata=SourceMetadata(
+            snapshot_at=metadata.snapshot_at,
+            companies_count=metadata.companies_count,
+            links_count=metadata.links_count,
+            companies_max_updated_at=metadata.companies_max_updated_at,
+            links_max_updated_at=metadata.links_max_updated_at,
+        ),
+        companies=_immutable_rows_copy(snapshot.companies),
+        links=_immutable_rows_copy(snapshot.links),
+        canonical_row_bytes=bytes(snapshot.canonical_row_bytes),
+        content_digest=snapshot.content_digest,
+    )
+
+
+def _immutable_plan_copy(plan: ProjectionPlan) -> ProjectionPlan:
+    return ProjectionPlan(
+        companies=_immutable_rows_copy(plan.companies),
+        eligible_links=_immutable_rows_copy(plan.eligible_links),
+        rejected_missing_local_client=plan.rejected_missing_local_client,
+        projection_digest=plan.projection_digest,
+    )
+
+
+def _immutable_counts_copy(counts: Mapping[str, int]) -> Mapping[str, int]:
+    return MappingProxyType(dict(counts))
+
+
+def _immutable_sequence_status_copy(
+    status: Mapping[str, Mapping[str, int | bool]],
+) -> Mapping[str, Mapping[str, int | bool]]:
+    return MappingProxyType(
+        {
+            sequence: MappingProxyType(dict(details))
+            for sequence, details in status.items()
+        }
+    )
+
+
+def _immutable_invariants_copy(
+    states: Mapping[str, InvariantState],
+) -> Mapping[str, InvariantState]:
+    return MappingProxyType(
+        {
+            table: InvariantState(
+                row_count=state.row_count,
+                schema_digest=state.schema_digest,
+                row_digest=state.row_digest,
+            )
+            for table, state in states.items()
+        }
+    )
+
+
+class _Transaction(Protocol):
+    async def __aenter__(self) -> Any: ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: Any,
+    ) -> bool | None: ...
+
+
+class ConnectionLike(Protocol):
+    def transaction(self, **kwargs: Any) -> _Transaction: ...
+
+    async def fetch(self, query: str, *args: Any) -> Sequence[Mapping[str, Any]]: ...
+
+    async def fetchrow(self, query: str, *args: Any) -> Mapping[str, Any] | None: ...
+
+    async def execute(self, query: str, *args: Any) -> str: ...
+
+    async def executemany(
+        self, query: str, args: Sequence[Sequence[Any]]
+    ) -> None: ...
+
+    async def close(self) -> None: ...
+
+
+RunCallable: TypeAlias = Callable[..., subprocess.CompletedProcess[bytes]]
+ConnectCallable: TypeAlias = Callable[..., Awaitable[ConnectionLike]]
+
+
+def _quoted_columns(columns: Sequence[str]) -> str:
+    """Return a comma-separated identifier list from a module-owned allowlist."""
+
+    for column in columns:
+        if re.fullmatch(r"[a-z_][a-z0-9_]*", column) is None:
+            raise ValueError("invalid allowlisted SQL identifier")
+    return ", ".join(columns)
+
+
+_COMPANY_COLUMN_SQL = _quoted_columns(COMPANY_COLUMNS)
+_LINK_COLUMN_SQL = _quoted_columns(LINK_COLUMNS)
+
+SOURCE_SNAPSHOT_SQL = f"""
+BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;
+
+SELECT json_build_object(
+    'kind', 'meta',
+    'database', current_database(),
+    'role', current_user,
+    'transaction_read_only', current_setting('transaction_read_only'),
+    'snapshot_at', statement_timestamp(),
+    'companies_count', (SELECT count(*) FROM public.companies),
+    'links_count', (SELECT count(*) FROM public.client_company_links),
+    'companies_max_updated_at', (SELECT max(updated_at) FROM public.companies),
+    'links_max_updated_at', (SELECT max(updated_at) FROM public.client_company_links)
+)::text;
+
+SELECT json_build_object('kind', 'company', 'row', to_jsonb(projected))::text
+FROM (
+    SELECT {_COMPANY_COLUMN_SQL}
+    FROM public.companies
+    ORDER BY id
+) AS projected;
+
+SELECT json_build_object('kind', 'link', 'row', to_jsonb(projected))::text
+FROM (
+    SELECT {_LINK_COLUMN_SQL}
+    FROM public.client_company_links
+    ORDER BY id
+) AS projected;
+
+COMMIT;
+""".strip()
+
+TARGET_ATTEST_SQL = """
+SELECT
+    current_database() AS database,
+    current_user AS role,
+    inet_server_addr()::text AS server_address,
+    inet_server_port() AS server_port,
+    current_setting('transaction_read_only') AS transaction_read_only,
+    current_setting('search_path') AS search_path,
+    to_regnamespace('public')::oid AS public_schema_oid,
+    to_regclass('public.companies')::text AS companies_relation,
+    company_relation.oid AS companies_relation_oid,
+    to_regclass('public.companies')::oid AS companies_regclass_oid,
+    company_namespace.oid AS companies_namespace_oid,
+    company_namespace.nspname AS companies_namespace,
+    company_relation.relname AS companies_relname,
+    company_relation.relkind AS companies_relkind,
+    to_regclass('public.client_company_links')::text AS links_relation,
+    link_relation.oid AS links_relation_oid,
+    to_regclass('public.client_company_links')::oid AS links_regclass_oid,
+    link_namespace.oid AS links_namespace_oid,
+    link_namespace.nspname AS links_namespace,
+    link_relation.relname AS links_relname,
+    link_relation.relkind AS links_relkind
+FROM pg_catalog.pg_class AS company_relation
+JOIN pg_catalog.pg_namespace AS company_namespace
+  ON company_namespace.oid = company_relation.relnamespace
+JOIN pg_catalog.pg_class AS link_relation
+  ON link_relation.oid = to_regclass('public.client_company_links')
+JOIN pg_catalog.pg_namespace AS link_namespace
+  ON link_namespace.oid = link_relation.relnamespace
+WHERE company_relation.oid = to_regclass('public.companies')
+  AND company_namespace.oid = to_regnamespace('public')
+  AND link_namespace.oid = to_regnamespace('public')
+""".strip()
+
+TARGET_COLUMNS_SQL = """
+SELECT table_name, column_name
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name IN ('companies', 'client_company_links')
+ORDER BY table_name, ordinal_position
+""".strip()
+
+TARGET_CONSTRAINTS_SQL = """
+SELECT
+    relation.relname AS table_name,
+    pg_get_constraintdef(constraint_row.oid) AS definition,
+    constraint_row.convalidated AS convalidated
+FROM pg_constraint AS constraint_row
+JOIN pg_class AS relation ON relation.oid = constraint_row.conrelid
+JOIN pg_namespace AS namespace_row ON namespace_row.oid = relation.relnamespace
+WHERE namespace_row.nspname = 'public'
+  AND relation.relname IN ('companies', 'client_company_links')
+ORDER BY relation.relname, constraint_row.conname
+""".strip()
+
+LOCAL_CLIENT_IDS_SQL = "SELECT id FROM public.clients ORDER BY id"
+
+TARGET_COUNTS_SQL = """
+SELECT
+    (SELECT count(*) FROM public.companies)::bigint AS companies,
+    (SELECT count(*) FROM public.client_company_links)::bigint AS client_company_links
+""".strip()
+
+TARGET_COMPANIES_SQL = f"""
+SELECT {_COMPANY_COLUMN_SQL}
+FROM public.companies
+ORDER BY id
+""".strip()
+
+TARGET_LINKS_SQL = f"""
+SELECT {_LINK_COLUMN_SQL}
+FROM public.client_company_links
+ORDER BY id
+""".strip()
+
+COMPANY_INSERT_SQL = f"""
+WITH projected AS (
+    SELECT *
+    FROM jsonb_populate_record(NULL::public.companies, $1::jsonb)
+)
+INSERT INTO public.companies ({_COMPANY_COLUMN_SQL})
+SELECT {_COMPANY_COLUMN_SQL}
+FROM projected
+""".strip()
+
+LINK_INSERT_SQL = f"""
+WITH projected AS (
+    SELECT *
+    FROM jsonb_populate_record(NULL::public.client_company_links, $1::jsonb)
+)
+INSERT INTO public.client_company_links ({_LINK_COLUMN_SQL})
+SELECT {_LINK_COLUMN_SQL}
+FROM projected
+""".strip()
+
+SET_LOCAL_SEARCH_PATH_SQL = "SET LOCAL search_path = public"
+SET_LOCAL_LOCK_TIMEOUT_SQL = "SET LOCAL lock_timeout = '5000ms'"
+SET_LOCAL_STATEMENT_TIMEOUT_SQL = "SET LOCAL statement_timeout = '30000ms'"
+CLIENTS_SHARE_LOCK_SQL = "LOCK TABLE public.clients IN SHARE MODE"
+ADVISORY_XACT_LOCK_SQL = (
+    "SELECT pg_advisory_xact_lock(4815162342)"
+)
+TARGET_TABLE_LOCK_SQL = (
+    "LOCK TABLE public.companies, public.client_company_links "
+    "IN SHARE ROW EXCLUSIVE MODE"
+)
+
+SEQUENCE_ATTEST_SQL = """
+WITH ownership AS (
+    SELECT
+        sequence_namespace.nspname || '.' || sequence_relation.relname AS sequence_name,
+        table_namespace.nspname || '.' || table_relation.relname || '.' || attribute.attname AS owned_by,
+        sequence_definition.seqincrement AS increment_by,
+        sequence_definition.seqcycle AS cycle
+    FROM pg_catalog.pg_depend
+    JOIN pg_catalog.pg_class AS sequence_relation
+      ON sequence_relation.oid = pg_depend.objid
+    JOIN pg_catalog.pg_namespace AS sequence_namespace
+      ON sequence_namespace.oid = sequence_relation.relnamespace
+    JOIN pg_catalog.pg_sequence AS sequence_definition
+      ON sequence_definition.seqrelid = sequence_relation.oid
+    JOIN pg_catalog.pg_class AS table_relation
+      ON table_relation.oid = pg_depend.refobjid
+    JOIN pg_catalog.pg_namespace AS table_namespace
+      ON table_namespace.oid = table_relation.relnamespace
+    JOIN pg_catalog.pg_attribute AS attribute
+      ON attribute.attrelid = table_relation.oid
+     AND attribute.attnum = pg_depend.refobjsubid
+    WHERE sequence_relation.relkind = 'S'
+      AND sequence_namespace.nspname = 'public'
+)
+SELECT
+    'public.companies_id_seq' AS companies_sequence,
+    (SELECT owned_by FROM ownership WHERE sequence_name = 'public.companies_id_seq') AS companies_owned_by,
+    (SELECT last_value FROM public.companies_id_seq) AS companies_last_value,
+    (SELECT is_called FROM public.companies_id_seq) AS companies_is_called,
+    (SELECT increment_by FROM ownership WHERE sequence_name = 'public.companies_id_seq') AS companies_increment_by,
+    (SELECT cycle FROM ownership WHERE sequence_name = 'public.companies_id_seq') AS companies_cycle,
+    'public.client_company_links_id_seq' AS links_sequence,
+    (SELECT owned_by FROM ownership WHERE sequence_name = 'public.client_company_links_id_seq') AS links_owned_by,
+    (SELECT last_value FROM public.client_company_links_id_seq) AS links_last_value,
+    (SELECT is_called FROM public.client_company_links_id_seq) AS links_is_called,
+    (SELECT increment_by FROM ownership WHERE sequence_name = 'public.client_company_links_id_seq') AS links_increment_by,
+    (SELECT cycle FROM ownership WHERE sequence_name = 'public.client_company_links_id_seq') AS links_cycle
+""".strip()
+
+def _protected_invariant_sql(table: str) -> str:
+    if table not in PROTECTED_TABLES:
+        raise ValueError("protected invariant table is not allowlisted")
+    return f"""
+WITH column_shape AS (
+    SELECT md5(string_agg(
+        column_name || ':' || data_type || ':' || is_nullable,
+        ',' ORDER BY ordinal_position
+    )) AS schema_digest
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = '{table}'
+), row_hashes AS (
+    SELECT md5(to_jsonb(protected_row)::text) AS row_hash
+    FROM public.{table} AS protected_row
+), ordered_rows AS (
+    SELECT row_hash FROM row_hashes ORDER BY row_hash
+)
+SELECT
+    (SELECT count(*) FROM ordered_rows)::bigint AS row_count,
+    (SELECT schema_digest FROM column_shape) AS schema_digest,
+    md5(COALESCE((SELECT string_agg(row_hash, ',' ORDER BY row_hash) FROM ordered_rows), '')) AS row_digest
+""".strip()
+
+
+PROTECTED_INVARIANT_SQL = tuple(
+    _protected_invariant_sql(table) for table in PROTECTED_TABLES
+)
+
+ALL_LOCAL_SQL = (
+    SET_LOCAL_SEARCH_PATH_SQL,
+    SET_LOCAL_LOCK_TIMEOUT_SQL,
+    SET_LOCAL_STATEMENT_TIMEOUT_SQL,
+    CLIENTS_SHARE_LOCK_SQL,
+    TARGET_TABLE_LOCK_SQL,
+    ADVISORY_XACT_LOCK_SQL,
+    TARGET_ATTEST_SQL,
+    TARGET_COLUMNS_SQL,
+    TARGET_CONSTRAINTS_SQL,
+    SEQUENCE_ATTEST_SQL,
+    LOCAL_CLIENT_IDS_SQL,
+    TARGET_COUNTS_SQL,
+    TARGET_COMPANIES_SQL,
+    TARGET_LINKS_SQL,
+    COMPANY_INSERT_SQL,
+    LINK_INSERT_SQL,
+    *PROTECTED_INVARIANT_SQL,
+)
+
+
+def _positive_int(value: Any, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise SourceSnapshotError(f"{label} must be a positive integer")
+    return value
+
+
+def _count_value(value: Any, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SourceSnapshotError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _project_row(
+    row: Mapping[str, Any], columns: Sequence[str], *, row_kind: str
+) -> JsonRow:
+    missing = [column for column in columns if column not in row]
+    if missing:
+        raise SourceSnapshotError(
+            f"source {row_kind} row is missing allowlisted columns"
+        )
+    projected = {column: row[column] for column in columns}
+    _positive_int(projected["id"], label=f"source {row_kind} id")
+    return projected
+
+
+def compute_content_digest(
+    *,
+    canonical_row_bytes: bytes,
+    domain: str,
+    version: str,
+    company_columns: Sequence[str],
+    link_columns: Sequence[str],
+) -> str:
+    """Bind raw source row bytes to an explicit versioned column contract."""
+
+    if not isinstance(canonical_row_bytes, bytes):
+        raise TypeError("canonical source rows must be bytes")
+    header = json.dumps(
+        ["header", domain, version, list(company_columns), list(link_columns)],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(header + b"\n" + canonical_row_bytes).hexdigest()
+
+
+def _digest_value(value: Any) -> Any:
+    if value is None:
+        return ["null"]
+    if isinstance(value, bool):
+        return ["bool", value]
+    if isinstance(value, int):
+        return ["int", str(value)]
+    if isinstance(value, Decimal):
+        return ["decimal", str(value)]
+    if isinstance(value, UUID):
+        return ["string", str(value)]
+    if isinstance(value, datetime):
+        return ["string", value.isoformat()]
+    if isinstance(value, date):
+        return ["string", value.isoformat()]
+    if isinstance(value, float):
+        raise TypeError("float is not lossless")
+    if isinstance(value, str):
+        return ["string", value]
+    if isinstance(value, Mapping):
+        return [
+            "object",
+            [[key, _digest_value(value[key])] for key in sorted(value)],
+        ]
+    if isinstance(value, (list, tuple)):
+        return ["array", [_digest_value(item) for item in value]]
+    raise TypeError("unsupported canonical value type")
+
+
+def _projection_canonical_bytes(
+    *,
+    companies: Sequence[Mapping[str, Any]],
+    eligible_links: Sequence[Mapping[str, Any]],
+) -> bytes:
+    records: list[Any] = [
+        [
+            "header",
+            PROJECTION_DIGEST_DOMAIN,
+            PROJECTION_DIGEST_VERSION,
+            list(COMPANY_COLUMNS),
+            list(LINK_COLUMNS),
+        ]
+    ]
+    records.extend(
+        [
+            "company",
+            [
+                _digest_value(
+                    json.loads(row[column], parse_float=Decimal)
+                    if column == "custom_fields" and isinstance(row[column], str)
+                    else row[column]
+                )
+                for column in COMPANY_COLUMNS
+            ],
+        ]
+        for row in sorted(companies, key=lambda row: int(row["id"]))
+    )
+    records.extend(
+        ["link", [_digest_value(row[column]) for column in LINK_COLUMNS]]
+        for row in sorted(eligible_links, key=lambda row: int(row["id"]))
+    )
+    return b"\n".join(
+        json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode()
+        for record in records
+    ) + b"\n"
+
+
+def compute_projection_digest(
+    *,
+    companies: Sequence[Mapping[str, Any]],
+    eligible_links: Sequence[Mapping[str, Any]],
+) -> str:
+    return hashlib.sha256(
+        _projection_canonical_bytes(
+            companies=companies, eligible_links=eligible_links
+        )
+    ).hexdigest()
+
+
+EMPTY_TARGET_DIGEST = compute_projection_digest(companies=(), eligible_links=())
+
+
+def _target_project_row(
+    row: Mapping[str, Any], columns: Sequence[str], *, row_kind: str
+) -> JsonRow:
+    missing = [column for column in columns if column not in row]
+    if missing:
+        raise TargetContractError(
+            f"target {row_kind} row is missing allowlisted columns"
+        )
+    projected = {column: row[column] for column in columns}
+    _positive_int(projected["id"], label=f"target {row_kind} id")
+    return projected
+
+
+async def read_target_projection(conn: ConnectionLike) -> TargetProjection:
+    """Acquire exact target rows and derive the canonical digest in Python."""
+
+    company_rows = await conn.fetch(TARGET_COMPANIES_SQL)
+    link_rows = await conn.fetch(TARGET_LINKS_SQL)
+    companies = tuple(
+        _target_project_row(row, COMPANY_COLUMNS, row_kind="company")
+        for row in company_rows
+    )
+    links = tuple(
+        _target_project_row(row, LINK_COLUMNS, row_kind="link")
+        for row in link_rows
+    )
+    return TargetProjection(
+        companies=companies,
+        links=links,
+        digest=compute_projection_digest(
+            companies=companies, eligible_links=links
+        ),
+    )
+
+
+def _source_metadata(record: Mapping[str, Any]) -> SourceMetadata:
+    database = record.get("database")
+    if database != EXPECTED_SOURCE_DATABASE:
+        raise SourceSnapshotError("source database attestation failed")
+    role = record.get("role")
+    if role != EXPECTED_SOURCE_ROLE:
+        raise SourceSnapshotError("source role attestation failed")
+    if record.get("transaction_read_only") != "on":
+        raise SourceSnapshotError("source read-only attestation failed")
+
+    snapshot_at = record.get("snapshot_at")
+    if not isinstance(snapshot_at, str) or not snapshot_at:
+        raise SourceSnapshotError("source snapshot timestamp is missing")
+
+    companies_max_updated_at = record.get("companies_max_updated_at")
+    links_max_updated_at = record.get("links_max_updated_at")
+    if companies_max_updated_at is not None and not isinstance(
+        companies_max_updated_at, str
+    ):
+        raise SourceSnapshotError("source company freshness metadata is invalid")
+    if links_max_updated_at is not None and not isinstance(
+        links_max_updated_at, str
+    ):
+        raise SourceSnapshotError("source link freshness metadata is invalid")
+
+    return SourceMetadata(
+        snapshot_at=snapshot_at,
+        companies_count=_count_value(
+            record.get("companies_count"), label="source companies_count"
+        ),
+        links_count=_count_value(
+            record.get("links_count"), label="source links_count"
+        ),
+        companies_max_updated_at=companies_max_updated_at,
+        links_max_updated_at=links_max_updated_at,
+    )
+
+
+def _validate_snapshot_graph(snapshot: SourceSnapshot) -> None:
+    if not snapshot.companies:
+        raise SourceSnapshotError("source company snapshot is empty")
+
+    company_ids: set[int] = set()
+    for company in snapshot.companies:
+        company_id = _positive_int(company["id"], label="source company id")
+        if company_id in company_ids:
+            raise SourceSnapshotError("source company ids are not unique")
+        company_ids.add(company_id)
+
+    link_ids: set[int] = set()
+    link_pairs: set[tuple[int, int]] = set()
+    for link in snapshot.links:
+        link_id = _positive_int(link["id"], label="source link id")
+        client_id = _positive_int(link["client_id"], label="source link client_id")
+        company_id = _positive_int(
+            link["company_id"], label="source link company_id"
+        )
+        if link_id in link_ids:
+            raise SourceSnapshotError("source link ids are not unique")
+        if company_id not in company_ids:
+            raise SourceSnapshotError("source link references an absent company")
+        pair = (client_id, company_id)
+        if pair in link_pairs:
+            raise SourceSnapshotError("source client/company link pairs are not unique")
+        link_ids.add(link_id)
+        link_pairs.add(pair)
+
+
+def parse_source_snapshot(stdout: bytes) -> SourceSnapshot:
+    """Parse and validate an in-memory JSON-lines snapshot without echoing rows."""
+
+    metadata: SourceMetadata | None = None
+    companies: list[JsonRow] = []
+    links: list[JsonRow] = []
+
+    if not isinstance(stdout, bytes):
+        raise SourceSnapshotError("source snapshot transport must be binary")
+    canonical_rows = bytearray()
+    for line_number, raw_line in enumerate(stdout.splitlines(keepends=True), start=1):
+        line = raw_line.rstrip(b"\r\n")
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line, parse_float=Decimal)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise SourceSnapshotError(
+                f"invalid JSON at source output line {line_number}"
+            ) from exc
+        if not isinstance(record, dict):
+            raise SourceSnapshotError(
+                f"invalid record type at source output line {line_number}"
+            )
+
+        kind = record.get("kind")
+        if kind == "meta":
+            if metadata is not None:
+                raise SourceSnapshotError("source emitted more than one metadata record")
+            metadata = _source_metadata(record)
+            continue
+        if kind not in {"company", "link"}:
+            raise SourceSnapshotError(
+                f"invalid record kind at source output line {line_number}"
+            )
+        row = record.get("row")
+        if not isinstance(row, dict):
+            raise SourceSnapshotError(
+                f"invalid {kind} row at source output line {line_number}"
+            )
+        if kind == "company":
+            companies.append(_project_row(row, COMPANY_COLUMNS, row_kind="company"))
+        else:
+            projected_link = _project_row(row, LINK_COLUMNS, row_kind="link")
+            _positive_int(
+                projected_link["client_id"], label="source link client_id"
+            )
+            _positive_int(
+                projected_link["company_id"], label="source link company_id"
+            )
+            links.append(projected_link)
+        canonical_rows.extend(raw_line)
+
+    if metadata is None:
+        raise SourceSnapshotError("source metadata record is missing")
+    if metadata.companies_count != len(companies):
+        raise SourceSnapshotError("source company count mismatch")
+    if metadata.links_count != len(links):
+        raise SourceSnapshotError("source link count mismatch")
+
+    snapshot = SourceSnapshot(
+        metadata=metadata,
+        companies=tuple(companies),
+        links=tuple(links),
+        canonical_row_bytes=bytes(canonical_rows),
+        content_digest=compute_content_digest(
+            canonical_row_bytes=bytes(canonical_rows),
+            domain=CONTENT_DIGEST_DOMAIN,
+            version=CONTENT_DIGEST_VERSION,
+            company_columns=COMPANY_COLUMNS,
+            link_columns=LINK_COLUMNS,
+        ),
+    )
+    _validate_snapshot_graph(snapshot)
+    return snapshot
+
+
+def fetch_source_snapshot(
+    *,
+    run: RunCallable = subprocess.run,
+    timeout_seconds: int = 180,
+) -> SourceSnapshot:
+    """Read one canonical PROD snapshot through the existing ``pg.sh`` authority."""
+
+    command = [
+        "bash",
+        str(PG_SH),
+        "-X",
+        "-q",
+        "-tA",
+        "-v",
+        "ON_ERROR_STOP=1",
+    ]
+    try:
+        result = run(
+            command,
+            input=SOURCE_SNAPSHOT_SQL.encode(),
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SourceSnapshotError("source snapshot command could not complete") from exc
+    if result.returncode != 0:
+        raise SourceSnapshotError(
+            f"source snapshot command failed with exit {result.returncode}"
+        )
+    return parse_source_snapshot(result.stdout)
+
+
+def source_shape_digest(snapshot: SourceSnapshot) -> str:
+    """Hash only entity/link types and integer identities, never row content."""
+
+    digest = hashlib.sha256()
+    for company in snapshot.companies:
+        digest.update(f"company:{company['id']}\n".encode())
+    for link in snapshot.links:
+        digest.update(
+            (
+                f"link:{link['id']}:{link['client_id']}:{link['company_id']}\n"
+            ).encode()
+        )
+    return digest.hexdigest()
+
+
+def build_projection_plan(
+    snapshot: SourceSnapshot, *, local_client_ids: set[int]
+) -> ProjectionPlan:
+    """Keep every company and only links whose client already exists locally."""
+
+    if any(
+        isinstance(client_id, bool) or not isinstance(client_id, int)
+        for client_id in local_client_ids
+    ):
+        raise TargetContractError("local client id set contains an invalid value")
+    eligible = tuple(
+        link for link in snapshot.links if link["client_id"] in local_client_ids
+    )
+    return ProjectionPlan(
+        companies=snapshot.companies,
+        eligible_links=eligible,
+        rejected_missing_local_client=len(snapshot.links) - len(eligible),
+        projection_digest=compute_projection_digest(
+            companies=snapshot.companies, eligible_links=eligible
+        ),
+    )
+
+
+def validate_target_dsn(dsn: str) -> None:
+    """Fail closed unless the DSN points exactly at loopback ``nuzantara_dev``."""
+
+    try:
+        parsed = urlparse(dsn)
+        port = parsed.port
+    except ValueError as exc:
+        raise ApplyGateError("target DSN is malformed") from exc
+    if parsed.scheme not in {"postgres", "postgresql"}:
+        raise ApplyGateError("target DSN must use PostgreSQL")
+    if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        raise ApplyGateError("target DSN must use a loopback host")
+    if port not in {None, 5432}:
+        raise ApplyGateError("target DSN must use the local PostgreSQL port")
+    if parsed.username != EXPECTED_TARGET_ROLE:
+        raise ApplyGateError("target DSN must use the local nuzantara role")
+    if parsed.path != f"/{EXPECTED_TARGET_DATABASE}":
+        raise ApplyGateError("target DSN must name nuzantara_dev")
+    if parsed.query or parsed.fragment or parsed.params:
+        raise ApplyGateError("target DSN options are not allowed")
+
+
+def validate_apply_request(
+    *,
+    apply: bool,
+    dsn: str,
+    environ: Mapping[str, str],
+    expected_content_digest: str | None,
+    actual_content_digest: str,
+) -> None:
+    """Require the explicit CLI flag, environment gate, and exact dev target."""
+
+    if not apply:
+        raise ApplyGateError("write requires the explicit --apply flag")
+    if environ.get(WRITE_ENABLE_ENV) != "true":
+        raise ApplyGateError(f"write requires {WRITE_ENABLE_ENV}=true")
+    if expected_content_digest is None or not re.fullmatch(
+        r"[0-9a-f]{64}", expected_content_digest
+    ):
+        raise ApplyGateError("write requires an expected content digest")
+    if expected_content_digest != actual_content_digest:
+        raise ApplyGateError("source content digest mismatch")
+    validate_target_dsn(dsn)
+
+
+def _normalized_constraint(definition: str) -> str:
+    return re.sub(r"\s+", " ", definition.upper().replace('"', "")).strip()
+
+
+def _has_constraint(definitions: Sequence[str], pattern: str) -> bool:
+    return any(re.search(pattern, _normalized_constraint(item)) for item in definitions)
+
+
+def validate_target_contract(
+    columns: Mapping[str, set[str]],
+    constraints: Mapping[str, Sequence[str]],
+) -> None:
+    """Validate required columns, keys, uniqueness, and link foreign keys."""
+
+    required_columns = {
+        "companies": set(COMPANY_COLUMNS),
+        "client_company_links": set(LINK_COLUMNS),
+    }
+    for table, required in required_columns.items():
+        if not required.issubset(columns.get(table, set())):
+            raise TargetContractError(f"target {table} column allowlist is incomplete")
+
+    company_constraints = constraints.get("companies", ())
+    link_constraints = constraints.get("client_company_links", ())
+    if not _has_constraint(company_constraints, r"PRIMARY KEY \(ID\)"):
+        raise TargetContractError("target companies primary key is missing")
+    if not _has_constraint(link_constraints, r"PRIMARY KEY \(ID\)"):
+        raise TargetContractError("target link primary key is missing")
+    if not _has_constraint(
+        link_constraints, r"UNIQUE \(CLIENT_ID, COMPANY_ID\)"
+    ):
+        raise TargetContractError("target client/company uniqueness is missing")
+    if not _has_constraint(
+        link_constraints,
+        r"FOREIGN KEY \(CLIENT_ID\) REFERENCES (?:PUBLIC\.)?CLIENTS\(ID\)",
+    ):
+        raise TargetContractError("target client_id foreign key is missing")
+    if not _has_constraint(
+        link_constraints,
+        r"FOREIGN KEY \(COMPANY_ID\) REFERENCES (?:PUBLIC\.)?COMPANIES\(ID\)",
+    ):
+        raise TargetContractError("target company_id foreign key is missing")
+
+
+def _has_validated_exact_foreign_key(
+    rows: Sequence[Mapping[str, Any]], *, column: str, target_table: str
+) -> bool:
+    """Require the one FK needed by the projection, not a look-alike constraint."""
+
+    pattern = (
+        rf"^FOREIGN KEY \({column.upper()}\) REFERENCES "
+        rf"(?:PUBLIC\.)?{target_table.upper()}\(ID\)(?: |$)"
+    )
+    return any(
+        isinstance(row.get("definition"), str)
+        and row.get("convalidated") is True
+        and re.search(pattern, _normalized_constraint(row["definition"]))
+        for row in rows
+    )
+
+
+def _attest_relation_identity(
+    record: Mapping[str, Any],
+    *,
+    prefix: str,
+    expected_relname: str,
+    public_schema_oid: int,
+) -> int:
+    """Validate one public table through mutually consistent catalog facts."""
+
+    relation_oid = record.get(f"{prefix}_relation_oid")
+    regclass_oid = record.get(f"{prefix}_regclass_oid")
+    namespace_oid = record.get(f"{prefix}_namespace_oid")
+    for value in (relation_oid, regclass_oid, namespace_oid):
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise TargetContractError(
+                f"target {prefix} catalog OID attestation failed"
+            )
+    if relation_oid != regclass_oid or namespace_oid != public_schema_oid:
+        raise TargetContractError(f"target {prefix} catalog identity failed")
+
+    relation_text = record.get(f"{prefix}_relation")
+    if relation_text not in {expected_relname, f"public.{expected_relname}"}:
+        raise TargetContractError(f"target {prefix} relation attestation failed")
+    if (
+        record.get(f"{prefix}_namespace") != "public"
+        or record.get(f"{prefix}_relname") != expected_relname
+        or record.get(f"{prefix}_relkind") != "r"
+    ):
+        raise TargetContractError(f"target {prefix} catalog attestation failed")
+    return cast(int, relation_oid)
+
+
+async def attest_target(
+    conn: ConnectionLike, *, expect_read_only: bool
+) -> None:
+    """Independently attest database, role, loopback server, port, and mode."""
+
+    record = await conn.fetchrow(TARGET_ATTEST_SQL)
+    if record is None:
+        raise TargetContractError("target attestation returned no row")
+    if record.get("database") != EXPECTED_TARGET_DATABASE:
+        raise TargetContractError("target database attestation failed")
+    if record.get("role") != EXPECTED_TARGET_ROLE:
+        raise TargetContractError("target role attestation failed")
+    if record.get("server_address") not in {"127.0.0.1", "::1"}:
+        raise TargetContractError("target server is not loopback")
+    if record.get("server_port") != 5432:
+        raise TargetContractError("target server port attestation failed")
+    expected_mode = "on" if expect_read_only else "off"
+    if record.get("transaction_read_only") != expected_mode:
+        raise TargetContractError("target transaction mode attestation failed")
+    if record.get("search_path") != "public":
+        raise TargetContractError("target search path attestation failed")
+    schema_oid = record.get("public_schema_oid")
+    if isinstance(schema_oid, bool) or not isinstance(schema_oid, int) or schema_oid <= 0:
+        raise TargetContractError("target public schema attestation failed")
+    companies_oid = _attest_relation_identity(
+        record,
+        prefix="companies",
+        expected_relname="companies",
+        public_schema_oid=schema_oid,
+    )
+    links_oid = _attest_relation_identity(
+        record,
+        prefix="links",
+        expected_relname="client_company_links",
+        public_schema_oid=schema_oid,
+    )
+    if companies_oid == links_oid:
+        raise TargetContractError("target relation identities are not distinct")
+
+
+async def assert_target_contract(conn: ConnectionLike) -> None:
+    column_rows = await conn.fetch(TARGET_COLUMNS_SQL)
+    constraint_rows = await conn.fetch(TARGET_CONSTRAINTS_SQL)
+    columns: dict[str, set[str]] = {
+        "companies": set(),
+        "client_company_links": set(),
+    }
+    constraints: dict[str, list[str]] = {
+        "companies": [],
+        "client_company_links": [],
+    }
+    for row in column_rows:
+        table = row.get("table_name")
+        column = row.get("column_name")
+        if table in columns and isinstance(column, str):
+            columns[table].add(column)
+    link_constraint_rows: list[Mapping[str, Any]] = []
+    for row in constraint_rows:
+        table = row.get("table_name")
+        definition = row.get("definition")
+        if table in constraints and isinstance(definition, str):
+            constraints[table].append(definition)
+    validate_target_contract(columns, constraints)
+    for row in constraint_rows:
+        if row.get("table_name") == "client_company_links":
+            link_constraint_rows.append(row)
+    if not _has_validated_exact_foreign_key(
+        link_constraint_rows, column="client_id", target_table="clients"
+    ):
+        raise TargetContractError("target client_id foreign key is not exact and validated")
+    if not _has_validated_exact_foreign_key(
+        link_constraint_rows, column="company_id", target_table="companies"
+    ):
+        raise TargetContractError("target company_id foreign key is not exact and validated")
+
+
+async def read_local_client_ids(conn: ConnectionLike) -> set[int]:
+    rows = await conn.fetch(LOCAL_CLIENT_IDS_SQL)
+    client_ids: set[int] = set()
+    for row in rows:
+        client_ids.add(_positive_int(row.get("id"), label="local client id"))
+    return client_ids
+
+
+async def read_target_counts(conn: ConnectionLike) -> dict[str, int]:
+    row = await conn.fetchrow(TARGET_COUNTS_SQL)
+    if row is None:
+        raise TargetContractError("target count query returned no row")
+    counts: dict[str, int] = {}
+    for key in ("companies", "client_company_links"):
+        value = row.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise TargetContractError("target count query returned an invalid value")
+        counts[key] = value
+    return counts
+
+
+async def read_protected_invariants(
+    conn: ConnectionLike,
+) -> dict[str, InvariantState]:
+    states: dict[str, InvariantState] = {}
+    for table, sql in zip(PROTECTED_TABLES, PROTECTED_INVARIANT_SQL, strict=True):
+        row = await conn.fetchrow(sql)
+        if row is None:
+            raise ProjectionInvariantError("protected table digest returned no row")
+        count = row.get("row_count")
+        schema_digest = row.get("schema_digest")
+        digest = row.get("row_digest")
+        if (
+            isinstance(count, bool)
+            or not isinstance(count, int)
+            or count < 0
+            or not isinstance(schema_digest, str)
+            or not isinstance(digest, str)
+        ):
+            raise ProjectionInvariantError("protected table digest is invalid")
+        states[table] = InvariantState(
+            row_count=count, schema_digest=schema_digest, row_digest=digest
+        )
+    return states
+
+
+def protected_shape_digest(states: Mapping[str, InvariantState]) -> str:
+    digest = hashlib.sha256()
+    for table in PROTECTED_TABLES:
+        state = states.get(table)
+        if state is None:
+            raise ProjectionInvariantError("protected table digest set is incomplete")
+        digest.update(
+            f"{table}:{state.row_count}:{state.schema_digest}:{state.row_digest}\n".encode()
+        )
+    return digest.hexdigest()
+
+
+def _plain_json(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, float):
+        raise TypeError("float is not lossless")
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, Mapping):
+        return "{" + ",".join(
+            f"{json.dumps(str(key), ensure_ascii=False)}:{_plain_json(value[key])}"
+            for key in sorted(value)
+        ) + "}"
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_plain_json(item) for item in value) + "]"
+    raise TypeError("unsupported JSON value type")
+
+
+def _json_payload(row: Mapping[str, Any], columns: Sequence[str]) -> tuple[str]:
+    projected = {column: row[column] for column in columns}
+    return (_plain_json(projected),)
+
+
+def sequence_restart_value(
+    *, last_value: int, is_called: bool, source_max_id: int
+) -> int:
+    for value, label, allow_zero in (
+        (last_value, "sequence last value", False),
+        (source_max_id, "source maximum id", True),
+    ):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or value < (0 if allow_zero else 1)
+            or value > 9223372036854775807
+        ):
+            raise TargetContractError(f"{label} is invalid")
+    if not isinstance(is_called, bool):
+        raise TargetContractError("sequence called state is invalid")
+    effective_next = last_value + 1 if is_called else last_value
+    restart = max(effective_next, source_max_id + 1)
+    if restart > 9223372036854775807:
+        raise TargetContractError("sequence restart exceeds bigint")
+    return restart
+
+
+_SEQUENCE_NAMES = {
+    "public.companies_id_seq",
+    "public.client_company_links_id_seq",
+}
+
+
+def sequence_restart_sql(sequence_name: str, restart: Any) -> str:
+    if sequence_name not in _SEQUENCE_NAMES:
+        raise TargetContractError("sequence name is not allowlisted")
+    if (
+        isinstance(restart, bool)
+        or not isinstance(restart, int)
+        or restart <= 0
+        or restart > 9223372036854775807
+    ):
+        raise TargetContractError("sequence restart value is invalid")
+    return f"ALTER SEQUENCE {sequence_name} RESTART WITH {restart}"
+
+
+def classify_target_state(
+    *,
+    companies_count: int,
+    links_count: int,
+    actual_digest: str,
+    desired_digest: str,
+) -> str:
+    if companies_count == 0 and links_count == 0:
+        return "empty"
+    if actual_digest == desired_digest:
+        return "exact-noop"
+    raise TargetContractError("target is neither empty nor the exact desired projection")
+
+
+def _sequence_state(record: Mapping[str, Any] | None) -> tuple[int, bool, int, bool]:
+    if record is None:
+        raise TargetContractError("sequence attestation returned no row")
+    exact = {
+        "companies_sequence": "public.companies_id_seq",
+        "companies_owned_by": "public.companies.id",
+        "links_sequence": "public.client_company_links_id_seq",
+        "links_owned_by": "public.client_company_links.id",
+    }
+    if any(record.get(key) != value for key, value in exact.items()):
+        raise TargetContractError("sequence identity or ownership attestation failed")
+    company_last = record.get("companies_last_value")
+    company_called = record.get("companies_is_called")
+    link_last = record.get("links_last_value")
+    link_called = record.get("links_is_called")
+    company_increment = record.get("companies_increment_by")
+    company_cycle = record.get("companies_cycle")
+    link_increment = record.get("links_increment_by")
+    link_cycle = record.get("links_cycle")
+    if (
+        isinstance(company_increment, bool)
+        or not isinstance(company_increment, int)
+        or company_increment != 1
+        or company_cycle is not False
+        or isinstance(link_increment, bool)
+        or not isinstance(link_increment, int)
+        or link_increment != 1
+        or link_cycle is not False
+    ):
+        raise TargetContractError("sequence definition attestation failed")
+    if not isinstance(company_called, bool) or not isinstance(link_called, bool):
+        raise TargetContractError("sequence called state attestation failed")
+    if (
+        isinstance(company_last, bool)
+        or not isinstance(company_last, int)
+        or company_last <= 0
+    ):
+        raise TargetContractError("sequence value attestation failed")
+    if (
+        isinstance(link_last, bool)
+        or not isinstance(link_last, int)
+        or link_last <= 0
+    ):
+        raise TargetContractError("sequence value attestation failed")
+    return company_last, company_called, link_last, link_called
+
+
+def _target_counts(target: TargetProjection) -> dict[str, int]:
+    return {
+        "companies": len(target.companies),
+        "client_company_links": len(target.links),
+    }
+
+
+def _sequence_status(
+    sequence_state: tuple[int, bool, int, bool], *, plan: ProjectionPlan
+) -> dict[str, dict[str, int | bool]]:
+    company_last, company_called, link_last, link_called = sequence_state
+    company_next = company_last + 1 if company_called else company_last
+    link_next = link_last + 1 if link_called else link_last
+    company_source_max = max(row["id"] for row in plan.companies)
+    link_source_max = max((row["id"] for row in plan.eligible_links), default=0)
+    return {
+        "companies": {
+            "last_value": company_last,
+            "is_called": company_called,
+            "next_value": company_next,
+            "source_max_id": company_source_max,
+            "safe": company_next > company_source_max,
+        },
+        "client_company_links": {
+            "last_value": link_last,
+            "is_called": link_called,
+            "next_value": link_next,
+            "source_max_id": link_source_max,
+            "safe": link_next > link_source_max,
+        },
+    }
+
+
+def _assert_exact_target_projection(
+    target: TargetProjection, *, plan: ProjectionPlan
+) -> None:
+    target_kind = classify_target_state(
+        companies_count=len(target.companies),
+        links_count=len(target.links),
+        actual_digest=target.digest,
+        desired_digest=plan.projection_digest,
+    )
+    if target_kind != "exact-noop":
+        raise TargetContractError("target projection does not match the desired rows")
+
+
+def _detached_apply_result(
+    *,
+    snapshot: SourceSnapshot,
+    plan: ProjectionPlan,
+    target_before_counts: Mapping[str, int],
+    target_after_counts: Mapping[str, int],
+    sequence_status: Mapping[str, Mapping[str, int | bool]],
+    protected_before: Mapping[str, InvariantState],
+    protected_after: Mapping[str, InvariantState],
+    companies_inserted: int,
+    links_inserted: int,
+    invariant_digest: str,
+    projection_digest: str,
+    no_op: bool,
+) -> ApplyResult:
+    """Detach every transaction-accepted fact behind immutable containers."""
+
+    return ApplyResult(
+        accepted_source=_immutable_source_copy(snapshot),
+        accepted_plan=_immutable_plan_copy(plan),
+        source_content_digest=snapshot.content_digest,
+        target_before_counts=_immutable_counts_copy(target_before_counts),
+        target_after_counts=_immutable_counts_copy(target_after_counts),
+        sequence_status=_immutable_sequence_status_copy(sequence_status),
+        protected_before=_immutable_invariants_copy(protected_before),
+        protected_after=_immutable_invariants_copy(protected_after),
+        companies_inserted=companies_inserted,
+        links_inserted=links_inserted,
+        invariant_digest=invariant_digest,
+        projection_digest=projection_digest,
+        no_op=no_op,
+    )
+
+
+async def apply_projection(
+    conn: ConnectionLike,
+    snapshot: SourceSnapshot,
+    *,
+    expected_content_digest: str,
+) -> ApplyResult:
+    """Apply one attested projection in one serializable target transaction."""
+
+    if (
+        re.fullmatch(r"[0-9a-f]{64}", expected_content_digest) is None
+        or expected_content_digest != snapshot.content_digest
+    ):
+        raise ApplyGateError("source content digest mismatch")
+
+    async with conn.transaction(isolation="serializable", readonly=False):
+        await conn.execute(SET_LOCAL_SEARCH_PATH_SQL)
+        await conn.execute(SET_LOCAL_LOCK_TIMEOUT_SQL)
+        await conn.execute(SET_LOCAL_STATEMENT_TIMEOUT_SQL)
+        await conn.execute(CLIENTS_SHARE_LOCK_SQL)
+        await conn.execute(TARGET_TABLE_LOCK_SQL)
+        await conn.execute(ADVISORY_XACT_LOCK_SQL)
+
+        await attest_target(conn, expect_read_only=False)
+        await assert_target_contract(conn)
+        sequence_state = _sequence_state(await conn.fetchrow(SEQUENCE_ATTEST_SQL))
+        protected_before = await read_protected_invariants(conn)
+        local_client_ids = await read_local_client_ids(conn)
+        plan = build_projection_plan(
+            snapshot, local_client_ids=local_client_ids
+        )
+        accepted_sequence_status = _sequence_status(sequence_state, plan=plan)
+
+        target_before = await read_target_projection(conn)
+        target_before_counts = _target_counts(target_before)
+        target_kind = classify_target_state(
+            companies_count=len(target_before.companies),
+            links_count=len(target_before.links),
+            actual_digest=target_before.digest,
+            desired_digest=plan.projection_digest,
+        )
+        if target_kind == "exact-noop":
+            company_last, company_called, link_last, link_called = sequence_state
+            company_next = company_last + 1 if company_called else company_last
+            link_next = link_last + 1 if link_called else link_last
+            company_target_max = max(
+                (row["id"] for row in target_before.companies), default=0
+            )
+            link_target_max = max(
+                (row["id"] for row in target_before.links), default=0
+            )
+            if company_next <= company_target_max or link_next <= link_target_max:
+                raise TargetContractError(
+                    "exact-noop target sequence is not safely ahead of projected ids"
+                )
+            target_final = await read_target_projection(conn)
+            _assert_exact_target_projection(target_final, plan=plan)
+            await assert_target_contract(conn)
+            protected_after = await read_protected_invariants(conn)
+            if protected_before != protected_after:
+                raise ProjectionInvariantError(
+                    "a protected table changed during company projection"
+                )
+            return _detached_apply_result(
+                snapshot=snapshot,
+                plan=plan,
+                target_before_counts=target_before_counts,
+                target_after_counts=_target_counts(target_final),
+                sequence_status=accepted_sequence_status,
+                protected_before=protected_before,
+                protected_after=protected_after,
+                companies_inserted=0,
+                links_inserted=0,
+                invariant_digest=protected_shape_digest(protected_after),
+                projection_digest=target_final.digest,
+                no_op=True,
+            )
+
+        company_payloads = [
+            _json_payload(row, COMPANY_COLUMNS) for row in plan.companies
+        ]
+        link_payloads = [
+            _json_payload(row, LINK_COLUMNS) for row in plan.eligible_links
+        ]
+        await conn.executemany(COMPANY_INSERT_SQL, company_payloads)
+        if link_payloads:
+            await conn.executemany(LINK_INSERT_SQL, link_payloads)
+
+        company_last, company_called, link_last, link_called = sequence_state
+        company_source_max = max(row["id"] for row in plan.companies)
+        link_source_max = max(
+            (row["id"] for row in plan.eligible_links), default=0
+        )
+        company_restart = sequence_restart_value(
+            last_value=company_last,
+            is_called=company_called,
+            source_max_id=company_source_max,
+        )
+        link_restart = sequence_restart_value(
+            last_value=link_last,
+            is_called=link_called,
+            source_max_id=link_source_max,
+        )
+        await conn.execute(
+            sequence_restart_sql("public.companies_id_seq", company_restart)
+        )
+        await conn.execute(
+            sequence_restart_sql(
+                "public.client_company_links_id_seq", link_restart
+            )
+        )
+
+        protected_after = await read_protected_invariants(conn)
+        if protected_before != protected_after:
+            raise ProjectionInvariantError(
+                "a protected table changed during company projection"
+            )
+        target_final = await read_target_projection(conn)
+        _assert_exact_target_projection(target_final, plan=plan)
+        await assert_target_contract(conn)
+
+        return _detached_apply_result(
+            snapshot=snapshot,
+            plan=plan,
+            target_before_counts=target_before_counts,
+            target_after_counts=_target_counts(target_final),
+            sequence_status=accepted_sequence_status,
+            protected_before=protected_before,
+            protected_after=protected_after,
+            companies_inserted=len(company_payloads),
+            links_inserted=len(link_payloads),
+            invariant_digest=protected_shape_digest(protected_after),
+            projection_digest=target_final.digest,
+            no_op=False,
+        )
+
+
+def build_report(
+    *,
+    snapshot: SourceSnapshot,
+    plan: ProjectionPlan,
+    mode: str,
+    target_before: Mapping[str, int] | None,
+    target_after: Mapping[str, int] | None,
+    invariant_digest: str,
+    sequence_status: Mapping[str, Any],
+    target_eligibility: str | None = None,
+) -> dict[str, Any]:
+    """Build a PII-free aggregate report; row content has no output path."""
+
+    if mode not in {"dry-run", "apply"}:
+        raise ValueError("invalid report mode")
+    if target_eligibility not in {None, "not_evaluated"}:
+        raise ValueError("invalid target eligibility state")
+
+    count_keys = {"companies", "client_company_links"}
+
+    def validated_counts(
+        value: Mapping[str, int] | None, *, allow_none: bool
+    ) -> dict[str, int] | None:
+        if value is None:
+            if allow_none:
+                return None
+            raise TargetContractError("report target counts are missing")
+        if set(value) != count_keys:
+            raise TargetContractError("report target counts are not allowlisted")
+        result: dict[str, int] = {}
+        for key in ("companies", "client_company_links"):
+            count = value[key]
+            if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+                raise TargetContractError("report target counts are invalid")
+            result[key] = count
+        return result
+
+    allowed_sequences = {"companies", "client_company_links"}
+    allowed_sequence_fields = {
+        "last_value",
+        "is_called",
+        "next_value",
+        "source_max_id",
+        "safe",
+    }
+    if not set(sequence_status).issubset(allowed_sequences):
+        raise TargetContractError("report sequence status is not allowlisted")
+    safe_sequence_status: dict[str, dict[str, int | bool]] = {}
+    for sequence, raw_status in sequence_status.items():
+        if not isinstance(raw_status, Mapping) or set(raw_status) != allowed_sequence_fields:
+            raise TargetContractError("report sequence details are not allowlisted")
+        for key in ("last_value", "next_value", "source_max_id"):
+            value = raw_status[key]
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise TargetContractError("report sequence details are invalid")
+        for key in ("is_called", "safe"):
+            if not isinstance(raw_status[key], bool):
+                raise TargetContractError("report sequence details are invalid")
+        safe_sequence_status[sequence] = {
+            key: raw_status[key] for key in allowed_sequence_fields
+        }
+
+    projection: dict[str, Any] = {
+        "companies": len(plan.companies),
+        "eligible_links": len(plan.eligible_links),
+        "rejected_links_missing_local_client": plan.rejected_missing_local_client,
+        "projection_digest": plan.projection_digest,
+    }
+    if target_eligibility == "not_evaluated":
+        projection["target_eligibility"] = "not_evaluated"
+        projection["eligible_links"] = "unknown"
+        projection["rejected_links_missing_local_client"] = "unknown"
+        projection["projection_digest"] = "unknown"
+
+    report: dict[str, Any] = {
+        "status": "ok",
+        "mode": mode,
+        "write_attempted": mode == "apply",
+        "source": {
+            "authority": "scripts/pg.sh:nuzantara_readonly",
+            "snapshot_at": snapshot.metadata.snapshot_at,
+            "companies_max_updated_at": (
+                snapshot.metadata.companies_max_updated_at
+            ),
+            "links_max_updated_at": snapshot.metadata.links_max_updated_at,
+            "companies": len(snapshot.companies),
+            "links": len(snapshot.links),
+            "content_digest": snapshot.content_digest,
+            "type_identity_digest": source_shape_digest(snapshot),
+        },
+        "projection": projection,
+        "target_before": validated_counts(
+            target_before, allow_none=target_eligibility == "not_evaluated"
+        ),
+        "target_after": validated_counts(target_after, allow_none=True),
+        "sequence_preflight": (
+            None if target_eligibility == "not_evaluated" else safe_sequence_status
+        ),
+        "protected_type_digest": invariant_digest,
+    }
+    return report
+
+
+async def _connect_target(
+    dsn: str, *, read_only: bool
+) -> ConnectionLike:
+    server_settings = {
+        "application_name": "intake_company_projection_dry_run"
+        if read_only
+        else "intake_company_projection_apply",
+    }
+    if read_only:
+        server_settings["default_transaction_read_only"] = "on"
+    connection = await asyncpg.connect(dsn, server_settings=server_settings)
+    return cast(ConnectionLike, connection)
+
+
+async def run_projection(
+    *,
+    apply: bool,
+    dsn: str,
+    environ: Mapping[str, str],
+    run_subprocess: RunCallable = subprocess.run,
+    connect: Callable[..., Awaitable[ConnectionLike]] = _connect_target,
+    expected_content_digest: str | None = None,
+) -> dict[str, Any]:
+    """Orchestrate the bounded source snapshot and local projection."""
+
+    snapshot = fetch_source_snapshot(run=run_subprocess)
+    if not apply:
+        plan = build_projection_plan(snapshot, local_client_ids=set())
+        return build_report(
+            snapshot=snapshot,
+            plan=plan,
+            mode="dry-run",
+            target_before=None,
+            target_after=None,
+            invariant_digest="unknown",
+            sequence_status={},
+            target_eligibility="not_evaluated",
+        )
+
+    validate_apply_request(
+        apply=True,
+        dsn=dsn,
+        environ=environ,
+        expected_content_digest=expected_content_digest,
+        actual_content_digest=snapshot.content_digest,
+    )
+    assert expected_content_digest is not None
+    conn = await connect(dsn, read_only=False)
+    try:
+        apply_result = await apply_projection(
+            conn,
+            snapshot,
+            expected_content_digest=expected_content_digest,
+        )
+        if apply_result.source_content_digest != snapshot.content_digest:
+            raise ProjectionInvariantError(
+                "accepted source content digest changed before reporting"
+            )
+        return build_report(
+            snapshot=apply_result.accepted_source,
+            plan=apply_result.accepted_plan,
+            mode="apply",
+            target_before=apply_result.target_before_counts,
+            target_after=apply_result.target_after_counts,
+            invariant_digest=apply_result.invariant_digest,
+            sequence_status=apply_result.sequence_status,
+        )
+    finally:
+        await conn.close()
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Dry-run the canonical PROD company/link projection into local "
+            "nuzantara_dev. Output is aggregate JSON only."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "apply the local projection (default: dry-run; also requires "
+            f"{WRITE_ENABLE_ENV}=true)"
+        ),
+    )
+    parser.add_argument(
+        "--expected-content-digest",
+        help="required exact source content SHA-256 when --apply is used",
+    )
+    return parser
+
+
+def _safe_error(exc: BaseException) -> dict[str, str]:
+    return {
+        "status": "error",
+        "error_type": type(exc).__name__,
+        "reason": "projection failed; row payloads are suppressed",
+    }
+
+
+def _run_cli_projection(**kwargs: Any) -> dict[str, Any]:
+    """Run the CLI coroutine even when an embedding host owns an event loop."""
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(run_projection(**kwargs))
+
+    result: dict[str, dict[str, Any]] = {}
+    failure: list[BaseException] = []
+
+    def runner() -> None:
+        try:
+            result["report"] = asyncio.run(run_projection(**kwargs))
+        except BaseException as exc:  # surfaced at the sanitized CLI boundary
+            failure.append(exc)
+
+    thread = threading.Thread(target=runner)
+    thread.start()
+    thread.join()
+    if failure:
+        raise failure[0]
+    return result["report"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    dsn = os.environ.get(TARGET_DSN_ENV, DEFAULT_TARGET_DSN)
+    started = time.monotonic()
+    try:
+        report = _run_cli_projection(
+            apply=args.apply,
+            dsn=dsn,
+            environ=os.environ,
+            expected_content_digest=args.expected_content_digest,
+        )
+    except Exception as exc:  # sanitized CLI boundary; never echo row-bearing errors
+        sys.stderr.write(json.dumps(_safe_error(exc), sort_keys=True) + "\n")
+        return 2
+    report["elapsed_ms"] = round((time.monotonic() - started) * 1000)
+    sys.stdout.write(json.dumps(report, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a read-only snapshot and transactional company/link projection refresh for local intake state
- enforce digest, schema, sequence, foreign-key, protected-table, and no-op safety invariants
- add focused tests for the projection contract and failure modes

## Validation
- ruff check
- py_compile
- mypy (configured scope)
- 182/182 focused intake projection tests
- independent final review and Fable gate evidence preserved locally

## Scope
- scripts/intake_company_projection.py
- apps/backend-rag/backend/tests/scripts/test_intake_company_projection.py

No database apply or runtime change is included.