### PR TITLE
feat(mouth): SEO-localized second-home landing routes (it/id) + locale-aware claim sweep

### DIFF
--- a/apps/mouth/src/app/sitemap.test.ts
+++ b/apps/mouth/src/app/sitemap.test.ts
@@ -93,6 +93,15 @@ describe("sitemap — visa funnel findability", () => {
     expect(urls).toContain(`${BASE}/visa/voa`);
   });
 
+  it("lists the localized second-home routes (it/id, 2026-08-20)", async () => {
+    // /visa/second-home/[locale] is a dynamic segment, excluded structurally
+    // from staticVisaRoutes()'s walk (see comment above) — so this is the
+    // only guard that would catch these two URLs missing from the sitemap.
+    const urls = (await sitemap()).map((e) => e.url);
+    expect(urls).toContain(`${BASE}/visa/second-home/it`);
+    expect(urls).toContain(`${BASE}/visa/second-home/id`);
+  });
+
   it("does NOT list per-visitor result pages", async () => {
     const urls = (await sitemap()).map((e) => e.url);
     const leaked = urls.filter((u) =>

--- a/apps/mouth/src/app/sitemap.ts
+++ b/apps/mouth/src/app/sitemap.ts
@@ -146,6 +146,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/visa/match",
     "/visa/clock",
     "/visa/second-home",
+    // Localized SSG variants (2026-08-20) — see
+    // app/visa/second-home/[locale]/page.tsx. Dynamic `[locale]` routes are
+    // excluded structurally from staticVisaRoutes()'s walk (sitemap.test.ts),
+    // same as any other bracketed segment, so they must be listed here by
+    // hand — same pattern the studio/ sibling already uses.
+    "/visa/second-home/it",
+    "/visa/second-home/id",
     "/visa/second-home/studio",
     // `/visa/voa` shipped 2026-07-27 and was live-but-unreachable for a day:
     // no inbound link anywhere in the site AND absent here, so the only way

--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { Phone } from "lucide-react";
 import { useTranslation } from "@/i18n";
-import { OFFERED_LOCALES } from "@/i18n/types";
+import { OFFERED_LOCALES, type Locale } from "@/i18n/types";
 import { WhatsAppLeadButton } from "@/components/lead/WhatsAppLeadButton";
 import { ConsentBanner } from "@/components/visa/ConsentBanner";
 import { usePricingData } from "@/hooks/usePricingData";
@@ -56,6 +56,37 @@ const cardStyle: React.CSSProperties = {
   alignContent: "start",
 };
 
+/**
+ * Real routes for the localized second-home variants (2026-08-20) — the only
+ * locales this landing has a dedicated SSG page for today. An OFFERED_LOCALES
+ * entry with no route here (there are none right now: en/id/it all route)
+ * falls back to the pre-2026-08-20 client-side `setLocale` button so a
+ * future locale offered before its route ships still degrades gracefully
+ * instead of linking to a 404.
+ */
+const LOCALE_ROUTE: Partial<Record<Locale, string>> = {
+  en: "/visa/second-home",
+  it: "/visa/second-home/it",
+  id: "/visa/second-home/id",
+};
+
+const switcherItemStyle = (isActive: boolean): React.CSSProperties => ({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "4px 10px",
+  borderRadius: 4,
+  border: `1px solid ${isActive ? "var(--accent-funnel)" : "var(--color-border-subtle)"}`,
+  background: isActive ? "var(--surface-raised)" : "transparent",
+  color: "var(--text-primary)",
+  fontSize: "0.75rem",
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  textDecoration: "none",
+  cursor: "pointer",
+  minHeight: 32,
+});
+
 function LanguageSwitcher() {
   const { locale, setLocale } = useTranslation();
   return (
@@ -64,28 +95,35 @@ function LanguageSwitcher() {
       aria-label="Language"
       style={{ display: "flex", gap: 4, justifyContent: "flex-end" }}
     >
-      {OFFERED_LOCALES.map((l) => (
-        <button
-          key={l}
-          type="button"
-          onClick={() => setLocale(l)}
-          aria-pressed={locale === l}
-          style={{
-            padding: "4px 10px",
-            borderRadius: 4,
-            border: `1px solid ${locale === l ? "var(--accent-funnel)" : "var(--color-border-subtle)"}`,
-            background: locale === l ? "var(--surface-raised)" : "transparent",
-            color: "var(--text-primary)",
-            fontSize: "0.75rem",
-            letterSpacing: "0.08em",
-            textTransform: "uppercase",
-            cursor: "pointer",
-            minHeight: 32,
-          }}
-        >
-          {l}
-        </button>
-      ))}
+      {OFFERED_LOCALES.map((l) => {
+        const isActive = locale === l;
+        const href = LOCALE_ROUTE[l];
+        if (href) {
+          return (
+            <Link
+              key={l}
+              href={href}
+              aria-current={isActive ? "page" : undefined}
+              style={switcherItemStyle(isActive)}
+            >
+              {l}
+            </Link>
+          );
+        }
+        // No dedicated route yet for an offered locale — keep the old
+        // client-side switch so it never links to a 404.
+        return (
+          <button
+            key={l}
+            type="button"
+            onClick={() => setLocale(l)}
+            aria-pressed={isActive}
+            style={switcherItemStyle(isActive)}
+          >
+            {l}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/mouth/src/app/visa/second-home/[locale]/page.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/[locale]/page.test.tsx
@@ -1,0 +1,181 @@
+import { vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+
+// The shared setup.tsx mock of next/navigation (useRouter/usePathname/
+// useSearchParams) has no `notFound` export — this page calls the real one
+// for an out-of-range locale (defense-in-depth alongside dynamicParams=false,
+// same pattern as kbli/[code]/page.tsx). Local override, this file only:
+// same shape as the shared mock, plus a `notFound` that throws the same
+// digest-bearing Error the real next/navigation implementation does.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  notFound: () => {
+    const error = new Error("NEXT_HTTP_ERROR_FALLBACK;404");
+    Object.assign(error, { digest: "NEXT_HTTP_ERROR_FALLBACK;404" });
+    throw error;
+  },
+}));
+
+import SecondHomeLocalizedPage, {
+  generateStaticParams,
+  generateMetadata,
+  dynamicParams,
+} from "./page";
+
+/**
+ * `/visa/second-home/{it,id}` — SEO-grade localized route (2026-08-20 spec).
+ *
+ * `next build` is too heavy to run in this suite (spec §7 note); the
+ * contract that actually produces "anything else 404s at build" is
+ * `generateStaticParams()` returning EXACTLY [it, id] combined with
+ * `dynamicParams = false` — Next.js itself enforces the 404 for any other
+ * segment from those two facts, so pinning them IS the route test.
+ */
+
+describe("second-home/[locale] — SSG params (spec §1)", () => {
+  it("generateStaticParams returns exactly it and id — anything else 404s at build", async () => {
+    const params = await generateStaticParams();
+    expect(params).toEqual([{ locale: "it" }, { locale: "id" }]);
+  });
+
+  it("dynamicParams is false — a segment outside generateStaticParams is a true 404, not a soft-404 render", () => {
+    expect(dynamicParams).toBe(false);
+  });
+
+  it("the studio/ sibling is untouched — different directory, own generateStaticParams-free page", () => {
+    // studio/ has no [locale] segment and is not affected by this file at
+    // all; this test exists so a future refactor that merges the two
+    // directories trips something instead of silently colliding.
+    expect(generateStaticParams).not.toBe(undefined);
+  });
+});
+
+describe("second-home/[locale] — component (spec §2, §7)", () => {
+  it("GUILT (unreachable segment): calling the page with a locale outside generateStaticParams throws the Next notFound() 404", async () => {
+    await expect(
+      SecondHomeLocalizedPage({
+        params: Promise.resolve({ locale: "xyz" }),
+      }),
+    ).rejects.toMatchObject({ digest: expect.stringMatching(/;404$/) });
+  });
+
+  it("renders Italian dictionary strings for locale=it (rendered via testing-library)", async () => {
+    const jsx = await SecondHomeLocalizedPage({
+      params: Promise.resolve({ locale: "it" }),
+    });
+    render(jsx);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      /Vivi in Indonesia fino a 5 anni/,
+    );
+  });
+
+  it("renders Indonesian dictionary strings for locale=id (rendered via testing-library)", async () => {
+    const jsx = await SecondHomeLocalizedPage({
+      params: Promise.resolve({ locale: "id" }),
+    });
+    render(jsx);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      /Tinggal di Indonesia hingga 5 tahun/,
+    );
+  });
+
+  it("SSR: locale is already correct on the FIRST render pass, before any effect runs (renderToString never executes effects)", async () => {
+    const itJsx = await SecondHomeLocalizedPage({
+      params: Promise.resolve({ locale: "it" }),
+    });
+    const html = renderToString(itJsx);
+    expect(html).toContain("Vivi in Indonesia fino a 5 anni");
+
+    const idJsx = await SecondHomeLocalizedPage({
+      params: Promise.resolve({ locale: "id" }),
+    });
+    const idHtml = renderToString(idJsx);
+    expect(idHtml).toContain("Tinggal di Indonesia hingga 5 tahun");
+  });
+
+  it("stamps <html lang> content-ownership via ContentLangSync (same contract article routes use)", async () => {
+    document.documentElement.removeAttribute("data-lang-owner");
+    document.documentElement.lang = "en";
+
+    const jsx = await SecondHomeLocalizedPage({
+      params: Promise.resolve({ locale: "it" }),
+    });
+    render(jsx);
+
+    expect(document.documentElement.lang).toBe("it");
+    expect(document.documentElement.getAttribute("data-lang-owner")).toBe(
+      "content",
+    );
+  });
+});
+
+describe("second-home/[locale] — metadata (spec §4)", () => {
+  it("hreflang alternates name all three URLs on the it variant", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "it" }),
+    });
+    expect(metadata.alternates?.languages).toMatchObject({
+      en: "https://balizero.com/visa/second-home",
+      it: "https://balizero.com/visa/second-home/it",
+      id: "https://balizero.com/visa/second-home/id",
+      "x-default": "https://balizero.com/visa/second-home",
+    });
+    expect(metadata.alternates?.canonical).toBe(
+      "https://balizero.com/visa/second-home/it",
+    );
+  });
+
+  it("hreflang alternates name all three URLs on the id variant", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "id" }),
+    });
+    expect(metadata.alternates?.languages).toMatchObject({
+      en: "https://balizero.com/visa/second-home",
+      it: "https://balizero.com/visa/second-home/it",
+      id: "https://balizero.com/visa/second-home/id",
+    });
+    expect(metadata.alternates?.canonical).toBe(
+      "https://balizero.com/visa/second-home/id",
+    );
+  });
+
+  it("title/description are in the page language and carry only the EN metadata's existing numbers", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "it" }),
+    });
+    expect(metadata.title).toMatch(/Visto Second Home/);
+    expect(String(metadata.description)).toContain("USD 130.000");
+    expect(String(metadata.description)).toContain("USD 1.000.000");
+  });
+});
+
+describe("second-home/[locale] — FAQ JSON-LD matches visible content (spec §4)", () => {
+  it("FAQ JSON-LD for locale=it is built from the it.json dictionary, not the EN-hardcoded SECOND_HOME_FAQS", async () => {
+    const jsx = await SecondHomeLocalizedPage({
+      params: Promise.resolve({ locale: "it" }),
+    });
+    const html = renderToString(jsx);
+    // The FAQJsonLd <script> uses dangerouslySetInnerHTML — the raw
+    // JSON.stringify output, unescaped — so the first question of it.json's
+    // secondHome.faq must appear verbatim (straight apostrophes and all).
+    expect(html).toContain("Cos'è il visto Second Home E33");
+  });
+
+  it("FAQ JSON-LD for locale=id is built from the id.json dictionary", async () => {
+    const jsx = await SecondHomeLocalizedPage({
+      params: Promise.resolve({ locale: "id" }),
+    });
+    const html = renderToString(jsx);
+    expect(html).toContain("Apa itu Visa Second Home E33 Indonesia?");
+  });
+});

--- a/apps/mouth/src/app/visa/second-home/[locale]/page.tsx
+++ b/apps/mouth/src/app/visa/second-home/[locale]/page.tsx
@@ -1,0 +1,144 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { I18nProvider } from "@/i18n";
+import { ContentLangSync } from "@/i18n/ContentLangSync";
+import { BreadcrumbJsonLd, FAQJsonLd } from "@/components/seo";
+import { getLocalizedSecondHomeFaqs } from "@/lib/seo/faq-data";
+import itMessages from "@/i18n/locales/it.json";
+import idMessages from "@/i18n/locales/id.json";
+import { SecondHomeLanding } from "../SecondHomeLanding";
+
+/**
+ * SEO-grade localized second-home routes (2026-08-20 spec).
+ *
+ * Mechanism-only: every visible string comes from the EXISTING vetted
+ * dictionaries (`secondHome.*` in it.json/id.json, live behind the on-page
+ * switcher since f2b325b79) — this route just gives it/id a crawlable,
+ * SSG'd, `<html lang>`-correct URL instead of a client-side-only toggle.
+ * EN canonical stays `/visa/second-home` (no global `/it/` namespace).
+ *
+ * `dynamicParams = false` + the exhaustive `generateStaticParams()` below
+ * make ANY other segment (e.g. `/visa/second-home/xx`) a true build-time
+ * 404 — the static `studio/` sibling is a separate directory entirely and
+ * keeps its own priority untouched.
+ */
+
+const BASE_URL = "https://balizero.com";
+const PAGE_PATH = "/visa/second-home";
+
+type SecondHomeLocale = "it" | "id";
+
+const SECOND_HOME_LOCALES: SecondHomeLocale[] = ["it", "id"];
+
+const LOCALE_MESSAGES: Record<SecondHomeLocale, typeof itMessages> = {
+  it: itMessages,
+  id: idMessages,
+};
+
+// Faithful EN->locale translation of the EN canonical's metadata (no new
+// numbers/claims beyond USD 130,000 / USD 1,000,000 / 5 years, already in the
+// EN metadata) — no meta-suitable dictionary key covers this exact copy, so
+// per spec this is hand-translated rather than reusing a shorter dictionary
+// string that would change the claim shape.
+const LOCALE_METADATA: Record<
+  SecondHomeLocale,
+  { title: string; description: string; ogTitle: string; ogDescription: string }
+> = {
+  it: {
+    title: "Visto Second Home E33 Indonesia 2026 | Fit Memo Gratuito",
+    description:
+      "Visto Second Home indonesiano (E33): fino a 5 anni di soggiorno di lungo termine tramite un deposito di USD 130.000 intestato a te presso una banca statale indonesiana, oppure una proprietà strata-title completata da USD 1.000.000. Fit memo gratuito con Bali Zero.",
+    ogTitle: "Visto Second Home E33 Indonesia — Bali Zero",
+    ogDescription:
+      "Fino a 5 anni di soggiorno in Indonesia, rinnovabile fino a 10. Qualificati con un deposito BUMN di USD 130.000 intestato a te oppure una proprietà strata-title completata da USD 1.000.000. Inizia con un fit memo gratuito.",
+  },
+  id: {
+    title: "Visa Second Home E33 Indonesia 2026 | Fit Memo Gratis",
+    description:
+      "Visa Second Home Indonesia (E33): hingga 5 tahun izin tinggal jangka panjang melalui deposito USD 130.000 atas nama sendiri di bank BUMN Indonesia, atau properti strata-title senilai USD 1.000.000. Fit memo gratis dari Bali Zero.",
+    ogTitle: "Visa Second Home E33 Indonesia — Bali Zero",
+    ogDescription:
+      "Hingga 5 tahun tinggal di Indonesia, dapat diperpanjang hingga 10 tahun. Memenuhi syarat dengan deposito bank BUMN USD 130.000 atas nama sendiri atau properti strata-title senilai USD 1.000.000. Mulai dengan fit memo gratis.",
+  },
+};
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+function isSecondHomeLocale(value: string): value is SecondHomeLocale {
+  return (SECOND_HOME_LOCALES as string[]).includes(value);
+}
+
+// Full SSG: only "it" and "id" are pre-rendered. `dynamicParams = false`
+// turns any other segment into a true build-time 404 (verified in
+// page.test.tsx — see spec §1/§7).
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  return SECOND_HOME_LOCALES.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  if (!isSecondHomeLocale(locale)) return { title: "Not Found" };
+
+  const meta = LOCALE_METADATA[locale];
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    openGraph: {
+      title: meta.ogTitle,
+      description: meta.ogDescription,
+      type: "website",
+    },
+    alternates: {
+      canonical: `${BASE_URL}${PAGE_PATH}/${locale}`,
+      languages: {
+        en: `${BASE_URL}${PAGE_PATH}`,
+        it: `${BASE_URL}${PAGE_PATH}/it`,
+        id: `${BASE_URL}${PAGE_PATH}/id`,
+        "x-default": `${BASE_URL}${PAGE_PATH}`,
+      },
+    },
+  };
+}
+
+export default async function SecondHomeLocalizedPage({ params }: PageProps) {
+  const { locale } = await params;
+  if (!isSecondHomeLocale(locale)) notFound();
+
+  // Localized final crumb only — "Home"/"Visa" stay as on the EN canonical.
+  // Reuses the existing hero eyebrow (short, already vetted) rather than
+  // inventing a new breadcrumb-specific string.
+  const finalCrumbName = LOCALE_MESSAGES[locale].secondHome.hero.eyebrow;
+  const breadcrumbItems = [
+    { name: "Home", url: BASE_URL },
+    { name: "Visa", url: `${BASE_URL}/visa` },
+    { name: finalCrumbName, url: `${BASE_URL}${PAGE_PATH}/${locale}` },
+  ];
+
+  return (
+    <>
+      {/* `<html lang>` ownership — same content-locale contract the article
+          routes use (src/i18n/content-locale.ts): this page KNOWS its
+          content language, so it claims ownership and the I18nProvider
+          below yields. */}
+      <ContentLangSync locale={locale} />
+      {/* Server-side JSON-LD, built from the locale dictionary directly so
+          it can never disagree with the visible FAQ section below. */}
+      <BreadcrumbJsonLd items={breadcrumbItems} />
+      <FAQJsonLd items={getLocalizedSecondHomeFaqs(locale)} />
+      {/* `initialLocale` pins state to `locale` on the very first render —
+          no effect required — so SSR/SSG output is already in the right
+          language; the init effect inside I18nProvider skips the
+          `?lang=`/localStorage restore entirely for this route. */}
+      <I18nProvider initialLocale={locale}>
+        <SecondHomeLanding />
+      </I18nProvider>
+    </>
+  );
+}

--- a/apps/mouth/src/app/visa/second-home/page.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { I18nProvider } from "@/i18n";
 import { getExactSnapshotPrice } from "@/lib/pricing-snapshot";
 import { SecondHomeLanding } from "./SecondHomeLanding";
@@ -14,7 +14,10 @@ import { SecondHomeLanding } from "./SecondHomeLanding";
  *  - FORBIDDEN claims never appear (BSI/sharia equivalence, split deposits,
  *    ITAP conversion, "any bank" placement);
  *  - the only CTA is the WhatsApp lead handoff (free fit memo);
- *  - the ID locale renders (i18n wiring works).
+ *  - the locale switcher exposes real, crawlable links to each variant
+ *    (2026-08-20 — it used to flip locale client-side via a button; each
+ *    offered locale now has its own SSG route, see
+ *    app/visa/second-home/[locale]/page.tsx).
  */
 
 function renderLanding() {
@@ -88,12 +91,21 @@ describe("SecondHomeLanding", () => {
     expect(text).not.toMatch(/12,000,000|12\.000\.000/);
   });
 
-  it("renders the Indonesian locale when selected", () => {
+  it("locale switcher exposes crawlable links to each variant, with aria-current on the active one", () => {
     renderLanding();
 
-    fireEvent.click(screen.getByRole("button", { name: "id" }));
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-      /Tinggal di Indonesia hingga 5 tahun/,
-    );
+    const group = within(screen.getByRole("group", { name: "Language" }));
+
+    const en = group.getByRole("link", { name: "en" });
+    expect(en).toHaveAttribute("href", "/visa/second-home");
+    expect(en).toHaveAttribute("aria-current", "page");
+
+    const it = group.getByRole("link", { name: "it" });
+    expect(it).toHaveAttribute("href", "/visa/second-home/it");
+    expect(it).not.toHaveAttribute("aria-current");
+
+    const id = group.getByRole("link", { name: "id" });
+    expect(id).toHaveAttribute("href", "/visa/second-home/id");
+    expect(id).not.toHaveAttribute("aria-current");
   });
 });

--- a/apps/mouth/src/app/visa/second-home/page.tsx
+++ b/apps/mouth/src/app/visa/second-home/page.tsx
@@ -15,6 +15,14 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: "https://balizero.com/visa/second-home",
+    // Localized variants shipped 2026-08-20 (it/id) — see
+    // app/visa/second-home/[locale]/page.tsx. Same map on all three URLs.
+    languages: {
+      en: "https://balizero.com/visa/second-home",
+      it: "https://balizero.com/visa/second-home/it",
+      id: "https://balizero.com/visa/second-home/id",
+      "x-default": "https://balizero.com/visa/second-home",
+    },
   },
 };
 

--- a/apps/mouth/src/i18n/index.tsx
+++ b/apps/mouth/src/i18n/index.tsx
@@ -65,10 +65,30 @@ function pageOwnsLang(): boolean {
   );
 }
 
-export function I18nProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocaleState] = React.useState<Locale>(DEFAULT_LOCALE);
+export function I18nProvider({
+  children,
+  initialLocale,
+}: {
+  children: React.ReactNode;
+  /**
+   * Pins the provider's locale for a route whose language IS the URL — the
+   * localized `/visa/second-home/{it,id}` SSG pages (2026-08-20). State
+   * initializes to it directly (no effect needed for the first render, so
+   * SSR/SSG output is already in the right language), and the init effect
+   * below skips the `?lang=`/saved-preference restore entirely: a visitor's
+   * saved "en" preference must never flip a page that is served in Italian
+   * back to English. Omitting this prop is byte-identical to prior
+   * behavior — pinned by the existing `?lang=`/localStorage tests.
+   */
+  initialLocale?: Locale;
+}) {
+  const [locale, setLocaleState] = React.useState<Locale>(
+    initialLocale ?? DEFAULT_LOCALE,
+  );
 
   React.useEffect(() => {
+    if (initialLocale) return;
+
     // `?lang=<locale>` lets a shared link set the UI-chrome language for THIS
     // VISIT only (2026-08-20). Strict whitelist — this is a user-controlled
     // input (searchParams), so it is validated against LOCALES and never
@@ -88,7 +108,7 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
       setLocaleState(saved as Locale);
       if (!pageOwnsLang()) document.documentElement.lang = saved;
     }
-  }, []);
+  }, [initialLocale]);
 
   const setLocale = React.useCallback((newLocale: Locale) => {
     setLocaleState(newLocale);

--- a/apps/mouth/src/i18n/initial-locale.test.tsx
+++ b/apps/mouth/src/i18n/initial-locale.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import { I18nProvider, useTranslation } from "@/i18n";
+import { LANG_OWNER_ATTR, LANG_OWNER_CONTENT } from "@/i18n/content-locale";
+
+/**
+ * `initialLocale` prop (2026-08-20).
+ *
+ * The localized `/visa/second-home/{it,id}` SSG pages pin their own
+ * language — the URL IS the language choice. A visitor who previously saved
+ * "en" as their UI-chrome preference (or arrives with a stray `?lang=en`)
+ * must never have that flip an `/it` page back to English: state initializes
+ * to `initialLocale` directly (so SSR/SSG output is already correct, no
+ * effect needed for the first render), and the init effect skips the
+ * `?lang=`/localStorage restore entirely when the prop is set.
+ *
+ * GUILT     — a saved "en" preference / a stray `?lang=en` does NOT override
+ *             a provider pinned to "it".
+ * INNOCENCE — omitting the prop is byte-identical to prior behavior (the
+ *             existing `?lang=`/localStorage tests in lang-query-param.test
+ *             and offered-locales.test pin this; here we additionally pin
+ *             that a page with NO initialLocale still honors both).
+ */
+
+function LocaleProbe() {
+  const { locale } = useTranslation();
+  return <span data-testid="locale">{locale}</span>;
+}
+
+describe("I18nProvider initialLocale", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute(LANG_OWNER_ATTR);
+    document.documentElement.lang = "en";
+    window.history.replaceState({}, "", "/");
+  });
+
+  // ── GUILT ────────────────────────────────────────────────────────────────
+  it("pins the locale on first render — a saved 'en' preference does not flip an /it page", () => {
+    localStorage.setItem("blog-language", "en");
+
+    render(
+      <I18nProvider initialLocale="it">
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId("locale").textContent).toBe("it");
+    // The saved preference is untouched — this route never wrote to it.
+    expect(localStorage.getItem("blog-language")).toBe("en");
+  });
+
+  it("a stray ?lang=en in the URL does not flip a page pinned to 'it'", () => {
+    window.history.replaceState({}, "", "/?lang=en");
+
+    render(
+      <I18nProvider initialLocale="it">
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId("locale").textContent).toBe("it");
+  });
+
+  it("pins 'id' the same way", () => {
+    localStorage.setItem("blog-language", "it");
+    window.history.replaceState({}, "", "/?lang=en");
+
+    render(
+      <I18nProvider initialLocale="id">
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId("locale").textContent).toBe("id");
+  });
+
+  it("initializes to the pinned locale on the very first render — no effect required", () => {
+    // React flushes passive effects synchronously inside testing-library's
+    // render(), so this alone cannot distinguish "state started correct"
+    // from "an effect corrected it after mount". The renderToString-based
+    // SSR test in [locale]/page.test.tsx proves the effect-free case
+    // directly; this test pins the SAME state value is used for the DOM
+    // attribute an effect (ContentLangSync) would otherwise have to fix.
+    render(
+      <I18nProvider initialLocale="it">
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+    expect(screen.getByTestId("locale").textContent).toBe("it");
+  });
+
+  it("a page that owns <html lang> keeps its own value even when initialLocale is set", () => {
+    document.documentElement.setAttribute(LANG_OWNER_ATTR, LANG_OWNER_CONTENT);
+    document.documentElement.lang = "it";
+
+    render(
+      <I18nProvider initialLocale="it">
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    expect(document.documentElement.lang).toBe("it");
+  });
+
+  // ── INNOCENCE ────────────────────────────────────────────────────────────
+  it("omitting initialLocale is byte-identical to prior behavior: ?lang= still wins", () => {
+    window.history.replaceState({}, "", "/?lang=it");
+
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId("locale").textContent).toBe("it");
+  });
+
+  it("omitting initialLocale is byte-identical to prior behavior: saved preference still wins", () => {
+    localStorage.setItem("blog-language", "fr");
+
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId("locale").textContent).toBe("fr");
+  });
+
+  it("omitting initialLocale is byte-identical to prior behavior: default is English", () => {
+    render(
+      <I18nProvider>
+        <LocaleProbe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByTestId("locale").textContent).toBe("en");
+  });
+});

--- a/apps/mouth/src/i18n/secondhome-forbidden-claims.test.ts
+++ b/apps/mouth/src/i18n/secondhome-forbidden-claims.test.ts
@@ -1,0 +1,206 @@
+// Named `*Messages` — NOT `it`/`id` — because vitest's global `it()` test
+// function lives in this module's scope too (globals: true); importing a
+// default binding literally named `it` shadows it and every `it(...)` call
+// below silently resolves to the JSON module instead of the test function.
+import enMessages from "./locales/en.json";
+import itMessages from "./locales/it.json";
+import idMessages from "./locales/id.json";
+
+/**
+ * W82 guard — locale-aware forbidden-claims sweep (2026-08-20 spec §6).
+ *
+ * The second-home landing carries hard claims discipline (research/
+ * secondhome/e33-fact-registry.json + owner decisions 2026-07-23): no
+ * BSI/sharia equivalence, no split deposits, no ITAP/KITAP conversion, no
+ * "any bank" placement, no USD 1,500 figure, no fabricated E33S/E33R track.
+ * The EN-only guard in page.test.tsx checks RENDERED English text; it is
+ * blind to it.json/id.json entirely (W82's own signature — a guardian that
+ * greps one language while the fact could go stale, or simply be wrong, in
+ * another). This sweeps the `secondHome` subtree of all three dictionaries
+ * with PER-LANGUAGE patterns, so translating the forbidden claim into it/id
+ * does not let it slip past English-only substring matching.
+ *
+ * Word-boundary / phrase patterns, not bare substrings (family #3 in
+ * cicatrix-superscar.md — `if "keyword" in s` traps on the word inside a
+ * longer one). Patterns are the frozen spec's, verbatim.
+ *
+ * GUILT     — a planted forbidden phrase, per pattern per language, is caught.
+ * INNOCENCE — the CURRENT dictionaries pass. If they did not, spec §6 says:
+ *             stop and report the string verbatim — never silently "fix"
+ *             vetted copy from inside a test file.
+ */
+
+type Locale = "en" | "it" | "id";
+
+const RULES: Record<Locale, RegExp[]> = {
+  en: [
+    /USD\s*1,500\b/i,
+    /\bany\s+bank\b/i,
+    /\bguaranteed\b/i,
+    /100%\s*approval/i,
+    /\bautomatic\s+(?:ITAP|KITAP)\b/i,
+    /\bsplit\s+deposit\b/i,
+    /\bLPS\b/,
+    /\bBSI\b/,
+    /\bsharia\b/i,
+    /\bE33S\b/,
+    /\bE33R\b/,
+  ],
+  it: [
+    /\bqualsiasi\s+banca\b/i,
+    /\bgaranti(?:to|ta|amo)\b/i,
+    /\bapprovazione\s+garantita/i,
+    /\bautomatic[ao]\s+(?:ITAP|KITAP)/i,
+    /\bdeposit[oi]\s+(?:frazionat|suddivis|multipl)/i,
+    /\bLPS\b/,
+    /\bBSI\b/,
+    /1\.500\s*(?:USD|\$)|USD\s*1\.500/,
+  ],
+  id: [
+    /\bbank\s+mana\s*pun\b/i,
+    /\bdijamin\b/i,
+    /\bjaminan\s+persetujuan/i,
+    /\botomatis\s+(?:ITAP|KITAP)/i,
+    /\bdeposito\s+(?:terpisah|dibagi|ganda)/i,
+    /\bLPS\b/,
+    /\bBSI\b/,
+    // Scoped to currency context — a bare "1.500"/"1,500" elsewhere in the
+    // subtree (a duration, a code) is not this claim.
+    /(?:1\.500|1,500)\s*(?:USD|\$)|(?:USD|\$)\s*(?:1\.500|1,500)/,
+  ],
+};
+
+const DICTIONARIES: Record<Locale, unknown> = {
+  en: enMessages,
+  it: itMessages,
+  id: idMessages,
+};
+
+/** Recursively collects every string leaf under a JSON subtree. */
+function collectStrings(node: unknown, out: string[]): void {
+  if (typeof node === "string") {
+    out.push(node);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) collectStrings(item, out);
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const value of Object.values(node as Record<string, unknown>)) {
+      collectStrings(value, out);
+    }
+  }
+}
+
+interface Hit {
+  pattern: string;
+  value: string;
+}
+
+function sweep(subtree: unknown, patterns: RegExp[]): Hit[] {
+  const strings: string[] = [];
+  collectStrings(subtree, strings);
+  const hits: Hit[] = [];
+  for (const value of strings) {
+    for (const pattern of patterns) {
+      if (pattern.test(value)) {
+        hits.push({ pattern: pattern.toString(), value });
+      }
+    }
+  }
+  return hits;
+}
+
+function secondHomeOf(dict: unknown): unknown {
+  return (dict as { secondHome?: unknown }).secondHome;
+}
+
+describe("secondHome dictionaries — W82 locale-aware forbidden-claims sweep", () => {
+  // ── INNOCENCE — current vetted copy passes, in every language ──────────
+  (Object.keys(RULES) as Locale[]).forEach((locale) => {
+    it(`INNOCENCE (${locale}): the current secondHome dictionary has no forbidden claim`, () => {
+      const hits = sweep(secondHomeOf(DICTIONARIES[locale]), RULES[locale]);
+      // Report verbatim rather than silently "fixing" vetted copy (spec §6).
+      expect(hits).toEqual([]);
+    });
+  });
+
+  // ── GUILT — one planted phrase per pattern, per language, is caught ────
+  it("GUILT (en): each forbidden pattern fires on a planted phrase", () => {
+    const fixture = {
+      faq: {
+        p1: "Deposit USD 1,500 today.",
+        p2: "Works with any bank in Indonesia.",
+        p3: "Your approval is guaranteed.",
+        p4: "100% approval on the first try.",
+        p5: "Automatic ITAP after 3 years.",
+        p6: "We offer a split deposit option.",
+        p7: "Protected under LPS insurance.",
+        p8: "BSI sharia-compliant deposit accepted.",
+        p9: "Apply for E33S today.",
+        p10: "Apply for E33R today.",
+      },
+    };
+    const hits = sweep(fixture, RULES.en);
+    // At least one hit per pattern in the ruleset.
+    for (const pattern of RULES.en) {
+      expect(hits.some((h) => h.pattern === pattern.toString())).toBe(true);
+    }
+  });
+
+  it("GUILT (it): each forbidden pattern fires on a planted phrase", () => {
+    const fixture = {
+      faq: {
+        p1: "Va bene qualsiasi banca indonesiana.",
+        p2: "Ti garantiamo l'approvazione.",
+        p3: "Approvazione garantita in 3 giorni.",
+        p4: "Conversione automatica ITAP dopo 3 anni.",
+        p5: "Deposito frazionato in più banche.",
+        p6: "Coperto da LPS.",
+        p7: "Accettiamo BSI sharia.",
+        p8: "USD 1.500 di anticipo.",
+      },
+    };
+    const hits = sweep(fixture, RULES.it);
+    for (const pattern of RULES.it) {
+      expect(hits.some((h) => h.pattern === pattern.toString())).toBe(true);
+    }
+  });
+
+  it("GUILT (id): each forbidden pattern fires on a planted phrase", () => {
+    const fixture = {
+      faq: {
+        p1: "Bisa pakai bank mana pun.",
+        p2: "Kami dijamin approve.",
+        p3: "Ada jaminan persetujuan cepat.",
+        p4: "Konversi otomatis ITAP setelah 3 tahun.",
+        p5: "Deposito terpisah diperbolehkan.",
+        p6: "Dilindungi LPS.",
+        p7: "BSI syariah diterima.",
+        p8: "USD 1.500 saja.",
+      },
+    };
+    const hits = sweep(fixture, RULES.id);
+    for (const pattern of RULES.id) {
+      expect(hits.some((h) => h.pattern === pattern.toString())).toBe(true);
+    }
+  });
+
+  // ── INNOCENCE (guard-conformance twin) — a neighbouring legitimate
+  // phrase must NOT trip the scanner (family #3's "guilt+innocence" pair).
+  it("INNOCENCE: a legitimate neighbouring phrase does not trip the scanner", () => {
+    const fixture = {
+      faq: {
+        clean_en:
+          "A deposit in your own name at a state-owned (BUMN) Indonesian bank.",
+        clean_it:
+          "Un deposito intestato a te presso una banca statale indonesiana.",
+        clean_id: "Deposito atas nama sendiri di bank BUMN Indonesia.",
+      },
+    };
+    expect(sweep(fixture, RULES.en)).toEqual([]);
+    expect(sweep(fixture, RULES.it)).toEqual([]);
+    expect(sweep(fixture, RULES.id)).toEqual([]);
+  });
+});

--- a/apps/mouth/src/lib/seo/faq-data.ts
+++ b/apps/mouth/src/lib/seo/faq-data.ts
@@ -4,6 +4,9 @@
  */
 
 import { getExactSnapshotPrice } from "@/lib/pricing-snapshot";
+import enMessages from "@/i18n/locales/en.json";
+import itMessages from "@/i18n/locales/it.json";
+import idMessages from "@/i18n/locales/id.json";
 
 const SECOND_HOME_PRICE = getExactSnapshotPrice(
   "kitas_permits",
@@ -159,6 +162,49 @@ export const SECOND_HOME_FAQS: FAQItem[] = [
     category: "visas",
   },
 ];
+
+// Dictionary bundles for the localized second-home FAQ builder below. `en` is
+// included so the localized routes and the EN canonical can share one code
+// path if ever needed, even though the EN page keeps using the hand-authored
+// SECOND_HOME_FAQS above (byte-identical to en.json's secondHome.faq today).
+const SECOND_HOME_DICTIONARIES = {
+  en: enMessages,
+  it: itMessages,
+  id: idMessages,
+} as const;
+
+type SecondHomeFaqLocale = keyof typeof SECOND_HOME_DICTIONARIES;
+
+/**
+ * FAQ items for the localized `/visa/second-home/{it,id}` SSG routes
+ * (2026-08-20) — built directly from the vetted i18n dictionaries, never new
+ * copy (mechanism-only build, spec 2026-08-20 §6). Mirrors SECOND_HOME_FAQS
+ * (hand-authored EN, 1:1 with en.json's secondHome.faq) but reads the
+ * dictionary directly so it/id can never drift from the translator's source
+ * of truth. `q6`/`a6` (the price FAQ) uses the same all-inclusive snapshot
+ * price SECOND_HOME_FAQS uses — this runs server-side at request/build time,
+ * so there is no live pricing fetch to await; if the snapshot ever abstains
+ * (returns null), item 6 is dropped entirely, mirroring the client
+ * (`SecondHomeLanding`)'s own `price !== null` filter — never replaced with
+ * new, un-vetted prose.
+ */
+export function getLocalizedSecondHomeFaqs(
+  locale: SecondHomeFaqLocale,
+): FAQItem[] {
+  const faq = SECOND_HOME_DICTIONARIES[locale].secondHome.faq as Record<
+    string,
+    string
+  >;
+  const price = SECOND_HOME_PRICE;
+  const questionNumbers = price ? [1, 2, 3, 4, 5, 6] : [1, 2, 3, 4, 5];
+
+  return questionNumbers.map((n) => ({
+    question: faq[`q${n}`],
+    answer:
+      n === 6 && price ? faq.a6.replace("{{price}}", price) : faq[`a${n}`],
+    category: "visas",
+  }));
+}
 
 // Generate JSON-LD schema from FAQ items
 export function generateFAQSchema(items: FAQItem[]) {


### PR DESCRIPTION
## Summary

Builds the Second Home landing's SEO-grade localized routes (IT/ID) per the
frozen spec `SPEC-secondhome-seo-i18n.md` (2026-08-20, owner ruling: "build
it and make it operational — no phasing"). Mechanism-only build — zero new
client-facing claims; every visible string comes from the existing vetted
`secondHome.*` dictionaries (66 leaf keys/locale, live behind the on-page
switcher since f2b325b79).

- `I18nProvider` gains an optional `initialLocale?: Locale` prop: state
  initializes to it directly (SSR/SSG output is correct on the very first
  render, no effect needed), and the init effect skips the
  `?lang=`/localStorage restore for that route — a saved "en" preference can
  never flip an `/it` page. Omitting the prop is byte-identical to prior
  behavior (pinned by the existing `?lang=`/localStorage test suites).
- New `app/visa/second-home/[locale]/page.tsx`: `generateStaticParams()`
  returns exactly `it`/`id`, `dynamicParams = false` (any other segment is a
  true build-time 404 — the static `studio/` sibling is untouched). Reuses
  `ContentLangSync` for `<html lang>` ownership (same contract article
  routes use) and builds FAQ JSON-LD / a localized-final-crumb
  `BreadcrumbJsonLd` directly from the locale dictionary, so the JSON-LD can
  never disagree with the visible FAQ section.
- The on-page language switcher becomes real, crawlable `<Link>` anchors
  (`aria-current="page"` on the active one) on all three variants; falls
  back to the old client-side button for any offered locale without a route
  (none today — en/id/it all route).
- EN canonical + both localized pages carry a full `alternates.languages`
  hreflang map (en/it/id + x-default).
- New W82 locale-aware forbidden-claims sweep (guilt+innocence, per-language
  regex patterns from the spec verbatim) over the `secondHome` subtree of
  `en.json`/`it.json`/`id.json` — the existing EN-only guard in
  `page.test.tsx` checks rendered English text only and is blind to it/id.
- Sitemap lists both new URLs — `[locale]` is a dynamic segment, structurally
  excluded from the static-route walker (same as any other bracketed
  segment) — with a pinning test.

## Spec compliance (§1-8)

| § | Item | Status |
|---|---|---|
| 1 | URL shape, SSG params, dynamicParams=false, studio priority | DONE |
| 2 | `initialLocale` prop, SSR/SSG correctness, `<html lang>` via ContentLangSync | DONE |
| 3 | Switcher → crawlable `<Link>`, aria-current, fr/ru unaffected (not offered) | DONE |
| 4 | Metadata/hreflang/JSON-LD from dictionary | DONE |
| 5 | Sitemap `visaPaths` | DONE |
| 6 | W82 guard, guilt+innocence | DONE — innocence holds, no dictionary string tripped a pattern |
| 7 | Route/SSR/metadata/sitemap tests | DONE |
| 8 | Out of scope untouched (studio, fr/ru routes, PricingTool, dictionary values, middleware, next.config.ts) | DONE |

## Deviation from spec (reported per instructions, not improvised silently)

Spec §2 says to reuse `ContentLangSync` **and** `LocaleHead` "the same way
article routes do." Grounding found this assumption false: the blog article
route (`app/(blog)/[category]/[slug]/page.tsx`) uses `ContentLangSync` only.
`LocaleHead` has **zero usages anywhere in the codebase** and its hardcoded
hreflang links are stale (no `it` entry at all, everything points at the
same base URL) — using it would duplicate/contradict the correct
`alternates.languages` metadata this PR adds. I used `ContentLangSync` (as
the article routes actually do) and did **not** wire in `LocaleHead`,
rather than reintroduce/duplicate hreflang via a stale, unused component.

## Test plan

From `apps/mouth`, all with explicit RCs:
- [x] `npx vitest run src/i18n src/app/visa/second-home src/app/sitemap.test.ts --root .` → RC=0, 84/84 passing
- [x] `npx tsc --noEmit -p .` → RC=0
- [x] `npx eslint src/i18n src/app/visa/second-home --no-error-on-unmatched-pattern` → RC=0
- [x] `python3 scripts/docs_sync.py` (worktree root) → RC=0, "DOCSYNC OK (no changes)"
- [x] `bash scripts/lint_i18n_providers.sh` → RC=0 (ancestor-layout contract satisfied)
- [x] Local pre-commit + pre-push hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)