### PR TITLE
fix(portal): one visibility predicate for documents, and repair the upload bell

### DIFF
--- a/apps/backend-rag/backend/services/portal/_document_visibility.py
+++ b/apps/backend-rag/backend/services/portal/_document_visibility.py
@@ -1,0 +1,50 @@
+"""Canonical "is this document currently visible to the client" predicate.
+
+One definition, reused by every portal-facing read of `documents`:
+- the vault (`_mixins/documents.py`: get_documents, download_document,
+  soft_delete_document, restore_document)
+- the dashboard/visa-tab/company-tab/timeline reads (`_mixins/dashboard.py`)
+
+Migration `db/migrations_v2/236_portal_documents_purpose_softdelete.sql`
+introduced client-initiated soft-delete (`deleted_at`) and its own comment
+states the intended invariant ("The vault list query filters
+`deleted_at IS NULL`") — but only updated the ONE consumer it named. The team
+archive flag (`is_archived`, older, pre-dating that migration) was never
+backfilled into the dashboard reads either. Both flags left the same fixed
+shape of bug: a document archived by the team or trashed by the client
+correctly disappeared from the vault and correctly 404'd on download, but
+kept counting in the dashboard tile and kept listing in the visa tab, the
+company tab, and the activity timeline — a ghost document that 404s if the
+client clicks it.
+
+Use `document_visibility_clause()` in every new/edited query instead of
+writing the three conditions out by hand, so there is one filter and not a
+second dialect that drifts again the next time this table grows a fourth
+"is this document currently hidden" flag.
+"""
+
+from __future__ import annotations
+
+
+def document_visibility_clause(alias: str = "") -> str:
+    """Return the SQL predicate for "this document is currently visible to
+    the client": not team-hidden, not client-hidden, not team-archived.
+
+    Args:
+        alias: optional table alias (e.g. "d") used in the query the
+            predicate is spliced into. Empty string when the query selects
+            from `documents` unaliased.
+
+    Returns:
+        A SQL fragment with no leading/trailing "AND" — splice it in with
+        " AND " on both sides, or use it as the sole WHERE body.
+    """
+    prefix = f"{alias}." if alias else ""
+    return (
+        f"{prefix}client_visible = true"
+        f" AND {prefix}deleted_at IS NULL"
+        f" AND COALESCE({prefix}is_archived, FALSE) = FALSE"
+    )
+
+
+__all__ = ["document_visibility_clause"]

--- a/apps/backend-rag/backend/services/portal/_mixins/dashboard.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/dashboard.py
@@ -15,6 +15,7 @@ import asyncpg
 
 from backend.app.utils.logging_utils import get_logger
 from backend.services.common.cache import cache_invalidating
+from backend.services.portal._document_visibility import document_visibility_clause
 from backend.services.portal._rbac import ClientContext, require_client_access
 
 logger = get_logger(__name__)
@@ -148,13 +149,13 @@ class PortalDashboardMixin:
             doc_counts = None
             try:
                 doc_counts = await conn.fetchrow(
-                    """
+                    f"""
                     SELECT
                         COUNT(*) as total,
                         COUNT(*) FILTER (WHERE status = 'pending') as pending
                     FROM documents
                     WHERE client_id = $1
-                    AND client_visible = true
+                    AND {document_visibility_clause()}
                     """,
                     client_id,
                 )
@@ -386,12 +387,12 @@ class PortalDashboardMixin:
 
             # Get immigration documents
             documents = await conn.fetch(
-                """
+                f"""
                 SELECT d.id, d.document_type, d.file_name, d.status,
                        d.expiry_date, d.file_url, d.file_id, d.file_size_kb, d.created_at
                 FROM documents d
                 WHERE d.client_id = $1
-                AND d.client_visible = true
+                AND {document_visibility_clause("d")}
                 AND d.document_type IN (
                     'passport', 'photo', 'cv', 'sponsor_letter',
                     'sktt', 'stm', 'kitas_card', 'merp', 'visa'
@@ -625,14 +626,14 @@ class PortalDashboardMixin:
 
             # Get company documents
             documents = await conn.fetch(
-                """
+                f"""
                 SELECT d.id, d.document_type, d.file_name, d.status, d.file_url, d.file_id
                 FROM documents d
                 JOIN practices p ON p.id = d.practice_id
                 JOIN practice_types pt ON pt.id = p.practice_type_id
                 WHERE p.client_id = $1
                 AND pt.category = 'company'
-                AND d.client_visible = true
+                AND {document_visibility_clause("d")}
                 ORDER BY d.created_at DESC
                 """,
                 client_id,
@@ -980,10 +981,10 @@ class PortalDashboardMixin:
             # Get recent documents
             try:
                 documents = await conn.fetch(
-                    """
+                    f"""
                     SELECT id, document_type, file_name, status, created_at
                     FROM documents
-                    WHERE client_id = $1 AND client_visible = true
+                    WHERE client_id = $1 AND {document_visibility_clause()}
                     ORDER BY created_at DESC
                     LIMIT $2
                     """,

--- a/apps/backend-rag/backend/services/portal/_mixins/documents.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/documents.py
@@ -30,6 +30,7 @@ from backend.app.utils.logging_utils import get_logger
 from backend.services.common.background import spawn
 from backend.services.common.cache import cache_invalidating
 from backend.services.pii.violation_store import hash_subject
+from backend.services.portal._document_visibility import document_visibility_clause
 from backend.services.portal._rbac import ClientContext, require_client_access
 from backend.services.portal.document_processing import (
     DocumentOCR,
@@ -196,7 +197,7 @@ class PortalDocumentsMixin:
     ) -> list[dict[str, Any]]:
         """Get all client-visible documents."""
         async with self.pool.acquire() as conn:
-            query = """
+            query = f"""
                 SELECT d.id, d.document_type, d.file_name, d.status,
                        d.expiry_date, d.file_url, d.file_id, d.file_size_kb, d.created_at,
                        d.document_purpose,
@@ -205,9 +206,7 @@ class PortalDocumentsMixin:
                 LEFT JOIN practices p ON p.id = d.practice_id
                 LEFT JOIN practice_types pt ON pt.id = p.practice_type_id
                 WHERE d.client_id = $1
-                AND d.client_visible = true
-                AND d.deleted_at IS NULL
-                AND COALESCE(d.is_archived, FALSE) = FALSE
+                AND {document_visibility_clause("d")}
             """
             params = [client_id]
 
@@ -247,14 +246,12 @@ class PortalDocumentsMixin:
         """Download a client-visible document through the portal proxy."""
         async with self.pool.acquire() as conn:
             row = await conn.fetchrow(
-                """
+                f"""
                 SELECT id, file_name, file_id, file_url, mime_type, status, storage_type
                 FROM documents
                 WHERE id = $1
                   AND client_id = $2
-                  AND client_visible = true
-                  AND deleted_at IS NULL
-                  AND COALESCE(is_archived, FALSE) = FALSE
+                  AND {document_visibility_clause()}
                 LIMIT 1
                 """,
                 document_id,
@@ -388,14 +385,12 @@ class PortalDocumentsMixin:
         async with self.pool.acquire() as conn:
             async with conn.transaction():
                 row = await conn.fetchrow(
-                    """
+                    f"""
                     UPDATE documents
                     SET deleted_at = NOW(), deleted_by = $3
                     WHERE id = $1
                       AND client_id = $2
-                      AND client_visible = true
-                      AND deleted_at IS NULL
-                      AND COALESCE(is_archived, FALSE) = FALSE
+                      AND {document_visibility_clause()}
                     RETURNING id, file_name, document_type
                     """,
                     document_id,
@@ -1261,21 +1256,36 @@ This is an automated notification from Bali Zero CRM.
                         lead_email,
                     )
 
-                # Also insert CRM notification alert for the bell
+                # Also insert CRM notification alert for the bell.
+                #
+                # `uq_notification_alert_daily` is a plain CREATE UNIQUE INDEX
+                # (migration_071_notification_alerts.py:34), not a named
+                # constraint — `ON CONFLICT ON CONSTRAINT <name>` only accepts
+                # an actual unique/exclusion constraint, so that form raised on
+                # every call and this insert never once landed (silently
+                # swallowed by the except below, logged at DEBUG). The
+                # column-list form matches any unique index on those columns,
+                # constraint or not — same form already used by the two other
+                # writers of this table: welcome_email_service.py:287 and the
+                # profile-update path pinned by
+                # test_portal_profile_update.py:82.
                 try:
                     await conn.execute(
                         """
                         INSERT INTO notification_alerts
                             (client_id, alert_type, status, message, email_subject)
                         VALUES ($1, 'portal_document_upload', 'sent', $2, $3)
-                        ON CONFLICT ON CONSTRAINT uq_notification_alert_daily DO NOTHING
+                        ON CONFLICT (client_id, alert_type, created_date) DO NOTHING
                         """,
                         client_id,
                         f"{client['full_name']} uploaded {document_type.replace('_', ' ')} via portal",
                         f"[Portal] {client['full_name']} uploaded {document_type.replace('_', ' ').title()}",
                     )
                 except Exception as alert_err:
-                    logger.debug("CRM alert insert failed (non-critical): %s", alert_err)
+                    # This used to be logger.debug — an exception that fires on
+                    # EVERY call (see above) is invisible by construction at
+                    # DEBUG. Warning so a future regression here is seen.
+                    logger.warning("CRM alert insert failed (non-critical): %s", alert_err)
 
         except Exception as e:
             # Don't fail upload if notification fails

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_dashboard_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_dashboard_mixin.py
@@ -626,3 +626,118 @@ async def test_get_timeline_continues_when_optional_sources_fail() -> None:
     assert result["scope"] == "portal"
     assert result["entries"]
     assert all(entry["type"] == "deadline" for entry in result["entries"])
+
+
+# ---------------------------------------------------------------------------
+# Ghost-document regression — the dashboard's document reads must use the
+# SAME visibility predicate as the vault (client_visible AND deleted_at IS
+# NULL AND COALESCE(is_archived, FALSE) = FALSE), not client_visible alone.
+#
+# Before the fix: an operator archiving a document, or a client soft-deleting
+# their own, correctly vanished it from the vault (services/portal/_mixins/
+# documents.py) and correctly 404'd on download — but it kept counting on
+# the dashboard tile, kept listing on the visa tab, the company tab, and the
+# activity timeline. Root cause per migration db/migrations_v2/236_portal_
+# documents_purpose_softdelete.sql:11-16 ("The vault list query filters
+# deleted_at IS NULL"): the invariant was documented for one consumer and
+# never backfilled into these four.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_dashboard_document_count_hides_archived_and_deleted() -> None:
+    service, conn = _service_with_conn()
+    conn.fetchrow.side_effect = [
+        {"id": 1, "full_name": "Client One", "email": "client@example.com"},
+        None,  # visa_practice
+        {"total": 2, "pending": 1},  # doc_counts
+    ]
+    conn.fetch.side_effect = [[], []]  # companies, action_items
+    conn.fetchval.return_value = 0
+
+    result = await service.get_dashboard(1, current_user=_ctx())
+
+    assert result["documents"] == {"total": 2, "pending": 1}
+    doc_counts_sql = conn.fetchrow.call_args_list[2].args[0]
+    assert "client_visible = true" in doc_counts_sql
+    assert "deleted_at IS NULL" in doc_counts_sql
+    assert "COALESCE(is_archived, FALSE) = FALSE" in doc_counts_sql
+
+
+@pytest.mark.asyncio
+async def test_get_visa_status_documents_hide_archived_and_deleted() -> None:
+    service, conn = _service_with_conn()
+    conn.fetchrow.side_effect = [
+        {"id": 1},
+        None,  # current_visa
+    ]
+    conn.fetch.side_effect = [
+        [],  # visa_history
+        [],  # documents
+    ]
+
+    result = await service.get_visa_status(1, current_user=_ctx())
+
+    assert result["documents"] == []
+    docs_sql = conn.fetch.call_args_list[1].args[0]
+    assert "d.client_visible = true" in docs_sql
+    assert "d.deleted_at IS NULL" in docs_sql
+    assert "COALESCE(d.is_archived, FALSE) = FALSE" in docs_sql
+
+
+@pytest.mark.asyncio
+async def test_get_company_detail_documents_hide_archived_and_deleted() -> None:
+    service, conn = _service_with_conn()
+    conn.fetchrow.side_effect = [
+        {"role": "director", "is_primary": True, "ownership_percentage": 50},
+        {
+            "id": 10,
+            "company_name": "PT Test",
+            "company_type": "PMA",
+            "nib": None,
+            "npwp_company": None,
+            "kbli_code": None,
+            "status": "active",
+            "registered_address": None,
+            "company_email": None,
+            "company_phone": None,
+            "akta_pendirian_no": None,
+            "akta_pendirian_date": None,
+            "sk_menhumkam_no": None,
+            "custom_fields": {},
+        },
+    ]
+    conn.fetch.side_effect = [
+        [],  # practices
+        [],  # documents
+        [],  # directors
+    ]
+
+    result = await service.get_company_detail(1, 10, current_user=_ctx())
+
+    assert result["documents"] == []
+    docs_sql = conn.fetch.call_args_list[1].args[0]
+    assert "d.client_visible = true" in docs_sql
+    assert "d.deleted_at IS NULL" in docs_sql
+    assert "COALESCE(d.is_archived, FALSE) = FALSE" in docs_sql
+
+
+@pytest.mark.asyncio
+async def test_get_timeline_recent_documents_hide_archived_and_deleted() -> None:
+    service, conn = _service_with_conn()
+    conn.fetch.side_effect = [
+        [],  # timeline_events
+        [],  # messages
+        [],  # documents
+        [],  # practices
+    ]
+
+    result = await service.get_timeline(1, limit=30, current_user=_ctx())
+
+    # No document entries synthesized (only derived deadline entries remain —
+    # see test_get_timeline_continues_when_optional_sources_fail for that shape).
+    assert not [e for e in result["entries"] if e["type"] == "document"]
+    docs_sql = conn.fetch.call_args_list[2].args[0]
+    assert "client_visible = true" in docs_sql
+    assert "deleted_at IS NULL" in docs_sql
+    assert "COALESCE(is_archived, FALSE) = FALSE" in docs_sql

--- a/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
+++ b/apps/backend-rag/backend/tests/unit/app/services/portal/test_documents_mixin.py
@@ -1221,6 +1221,66 @@ async def test_restore_uses_valid_event_type_on_separate_conn() -> None:
     assert "document_restored" not in sql
 
 
+# ---------------------------------------------------------------------------
+# notification_alerts ON CONFLICT — uq_notification_alert_daily is a plain
+# CREATE UNIQUE INDEX (migration_071_notification_alerts.py:34), not a named
+# constraint. `ON CONFLICT ON CONSTRAINT <name>` only accepts an actual
+# unique/exclusion constraint, so that form raised on EVERY call and the
+# operator's in-app bell never once fired for a client upload — silently
+# swallowed by the except below (previously logged at DEBUG, invisible by
+# construction for a 100%-failure-rate exception). The column-list form is
+# the one the table's two other writers already use successfully:
+# welcome_email_service.py:287 and the profile-update path pinned by
+# test_portal_profile_update.py:82.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notify_lead_alert_insert_uses_column_list_conflict_form() -> None:
+    service, mock_conn = _make_service_with_fetchrow(
+        {"full_name": "Client One", "assigned_to": "lead@example.com"}
+    )
+    qa_support_mail_sink = MagicMock()
+    qa_support_mail_sink.send_document_notification = AsyncMock()
+
+    await service._notify_lead_about_document(
+        client_id=1,
+        document_name="passport.pdf",
+        document_type="passport",
+        qa_support_mail_sink=qa_support_mail_sink,
+    )
+
+    alert_sql = mock_conn.execute.call_args.args[0]
+    assert "notification_alerts" in alert_sql
+    assert "ON CONFLICT (client_id, alert_type, created_date) DO NOTHING" in alert_sql
+    assert "ON CONFLICT ON CONSTRAINT" not in alert_sql
+
+
+@pytest.mark.asyncio
+async def test_notify_lead_alert_insert_failure_logs_warning_not_debug() -> None:
+    service, mock_conn = _make_service_with_fetchrow(
+        {"full_name": "Client One", "assigned_to": "lead@example.com"}
+    )
+    mock_conn.execute.side_effect = RuntimeError(
+        'constraint "uq_notification_alert_daily" for table "notification_alerts" does not exist'
+    )
+    qa_support_mail_sink = MagicMock()
+    qa_support_mail_sink.send_document_notification = AsyncMock()
+
+    with patch("backend.services.portal._mixins.documents.logger") as mock_logger:
+        # Must not raise — a broken bell insert must never break the upload.
+        await service._notify_lead_about_document(
+            client_id=1,
+            document_name="passport.pdf",
+            document_type="passport",
+            qa_support_mail_sink=qa_support_mail_sink,
+        )
+
+    mock_logger.warning.assert_called_once()
+    assert "CRM alert insert failed" in mock_logger.warning.call_args.args[0]
+    mock_logger.debug.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_timeline_failure_does_not_break_soft_delete() -> None:
     """If the audit-log INSERT fails, the soft-delete result still succeeds —


### PR DESCRIPTION
## What a client sees today

A document the team archives, or the client themselves trashes, correctly disappears from
the portal vault and correctly 404s on download — and **keeps counting in the dashboard
tile and keeps listing in the visa tab, the company tab and the activity timeline.** A
ghost entry that 404s when clicked.

## Why

The visibility invariant existed in **four hand-written copies**. The vault gated on
`client_visible AND deleted_at IS NULL AND COALESCE(is_archived, FALSE) = FALSE`; the four
sibling reads of the same table for the same client filtered only `client_visible`.

The tree states the cause itself: `db/migrations_v2/236_portal_documents_purpose_softdelete.sql`
introduced client soft-delete and its own comment says *"The vault list query filters
`deleted_at IS NULL`"* — the author updated the one consumer they named. `is_archived`,
older than that migration, had never been carried into those four either.

**Cure is one definition.** `services/portal/_document_visibility.py` now holds the
predicate; all seven queries splice it in. The next flag this table grows gets added once
instead of six times. (The `alias` argument is only ever an in-code literal — no user
input reaches the SQL.)

## Second defect: the operator's bell has never rung for a client upload

`documents.py` used `ON CONFLICT ON CONSTRAINT uq_notification_alert_daily`, but
`migration_071_notification_alerts.py:34` creates that name with `CREATE UNIQUE INDEX`, and
`ON CONFLICT ON CONSTRAINT` accepts only a real unique/exclusion constraint. The insert
therefore raised on **every** call, into an `except` logged at `DEBUG` — invisible by
construction. Switched to the column-list form its two sibling writers already use
(`welcome_email_service.py:287`, and the profile-update path pinned by
`test_portal_profile_update.py:82`), which matches a bare unique index. The swallow is
raised to `WARNING` so a future regression here is seen.

Note the email path was fine throughout — the operator was notified by email, just never
in-app. That is why nobody noticed.

## Measured

- **4 of 8** client-facing document reads diverged from the vault's filter.
- **1 of 3** `notification_alerts` writers used the broken `ON CONFLICT` form.

## Verification

```
cd apps/backend-rag && PYTHONPATH=. python -m pytest \
  backend/tests/unit/app/services/portal/test_dashboard_mixin.py \
  backend/tests/unit/app/services/portal/test_documents_mixin.py -q
```

Mutation-verified: reducing the shared predicate back to `client_visible` alone turns
**six** tests red, each naming its own surface — count tile, visa tab, company detail,
timeline, vault list, vault soft-delete. Restoring it returns all green.