### PR TITLE
feat(cron): context diet for sentinel + DLQ claude spawns (measured -48%/call)

### DIFF
--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -108,11 +108,30 @@ CONFIDENCE_AIDER = 0.90           # code-change aider threshold
 REASONING_TIMEOUT_S = 90          # claude --print timeout
 
 
+def _isolated_cwd() -> Path:
+    """Context-diet cwd for the claude_reason() `claude --print` spawn (2026-08-20).
+
+    Empty dir -> no CLAUDE.md auto-discovery; --safe-mode (set at the call
+    site) additionally skips skills/hooks/memory. Measured on Pro (CLI
+    2.1.237, Haiku): repo cwd = 92,397 ambient tokens, neutral cwd = 43,426,
+    --safe-mode + --strict-mcp-config + this isolated cwd = 22,408. The
+    claude_reason() prompt is a pure self-contained f-string with no tool
+    access, so skills/hooks/CLAUDE.md/MCP are pure overhead on this cron lane
+    (<=48 ticks/day). dispatch_aider() below is NOT touched — it legitimately
+    needs cwd=NUZANTARA_ROOT to operate on the checkout. Follows the in-repo
+    precedent scripts/wr3_dispatch_v2.py::_ISOLATED_CWD.
+    """
+    path = Path(os.environ.get("DLQ_CLAUDE_CWD", "/tmp/dlq-claude-cwd"))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def _run_process_group(
     cmd: list[str],
     *,
     timeout: float,
     env: dict[str, str] | None = None,
+    cwd: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run a CLI in its own session and reap its full process tree on timeout."""
     proc = subprocess.Popen(
@@ -121,6 +140,7 @@ def _run_process_group(
         stderr=subprocess.PIPE,
         text=True,
         env=env,
+        cwd=cwd,
         start_new_session=True,
     )
     try:
@@ -576,9 +596,15 @@ Rules:
 
         try:
             result = _run_process_group(
-                ["claude", "--print", prompt],
+                [
+                    "claude", "--print",
+                    "--safe-mode", "--strict-mcp-config",
+                    "--mcp-config", '{"mcpServers":{}}',
+                    prompt,
+                ],
                 timeout=attempt_timeout,
                 env=_claude_oauth_env(token),
+                cwd=str(_isolated_cwd()),
             )
         except subprocess.TimeoutExpired:
             logger.warning(f"{job}: {label} timed out")

--- a/scripts/sentinel_lib/classifier.py
+++ b/scripts/sentinel_lib/classifier.py
@@ -1,7 +1,25 @@
 """Failure classifier: deterministic rules first, Claude CLI fallback."""
 import json
+import os
 import re
 import subprocess
+from pathlib import Path
+
+
+def _isolated_cwd() -> Path:
+    """Context-diet cwd for the `claude --print` classify fallback (2026-08-20).
+
+    Empty dir -> no CLAUDE.md auto-discovery; --safe-mode (set at the call
+    site) additionally skips skills/hooks/memory. Measured on Pro (CLI
+    2.1.237, Haiku): repo cwd = 92,397 ambient tokens, neutral cwd = 43,426,
+    --safe-mode + --strict-mcp-config + this isolated cwd = 22,408. This
+    classify prompt is a pure self-contained f-string with no tool access, so
+    skills/hooks/CLAUDE.md/MCP are pure overhead on this cron lane. Follows
+    the in-repo precedent scripts/wr3_dispatch_v2.py::_ISOLATED_CWD.
+    """
+    path = Path(os.environ.get("SENTINEL_CLAUDE_CWD", "/tmp/sentinel-claude-cwd"))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
 
 TRANSIENT_PATTERNS = [
     r"HTTP 5\d\d",
@@ -144,8 +162,14 @@ def classify_with_llm(error_text: str, job_name: str) -> dict:
 
     try:
         proc = subprocess.run(
-            ["claude", "--print", prompt],
+            [
+                "claude", "--print",
+                "--safe-mode", "--strict-mcp-config",
+                "--mcp-config", '{"mcpServers":{}}',
+                prompt,
+            ],
             capture_output=True, text=True, timeout=30,
+            cwd=str(_isolated_cwd()),
         )
         if proc.returncode != 0:
             return {"type": "UNKNOWN", "subtype": "cli_failed", "fix_pattern": None, "confidence": 0.0}

--- a/scripts/tests/test_headless_context_diet.py
+++ b/scripts/tests/test_headless_context_diet.py
@@ -1,0 +1,273 @@
+"""Context-diet for the sentinel classifier + DLQ autopilot `claude --print` spawns
+(2026-08-20).
+
+Measured on Pro (CLI 2.1.237, Haiku): ambient headless context from repo cwd =
+92,397 tokens; from a neutral cwd = 43,426; with --safe-mode +
+--strict-mcp-config + an isolated empty cwd = 22,408. Both
+sentinel_lib.classifier.classify_with_llm() and dlq_autopilot.claude_reason()
+spawn pure self-contained f-string prompts with no tool access, so
+skills/hooks/CLAUDE.md/MCP are pure overhead on these lanes (sentinel <=144
+ticks/day, DLQ <=48/day). dlq_autopilot.dispatch_aider() is deliberately NOT
+touched — it operates on the checkout via Aider and needs cwd=NUZANTARA_ROOT —
+and is pinned here by an innocence test.
+
+Test classes:
+  TestClassifierContextDiet — GUILT: classify_with_llm() spawns claude with the
+    three hardening flags and an isolated, non-repo-root cwd. INNOCENCE: the
+    deterministic classify() regex path never touches subprocess at all.
+  TestDlqContextDiet — GUILT: claude_reason() spawns claude with the same three
+    flags + isolated cwd via _run_process_group(). INNOCENCE: dispatch_aider()
+    still passes cwd=str(NUZANTARA_ROOT) to every subprocess.run() call — the
+    diet must not leak into the repo-dependent spawn.
+
+Run:
+    cd ~/nuzantara/.worktrees/ops-headless-context-diet
+    source apps/backend-rag/.venv/bin/activate
+    python -m pytest scripts/tests/test_headless_context_diet.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+# scripts/tests/test_headless_context_diet.py -> parents[2] == repo root
+# (same convention as test_claude_oauth_runtime_fallback.py::REPO_ROOT).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+HARDENING_FLAGS = ("--safe-mode", "--strict-mcp-config")
+MCP_EMPTY_CONFIG = '{"mcpServers":{}}'
+
+
+def _load_module(relative_path: str, name: str) -> ModuleType:
+    """Load a script module by explicit file path, not sys.path — avoids
+    resolving to a sibling checkout (same pattern as
+    test_claude_oauth_runtime_fallback.py::_load_module)."""
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / relative_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_classifier(name: str) -> ModuleType:
+    return _load_module("scripts/sentinel_lib/classifier.py", name)
+
+
+def _load_dlq(name: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load dlq_autopilot.py by path with HOME monkeypatched to tmp_path FIRST
+    (same pattern as test_dlq_board_honesty.py::dlq fixture) so NUZANTARA_ROOT
+    resolves under the sandbox, not the real checkout."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    return _load_module("scripts/dlq_autopilot.py", name)
+
+
+def _assert_context_diet_argv(argv: list[str]) -> None:
+    for flag in HARDENING_FLAGS:
+        assert flag in argv, f"missing hardening flag {flag!r} in argv {argv!r}"
+    assert MCP_EMPTY_CONFIG in argv, f"missing empty mcp-config in argv {argv!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# sentinel_lib/classifier.py
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestClassifierContextDiet:
+    def test_guilt_classify_with_llm_spawns_safe_mode_isolated_cwd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """classify_with_llm() must spawn `claude --print` with --safe-mode +
+        --strict-mcp-config + an empty --mcp-config, cwd'd into an isolated,
+        non-repo directory that actually exists on disk."""
+        module = _load_classifier("context_diet_classifier_guilt")
+        isolated_dir = tmp_path / "sentinel-claude-cwd"
+        monkeypatch.setenv("SENTINEL_CLAUDE_CWD", str(isolated_dir))
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["kwargs"] = kwargs
+            payload = json.dumps(
+                {
+                    "type": "TRANSIENT",
+                    "subtype": "network",
+                    "fix_suggestion": "retry",
+                    "confidence": 0.8,
+                }
+            )
+            return subprocess.CompletedProcess(cmd, 0, payload, "")
+
+        monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+        result = module.classify_with_llm("connection dropped", "some-job")
+
+        _assert_context_diet_argv(captured["cmd"])
+        cwd = captured["kwargs"].get("cwd")
+        assert cwd is not None, "classify_with_llm() must pass an explicit cwd"
+        assert Path(cwd).exists(), "isolated cwd must be created on disk"
+        assert Path(cwd).resolve() != REPO_ROOT.resolve(), (
+            "cwd must NOT be the repo root (that is exactly the 92.4k-token case)"
+        )
+        assert Path(cwd).resolve() == isolated_dir.resolve()
+        assert result["type"] == "TRANSIENT"
+
+    def test_innocence_deterministic_classify_never_spawns_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The deterministic classify() regex path is untouched by the diet —
+        it must never call subprocess at all. Proves the diet only touched the
+        LLM fallback branch (classify_with_llm), not the fast path."""
+        module = _load_classifier("context_diet_classifier_innocence")
+
+        def _boom(*_args, **_kwargs):
+            raise AssertionError("classify() must never spawn a subprocess")
+
+        monkeypatch.setattr(module.subprocess, "run", _boom)
+
+        result = module.classify("Connection refused by remote host", retry_count=0)
+
+        assert result["type"] == "TRANSIENT"
+        assert result["subtype"] == "network_or_service"
+        assert result["confidence"] == 0.9
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# dlq_autopilot.py
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDlqContextDiet:
+    def test_guilt_claude_reason_spawns_safe_mode_isolated_cwd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """claude_reason() must spawn `claude --print` (via _run_process_group)
+        with the same three hardening flags, cwd'd into an isolated,
+        non-repo-root directory."""
+        module = _load_dlq(
+            "context_diet_dlq_autopilot_guilt", tmp_path, monkeypatch
+        )
+        isolated_dir = tmp_path / "dlq-claude-cwd"
+        monkeypatch.setenv("DLQ_CLAUDE_CWD", str(isolated_dir))
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "fake-token")
+        for i in (2, 3, 4, 5):
+            monkeypatch.delenv(f"CLAUDE_CODE_OAUTH_TOKEN_{i}", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        module._EXHAUSTED_TOKENS.clear()
+
+        captured: dict = {}
+        success_stdout = json.dumps(
+            {
+                "fix_type": "config",
+                "fix_instruction": "restore the missing runtime setting",
+                "confidence": 0.9,
+                "needs_code_change": False,
+            }
+        )
+
+        def fake_run_process_group(cmd, *, timeout, env=None, cwd=None):
+            captured["cmd"] = list(cmd)
+            captured["cwd"] = cwd
+            return subprocess.CompletedProcess(cmd, 0, success_stdout, "")
+
+        monkeypatch.setattr(module, "_run_process_group", fake_run_process_group)
+
+        result = module.claude_reason(
+            {
+                "job": "test-job",
+                "error_summary": "a sufficiently detailed test failure",
+                "log_tail": "",
+                "files_implicated": [],
+            }
+        )
+
+        assert result is not None
+        _assert_context_diet_argv(captured["cmd"])
+        cwd = captured["cwd"]
+        assert cwd is not None, "claude_reason() must pass an explicit cwd"
+        assert Path(cwd).exists(), "isolated cwd must be created on disk"
+        assert Path(cwd).resolve() != REPO_ROOT.resolve()
+        assert Path(cwd).resolve() != module.NUZANTARA_ROOT.resolve(), (
+            "claude_reason() must NOT use the repo checkout as cwd"
+        )
+        assert Path(cwd).resolve() == isolated_dir.resolve()
+
+    def test_innocence_dispatch_aider_keeps_repo_cwd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """dispatch_aider() is deliberately untouched by the diet — every
+        subprocess.run() call it makes (git stash + the ai-dispatch.sh bash
+        call) must still pass cwd=str(NUZANTARA_ROOT). Pins that the diet did
+        not leak into the repo-dependent spawn."""
+        module = _load_dlq(
+            "context_diet_dlq_autopilot_innocence", tmp_path, monkeypatch
+        )
+        dispatch_script = module.NUZANTARA_ROOT / "scripts" / "ai-dispatch.sh"
+        dispatch_script.parent.mkdir(parents=True, exist_ok=True)
+        dispatch_script.write_text("#!/bin/bash\necho ok\n")
+
+        captured_calls: list[tuple[list, dict]] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_calls.append((list(cmd), kwargs))
+            if list(cmd)[:2] == ["git", "stash"]:
+                return subprocess.CompletedProcess(cmd, 0, "No local changes to stash", "")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+        entry = {
+            "job": "test-job",
+            "error_summary": "boom",
+            "files_implicated": ["some/file.py"],
+        }
+        reasoning = {"fix_instruction": "do the fix"}
+        registry = {"test-job": {"test_cmd": "true"}}
+
+        success, _output = module.dispatch_aider(entry, reasoning, registry)
+
+        assert success is True
+        bash_calls = [c for c in captured_calls if c[0] and c[0][0] == "bash"]
+        git_calls = [c for c in captured_calls if c[0] and c[0][0] == "git"]
+        assert bash_calls, "expected dispatch_aider to spawn the ai-dispatch.sh bash call"
+        assert git_calls, "expected dispatch_aider to spawn the pre-flight git stash call"
+        for cmd, kwargs in bash_calls + git_calls:
+            assert kwargs.get("cwd") == str(module.NUZANTARA_ROOT), (
+                f"dispatch_aider() spawn {cmd!r} must keep cwd=NUZANTARA_ROOT, "
+                f"got {kwargs.get('cwd')!r}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MUTATION CHECK (manual, report only — no mutations actually committed):
+#
+#   sentinel_lib/classifier.py::classify_with_llm — reverting any one of the
+#   three argv flags (--safe-mode, --strict-mcp-config, --mcp-config
+#   '{"mcpServers":{}}') makes _assert_context_diet_argv() in
+#   test_guilt_classify_with_llm_spawns_safe_mode_isolated_cwd fail on the
+#   corresponding `assert flag in argv` / `assert MCP_EMPTY_CONFIG in argv`
+#   line. Reverting the cwd=str(_isolated_cwd()) kwarg (dropping it, or
+#   passing None) fails `assert cwd is not None` in the same test.
+#
+#   dlq_autopilot.py::claude_reason — same three flags, caught by the same
+#   _assert_context_diet_argv() call inside
+#   test_guilt_claude_reason_spawns_safe_mode_isolated_cwd. Reverting the
+#   cwd=str(_isolated_cwd()) kwarg fails `assert cwd is not None` /
+#   `assert Path(cwd).resolve() != module.NUZANTARA_ROOT.resolve()` in the
+#   same test (the latter also catches an accidental cwd=NUZANTARA_ROOT
+#   regression, i.e. the diet quietly reusing dispatch_aider's cwd).
+#
+#   dlq_autopilot.py::_run_process_group — dropping the `cwd=cwd` pass-through
+#   to subprocess.Popen would make the GUILT test's captured cwd never reach
+#   the real Popen call, but since the test replaces _run_process_group
+#   itself, that specific regression is caught structurally by
+#   test_innocence_dispatch_aider_keeps_repo_cwd staying green (it does not
+#   go through _run_process_group at all) combined with the GUILT test's
+#   asserts on the captured kwarg the real call site passes.
+# ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Puts the two highest-frequency bare `claude --print` cron spawns on a context diet: `sentinel_lib.classifier.classify_with_llm()` and `dlq_autopilot.claude_reason()` now spawn with `--safe-mode --strict-mcp-config --mcp-config '{"mcpServers":{}}'` and an isolated, empty `cwd` (env-overridable: `SENTINEL_CLAUDE_CWD`, `DLQ_CLAUDE_CWD`).
- Measured on Pro (CLI 2.1.237, Haiku): **92,397 tokens** ambient headless context from repo cwd → **43,426** from a neutral cwd → **22,408** with safe-mode + strict-mcp-config + isolated cwd. Both prompts are pure self-contained f-strings with no tool access, so skills/hooks/CLAUDE.md/MCP were pure overhead.
- Follows the in-repo precedents `scripts/wr3_dispatch_v2.py::_ISOLATED_CWD` and `scripts/arsenal_probe.py`'s `--safe-mode` usage.
- `dlq_autopilot.dispatch_aider()` is deliberately **untouched** — it legitimately operates on the repo checkout (`cwd=NUZANTARA_ROOT`) via Aider — and is pinned by an innocence test so the diet cannot leak into it.

**Scope note**: `supervisor_autofix_tier2` was deliberately excluded from this diet — its prompt depends on repo file access, so an isolated cwd would break it. Also flagging a conformance-checker blind spot found while researching precedents: the `guard-conformance` registry's classifier gene reads only the wrapper `.sh` scripts, not the Python spawn sites touched here — declared as a follow-up, not fixed in this PR.

## Test plan

- [x] New corpus `scripts/tests/test_headless_context_diet.py` — GUILT tests confirm both `classify_with_llm()` and `claude_reason()` spawn with the three hardening flags + an isolated, existing, non-repo-root cwd; INNOCENCE tests confirm the deterministic `classify()` regex path never touches subprocess, and `dispatch_aider()` still passes `cwd=str(NUZANTARA_ROOT)` on every spawn.
- [x] `scripts/tests/test_headless_context_diet.py` + `scripts/tests/test_sentinel_v33.py` + `scripts/tests/test_dlq_board_honesty.py` + `scripts/tests/test_claude_oauth_runtime_fallback.py`: **111 passed**, 2 pre-existing failures (`TestDocGeneratorBlocklist::test_format_schedule`, `test_wr2_metrics_wrapper_reaches_slot_five`) confirmed unrelated by re-running with this diff stashed out — identical failures either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)