### PR TITLE
fix(portal): record client self-service profile edits in the CRM audit trail

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/billing.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/billing.py
@@ -272,19 +272,6 @@ class PortalBillingMixin:
                 params.append(client_id)
                 set_clause = ", ".join(set_parts)
 
-                # Capture pre-update values for the audit trail. This is a
-                # standalone read (not the phone-lock convergence loop
-                # below, which only re-reads phone/whatsapp to compute its
-                # lock set) so it covers whichever editable fields changed
-                # and always runs BEFORE the UPDATE.
-                audit_old_row = await conn.fetchrow(
-                    f"SELECT {', '.join(safe_fields.keys())} FROM clients WHERE id = $1",
-                    client_id,
-                )
-                audit_old_state = (
-                    {k: audit_old_row[k] for k in safe_fields} if audit_old_row else {}
-                )
-
                 async with conn.transaction():
                     if "phone" in safe_fields or "whatsapp" in safe_fields:
                         # Phone AND whatsapp are OWNERSHIP columns: intake
@@ -340,6 +327,26 @@ class PortalBillingMixin:
                                 "phone_lock_convergence_failed — concurrent phone "
                                 "writers, retry the profile update"
                             )
+                    # Capture pre-update values for the audit trail. Placed
+                    # HERE deliberately: inside the same transaction as the
+                    # UPDATE, and AFTER the phone-lock block above, so for a
+                    # phone/whatsapp write the row is already locked when we
+                    # read it. Read outside the transaction, another writer
+                    # could land between the read and the UPDATE and the trail
+                    # would record an old value that was never the value we
+                    # overwrote — an audit row that states a wrong prior value
+                    # is worse than no audit row, because it reads as evidence.
+                    # (It does NOT close the lost-update gap on non-phone
+                    # fields — there is no version column on `clients` either
+                    # side of the handoff; that is a wider design change and is
+                    # named in this PR's body, not fixed here.)
+                    audit_old_row = await conn.fetchrow(
+                        f"SELECT {', '.join(safe_fields.keys())} FROM clients WHERE id = $1",
+                        client_id,
+                    )
+                    audit_old_state = (
+                        {k: audit_old_row[k] for k in safe_fields} if audit_old_row else {}
+                    )
                     await conn.execute(
                         f"UPDATE clients SET {set_clause}, updated_at = NOW() WHERE id = ${len(params)} AND deleted_at IS NULL",
                         *params,

--- a/apps/backend-rag/backend/services/portal/_mixins/billing.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/billing.py
@@ -11,6 +11,7 @@ from typing import Any
 import asyncpg
 import httpx
 
+from backend.app.services.crm.audit_logger import audit_logger
 from backend.app.utils.logging_utils import get_logger
 from backend.phone_lock import lock_phone_cores, phone_core
 from backend.services.common.cache import cache_invalidating
@@ -248,6 +249,10 @@ class PortalBillingMixin:
         Side effects when fields are actually changed:
         - Inserts a notification_alerts record (portal_profile_update) for the CRM bell
         - Inserts a portal_messages record (client_to_team) so the team sees the change
+        - Inserts a crm_audit_log record (old/new values, actor tagged as the
+          client) — the same structured trail the CRM's own PATCH path writes
+          via @audit_change, so a client self-service edit is no longer
+          invisible to that trail. Best-effort: never fails the update.
         - Cache invalidation handled by the router layer
 
         Returns the updated profile.
@@ -266,6 +271,19 @@ class PortalBillingMixin:
 
                 params.append(client_id)
                 set_clause = ", ".join(set_parts)
+
+                # Capture pre-update values for the audit trail. This is a
+                # standalone read (not the phone-lock convergence loop
+                # below, which only re-reads phone/whatsapp to compute its
+                # lock set) so it covers whichever editable fields changed
+                # and always runs BEFORE the UPDATE.
+                audit_old_row = await conn.fetchrow(
+                    f"SELECT {', '.join(safe_fields.keys())} FROM clients WHERE id = $1",
+                    client_id,
+                )
+                audit_old_state = (
+                    {k: audit_old_row[k] for k in safe_fields} if audit_old_row else {}
+                )
 
                 async with conn.transaction():
                     if "phone" in safe_fields or "whatsapp" in safe_fields:
@@ -366,6 +384,47 @@ class PortalBillingMixin:
                 except Exception as e:
                     logger.warning(
                         "Failed to insert portal_messages record for client %s: %s", client_id, e
+                    )
+
+                # Structured audit trail (crm_audit_log) — the same trail the
+                # CRM's PATCH /api/crm/clients/{id} path writes via
+                # @audit_change. Actor is tagged "portal-client:<email>" (not
+                # a bare email) so an operator reading the trail can tell a
+                # client self-service edit apart from a staff-made change —
+                # this repo has no prior non-staff convention for this
+                # column beyond "system" for fully-automated jobs, and a
+                # client is a human actor, not "system". Never allowed to
+                # fail the profile update itself (log_state_change already
+                # never raises — it wraps its own DB call — but the wrapper
+                # here matches the notification_alerts/portal_messages
+                # pattern above and upgrades to ERROR so a swallowed audit
+                # failure is never a silent hole).
+                try:
+                    actor_email = current_user.get("email") or f"client-{client_id}"
+                    audit_ok = await audit_logger.log_state_change(
+                        entity_type="client",
+                        entity_id=client_id,
+                        old_state=audit_old_state,
+                        new_state=safe_fields,
+                        user_email=f"portal-client:{actor_email}",
+                        change_type="update",
+                        metadata={"source": "portal_self_service", "client_id": client_id},
+                    )
+                    if not audit_ok:
+                        logger.error(
+                            "crm_audit_log write returned failure for portal profile "
+                            "update, client %s fields %s",
+                            client_id,
+                            list(safe_fields.keys()),
+                        )
+                except Exception as e:
+                    logger.error(
+                        "crm_audit_log write raised for portal profile update, "
+                        "client %s fields %s: %s",
+                        client_id,
+                        list(safe_fields.keys()),
+                        e,
+                        exc_info=True,
                     )
 
             return await self._get_profile_data(conn, client_id)

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal_profile_update.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal_profile_update.py
@@ -1,6 +1,6 @@
 """Tests for portal profile update."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -211,9 +211,12 @@ async def test_update_profile_phone_lock_fails_closed_on_nonconvergence():
     cooperative writers for all 3 convergence rounds must abort the update
     (fail CLOSED), never proceed while the row's current core is unlocked."""
     service, mock_conn = _make_service()
-    # Every re-read shows a DIFFERENT phone (fresh core each time) — the lock
-    # set can never cover the row's current cores.
+    # First item is the audit-trail pre-update read (one call, always, before
+    # the transaction); the remaining three are the phone-lock convergence
+    # loop's re-reads. Every re-read there shows a DIFFERENT phone (fresh
+    # core each time) — the lock set can never cover the row's current cores.
     mock_conn.fetchrow.side_effect = [
+        {**_PROFILE_ROW, "phone": "+62800000000", "phone_normalized": "62800000000"},
         {**_PROFILE_ROW, "phone": "+62811111111", "phone_normalized": "62811111111"},
         {**_PROFILE_ROW, "phone": "+62822222222", "phone_normalized": "62822222222"},
         {**_PROFILE_ROW, "phone": "+62833333333", "phone_normalized": "62833333333"},
@@ -270,3 +273,92 @@ async def test_update_profile_whatsapp_only_takes_phone_lock():
     assert lock_sqls  # the whatsapp-only update DID take the phonecore lock
     update_sqls = [c[0][0] for c in mock_conn.execute.call_args_list if "UPDATE clients" in c[0][0]]
     assert update_sqls and "whatsapp" in update_sqls[0]
+
+
+# ============================================
+# CRM AUDIT TRAIL (crm_audit_log)
+#
+# The portal write path used to update `clients` and only ever notify two
+# soft channels (notification_alerts, portal_messages) — never the
+# structured `crm_audit_log` table the CRM's own PATCH path writes via
+# @audit_change. These tests pin the fix: update_profile now calls
+# CRMAuditLogger.log_state_change (reused, not reimplemented) with an
+# actor tagged unambiguously as the client, is a no-op when nothing was
+# actually written, and can never fail the client's own update.
+# ============================================
+
+_AUDIT_LOG_TARGET = "backend.services.portal._mixins.billing.audit_logger.log_state_change"
+
+
+@pytest.mark.asyncio
+async def test_update_profile_writes_crm_audit_log_entry():
+    """GUILT: a real field change writes a crm_audit_log entry (via the
+    existing CRMAuditLogger.log_state_change API) naming the changed
+    field, with old and new values, and an actor tagged as the client —
+    not a bare staff-indistinguishable email."""
+    service, _mock_conn = _make_service(
+        fetchrow_return={**_PROFILE_ROW, "address": "OLD ADDRESS"},
+    )
+
+    with patch(_AUDIT_LOG_TARGET, new=AsyncMock(return_value=True)) as mock_audit:
+        result = await service.update_profile(
+            client_id=1,
+            fields={"address": "NEW ADDRESS"},
+            current_user={"client_id": 1, "email": "c1@example.com"},
+        )
+
+    assert result is not None
+    mock_audit.assert_awaited_once()
+    kwargs = mock_audit.call_args.kwargs
+    assert kwargs["entity_type"] == "client"
+    assert kwargs["entity_id"] == 1
+    assert kwargs["old_state"] == {"address": "OLD ADDRESS"}
+    assert kwargs["new_state"] == {"address": "NEW ADDRESS"}
+    # Actor must be unambiguously the client, not a bare email — an
+    # operator can't tell "client" from "staff" out of an @domain alone.
+    assert kwargs["user_email"] == "portal-client:c1@example.com"
+    assert kwargs["change_type"] == "update"
+
+
+@pytest.mark.asyncio
+async def test_update_profile_non_editable_fields_write_no_audit_row():
+    """INNOCENCE: an update whose fields are all non-editable (safe_fields
+    empty, no UPDATE runs) writes NO crm_audit_log row — an audit trail
+    that records non-events is noise."""
+    service, _mock_conn = _make_service()
+
+    with patch(_AUDIT_LOG_TARGET, new=AsyncMock(return_value=True)) as mock_audit:
+        result = await service.update_profile(
+            client_id=1,
+            fields={"full_name": "HACKED", "nationality": "RU"},
+            current_user={"client_id": 1, "email": "c1@example.com"},
+        )
+
+    assert result is not None
+    mock_audit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_profile_audit_log_failure_does_not_raise():
+    """RESILIENCE: if the crm_audit_log write raises, the profile update
+    still succeeds (the client is never blocked by an audit-plumbing bug)
+    AND the failure is logged loudly — never swallowed silently."""
+    service, _mock_conn = _make_service()
+
+    with (
+        patch(
+            _AUDIT_LOG_TARGET, new=AsyncMock(side_effect=Exception("audit db exploded"))
+        ) as mock_audit,
+        patch("backend.services.portal._mixins.billing.logger") as mock_logger,
+    ):
+        result = await service.update_profile(
+            client_id=1,
+            fields={"address": "NEW ADDRESS"},
+            current_user={"client_id": 1, "email": "c1@example.com"},
+        )
+
+    assert result is not None  # the client's own update was not affected
+    mock_audit.assert_awaited_once()
+    assert mock_logger.error.called, "audit failure must be logged, not swallowed silently"
+    logged = " ".join(str(c) for c in mock_logger.error.call_args_list)
+    assert "crm_audit_log" in logged


### PR DESCRIPTION
## Summary

When a client edits their own profile from the portal (`PortalService.update_profile`, `apps/backend-rag/backend/services/portal/_mixins/billing.py`), the mutation never reached the operator's structured audit trail (`crm_audit_log`). The portal write path updated `clients` and only ever notified two soft channels — a `notification_alerts` row and a `portal_messages` thread entry. The CRM's own equivalent, `PATCH /api/crm/clients/{id}`, carries `@audit_change` and writes `crm_audit_log` via `CRMAuditLogger.log_state_change` on every update.

Worse, the standby bell is lossy by design: the `notification_alerts` insert is `ON CONFLICT (client_id, alert_type, created_date) DO NOTHING` — one bell per client per UTC day. A client's second edit the same day updates the row and pings nothing.

Why it matters: `phone`/`whatsapp` are **ownership columns** per the function's own comment — intake delivery and the upload ownership token resolve identity over them. A client silently re-pointing who receives their documents is exactly the event an audit trail exists to catch.

## What changed

- Reuses the existing `CRMAuditLogger.log_state_change` API (no parallel logging mechanism invented, `@audit_change` decorator untouched) to write old/new values + changed field(s) into `crm_audit_log` after a successful profile update.
- Old values are captured by a **standalone** pre-update read, independent of the phone-lock convergence loop a few lines below (that loop's correctness is untouched, per scope).
- Actor is tagged `"portal-client:<email>"`, not a bare email. The repo's only existing non-staff convention for this column is `"system"` (for fully-automated jobs) — that doesn't fit a human client actor, and an operator reading the trail otherwise can't tell a client self-service edit apart from a staff-made one.
- The audit write can never fail the client's own update: wrapped in the same try/except pattern the two existing soft channels use, but logs at **ERROR** (not WARNING) so a swallowed audit failure is never a silent hole.

## Tests

`backend/tests/unit/routers/test_portal_profile_update.py`:
- **GUILT** — a real field change writes a `crm_audit_log` entry naming the changed field, with old/new values and the client-tagged actor. Asserts on the captured call kwargs, not a bare "no exception".
- **INNOCENCE** — an update whose fields are all non-editable (`safe_fields` empty, no UPDATE runs) writes no audit row.
- **RESILIENCE** — an audit-write exception does not fail the profile update, and is logged loudly.
- One pre-existing test (`test_update_profile_phone_lock_fails_closed_on_nonconvergence`) updated: the new pre-update read adds one `conn.fetchrow` call ahead of the phone-lock convergence loop's own re-reads, so its `side_effect` list needed one more entry.

**Mutation-verify**: disabled the audit call → 12/12 green went to 10/12 (both new guilt-shaped tests went red, for the right reason — audit never awaited) → restored → 12/12 green again.

## NOT changed here

- The lost-update problem (no optimistic locking / version column on `clients`) — a wider design change, owner's call.
- The `notification_alerts` daily dedup — the bell is left exactly as lossy as it was.
- `documents_proxy.py` header escaping.
- Anything about archived clients or the shared-phone axis.

## Test plan

- [x] `PYTHONPATH=. pytest backend/tests/unit/routers/test_portal_profile_update.py -q` → 12 passed
- [x] `PYTHONPATH=. pytest backend/tests/unit/routers/test_portal.py backend/tests/unit/services/portal/ backend/tests/ -k "portal or audit_log" -q` → all green
- [x] `PYTHONPATH=. pytest backend/tests/services/rag/ -q` → all green (unrelated-suite sanity)
- [x] `python -c "from backend.app.dependencies import get_current_user; print('OK')"` → OK
- [x] `ruff check` on both changed files → clean
- [x] Mutation-verify on the audit call (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0125tFJz7D3S4ZkLTivvuSXR