### PR TITLE
feat(visa-engine): RulePack seq-12 — weekly re-attestation of all 18 portal sources

### DIFF
--- a/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq12.py
+++ b/apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq12.py
@@ -1,0 +1,362 @@
+"""fold_pack_seq12.py — assemble RulePack seq-12 from seq-11 + the inc5
+freshness re-stamps. One concern, nothing else changes:
+
+**Source re-stamp only.** All 18 OFFICIAL_PORTAL source_records get
+``verified_at``/``verified_by`` bumped, each backed by a live QW-5-method
+re-verification (inc5-pack-edits/freshness-restamp-2026-08-20.md — 17
+CURRENT + 1 CURRENT-with-standing-exception, 0 CHANGED, 0 UNREACHABLE,
+zero drops). ``content_sha256`` is untouched on every record: no page
+changed semantically, so the description stays; only the attestation
+clock moves. This is the weekly re-attestation lane (Zero GO 2026-08-20)
+that keeps the active pack's portal sources inside their 7-day
+``freshness_policy`` window — without it, production trips
+``DECISIVE_SOURCE_STALE`` and abstains on ~2026-08-26.
+
+No rule edits, no product edits, no drops. ``_assert_untouched`` holds
+``rules`` and ``products`` to whole-collection canonical equality with
+seq-11 — there is no carve-out to make.
+
+The restamped set is derived from the payload by ENTITY, never from a
+frozen id list: it must equal exactly the set of records whose
+``authority_type`` is ``OFFICIAL_PORTAL`` (all of which carry the 7-day
+policy). The count 18 is additionally pinned as a drift tripwire — if the
+pack gains or loses a portal source, this fold was authored against a
+different world and must abort, not adapt.
+
+Every input is read from disk at run time. The chain hash is read LIVE
+from ``rulepack-prod-011.signed.json`` and asserted against the expected
+anchor; the seq-11 source bytes are additionally re-hashed (RFC 8785 JCS)
+and must equal that same value — a source/signed mismatch aborts the
+fold. Every restamp carries ledger-drift guards ({current_value,
+new_value} pairs asserted against the seq-11 bytes before mutating).
+Deterministic: fixed timestamps, no ``datetime.now()`` — re-running is
+byte-identical.
+
+Usage::
+
+    PYTHONPATH=. python -m backend.scripts.visa_engine.fold_pack_seq12
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+from backend.services.visa_engine.bundle import canonicalize_json
+from backend.services.visa_engine.models import RulePackPayload
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_THIS_FILE = Path(__file__).resolve()
+_BACKEND_ROOT = _THIS_FILE.parents[2]  # apps/backend-rag/backend
+_REPO_ROOT = _THIS_FILE.parents[5]
+
+_PACKS_DIR = _BACKEND_ROOT / "services" / "visa_engine" / "contracts" / "packs"
+_SEQ11_SOURCE = _PACKS_DIR / "rulepack-prod-011.source.json"
+_SEQ11_SIGNED = _PACKS_DIR / "rulepack-prod-011.signed.json"
+_SEQ12_SOURCE = _PACKS_DIR / "rulepack-prod-012.source.json"
+
+_INC5_EDITS_DIR = _REPO_ROOT / "research" / "visa" / "doctrine-factory" / "e5" / "inc5-pack-edits"
+_RESTAMP_EDITS = _INC5_EDITS_DIR / "source-restamp-edits.json"
+
+_PRETTIER_BIN = _REPO_ROOT / "node_modules" / ".bin" / "prettier"
+
+# ---------------------------------------------------------------------------
+# seq-12 identity (the uuid5 anchor is verified, never assumed)
+# ---------------------------------------------------------------------------
+
+_SEQ12_SEQUENCE = 12
+_SEQ12_VERSION = "2026.8.20"  # same-day precedent: seq-2/seq-3 shared 2026.8.8
+_SEQ12_RULE_PACK_ID_URL = (
+    "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/12"
+)
+_EXPECTED_SEQ12_RULE_PACK_ID = uuid.UUID("dd98e153-4f89-5176-b32e-d936b7bb2351")
+
+# The signed seq-11 payload hash this pack must chain to. Read LIVE from the
+# signed file at run time AND asserted equal to this anchor AND equal to the
+# recomputed canonical hash of the seq-11 SOURCE bytes — three independent
+# derivations of one value, any mismatch aborts.
+_EXPECTED_SEQ11_PAYLOAD_SHA256 = (
+    "836acc511bcadd41c28284e7f00bd8be27c6109ebcc5536f7053c3f61eaa2865"
+)
+
+# Fixed (not datetime.now()) so re-running this script is byte-identical.
+_SEQ12_CREATED_AT = "2026-08-20T07:00:00Z"
+_SEQ12_CREATED_BY = "agent.air-m5.backend-rag.visa-seq12-restamp.fold-2026-08-20"
+
+# Drift tripwire on the restamp batch size: the QW-5 capture doc attests
+# exactly 18 portal records. A different count means the pack (or the edit
+# file) drifted from what this fold was authored against — abort, don't adapt.
+_EXPECTED_RESTAMP_COUNT = 18
+_PORTAL_AUTHORITY_TYPE = "OFFICIAL_PORTAL"
+
+
+class FoldPackError(RuntimeError):
+    """A fail-loud gate inside the fold tripped — never silently degrade."""
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# Identity + chain
+# ---------------------------------------------------------------------------
+
+
+def _verify_rule_pack_id() -> uuid.UUID:
+    computed = uuid.uuid5(uuid.NAMESPACE_URL, _SEQ12_RULE_PACK_ID_URL)
+    if computed != _EXPECTED_SEQ12_RULE_PACK_ID:
+        raise FoldPackError(
+            f"seq-12 rule_pack_id convention drifted: uuid5(NAMESPACE_URL, "
+            f"{_SEQ12_RULE_PACK_ID_URL!r}) = {computed}, expected "
+            f"{_EXPECTED_SEQ12_RULE_PACK_ID} — do not hand-adjust either side"
+        )
+    return computed
+
+
+def _chain_hash(seq11_source: dict[str, Any]) -> str:
+    signed = _load_json(_SEQ11_SIGNED)
+    declared = signed.get("payload_sha256")
+    if declared != _EXPECTED_SEQ11_PAYLOAD_SHA256:
+        raise FoldPackError(
+            f"{_SEQ11_SIGNED} declares payload_sha256={declared!r}, expected "
+            f"{_EXPECTED_SEQ11_PAYLOAD_SHA256!r} — the signed seq-11 on disk is "
+            "not the one this fold was authored against"
+        )
+    recomputed = hashlib.sha256(canonicalize_json(seq11_source)).hexdigest()
+    if recomputed != declared:
+        raise FoldPackError(
+            f"seq-11 SOURCE bytes re-hash to {recomputed}, but the signed file "
+            f"declares {declared} — source/signed mismatch, refusing to chain"
+        )
+    return declared
+
+
+def _apply_identity(payload: dict[str, Any], seq11_source: dict[str, Any]) -> None:
+    payload["sequence"] = _SEQ12_SEQUENCE
+    payload["version"] = _SEQ12_VERSION
+    payload["rule_pack_id"] = str(_verify_rule_pack_id())
+    payload["previous_payload_sha256"] = _chain_hash(seq11_source)
+    payload["created_at"] = _SEQ12_CREATED_AT
+    payload["created_by"] = _SEQ12_CREATED_BY
+    # rollback_of_payload_sha256 stays null; top-level valid_period untouched
+    # (not in _IDENTITY_KEYS, so the byte-invariance sweep asserts it equals
+    # seq-11's).
+
+
+# ---------------------------------------------------------------------------
+# The one edit — verified_at/verified_by re-stamps on the 18 portal records
+# ---------------------------------------------------------------------------
+
+
+def _apply_restamps(payload: dict[str, Any]) -> int:
+    edits = _load_json(_RESTAMP_EDITS)
+    records_by_id = {r["source_record_id"]: r for r in payload["source_records"]}
+
+    restamps = edits["restamps"]
+    if len(restamps) != _EXPECTED_RESTAMP_COUNT:
+        raise FoldPackError(
+            f"expected exactly {_EXPECTED_RESTAMP_COUNT} restamps, edit file "
+            f"carries {len(restamps)}"
+        )
+
+    # Entity check, not a frozen id list: the restamped set must be exactly
+    # the set of OFFICIAL_PORTAL records in the pack — every portal record
+    # re-attested, no non-portal record touched. A frozen list here would be
+    # a W106 measurement that silently rots when the pack's source roster
+    # changes; the authority_type IS the entity this lane exists to serve.
+    portal_ids = {
+        r["source_record_id"]
+        for r in payload["source_records"]
+        if r.get("authority_type") == _PORTAL_AUTHORITY_TYPE
+    }
+    restamp_ids = {e["source_record_id"] for e in restamps}
+    if restamp_ids != portal_ids:
+        missing = sorted(portal_ids - restamp_ids)
+        extra = sorted(restamp_ids - portal_ids)
+        raise FoldPackError(
+            "restamp set is not exactly the OFFICIAL_PORTAL set — "
+            f"portal records not restamped: {missing}; "
+            f"restamps naming non-portal/unknown records: {extra}"
+        )
+
+    for edit in restamps:
+        sid = edit["source_record_id"]
+        record = records_by_id.get(sid)
+        if record is None:
+            raise FoldPackError(f"restamp names unknown source_record_id {sid!r}")
+        if record.get("verified_at") != edit["current_verified_at"] or record.get(
+            "verified_by"
+        ) != edit["current_verified_by"]:
+            raise FoldPackError(
+                f"source_record {sid!r} verified_at/verified_by do not match the "
+                "edit file's declared current values — ledger drift, not applying blind"
+            )
+        # Re-attestation moves the clock forward: both stamps are
+        # "YYYY-MM-DDTHH:MM:SSZ" UTC, so lexicographic order is chronological.
+        if not edit["new_verified_at"] > record["verified_at"]:
+            raise FoldPackError(
+                f"source_record {sid!r}: new verified_at "
+                f"{edit['new_verified_at']!r} does not advance past the current "
+                f"{record['verified_at']!r} — a re-stamp that moves time backward "
+                "or holds it still is not an attestation"
+            )
+        record["verified_at"] = edit["new_verified_at"]
+        record["verified_by"] = edit["new_verified_by"]
+
+    return len(restamps)
+
+
+# ---------------------------------------------------------------------------
+# Byte-invariance sweep — everything not declared touched must match seq-11
+# ---------------------------------------------------------------------------
+
+#: Top-level payload keys this fold is ALLOWED to differ from seq-11 on.
+_IDENTITY_KEYS = frozenset(
+    {"sequence", "version", "rule_pack_id", "previous_payload_sha256", "created_at", "created_by"}
+)
+
+#: The ONLY per-record fields the restamp is allowed to change.
+_RESTAMP_FIELDS = frozenset({"verified_at", "verified_by"})
+
+
+def _assert_untouched(
+    payload: dict[str, Any], seq11: dict[str, Any], restamped_ids: set[str]
+) -> None:
+    for key in set(seq11) | set(payload):
+        if key in _IDENTITY_KEYS or key == "source_records":
+            continue
+        if _canon(payload.get(key)) != _canon(seq11.get(key)):
+            raise FoldPackError(
+                f"top-level payload key {key!r} drifted from seq-11 — this fold "
+                "declares no edit there"
+            )
+    # The loop above already covers "rules" and "products" as whole
+    # collections — this fold declares ZERO edits in either, so there is no
+    # carve-out to make and no per-item sweep to run.
+
+    seq11_records = {r["source_record_id"]: r for r in seq11["source_records"]}
+    new_records = {r["source_record_id"]: r for r in payload["source_records"]}
+    if set(new_records) != set(seq11_records):
+        raise FoldPackError(
+            "source_record set (by source_record_id) drifted from seq-11 — this "
+            "fold declares no record add/remove/drop"
+        )
+    for sid, record in new_records.items():
+        baseline = seq11_records[sid]
+        if sid in restamped_ids:
+            b = {k: v for k, v in baseline.items() if k not in _RESTAMP_FIELDS}
+            c = {k: v for k, v in record.items() if k not in _RESTAMP_FIELDS}
+            if _canon(b) != _canon(c):
+                raise FoldPackError(
+                    f"source_record {sid!r} changed beyond verified_at/verified_by "
+                    "— content_sha256 and every other field must ride through "
+                    "untouched on a pure re-stamp"
+                )
+        elif _canon(record) != _canon(baseline):
+            raise FoldPackError(
+                f"source_record {sid!r} drifted from seq-11 outside the declared "
+                "restamp set"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Write (atomic + prettier — fold_pack.py's Codex-finding-7 shape)
+# ---------------------------------------------------------------------------
+
+
+def _write_pack(payload: dict[str, Any], out_path: Path) -> None:
+    if not _PRETTIER_BIN.exists():
+        raise FoldPackError(
+            f"prettier binary not found at {_PRETTIER_BIN} — run `npm install` at repo root"
+        )
+
+    text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f"{out_path.stem}.tmp.", suffix=out_path.suffix, dir=str(out_path.parent)
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with open(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        result = subprocess.run(
+            [str(_PRETTIER_BIN), "--write", str(tmp_path)],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise FoldPackError(
+                f"prettier --write {tmp_path} failed (rc={result.returncode}):\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        tmp_path.replace(out_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def assemble_payload() -> dict[str, Any]:
+    seq11_original = _load_json(_SEQ11_SOURCE)
+    payload = copy.deepcopy(seq11_original)
+
+    _apply_identity(payload, seq11_original)
+    restamp_count = _apply_restamps(payload)
+    restamped_ids = {
+        e["source_record_id"] for e in _load_json(_RESTAMP_EDITS)["restamps"]
+    }
+    if restamp_count != len(restamped_ids):
+        raise FoldPackError(
+            f"restamp edit file carries duplicate source_record_ids — "
+            f"{restamp_count} entries but {len(restamped_ids)} distinct ids"
+        )
+    _assert_untouched(payload, seq11_original, restamped_ids)
+
+    try:
+        RulePackPayload.model_validate(payload)
+    except Exception as exc:  # re-raised loud with context
+        raise FoldPackError(
+            f"assembled seq-12 payload failed RulePackPayload validation: {exc}"
+        ) from exc
+
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    del argv  # no CLI flags — deterministic single-purpose script
+    try:
+        payload = assemble_payload()
+    except FoldPackError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    _write_pack(payload, _SEQ12_SOURCE)
+    print(
+        f"wrote {_SEQ12_SOURCE} — {len(payload['rules'])} rule(s), "
+        f"{len(payload['products'])} product(s), {len(payload['source_records'])} source_record(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-012.source.json
+++ b/apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-012.source.json
@@ -1,0 +1,9066 @@
+{
+  "created_at": "2026-08-20T07:00:00Z",
+  "created_by": "agent.air-m5.backend-rag.visa-seq12-restamp.fold-2026-08-20",
+  "decision_domain": "IMMIGRATION_VISA",
+  "engine_contract_version": "1.0.0",
+  "engine_max_version": "1.0.0",
+  "engine_min_version": "1.0.0",
+  "environment": "PRODUCTION",
+  "hit_policy": {
+    "eligibility": "COVER_ALL_DECLARED_PURPOSES",
+    "hard_filter": "COLLECT_ALL",
+    "human_review": "COLLECT_ALL",
+    "ranking": "SUM_TRUE_INTEGER_WEIGHTS"
+  },
+  "jurisdiction": "ID",
+  "previous_payload_sha256": "836acc511bcadd41c28284e7f00bd8be27c6109ebcc5536f7053c3f61eaa2865",
+  "rollback_of_payload_sha256": null,
+  "products": [
+    {
+      "product_version_id": "c8277316-c29d-5fde-bf9f-2611099a0029",
+      "product_code": "E28A",
+      "legacy_codes": ["B211"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Visa (E28A)",
+        "id": "Visa Investor (E28A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": [
+        "operational_work_beyond_management_and_ownership"
+      ],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 730,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 100,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Investor KITAS 2 Years (Offshore)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ca8c1177-ad94-5261-82a6-68bc912d31bb",
+      "product_code": "E28B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Company Establishment (E28B)",
+        "id": "Visa Investor Pendirian Perusahaan (E28B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "b074270f-fa7c-598b-a728-81ca89432364",
+      "product_code": "E28C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Capital Market (E28C)",
+        "id": "Visa Investor Tanpa Mendirikan Perusahaan (E28C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work", "corporate_establishment"],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "ee4fef98-3497-507c-8486-225932364e26",
+      "product_code": "E28D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — Branch or Subsidiary (E28D)",
+        "id": "Visa Investor Pendirian Kantor Cabang atau Anak Perusahaan (E28D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work_outside_managing_subsidiary"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "2df6f723-7fc3-585a-b26f-0e8c060a2d8d",
+      "product_code": "E28F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Investor Golden Visa — New Capital (IKN) Subsidiary (E28F)",
+        "id": "Visa Investor Anak Perusahaan Ibukota Nusantara (E28F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT"],
+      "prohibited_activities": ["operational_work"],
+      "sponsor_types": ["INVESTMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "cf4d7f3d-1253-5036-8953-79ab3d3e7009",
+      "product_code": "E33",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa (E33)",
+        "id": "Visa Rumah Kedua (E33)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["SECOND_HOME", "TOURISM"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "guarantee_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33 Second Home (5 Years)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5c18e265-ddb2-5010-8d24-a2f19df89850",
+      "product_code": "E33A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Special-Expertise Government Invitation (E33A)",
+        "id": "Visa Rumah Kedua Tenaga Ahli Undangan Pemerintah (E33A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "32b6fb5f-5a24-5763-95f9-0b77be18353c",
+      "product_code": "E33B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Special-Expertise Collaboration (E33B)",
+        "id": "Visa Rumah Kedua Kolaborasi Keahlian Khusus (E33B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "EMPLOYMENT",
+        "BUSINESS_MEETINGS",
+        "INVESTMENT",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "9cc14fee-49dc-5549-8bc8-90bdaf52d1f3",
+      "product_code": "E33C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — World-Figure Government Invitation (E33C)",
+        "id": "Visa Rumah Kedua Tokoh Dunia Undangan Pemerintah (E33C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "INVESTMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 3650
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "796d09bd-3220-5c91-a6ce-e3a99a9b0ddb",
+      "product_code": "E33E",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Golden Visa — Elderly 5-Year (E33E)",
+        "id": "Visa Rumah Kedua Lansia untuk 5 Tahun Golden Visa (E33E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services",
+        "deposit_value_below_commitment"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 1825,
+        "maximum_days": 1825
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Retirement (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7c1da88f-f7cd-571a-95c2-7da32463d3e6",
+      "product_code": "E33F",
+      "legacy_codes": ["E311A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Elderly 1-Year (E33F)",
+        "id": "Visa Rumah Kedua Lansia untuk 1 Tahun (E33F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": [
+        "RETIREMENT",
+        "BUSINESS_MEETINGS",
+        "TOURISM",
+        "FAMILY"
+      ],
+      "prohibited_activities": [
+        "overstay",
+        "work_inconsistent_with_permit",
+        "sale_of_goods_or_services"
+      ],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33F Second Home Senior (1 Year, Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "51e023ea-3229-5233-b88f-cb204b5df713",
+      "product_code": "E33G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Second Home Visa — Remote Worker (E33G)",
+        "id": "Visa Rumah Kedua Pekerja Jarak Jauh (E33G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "work_for_indonesian_entity",
+        "indonesian_source_compensation_including_in_kind",
+        "indonesian_company_ownership",
+        "sale_of_goods_or_services_beyond_remote_work"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E33G Remote Worker (Offshore)"
+      },
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "aee1a12d-3285-526e-8a6f-3d8467fe5d72",
+      "product_code": "A1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa-Free Tourism Visit (A1)",
+        "id": "Bebas Visa Kunjungan Wisata (A1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "TRANSIT"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "A1 Visa-Free Tourism"
+      },
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4e30cbe0-c4bf-59be-9bf8-513e66946e44",
+      "product_code": "B1",
+      "legacy_codes": ["B213"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visa on Arrival — Tourism (B1)",
+        "id": "Visa Saat Kedatangan Wisata (B1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "study",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 30,
+        "maximum_days": 30
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 30,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "B1 Visa on Arrival (VOA)"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "7a07cbb0-564f-5c3f-9720-6ad62c4789cd",
+      "product_code": "C1",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Tourist Visit Visa (C1)",
+        "id": "Visa Kunjungan Wisata (C1)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "business_meetings",
+        "journalism"
+      ],
+      "sponsor_types": ["NONE", "INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C1 Tourism"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "de433757-f7af-5762-ad65-41bc16bc2ae1",
+      "product_code": "C2",
+      "legacy_codes": ["B211B", "B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Business Visit Visa (C2)",
+        "id": "Visa Kunjungan Bisnis (C2)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C2 Business"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "8cf5e09b-6e02-536f-aeca-4aaecaca09c7",
+      "product_code": "C6",
+      "legacy_codes": ["B211A"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Social Activity Visit Visa (C6)",
+        "id": "Visa Kunjungan Kegiatan Sosial (C6)"
+      },
+      "category": "SHORT_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": ["paid_employment", "business_meetings"],
+      "sponsor_types": ["INDIVIDUAL", "EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "SINGLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "C6 Social Activity"
+      },
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "760025cf-d51d-5687-9e98-b921010b9018",
+      "product_code": "BRIDGING",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Bridging Visa — Transitional Stay Permit",
+        "id": "Izin Tinggal Peralihan"
+      },
+      "category": "OTHER",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["OTHER"],
+      "prohibited_activities": [
+        "employment_relationship",
+        "exit_terminates_permit"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "NOT_APPLICABLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": null,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": false,
+        "anchor": "NOT_APPLICABLE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "single_entry_visas",
+        "item_key": "Bridging Visa"
+      },
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "3da72c7b-783e-51e3-9168-6c54bce709ed",
+        "2eabe49e-b71b-575a-b2e8-2be3f8e5b718"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "e1d761e9-56c5-57c3-9c01-986d3c333157",
+      "product_code": "E23",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa (E23)",
+        "id": "Visa Kerja (E23)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": [
+        "work_for_non_sponsor_entity",
+        "hr_personnel_positions",
+        "passive_investment_management"
+      ],
+      "sponsor_types": ["EMPLOYER"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Working KITAS (Offshore)"
+      },
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fa143e97-b444-5ae4-9b05-6365f15e3ec7",
+      "product_code": "E23U",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Foreign Diplomat House Assistant (E23U)",
+        "id": "Visa Kerja Asisten Rumah Tangga Diplomat Asing (E23U)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_non_diplomat_employer"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e8a1d738-daa7-5c99-a0c6-800b25579129",
+      "product_code": "E23V",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Working Visa — Trade and Economic Office (E23V)",
+        "id": "Visa Kerja Kantor Dagang dan Ekonomi (E23V)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["EMPLOYMENT"],
+      "prohibited_activities": ["work_for_standard_corporate_employers"],
+      "sponsor_types": ["GOVERNMENT"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "e2a49f0f-74af-5a15-ab0b-6273fbcd40ce",
+      "product_code": "E31A",
+      "legacy_codes": ["C317"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of Indonesian Citizen (E31A)",
+        "id": "Visa Keluarga Suami/Istri WNI (E31A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": [],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Spouse 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "5d5f9bd4-349b-54d7-841a-784c0afba068",
+      "product_code": "E31B",
+      "legacy_codes": ["C318"],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Spouse of ITAS/ITAP Holder (E31B)",
+        "id": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "62ab2d13-1d7e-5048-9cf7-9622c0098439",
+      "product_code": "E31C",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Legal Mixed Marriage (E31C)",
+        "id": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3204e973-59da-5da1-bad0-06a7172e5b2c",
+      "product_code": "E31D",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Stepchild of Foreigner in Legal Mixed Marriage (E31D)",
+        "id": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1266d5cb-84a3-51f7-b82d-c6b756254074",
+      "product_code": "E31E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of ITAS/ITAP Holder (E31E)",
+        "id": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "3f7f6a94-32c8-54d7-b1d4-4d89082edbcc",
+      "product_code": "E31F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child of Indonesian Citizen Parent (E31F)",
+        "id": "Visa Keluarga Anak dengan Orang Tua WNI (E31F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "fbc980d5-47b6-5f16-974d-25158dfffc06",
+      "product_code": "E31G",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Indonesian Citizen Child (E31G)",
+        "id": "Visa Keluarga Orang Tua dari Anak WNI (E31G)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "1185c36d-833c-5e41-8e0d-6e4f7c8f7378",
+      "product_code": "E31H",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Parent of Child ITAS/ITAP Holder (E31H)",
+        "id": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "4a4a0f7c-a6a0-5835-acd6-8a096342ef68",
+      "product_code": "E31J",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Family Visa — Child Joining Sibling ITAS/ITAP Holder (E31J)",
+        "id": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["FAMILY"],
+      "prohibited_activities": ["paid_employment"],
+      "sponsor_types": ["INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 365
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 5,
+        "days_per_extension": 365,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "Dependent 1 Year (Offshore)"
+      },
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "374e79e0-f0bf-5291-8cba-974e794e210a",
+      "product_code": "D1",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Tourism — Multiple Entry (D1)",
+        "id": "Visa Kunjungan Wisata — Beberapa Kali Perjalanan (D1)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D1 Tourism (1 Year)"
+      },
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "306725c1-7269-5c45-a4b8-188265fcf4d8",
+      "product_code": "D2",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Business — Multiple Entry (D2)",
+        "id": "Visa Kunjungan Bisnis (D2)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["BUSINESS_MEETINGS", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "continuous_supervision_production_sales"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 60,
+        "maximum_days": 60
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 2,
+        "days_per_extension": 60,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D2 Business (1 Year)"
+      },
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "63f64a7e-2bff-5a48-8c3b-7ad5349e8c91",
+      "product_code": "D12",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Visit Visa Pre-Investment — Multiple Entry (D12)",
+        "id": "Visa Kunjungan Pra-Investasi (D12)"
+      },
+      "category": "MULTIPLE_ENTRY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["INVESTMENT", "TOURISM", "FAMILY"],
+      "prohibited_activities": [
+        "selling_goods_services",
+        "indonesian_source_remuneration"
+      ],
+      "sponsor_types": ["NONE"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 180,
+        "maximum_days": 180
+      },
+      "extension_policy": {
+        "allowed": true,
+        "maximum_extensions": 1,
+        "days_per_extension": 180,
+        "status": "VERIFIED",
+        "reason_code": null
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "ENTRY_DATE",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "multiple_entry_visas",
+        "item_key": "D12 Business Investigation (1 Year)"
+      },
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+      "product_code": "E30",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Education Visa (E30)",
+        "id": "Visa Pendidikan (E30)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": false
+    },
+    {
+      "product_version_id": "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+      "product_code": "E30A",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Primary/Secondary Education Visa (E30A)",
+        "id": "Visa Pendidikan Dasar dan Menengah (E30A)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 730
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30A Education Visa (1 Year)"
+      },
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "904d99ec-d198-5eb8-9dc4-0b2047e49137",
+      "product_code": "E30B",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Higher Education Visa (E30B)",
+        "id": "Visa Pendidikan Tinggi (E30B)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION", "INDIVIDUAL"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "FIXED_DAYS",
+        "minimum_days": 365,
+        "maximum_days": 1460
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": {
+        "category": "kitas_permits",
+        "item_key": "E30B Higher Education (1 Year)"
+      },
+      "source_refs": [
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "31850f85-8d19-58df-bb66-b04968c9aff0"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "19e3ea6c-95c6-5998-b9d7-efc77f583589",
+      "product_code": "E30E",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "SEZ Education Visa (E30E)",
+        "id": "Visa Pendidikan Kawasan Ekonomi Khusus (E30E)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    },
+    {
+      "product_version_id": "235f5dfc-2feb-5d5b-ab09-0f4e4122819e",
+      "product_code": "E30F",
+      "legacy_codes": [],
+      "legacy_slugs": [],
+      "names": {
+        "en": "Student Exchange Visa (E30F)",
+        "id": "Visa Pertukaran Pelajar (E30F)"
+      },
+      "category": "LIMITED_STAY",
+      "status": "ACTIVE",
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "covered_purposes": ["STUDY"],
+      "prohibited_activities": [
+        "paid_employment",
+        "selling_goods_services",
+        "indonesian_source_remuneration",
+        "political_activity"
+      ],
+      "sponsor_types": ["EDUCATION"],
+      "entry_policy": {
+        "entry_count": "MULTIPLE"
+      },
+      "stay_policy": {
+        "kind": "VARIABLE_BY_GRANT",
+        "minimum_days": null,
+        "maximum_days": null
+      },
+      "extension_policy": {
+        "allowed": false,
+        "maximum_extensions": 0,
+        "days_per_extension": null,
+        "status": "UNKNOWN",
+        "reason_code": "EXTENSION_POLICY_NOT_VERIFIED"
+      },
+      "clock_policy": {
+        "available": true,
+        "anchor": "PERMIT_ISSUED_AT",
+        "checkpoints": []
+      },
+      "pricing_key": null,
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"
+      ],
+      "public_catalog": true
+    }
+  ],
+  "rules": [
+    {
+      "rule_id": "hf.citizen",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "derived.has_indonesian_citizenship",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "APPLICANT_IS_INDONESIAN_CITIZEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.has_indonesian_citizenship"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.citizen",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.overstay-exceeds-60-days",
+      "stage": "HARD_FILTER",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 60
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "OVERSTAY_EXCEEDS_60_DAYS"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.hf.overstay-exceeds-60-days",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.calling-visa",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "intersects",
+        "fact": "person.nationalities",
+        "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CALLING_VISA_REVIEW"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["bc309fa9-d14e-5625-b914-72fe4a68c19d"],
+      "explanation_key": "explain.review.calling-visa",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.active-overstay",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "gt",
+        "fact": "immigration.overstay_days",
+        "value": 0
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "ACTIVE_OVERSTAY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["immigration.overstay_days"],
+      "source_refs": ["e76bf823-2b36-522f-b2f7-e51eb7715e44"],
+      "explanation_key": "explain.review.active-overstay",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.a1.not-bvk-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "BN",
+            "MY",
+            "TH",
+            "SG",
+            "PH",
+            "KH",
+            "LA",
+            "MM",
+            "VN",
+            "TL",
+            "SR",
+            "CO",
+            "HK",
+            "TR",
+            "BR",
+            "PE",
+            "MO",
+            "KZ",
+            "BY"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BVK_NATIONALITY_ONLY"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.hf.a1.not-bvk-nationality",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.a1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "TRANSIT"]
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "BN",
+              "MY",
+              "TH",
+              "SG",
+              "PH",
+              "KH",
+              "LA",
+              "MM",
+              "VN",
+              "TL",
+              "SR",
+              "CO",
+              "HK",
+              "TR",
+              "BR",
+              "PE",
+              "MO",
+              "KZ",
+              "BY"
+            ]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "A1_BVK_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "TRANSIT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": ["808d691c-374e-5581-8186-9eb54d0ca7ab"],
+      "explanation_key": "explain.el.a1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["aee1a12d-3285-526e-8a6f-3d8467fe5d72"]
+    },
+    {
+      "rule_id": "el.b1.tourism",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 30
+          },
+          {
+            "op": "intersects",
+            "fact": "person.nationalities",
+            "values": [
+              "ZA",
+              "AL",
+              "US",
+              "AD",
+              "SA",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BH",
+              "NL",
+              "BY",
+              "BE",
+              "BR",
+              "BN",
+              "BA",
+              "BG",
+              "CZ",
+              "CL",
+              "DK",
+              "EC",
+              "EE",
+              "PH",
+              "FI",
+              "GT",
+              "HK",
+              "HU",
+              "IN",
+              "GB",
+              "IE",
+              "IT",
+              "IS",
+              "JP",
+              "DE",
+              "KH",
+              "CA",
+              "KZ",
+              "KE",
+              "CO",
+              "KR",
+              "HR",
+              "KW",
+              "LA",
+              "LV",
+              "LI",
+              "LT",
+              "LU",
+              "MV",
+              "MY",
+              "MT",
+              "MA",
+              "MU",
+              "MX",
+              "EG",
+              "MC",
+              "MN",
+              "MZ",
+              "MM",
+              "NO",
+              "OM",
+              "PS",
+              "PG",
+              "FR",
+              "PE",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "NZ",
+              "RS",
+              "SC",
+              "SG",
+              "CY",
+              "SK",
+              "SI",
+              "ES",
+              "SR",
+              "SE",
+              "CH",
+              "TW",
+              "TZ",
+              "TH",
+              "TL",
+              "CN",
+              "TN",
+              "TR",
+              "AE",
+              "UZ",
+              "UA",
+              "VA",
+              "VE",
+              "VN",
+              "JO",
+              "GR"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "B1_VOA_ELIGIBLE",
+        "covered_purposes": ["TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "person.nationalities"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a"
+      ],
+      "explanation_key": "explain.el.b1.tourism",
+      "safety_critical": false,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "el.c1.tourism-family",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["TOURISM", "FAMILY"]
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C1_VISIT_ELIGIBLE",
+        "covered_purposes": ["TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c1.tourism-family",
+      "safety_critical": false,
+      "product_version_ids": ["7a07cbb0-564f-5c3f-9720-6ad62c4789cd"]
+    },
+    {
+      "rule_id": "el.c2.business",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["BUSINESS_MEETINGS", "INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C2_BUSINESS_ELIGIBLE",
+        "covered_purposes": ["BUSINESS_MEETINGS", "INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c2.business",
+      "safety_critical": false,
+      "product_version_ids": ["de433757-f7af-5762-ad65-41bc16bc2ae1"]
+    },
+    {
+      "rule_id": "el.c6.social",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          },
+          {
+            "op": "lte",
+            "fact": "intent.stay_days",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "C6_SOCIAL_ELIGIBLE",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.c6.social",
+      "safety_critical": false,
+      "product_version_ids": ["8cf5e09b-6e02-536f-aeca-4aaecaca09c7"]
+    },
+    {
+      "rule_id": "hf.e28a.paid-capital-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.paid_up_capital_idr",
+        "value": 2500000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_PAID_CAPITAL_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.paid_up_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.paid-capital-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "hf.e28a.total-investment-below-min",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "investment.investment_capital_idr",
+        "value": 10000000000
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E28A_TOTAL_INVESTMENT_BELOW_MIN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["investment.investment_capital_idr"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e28a.total-investment-below-min",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "el.e28a.investment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          },
+          {
+            "op": "in",
+            "fact": "investment.proposed_role",
+            "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+          },
+          {
+            "op": "gte",
+            "fact": "investment.paid_up_capital_idr",
+            "value": 2500000000
+          },
+          {
+            "op": "gte",
+            "fact": "investment.investment_capital_idr",
+            "value": 10000000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E28A_INVESTMENT_ELIGIBLE",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.investment_capital_idr",
+        "investment.paid_up_capital_idr",
+        "investment.proposed_role",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.el.e28a.investment",
+      "safety_critical": false,
+      "product_version_ids": ["c8277316-c29d-5fde-bf9f-2611099a0029"]
+    },
+    {
+      "rule_id": "review.e28b.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28B_USD_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28b.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ca8c1177-ad94-5261-82a6-68bc912d31bb"]
+    },
+    {
+      "rule_id": "review.e28c.usd-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28C_USD_THRESHOLD_AND_INSTRUMENT_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28c.usd-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["b074270f-fa7c-598b-a728-81ca89432364"]
+    },
+    {
+      "rule_id": "review.e28d.usd-threshold-turnover-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28D"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28D_USD_THRESHOLD_AND_TURNOVER_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28d.usd-threshold-turnover-manual",
+      "safety_critical": false,
+      "product_version_ids": ["ee4fef98-3497-507c-8486-225932364e26"]
+    },
+    {
+      "rule_id": "review.e28f.ikn-threshold-manual",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E28F"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E28F_IKN_THRESHOLD_MANUAL_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e28f.ikn-threshold-manual",
+      "safety_critical": false,
+      "product_version_ids": ["2df6f723-7fc3-585a-b26f-0e8c060a2d8d"]
+    },
+    {
+      "rule_id": "el.e33.deposit-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.bank_deposit_usd",
+            "value": 130000
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_at_state_bank",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "secondhome.bank_deposit_in_own_name",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_DEPOSIT_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.deposit-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-basis",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.qualifying_property_value_usd",
+            "value": 1000000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_BASIS_ELIGIBLE",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-basis",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.property-qualification",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.qualifying_property_value_usd",
+                "value": 1000000
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33_PROPERTY_QUALIFICATION_ADVISOR_CHECK",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.property-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "el.e33.guarantee-maintenance",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["SECOND_HOME"]
+              },
+              {
+                "op": "any",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "op": "any",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 130000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "intersects",
+                    "fact": "intent.purposes",
+                    "values": ["SECOND_HOME"]
+                  },
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.qualifying_property_value_usd",
+                    "value": 1000000
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "GUARANTEE_VALUE_MUST_BE_MAINTAINED",
+        "covered_purposes": ["SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.qualifying_property_value_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33.guarantee-maintenance",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33.work-rangkap-kegiatan",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["SECOND_HOME"]
+          },
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33_WORK_RANGKAP_KEGIATAN_GATED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33.work-rangkap-kegiatan",
+      "safety_critical": false,
+      "product_version_ids": ["cf4d7f3d-1253-5036-8953-79ab3d3e7009"]
+    },
+    {
+      "rule_id": "review.e33a.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33A"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33a.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "review.e33b.expertise-qualification",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33B"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33B_EXPERTISE_QUALIFICATION_CHECK"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33b.expertise-qualification",
+      "safety_critical": false,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "review.e33c.central-government-invitation",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.requested_product_code",
+            "value": "E33C"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "GOVT_INVITATION_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e33c.central-government-invitation",
+      "safety_critical": false,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "hf.e33e.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33e.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.age-55-59-disputed-band",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "between",
+                "fact": "derived.age_years",
+                "lower": 55,
+                "upper": 59
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["RETIREMENT"]
+              },
+              {
+                "op": "gte",
+                "fact": "derived.age_years",
+                "value": 55
+              },
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "op": "gte",
+                    "fact": "secondhome.bank_deposit_usd",
+                    "value": 50000
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_at_state_bank",
+                    "value": true
+                  },
+                  {
+                    "op": "eq",
+                    "fact": "secondhome.bank_deposit_in_own_name",
+                    "value": true
+                  }
+                ]
+              },
+              {
+                "op": "gte",
+                "fact": "secondhome.passive_monthly_income_usd",
+                "value": 3000
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_AGE_55_59_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY", "RETIREMENT", "SECOND_HOME", "TOURISM"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.age-55-59-disputed-band",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "el.e33e.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "derived.age_years",
+            "value": 55
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "gte",
+                "fact": "secondhome.bank_deposit_usd",
+                "value": 50000
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_at_state_bank",
+                "value": true
+              },
+              {
+                "op": "eq",
+                "fact": "secondhome.bank_deposit_in_own_name",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33E_RETIREMENT_ELIGIBLE",
+        "covered_purposes": ["RETIREMENT", "SECOND_HOME", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "intent.purposes",
+        "secondhome.bank_deposit_at_state_bank",
+        "secondhome.bank_deposit_in_own_name",
+        "secondhome.bank_deposit_usd",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33e.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["796d09bd-3220-5c91-a6ce-e3a99a9b0ddb"]
+    },
+    {
+      "rule_id": "hf.e33f.sponsor-required",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "family.sponsor_confirmed",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "SPONSOR_REQUIRED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["family.sponsor_confirmed"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.hf.e33f.sponsor-required",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "el.e33f.retirement",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["RETIREMENT"]
+          },
+          {
+            "op": "gte",
+            "fact": "secondhome.passive_monthly_income_usd",
+            "value": 3000
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E33F_RETIREMENT_ELIGIBLE",
+        "covered_purposes": [
+          "RETIREMENT",
+          "BUSINESS_MEETINGS",
+          "TOURISM",
+          "FAMILY"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.sponsor_confirmed",
+        "intent.purposes",
+        "secondhome.passive_monthly_income_usd"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e33f.retirement",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-employer",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.employer_is_indonesian_entity",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_EMPLOYER_NOT_ALLOWED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.employer_is_indonesian_entity"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-employer",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.e33g.indonesian-source-compensation",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "work.indonesia_source_compensation",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "INDONESIAN_SOURCE_COMPENSATION_BANNED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["work.indonesia_source_compensation"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.e33g.indonesian-source-compensation",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-market",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "LOCAL_MARKET_ACTIVITY_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "work.serves_indonesian_clients"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-market",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "review.e33g.local-company-ownership",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "investment.pt_pma_committed",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_EXCLUDES_LOCAL_COMPANY_OWNERSHIP"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "investment.pt_pma_committed"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.e33g.local-company-ownership",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e33g.remote-work",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REMOTE_WORK_ELIGIBLE",
+        "covered_purposes": ["REMOTE_WORK", "TOURISM", "FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.e33g.remote-work",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "hf.bridging.offshore",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.currently_in_indonesia",
+        "value": false
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_ONSHORE_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.currently_in_indonesia"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.offshore",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.from-visit-itk",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "in",
+        "fact": "immigration.current_status_code",
+        "values": [
+          "ITK_FROM_BVK",
+          "ITK_FROM_VISIT_C",
+          "ITK_FROM_VISIT_D",
+          "A1",
+          "C1",
+          "C2",
+          "C6"
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_FROM_VISIT_ITK_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": [
+        "9248b1d7-9172-54d9-ad61-251e83a2285b",
+        "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d"
+      ],
+      "explanation_key": "explain.hf.bridging.from-visit-itk",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "hf.bridging.to-bridging",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "eq",
+        "fact": "immigration.current_status_code",
+        "value": "ITK_PERALIHAN"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "BRIDGING_TO_BRIDGING_PROHIBITED"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["immigration.current_status_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.hf.bridging.to-bridging",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.t3-window-manual",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_T3_WINDOW_ADVISOR_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.t3-window-manual",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.overstay-shield-payment",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_expiry"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_OVERSTAY_SHIELD_PAYMENT_CHECK",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_expiry",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.overstay-shield-payment",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.source-status-verify",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "eq",
+                "fact": "immigration.currently_in_indonesia",
+                "value": true
+              },
+              {
+                "op": "known",
+                "fact": "immigration.current_status_code"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "intent.purposes",
+                "values": ["OTHER"]
+              },
+              {
+                "op": "neq",
+                "fact": "intent.requested_product_code",
+                "value": "BRIDGING"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_SOURCE_STATUS_VERIFY",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "immigration.current_status_code",
+        "immigration.currently_in_indonesia",
+        "intent.purposes",
+        "intent.requested_product_code"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.source-status-verify",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "review.bridging.adverse-history",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "immigration.currently_in_indonesia",
+            "value": true
+          },
+          {
+            "op": "intersects",
+            "fact": "immigration.violation_history",
+            "values": [
+              "OVERSTAY",
+              "DEPORTATION",
+              "BLACKLIST",
+              "IMMIGRATION_INVESTIGATION"
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "BRIDGING_ADVERSE_HISTORY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": [
+        "immigration.currently_in_indonesia",
+        "immigration.violation_history"
+      ],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.review.bridging.adverse-history",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.bridging.destination-stated",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["OTHER"]
+          },
+          {
+            "op": "neq",
+            "fact": "intent.requested_product_code",
+            "value": "BRIDGING"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "BRIDGING_DESTINATION_STATED",
+        "covered_purposes": ["OTHER"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["9248b1d7-9172-54d9-ad61-251e83a2285b"],
+      "explanation_key": "explain.el.bridging.destination-stated",
+      "safety_critical": false,
+      "product_version_ids": ["760025cf-d51d-5687-9e98-b921010b9018"]
+    },
+    {
+      "rule_id": "el.e23-employment-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["EMPLOYMENT"]
+          },
+          {
+            "fact": "work.employer_is_indonesian_entity",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "work.indonesian_work_sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-employment-support",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e23-operational-work-boundary",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "investment.proposed_role",
+                "op": "in",
+                "values": ["SHAREHOLDER_DIRECTOR", "SHAREHOLDER_COMMISSIONER"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["EMPLOYMENT"]
+              },
+              {
+                "fact": "work.employer_is_indonesian_entity",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "work.indonesian_work_sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E23_REQUIRED_FOR_OPERATIONAL_WORK_EVEN_IF_DIRECTOR",
+        "covered_purposes": ["EMPLOYMENT"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "intent.purposes",
+        "investment.proposed_role",
+        "work.employer_is_indonesian_entity",
+        "work.indonesian_work_sponsor_confirmed"
+      ],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.el.e23-operational-work-boundary",
+      "safety_critical": false,
+      "product_version_ids": ["e1d761e9-56c5-57c3-9c01-986d3c333157"]
+    },
+    {
+      "rule_id": "el.e31a-spouse-wni-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "family.marriage_registered"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-spouse-wni-support",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-funds-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_FUNDS_2000",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31a-funds-2000",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-spousal-work-article-61",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SPOUSAL_WORK_ARTICLE_61_CONTEXT",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-spousal-work-article-61",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31a-kitap-prerequisites",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "process.wants_onshore_conversion",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "KITAP_TWO_YEAR_MARRIAGE_AND_INTEGRATION_NOT_VERIFIED",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes",
+        "process.wants_onshore_conversion"
+      ],
+      "source_refs": ["5a0d367b-bf64-535d-83e4-f40c45de2008"],
+      "explanation_key": "explain.el.e31a-kitap-prerequisites",
+      "safety_critical": false,
+      "product_version_ids": ["e2a49f0f-74af-5a15-ab0b-6273fbcd40ce"]
+    },
+    {
+      "rule_id": "el.e31b-spouse-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SPOUSE"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.marriage_registered",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-spouse-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31b-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SPOUSE"
+              },
+              {
+                "fact": "family.marriage_registered",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "570f2bc4-5120-561f-90ba-58fcd9507514",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31b-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["5d5f9bd4-349b-54d7-841a-784c0afba068"]
+    },
+    {
+      "rule_id": "el.e31c-child-mixed-marriage-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "family.relation_to_sponsor"],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-child-mixed-marriage-support",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31c-mixed-marriage-parents",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          },
+          {
+            "fact": "family.marriage_registered",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_MIXED_MARRIAGE_PARENTS",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31c-mixed-marriage-parents",
+      "safety_critical": false,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    },
+    {
+      "rule_id": "el.e31d-stepchild-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-stepchild-support",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-step-parent-relation",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_STEP_PARENT_RELATION",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-step-parent-relation",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "el.e31d-sponsor-mixed-marriage",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_MIXED_MARRIAGE",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes"],
+      "source_refs": [
+        "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31d-sponsor-mixed-marriage",
+      "safety_critical": false,
+      "product_version_ids": ["3204e973-59da-5da1-bad0-06a7172e5b2c"]
+    },
+    {
+      "rule_id": "hf.e31e-adult-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "derived.age_years",
+        "op": "gte",
+        "value": 18
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNDER_18"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-adult-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "hf.e31e-married-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "person.marital_status",
+        "op": "neq",
+        "value": "SINGLE"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_UNMARRIED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["person.marital_status"],
+      "source_refs": ["c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24"],
+      "explanation_key": "explain.hf.e31e-married-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-child-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          },
+          {
+            "fact": "derived.age_years",
+            "op": "lt",
+            "value": 18
+          },
+          {
+            "fact": "person.marital_status",
+            "op": "eq",
+            "value": "SINGLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "derived.age_years",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31e-child-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31e-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "lt",
+                "value": 18
+              },
+              {
+                "fact": "person.marital_status",
+                "op": "eq",
+                "value": "SINGLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes",
+        "person.marital_status"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "ecd22722-3e42-5808-be18-45fbb7d8e9c5"
+      ],
+      "explanation_key": "explain.el.e31e-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1266d5cb-84a3-51f7-b82d-c6b756254074"]
+    },
+    {
+      "rule_id": "el.e31f-child-wni-parent-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "PARENT"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31f-child-wni-parent-support",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31f-adult-age-review",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "PARENT"
+              },
+              {
+                "fact": "family.sponsor_nationalities",
+                "op": "intersects",
+                "values": ["ID"]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31F_ADULT_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "f9306203-0bdc-5dd8-9603-554e7eefedc8"
+      ],
+      "explanation_key": "explain.el.e31f-adult-age-review",
+      "safety_critical": false,
+      "product_version_ids": ["3f7f6a94-32c8-54d7-b1d4-4d89082edbcc"]
+    },
+    {
+      "rule_id": "el.e31g-parent-wni-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_nationalities",
+            "op": "intersects",
+            "values": ["ID"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_nationalities"
+      ],
+      "source_refs": [
+        "86880290-68c2-5220-8f9e-2350678e5f09",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31g-parent-wni-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["fbc980d5-47b6-5f16-974d-25158dfffc06"]
+    },
+    {
+      "rule_id": "el.e31h-parent-itas-child-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "CHILD"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-parent-itas-child-support",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31h-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "CHILD"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "153beca1-a24b-5440-bac0-b46c3d19da6f",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31h-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["1185c36d-833c-5e41-8e0d-6e4f7c8f7378"]
+    },
+    {
+      "rule_id": "el.e31j-sibling-itas-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["FAMILY"]
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "op": "eq",
+            "value": "SIBLING"
+          },
+          {
+            "fact": "family.sponsor_status_code",
+            "op": "known"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sibling-itas-support",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-sponsor-itas-itap",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "REQ_SPONSOR_ITAS_ITAP",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-sponsor-itas-itap",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.e31j-dependency-age",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "derived.age_years",
+                "op": "gte",
+                "value": 18
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["FAMILY"]
+              },
+              {
+                "fact": "family.relation_to_sponsor",
+                "op": "eq",
+                "value": "SIBLING"
+              },
+              {
+                "fact": "family.sponsor_status_code",
+                "op": "known"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "E31J_DEPENDENCY_AGE_ADVISOR_CHECK",
+        "covered_purposes": ["FAMILY"]
+      },
+      "on_unknown": "NO_EFFECT",
+      "required_facts": [
+        "derived.age_years",
+        "family.relation_to_sponsor",
+        "family.sponsor_status_code",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e31j-dependency-age",
+      "safety_critical": false,
+      "product_version_ids": ["4a4a0f7c-a6a0-5835-acd6-8a096342ef68"]
+    },
+    {
+      "rule_id": "el.d1-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "op": "eq",
+            "fact": "intent.entry_pattern",
+            "value": "MULTIPLE"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": [
+          "TOURISM",
+          "FAMILY",
+          "TRANSIT",
+          "BUSINESS_MEETINGS"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "intent.entry_pattern"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D1",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d1-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["TOURISM", "FAMILY", "TRANSIT", "BUSINESS_MEETINGS"]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "all",
+                "args": [
+                  {
+                    "fact": "intent.purposes",
+                    "op": "intersects",
+                    "values": [
+                      "TOURISM",
+                      "FAMILY",
+                      "TRANSIT",
+                      "BUSINESS_MEETINGS"
+                    ]
+                  },
+                  {
+                    "fact": "intent.stay_days",
+                    "op": "lte",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "op": "eq",
+                "fact": "intent.entry_pattern",
+                "value": "MULTIPLE"
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": [
+          "BUSINESS_MEETINGS",
+          "FAMILY",
+          "TOURISM",
+          "TRANSIT"
+        ]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.entry_pattern",
+        "intent.purposes",
+        "intent.stay_days"
+      ],
+      "source_refs": [
+        "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d1-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["374e79e0-f0bf-5291-8cba-974e794e210a"]
+    },
+    {
+      "rule_id": "el.d2-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 60
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-funds-usd-2000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D2",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-funds-usd-2000",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d2-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["BUSINESS_MEETINGS"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["BUSINESS_MEETINGS"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 60
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["BUSINESS_MEETINGS"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d2-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["306725c1-7269-5c45-a4b8-188265fcf4d8"]
+    },
+    {
+      "rule_id": "el.d12-multi-entry-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["INVESTMENT"]
+          },
+          {
+            "fact": "intent.stay_days",
+            "op": "lte",
+            "value": 180
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.stay_days"],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-multi-entry-support",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-passport-validity",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-passport-validity",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-funds-usd-5000",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PROOF_OF_FUNDS_D12",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-funds-usd-5000",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-cv-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "CV_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-cv-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-itinerary-required",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "ITINERARY_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-itinerary-required",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.d12-support-letter",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "op": "neq",
+                "fact": "investment.pt_pma_committed",
+                "value": true
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["INVESTMENT"]
+              },
+              {
+                "fact": "intent.stay_days",
+                "op": "lte",
+                "value": 180
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "SUPPORT_LETTER_REQUIRED",
+        "covered_purposes": ["INVESTMENT"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "intent.stay_days",
+        "investment.pt_pma_committed"
+      ],
+      "source_refs": [
+        "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.d12-support-letter",
+      "safety_critical": false,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "hf.d12-onshore-conversion-excluded",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "process.wants_onshore_conversion",
+        "op": "eq",
+        "value": true
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "D12_NOT_CONVERTIBLE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["process.wants_onshore_conversion"],
+      "source_refs": ["5e64ec6b-8fcc-5518-b70f-87bf22aa5e29"],
+      "explanation_key": "explain.hf.d12-onshore-conversion-excluded",
+      "safety_critical": true,
+      "product_version_ids": ["63f64a7e-2bff-5a48-8c3b-7ad5349e8c91"]
+    },
+    {
+      "rule_id": "el.e30-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "op": "eq",
+            "value": true
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "op": "eq",
+            "value": true
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-student-support",
+      "safety_critical": false,
+      "product_version_ids": [
+        "94d26bed-b3ba-5b9a-9c6c-9c137854293c",
+        "5028908f-25be-5ef1-91b9-0d6bccfc0e1f",
+        "904d99ec-d198-5eb8-9dc4-0b2047e49137"
+      ]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-living-cost-2000.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "LIVING_COST_USD2000",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-living-cost-2000.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30",
+      "safety_critical": false,
+      "product_version_ids": ["94d26bed-b3ba-5b9a-9c6c-9c137854293c"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30a",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30a",
+      "safety_critical": false,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "el.e30-passport-validity.e30b",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PASSPORT_VALIDITY_6_MONTHS_REQUIRED",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "38242587-f4da-5c31-b0ea-662f7fdc475c",
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30-passport-validity.e30b",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.e30a-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["PRIMARY", "SECONDARY"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DASMEN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30a-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["5028908f-25be-5ef1-91b9-0d6bccfc0e1f"]
+    },
+    {
+      "rule_id": "hf.e30b-level-band",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["STUDY"]
+          },
+          {
+            "fact": "study.level",
+            "op": "not_in",
+            "values": ["VOCATIONAL", "UNDERGRADUATE", "POSTGRADUATE"]
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "LEVEL_BAND_DIKTI"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "study.level"],
+      "source_refs": ["e3572ad2-08a9-55bd-b818-353b3e9db715"],
+      "explanation_key": "explain.hf.e30b-level-band",
+      "safety_critical": true,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "el.e30b-izin-belajar",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "op": "intersects",
+            "values": ["STUDY"]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "fact": "intent.purposes",
+                "op": "intersects",
+                "values": ["STUDY"]
+              },
+              {
+                "fact": "study.admission_confirmed",
+                "op": "eq",
+                "value": true
+              },
+              {
+                "fact": "study.sponsor_confirmed",
+                "op": "eq",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "STUDY_PERMIT_KEMDIKBUD",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30b-izin-belajar",
+      "safety_critical": false,
+      "product_version_ids": ["904d99ec-d198-5eb8-9dc4-0b2047e49137"]
+    },
+    {
+      "rule_id": "hf.b1.not-voa-nationality",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "not",
+        "arg": {
+          "op": "intersects",
+          "fact": "person.nationalities",
+          "values": [
+            "ZA",
+            "AL",
+            "US",
+            "AD",
+            "SA",
+            "AR",
+            "AM",
+            "AU",
+            "AT",
+            "AZ",
+            "BH",
+            "NL",
+            "BY",
+            "BE",
+            "BR",
+            "BN",
+            "BA",
+            "BG",
+            "CZ",
+            "CL",
+            "DK",
+            "EC",
+            "EE",
+            "PH",
+            "FI",
+            "GT",
+            "HK",
+            "HU",
+            "IN",
+            "GB",
+            "IE",
+            "IT",
+            "IS",
+            "JP",
+            "DE",
+            "KH",
+            "CA",
+            "KZ",
+            "KE",
+            "CO",
+            "KR",
+            "HR",
+            "KW",
+            "LA",
+            "LV",
+            "LI",
+            "LT",
+            "LU",
+            "MV",
+            "MY",
+            "MT",
+            "MA",
+            "MU",
+            "MX",
+            "EG",
+            "MC",
+            "MN",
+            "MZ",
+            "MM",
+            "NO",
+            "OM",
+            "PS",
+            "PG",
+            "FR",
+            "PE",
+            "PL",
+            "PT",
+            "QA",
+            "RO",
+            "RU",
+            "RW",
+            "NZ",
+            "RS",
+            "SC",
+            "SG",
+            "CY",
+            "SK",
+            "SI",
+            "ES",
+            "SR",
+            "SE",
+            "CH",
+            "TW",
+            "TZ",
+            "TH",
+            "TL",
+            "CN",
+            "TN",
+            "TR",
+            "AE",
+            "UZ",
+            "UA",
+            "VA",
+            "VE",
+            "VN",
+            "JO",
+            "GR"
+          ]
+        }
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "VOA_NATIONALITY_ONLY"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": ["38a6cb08-041f-51e4-86e4-9e73243acd3a"],
+      "explanation_key": "explain.hf.b1.not-voa-nationality",
+      "safety_critical": true,
+      "product_version_ids": ["4e30cbe0-c4bf-59be-9bf8-513e66946e44"]
+    },
+    {
+      "rule_id": "review.citizenship-conflict",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "any",
+        "args": [
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "ZA",
+                  "AL",
+                  "US",
+                  "AD",
+                  "SA",
+                  "AR",
+                  "AM",
+                  "AU",
+                  "AT",
+                  "AZ",
+                  "BH",
+                  "NL",
+                  "BY",
+                  "BE",
+                  "BR",
+                  "BN",
+                  "BA",
+                  "BG",
+                  "CZ",
+                  "CL",
+                  "DK",
+                  "EC",
+                  "EE",
+                  "PH",
+                  "FI",
+                  "GT",
+                  "HK",
+                  "HU",
+                  "IN",
+                  "GB",
+                  "IE",
+                  "IT",
+                  "IS",
+                  "JP",
+                  "DE",
+                  "KH",
+                  "CA",
+                  "KZ",
+                  "KE",
+                  "CO",
+                  "KR",
+                  "HR",
+                  "KW",
+                  "LA",
+                  "LV",
+                  "LI",
+                  "LT",
+                  "LU",
+                  "MV",
+                  "MY",
+                  "MT",
+                  "MA",
+                  "MU",
+                  "MX",
+                  "EG",
+                  "MC",
+                  "MN",
+                  "MZ",
+                  "MM",
+                  "NO",
+                  "OM",
+                  "PS",
+                  "PG",
+                  "FR",
+                  "PE",
+                  "PL",
+                  "PT",
+                  "QA",
+                  "RO",
+                  "RU",
+                  "RW",
+                  "NZ",
+                  "RS",
+                  "SC",
+                  "SG",
+                  "CY",
+                  "SK",
+                  "SI",
+                  "ES",
+                  "SR",
+                  "SE",
+                  "CH",
+                  "TW",
+                  "TZ",
+                  "TH",
+                  "TL",
+                  "CN",
+                  "TN",
+                  "TR",
+                  "AE",
+                  "UZ",
+                  "UA",
+                  "VA",
+                  "VE",
+                  "VN",
+                  "JO",
+                  "GR"
+                ]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AF",
+                  "AG",
+                  "AI",
+                  "AO",
+                  "AQ",
+                  "AS",
+                  "AW",
+                  "AX",
+                  "BB",
+                  "BD",
+                  "BF",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BO",
+                  "BQ",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BZ",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CI",
+                  "CK",
+                  "CM",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "DJ",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EH",
+                  "ER",
+                  "ET",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "GA",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GS",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HM",
+                  "HN",
+                  "HT",
+                  "ID",
+                  "IL",
+                  "IM",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "JE",
+                  "JM",
+                  "KG",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KP",
+                  "KY",
+                  "LB",
+                  "LC",
+                  "LK",
+                  "LR",
+                  "LS",
+                  "LY",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MW",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NG",
+                  "NI",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "PA",
+                  "PF",
+                  "PK",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PW",
+                  "PY",
+                  "RE",
+                  "SB",
+                  "SD",
+                  "SH",
+                  "SJ",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SO",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TJ",
+                  "TK",
+                  "TM",
+                  "TO",
+                  "TT",
+                  "TV",
+                  "UG",
+                  "UM",
+                  "UY",
+                  "VC",
+                  "VG",
+                  "VI",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          },
+          {
+            "op": "all",
+            "args": [
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": ["AF", "IL", "KP", "LR", "NG", "SO"]
+              },
+              {
+                "op": "intersects",
+                "fact": "person.nationalities",
+                "values": [
+                  "AD",
+                  "AE",
+                  "AG",
+                  "AI",
+                  "AL",
+                  "AM",
+                  "AO",
+                  "AQ",
+                  "AR",
+                  "AS",
+                  "AT",
+                  "AU",
+                  "AW",
+                  "AX",
+                  "AZ",
+                  "BA",
+                  "BB",
+                  "BD",
+                  "BE",
+                  "BF",
+                  "BG",
+                  "BH",
+                  "BI",
+                  "BJ",
+                  "BL",
+                  "BM",
+                  "BN",
+                  "BO",
+                  "BQ",
+                  "BR",
+                  "BS",
+                  "BT",
+                  "BV",
+                  "BW",
+                  "BY",
+                  "BZ",
+                  "CA",
+                  "CC",
+                  "CD",
+                  "CF",
+                  "CG",
+                  "CH",
+                  "CI",
+                  "CK",
+                  "CL",
+                  "CM",
+                  "CN",
+                  "CO",
+                  "CR",
+                  "CU",
+                  "CV",
+                  "CW",
+                  "CX",
+                  "CY",
+                  "CZ",
+                  "DE",
+                  "DJ",
+                  "DK",
+                  "DM",
+                  "DO",
+                  "DZ",
+                  "EC",
+                  "EE",
+                  "EG",
+                  "EH",
+                  "ER",
+                  "ES",
+                  "ET",
+                  "FI",
+                  "FJ",
+                  "FK",
+                  "FM",
+                  "FO",
+                  "FR",
+                  "GA",
+                  "GB",
+                  "GD",
+                  "GE",
+                  "GF",
+                  "GG",
+                  "GH",
+                  "GI",
+                  "GL",
+                  "GM",
+                  "GN",
+                  "GP",
+                  "GQ",
+                  "GR",
+                  "GS",
+                  "GT",
+                  "GU",
+                  "GW",
+                  "GY",
+                  "HK",
+                  "HM",
+                  "HN",
+                  "HR",
+                  "HT",
+                  "HU",
+                  "ID",
+                  "IE",
+                  "IM",
+                  "IN",
+                  "IO",
+                  "IQ",
+                  "IR",
+                  "IS",
+                  "IT",
+                  "JE",
+                  "JM",
+                  "JO",
+                  "JP",
+                  "KE",
+                  "KG",
+                  "KH",
+                  "KI",
+                  "KM",
+                  "KN",
+                  "KR",
+                  "KW",
+                  "KY",
+                  "KZ",
+                  "LA",
+                  "LB",
+                  "LC",
+                  "LI",
+                  "LK",
+                  "LS",
+                  "LT",
+                  "LU",
+                  "LV",
+                  "LY",
+                  "MA",
+                  "MC",
+                  "MD",
+                  "ME",
+                  "MF",
+                  "MG",
+                  "MH",
+                  "MK",
+                  "ML",
+                  "MM",
+                  "MN",
+                  "MO",
+                  "MP",
+                  "MQ",
+                  "MR",
+                  "MS",
+                  "MT",
+                  "MU",
+                  "MV",
+                  "MW",
+                  "MX",
+                  "MY",
+                  "MZ",
+                  "NA",
+                  "NC",
+                  "NE",
+                  "NF",
+                  "NI",
+                  "NL",
+                  "NO",
+                  "NP",
+                  "NR",
+                  "NU",
+                  "NZ",
+                  "OM",
+                  "PA",
+                  "PE",
+                  "PF",
+                  "PG",
+                  "PH",
+                  "PK",
+                  "PL",
+                  "PM",
+                  "PN",
+                  "PR",
+                  "PS",
+                  "PT",
+                  "PW",
+                  "PY",
+                  "QA",
+                  "RE",
+                  "RO",
+                  "RS",
+                  "RU",
+                  "RW",
+                  "SA",
+                  "SB",
+                  "SC",
+                  "SD",
+                  "SE",
+                  "SG",
+                  "SH",
+                  "SI",
+                  "SJ",
+                  "SK",
+                  "SL",
+                  "SM",
+                  "SN",
+                  "SR",
+                  "SS",
+                  "ST",
+                  "SV",
+                  "SX",
+                  "SY",
+                  "SZ",
+                  "TC",
+                  "TD",
+                  "TF",
+                  "TG",
+                  "TH",
+                  "TJ",
+                  "TK",
+                  "TL",
+                  "TM",
+                  "TN",
+                  "TO",
+                  "TR",
+                  "TT",
+                  "TV",
+                  "TW",
+                  "TZ",
+                  "UA",
+                  "UG",
+                  "UM",
+                  "US",
+                  "UY",
+                  "UZ",
+                  "VA",
+                  "VC",
+                  "VE",
+                  "VG",
+                  "VI",
+                  "VN",
+                  "VU",
+                  "WF",
+                  "WS",
+                  "YE",
+                  "YT",
+                  "ZA",
+                  "ZM",
+                  "ZW"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "CITIZENSHIP_LIST_DIVERGENCE"
+      },
+      "on_unknown": "HUMAN_REVIEW",
+      "required_facts": ["person.nationalities"],
+      "source_refs": [
+        "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+        "bc309fa9-d14e-5625-b914-72fe4a68c19d"
+      ],
+      "explanation_key": "explain.review.citizenship-conflict",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "review.minor-without-guardian",
+      "stage": "HUMAN_REVIEW",
+      "scope": "GLOBAL",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-09T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "eq",
+            "fact": "derived.is_minor",
+            "value": true
+          },
+          {
+            "op": "eq",
+            "fact": "family.sponsor_confirmed",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "MINOR_WITHOUT_CONFIRMED_GUARDIAN"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.is_minor", "family.sponsor_confirmed"],
+      "source_refs": ["38242587-f4da-5c31-b0ea-662f7fdc475c"],
+      "explanation_key": "explain.review.minor-without-guardian",
+      "safety_critical": true,
+      "product_version_ids": null
+    },
+    {
+      "rule_id": "hf.e33f.age-below-55",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "lt",
+        "fact": "derived.age_years",
+        "value": 55
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "AGE_BELOW_55"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["derived.age_years"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33f.age-below-55",
+      "safety_critical": false,
+      "product_version_ids": ["7c1da88f-f7cd-571a-95c2-7da32463d3e6"]
+    },
+    {
+      "rule_id": "review.e33g.income-evidence",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "op": "intersects",
+            "fact": "intent.purposes",
+            "values": ["REMOTE_WORK"]
+          },
+          {
+            "op": "eq",
+            "fact": "work.employer_is_indonesian_entity",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.serves_indonesian_clients",
+            "value": false
+          },
+          {
+            "op": "eq",
+            "fact": "work.indonesia_source_compensation",
+            "value": false
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E33G_INCOME_EVIDENCE_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "work.employer_is_indonesian_entity",
+        "work.indonesia_source_compensation",
+        "work.serves_indonesian_clients"
+      ],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.review.e33g.income-evidence",
+      "safety_critical": false,
+      "product_version_ids": ["51e023ea-3229-5233-b88f-cb204b5df713"]
+    },
+    {
+      "rule_id": "el.e30e-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "values": ["EDUCATION", "INDIVIDUAL"],
+            "op": "in"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.el.e30e-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["19e3ea6c-95c6-5998-b9d7-efc77f583589"]
+    },
+    {
+      "rule_id": "el.e30f-student-support",
+      "stage": "ELIGIBILITY",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["STUDY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "study.admission_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "study.sponsor_confirmed",
+            "value": true,
+            "op": "eq"
+          },
+          {
+            "fact": "sponsor.type",
+            "value": "EDUCATION",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "SUPPORT",
+        "reason_code": "PURPOSE_PRODUCT_MATCH",
+        "covered_purposes": ["STUDY"]
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "intent.purposes",
+        "sponsor.type",
+        "study.admission_confirmed",
+        "study.sponsor_confirmed"
+      ],
+      "source_refs": [
+        "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.el.e30f-student-support",
+      "safety_critical": false,
+      "product_version_ids": ["235f5dfc-2feb-5d5b-ab09-0f4e4122819e"]
+    },
+    {
+      "rule_id": "hf.e33a.sponsor-not-government",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "value": "GOVERNMENT",
+        "op": "neq"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33A_SPONSOR_NOT_GOVERNMENT"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33a.sponsor-not-government",
+      "safety_critical": true,
+      "product_version_ids": ["5c18e265-ddb2-5010-8d24-a2f19df89850"]
+    },
+    {
+      "rule_id": "hf.e33b.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33B_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33b.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["32b6fb5f-5a24-5763-95f9-0b77be18353c"]
+    },
+    {
+      "rule_id": "hf.e33c.sponsor-not-government-or-none",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "fact": "sponsor.type",
+        "values": ["GOVERNMENT", "NONE"],
+        "op": "not_in"
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "E33C_SPONSOR_NOT_GOVERNMENT_OR_NONE"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["sponsor.type"],
+      "source_refs": [
+        "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+        "9248b1d7-9172-54d9-ad61-251e83a2285b"
+      ],
+      "explanation_key": "explain.hf.e33c.sponsor-not-government-or-none",
+      "safety_critical": true,
+      "product_version_ids": ["9cc14fee-49dc-5549-8bc8-90bdaf52d1f3"]
+    },
+    {
+      "rule_id": "review.e23u.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23U",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23U_DIPLOMATIC_HOUSEHOLD_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23u.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["fa143e97-b444-5ae4-9b05-6365f15e3ec7"]
+    },
+    {
+      "rule_id": "review.e23v.requested-product",
+      "stage": "HUMAN_REVIEW",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["EMPLOYMENT"],
+            "op": "intersects"
+          },
+          {
+            "fact": "intent.requested_product_code",
+            "value": "E23V",
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "REQUIRE_REVIEW",
+        "reason_code": "E23V_TRADE_OFFICE_STAFF_REVIEW"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": ["intent.purposes", "intent.requested_product_code"],
+      "source_refs": ["6f5135f2-1f77-571f-88ed-26d1d2b9efba"],
+      "explanation_key": "explain.review.e23v.requested-product",
+      "safety_critical": false,
+      "product_version_ids": ["e8a1d738-daa7-5c99-a0c6-800b25579129"]
+    },
+    {
+      "rule_id": "hf.e31c-marriage-not-registered",
+      "stage": "HARD_FILTER",
+      "scope": "PRODUCTS",
+      "priority": 100,
+      "valid_period": {
+        "from": "2026-08-19T00:00:00Z",
+        "to": null
+      },
+      "when": {
+        "op": "all",
+        "args": [
+          {
+            "fact": "intent.purposes",
+            "values": ["FAMILY"],
+            "op": "intersects"
+          },
+          {
+            "fact": "family.relation_to_sponsor",
+            "value": "PARENT",
+            "op": "eq"
+          },
+          {
+            "fact": "family.marriage_registered",
+            "value": false,
+            "op": "eq"
+          }
+        ]
+      },
+      "effect": {
+        "type": "EXCLUDE",
+        "reason_code": "REQ_PARENTS_MARRIAGE_REGISTERED"
+      },
+      "on_unknown": "NEEDS_INPUT",
+      "required_facts": [
+        "family.marriage_registered",
+        "family.relation_to_sponsor",
+        "intent.purposes"
+      ],
+      "source_refs": [
+        "40523028-431b-5ae0-a937-277882f0f243",
+        "e3572ad2-08a9-55bd-b818-353b3e9db715"
+      ],
+      "explanation_key": "explain.hf.e31c-marriage-not-registered",
+      "safety_critical": true,
+      "product_version_ids": ["62ab2d13-1d7e-5048-9cf7-9622c0098439"]
+    }
+  ],
+  "rule_pack_id": "dd98e153-4f89-5176-b32e-d936b7bb2351",
+  "sequence": 12,
+  "version": "2026.8.20",
+  "valid_period": {
+    "from": "2026-07-25T00:00:00Z",
+    "to": null
+  },
+  "source_records": [
+    {
+      "source_record_id": "6f5135f2-1f77-571f-88ed-26d1d2b9efba",
+      "source_key": "kepmen-mip-08-gr-01-01-2025-visa-catalog",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Kepmen M.IP-08.GR.01.01/2025 — Indeks Visa Indonesia (katalog daftar-visa imigrasi.go.id)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia",
+      "language": "id",
+      "document_number": "Kepmen M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28D"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E28F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33A"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33B"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33C"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33E"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33F"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/E33G"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/B1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C1"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C2"
+        },
+        {
+          "kind": "PAGE",
+          "value": "/wna/daftar-visa-indonesia/C6"
+        }
+      ],
+      "content_sha256": "be6bf44d2d6f8ee8e766ac3b8007c274b84fe7773a516a59ce2f9629049ec3f9",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "9248b1d7-9172-54d9-ad61-251e83a2285b",
+      "source_key": "permenkumham-22-2023-jo-11-2024-stay-permits",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham 22/2023 jo. Permenkumham 11/2024 — Izin Tinggal Keimigrasian (Ps. 33/61/62/63, 86A, 94A, 94B, 113, 185)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Details/285156/permenkumham-no-11-tahun-2024",
+      "language": "id",
+      "document_number": "Permenkumham 22/2023 jo. Permenkumham 11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33(2)(j)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 62"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 63"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 86A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94A"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 94B"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 185"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 39"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 40"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 57"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 58"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 59"
+        }
+      ],
+      "content_sha256": "052dfa1315385c57d2d92140000a140f99adac25f1449fbddcaca19ca2e4ce1a",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "808d691c-374e-5581-8186-9eb54d0ca7ab",
+      "source_key": "permen-imipas-10-2026-bvk-nationality-list",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 10/2026 — Daftar Negara Bebas Visa Kunjungan (BVK)",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-bebas-visa-kunjungan",
+      "language": "id",
+      "document_number": "Permen Imipas Nomor 10 Tahun 2026",
+      "locators": [],
+      "content_sha256": "af7287e82df4f96f162ee094608aa40c3d3ce40899fdb685509743597cbd0ff3",
+      "legal_period": {
+        "from": "2026-07-09T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "e76bf823-2b36-522f-b2f7-e51eb7715e44",
+      "source_key": "uu-6-2011-jo-uu-63-2024-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU 6/2011 jo. UU 63/2024 tentang Keimigrasian — kewarganegaraan dan ketentuan overstay",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/id/visa-kunjungan/",
+      "language": "id",
+      "document_number": "UU 6/2011 jo. UU 63/2024",
+      "locators": [],
+      "content_sha256": "30aeb54b897b32b07a91f7ce1fdef58cd33f495bffb52e049f0031fd87221428",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Calling Visa — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Calling Visa country list; national Ditjen Imigrasi display"
+        }
+      ],
+      "content_sha256": "cfc36c1b65af69564e9a56b69c3b680288ece3d17350b6b46e9b396b3888f305",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "cd613d5b-83da-5150-a7b5-759eb4d224fe",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Siaran Pers Ditjen Imigrasi 2024-04-24 — Izin Tinggal Peralihan Jembatani Proses Transisi Izin Tinggal WNA di RI",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "26ab52ca35af9e1d1b18fedff1df355f1cada57a710f49c816d4fe2708447848",
+      "legal_period": {
+        "from": "2024-04-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "65ffed8d-ccb2-512b-b093-60733b31269d",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2eabe49e-b71b-575a-b2e8-2be3f8e5b718",
+      "source_key": "permen-imipas-5-2025-penjamin-revocation",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permen Imipas 5/2025 — Pencabutan Permenkumham 36/2021 tentang Penjamin Keimigrasian",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/378168/Permen%20Imipas%20Nomor%205%20Tahun%202025.pdf",
+      "language": "id",
+      "document_number": "Permen Imipas 5/2025",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 1"
+        }
+      ],
+      "content_sha256": "b1c33d5ca2d6fa582ce827dc7caa3b512728186ae40c21c60ec7106ebe9bc759",
+      "legal_period": {
+        "from": "2025-02-07T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a1",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Layanan Alih Status — Izin Tinggal Kunjungan Menjadi Izin Tinggal Terbatas",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19fb4a4eba22194a3a14fa3a6be76e704835dc4a8fd27b2f2f0536495ead09ce",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "0b9d2466-a9e1-556f-8585-7ef501c3c837",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "e3572ad2-08a9-55bd-b818-353b3e9db715",
+      "source_key": "kemenimipas.kepmen-mip-08-gr-01-01-2025.klasifikasi-visa",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Keputusan Menteri Imigrasi dan Pemasyarakatan M.IP-08.GR.01.01/2025 tentang Klasifikasi Visa",
+      "publisher": "Kementerian Imigrasi dan Pemasyarakatan (Kemenimipas)",
+      "canonical_url": "https://kemenimipas.go.id/attachments/2025/peraturan/20250813_09_Kepmen_No_M.IP-08.GR.01.01_Th_2025_Tentang_Klasifikasi_Visa.pdf",
+      "language": "id",
+      "document_number": "M.IP-08.GR.01.01/2025",
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Lampiran"
+        }
+      ],
+      "content_sha256": "b8e326667c892ab2dfb52be220c82a0716bab6a516fe925c5e45096e9ef81c33",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "c9e6f0e4-5e84-572d-b1ca-e4e11ab50c24",
+      "source_key": "peraturan-bpk.permenkumham-22-2023.visa-izin-tinggal",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 22 Tahun 2023 tentang Visa dan Izin Tinggal",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/330147/Permenkumham%20Nomor%2022%20Tahun%202023.pdf",
+      "language": "id",
+      "document_number": "22/2023",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 42"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 113"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 33"
+        }
+      ],
+      "content_sha256": "2e9165804c38e9a60b4f1c4a046bd727a97043d7386be90d608c68db31c015d4",
+      "legal_period": {
+        "from": "2023-08-22T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "31850f85-8d19-58df-bb66-b04968c9aff0",
+      "source_key": "peraturan-bpk.permenkumham-11-2024.perubahan-22-2023",
+      "version": 1,
+      "authority_type": "IMPLEMENTING_REGULATION",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Permenkumham Nomor 11 Tahun 2024 tentang Perubahan atas Permenkumham 22/2023",
+      "publisher": "Kementerian Hukum dan Hak Asasi Manusia RI",
+      "canonical_url": "https://peraturan.bpk.go.id/Download/344251/Permenkumham%20Nomor%2011%20Tahun%202024.pdf",
+      "language": "id",
+      "document_number": "11/2024",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 105 ayat (7)"
+        }
+      ],
+      "content_sha256": "ecbbeccc196145f47f24e68473a27c19d6f0408e607abb365ce9acd22cbf5f02",
+      "legal_period": {
+        "from": "2024-04-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "5a0d367b-bf64-535d-83e4-f40c45de2008",
+      "source_key": "peraturan.bpk.go.id.uu-6-2011-keimigrasian",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Pasal 60 ayat (2) dan Pasal 61",
+      "publisher": "Badan Pemeriksa Keuangan Republik Indonesia",
+      "canonical_url": "https://peraturan.bpk.go.id/Home/Download/28550/UU%206%20Tahun%202011.pdf",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 60 ayat (2)"
+        },
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "63708ca9b50ac067834a50c395385fdc6abda22e6e51def88983cd1ad685edc4",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-10T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-10T00:00:00Z",
+      "verified_at": "2026-08-10T00:00:00Z",
+      "verified_by": "agent.air-m5.visa-seq6-semantics",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "4886ebe6-41ae-5c6f-bf5d-b98e182be435",
+      "source_key": "imigrasi.go.id.uu-6-2011-keimigrasian.bab-5",
+      "version": 1,
+      "authority_type": "PRIMARY_LAW",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "UU Nomor 6 Tahun 2011 tentang Keimigrasian — Bab V (Izin Tinggal), reproduksi Ditjen Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/uu_imigrasi/bab-5",
+      "language": "id",
+      "document_number": "UU 6/2011",
+      "locators": [
+        {
+          "kind": "ARTICLE",
+          "value": "Pasal 61"
+        }
+      ],
+      "content_sha256": "7585f108f2ec029b954f42951dcb56c4afa3aca09eb018c02134782661664272",
+      "legal_period": {
+        "from": "2011-05-05T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-07-24T00:00:00Z",
+      "verified_at": "2026-07-24T00:00:00Z",
+      "verified_by": "agent.m5.visa-authoring-a2",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 31536000
+      }
+    },
+    {
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri WNI (E31A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "7ee2871fa937249756d8f8048067e3444b1aa738ec41737832180807a674932c",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "9ed9ed7a-5998-557f-ac98-ceaf2cb520df",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Suami/Istri Pemegang ITAS/ITAP (E31B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "178c059aa106c9e9a338f1c9980e66ca7a3f74b961ebccb372ad07aa20d6102f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "c89c8de0-b131-5491-a604-f0ee79f18fe9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Hasil Perkawinan Sah WNA-WNI (E31C) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4cd930e3f7b9ed99a92e0a11b025532d53a2405766fee2d9d8153cc97e129473",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "a88e1fe2-b363-5541-94bd-c7bd62ff1649",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Bawaan WNA Perkawinan Sah WNA-WNI (E31D) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "f957654b7f9c1ece0c6f162812ff0384e3dab195af1f7ebb7cce30ce458af78e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "8b9a48dc-2f86-5b0c-be51-5dba1e7a64fc",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak Pemegang ITAS/ITAP (E31E) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "4dcd01efc33454f722aa01fd3273fd8cca112bc161e4b3edd71710e4751beca5",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "8062c9aa-44d7-5aee-8bca-a8446af0c4a0",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak dengan Orang Tua WNI (E31F) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "44054b731caef383470f56dc318c7ff6a9b3e222b513296f777ec61a0def5f0b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "b251f6cb-14df-5997-92b7-37f235a33e89",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak WNI (E31G) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "64a3d8c4af611cd072d82abde72f0213e19aa121e367f4c9c58d5a791d86a34b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "6da01441-8a97-5192-89f8-6384486ba4e9",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Orang Tua dari Anak Pemegang ITAS/ITAP (E31H) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "19dcb960b348bc7a51986fae48e8ae8a08c18ccc65958065c3cbb99c7f30fd1b",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "4a6e547e-1a2a-50c4-981d-64638564d546",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang ITAS/ITAP (E31J) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "fdba98fd4fc827b87d4ae11fd6365fcd7330b174d4e737a6c4d416066055e4c3",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "be01ea72-a43d-578d-83fd-6da4f27c0f71",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Wisata Beberapa Kali Perjalanan (D1) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "6e918e1fa848260b2fab7673bfe99aef37c248c0b248c35c667238d5e2eaf497",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "28775be4-5726-53d2-9126-eea1bd9ef27f",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Bisnis (D2) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "24519738205bc39a0befb8f4f0d6dde3ca13dca72add2163ace0b79726882bb0",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "4b47cdb0-db95-585d-9d8c-6bba92fe50bb",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Kunjungan Pra-Investasi (D12) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "2961a6046e9efa279e4e2411012b41206f502a8db1c7819c2422cca95a93148e",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "4ca7cfef-4e5f-51d4-869f-46e9a9c36022",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Dasar dan Menengah (E30A) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "a97d5b1c108ffc886d222174b4026e5dc6ad920fdb1f2cb17a0a2b6718f63e2f",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "d0218b81-27bf-524b-bf31-6c398844f601",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "version": 2,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Visa Pendidikan Tinggi (E30B) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B",
+      "language": "id",
+      "document_number": null,
+      "locators": [],
+      "content_sha256": "34a8958e439b38e8666d965fb60b64ba5cb04cb3facf92ba2d97ebf7e7c382ad",
+      "legal_period": {
+        "from": "2025-06-01T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-06T06:19:49Z",
+      "verified_at": "2026-08-20T06:15:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": "49e11be4-32ec-57fd-bd4b-f6e6a8e914e5",
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    },
+    {
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "source_key": "imigrasi-voa-country-list",
+      "version": 1,
+      "authority_type": "OFFICIAL_PORTAL",
+      "status": "VERIFIED",
+      "jurisdiction": "ID",
+      "title": "Daftar Negara Subjek Visa on Arrival (VoA) — Direktorat Jenderal Imigrasi",
+      "publisher": "Direktorat Jenderal Imigrasi (Ditjen Imigrasi)",
+      "canonical_url": "https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival",
+      "language": "id",
+      "document_number": null,
+      "locators": [
+        {
+          "kind": "SECTION",
+          "value": "Daftar Negara, Pemerintah Dari Daerah Administrasi Khusus Suatu Negara, dan Entitas Tertentu (97 entries); cross-verified detik.com d-8322745 and depok.imigrasi.go.id/47666-2"
+        }
+      ],
+      "content_sha256": "41fe2acb27c70180a8269736abe7eb605e4dfd7f55b4d4bd31b1cbd4b480f265",
+      "legal_period": {
+        "from": "2026-07-24T00:00:00Z",
+        "to": null
+      },
+      "recorded_period": {
+        "from": "2026-08-08T00:00:00Z",
+        "to": null
+      },
+      "retrieved_at": "2026-08-08T00:00:00Z",
+      "verified_at": "2026-08-20T06:14:00Z",
+      "verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20",
+      "supersedes_source_record_id": null,
+      "freshness_policy": {
+        "kind": "MAX_AGE_SINCE_VERIFIED_AT",
+        "max_age_seconds": 604800
+      }
+    }
+  ]
+}

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_seq12_pack.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_seq12_pack.py
@@ -1,0 +1,328 @@
+"""seq-12 freshness re-stamp — gates for the assembled
+``rulepack-prod-012.source.json`` (see
+``backend.scripts.visa_engine.fold_pack_seq12``).
+
+Unlike ``test_seq11_pack.py`` this module does NOT skip when the pack file
+is missing: seq-12 ships in the same PR as its fold, so an absent
+``rulepack-prod-012.source.json`` is a defect (armed-on-paper, scar family
+#2), never a legitimate pre-fold state. Six checks, each verified against
+the real files on disk:
+
+(a) chain gate — seq-12's ``previous_payload_sha256`` equals the
+    RECOMPUTED SHA256(JCS(...)) of seq-11's own source payload (never a
+    declared-field-vs-declared-field comparison — the house pattern from
+    ``test_seq10_pack.py``/``test_seq11_pack.py``, one generation later).
+(b) identity — ``sequence == 12``, ``rule_pack_id`` matches the uuid5
+    convention recomputed in-test (never imported from the fold module as
+    a trusted constant).
+(c) restamp parity — exactly 18 source_records differ from seq-11, each
+    ONLY in ``verified_at``/``verified_by``; the restamped set is exactly
+    the OFFICIAL_PORTAL set (entity, not a frozen id list); every restamp
+    advances the clock; every restamped stamp equals the inc5 edits-file
+    ledger value (pack ↔ capture-ledger parity); ``content_sha256`` is
+    byte-identical on all 28 records — with a positive control proving
+    the only-restamp-fields-differ checker CAN fail on a mutated record.
+(d) byte-invariance — rules and products are canonically identical to
+    seq-11's as WHOLE collections (this fold declares zero edits in
+    either); the 10 non-restamped source_records are fully identical;
+    every top-level key outside the identity set is identical.
+(e) regeneration parity — the disk file is canonically identical to what
+    ``fold_pack_seq12.assemble_payload()`` produces right now (the fold
+    is deterministic; a hand-edited pack diverges here). This is the one
+    test that imports the fold module — the property checks above stay
+    independent re-derivations (W100: a test that reuses the code it is
+    grading is not evidence).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from backend.services.visa_engine.bundle import canonicalize_json
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_PACKS_DIR = (
+    _REPO_ROOT
+    / "apps"
+    / "backend-rag"
+    / "backend"
+    / "services"
+    / "visa_engine"
+    / "contracts"
+    / "packs"
+)
+_SEQ11_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-011.source.json"
+_SEQ11_SIGNED_PATH = _PACKS_DIR / "rulepack-prod-011.signed.json"
+_SEQ12_SOURCE_PATH = _PACKS_DIR / "rulepack-prod-012.source.json"
+
+_RESTAMP_EDITS_PATH = (
+    _REPO_ROOT
+    / "research"
+    / "visa"
+    / "doctrine-factory"
+    / "e5"
+    / "inc5-pack-edits"
+    / "source-restamp-edits.json"
+)
+
+_EXPECTED_RESTAMP_COUNT = 18
+_PORTAL_AUTHORITY_TYPE = "OFFICIAL_PORTAL"
+_RESTAMP_FIELDS = frozenset({"verified_at", "verified_by"})
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _canon(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _differs_only_in_restamp_fields(baseline: dict[str, Any], candidate: dict[str, Any]) -> bool:
+    """True iff the two records are canonically identical once
+    ``verified_at``/``verified_by`` are removed from both. Independent
+    re-implementation (not imported from the fold module)."""
+
+    b = {k: v for k, v in baseline.items() if k not in _RESTAMP_FIELDS}
+    c = {k: v for k, v in candidate.items() if k not in _RESTAMP_FIELDS}
+    return _canon(b) == _canon(c)
+
+
+@pytest.fixture(scope="module")
+def seq11_source() -> dict[str, Any]:
+    return _read_json(_SEQ11_SOURCE_PATH)
+
+
+@pytest.fixture(scope="module")
+def seq12_source() -> dict[str, Any]:
+    return _read_json(_SEQ12_SOURCE_PATH)
+
+
+@pytest.fixture(scope="module")
+def restamp_edits() -> dict[str, Any]:
+    return _read_json(_RESTAMP_EDITS_PATH)
+
+
+# ---------------------------------------------------------------------------
+# (a) chain + (b) identity
+# ---------------------------------------------------------------------------
+
+
+class TestChainGate:
+    def test_pack_file_exists(self) -> None:
+        assert _SEQ12_SOURCE_PATH.exists(), (
+            "rulepack-prod-012.source.json is missing — the seq-12 fold ships "
+            "in the same PR as this test; an absent pack is a defect, not a "
+            "pre-fold state"
+        )
+
+    def test_previous_payload_sha256_chains_to_recomputed_seq11(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        recomputed = hashlib.sha256(canonicalize_json(seq11_source)).hexdigest()
+        seq11_signed = _read_json(_SEQ11_SIGNED_PATH)
+        assert recomputed == seq11_signed["payload_sha256"]
+        assert seq12_source["previous_payload_sha256"] == recomputed
+
+    def test_sequence_is_12(self, seq12_source: dict[str, Any]) -> None:
+        assert seq12_source["sequence"] == 12
+
+    def test_rule_pack_id_matches_uuid5_convention(self, seq12_source: dict[str, Any]) -> None:
+        expected = uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/12",
+        )
+        assert seq12_source["rule_pack_id"] == str(expected)
+        # Formula sanity: the same convention reproduces seq-11's id.
+        seq11_expected = uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            "https://balizero.com/visa-oracle/rule-pack/PRODUCTION/ID/IMMIGRATION_VISA/11",
+        )
+        assert str(seq11_expected) == "5c3974ab-bb15-5a73-b74f-f9f0af88a4a7"
+
+
+# ---------------------------------------------------------------------------
+# (c) restamp parity — the one declared edit, held to its exact shape
+# ---------------------------------------------------------------------------
+
+
+class TestRestampParity:
+    def test_exactly_18_records_differ_and_only_in_restamp_fields(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        seq11_by_id = {r["source_record_id"]: r for r in seq11_source["source_records"]}
+        changed = []
+        illegal = []
+        for record in seq12_source["source_records"]:
+            baseline = seq11_by_id[record["source_record_id"]]
+            if _canon(record) == _canon(baseline):
+                continue
+            changed.append(record["source_record_id"])
+            if not _differs_only_in_restamp_fields(baseline, record):
+                illegal.append(record["source_record_id"])
+        assert len(changed) == _EXPECTED_RESTAMP_COUNT
+        assert illegal == []
+
+    def test_restamped_set_is_exactly_the_official_portal_set(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        seq11_by_id = {r["source_record_id"]: r for r in seq11_source["source_records"]}
+        changed = {
+            r["source_record_id"]
+            for r in seq12_source["source_records"]
+            if _canon(r) != _canon(seq11_by_id[r["source_record_id"]])
+        }
+        portal = {
+            r["source_record_id"]
+            for r in seq12_source["source_records"]
+            if r.get("authority_type") == _PORTAL_AUTHORITY_TYPE
+        }
+        assert changed == portal
+        assert len(portal) == _EXPECTED_RESTAMP_COUNT
+
+    def test_every_restamp_advances_the_clock(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        seq11_by_id = {r["source_record_id"]: r for r in seq11_source["source_records"]}
+        not_advanced = []
+        checked = 0
+        for record in seq12_source["source_records"]:
+            baseline = seq11_by_id[record["source_record_id"]]
+            if record["verified_at"] == baseline["verified_at"]:
+                continue
+            checked += 1
+            # Both stamps are "YYYY-MM-DDTHH:MM:SSZ" UTC — lexicographic
+            # order is chronological for this fixed shape.
+            if not record["verified_at"] > baseline["verified_at"]:
+                not_advanced.append(record["source_record_id"])
+        assert checked == _EXPECTED_RESTAMP_COUNT
+        assert not_advanced == []
+
+    def test_pack_stamps_equal_the_inc5_ledger(
+        self, seq12_source: dict[str, Any], restamp_edits: dict[str, Any]
+    ) -> None:
+        seq12_by_id = {r["source_record_id"]: r for r in seq12_source["source_records"]}
+        mismatches = []
+        assert len(restamp_edits["restamps"]) == _EXPECTED_RESTAMP_COUNT
+        for edit in restamp_edits["restamps"]:
+            record = seq12_by_id[edit["source_record_id"]]
+            if (
+                record["verified_at"] != edit["new_verified_at"]
+                or record["verified_by"] != edit["new_verified_by"]
+            ):
+                mismatches.append(edit["source_record_id"])
+        assert mismatches == []
+
+    def test_content_sha256_untouched_on_all_records(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        seq11_by_id = {r["source_record_id"]: r for r in seq11_source["source_records"]}
+        drifted = []
+        for record in seq12_source["source_records"]:
+            baseline = seq11_by_id[record["source_record_id"]]
+            if record.get("content_sha256") != baseline.get("content_sha256"):
+                drifted.append(record["source_record_id"])
+        assert len(seq12_source["source_records"]) == len(seq11_source["source_records"])
+        assert drifted == []
+
+    def test_positive_control_checker_detects_a_mutated_record(
+        self, seq11_source: dict[str, Any]
+    ) -> None:
+        baseline = seq11_source["source_records"][0]
+        mutated = dict(baseline)
+        mutated["title"] = str(baseline.get("title")) + " TAMPERED"
+        mutated["verified_at"] = "2099-01-01T00:00:00Z"
+        assert _differs_only_in_restamp_fields(baseline, mutated) is False
+        # ...while a pure re-stamp of the same record passes the checker.
+        restamped = dict(baseline)
+        restamped["verified_at"] = "2099-01-01T00:00:00Z"
+        restamped["verified_by"] = "someone.else"
+        assert _differs_only_in_restamp_fields(baseline, restamped) is True
+
+
+# ---------------------------------------------------------------------------
+# (d) byte-invariance — rules, products, non-restamped records, top level
+# ---------------------------------------------------------------------------
+
+
+class TestByteInvariance:
+    def test_rules_canonically_identical_to_seq11(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        assert len(seq12_source["rules"]) == len(seq11_source["rules"])
+        assert _canon(seq12_source["rules"]) == _canon(seq11_source["rules"])
+
+    def test_products_canonically_identical_to_seq11(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        assert len(seq12_source["products"]) == len(seq11_source["products"])
+        assert _canon(seq12_source["products"]) == _canon(seq11_source["products"])
+
+    def test_source_record_set_unchanged(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        seq11_ids = {r["source_record_id"] for r in seq11_source["source_records"]}
+        seq12_ids = {r["source_record_id"] for r in seq12_source["source_records"]}
+        assert seq11_ids == seq12_ids
+        assert len(seq12_source["source_records"]) == len(seq11_source["source_records"])
+
+    def test_non_restamped_records_fully_identical(
+        self,
+        seq11_source: dict[str, Any],
+        seq12_source: dict[str, Any],
+        restamp_edits: dict[str, Any],
+    ) -> None:
+        restamped_ids = {e["source_record_id"] for e in restamp_edits["restamps"]}
+        seq11_by_id = {r["source_record_id"]: r for r in seq11_source["source_records"]}
+        drifted = []
+        checked = 0
+        for record in seq12_source["source_records"]:
+            if record["source_record_id"] in restamped_ids:
+                continue
+            checked += 1
+            if _canon(record) != _canon(seq11_by_id[record["source_record_id"]]):
+                drifted.append(record["source_record_id"])
+        assert checked == len(seq12_source["source_records"]) - _EXPECTED_RESTAMP_COUNT
+        assert drifted == []
+
+    def test_top_level_keys_other_than_identity_unchanged(
+        self, seq11_source: dict[str, Any], seq12_source: dict[str, Any]
+    ) -> None:
+        identity_keys = {
+            "sequence",
+            "version",
+            "rule_pack_id",
+            "previous_payload_sha256",
+            "created_at",
+            "created_by",
+        }
+        for key in set(seq11_source) | set(seq12_source):
+            if key in identity_keys or key == "source_records":
+                continue
+            assert _canon(seq12_source.get(key)) == _canon(seq11_source.get(key)), (
+                f"top-level key {key!r} drifted from seq-11"
+            )
+
+
+# ---------------------------------------------------------------------------
+# (e) regeneration parity — the disk file IS the fold's output
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerationParity:
+    def test_disk_pack_equals_freshly_assembled_payload(
+        self, seq12_source: dict[str, Any]
+    ) -> None:
+        from backend.scripts.visa_engine import fold_pack_seq12
+
+        regenerated = fold_pack_seq12.assemble_payload()
+        assert (
+            hashlib.sha256(canonicalize_json(regenerated)).hexdigest()
+            == hashlib.sha256(canonicalize_json(seq12_source)).hexdigest()
+        )

--- a/research/visa/doctrine-factory/e5/inc5-pack-edits/freshness-restamp-2026-08-20.md
+++ b/research/visa/doctrine-factory/e5/inc5-pack-edits/freshness-restamp-2026-08-20.md
@@ -1,0 +1,316 @@
+---
+date: 2026-08-20
+domain: visa
+client_case: none — engine doctrine work (weekly re-attestation lane, RulePack seq-12 source re-stamp)
+sources:
+  - https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-calling-visa
+  - https://www.imigrasi.go.id/wna/daftar-negara-voa-bvk-calling-visa/daftar-negara-subjek-visa-on-arrival
+  - https://www.imigrasi.go.id/siaran_pers/2024/04/23/izin-tinggal-peralihan-jembatani-proses-transisi-izin-tinggal-wna-di-ri
+  - https://www.imigrasi.go.id/wna/izin-tinggal-keimigrasian/izin-tinggal-kunjungan-menjadi-izin-tinggal-terbatas
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31A
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31B
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31C
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31D
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31E
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31F
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31G
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31H
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E31J
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D1
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D2
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/D12
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30A
+  - https://www.imigrasi.go.id/wna/daftar-visa-indonesia/E30B
+discovered_by: agent.air-m5.backend-rag.visa-seq12-restamp (3 reader agents + orchestrator)
+adversarial_review: kimi-k3
+---
+
+# Live source re-verification for the seq-12 `verified_at` re-stamp (2026-08-20)
+
+**Method** — same as QW-5 (`sources/freshness-recheck-2026-08-16.md`), the seq-9 inc3 recheck
+(`inc3-pack-edits/freshness-2026-08-19.md`), and the seq-10 inc4 recheck
+(`inc4-pack-edits/freshness-restamp-2026-08-19.md`): for each `OFFICIAL_PORTAL` source record in
+`rulepack-prod-011.source.json`, the rules/products citing it were resolved via `source_refs` to
+determine the exact fact the record is cited FOR, then the live page was fetched (`WebFetch`) and
+its current content compared against that claimed fact. HTTP reachability alone was never treated
+as proof. Fetches executed 2026-08-20 ~06:14–06:16 UTC by three parallel readers (1 =
+lists/procedural, 2 = E31 family, 3 = D-series/E30), plus an independent orchestrator spot-check on
+two records.
+
+**Trigger** — this is a scheduled **weekly re-attestation** cycle, run on Zero's 2026-08-20 GO for
+the weekly re-attestation cadence, NOT a reaction to a `DECISIVE_SOURCE_STALE` trip. All 18 records
+carry a 7-day `MAX_AGE_SINCE_VERIFIED_AT`; the seq-9/seq-10 stamps put their due dates at
+2026-08-25 (`ecd22722` E31E, stamped in the seq-9 fold at `2026-08-18T21:41:23Z` — note the
+carried `verified_by` label ends `qw5-recheck-2026-08-19`: the label names the seq-9 fold cycle's
+recheck date while the fetch itself ran 21:41Z the evening before; a pre-existing seq-9 label/stamp
+skew, disclosed here, not introduced or repeated by this batch) and 2026-08-26 (the other 17: 16
+stamped in the seq-10 fold between `04:20:00Z` and `04:22:00Z`, plus `2d090f3a` E31J at
+`04:31:03Z` by the seq-10 orchestrator) — i.e. every record here was
+re-verified 5-6 days **before** it would otherwise trip `HUMAN_REVIEW`. This is a **PRE-EXPIRY
+re-stamp by design**: zero abstain gap — the engine never sees a stale-source path on any
+rule/product these 18 records back.
+
+## Verdict tally
+
+| Verdict | Count | Records |
+|---|---|---|
+| CURRENT | 17 | bc309fa9, 38a6cb08, 3da72c7b, dcf08e19, 950a9f63, 570f2bc4, 40523028, 50457cd0, ecd22722, f9306203, 86880290, 153beca1, 2d090f3a, ca5a2ce8, d3ad622e, 5e64ec6b, cb1b7182 |
+| CURRENT WITH EXCEPTION | 1 | 38242587 (E30A — see §17) |
+| CHANGED | 0 | — |
+| UNREACHABLE | 0 | — |
+
+Every verdict below re-stamps `verified_at` to the record's actual fetch time and `verified_by` to
+`agent.air-m5.backend-rag.visa-seq12-reader-<n>.qw5-recheck-2026-08-20` (reader-1 for the
+lists/procedural batch, reader-2 for the E31 family + E31E, reader-3 for the D-series/E30 batch).
+`content_sha256` is untouched everywhere: no page changed vs the prior seq-9/seq-10 description,
+and the field tracks the page's content identity, not the stamp
+(`test_seq7_sponsor_witnesses.py:220` precedent).
+
+## Per-record findings
+
+### 1. `bc309fa9` — Calling Visa country list — CURRENT — 2026-08-20T06:14Z
+Facts cited for: the closed 6-entry Calling Visa list; Cameroon/Guinea must be ABSENT (seq-3
+retroactive-cure premise). Live page: exactly 6 entries — Afganistan, Israel, Korea Utara, Liberia,
+Nigeria, Somalia. No Kamerun, no Guinea. 1:1 match, identical to the seq-10 finding.
+
+### 2. `38a6cb08` — VOA country list — CURRENT — 2026-08-20T06:14Z
+Facts cited for: the ~97-country VOA-eligible list, Italy present. Live page: 97 entries, Italia
+present (#32), Nigeria absent (consistent — Nigeria is calling-visa-only, per §1). Same count and
+membership as seq-10.
+
+### 3. `3da72c7b` — Izin Tinggal Peralihan press release — CURRENT — 2026-08-20T06:14Z
+Facts cited for: bridging concept, 60-day validity, 3-day pre-expiry filing window. All three
+confirmed verbatim: *"Izin tinggal tersebut menjadi 'jembatan' antara izin tinggal sebelumnya untuk
+memperoleh izin tinggal baru"*; *"Masa berlaku Izin Tinggal Peralihan yakni 60 hari"*; *"...paling
+lambat 3 (tiga) hari sebelum masa berlaku izin tinggal sebelumnya habis."* Word-for-word match to
+seq-10.
+
+### 4. `dcf08e19` — ITK→ITAS conversion service page — CURRENT — 2026-08-20T06:14Z
+Facts cited for: 30-day pre-expiry filing window, 4-step conversion procedure. Confirmed:
+*"Permohonan alih status ITK menjadi ITAS diajukan dalam waktu paling lama 30 hari sebelum jangka
+waktu Izin Tinggal Kunjungan berakhir"* + the same 4-step Tata Cara Permohonan. Same
+narrow-scope-corroborator caveat as seq-10 (silent on excluded ITK status codes, carried elsewhere,
+no contradiction).
+
+### 5. `950a9f63` — E31A — CURRENT — 2026-08-20T06:15Z
+Facts cited for: spouse-of-WNI sponsor/classification fact, USD 2,000 living-costs fact. Confirmed:
+*"E31A Visa Keluarga Suami/Istri WNI"* + *"bukti memiliki biaya hidup ... dengan jumlah minimal USD
+$2000."* Identical wording to seq-10.
+
+### 6. `570f2bc4` — E31B — CURRENT — 2026-08-20T06:15Z
+Facts cited for: sponsor holds ITAS/ITAP. Confirmed by title *"E31B Visa Keluarga Suami/Istri
+Pemegang ITAS/ITAP"* — carried by the classification, not a separate Persyaratan bullet, same
+interpretive posture as seq-10.
+
+### 7. `40523028` — E31C — CURRENT — 2026-08-20T06:15Z
+Facts cited for: official proof of the parents' legally registered marriage (two routes),
+birth-certificate proof. Confirmed on the live page. **Orchestrator spot-check (2026-08-20
+~06:30Z, W65 independent re-fetch)**: the full two-route marriage-proof clause is verbatim on the
+live page — *"Bukti pelaporan atau pencatatan pada Perwakilan Republik Indonesia atau instansi yang
+berwenang di bidang pencatatan sipil dan akta perkawinan yang telah diterjemahkan dalam bahasa
+Indonesia oleh penerjemah tersumpah; atau Buku nikah atau akta perkawinan yang dikeluarkan oleh
+kementerian atau lembaga berwenang (jika perkawinan dilakukan di wilayah Indonesia)."* This confirms
+reader 2's own read that its shorter extraction was a WebFetch artifact of that specific call, not
+page drift — see Method gotchas below.
+
+### 8. `50457cd0` — E31D — CURRENT — 2026-08-20T06:15Z
+Facts cited for: step-child scope, sponsor requirement. Confirmed by title *"E31D Visa Keluarga Anak
+Bawaan WNA Perkawinan Sah WNA-WNI"* + document set (birth certificate, parents' marriage proof, WNI
+parent's Kartu Keluarga) — same implicit-but-unambiguous status as seq-10.
+
+### 9. `ecd22722` — E31E — CURRENT — 2026-08-20T06:15Z
+Facts cited for: parent holds a valid ITAS/ITAP/Visa Tinggal Terbatas (`REQ_SPONSOR_ITAS_ITAP` only
+— the two `hf.e31e-*` HARD_FILTER rules were replaced off this record in the seq-9 fold and are out
+of scope). Confirmed: *"Izin Tinggal Terbatas/Izin Tinggal Tetap atau Visa Tinggal Terbatas milik
+orang tua yang masih berlaku."* No age/marital-status language found anywhere on the page,
+consistent with the seq-9 replacement rationale — no regression back toward support for the rules
+that no longer cite this record. **This record's prior write-up lives in
+`inc3-pack-edits/freshness-2026-08-19.md` (seq-9 fold), not inc4** — it was re-stamped a day before
+the E31A/B/C/D/F/G/H/J batch and was explicitly excluded from the inc4 doc by that doc's own line
+46-47.
+
+### 10. `f9306203` — E31F — CURRENT — 2026-08-20T06:15Z
+Facts cited for: Indonesian court-decision proof of the legal relationship between the foreign child
+and the Indonesian-citizen parent. Confirmed verbatim: *"Putusan pengadilan Indonesia yang
+menjelaskan status hubungan hukum antara Warga Negara Asing dengan orangtua warga negara
+Indonesia."*
+
+### 11. `86880290` — E31G — CURRENT — 2026-08-20T06:15Z
+Facts cited for: sponsor requirement + evisa account requirement, 6-month passport validity, USD
+2,000/3-month bank-statement clause. All four cited facts confirmed verbatim (reader 2's live
+quotes):
+- Title/classification: *"E31G Visa Keluarga Orang Tua dari Anak WNI"*
+- Sponsor: *"Anda membutuhkan penjamin/sponsor untuk mengajukan visa ini."*
+- Sponsor evisa account: *"Penjamin (sponsor) harus memiliki akun di evisa.imigrasi.go.id sebelum
+  mengajukan visa."*
+- Passport validity: *"Paspor kebangsaan yang sah dan masih berlaku paling singkat 6 bulan sebelum
+  masa berlakunya habis"*
+- Funds clause: *"bukti memiliki biaya hidup selama berada di wilayah Indonesia berupa rekening
+  koran 3 bulan terakhir..."* — exact match to seq-10.
+
+### 12. `153beca1` — E31H — CURRENT — 2026-08-20T06:15Z
+Facts cited for: child holds a valid ITAS/ITAP/Visa Tinggal Terbatas. Confirmed byte-for-byte:
+*"Izin Tinggal Terbatas/Izin Tinggal Tetap atau Visa Tinggal Terbatas yang masih berlaku milik
+anak."*
+
+### 13. `2d090f3a` — E31J — CURRENT — 2026-08-20T06:15Z
+Facts cited for: sibling holds a valid ITAS/ITAP, sponsor requirement, dependency-age (not expected
+on this page, co-sourced with the Kepmen record `e3572ad2`). Confirmed verbatim (reader 2's live
+quotes):
+- Title/classification: *"E31J Visa Keluarga Anak yang Bergabung dengan Saudara Kandung Pemegang
+  ITAS/ITAP"*
+- Sponsor: *"Anda membutuhkan penjamin/sponsor untuk mengajukan visa ini."*
+- Sibling holds ITAS/ITAP: *"Visa tinggal terbatas, Izin Tinggal Terbatas/Izin Tinggal Tetap atau
+  Visa Tinggal Terbatas yang masih berlaku milik saudara kandung."* (plus *"Bukti jaminan dari
+  Penjamin atau pernyataan komitmen saudara kandung."*)
+- No dependency-age language on the page found — exactly matches seq-10 (that fact rides on the
+  Kepmen co-source, as expected).
+
+### 14. `ca5a2ce8` — D1 — CURRENT — 2026-08-20T06:15Z
+Facts cited for: multi-entry support, passport validity, USD 2,000 funds, CV, itinerary, support
+letter. All 6 cited facts reconfirmed verbatim against the live page (reader 3's quotes):
+- Multi-entry / 60-day stay: *"Visa Kunjungan untuk beberapa kali masuk ke Indonesia dengan izin
+  tinggal maksimal 60 hari"*
+- Passport validity: *"dokumen perjalanan yang sah dan masih berlaku paling singkat 6 bulan sebelum
+  masa berlakunya habis"*
+- Funds (USD 2000): *"bukti memiliki biaya hidup selama berada di wilayah Indonesia berupa rekening
+  koran 3 bulan terakhir atas nama Orang Asing atau penjamin sebesar minimal USD2000"*
+- CV: *"curriculum vitae"* · Itinerary: *"rencana perjalanan (travel itinerary)"*
+- Support letter: *"surat keterangan, undangan, atau korespondensi dari instansi pemerintah atau
+  lembaga swasta"* OR *"surat keterangan dari suami/istri atau orang tua (WNI)"*
+No drift.
+
+### 15. `d3ad622e` — D2 — CURRENT — 2026-08-20T06:15Z
+All 6 cited facts reconfirmed verbatim (reader 3's quotes — the wording overlaps D1's but each was
+fetched and quoted from the D2 page itself, not inherited):
+- Multi-entry: *"Visa Kunjungan untuk beberapa kali masuk ke Indonesia dengan izin tinggal maksimal
+  60 hari setiap kedatangan"*
+- Passport validity: *"dokumen perjalanan yang sah dan masih berlaku paling singkat 6 bulan sebelum
+  masa berlakunya habis"*
+- Funds: *"...sebesar minimal USD2000"* · CV: *"curriculum vitae"* · Itinerary: *"rencana
+  perjalanan (travel itinerary)"*
+- Support letter: *"surat keterangan, undangan, atau korespondensi dari instansi pemerintah atau
+  lembaga swasta"*
+- Business purpose (matches pack citation verbatim): *"berbisnis, mengikuti rapat, serta melakukan
+  pembelian barang. Anda juga dapat melakukan pembicaraan, pembahasan, negosiasi, dan/atau
+  menandatangani perjanjian bisnis"*
+No drift.
+
+### 16. `5e64ec6b` — D12 — CURRENT — 2026-08-20T06:15Z
+Facts cited for: the shared D-series 6 facts (USD 5,000 variant) plus the non-convertibility
+hard-filter `hf.d12-onshore-conversion-excluded`. Non-convertibility clause reconfirmed verbatim on
+a targeted second fetch: *"...bisa diperpanjang untuk 180 hari berikutnya namun tidak bisa
+dialihkan menjadi izin tinggal terbatas."* See Method gotchas below.
+
+### 17. `38242587` — E30A — CURRENT WITH EXCEPTION — 2026-08-20T06:15Z
+Facts cited for: 6-month passport validity, USD 2,000 living-costs. Both confirmed verbatim
+(reader 3's live quotes):
+- Passport validity: *"Paspor kebangsaan yang sah dan masih berlaku paling singkat 6 bulan sebelum
+  masa berlakunya habis"*
+- Funds (USD 2000): *"bukti memiliki biaya hidup selama berada di wilayah Indonesia berupa rekening
+  koran 3 bulan terakhir atas nama Orang Asing atau penjamin dengan jumlah minimal USD $2000 (dua
+  ribu Dolar Amerika Serikat) atau jumlah yang setara"*
+Stay-policy cross-check: pack 365-730 days ↔ live *"Stay Duration: 1 or 2 years (selectable),
+calculated from arrival date."* Match.
+**Exception (unchanged, ledgered)**: `review.minor-without-guardian` is a GLOBAL rule whose sole
+`source_ref` is this record; reader 3 searched the full live page text for "anak"/"wali"/"minor"/
+"guardian" — zero occurrences of any of the four terms anywhere on the page. The exception still
+stands as ledgered — not cured, not regressed, unchanged from the seq-10 finding.
+
+### 18. `cb1b7182` — E30B — CURRENT — 2026-08-20T06:15Z
+Facts cited for: passport validity, USD 2,000 living-costs, acceptance-letter and sponsor-proof
+clauses backing `el.e30b-izin-belajar`. All confirmed verbatim (reader 3's live quotes):
+- Passport validity: *"Paspor kebangsaan yang sah dan masih berlaku paling singkat 6 bulan sebelum
+  masa berlakunya habis"* (identical to E30A)
+- Funds: *"...dengan jumlah minimal USD $2000 (dua ribu Dolar Amerika Serikat) atau jumlah yang
+  setara"* (identical wording to E30A, quoted from the E30B page itself)
+- Acceptance letter (matches pack citation verbatim): *"Surat penerimaan dari institusi pendidikan
+  yang mencantumkan lama masa pendidikan yang akan ditempuh orang asing."*
+- Sponsor proof (matches pack citation verbatim): *"bukti penjaminan dari Penjamin yang merupakan
+  perorangan atau institusi pendidikan di mana WNA menempuh pendidikan"*
+Stay-policy cross-check: pack 365-1460 days ↔ live *"Stay Duration Options: 1 tahun, 2 tahun, atau
+4 tahun."* Match.
+Known terminology gap (reader 3 searched the live page for "Izin Belajar" and
+"Kemdikbud"/"Kemendikbud" — zero occurrences of either) persists unchanged — recorded, not a
+regression.
+
+## Method gotchas
+
+- **E31C extraction artifact (reader 2)**: the first WebFetch pass on record 7 (`40523028`)
+  returned a truncated paraphrase of the two-route marriage-proof clause, missing the "...oleh
+  penerjemah tersumpah; atau Buku nikah..." tail. Reader 2 flagged this itself as a likely
+  summarizer artifact rather than page drift (the opening clause was byte-identical, nothing on the
+  page contradicted the second route). **Confirmed by the orchestrator's independent W65
+  spot-check** (§7 above): the full clause is verbatim on the live page. Lesson held: a single
+  WebFetch pass can silently truncate/paraphrase a load-bearing verbatim quote even when the page
+  itself has not changed.
+- **D12 targeted re-fetch (reader 3)**: the first WebFetch pass on record 16 (`5e64ec6b`) conflated
+  the non-convertibility clause (180-day extension, no conversion to ITAS) with a *different*,
+  unrelated sentence elsewhere on the page (the general 1-2 year overall-duration blurb). Both
+  sentences are genuinely present and not in conflict, but the summarizer silently merged/paraphrased
+  them on first read. A second, narrowly-scoped fetch isolated the exact non-convertibility string.
+  Lesson: do not trust a single WebFetch pass for a load-bearing verbatim quote when the
+  summarizer's phrasing does not exactly match what is being checked against — re-fetch narrow.
+
+## E30A/E30B PNBP price grounding
+
+Re-confirmed live on both pages (not currently cited by a pack rule — informational only, grounds
+the composed prices published on the E30A/E30B product pages):
+
+| Product | 1 tahun | 2 tahun | 4 tahun |
+|---|---|---|---|
+| E30A | Rp 6.000.000 | Rp 8.500.000 | — |
+| E30B | Rp 6.000.000 | Rp 8.500.000 | Rp 12.000.000 |
+
+Pack `pricing_key.item_key` is `"E30A Education Visa (1 Year)"` / `"E30B Higher Education (1 Year)"`
+only — the multi-year figures live on the page with no matching pack pricing_key at present;
+flagged for whoever owns the pricing-key completeness question, not fixed here (out of scope — this
+task is freshness re-verification, not pricing edits).
+
+## Adversarial review
+
+**Orchestrator independent spot-check (W65, 2026-08-20 ~06:30Z)** — two records re-fetched
+independently by the orchestrator, outside the three reader agents' own fetches, to test for
+phantom/fabricated quotes before folding the re-stamp:
+
+1. `bc309fa9` (Calling Visa list) re-fetched independently: exactly 6 countries (Afganistan,
+   Israel, Korea Utara, Liberia, Nigeria, Somalia), Kamerun and Guinea ABSENT — matches reader 1
+   verbatim.
+2. `40523028` (E31C) re-fetched independently: the full two-route marriage-proof clause is on the
+   live page verbatim (quoted in §7 / Method gotchas above) — reader 2's truncation is confirmed to
+   be a WebFetch extraction artifact of that specific call, not page drift.
+
+Both spot-checks corroborate the reader findings; no fabricated quote, no verdict broader than its
+evidence, no timestamp inconsistency found in either record. No CHANGED verdict was produced by
+this batch — all 17 CURRENT verdicts and the 1 CURRENT WITH EXCEPTION stand as reported.
+
+**Cross-family refuter: Kimi K3 (Moonshot), 2026-08-20 — generator≠grader with parentage
+declared (W100):** the three readers, the assembler, and the orchestrator are all Claude-family;
+the refuter seat is cross-family by construction. Codex GPT-5.6-sol was dispatched first and came
+back quota-dead (usage limit until 2026-08-22) — the cascade fell to Kimi K3, which executed the
+full review (both files cross-checked programmatically against the pack bytes).
+
+Kimi's initial verdict was **FAIL — evidentiary, not computational**. It confirmed the machine
+layer byte-perfect (all 18 restamps match the pack's current stamps exactly, advance correctly,
+reader attribution consistent 1:1, canonical URLs = frontmatter sources, freshness policies
+604800s across the board) and refuted the CAPTURE on six counts, every one accepted and repaired
+in this same document before commit:
+
+1. §11 E31G, §13 E31J, §14 D1, §17 E30A, §18 E30B claimed "confirmed verbatim" with zero quotes,
+   and §15 D2 quoted 1 of 6 facts while inheriting the rest from the unquoted D1 section —
+   contradicting the edit file's own "verbatim quotes per record" promise. **Repaired**: the
+   readers' live quotes (which existed in their raw outputs all along — the assembly step had
+   summarized them away) are now imported verbatim into all six sections; D2's quotes are its own
+   page's, not inherited.
+2. The "`2026-08-19T04:2x:xxZ`" shorthand for the 17 seq-10 stamps was false for `2d090f3a` E31J
+   (`04:31:03Z`). **Repaired**: the Trigger paragraph now states the real range (16 records
+   04:20-04:22, E31J 04:31:03Z).
+3. `ecd22722`'s carried seq-9 stamp (`2026-08-18T21:41:23Z`) disagrees with its `verified_by`
+   label date (`...2026-08-19`) — a pre-existing seq-9 label/stamp skew, not introduced here.
+   **Disclosed** in the Trigger paragraph rather than silently repeated.
+
+Kimi found lanes (b) id/stamp, (c) reader attribution, and (f) quote-supports-fact explicitly
+CLEAN (every quote that was present does support its cited fact; the §6 E31B classification-carried
+posture is disclosed, consistent with seq-10, and was noted, not refuted). With the six evidentiary
+repairs applied, no REFUTED finding remains unaddressed; the FAIL bit exactly what it should have
+and the capture now meets its own stated bar.

--- a/research/visa/doctrine-factory/e5/inc5-pack-edits/source-restamp-edits.json
+++ b/research/visa/doctrine-factory/e5/inc5-pack-edits/source-restamp-edits.json
@@ -1,0 +1,167 @@
+{
+  "_comment": "E5 increment 5 (seq-12), weekly re-attestation lane. 18 verified_at/verified_by re-stamps, each backed by a live QW-5-method re-verification recorded in freshness-restamp-2026-08-20.md (verbatim quotes per record), plus an independent orchestrator spot-check (W65) on 2 records (bc309fa9, 40523028). content_sha256 untouched everywhere: no page changed semantically vs the prior seq-9/seq-10 description. Zero drops this batch — all 18 records confirmed live and cited, no record loses its last ref. PRE-EXPIRY re-stamp: prior due dates were 2026-08-25 (ecd22722, seq-9 stamp) / 2026-08-26 (the other 17, seq-10 stamps) — this batch runs 5-6 days ahead of the DECISIVE_SOURCE_STALE trip, zero abstain gap by design. Applied by fold_pack_seq12.py with ledger-drift checks: every current_* value must match the seq-9/seq-10 bytes or the fold refuses.",
+  "restamps": [
+    {
+      "source_record_id": "153beca1-a24b-5440-bac0-b46c3d19da6f",
+      "source_key": "imigrasi.go.id.e31h.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:21:00Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "2d090f3a-5a93-5181-b3d1-253d87a1a17c",
+      "source_key": "imigrasi.go.id.e31j.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:31:03Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-orchestrator.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "38242587-f4da-5c31-b0ea-662f7fdc475c",
+      "source_key": "imigrasi.go.id.e30a.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:21:51Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "38a6cb08-041f-51e4-86e4-9e73243acd3a",
+      "source_key": "imigrasi-voa-country-list",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:35Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:14:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "3da72c7b-783e-51e3-9168-6c54bce709ed",
+      "source_key": "imigrasi-press-2024-04-24-izin-tinggal-peralihan",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:35Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:14:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "40523028-431b-5ae0-a937-277882f0f243",
+      "source_key": "imigrasi.go.id.e31c.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:22:00Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "50457cd0-b67f-5b88-bf66-33bcf62f3d9b",
+      "source_key": "imigrasi.go.id.e31d.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:00Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "570f2bc4-5120-561f-90ba-58fcd9507514",
+      "source_key": "imigrasi.go.id.e31b.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:21:00Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "5e64ec6b-8fcc-5518-b70f-87bf22aa5e29",
+      "source_key": "imigrasi.go.id.d12.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:21:51Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "86880290-68c2-5220-8f9e-2350678e5f09",
+      "source_key": "imigrasi.go.id.e31g.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:00Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "950a9f63-0b78-5a9e-ba12-9454e4b7dfb2",
+      "source_key": "imigrasi.go.id.e31a.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:00Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "bc309fa9-d14e-5625-b914-72fe4a68c19d",
+      "source_key": "imigrasi-calling-visa-country-list",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:35Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:14:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "ca5a2ce8-83bb-58ec-b2d9-285833cf085a",
+      "source_key": "imigrasi.go.id.d1.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:21:51Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "cb1b7182-1e29-58df-9aec-4e9bf66e10de",
+      "source_key": "imigrasi.go.id.e30b.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:21:51Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "d3ad622e-f2d9-5b31-8ede-bc87e6b9cc0e",
+      "source_key": "imigrasi.go.id.d2.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:21:51Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-3.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-3.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "dcf08e19-fbc3-5f96-93fa-0325b1ffe91d",
+      "source_key": "imigrasi-alih-status-itk-itas-service-page",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:35Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-1.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:14:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-1.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "ecd22722-3e42-5808-be18-45fbb7d8e9c5",
+      "source_key": "imigrasi.go.id.e31e.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-18T21:41:23Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq9-implementer-b.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    },
+    {
+      "source_record_id": "f9306203-0bdc-5dd8-9603-554e7eefedc8",
+      "source_key": "imigrasi.go.id.e31f.daftar-visa-indonesia",
+      "field": "verified_at+verified_by",
+      "current_verified_at": "2026-08-19T04:20:00Z",
+      "current_verified_by": "agent.air-m5.backend-rag.visa-e5-seq10-reader-2.qw5-recheck-2026-08-19",
+      "new_verified_at": "2026-08-20T06:15:00Z",
+      "new_verified_by": "agent.air-m5.backend-rag.visa-seq12-reader-2.qw5-recheck-2026-08-20"
+    }
+  ]
+}

--- a/scripts/detect_secrets_auto_triage.py
+++ b/scripts/detect_secrets_auto_triage.py
@@ -344,6 +344,30 @@ CONTENT_KEYED_RULES: list[tuple[re.Pattern[str], re.Pattern[str], str]] = [
         "the public signed seq-10 RulePack payload, triple-derived at run "
         "time; exact value pinned, never a credential",
     ),
+    # fold_pack_seq12.py: _EXPECTED_SEQ11_PAYLOAD_SHA256 is the chain anchor —
+    # the content-derived sha256 of the PUBLIC signed seq-11 RulePack payload
+    # (same value class as the contracts/packs/rulepack-*.json rule in
+    # AUTO_APPROVE_RULES: hashes of public legal documents, never
+    # credentials). The fold script pins it so the seq-12 chain link is
+    # triple-derived at run time (declared == anchor == recomputed from the
+    # seq-11 source bytes) and any mismatch aborts the fold.
+    #
+    # Content-keyed and pinned to the EXACT anchor value, not a hex shape:
+    # this is production code with an open surface for future edits — a real
+    # credential pasted anywhere else in the file (or even another 64-hex
+    # value on this line) stays flagged. The approved line is the bare
+    # continuation-string line of the parenthesized assignment, end-anchored.
+    (
+        re.compile(
+            r"^apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq12\.py$"
+        ),
+        re.compile(
+            r'^\s*"836acc511bcadd41c28284e7f00bd8be27c6109ebcc5536f7053c3f61eaa2865"\s*$'
+        ),
+        "fold_pack_seq12.py: seq-11 chain anchor — content-derived sha256 of "
+        "the public signed seq-11 RulePack payload, triple-derived at run "
+        "time; exact value pinned, never a credential",
+    ),
 ]
 
 # Each rule is (pattern, reason). The pattern matches the file path

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -217,13 +217,14 @@ def test_kbli_gold_rule_registered_and_scoped_to_exactly_one_file() -> None:
     """Sanity: the KBLI gold-set rule is path-scoped to kbli-gold-all.json
     only — not the other KBLI files, which stay on the closed-writer-set
     path rules in AUTO_APPROVE_RULES."""
-    assert len(CONTENT_KEYED_RULES) == 11  # +1: infra/llm-credentials/declared.json sha256_16 (2026-08-12)
+    assert len(CONTENT_KEYED_RULES) == 12  # +1: infra/llm-credentials/declared.json sha256_16 (2026-08-12)
     # +1: apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py public_key (2026-08-13)
     # +1: research/visa/2026-08-12-gold-replay-live-report.json payload_sha256 (2026-08-13)
     # +1: scripts/lint_telegram_tokens.py KNOWN_COMPROMISED sha256[:16] key (2026-08-14)
     # +1: traffic-source fail-closed proof identity/integrity anchors (2026-08-15)
     # +1: fold_pack_seq10.py seq-9 chain anchor exact-value pin (2026-08-19)
     # +1: fold_pack_seq11.py seq-10 chain anchor exact-value pin (2026-08-20)
+    # +1: fold_pack_seq12.py seq-11 chain anchor exact-value pin (2026-08-20)
     path_pat, _content_pat, reason = CONTENT_KEYED_RULES[1]
     assert path_pat.search(KBLI_GOLD_ALL)
     assert not path_pat.search("apps/mouth/data/KBLI_2025_FINAL_CLEAN.json")
@@ -1099,4 +1100,82 @@ def test_innocence_fold_seq11_keyed_assignment_not_approved() -> None:
     parenthesized assignment, never a `"key": "value"` shape."""
     _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[10]
     keyed_line = f'    "payload_sha256": "{FOLD_PACK_SEQ11_ANCHOR}",'
+    assert content_pat.match(keyed_line) is None
+
+
+# ---------------------------------------------------------------------------
+# fold_pack_seq12.py — seq-11 chain anchor exact-value pin (CONTENT_KEYED_RULES[11])
+# ---------------------------------------------------------------------------
+# Same class and discipline as the seq-10/seq-11 fold rules directly above:
+# the pinned value is the sha256 of the PUBLIC signed seq-11 RulePack payload,
+# and the rule approves ONLY the bare continuation-string line of the
+# parenthesized assignment, end-anchored, in exactly one file.
+
+FOLD_PACK_SEQ12 = "apps/backend-rag/backend/scripts/visa_engine/fold_pack_seq12.py"
+FOLD_PACK_SEQ12_ANCHOR = (
+    "836acc511bcadd41c28284e7f00bd8be27c6109ebcc5536f7053c3f61eaa2865"
+)
+
+
+def test_fold_seq12_rule_registered_and_scoped_to_exactly_one_file() -> None:
+    path_pat, _content_pat, reason = CONTENT_KEYED_RULES[11]
+    assert path_pat.search(FOLD_PACK_SEQ12)
+    assert not path_pat.search(FOLD_PACK_SEQ11)
+    assert not path_pat.search(FOLD_PACK_SEQ10)
+    assert not path_pat.search(
+        "apps/backend-rag/backend/scripts/visa_engine/gold_replay_driver.py"
+    )
+    assert not path_pat.search("scripts/fold_pack_seq12.py")
+    assert "credential" in reason
+
+
+def test_guilt_fold_seq12_real_finding_approved() -> None:
+    """The exact real line 89 in the fold script must be approved — read live
+    off disk, so this fails if the file and rule ever drift, not merely if
+    someone edits a string literal in this test."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[11]
+    lines = Path(FOLD_PACK_SEQ12).read_text(encoding="utf-8").splitlines()
+    real_line = lines[88]  # line 89, 1-indexed
+    assert real_line == f'    "{FOLD_PACK_SEQ12_ANCHOR}"'
+    assert content_pat.match(real_line), f"should be approved: {real_line!r}"
+
+
+def test_innocence_fold_seq12_other_hex_value_not_approved() -> None:
+    """A DIFFERENT 64-hex bare string line must not be approved — proves the
+    rule is pinned to the exact anchor value, not merely to the shape.
+    The seq-10 anchor (rule 11's value) doubles as the nearest-neighbour
+    innocent: a REAL sibling anchor must still not launder through THIS rule."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[11]
+    other_hex_line = '    "' + "a" * 64 + '"'
+    assert content_pat.match(other_hex_line) is None
+    sibling_anchor_line = f'    "{FOLD_PACK_SEQ11_ANCHOR}"'
+    assert content_pat.match(sibling_anchor_line) is None
+
+
+def test_innocence_fold_seq12_uppercase_not_approved() -> None:
+    """The same value uppercased must not be approved — the anchor is
+    lowercase hex, matching hashlib.hexdigest's own output."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[11]
+    uppercase_line = f'    "{FOLD_PACK_SEQ12_ANCHOR.upper()}"'
+    assert content_pat.match(uppercase_line) is None
+
+
+def test_innocence_fold_seq12_ride_along_statement_not_approved() -> None:
+    """The value followed by a second statement or token on the same line
+    must not launder the ride-along — end-anchored, same discipline as every
+    other rule in this list."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[11]
+    for compound in (
+        f'    "{FOLD_PACK_SEQ12_ANCHOR}"; import os',
+        f'    "{FOLD_PACK_SEQ12_ANCHOR}" "second_token"',
+    ):
+        assert content_pat.match(compound) is None, f"must NOT be approved: {compound!r}"
+
+
+def test_innocence_fold_seq12_keyed_assignment_not_approved() -> None:
+    """A JSON-style keyed line carrying the same value must not be approved —
+    the rule approves only the bare continuation-string shape of the
+    parenthesized assignment, never a `"key": "value"` shape."""
+    _path_pat, content_pat, _reason = CONTENT_KEYED_RULES[11]
+    keyed_line = f'    "payload_sha256": "{FOLD_PACK_SEQ12_ANCHOR}",'
     assert content_pat.match(keyed_line) is None


### PR DESCRIPTION
## What

RulePack **seq-12** — the first run of the weekly re-attestation lane (Zero GO 2026-08-20: "go, ma fai in modo che sia perfetto"). One concern: re-stamp `verified_at`/`verified_by` on all **18 OFFICIAL_PORTAL** source_records, each backed by a live QW-5-method re-verification executed 2026-08-20 ~06:14–06:15Z by 3 parallel reader agents + 2 independent orchestrator spot-checks (W65). **Zero rule edits, zero product edits, zero drops, `content_sha256` untouched everywhere** — no page changed semantically vs 2026-08-19.

Without this pack, the active seq-11's portal stamps cross their 7-day `freshness_policy` window ~2026-08-25/26 and production trips `DECISIVE_SOURCE_STALE` → blanket HUMAN_REVIEW abstain (the "visa oracle muto" Zero ordered us to prevent). This batch runs 5–6 days ahead of that cliff.

## Pieces

- `fold_pack_seq12.py` — deterministic fold seq-11 → seq-12. Chain anchor `836acc51…` triple-derived (declared in `rulepack-prod-011.signed.json` == pinned constant == recomputed SHA256(JCS(seq-11 source))); rule_pack_id `dd98e153-4f89-5176-b32e-d936b7bb2351` = uuid5 convention, verified never assumed. The restamped set is derived by ENTITY (== the OFFICIAL_PORTAL set), never a frozen id list (W106); count 18 pinned as drift tripwire; every restamp guarded on {current → new} ledger values and on clock advancement; `_assert_untouched` holds rules AND products to whole-collection canonical equality (no carve-outs) and every non-restamped record to full equality.
- `rulepack-prod-012.source.json` — the folded pack (110 rules / 38 products / 28 source_records, identical counts to seq-11). Idempotence proven: two fold runs → byte-identical file (sha256 `b76800da…`).
- `test_seq12_pack.py` — 14 tests, no skip-if-missing (the pack ships in this PR; absence = red, scar family #2): chain gate recomputed from bytes, uuid5 identity, restamp parity (18 exactly, only `verified_at`/`verified_by`, set == portal set, clock advances, pack == inc5 ledger, content_sha256 untouched ×28) + positive control proving the checker CAN fail, byte-invariance (rules/products/top-level/10 untouched records), regeneration parity (disk == fresh `assemble_payload()`).
- `inc5-pack-edits/` — QW-5 capture doc (18/18: 17 CURRENT + 1 CURRENT WITH EXCEPTION (E30A `review.minor-without-guardian` sourcing defect, standing & disclosed) + 0 CHANGED + 0 UNREACHABLE; verbatim quotes per record; method gotchas: E31C truncation + D12 conflation both proven WebFetch extraction artifacts, not page drift) + machine edits JSON (18 restamps, verified programmatically against pack bytes).
- Detect Secrets rule **#12** (preemptive, per-pack ritual): exact-value pin of the seq-11 chain anchor on `fold_pack_seq12.py`'s bare continuation line; corpus 11→12 with guilt-on-disk + 4 innocence tests (sibling anchor, uppercase, ride-along, keyed shape). 81/81 green.

## Verification

- `pytest test_seq12_pack.py test_seq11_pack.py test_seq10_pack.py test_gold_replay_driver.py` — 63/63 green locally (gold replay's derived `_OFFLINE_AT` absorbs unsigned seq-12 by construction).
- `pytest scripts/tests/test_detect_secrets_auto_triage.py` — 81/81.
- Cross-family adversarial review of the capture + edits: seat and verdict recorded in the doc's `## Adversarial review` section (generator≠grader — readers/assembler are Claude-family).
- Orchestrator W65 spot-checks: calling-visa list (exactly 6 countries, Kamerun/Guinea absent) and E31C two-route marriage clause re-fetched independently, both verbatim-confirmed.

## After merge (same session, this lane)

Sign seq-12 (kid `prod-2026-07-1`) → bundle PR → activation ceremony 11→12 (`--current-sequence 11 --current-payload-sha256 836acc51…`) → live smoke proving no `DECISIVE_SOURCE_STALE`. ENFORCE stays NO-GO (DPIA/analytics-TTL Zero-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
