### PR TITLE
fix(portal): stop serving the operator's internal notes to the client

### DIFF
--- a/apps/backend-rag/backend/app/routers/portal.py
+++ b/apps/backend-rag/backend/app/routers/portal.py
@@ -1042,7 +1042,11 @@ async def get_required_documents(
                 SELECT
                     prd.id, prd.practice_id, prd.document_type, prd.document_label,
                     prd.description, prd.is_required, prd.uploaded_by_client,
-                    prd.status, prd.client_notes, prd.team_member_notes,
+                    -- team_member_notes is DELIBERATELY not selected: it is the
+                    -- operator's internal note (authoring UI labels it "Team Notes"
+                    -- / "Add notes for the team..."). The client-facing note is
+                    -- `description`, which the portal already renders.
+                    prd.status, prd.client_notes,
                     COALESCE(pt.name, p.practice_type_code) as process_name,
                     p.status as process_status
                 FROM practice_required_documents prd
@@ -1066,7 +1070,6 @@ async def get_required_documents(
                 "uploaded_by_client": row["uploaded_by_client"],
                 "status": row["status"],
                 "client_notes": row["client_notes"],
-                "team_member_notes": row["team_member_notes"],
             }
             for row in rows
         ]

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -622,7 +622,47 @@ class TestProcessDocuments:
         response = client.get("/api/portal/process/required-documents")
 
         assert response.status_code == 200
-        assert response.json()["data"] == [completed_doc]
+        # The DB row carries `team_member_notes`; the CLIENT response must not.
+        # It is the operator's internal note (authoring UI: "Team Notes" /
+        # "Add notes for the team..."), and the client-facing note is
+        # `description`. Asserting the response equals the raw row would pin
+        # the leak — that is what this assertion used to do.
+        expected = {k: v for k, v in completed_doc.items() if k != "team_member_notes"}
+        assert response.json()["data"] == [expected]
+
+    def test_required_documents_never_expose_team_member_notes(
+        self,
+        client: TestClient,
+        mock_db_pool,
+    ) -> None:
+        """Internal staff notes must not reach the client, even when set."""
+        row = {
+            "id": 8,
+            "practice_id": 82,
+            "process_name": "KITAS",
+            "process_status": "on_process",
+            "document_type": "passport",
+            "document_label": "Passport copy",
+            "description": "Please re-upload, the scan is blurry",
+            "is_required": True,
+            "uploaded_by_client": False,
+            "status": "pending",
+            "client_notes": None,
+            "team_member_notes": "INTERNAL: chase the agent, client is unreliable",
+        }
+        mock_db_pool._mock_conn.fetch.return_value = [row]
+
+        response = client.get("/api/portal/process/required-documents")
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload, "expected one document in the response"
+        for item in payload:
+            assert "team_member_notes" not in item
+        # the client-facing note still travels
+        assert payload[0]["description"] == "Please re-upload, the scan is blurry"
+        # and the internal text appears nowhere in the serialised body
+        assert "INTERNAL:" not in response.text
 
 
 # ============================================

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.test.tsx
@@ -122,7 +122,6 @@ const pendingDocument: ClientRequiredDocument = {
   uploaded_by_client: false,
   status: "pending",
   client_notes: null,
-  team_member_notes: null,
 };
 
 const secondPendingDocument: ClientRequiredDocument = {

--- a/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/process/page.tsx
@@ -558,14 +558,6 @@ function ProcessCard({
                     <StatusBadge
                       status={doc.status as keyof typeof STATUS_CONFIG}
                     />
-                    {doc.team_member_notes && (
-                      <span
-                        className="text-xs"
-                        style={{ color: "var(--bz-text-2)" }}
-                      >
-                        Note: {doc.team_member_notes}
-                      </span>
-                    )}
                   </div>
                 </div>
 

--- a/apps/mouth/src/lib/types/required-documents.ts
+++ b/apps/mouth/src/lib/types/required-documents.ts
@@ -50,7 +50,6 @@ export interface ClientRequiredDocument {
   uploaded_by_client: boolean;
   status: DocumentStatus;
   client_notes: string | null;
-  team_member_notes: string | null;
 }
 
 // Predefined document types for selection


### PR DESCRIPTION
## What a client could read

`GET /api/portal/process/required-documents` selected `prd.team_member_notes` and returned
it verbatim — and the client portal **printed it on screen**, as `Note: ...`
(`apps/mouth/src/app/portal/(authenticated)/process/page.tsx`). Not merely present in the
JSON: rendered.

## Why this is a defect and not a product decision

The product states the field's audience in its own copy. In the operator-only card
(`apps/mouth/src/app/(workspace)/process/[id]/RequiredDocumentsCard.tsx`) there are three
note fields, and they are deliberately distinguished:

| field | operator UI | audience |
|---|---|---|
| `description` | placeholder **"Add notes for the client..."** | the client |
| `client_notes` | rendered back as **"Client notes:"** | from the client |
| `team_member_notes` | label **"Team Notes"**, placeholder **"Add notes for the team..."** | the team |

The client-facing channel already exists, already works, and the portal already renders
it — `description`, in the block immediately above the offending one. `team_member_notes`
was a second, unintended channel.

The type system carried the same split and the same mistake: `RequiredDocument` (operator)
and `ClientRequiredDocument` (client) are separate interfaces in
`lib/types/required-documents.ts`, and the internal field had been added to the client one.

## A green test was holding the leak alive

`test_completed_process_documents_remain_visible` asserted the response equalled the raw DB
row, `team_member_notes` included. Any fix would have turned it red, and it read as
coverage. It now asserts the response equals that row **minus** the field.

## Changed

- `app/routers/portal.py::get_required_documents` — dropped from the SELECT and from the
  response dict, with a comment saying why so it does not come back.
- client render block removed; `ClientRequiredDocument` and its fixture updated.
- New `test_required_documents_never_expose_team_member_notes`: asserts the key is absent,
  that `description` still travels, and that the internal text appears nowhere in the body.

## Verification

```
cd apps/backend-rag && PYTHONPATH=. python -m pytest backend/tests/unit/routers/test_portal.py -q
```

Mutation-verified: putting the field back returns **RC 1** with two named failures
(`test_completed_process_documents_remain_visible`,
`test_required_documents_never_expose_team_member_notes`), each quoting `team_member_notes`;
removing it again returns **RC 0**.

## Deliberately not here

`portal_process_timeline.py` also returns `assigned_to` and `changed_by` to the client, and
the client UI consumes `assigned_to` — a separate question with a live consumer attached,
not something to fold into this diff.

## For the owner

The exposure is not hypothetical and it is not new: whatever staff wrote into "Team Notes"
has been visible to the client on that screen. Reviewing what is in that column, and
whether anything needs to be said to anyone, is a call for you — this PR only closes the
channel.