### PR TITLE
feat(bot): two-leg seat sentinel for the wa-codex broker (S3, spec §4.4)

### DIFF
--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: 2db42b7730eba415f51571ca1afa40e72bbb4f44c93505f711731f4b23bd7614
+checksum: c16640746ed5899fa4a55fcf3789e4bde45417f3a5c4ba0285066989ecb5f7c5
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -2027,6 +2027,28 @@ organs:
     (WA_GENERATION_PROVIDER defaults to gemini) until the owner-gated S4 cutover;
     the daemon itself is inert until the operator provisions the host (scripts/provision_zantara_codex.sh)
     and logs the seat in.'
+  cicatrix_refs: []
+- id: pro.wa_codex_seat_probe
+  runtime: pro_launchd
+  type: cron
+  expected_hb_seconds: 0
+  owner_module: infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh
+  dependencies: []
+  recovery_action: launchctl_kickstart
+  recovery_params:
+    host: pro
+    label: com.balizero.wa-codex-seat-probe
+  severity_on_silence: warning
+  notes: 'WA codex seat probe (BOT-V4 S3 Piece A, spec research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md
+    section 4.4). One-shot LaunchDAEMON (StartInterval 6h + RunAtLoad, UserName demotion
+    to zantara-codex): codex login status + 1-token synthetic exec, classified with
+    the daemon''s _AUTH_DEATH_RE, enum-only verdict written to /usr/local/var/wa-codex-broker/seat-status.json
+    (0644). Liveness ground truth is that STATUS FILE: scripts/wa_codex_seat_sentinel.py
+    (Piece B, cron-runner as nuzantara) pages probe_silent when the file is missing
+    or older than 2x the probe interval - hence expected_hb_seconds 0 here, like the
+    broker: the sidecar is written only at start and on refusal exits, and lives in
+    the zantara-codex home, unreadable to other users by design. Kill switch WA_CODEX_SEAT_PROBE_ENABLED=false
+    in the shared env file (clean exit; the probe never reads WA_BROKER_KEY).'
   cicatrix_refs: []
 - id: pro.wr2_daily_carousel
   runtime: pro_launchd

--- a/apps/organism/organism/organs_registry.yaml
+++ b/apps/organism/organism/organs_registry.yaml
@@ -1,6 +1,6 @@
 version: 1
 checksum_algo: sha256
-checksum: c16640746ed5899fa4a55fcf3789e4bde45417f3a5c4ba0285066989ecb5f7c5
+checksum: 1a4406c5474645e5b26eff55b9e3e1132547410c3273580f64b7a9872d4a90b1
 organs:
 - id: infra.postgres
   runtime: fly_machine
@@ -2043,12 +2043,13 @@ organs:
     section 4.4). One-shot LaunchDAEMON (StartInterval 6h + RunAtLoad, UserName demotion
     to zantara-codex): codex login status + 1-token synthetic exec, classified with
     the daemon''s _AUTH_DEATH_RE, enum-only verdict written to /usr/local/var/wa-codex-broker/seat-status.json
-    (0644). Liveness ground truth is that STATUS FILE: scripts/wa_codex_seat_sentinel.py
-    (Piece B, cron-runner as nuzantara) pages probe_silent when the file is missing
-    or older than 2x the probe interval - hence expected_hb_seconds 0 here, like the
-    broker: the sidecar is written only at start and on refusal exits, and lives in
-    the zantara-codex home, unreadable to other users by design. Kill switch WA_CODEX_SEAT_PROBE_ENABLED=false
-    in the shared env file (clean exit; the probe never reads WA_BROKER_KEY).'
+    (0640 group staff - nuzantara reads via the group bit). Liveness ground truth
+    is that STATUS FILE: scripts/wa_codex_seat_sentinel.py (Piece B, cron-runner as
+    nuzantara) pages probe_silent when the file is missing or older than 2x the probe
+    interval - hence expected_hb_seconds 0 here, like the broker: the sidecar is written
+    only at start and on refusal exits, and lives in the zantara-codex home, unreadable
+    to other users by design. Kill switch WA_CODEX_SEAT_PROBE_ENABLED=false in the
+    shared env file (clean exit; the probe never reads WA_BROKER_KEY).'
   cicatrix_refs: []
 - id: pro.wr2_daily_carousel
   runtime: pro_launchd

--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -812,6 +812,18 @@
       "_note": "WA codex broker daemon wrapper (BOT-V4 S2 PR-6), installed root-owned by scripts/provision_zantara_codex.sh. System-domain LaunchDaemon payload under the registry's absolute-prefix exception (fw-guard precedent 2026-08-14): the daemon runs AS the login-less zantara-codex user, and a root-owned payload outside any user-writable $HOME denies a compromised zantara-codex identity persistence across restarts. World-readable, so the lint can verify this pair as any user. Re-run provisioning after changing the repo twin: the merge alone never updates the live copy (W107 delivery gotcha)."
     },
     {
+      "live": "/usr/local/libexec/wa-codex-seat-probe-wrapper.sh",
+      "repo": "infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh",
+      "machines": ["pro"],
+      "_note": "S3 seat-probe wrapper (Piece A of the seat sentinel pair, research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md), installed root-owned by scripts/provision_zantara_codex.sh step 8. Same fw-guard precedent (2026-08-14) as the broker wrapper above and the same absolute-prefix exception — this LaunchDAEMON also runs AS the login-less zantara-codex user. World-readable, so the lint can verify this pair as any user. Re-run provisioning after changing the repo twin: the merge alone never updates the live copy (W107 delivery gotcha)."
+    },
+    {
+      "live": "/usr/local/lib/wa-codex-broker/seat_probe.py",
+      "repo": "scripts/wa_codex_seat_probe.py",
+      "machines": ["pro"],
+      "_note": "S3 seat-probe payload (Piece A) that the wrapper above execs, installed root-owned alongside the daemon's own runtime tree (same /usr/local/lib/wa-codex-broker RUNTIME_DIR, same fresh-copy-every-run discipline as the daemon code in step 3 — a merge alone never updates this live copy, W107 delivery gotcha). Imports backend.llm.codex_exec_client._AUTH_DEATH_RE from the sibling `backend/` package that step 3 already installs into this same directory tree — the two payloads share one runtime root by design, so they cannot disagree about the auth-death regex without both copies being re-provisioned together."
+    },
+    {
       "live": "~/scripts/mini-secrets-perms-sweep.sh",
       "repo": "infra/launchagents/wrappers/mini-secrets-perms-sweep.sh",
       "machines": ["mini"]

--- a/infra/launchagents/com.balizero.wa-codex-seat-probe.plist
+++ b/infra/launchagents/com.balizero.wa-codex-seat-probe.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- LaunchDAEMON, not LaunchAgent (deliberate, spec §4.1, same reasoning
+	     as com.balizero.wa-codex-broker): zantara-codex is a login-less user,
+	     and a LaunchAgent for a user who never logs in never runs (scar
+	     family #2, armed-to-nothing). Installed by
+	     scripts/provision_zantara_codex.sh into /Library/LaunchDaemons with
+	     UserName demotion — launchd starts it at boot as zantara-codex, no
+	     session required. -->
+	<key>Label</key>
+	<string>com.balizero.wa-codex-seat-probe</string>
+	<key>UserName</key>
+	<string>zantara-codex</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/libexec/wa-codex-seat-probe-wrapper.sh</string>
+	</array>
+	<key>WorkingDirectory</key>
+	<string>/Users/zantara-codex</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>HOME</key>
+		<string>/Users/zantara-codex</string>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/bin:/bin</string>
+	</dict>
+	<!-- ONE-SHOT cron shape (scar family #7): the probe runs one login-status
+	     check + one synthetic exec, writes its status file, and exits — it
+	     is NOT a long-running server, so KeepAlive stays ABSENT here (unlike
+	     the broker's exec-to-blocking-loop shape). StartInterval owns the
+	     cadence: 21600s = 6h, so the probe's own 1-token codex exec
+	     consumption is negligible (spec §4.4 accounting) while still
+	     catching an auth death well inside any reasonable response window. -->
+	<key>StartInterval</key>
+	<integer>21600</integer>
+	<!-- RunAtLoad (Kimi r1 m5): without it the first probe lands up to 6h
+	     after bootstrap AND after every reboot — a blind window, plus a
+	     false probe_silent page when a reboot pushes the status file's age
+	     past the sentinel's 2x-interval boundary minutes before the next
+	     scheduled run. One immediate run at load closes both. -->
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>/usr/local/var/wa-codex-broker/seat-probe.log</string>
+	<key>StandardErrorPath</key>
+	<string>/usr/local/var/wa-codex-broker/seat-probe.err</string>
+</dict>
+</plist>

--- a/infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh
+++ b/infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# wa-codex-seat-probe-wrapper.sh — launchd payload for
+# com.balizero.wa-codex-seat-probe (S3, Piece A of the seat sentinel pair).
+#
+# Runs as the login-less user `zantara-codex` on Pro, SAME identity as
+# com.balizero.wa-codex-broker (spec §4.1,
+# research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md). The
+# LIVE copy is /usr/local/libexec/wa-codex-seat-probe-wrapper.sh —
+# ROOT-OWNED, outside any user-writable $HOME, same fw-guard precedent
+# (2026-08-14) as the broker wrapper: the process runs AS zantara-codex, so
+# a compromised zantara-codex identity gains no privilege by editing a
+# home-dir wrapper, but a root-owned payload denies it PERSISTENCE. Placed
+# by scripts/provision_zantara_codex.sh; the pair is declared in
+# infra/home-fork/declared-pairs.json (superscar #1 — re-run provisioning
+# after changing this file, the merge alone leaves the live copy stale).
+#
+# Shape notes (scar-family antidotes, load-bearing — same discipline as
+# wa-codex-broker-wrapper.sh):
+# - `exec` into the ONE-SHOT probe under NO KeepAlive (family #7: this is a
+#   cron-shaped payload, not a long-running server — StartInterval owns the
+#   cadence, launchd must never restart-storm a one-shot that exits 0/2).
+# - Guarded env-file source — never a bare `. file || true` under errexit
+#   (W108: sh treats a failed `.` as a special-builtin exit; the guard
+#   must come BEFORE the source, as an if).
+# - Absolute interpreter path (W108: a PATH-resolved python is the failure
+#   mode the probe would then have to report on).
+# - The env file may still carry WA_BROKER_KEY (this probe never reads it,
+#   but the file is shared with the broker) — 0600, never echoed, never on
+#   argv (family #4 / W115). This probe only consumes WA_CODEX_BIN and
+#   CODEX_HOME from it.
+
+set -u
+
+HOME_DIR="/Users/zantara-codex"
+RUNTIME_DIR="/usr/local/lib/wa-codex-broker"
+ENV_FILE="$HOME_DIR/.wa-codex-broker.env"
+VENV_PY="$RUNTIME_DIR/.venv/bin/python3"
+PROBE_SCRIPT="$RUNTIME_DIR/seat_probe.py"
+TAG="wa-codex-seat-probe-wrapper"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "$TAG: env file missing: $ENV_FILE - refusing to run (run provisioning)" >&2
+    exit 78 # EX_CONFIG
+fi
+
+# Extract ONLY the two keys this probe consumes. A `set -a` source would
+# hand WA_BROKER_KEY to the probe and, through it, into the `codex`
+# subprocess environment — a secret delivered to a process with no use for
+# it (scar 2026-08-18: dispatching an external CLI delivers the ENVIRONMENT,
+# not just the prompt). Each extraction sources in a SUBSHELL so nothing
+# else leaks into this process; a failed source yields an empty value, and
+# empty degrades safely (binary falls back to PATH, CODEX_HOME to $HOME).
+WA_CODEX_BIN="$(. "$ENV_FILE" >/dev/null 2>&1; printf '%s' "${WA_CODEX_BIN:-}")"
+CODEX_HOME="$(. "$ENV_FILE" >/dev/null 2>&1; printf '%s' "${CODEX_HOME:-}")"
+# Export only NON-EMPTY values (Kimi r1 m7): an exported empty string is
+# NOT "unset" to the child — codex would receive CODEX_HOME= verbatim and
+# may treat it as a literal empty path instead of falling back to $HOME.
+# unset + absent key is the only shape that truly degrades to the default.
+if [ -n "$WA_CODEX_BIN" ]; then export WA_CODEX_BIN; else unset WA_CODEX_BIN; fi
+if [ -n "$CODEX_HOME" ]; then export CODEX_HOME; else unset CODEX_HOME; fi
+
+if [ ! -x "$VENV_PY" ]; then
+    echo "$TAG: venv python missing or not executable: $VENV_PY - run provisioning" >&2
+    exit 78
+fi
+if [ ! -f "$PROBE_SCRIPT" ]; then
+    echo "$TAG: probe script missing: $PROBE_SCRIPT - run provisioning" >&2
+    exit 78
+fi
+
+cd "$RUNTIME_DIR" || exit 78
+export PYTHONPATH="$RUNTIME_DIR"
+
+exec "$VENV_PY" "$PROBE_SCRIPT"

--- a/infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh
+++ b/infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh
@@ -37,10 +37,38 @@ ENV_FILE="$HOME_DIR/.wa-codex-broker.env"
 VENV_PY="$RUNTIME_DIR/.venv/bin/python3"
 PROBE_SCRIPT="$RUNTIME_DIR/seat_probe.py"
 TAG="wa-codex-seat-probe-wrapper"
+ORGAN_ID="pro.wa_codex_seat_probe"
+SIDECAR_DIR="$HOME_DIR/.organism/last_seen"
+
+# G2_heartbeat — sidecar at start and on every refusal exit, same shape as
+# the broker wrapper. The probe's liveness ground truth is its STATUS FILE
+# (the sentinel pages probe_silent past 2x the interval), not this sidecar
+# — the registry entry carries expected_hb_seconds=0 accordingly; the
+# sidecar exists so a refusal exit is distinguishable from never-having-run
+# (and it lives in the zantara-codex home, unreadable to other users by
+# design, same as the broker's).
+heartbeat() { # $1 status, $2 note
+    mkdir -p "$SIDECAR_DIR" 2>/dev/null || return 0
+    printf '{"ts":"%s","status":"%s","note":"%s"}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" > "$SIDECAR_DIR/$ORGAN_ID.json"
+}
 
 if [ ! -f "$ENV_FILE" ]; then
     echo "$TAG: env file missing: $ENV_FILE - refusing to run (run provisioning)" >&2
+    heartbeat "refused" "env file missing"
     exit 78 # EX_CONFIG
+fi
+
+# G5_kill_switch — operator stop without uninstall (set in the shared env
+# file). Extracted the same subshell way as the two keys below — this
+# wrapper deliberately never `set -a`-sources the whole file (WA_BROKER_KEY
+# lives there). Clean exit 0 under StartInterval simply skips this run; the
+# disabled heartbeat keeps a healer from resurrecting an intentional stop.
+PROBE_ENABLED="$(. "$ENV_FILE" >/dev/null 2>&1; printf '%s' "${WA_CODEX_SEAT_PROBE_ENABLED:-true}")"
+if [ "$PROBE_ENABLED" = "false" ]; then
+    echo "$TAG: WA_CODEX_SEAT_PROBE_ENABLED=false - kill switch active, exiting clean" >&2
+    heartbeat "disabled" "kill switch"
+    exit 0
 fi
 
 # Extract ONLY the two keys this probe consumes. A `set -a` source would
@@ -61,14 +89,17 @@ if [ -n "$CODEX_HOME" ]; then export CODEX_HOME; else unset CODEX_HOME; fi
 
 if [ ! -x "$VENV_PY" ]; then
     echo "$TAG: venv python missing or not executable: $VENV_PY - run provisioning" >&2
+    heartbeat "refused" "venv python missing"
     exit 78
 fi
 if [ ! -f "$PROBE_SCRIPT" ]; then
     echo "$TAG: probe script missing: $PROBE_SCRIPT - run provisioning" >&2
+    heartbeat "refused" "probe script missing"
     exit 78
 fi
 
-cd "$RUNTIME_DIR" || exit 78
+cd "$RUNTIME_DIR" || { heartbeat "refused" "cd failed"; exit 78; }
 export PYTHONPATH="$RUNTIME_DIR"
 
+heartbeat "starting" "exec probe"
 exec "$VENV_PY" "$PROBE_SCRIPT"

--- a/infra/launchagents/wrappers/wa-codex-seat-sentinel.sh
+++ b/infra/launchagents/wrappers/wa-codex-seat-sentinel.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# wa-codex-seat-sentinel.sh — wrapper cron per scripts/wa_codex_seat_sentinel.py.
+#
+# Invocato da crontab attraverso `cron-runner.sh`, che scrive la ricevuta e —
+# dalla cura W107 — allarma sull'exit non-zero. Questo wrapper esiste solo per
+# tre cose che il python non puo fare da se: scegliere l'interprete giusto,
+# dire ad alta voce se quell'interprete non c'e, e non mangiarsi il codice di
+# uscita per strada. Runs in-place from the repo checkout as `nuzantara` —
+# DIFFERENT identity from the probe (Piece A), which runs as zantara-codex.
+#
+# Le tre trappole che questo file evita, tutte pagate in cicatrici:
+#
+#   W108 — l'interprete e ASSOLUTO, mai risolto via PATH. Un allarme che gira
+#          sull'interprete la cui corruzione e fra le cause del guasto che deve
+#          riportare condivide il modo di guasto della cosa che riporta.
+#   W101 — nessuna pipeline nuda sotto `set -e`: errexit aborta SULLA pipeline
+#          e la cattura del codice diventa codice morto proprio sul percorso
+#          per cui esiste. Qui l'errexit e disarmato attorno al job e il codice
+#          e catturato, non dedotto dall'essere sopravvissuti.
+#   W81  — se il payload non c'e, il cron e armato a vuoto. Lo diciamo con un
+#          exit 2 (CANNOT-VERIFY) invece di uscire 0 come se fosse tutto a
+#          posto: non-ho-potuto-guardare non e "va tutto bene".
+#
+# Runs in-place from the repo checkout (like wa-session-liveness.sh) — NO
+# declared-pairs entry: there is no separate HOME-fork copy to drift from.
+#
+# Exit: 0 = ho guardato entrambe le fonti (anche se un verdetto e RED: quel
+# verdetto viaggia via Telegram) · 2 = non ho potuto leggere il gauge.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ORGAN="$REPO/scripts/wa_codex_seat_sentinel.py"
+PYTHON="$REPO/apps/backend-rag/.venv/bin/python"
+
+# Signature guard: se la root derivata non contiene l'organo, la derivazione e
+# sbagliata — e proseguire significherebbe misurare un altro repo (W105).
+if [ ! -f "$ORGAN" ]; then
+    echo "CANNOT-VERIFY: organo assente a $ORGAN (REPO derivata: $REPO)" >&2
+    exit 2
+fi
+
+if [ ! -x "$PYTHON" ]; then
+    echo "CANNOT-VERIFY: interprete assente a $PYTHON" >&2
+    exit 2
+fi
+
+set +e
+"$PYTHON" "$ORGAN" "$@"
+RC=$?
+set -e
+
+echo "wa-codex-seat-sentinel rc=$RC"
+exit "$RC"

--- a/scripts/provision_zantara_codex.sh
+++ b/scripts/provision_zantara_codex.sh
@@ -32,6 +32,14 @@
 #      UserName, never a LaunchAgent) and bootstraps it ONLY when the env
 #      file has no placeholders left — half-configured is refused, not
 #      half-armed (superscar #2).
+#   8. Installs the S3 seat-probe pair (Piece A of the seat sentinel,
+#      research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md):
+#      /usr/local/var/wa-codex-broker (shared state dir), the probe wrapper
+#      + script (root-owned, same fresh-copy-every-run discipline as step
+#      3), and its own LaunchDAEMON. Bootstrapped UNCONDITIONALLY — unlike
+#      the broker, the probe needs no WA_BROKER_KEY (it only reads
+#      WA_CODEX_BIN/CODEX_HOME from the same env file), so it is useful
+#      even before the operator fills the placeholders.
 #
 # What it deliberately does NOT do (spec §Solo-operatore — operator actions):
 #   - `codex login` as zantara-codex (one-time device-code flow):
@@ -50,17 +58,27 @@ set -euo pipefail
 BROKER_USER="zantara-codex"
 BROKER_HOME="/Users/${BROKER_USER}"
 RUNTIME_DIR="/usr/local/lib/wa-codex-broker"
+STATE_DIR="/usr/local/var/wa-codex-broker"
 WRAPPER_DST="/usr/local/libexec/wa-codex-broker-wrapper.sh"
 ENV_FILE="${BROKER_HOME}/.wa-codex-broker.env"
 CANARY_RECORD="/var/root/wa-codex-canaries.txt"
 PLIST_LABEL="com.balizero.wa-codex-broker"
 PLIST_DST="/Library/LaunchDaemons/${PLIST_LABEL}.plist"
 
+# S3 seat-probe pair (Piece A of the seat sentinel — step 8 below).
+PROBE_WRAPPER_DST="/usr/local/libexec/wa-codex-seat-probe-wrapper.sh"
+PROBE_SCRIPT_DST="${RUNTIME_DIR}/seat_probe.py"
+PROBE_PLIST_LABEL="com.balizero.wa-codex-seat-probe"
+PROBE_PLIST_DST="/Library/LaunchDaemons/${PROBE_PLIST_LABEL}.plist"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 BACKEND_SRC="${REPO_ROOT}/apps/backend-rag/backend"
 WRAPPER_SRC="${REPO_ROOT}/infra/launchagents/wrappers/wa-codex-broker-wrapper.sh"
 PLIST_SRC="${REPO_ROOT}/infra/launchagents/${PLIST_LABEL}.plist"
+PROBE_SCRIPT_SRC="${REPO_ROOT}/scripts/wa_codex_seat_probe.py"
+PROBE_WRAPPER_SRC="${REPO_ROOT}/infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh"
+PROBE_PLIST_SRC="${REPO_ROOT}/infra/launchagents/${PROBE_PLIST_LABEL}.plist"
 
 log() { echo "[provision-zantara-codex] $*"; }
 
@@ -69,7 +87,8 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 for src in "${BACKEND_SRC}/services/integrations/wa_codex_daemon.py" \
-    "${BACKEND_SRC}/llm/codex_exec_client.py" "${WRAPPER_SRC}" "${PLIST_SRC}"; do
+    "${BACKEND_SRC}/llm/codex_exec_client.py" "${WRAPPER_SRC}" "${PLIST_SRC}" \
+    "${PROBE_SCRIPT_SRC}" "${PROBE_WRAPPER_SRC}" "${PROBE_PLIST_SRC}"; do
     if [ ! -f "$src" ]; then
         log "ERROR: source file missing: $src (run from a current repo checkout)"
         exit 1
@@ -216,16 +235,67 @@ if grep -q "__FILL_ME__" "${ENV_FILE}"; then
     log "bootstrap: SKIP — env file still has __FILL_ME__ placeholders."
     log "  After filling it (and codex login), arm with:"
     log "    sudo launchctl bootstrap system ${PLIST_DST}"
+elif launchctl print "system/${PLIST_LABEL}" >/dev/null 2>&1; then
+    # Loaded-state is checked EXPLICITLY (Kimi r1 M2): the old pattern read
+    # ANY bootstrap failure as "already loaded" (2>/dev/null + rc), so a
+    # malformed plist or a permission error green-ticked as armed — the
+    # installer itself reproducing superscar #2. And kickstart -k does NOT
+    # re-read a changed plist; only bootout+bootstrap does.
+    log "bootstrap: SKIP (already loaded). A CHANGED plist needs a reload:"
+    log "    sudo launchctl bootout system/${PLIST_LABEL} && sudo launchctl bootstrap system ${PLIST_DST}"
+    log "  (kickstart -k restarts the job but does NOT re-read the plist)"
 else
     set +e
-    launchctl bootstrap system "${PLIST_DST}" 2>/dev/null
+    BOOT_ERR="$(launchctl bootstrap system "${PLIST_DST}" 2>&1)"
     BOOT_RC=$?
     set -e
     if [ "${BOOT_RC}" -eq 0 ]; then
         log "bootstrap: DONE (daemon armed)"
+    elif printf '%s' "${BOOT_ERR}" | grep -qi "already loaded\|already bootstrapped\|service already"; then
+        # Kimi r2 #1: launchctl print can transiently fail while the service
+        # IS loaded — then bootstrap answers "already loaded". That state is
+        # ARMED, not broken: hard-failing here would page on a healthy daemon.
+        log "bootstrap: SKIP (bootstrap says already loaded — print missed it)"
     else
-        log "bootstrap: already loaded (rc=${BOOT_RC}) — restart with:"
-        log "    sudo launchctl kickstart -k system/${PLIST_LABEL}"
+        log "ERROR: bootstrap FAILED (rc=${BOOT_RC}): ${BOOT_ERR}"
+        exit 1
+    fi
+fi
+
+# --- 8. seat probe (S3, Piece A) ------------------------------------------
+install -d -o "${BROKER_USER}" -g staff -m 0755 "${STATE_DIR}"
+log "seat-probe state dir ${STATE_DIR}: DONE"
+
+# Fresh copy every run, same reasoning as step 3: the merge alone never
+# updates a live copy (superscar #1).
+install -o root -g wheel -m 0644 "${PROBE_SCRIPT_SRC}" "${PROBE_SCRIPT_DST}"
+install -o root -g wheel -m 0755 "${PROBE_WRAPPER_SRC}" "${PROBE_WRAPPER_DST}"
+log "seat-probe script + wrapper: DONE (root-owned)"
+
+install -o root -g wheel -m 0644 "${PROBE_PLIST_SRC}" "${PROBE_PLIST_DST}"
+log "seat-probe plist installed: ${PROBE_PLIST_DST}"
+# Unconditional bootstrap — the probe needs no WA_BROKER_KEY (only
+# WA_CODEX_BIN/CODEX_HOME from the shared env file), so it is useful even
+# while the broker's own env-file placeholders are still unfilled.
+if launchctl print "system/${PROBE_PLIST_LABEL}" >/dev/null 2>&1; then
+    # Same explicit loaded-check as the broker section above (Kimi r1 M2).
+    log "seat-probe bootstrap: SKIP (already loaded). A CHANGED plist needs a reload:"
+    log "    sudo launchctl bootout system/${PROBE_PLIST_LABEL} && sudo launchctl bootstrap system ${PROBE_PLIST_DST}"
+    log "  (kickstart -k restarts the job but does NOT re-read the plist)"
+else
+    set +e
+    PROBE_BOOT_ERR="$(launchctl bootstrap system "${PROBE_PLIST_DST}" 2>&1)"
+    PROBE_BOOT_RC=$?
+    set -e
+    if [ "${PROBE_BOOT_RC}" -eq 0 ]; then
+        log "seat-probe bootstrap: DONE (armed)"
+    elif printf '%s' "${PROBE_BOOT_ERR}" | grep -qi "already loaded\|already bootstrapped\|service already"; then
+        # Kimi r2 #1, symmetric with the broker section (W101-recidiva lesson:
+        # a fix that covers only the phase that bit you is half a fix).
+        log "seat-probe bootstrap: SKIP (bootstrap says already loaded — print missed it)"
+    else
+        log "ERROR: seat-probe bootstrap FAILED (rc=${PROBE_BOOT_RC}): ${PROBE_BOOT_ERR}"
+        exit 1
     fi
 fi
 
@@ -235,3 +305,15 @@ log "     sudo -u ${BROKER_USER} CODEX_HOME=${BROKER_HOME}/.codex HOME=${BROKER_
 log "2) fill ${ENV_FILE} (WA_BROKER_KEY, WA_CODEX_CLI_VERSION_PIN)"
 log "3) fly secrets import -a nuzantara-rag < ${CANARY_RECORD}"
 log "4) re-run this script (or launchctl bootstrap) to arm"
+log "5) arm Piece B (the reader — Kimi r1 M3: the probe writes a status file"
+log "   NOBODY reads until this runs) as the NORMAL cron user, not root:"
+log "   add a cron-runner crontab entry for"
+log "     infra/launchagents/wrappers/wa-codex-seat-sentinel.sh"
+log "   from this machine's MAIN checkout (~/nuzantara — NEVER a .worktrees/"
+log "   lane path: lanes get reaped after merge and the cron would point at"
+log "   nothing; Kimi r2 #4). Same pattern as the other cron-runner lines"
+log "   in \`crontab -l\`, e.g. every 15 minutes."
+log "NOTE (Kimi r2 #3): the probe bootstraps with RunAtLoad, so its FIRST run"
+log "   fires NOW — before step 1's login — and records auth_death. Expect ONE"
+log "   RED 'AUTH DEAD' page from the first sentinel run if it lands within"
+log "   the probe's 6h cadence of your login; the next probe run clears it."

--- a/scripts/tests/test_wa_codex_seat_probe.py
+++ b/scripts/tests/test_wa_codex_seat_probe.py
@@ -1,0 +1,120 @@
+"""Tests per scripts/wa_codex_seat_probe.py — il classify() puro.
+
+La disciplina di scansione imita la regola R26 del daemon: solo il testo di
+un comando FALLITO viene scansionato, e per `exec` solo STDERR. Le innocenze
+qui sotto sono il punto: "unauthorized"/"login" sono lessico ordinario del
+dominio visti dentro una risposta legittima del modello (famiglia #3) — un
+probe che scansiona l'output di un comando riuscito pagina AUTH DEAD su un
+seat sano.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_MODULE_PATH = Path(__file__).parents[1] / "wa_codex_seat_probe.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("wa_codex_seat_probe", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+probe = _load()
+
+# ------------------------------------------------------------------- GUILT
+
+
+def test_guilt_logged_out_login_status_is_auth_death() -> None:
+    """Misurato live 2026-08-20: da sloggato `codex login status` stampa
+    "Not logged in" su STDOUT con rc=1."""
+    verdict = probe.classify(1, "Not logged in\n", "", 0, "pong", "")
+    assert verdict == probe.VERDICT_AUTH_DEATH
+
+
+def test_guilt_exec_401_on_stderr_is_auth_death() -> None:
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 1, "", "error 401: unauthorized")
+    assert verdict == probe.VERDICT_AUTH_DEATH
+
+
+def test_guilt_both_unrun_is_probe_error() -> None:
+    rc = probe._UNRUN_RC
+    assert probe.classify(rc, "", "", rc, "", "") == probe.VERDICT_PROBE_ERROR
+
+
+def test_guilt_nonzero_without_auth_signature_is_other_failure() -> None:
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 1, "", "boom: disk full")
+    assert verdict == probe.VERDICT_OTHER_FAILURE
+
+
+# --------------------------------------------------------------- INNOCENCE
+
+
+def test_innocence_healthy_run_is_ok_even_if_the_answer_discusses_logins() -> None:
+    """LA innocenza chiave (R26): un exec RIUSCITO il cui stdout contiene
+    lessico auth-shaped (risposta legittima su credenziali del CLIENTE) non
+    deve mai classificare auth_death — l'output di un comando a rc=0 non
+    viene scansionato affatto."""
+    answer = "Your portal login is unauthorized until the KITAS is renewed."
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 0, answer, "")
+    assert verdict == probe.VERDICT_OK
+
+
+def test_innocence_failed_exec_stdout_is_not_scanned_only_stderr() -> None:
+    """Anche a exec fallito, lo STDOUT (potenziale risposta parziale del
+    modello) resta fuori dalla superficie di scansione — solo stderr conta
+    per l'exec (regola R26 del daemon)."""
+    partial_answer = "...the client's session invalidated her visa portal access"
+    verdict = probe.classify(0, "Logged in using ChatGPT\n", "", 1, partial_answer, "boom")
+    assert verdict == probe.VERDICT_OTHER_FAILURE
+
+
+def test_innocence_healthy_login_status_output_does_not_match() -> None:
+    """Misurato live 2026-08-20: da loggato stampa "Logged in using ChatGPT"
+    con rc=0 — e comunque un rc=0 non viene scansionato."""
+    assert probe.classify(0, "Logged in using ChatGPT\n", "", 0, "pong", "") == probe.VERDICT_OK
+
+
+def test_fallback_regex_is_byte_identical_to_the_daemon_detector() -> None:
+    """Superscar #1 applicata a una regex: la copia fallback DEVE restare
+    byte-identica a `_AUTH_DEATH_RE` del daemon, o i due rilevatori
+    divergono sullo stesso testo. Questo test confronta pattern e flag
+    contro la fonte nel repo (il probe sul host importa la copia runtime;
+    qui nel repo le due definizioni devono combaciare)."""
+    daemon_src = (
+        Path(__file__).parents[2]
+        / "apps"
+        / "backend-rag"
+        / "backend"
+        / "llm"
+        / "codex_exec_client.py"
+    )
+    # Textual extraction, not import: the daemon module pulls in backend.*
+    # and this comparison is about the SOURCE definitions staying identical.
+    import re as _re
+
+    text = daemon_src.read_text()
+    match = _re.search(r"_AUTH_DEATH_RE[^=]*= re\.compile\((.*?)\n\)", text, _re.DOTALL)
+    assert match is not None, "daemon _AUTH_DEATH_RE definition not found"
+    daemon_body = "".join(_re.findall(r'r"([^"]*)"', match.group(1)))
+    probe_text = _MODULE_PATH.read_text()
+    probe_match = _re.search(
+        r"AUTH_DEATH_RE = re\.compile\((.*?)\n    \)", probe_text, _re.DOTALL
+    )
+    assert probe_match is not None, "probe fallback AUTH_DEATH_RE definition not found"
+    probe_body = "".join(_re.findall(r'r"([^"]*)"', probe_match.group(1)))
+    assert probe_body == daemon_body, (
+        "the probe's fallback regex drifted from the daemon's _AUTH_DEATH_RE — "
+        "update the copy in scripts/wa_codex_seat_probe.py"
+    )
+    # Flags too (Kimi r1 m9): dropping re.IGNORECASE on either side keeps the
+    # bodies identical while the detectors diverge on case.
+    assert "re.IGNORECASE" in match.group(1), "daemon regex lost re.IGNORECASE"
+    assert "re.IGNORECASE" in probe_match.group(1), "probe fallback lost re.IGNORECASE"

--- a/scripts/tests/test_wa_codex_seat_sentinel.py
+++ b/scripts/tests/test_wa_codex_seat_sentinel.py
@@ -1,0 +1,355 @@
+"""Tests per scripts/wa_codex_seat_sentinel.py.
+
+Ogni cosa che questo organo afferma deve avere il suo test di COLPEVOLEZZA e
+il suo test di INNOCENZA: un guardiano senza il secondo e un allarme che
+urla, uno senza il primo e un allarme decorativo. Una terza famiglia qui e
+la piu importante: **il gauge non-letto non e "va tutto bene"** — un
+`gauge_row=None` deve fermare la CLI a 2, mai passare per un run pulito.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_MODULE_PATH = Path(__file__).parents[1] / "wa_codex_seat_sentinel.py"
+NOW = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("wa_codex_seat_sentinel", _MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+wa = _load()
+
+
+def _gauge(
+    breaker_state: str = "closed",
+    consecutive_failures: int = 0,
+    staleness_s: float = 60.0,
+) -> tuple[str, str, int, float]:
+    return ("2026-08-20T11:59:00+00:00", breaker_state, consecutive_failures, staleness_s)
+
+
+def _probe(verdict: str = "ok", login_rc: int = 0, exec_rc: int = 0) -> dict:
+    return {
+        "checked_at": "2026-08-20T11:59:50Z",
+        "verdict": verdict,
+        "login_status_rc": login_rc,
+        "exec_rc": exec_rc,
+    }
+
+
+# --------------------------------------------------------------------- GUILT
+
+
+def test_guilt_auth_death_is_red_with_the_relogin_command() -> None:
+    verdicts = wa.evaluate(_probe("auth_death", 1, 1), 10.0, _gauge(), NOW)
+    assert len(verdicts) == 1
+    v = verdicts[0]
+    assert v.level == wa.RED
+    assert v.condition == "auth_death"
+    assert "codex login" in v.message
+    assert "sudo -u zantara-codex" in v.message
+
+
+def test_guilt_missing_probe_file_is_red_naming_probe_silent() -> None:
+    """`probe_status=None` — il caso "file assente": deve nominare la causa,
+    non limitarsi a un generico 'qualcosa non va'."""
+    verdicts = wa.evaluate(None, None, _gauge(), NOW)
+    assert len(verdicts) == 1
+    assert verdicts[0].level == wa.RED
+    assert verdicts[0].condition == "probe_silent"
+    assert "probe silent" in verdicts[0].message
+
+
+def test_guilt_probe_age_past_2x_interval_is_red_probe_silent() -> None:
+    """Un file PRESENTE ma vecchio di oltre 2x l'intervallo del probe conta
+    come silenzio quanto un file assente — il probe potrebbe essere morto."""
+    stale_age_s = 2 * wa.DEFAULT_PROBE_INTERVAL_S + 1
+    verdicts = wa.evaluate(_probe(), stale_age_s, _gauge(), NOW)
+    assert any(v.condition == "probe_silent" for v in verdicts)
+
+
+def test_guilt_breaker_open_is_red_naming_the_sudo_grep_hint() -> None:
+    verdicts = wa.evaluate(_probe(), 10.0, _gauge(breaker_state="open"), NOW)
+    breaker = [v for v in verdicts if v.condition == "breaker_open"]
+    assert len(breaker) == 1
+    assert breaker[0].level == wa.RED
+    assert "sudo grep 'AUTH DEATH'" in breaker[0].message
+    assert "wa-codex-broker.err" in breaker[0].message
+
+
+def test_guilt_three_consecutive_failures_with_closed_breaker_is_red() -> None:
+    """Il breaker puo non essersi ancora aperto (soglia server-side diversa)
+    ma 3 fallimenti di fila sono gia un segnale che questo organo non deve
+    aspettare che il breaker confermi da solo."""
+    verdicts = wa.evaluate(_probe(), 10.0, _gauge(consecutive_failures=3), NOW)
+    assert any(v.condition == "breaker_open" for v in verdicts)
+
+
+def test_guilt_gauge_staleness_700s_is_red_daemon_silent() -> None:
+    verdicts = wa.evaluate(_probe(), 10.0, _gauge(staleness_s=700.0), NOW)
+    silent = [v for v in verdicts if v.condition == "daemon_silent"]
+    assert len(silent) == 1
+    assert silent[0].level == wa.RED
+    assert "daemon silent" in silent[0].message
+
+
+def test_guilt_other_failure_verdict_is_warn_not_red() -> None:
+    """`other_failure` e reale (il probe ha girato ed e fallito) ma NON e
+    una morte d'autenticazione confermata: WARN, non RED."""
+    verdicts = wa.evaluate(_probe("other_failure", 1, 0), 10.0, _gauge(), NOW)
+    other = [v for v in verdicts if v.condition == "other_failure"]
+    assert len(other) == 1
+    assert other[0].level == wa.WARN
+    assert "other_failure" in other[0].message
+
+
+def test_guilt_unrecognized_probe_verdict_falls_visibly_as_warn_never_silent() -> None:
+    """W116: un finale non mappato (un probe futuro che scrive p.es.
+    "quota_exhausted") deve cadere VISIBILE, mai nel secchio sano."""
+    verdicts = wa.evaluate(_probe("quota_exhausted", 0, 1), 10.0, _gauge(), NOW)
+    assert len(verdicts) == 1
+    assert verdicts[0].level == wa.WARN
+    assert "quota_exhausted" in verdicts[0].message
+
+
+def test_guilt_never_seen_daemon_null_staleness_parses_to_daemon_silent() -> None:
+    """broker_last_seen_at NULL (daemon mai visto) arriva da psql -A -t come
+    campo VUOTO: il parser lo legge come staleness infinita (verdetto
+    daemon_silent), mai come riga imparsabile (CANNOT-VERIFY) ne' come sana."""
+    import subprocess as _sp
+
+    fake = _sp.CompletedProcess(args=[], returncode=0, stdout="|closed|0|\n", stderr="")
+    original_run = _sp.run
+    try:
+        _sp.run = lambda *a, **k: fake  # type: ignore[assignment]
+        row = wa._read_gauge()
+    finally:
+        _sp.run = original_run
+    assert row is not None
+    assert row[3] == float("inf")
+    verdicts = wa.evaluate(_probe(), 10.0, row, NOW)
+    assert any(v.condition == "daemon_silent" for v in verdicts)
+
+
+# ----------------------------------------------------------------- INNOCENCE
+
+
+def test_innocence_fresh_ok_status_and_healthy_gauge_is_silent() -> None:
+    assert wa.evaluate(_probe(), 10.0, _gauge(), NOW) == []
+
+
+def test_innocence_two_consecutive_failures_with_closed_breaker_is_silent() -> None:
+    assert wa.evaluate(_probe(), 10.0, _gauge(consecutive_failures=2), NOW) == []
+
+
+def test_innocence_a_normal_poll_gap_after_restart_is_silent() -> None:
+    """60s di silenzio dopo un riavvio e fisiologico — misurato contro il
+    limite di 600s, non un valore a caso."""
+    assert wa.evaluate(_probe(), 10.0, _gauge(staleness_s=60.0), NOW) == []
+
+
+def test_innocence_probe_age_just_under_2x_interval_is_silent() -> None:
+    just_fresh_s = 2 * wa.DEFAULT_PROBE_INTERVAL_S - 1
+    verdicts = wa.evaluate(_probe(), just_fresh_s, _gauge(), NOW)
+    assert verdicts == []
+
+
+# --------------------------------------------------------- CANNOT-VERIFY (gauge)
+
+
+def test_evaluate_refuses_a_none_gauge_row_rather_than_a_silent_empty_list() -> None:
+    """Se qualcuno chiama evaluate() con gauge_row=None direttamente
+    (bypassando run()), deve fallire RUMOROSAMENTE — un ritorno [] qui si
+    leggerebbe come 'tutto sano', esattamente il passaggio pulito che un
+    gauge mai letto non deve mai produrre."""
+    with pytest.raises(ValueError):
+        wa.evaluate(_probe(), 10.0, None, NOW)
+
+
+def test_cannot_verify_when_gauge_unreadable_exits_2_not_a_clean_pass(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Il ramo piu importante del brief: un gauge irraggiungibile (query
+    fallita, output vuoto, forma non parsabile) deve fermare run() a 2 — MAI
+    a un 0 silenzioso che si legge come 'tutto sano'. Dopo la cura Kimi M1 il
+    lato probe viaggia COMUNQUE: qui il probe e assente, quindi arrivano DUE
+    messaggi (probe_silent RED + CANNOT-VERIFY), non uno."""
+    monkeypatch.setattr(wa, "_read_probe_status", lambda: (None, None))
+    monkeypatch.setattr(wa, "_read_gauge", lambda: None)
+    sent: list[str] = []
+    monkeypatch.setattr(
+        wa,
+        "send_to_gateway",
+        lambda msg, host, level, condition: sent.append(msg) or True,
+    )
+
+    rc = wa.run(NOW)
+    capsys.readouterr()
+
+    assert rc == wa.EXIT_CANNOT_VERIFY == 2
+    assert len(sent) == 2
+    assert "probe silent" in sent[0]
+    assert "CANNOT-VERIFY" in sent[1]
+
+
+def test_innocence_run_exits_0_when_both_sources_are_readable_and_healthy(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """INNOCENZA del test sopra, stesso meccanismo: senza questo, un
+    `_read_gauge` cablato a restituire sempre None farebbe passare il test
+    di CANNOT-VERIFY per la ragione sbagliata."""
+    monkeypatch.setattr(wa, "_read_probe_status", lambda: (_probe(), 10.0))
+    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    sent: list[str] = []
+    monkeypatch.setattr(
+        wa,
+        "send_to_gateway",
+        lambda msg, host, level, condition: sent.append(msg) or True,
+    )
+
+    rc = wa.run(NOW)
+    out = capsys.readouterr().out
+
+    assert rc == wa.EXIT_OK
+    assert sent == []
+    assert "all conditions healthy" in out
+
+
+def test_guilt_cannot_verify_gauge_still_delivers_an_in_hand_auth_death(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Kimi r1 M1: seat morto E gauge illeggibile insieme (il momento
+    degradato in cui le due cose co-occorrono) — l'auth_death gia in mano
+    NON deve nascondersi dietro il CANNOT-VERIFY generico: viaggia comunque,
+    e l'exit resta 2."""
+    monkeypatch.setattr(wa, "_read_probe_status", lambda: (_probe("auth_death", 1, 1), 10.0))
+    monkeypatch.setattr(wa, "_read_gauge", lambda: None)
+    sent: list[str] = []
+    monkeypatch.setattr(
+        wa,
+        "send_to_gateway",
+        lambda msg, host, level, condition: sent.append(msg) or True,
+    )
+
+    rc = wa.run(NOW)
+    capsys.readouterr()
+
+    assert rc == wa.EXIT_CANNOT_VERIFY
+    assert any("codex login" in m for m in sent), "the in-hand auth_death must still travel"
+    assert any("CANNOT-VERIFY" in m for m in sent)
+
+
+def test_guilt_failed_red_delivery_exits_nonzero_so_the_receipt_alarm_fires(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Kimi r1 M4: gateway morto durante un RED reale — 'alert FALLITO' su
+    un log che nessuno legge + exit 0 = verdetto perso in silenzio. L'unico
+    canale rimasto e la receipt-alarm del cron-runner, che scatta SOLO su
+    exit non-zero: quindi non-zero deve essere."""
+    monkeypatch.setattr(wa, "_read_probe_status", lambda: (_probe("auth_death", 1, 1), 10.0))
+    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    monkeypatch.setattr(
+        wa,
+        "send_to_gateway",
+        lambda msg, host, level, condition: False,
+    )
+
+    rc = wa.run(NOW)
+    capsys.readouterr()
+
+    assert rc == wa.EXIT_CANNOT_VERIFY
+
+
+def test_innocence_failed_warn_delivery_still_exits_0(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """INNOCENZA del confine M4 (Kimi r2 #5): un WARN e best-effort per
+    contratto dichiarato — la sua mancata consegna NON deve diventare una
+    receipt-page. Senza questo pin, un flip futuro di _emit che conta anche
+    i WARN trasforma ogni outage del tier digest in un page, e niente
+    diventa rosso."""
+    monkeypatch.setattr(wa, "_read_probe_status", lambda: (_probe("other_failure", 0, 1), 10.0))
+    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    monkeypatch.setattr(
+        wa,
+        "send_to_gateway",
+        lambda msg, host, level, condition: False,
+    )
+
+    rc = wa.run(NOW)
+    capsys.readouterr()
+
+    assert rc == wa.EXIT_OK
+
+
+def test_run_exits_0_even_with_red_verdicts_because_the_verdict_travels_by_alert(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Un probe assente (RED probe_silent) non deve far fallire il cron: il
+    verdetto viaggia via Telegram, non via exit code — stessa convenzione di
+    wa_session_liveness.py. Il 2 resta riservato al 'non ho potuto guardare'."""
+    monkeypatch.setattr(wa, "_read_probe_status", lambda: (None, None))
+    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    sent: list[str] = []
+    monkeypatch.setattr(
+        wa,
+        "send_to_gateway",
+        lambda msg, host, level, condition: sent.append(msg) or True,
+    )
+
+    rc = wa.run(NOW)
+    capsys.readouterr()
+
+    assert rc == wa.EXIT_OK
+    assert len(sent) == 1
+
+
+# ------------------------------------------------- fallback gateway judgment
+
+
+class _FakeProc:
+    def __init__(self, rc: int, stderr: str) -> None:
+        self.returncode = rc
+        self.stderr = stderr
+
+
+def test_innocence_fallback_counts_a_spooled_verdict_as_responsibility_taken(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Kimi r2 #2: la barra del fallback rispecchia il contratto dell'alerter
+    (alerter.py:207) — spooled/deduped/logged = il gateway POSSIEDE la notizia.
+    Con M4 che da i denti al False, giudicare 'fallito' un RED spoolato
+    fabbricherebbe una receipt-page falsa durante un semplice rate-limit."""
+    monkeypatch.setitem(sys.modules, "sentinel_lib", None)
+    monkeypatch.setattr(
+        wa.subprocess, "run", lambda *a, **k: _FakeProc(0, "tg_notify: spooled\n")
+    )
+
+    assert wa.send_to_gateway("msg", "host", wa.RED, "auth_death") is True
+    capsys.readouterr()
+
+
+def test_guilt_fallback_refuses_rc0_with_no_canonical_verdict(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """COLPEVOLEZZA gemella: rc 0 senza NESSUN verdetto canonico non e
+    responsabilita presa — il silenzio del gateway resta un fallimento
+    (W104: giudica la REPLY, mai l'exit code)."""
+    monkeypatch.setitem(sys.modules, "sentinel_lib", None)
+    monkeypatch.setattr(wa.subprocess, "run", lambda *a, **k: _FakeProc(0, "some noise\n"))
+
+    assert wa.send_to_gateway("msg", "host", wa.RED, "auth_death") is False
+    capsys.readouterr()

--- a/scripts/tests/test_wa_codex_seat_sentinel.py
+++ b/scripts/tests/test_wa_codex_seat_sentinel.py
@@ -212,7 +212,7 @@ def test_innocence_run_exits_0_when_both_sources_are_readable_and_healthy(
     `_read_gauge` cablato a restituire sempre None farebbe passare il test
     di CANNOT-VERIFY per la ragione sbagliata."""
     monkeypatch.setattr(wa, "_read_probe_status", lambda: (_probe(), 10.0))
-    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    monkeypatch.setattr(wa, "_read_gauge", _gauge)
     sent: list[str] = []
     monkeypatch.setattr(
         wa,
@@ -260,7 +260,7 @@ def test_guilt_failed_red_delivery_exits_nonzero_so_the_receipt_alarm_fires(
     canale rimasto e la receipt-alarm del cron-runner, che scatta SOLO su
     exit non-zero: quindi non-zero deve essere."""
     monkeypatch.setattr(wa, "_read_probe_status", lambda: (_probe("auth_death", 1, 1), 10.0))
-    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    monkeypatch.setattr(wa, "_read_gauge", _gauge)
     monkeypatch.setattr(
         wa,
         "send_to_gateway",
@@ -282,7 +282,7 @@ def test_innocence_failed_warn_delivery_still_exits_0(
     i WARN trasforma ogni outage del tier digest in un page, e niente
     diventa rosso."""
     monkeypatch.setattr(wa, "_read_probe_status", lambda: (_probe("other_failure", 0, 1), 10.0))
-    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    monkeypatch.setattr(wa, "_read_gauge", _gauge)
     monkeypatch.setattr(
         wa,
         "send_to_gateway",
@@ -302,7 +302,7 @@ def test_run_exits_0_even_with_red_verdicts_because_the_verdict_travels_by_alert
     verdetto viaggia via Telegram, non via exit code — stessa convenzione di
     wa_session_liveness.py. Il 2 resta riservato al 'non ho potuto guardare'."""
     monkeypatch.setattr(wa, "_read_probe_status", lambda: (None, None))
-    monkeypatch.setattr(wa, "_read_gauge", lambda: _gauge())
+    monkeypatch.setattr(wa, "_read_gauge", _gauge)
     sent: list[str] = []
     monkeypatch.setattr(
         wa,

--- a/scripts/wa_codex_seat_probe.py
+++ b/scripts/wa_codex_seat_probe.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""wa_codex_seat_probe.py — S3 seat-death probe for the wa-codex broker's
+OpenAI/Codex seat (Piece A of the seat sentinel pair).
+
+Runs AS zantara-codex, via a system LaunchDaemon (spec §4.1,
+research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md — same
+login-less-user shape as the broker daemon itself). zantara-codex's home is
+`drwx------` — unreadable cross-user by the cron identity `nuzantara` — so
+this probe is the ONLY thing that can look at codex's own auth state, and
+the status file it writes is the sole channel that crosses the user
+boundary. Piece B, scripts/wa_codex_seat_sentinel.py, runs as `nuzantara`
+and reads that file (plus the server-side broker gauge) to decide whether to
+alert.
+
+WHY (2026-08-20): today auth death is detectable only by (a) an "AUTH DEATH"
+line the broker daemon logs to a file the cron user cannot read, or (b) the
+server-side broker gauge accumulating `consecutive_failures` — but only when
+jobs actually flow, and the lane is flag-OFF with zero jobs right now.
+Without this probe, a dead seat sits invisible until someone flips the flag.
+This organ manufactures a signal independent of job traffic: `codex login
+status` plus a 1-token synthetic `codex exec`, on the plist's own
+StartInterval, regardless of whether the broker has anything to claim.
+
+CLASSIFICATION — declared limit: quota exhaustion (CodexQuotaError-shaped
+failures in backend/llm/codex_exec_client.py) is NOT distinguished from any
+other non-auth, non-invocation failure here — both land in `other_failure`.
+S1.5 owns sharpening that bucket further. This probe answers exactly one
+question: is the seat's LOGIN dead, yes or no.
+
+LEAK SURFACE (Law 2 / scar family #4 — secret/PII in the clear): the status
+file carries ONLY the verdict enum, the two raw exit codes, and a UTC
+timestamp. No stdout/stderr from `codex` — which could echo prompt content,
+an operator's local path, or other free text — ever reaches the file,
+stdout, or a log line above WARNING.
+
+EXIT: 0 = probed and the status file was written (even verdict=auth_death —
+per scar family #2 "esiste ≠ armato", the FILE existing IS the alarm
+mechanism, so a probe that saw the death and reported it is a SUCCESSFUL
+run, not a failure). 2 = the whole probe attempt raised unexpectedly, or the
+status file could not be written — CANNOT-VERIFY, never a silent "ok".
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final, Mapping, Sequence
+
+logger = logging.getLogger("wa_codex_seat_probe")
+
+# --- auth-death detection: REUSE the daemon's own detector -----------------
+# Primary path: scripts/provision_zantara_codex.sh already installs a
+# root-owned copy of backend/llm/codex_exec_client.py under
+# /usr/local/lib/wa-codex-broker/backend/llm/ for the daemon itself, and
+# infra/launchagents/wrappers/wa-codex-seat-probe-wrapper.sh sets
+# PYTHONPATH=/usr/local/lib/wa-codex-broker before exec'ing this script — so
+# the import below resolves against that SAME runtime tree, not a repo
+# checkout the zantara-codex user does not have.
+#
+# If that import ever fails (runtime tree not provisioned, or provisioning
+# drifted from the daemon's), fall back to a LOCAL COPY of the same pattern,
+# marked below. The copy MUST be kept byte-identical to
+# backend/llm/codex_exec_client.py::_AUTH_DEATH_RE or the two detectors will
+# disagree about the same log line — superscar #1 (HOME-fork drift) applied
+# to a regex instead of a whole script. The import is PRIMARY; this copy is
+# a degraded fallback, never the source of truth.
+try:
+    from backend.llm.codex_exec_client import _AUTH_DEATH_RE as AUTH_DEATH_RE
+
+    _AUTH_DEATH_SOURCE: Final[str] = "import"
+except ImportError:  # pragma: no cover — exercised only when the runtime
+    # tree is missing/stale; kept in sync by hand with the primary above.
+    AUTH_DEATH_RE = re.compile(
+        r"\b(?:"
+        r"401\s+unauthorized|"
+        r"error\s+401\b|"
+        r"401\s+error\b|"
+        r"http\s+401\b|"
+        r"unauthorized|"
+        r"token_revoked|"
+        r"refresh_token(?:_reused|_revoked|_expired)?|"
+        r"token\s+has\s+expired|"
+        r"not\s+logged\s+in|"
+        r"login\s+required|"
+        r"sign[- ]in\s+required|"
+        r"need(?:s)?\s+to\s+sign[- ]in|"
+        r"session\s+invalidated|"
+        r"auth(?:entication)?\s+(?:failed|error|required|expired)|"
+        r"run\s+`?codex\s+login`?"
+        r")(?!\w)",
+        re.IGNORECASE,
+    )
+    _AUTH_DEATH_SOURCE = "fallback-copy"
+
+# The synthetic prompt MUST stay an inert, domain-free literal (Kimi r1 m8):
+# this probe scans a FAILED exec's stderr raw, without the daemon's
+# `_strip_known_lines` defusal — safe only while the prompt (and thus any
+# echoed prompt/answer line) cannot contain auth-shaped vocabulary. A
+# visa-domain prompt here ("check the client's login…") would reopen the
+# family-#3 false positive the daemon spent rounds R25-R27 closing.
+_PROBE_PROMPT: Final[str] = "ping"
+
+_ENV_BIN: Final[str] = "WA_CODEX_BIN"
+_ENV_STATUS_FILE: Final[str] = "WA_CODEX_SEAT_STATUS_FILE"
+_DEFAULT_STATUS_FILE: Final[str] = "/usr/local/var/wa-codex-broker/seat-status.json"
+_TIMEOUT_S: Final[int] = 60
+
+# Sentinel exit code for a subprocess that never produced a real exit code
+# (timeout or spawn failure). Never a real `codex` exit code — codex exits
+# 0..255 like any CLI.
+_UNRUN_RC: Final[int] = -1
+
+VERDICT_OK: Final[str] = "ok"
+VERDICT_AUTH_DEATH: Final[str] = "auth_death"
+VERDICT_OTHER_FAILURE: Final[str] = "other_failure"
+VERDICT_PROBE_ERROR: Final[str] = "probe_error"
+
+EXIT_OK: Final[int] = 0
+EXIT_CANNOT_VERIFY: Final[int] = 2
+
+
+@dataclass(frozen=True)
+class ProbeStatus:
+    """The ENTIRE contents of the status file. No field here may ever carry
+    free text from a codex invocation — see module docstring, LEAK SURFACE.
+    """
+
+    checked_at: str
+    verdict: str
+    login_status_rc: int
+    exec_rc: int
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "checked_at": self.checked_at,
+                "verdict": self.verdict,
+                "login_status_rc": self.login_status_rc,
+                "exec_rc": self.exec_rc,
+            }
+        )
+
+
+def resolve_binary(env: Mapping[str, str]) -> str | None:
+    """Same resolution order as CodexExecClient._resolve_binary (minus the
+    constructor-arg step, which has no meaning for a standalone probe):
+    env `WA_CODEX_BIN` first, else `codex` on PATH. None = unresolvable."""
+    explicit = env.get(_ENV_BIN, "").strip()
+    if explicit:
+        return explicit
+    return shutil.which("codex")
+
+
+_CHILD_ENV_KEEP: Final[tuple[str, ...]] = (
+    "PATH",
+    "HOME",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "TMPDIR",
+    "CODEX_HOME",
+)
+
+
+def _child_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Minimal codex child env — the same allowlist discipline as the
+    daemon's `CodexExecClient._build_env`: a probe launched from a fat
+    interactive shell must never hand unrelated secrets to an agentic child
+    process (scar 2026-08-18: dispatching an external CLI delivers the
+    ENVIRONMENT, not just the prompt). The wrapper already strips the env
+    file down to WA_CODEX_BIN/CODEX_HOME; this is the second, in-process
+    layer."""
+    return {key: env[key] for key in _CHILD_ENV_KEEP if key in env}
+
+
+def _run(binary: str, args: Sequence[str], env: Mapping[str, str]) -> tuple[int, str, str]:
+    """Runs one codex subcommand. Returns (rc, stdout, stderr); rc=_UNRUN_RC
+    on timeout or spawn failure — the caller reads the SENTINEL value, never
+    an exception, and neither failure mode leaks free text (both return
+    empty strings for stdout/stderr, since the file this feeds never
+    carries codex's raw text anyway)."""
+    try:
+        proc = subprocess.run(
+            [binary, *args],
+            env=_child_env(env),
+            capture_output=True,
+            text=True,
+            # Same decode discipline as the daemon (its R25-8 note): codex
+            # emitting invalid UTF-8 must degrade to replacement chars, not
+            # raise UnicodeDecodeError past the except clauses below and
+            # skip the status write entirely (Kimi r1 m6).
+            errors="replace",
+            timeout=_TIMEOUT_S,
+            check=False,
+        )
+        return proc.returncode, proc.stdout or "", proc.stderr or ""
+    except subprocess.TimeoutExpired:
+        logger.warning("wa_codex_seat_probe: %s timed out after %ss", list(args), _TIMEOUT_S)
+        return _UNRUN_RC, "", ""
+    except OSError as exc:
+        logger.warning(
+            "wa_codex_seat_probe: %s failed to spawn: %s", list(args), type(exc).__name__
+        )
+        return _UNRUN_RC, "", ""
+
+
+def classify(
+    login_rc: int,
+    login_out: str,
+    login_err: str,
+    exec_rc: int,
+    exec_out: str,
+    exec_err: str,
+) -> str:
+    """Pure — no I/O, so this is where a future unit test would live.
+
+    Priority: an auth-death signature on EITHER command outranks a generic
+    nonzero (a `login status` that spawns fine but `exec` correctly reports
+    401 is still auth_death, not other_failure). The regex is searched on
+    EACH text independently — never concatenated — matching the discipline
+    of the upstream `_auth_death_detected`: joining texts with any separator
+    risks the regex's `\\s+` alternatives bridging two innocent fragments
+    across the seam into a false match.
+
+    Scanning discipline imitates the daemon's R26 rule: only a FAILED
+    command's text is scanned — a succeeding command's output is a status
+    line or a model answer whose vocabulary is innocent by construction
+    (family #3: "unauthorized"/"login"/"expired" are ordinary visa-domain
+    words in a legitimate answer). Per-command surface: for `login status`
+    BOTH streams (measured 2026-08-20 on the live CLI: the logged-out
+    marker "Not logged in" arrives on STDOUT, rc=1; healthy prints "Logged
+    in using ChatGPT", rc=0, no match); for `exec` STDERR ONLY (the
+    daemon's measured evidence places codex's own diagnostics on stderr,
+    and exec stdout may carry a partial model answer discussing a CLIENT's
+    login/credential).
+
+    Only if NEITHER command produced a real exit code at all is this a
+    probe_error (we could not observe anything, auth-dead or otherwise).
+    Any other nonzero combination is other_failure (declared limit: not
+    further distinguished from quota exhaustion — see module docstring)."""
+    guilty_texts: list[str] = []
+    if login_rc not in (0, _UNRUN_RC):
+        guilty_texts.extend((login_out, login_err))
+    if exec_rc not in (0, _UNRUN_RC):
+        guilty_texts.append(exec_err)
+    if any(AUTH_DEATH_RE.search(t) for t in guilty_texts if t):
+        return VERDICT_AUTH_DEATH
+    if login_rc == _UNRUN_RC and exec_rc == _UNRUN_RC:
+        return VERDICT_PROBE_ERROR
+    if login_rc != 0 or exec_rc != 0:
+        return VERDICT_OTHER_FAILURE
+    return VERDICT_OK
+
+
+def probe(env: Mapping[str, str] | None = None) -> ProbeStatus:
+    """Runs both checks and classifies the outcome. Always returns a
+    ProbeStatus — a fully-unresolvable binary is itself a verdict
+    (probe_error), not an exception; the caller still gets to write it."""
+    resolved_env = dict(env if env is not None else os.environ)
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    binary = resolve_binary(resolved_env)
+    if binary is None:
+        logger.error(
+            "wa_codex_seat_probe: codex binary unresolvable (WA_CODEX_BIN unset, not on PATH)"
+        )
+        return ProbeStatus(now_iso, VERDICT_PROBE_ERROR, _UNRUN_RC, _UNRUN_RC)
+
+    login_rc, login_out, login_err = _run(binary, ["login", "status"], resolved_env)
+    exec_rc, exec_out, exec_err = _run(
+        binary,
+        ["exec", "--sandbox", "read-only", "--skip-git-repo-check", _PROBE_PROMPT],
+        resolved_env,
+    )
+    verdict = classify(login_rc, login_out, login_err, exec_rc, exec_out, exec_err)
+    return ProbeStatus(now_iso, verdict, login_rc, exec_rc)
+
+
+def write_status_atomic(status: ProbeStatus, path: Path) -> None:
+    """tmp+rename in the SAME directory (atomic on one filesystem) — Piece B
+    never observes a half-written file. Mode 0644: Piece B runs as a
+    DIFFERENT user (nuzantara) and must be able to read this file even
+    though it lives under a directory this probe (zantara-codex) owns."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".seat-status-", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(status.to_json())
+        os.chmod(tmp_name, 0o644)
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def default_status_path() -> Path:
+    return Path(os.environ.get(_ENV_STATUS_FILE, _DEFAULT_STATUS_FILE))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="wa_codex_seat_probe: %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.parse_args(argv)  # no flags today; keeps the CLI extensible
+
+    logger.info("auth-death detector source: %s", _AUTH_DEATH_SOURCE)
+
+    try:
+        status = probe()
+    except Exception as exc:  # noqa: BLE001 — any unexpected failure here is
+        # CANNOT-VERIFY, not a stack trace on stdout: nothing valid to write.
+        logger.error("probe failed unexpectedly: %s", type(exc).__name__)
+        return EXIT_CANNOT_VERIFY
+
+    status_path = default_status_path()
+    try:
+        write_status_atomic(status, status_path)
+    except OSError as exc:
+        logger.error(
+            "could not write status file %s: %s", status_path, type(exc).__name__
+        )
+        return EXIT_CANNOT_VERIFY
+
+    logger.info("verdict=%s written to %s", status.verdict, status_path)
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wa_codex_seat_probe.py
+++ b/scripts/wa_codex_seat_probe.py
@@ -288,9 +288,12 @@ def probe(env: Mapping[str, str] | None = None) -> ProbeStatus:
 
 def write_status_atomic(status: ProbeStatus, path: Path) -> None:
     """tmp+rename in the SAME directory (atomic on one filesystem) — Piece B
-    never observes a half-written file. Mode 0644: Piece B runs as a
-    DIFFERENT user (nuzantara) and must be able to read this file even
-    though it lives under a directory this probe (zantara-codex) owns."""
+    never observes a half-written file. Mode 0640, group staff: Piece B runs
+    as a DIFFERENT user (nuzantara, a staff member — measured on Pro:
+    gid=20(staff)) and reads via the group bit; "others" get nothing. The
+    payload is enum-only by design, but family-#4 hygiene says grant the one
+    reader, not the world (this probe's process group is staff, so the tmp
+    file inherits it)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(
         dir=str(path.parent), prefix=".seat-status-", suffix=".tmp"
@@ -298,7 +301,7 @@ def write_status_atomic(status: ProbeStatus, path: Path) -> None:
     try:
         with os.fdopen(fd, "w") as handle:
             handle.write(status.to_json())
-        os.chmod(tmp_name, 0o644)
+        os.chmod(tmp_name, 0o640)
         os.replace(tmp_name, str(path))
     except BaseException:
         with contextlib.suppress(OSError):

--- a/scripts/wa_codex_seat_probe.py
+++ b/scripts/wa_codex_seat_probe.py
@@ -293,7 +293,9 @@ def write_status_atomic(status: ProbeStatus, path: Path) -> None:
     gid=20(staff)) and reads via the group bit; "others" get nothing. The
     payload is enum-only by design, but family-#4 hygiene says grant the one
     reader, not the world (this probe's process group is staff, so the tmp
-    file inherits it)."""
+    file inherits it). CodeQL's py/overly-permissive-file flags ANY group
+    bit — dismissed as won't-fix (alert #8634): the group bit IS the channel
+    this organ exists to provide; 0600 would sever probe→sentinel."""
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(
         dir=str(path.parent), prefix=".seat-status-", suffix=".tmp"

--- a/scripts/wa_codex_seat_sentinel.py
+++ b/scripts/wa_codex_seat_sentinel.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""wa_codex_seat_sentinel.py — S3 seat-death sentinel (Piece B), reader half
+of the seat sentinel pair for the wa-codex broker's OpenAI/Codex leg.
+
+Runs as `nuzantara` via cron-runner.sh — a DIFFERENT user from the probe
+(Piece A, scripts/wa_codex_seat_probe.py, runs as the login-less
+zantara-codex whose home is unreadable cross-user). This organ reads TWO
+independent sources and never trusts either one alone:
+
+1. The probe's status file — the ONLY channel that crosses the user
+   boundary from zantara-codex's sandbox. A `verdict=auth_death` here is a
+   direct, job-traffic-independent signal: the probe checks even when the
+   lane is flag-OFF and zero jobs flow.
+2. The prod `wa_broker_gauge` row (server-side, via `scripts/pg.sh`) — the
+   admission/liveness gauge every `/claim` poll upserts. Catches the case
+   the probe cannot see at all: the daemon itself silently stopped polling
+   (crash, version-pin pause, host down) even though its OWN auth is fine.
+
+Neither source alone is sufficient (scar family #2, "esiste ≠ armato"): a
+probe that never ran again would sit at a stale timestamp forever unless
+something ELSE notices the silence, and a gauge read alone cannot name
+"auth" as the cause — the daemon logs that, in a file this user cannot
+read. Two guardians, two blind spots each; together they cover the pair.
+
+W104 discipline (`redis-cli` exits 0 with `NOAUTH` on stdout — the twin
+lesson generalizes to any CLI): the gauge query is JUDGED BY ITS OUTPUT, not
+its exit code alone — empty stdout or a shape that does not parse into
+exactly 4 fields is CANNOT-VERIFY, never read as "clean".
+
+EXIT: 0 = both sources were read (verdicts, if any, travel via Telegram
+alert — same convention as wa_session_liveness.py, not via exit code). 2 =
+the gauge could not be read/parsed at all — CANNOT-VERIFY, never a silent 0
+(the cron-runner.sh receipt alarm, the W107 cure, picks up non-zero exits).
+A probe file that is simply MISSING is deliberately NOT a CANNOT-VERIFY
+here: it is itself a RED verdict ("probe silent") — an unarmed probe is a
+finding this organ can and must name, not a reason to give up looking at
+the gauge.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import socket
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final, Optional, Sequence
+
+logger = logging.getLogger("wa_codex_seat_sentinel")
+
+REPO: Final[Path] = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from scripts.tg_gateway_verdict import extract_gateway_verdict  # noqa: E402
+
+_ENV_STATUS_FILE: Final[str] = "WA_CODEX_SEAT_STATUS_FILE"
+_DEFAULT_STATUS_FILE: Final[str] = "/usr/local/var/wa-codex-broker/seat-status.json"
+_ENV_PROBE_INTERVAL_S: Final[str] = "WA_CODEX_PROBE_INTERVAL_S"
+DEFAULT_PROBE_INTERVAL_S: Final[float] = 21600.0  # 6h — matches the probe plist's StartInterval.
+
+_GAUGE_STALENESS_LIMIT_S: Final[float] = 600.0
+_BREAKER_FAILURE_LIMIT: Final[int] = 3
+_GAUGE_QUERY_TIMEOUT_S: Final[int] = 30
+
+RED: Final[str] = "RED"
+WARN: Final[str] = "WARN"
+
+EXIT_OK: Final[int] = 0
+EXIT_CANNOT_VERIFY: Final[int] = 2
+
+AUTH_DEATH_MSG: Final[str] = (
+    "codex seat AUTH DEAD — operator: sudo -u zantara-codex "
+    "CODEX_HOME=/Users/zantara-codex/.codex HOME=/Users/zantara-codex "
+    "/opt/homebrew/bin/codex login"
+)
+PROBE_SILENT_MSG: Final[str] = "seat probe silent (not armed, or its daemon died)"
+BREAKER_MSG: Final[str] = (
+    "codex leg failing — cause is named only in the daemon log: "
+    "sudo grep 'AUTH DEATH' /Users/zantara-codex/logs/wa-codex-broker.err"
+)
+DAEMON_SILENT_MSG: Final[str] = "daemon silent (dead / version-pin pause / host down)"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    level: str  # RED | WARN
+    condition: str  # stable per-condition dedup component (never the measurement)
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Pure logic — no I/O, this is where the tests live.
+# ---------------------------------------------------------------------------
+
+
+def _probe_side(
+    probe_status: Optional[dict],
+    probe_age_s: Optional[float],
+    probe_interval_s: float,
+) -> list[Verdict]:
+    """Verdicts from the probe status file ALONE — split out so `run()` can
+    still emit an in-hand `auth_death` when the gauge is unreadable (Kimi r1
+    M1: the CANNOT-VERIFY path must never swallow a verdict already in
+    hand — the operator would be paged 'could not read gauge' while the
+    actionable re-login command sits in the status file unread)."""
+    verdicts: list[Verdict] = []
+    stale = probe_age_s is None or probe_age_s >= 2 * probe_interval_s
+    if probe_status is None or stale:
+        verdicts.append(Verdict(RED, "probe_silent", PROBE_SILENT_MSG))
+    else:
+        probe_verdict = probe_status.get("verdict")
+        if probe_verdict == "auth_death":
+            verdicts.append(Verdict(RED, "auth_death", AUTH_DEATH_MSG))
+        elif probe_verdict != "ok":
+            # other_failure, probe_error, AND any vocabulary this reader does
+            # not know yet (a future probe adding e.g. "quota_exhausted" must
+            # fall somewhere VISIBLE, never into silence — W116: an unmapped
+            # finale that lands in the healthy bucket is how the next real
+            # signal gets lost).
+            verdicts.append(
+                Verdict(
+                    WARN,
+                    "other_failure",
+                    "seat probe reports {0} (rc login={1} rc exec={2})".format(
+                        probe_verdict,
+                        probe_status.get("login_status_rc"),
+                        probe_status.get("exec_rc"),
+                    ),
+                )
+            )
+        # probe_verdict == "ok": the only value that produces no verdict.
+    return verdicts
+
+
+def _gauge_side(gauge_row: tuple[str, str, int, float]) -> list[Verdict]:
+    # The gauge row is single-row by CHECK (id = 1); the query pins WHERE
+    # id = 1 anyway, like every other reader (Kimi r1 m10).
+    _last_seen_raw, breaker_state, consecutive_failures, staleness_s = gauge_row
+    verdicts: list[Verdict] = []
+    if breaker_state != "closed" or consecutive_failures >= _BREAKER_FAILURE_LIMIT:
+        verdicts.append(Verdict(RED, "breaker_open", BREAKER_MSG))
+    if staleness_s > _GAUGE_STALENESS_LIMIT_S:
+        verdicts.append(Verdict(RED, "daemon_silent", DAEMON_SILENT_MSG))
+    return verdicts
+
+
+def evaluate(
+    probe_status: Optional[dict],
+    probe_age_s: Optional[float],
+    gauge_row: Optional[tuple[str, str, int, float]],
+    now: datetime,
+    probe_interval_s: float = DEFAULT_PROBE_INTERVAL_S,
+) -> list[Verdict]:
+    """Pure classification over both sources. `now` is a parameter, not
+    `datetime.now()` read internally, so a test controls freshness exactly.
+
+    `gauge_row=None` is REFUSED, not silently absorbed into an empty verdict
+    list: a gauge the caller could not read is a CANNOT-VERIFY case that
+    must be handled BEFORE this function runs (see `run()`) — an unread
+    gauge is not the same fact as "the gauge says everything is fine", and
+    this function must never let the two collapse into the same empty
+    return value (that would read as a clean pass on a source we never
+    looked at).
+    """
+    if gauge_row is None:
+        raise ValueError(
+            "evaluate() requires an already-resolved gauge_row — a gauge "
+            "that could not be read/parsed is CANNOT-VERIFY and must be "
+            "handled by the caller before this function runs, never "
+            "silently folded into an empty (= healthy-looking) verdict list."
+        )
+    return _probe_side(probe_status, probe_age_s, probe_interval_s) + _gauge_side(gauge_row)
+
+
+# ---------------------------------------------------------------------------
+# I/O — readers. Each ALWAYS returns a value (never raises on the ordinary
+# "not there"/"unreadable" cases); `run()` decides what that means.
+# ---------------------------------------------------------------------------
+
+
+def _status_file_path() -> Path:
+    return Path(os.environ.get(_ENV_STATUS_FILE, _DEFAULT_STATUS_FILE))
+
+
+def _probe_interval_s() -> float:
+    try:
+        return float(os.environ.get(_ENV_PROBE_INTERVAL_S, DEFAULT_PROBE_INTERVAL_S))
+    except ValueError:
+        return DEFAULT_PROBE_INTERVAL_S
+
+
+def _read_probe_status() -> tuple[Optional[dict], Optional[float]]:
+    """(status_dict, age_seconds) — (None, None) for BOTH "file missing" and
+    "file present but unreadable/corrupt/malformed": `evaluate()` treats
+    both identically as "probe silent", since neither lets us trust a
+    verdict inside it."""
+    path = _status_file_path()
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None, None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("probe status file is not valid JSON: %s", path)
+        return None, None
+    checked_at_raw = data.get("checked_at")
+    if not isinstance(checked_at_raw, str):
+        logger.warning("probe status file missing/malformed checked_at: %s", path)
+        return None, None
+    try:
+        checked_at = datetime.strptime(checked_at_raw, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        logger.warning("probe status checked_at unparseable: %r", checked_at_raw)
+        return None, None
+    age_s = (datetime.now(timezone.utc) - checked_at).total_seconds()
+    return data, age_s
+
+
+def _read_gauge() -> Optional[tuple[str, str, int, float]]:
+    """Runs the gauge query via scripts/pg.sh and JUDGES THE OUTPUT (W104):
+    empty stdout, or a shape that does not split into exactly 4 fields, or
+    a field that does not convert — all return None (CANNOT-VERIFY), never
+    a guessed/default row."""
+    pg_sh = REPO / "scripts" / "pg.sh"
+    query = (
+        "SELECT broker_last_seen_at, breaker_state, consecutive_failures, "
+        "EXTRACT(EPOCH FROM (now() - broker_last_seen_at)) FROM wa_broker_gauge "
+        "WHERE id = 1"
+    )
+    try:
+        proc = subprocess.run(
+            ["bash", str(pg_sh), "-A", "-t", "-c", query],
+            cwd=str(REPO),
+            capture_output=True,
+            text=True,
+            timeout=_GAUGE_QUERY_TIMEOUT_S,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("gauge query failed to run: %s", type(exc).__name__)
+        return None
+
+    line = next((ln for ln in reversed(proc.stdout.splitlines()) if ln.strip()), "")
+    if not line:
+        logger.warning(
+            "gauge query returned no output (rc=%s): %s",
+            proc.returncode,
+            (proc.stderr or "").strip()[:200],
+        )
+        return None
+
+    fields = [f.strip() for f in line.split("|")]
+    if len(fields) != 4:
+        logger.warning("gauge query output unparseable (expected 4 fields, got %d): %r", len(fields), line)
+        return None
+
+    _last_seen_raw, breaker_state, consecutive_failures_raw, staleness_raw = fields
+    if not breaker_state:
+        logger.warning("gauge query returned an empty breaker_state: %r", line)
+        return None
+    try:
+        consecutive_failures = int(consecutive_failures_raw)
+        # broker_last_seen_at is NULL until the daemon's FIRST poll ever —
+        # psql -A -t renders NULL as an empty field. That is not an
+        # unparseable row (CANNOT-VERIFY); it is the honest fact "the daemon
+        # has never been seen", i.e. infinite staleness → daemon_silent RED.
+        staleness_s = float("inf") if staleness_raw == "" else float(staleness_raw)
+    except ValueError:
+        logger.warning("gauge query numeric fields unparseable: %r", line)
+        return None
+
+    return (_last_seen_raw, breaker_state, consecutive_failures, staleness_s)
+
+
+def hostname() -> str:
+    return socket.gethostname().split(".")[0]
+
+
+# ---------------------------------------------------------------------------
+# Alerting — same chain as wa_session_liveness.py::send_to_gateway.
+# ---------------------------------------------------------------------------
+
+
+def send_to_gateway(message: str, host: str, level: str, condition: str) -> bool:
+    """alerter (dedup) -> tg_notify, same chain as every other sentinel in
+    this tree. RED -> alerter level CRITICAL / gateway tier p0. WARN ->
+    alerter level WARNING / gateway tier digest (alerter.send_alert's own
+    tier mapping: CRITICAL/DEADMAN -> p0, WARNING/INFO -> digest)."""
+    alerter_level = "CRITICAL" if level == RED else "WARNING"
+    try:
+        sys.path.insert(0, str(REPO / "scripts"))
+        from sentinel_lib import alerter  # noqa: PLC0415
+
+        return bool(alerter.send_alert(message, level=alerter_level, condition=condition))
+    except Exception:  # noqa: BLE001 — fallback diretto al gateway
+        gateway = REPO / "scripts" / "tg_notify.py"
+        if not gateway.exists():
+            return False
+        tier = "p0" if level == RED else "digest"
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        dedup_key = f"wa-codex-seat-{condition}-{today}"
+        try:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(gateway),
+                    "--tier",
+                    tier,
+                    "--source",
+                    "wa-codex-seat-sentinel",
+                    "--dedup-key",
+                    dedup_key,
+                    message,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — notification failure is fail-closed
+            print(f"tg_notify: ERRORE subprocess ({type(exc).__name__})", file=sys.stderr)
+            return False
+        verdict = extract_gateway_verdict(proc.stderr)
+        print(f"tg_notify: {verdict or f'NESSUN verdetto rc={proc.returncode}'}", file=sys.stderr)
+        # Kimi r2 #2: mirror the alerter's OWN responsibility bar (alerter.py:207
+        # counts every canonical verdict — spooled/deduped/logged mean the gateway
+        # durably owns the news), not the stricter gateway_delivered()=="sent".
+        # With M4 giving False teeth (exit 2 -> receipt page), judging a spooled
+        # RED as "failed" would manufacture a false CANNOT-VERIFY during a mere
+        # rate-limit spool. A canonical verdict on rc 0 = responsibility taken.
+        return proc.returncode == 0 and verdict is not None
+
+
+def _emit_cannot_verify(host: str) -> bool:
+    message = (
+        f"wa-codex-seat-sentinel [{host}] — CANNOT-VERIFY: could not read/parse "
+        "the wa_broker_gauge row (pg.sh query failed, returned no output, or an "
+        "unparseable shape).\n\nNo verdict was reached: this is NOT a health verdict."
+    )
+    return send_to_gateway(message, host, RED, "gauge_cannot_verify")
+
+
+def _emit(verdicts: Sequence[Verdict], host: str) -> bool:
+    """Sends every verdict; returns False if any RED failed to deliver.
+    A lost RED is fail-open on the exact path this organ exists for (Kimi
+    r1 M4): the caller must then exit non-zero so the cron-runner receipt
+    alarm — the W107 backup channel that fires only on non-zero exits —
+    gets its chance. WARN deliveries are best-effort (digest tier)."""
+    all_red_delivered = True
+    for v in verdicts:
+        sent = send_to_gateway(f"{v.level} wa-codex-seat [{host}]: {v.message}", host, v.level, v.condition)
+        print(f"{v.level} {v.condition}: alert {'inviato' if sent else 'FALLITO'} — {v.message}")
+        if not sent and v.level == RED:
+            all_red_delivered = False
+    return all_red_delivered
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def run(now: Optional[datetime] = None) -> int:
+    now = now or datetime.now(timezone.utc)
+    host = hostname()
+
+    probe_status, probe_age_s = _read_probe_status()
+    gauge_row = _read_gauge()
+
+    if gauge_row is None:
+        # In-hand probe verdicts still travel (Kimi r1 M1): a dead seat AND
+        # an unreadable gauge tend to co-occur in a degraded moment, and the
+        # actionable auth_death must not hide behind a generic CANNOT-VERIFY.
+        _emit(_probe_side(probe_status, probe_age_s, _probe_interval_s()), host)
+        _emit_cannot_verify(host)
+        print(
+            "wa-codex-seat-sentinel: CANNOT-VERIFY — could not read/parse the "
+            "broker gauge; gauge-side verdicts not reached",
+            file=sys.stderr,
+        )
+        return EXIT_CANNOT_VERIFY
+
+    verdicts = evaluate(probe_status, probe_age_s, gauge_row, now, _probe_interval_s())
+
+    if not verdicts:
+        print(f"wa-codex-seat-sentinel [{host}]: all conditions healthy")
+        return EXIT_OK
+
+    all_red_delivered = _emit(verdicts, host)
+    if not all_red_delivered:
+        # Fail-open guard (Kimi r1 M4): a RED that could not be delivered —
+        # gateway down, spool refused — must surface through the ONE channel
+        # left, the cron-runner receipt alarm on non-zero exit.
+        print(
+            "wa-codex-seat-sentinel: RED alert delivery FAILED — exiting "
+            "non-zero so the receipt alarm fires",
+            file=sys.stderr,
+        )
+        return EXIT_CANNOT_VERIFY
+    # Delivered verdicts travel via the Telegram alert above, not the exit
+    # code — same convention as wa_session_liveness.py: the sentinel SAW the
+    # problem and DELIVERED it, which is a successful run, not a failure.
+    return EXIT_OK
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="wa_codex_seat_sentinel: %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.parse_args(argv)
+    return run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

The ChatGPT-provider broker lane is flag-OFF with zero jobs, so an auth death of the `zantara-codex` seat is invisible today: the daemon folds it to `error_class=cli_failure` on the wire (closed vocabulary), "AUTH DEATH" is nameable only in a log under a `0700` home the cron user cannot read, and `wa_broker_gauge.consecutive_failures`/`breaker_state` only move when jobs flow. This PR manufactures a traffic-independent signal and reads it across the user boundary:

- **Piece A** — `scripts/wa_codex_seat_probe.py` + `com.balizero.wa-codex-seat-probe` LaunchDaemon (UserName `zantara-codex`, StartInterval 6h + RunAtLoad): `codex login status` + a 1-token synthetic `codex exec` ping, classified with the daemon's own `_AUTH_DEATH_RE` (imported from the runtime tree, with a byte-identity-tested fallback copy) under R26 discipline — scan only a FAILED command's text, exec **stderr only** (stdout may carry a model answer with innocent auth vocabulary). Writes an **enum-only** status JSON to `/usr/local/var/wa-codex-broker/seat-status.json` (0640 group-staff — nuzantara reads via the group bit): verdict + rcs + timestamp, no codex free text crosses the boundary.
- **Piece B** — `scripts/wa_codex_seat_sentinel.py` + in-repo wrapper (normal cron user via cron-runner): reads the status file + the gauge (`pg.sh -A -t`, output judged — W104), alerts via `sentinel_lib.alerter` (dedup; RED→p0, WARN→digest) with a `tg_notify` fallback judged on the gateway's canonical verdict. Unreadable gauge = exit 2 CANNOT-VERIFY, never a clean pass; an in-hand `auth_death` still travels even then; a failed RED delivery exits 2 so the cron-runner receipt alarm fires.
- **Provisioning** (`scripts/provision_zantara_codex.sh`): installs/arms Piece A (explicit `launchctl print` loaded-check → SKIP with honest bootout+bootstrap reload advice; bootstrap failures captured and fatal, "already loaded" print/bootstrap disagreement special-cased on both sections); footer documents arming Piece B from the MAIN checkout and warns about the expected first-run `auth_death` page. Live copies declared in `infra/home-fork/declared-pairs.json` (superscar #1).

Deliberately NOT in v1 (declared limit): quota classification (`CodexQuotaError` is S1.5's object — quota trips the breaker with a timed reopen; auth-death stops the lane and pages, per spec §4.4/C8).

## Verification

- 30 guilt/innocence/CANNOT-VERIFY tests (`scripts/tests/test_wa_codex_seat_{probe,sentinel}.py`), including the R26 innocence case (healthy exec whose ANSWER discusses "unauthorized" stays `ok`) and the byte-identity + `re.IGNORECASE` pin against the daemon regex.
- Mutation-verified: disabling the M1 cure (in-hand auth_death on gauge-None), the M4 cure (failed RED delivery → exit 2) and the r2 fallback-bar cure each reds exactly its own test; restores byte-identical.
- `bash -n` both wrappers + provisioning, `plutil -lint` plist, `py_compile`, `ruff` clean.
- Cross-family adversarial review: **Kimi K3, two rounds** (r1 FIX-FIRST: 4 MAJOR + 6 minor, all cured; r2 pointed at the cures themselves per W113: **VERDICT: SHIP** with 5 minors, all cured in this diff).

## Post-merge (tracked in modus PENDING-ARMS row 19)

Re-run provisioning on Pro (root) to install Piece A; arm Piece B via a cron-runner crontab line from the main checkout (pattern measured live on Pro's crontab); PROVE-LIVE = status file appears + one clean sentinel run + innocence week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)