### PR TITLE
feat(mouth): Second Home Studio design pass — brand accent, choice affordance, gated Continue, localized consent

### DIFF
--- a/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
+++ b/apps/mouth/src/app/visa/second-home/SecondHomeLanding.tsx
@@ -140,7 +140,14 @@ export function SecondHomeLanding() {
     }));
 
   return (
-    <div style={{ display: "grid", gap: "var(--space-6, 3rem)" }}>
+    // data-funnel="visa" (2026-08-20 design pass): resolves --accent-funnel
+    // to the visa funnel's red identity instead of the editorial-theme
+    // default blue (see StudioApp.tsx for the full explanation — same
+    // defect, same fix, this route has no AppFrame ancestor either).
+    <div
+      data-funnel="visa"
+      style={{ display: "grid", gap: "var(--space-6, 3rem)" }}
+    >
       <LanguageSwitcher />
 
       {/* ── HERO ── */}

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.test.tsx
@@ -318,6 +318,68 @@ describe("StudioApp", () => {
     });
   });
 
+  describe("Continue gating (2026-08-20 design pass) — disabled until the step's question is answered", () => {
+    it("guilt: the age step's Continue is disabled before any option is selected", () => {
+      render(<StudioApp />);
+      expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+    });
+
+    it("innocence: selecting an option enables Continue on that same step", () => {
+      render(<StudioApp />);
+      clickButton("Under 55");
+      expect(
+        screen.getByRole("button", { name: "Continue" }),
+      ).not.toBeDisabled();
+    });
+
+    it("guilt: Continue re-disables on the NEXT step until it too is answered (per-step state, not sticky)", async () => {
+      render(<StudioApp />);
+      clickButton("Under 55");
+      clickButton("Continue");
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: /which route are you considering/i,
+          }),
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: "Continue" })).toBeDisabled();
+
+      clickButton("Bank deposit");
+      expect(
+        screen.getByRole("button", { name: "Continue" }),
+      ).not.toBeDisabled();
+    });
+
+    it("innocence: the family step (multi-select, always answered) has Continue enabled with zero selections", async () => {
+      render(<StudioApp />);
+      clickButton("Under 55");
+      clickButton("Continue");
+      clickButton("Bank deposit");
+      clickButton("Continue");
+      clickButton("USD 130,000 is ready");
+      clickButton("Continue");
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /who would you want/i }),
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole("button", { name: "Continue" }),
+      ).not.toBeDisabled();
+    });
+
+    it("guilt: clicking a disabled Continue does not advance the step (fireEvent.click on a disabled button is a no-op)", () => {
+      render(<StudioApp />);
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+      expect(
+        screen.getByRole("heading", { name: /how old are you/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe("P1-C9 — CustodyMap renders only for deposit-holding verdicts (E33/E33E)", () => {
     it("under_55 deposit strong_fit (E33): CustodyMap renders", async () => {
       window.location.hash = `#p=${encodePlanFragment(fullPlan())}`;

--- a/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/StudioApp.tsx
@@ -548,6 +548,17 @@ export function StudioApp() {
 
   return (
     <div
+      // data-funnel="visa" (2026-08-20 design pass): without this attribute
+      // --accent-funnel falls through to the site's default `editorial`
+      // theme value (#3a6dff, McKinsey blue — packages/core/tokens/themes/
+      // editorial.css) instead of the visa funnel's own red identity
+      // (semantic.css [data-theme="editorial"] [data-funnel="visa"]). Every
+      // accent in this tree already reads var(--accent-funnel) correctly —
+      // the token was never hardcoded, it was just never scoped. Matches
+      // the other /visa funnel pages, which get this via AppFrame's
+      // `funnel="visa"` prop (packages/core/components/apps/AppFrame.tsx);
+      // this route has no AppFrame ancestor, so it sets the attribute here.
+      data-funnel="visa"
       style={{
         display: "grid",
         gap: "var(--space-5, 2rem)",
@@ -682,6 +693,16 @@ export function StudioApp() {
         @media (min-width: 900px) {
           .bz-shs-layout {
             grid-template-columns: minmax(0, 1fr) 320px;
+          }
+          /* Desktop layout balance (2026-08-20 design pass): the memo rail
+           * used to sit static at the top of its column and scroll away as
+           * a tall question card grew below it, leaving a "dead" empty
+           * column on wide viewports. align-items:start above already
+           * keeps the rail from stretching to the main column's height —
+           * required for sticky to have room to move within. */
+          .bz-shs-layout > aside {
+            position: sticky;
+            top: var(--space-5, 2rem);
           }
         }
         @media (prefers-reduced-motion: reduce) {

--- a/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/CustodyMap.tsx
@@ -58,15 +58,35 @@ export function CustodyMap() {
             key={step}
             style={{ display: "grid", gap: "var(--space-1, 0.3rem)" }}
           >
-            <div style={{ display: "flex", gap: "var(--space-2, 0.5rem)" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-2, 0.5rem)",
+              }}
+            >
+              {/* Step badge — matches the timeline's rounded, bordered
+               *  "owner chip" language (TimelineView.tsx) instead of a bare
+               *  numeral, aria-hidden since the number is decorative
+               *  (the step order is already conveyed by the <ol>). */}
               <span
                 aria-hidden
                 style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                  width: 24,
+                  height: 24,
+                  borderRadius: "50%",
+                  border: "1.5px solid var(--accent-funnel)",
                   fontFamily: "var(--font-serif, Georgia, serif)",
+                  fontSize: "0.8rem",
+                  fontWeight: 600,
                   color: "var(--accent-funnel-text, var(--accent-funnel))",
                 }}
               >
-                {i + 1}.
+                {i + 1}
               </span>
               <strong style={{ color: "var(--text-primary)" }}>
                 {getCopy(`custody.steps.${step}.title`)}

--- a/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
+++ b/apps/mouth/src/app/visa/second-home/studio/components/QuestionCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useId, type ReactNode, type Ref } from "react";
+import { ChevronRight } from "lucide-react";
 
 export interface QuestionCardProps {
   heading: string;
@@ -62,14 +63,28 @@ export function QuestionCard({
       <p style={{ margin: 0, lineHeight: 1.6, color: "var(--text-primary)" }}>
         {body}
       </p>
-      <details style={{ fontSize: "var(--text-sm, 0.88rem)" }}>
+      <details
+        className="bz-shs-why"
+        style={{ fontSize: "var(--text-sm, 0.88rem)" }}
+      >
         <summary
+          className="bz-shs-why-summary"
           style={{
             cursor: "pointer",
             color: "var(--color-text-muted)",
             fontWeight: 600,
+            listStyle: "none",
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-1, 0.35rem)",
           }}
         >
+          <ChevronRight
+            size={14}
+            aria-hidden
+            className="bz-shs-why-chevron"
+            style={{ flexShrink: 0 }}
+          />
           Why we ask
         </summary>
         <p
@@ -94,6 +109,47 @@ export function QuestionCard({
       <div style={{ display: "grid", gap: "var(--space-2, 0.5rem)" }}>
         {children}
       </div>
+      {/* Single instance per render (only one question stage is ever
+       *  mounted at a time) — matches the local-<style> pattern already
+       *  used by ProgressRail/MemoPreview. Transitions here are already
+       *  covered by StudioApp's `.bz-shs-layout * { transition: none }`
+       *  reduced-motion rule, since QuestionCard only ever renders inside
+       *  that container — no separate media query needed. */}
+      <style>{`
+        .bz-shs-why-summary::-webkit-details-marker {
+          display: none;
+        }
+        .bz-shs-why-chevron {
+          transition: transform 150ms ease-out;
+        }
+        .bz-shs-why[open] > .bz-shs-why-summary .bz-shs-why-chevron {
+          transform: rotate(90deg);
+        }
+        /* OptionButton (P2 design pass): border/background driven by the
+         * data-selected attribute rather than inline styles, so :hover can
+         * actually take effect — an inline style attribute always beats a
+         * stylesheet rule regardless of pseudo-class, so a hover rule
+         * targeting a JS-computed inline border/background would silently
+         * never apply. */
+        .bz-shs-option {
+          border: 1px solid var(--color-border-subtle);
+          background: transparent;
+          transition:
+            border-color 150ms ease-out,
+            background-color 150ms ease-out;
+        }
+        .bz-shs-option:hover {
+          border-color: var(--accent-funnel);
+          background: color-mix(in srgb, var(--accent-funnel) 6%, transparent);
+        }
+        .bz-shs-option[data-selected="true"] {
+          border: 2px solid var(--accent-funnel);
+          background: color-mix(in srgb, var(--accent-funnel) 12%, transparent);
+        }
+        .bz-shs-option[data-selected="true"]:hover {
+          background: color-mix(in srgb, var(--accent-funnel) 16%, transparent);
+        }
+      `}</style>
     </div>
   );
 }
@@ -114,8 +170,77 @@ export interface OptionButtonProps {
   variant?: "radio" | "toggle";
 }
 
+/** Decorative leading affordance for a radio-variant option: an empty ring
+ *  that fills with an accent dot when selected. `aria-hidden` — the radio
+ *  semantics live on the parent `role="radio"`/`aria-checked` button, this
+ *  is purely visual and contributes nothing to its accessible name. */
+function RadioAffordance({ selected }: { selected: boolean }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        width: 20,
+        height: 20,
+        borderRadius: "50%",
+        border: selected
+          ? "2px solid var(--accent-funnel)"
+          : "1.5px solid var(--color-border-subtle)",
+      }}
+    >
+      {selected ? (
+        <span
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            background: "var(--accent-funnel)",
+          }}
+        />
+      ) : null}
+    </span>
+  );
+}
+
+/** Decorative leading affordance for a toggle-variant option (the family
+ *  multi-select step): a small square that fills with a check mark when
+ *  selected. `aria-hidden` for the same reason as RadioAffordance. */
+function CheckAffordance({ selected }: { selected: boolean }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        width: 20,
+        height: 20,
+        borderRadius: 5,
+        border: selected
+          ? "2px solid var(--accent-funnel)"
+          : "1.5px solid var(--color-border-subtle)",
+        background: selected ? "var(--accent-funnel)" : "transparent",
+        color: "var(--text-on-accent, #fff)",
+        fontSize: 13,
+        lineHeight: 1,
+      }}
+    >
+      {selected ? "✓" : null}
+    </span>
+  );
+}
+
 /** Large, keyboard-focusable option card. Never strips the native focus
- *  ring (accessibility — spec §0 "visible focus"). */
+ *  ring (accessibility — spec §0 "visible focus"). Border/background are
+ *  driven by the `bz-shs-option` CSS class + `data-selected` attribute
+ *  (see QuestionCard's local <style>) rather than inline styles, so hover
+ *  can layer on top; the leading radio/check affordance is decorative
+ *  (`aria-hidden`) — the real selected-state semantics stay on
+ *  `role`/`aria-checked`/`aria-pressed`, unchanged. */
 export function OptionButton({
   label,
   selected,
@@ -130,13 +255,14 @@ export function OptionButton({
       role={isRadio ? "radio" : undefined}
       aria-checked={isRadio ? selected : undefined}
       aria-pressed={isRadio ? undefined : selected}
+      className="bz-shs-option"
+      data-selected={selected ? "true" : "false"}
       style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-3, 0.75rem)",
         padding: "var(--space-3, 0.85rem) var(--space-4, 1.1rem)",
         borderRadius: 8,
-        border: selected
-          ? "2px solid var(--accent-funnel)"
-          : "1px solid var(--color-border-subtle)",
-        background: selected ? "var(--surface-base)" : "transparent",
         color: "var(--text-primary)",
         textAlign: "left",
         cursor: "pointer",
@@ -145,7 +271,12 @@ export function OptionButton({
         fontFamily: "inherit",
       }}
     >
-      {label}
+      {isRadio ? (
+        <RadioAffordance selected={selected} />
+      ) : (
+        <CheckAffordance selected={selected} />
+      )}
+      <span>{label}</span>
     </button>
   );
 }

--- a/apps/mouth/src/components/visa/ConsentBanner.tsx
+++ b/apps/mouth/src/components/visa/ConsentBanner.tsx
@@ -2,11 +2,33 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useOptionalTranslation } from "@/i18n";
 
 const CONSENT_KEY = "visa_oracle_consent";
 
+// Fallback for routes that mount this banner OUTSIDE any <I18nProvider>
+// ancestor — /visa itself has none anywhere in its layout chain (verified
+// 2026-08-20), while /visa/second-home/* (landing + Studio) does via that
+// route's layout.tsx. useOptionalTranslation() returns null there instead
+// of throwing (the useTranslation() white-screen class), so this banner
+// carries its own EN default rather than assume a provider is present.
+const CONSENT_EN_FALLBACK = {
+  text: "We use session data to provide visa guidance. By continuing, you agree to our",
+  privacyPolicy: "Privacy Policy",
+  and: "and",
+  termsOfService: "Terms of Service",
+  dismiss: "Got it",
+} as const;
+
+function useConsentCopy() {
+  const i18n = useOptionalTranslation();
+  return (key: keyof typeof CONSENT_EN_FALLBACK): string =>
+    i18n ? i18n.t(`common.consent.${key}`) : CONSENT_EN_FALLBACK[key];
+}
+
 export function ConsentBanner() {
   const [visible, setVisible] = useState(false);
+  const tc = useConsentCopy();
 
   useEffect(() => {
     // SSR guard: only run in the browser
@@ -40,22 +62,21 @@ export function ConsentBanner() {
           className="text-sm text-center sm:text-left"
           style={{ color: "var(--tx-secondary)" }}
         >
-          We use session data to provide visa guidance. By continuing, you agree
-          to our{" "}
+          {tc("text")}{" "}
           <Link
             href="/visa/privacy"
             className="underline hover:opacity-80 transition-opacity"
             style={{ color: "var(--bz-accent)" }}
           >
-            Privacy Policy
+            {tc("privacyPolicy")}
           </Link>{" "}
-          and{" "}
+          {tc("and")}{" "}
           <Link
             href="/visa/terms"
             className="underline hover:opacity-80 transition-opacity"
             style={{ color: "var(--bz-accent)" }}
           >
-            Terms of Service
+            {tc("termsOfService")}
           </Link>
           .
         </p>
@@ -67,7 +88,7 @@ export function ConsentBanner() {
             color: "#ffffff",
           }}
         >
-          Got it
+          {tc("dismiss")}
         </button>
       </div>
     </div>

--- a/apps/mouth/src/i18n/index.tsx
+++ b/apps/mouth/src/i18n/index.tsx
@@ -143,3 +143,16 @@ export function useTranslation(): I18nContextValue {
   if (!ctx) throw new Error("useTranslation must be used within I18nProvider");
   return ctx;
 }
+
+/**
+ * Optional variant of useTranslation() for components that render on some
+ * routes with an <I18nProvider> ancestor and on others without one — e.g.
+ * ConsentBanner, shared across /visa/second-home/* (wrapped by that route's
+ * layout.tsx) and /visa itself (no I18nProvider anywhere in its layout
+ * chain, verified 2026-08-20). useTranslation() would throw there (the
+ * white-screen class scripts/lint_i18n_providers.sh exists to catch);
+ * returns null instead so the caller can carry its own EN-only fallback.
+ */
+export function useOptionalTranslation(): I18nContextValue | null {
+  return React.useContext(I18nContext);
+}

--- a/apps/mouth/src/i18n/locales/en.json
+++ b/apps/mouth/src/i18n/locales/en.json
@@ -28,7 +28,14 @@
       "viewFullTeam": "View full team",
       "learnMore": "Learn more"
     },
-    "error": "Something went wrong. Please refresh the page."
+    "error": "Something went wrong. Please refresh the page.",
+    "consent": {
+      "text": "We use session data to provide visa guidance. By continuing, you agree to our",
+      "privacyPolicy": "Privacy Policy",
+      "and": "and",
+      "termsOfService": "Terms of Service",
+      "dismiss": "Got it"
+    }
   },
   "home": {
     "hero": {

--- a/apps/mouth/src/i18n/locales/id.json
+++ b/apps/mouth/src/i18n/locales/id.json
@@ -28,7 +28,14 @@
       "viewFullTeam": "Lihat tim lengkap",
       "learnMore": "Pelajari lebih lanjut"
     },
-    "error": "Terjadi kesalahan. Silakan muat ulang halaman."
+    "error": "Terjadi kesalahan. Silakan muat ulang halaman.",
+    "consent": {
+      "text": "Kami menggunakan data sesi untuk memberikan panduan visa. Dengan melanjutkan, Anda menyetujui",
+      "privacyPolicy": "Kebijakan Privasi",
+      "and": "dan",
+      "termsOfService": "Ketentuan Layanan",
+      "dismiss": "Mengerti"
+    }
   },
   "home": {
     "hero": {

--- a/apps/mouth/src/i18n/locales/it.json
+++ b/apps/mouth/src/i18n/locales/it.json
@@ -28,7 +28,14 @@
       "viewFullTeam": "Vedi il team completo",
       "learnMore": "Scopri di più"
     },
-    "error": "Qualcosa è andato storto. Ricarica la pagina."
+    "error": "Qualcosa è andato storto. Ricarica la pagina.",
+    "consent": {
+      "text": "Utilizziamo i dati di sessione per offrirti assistenza sui visti. Continuando, accetti",
+      "privacyPolicy": "la nostra Informativa sulla Privacy",
+      "and": "e",
+      "termsOfService": "i nostri Termini di Servizio",
+      "dismiss": "Ho capito"
+    }
   },
   "home": {
     "hero": {


### PR DESCRIPTION
## Summary

UX-polish pass on the Second Home Studio wizard + landing (design only — no copy/claim changes, no rule/codec logic changes beyond the Continue-gating test coverage described below).

- **Accent unification (P1)**: root cause was a missing `data-funnel="visa"` attribute on both `StudioApp` and `SecondHomeLanding` — every accent already read `var(--accent-funnel)` correctly (never hardcoded), but under the site's default `editorial` theme that token falls through to McKinsey blue (`#3a6dff`) instead of the visa funnel's red identity, which only applies when `[data-funnel="visa"]` is present in the ancestor chain. Other `/visa` pages get this via `AppFrame`'s `funnel` prop; this route has no `AppFrame` ancestor, so the attribute is set directly on both root wrappers.
- **Options become visible choices (P1)**: `OptionButton` gets a leading radio-dot (single-select) or check-box (family multi-select) affordance, a real `:hover` state, and a stronger selected treatment (accent border + tinted background via `color-mix`). Border/background moved off inline styles onto a `bz-shs-option` CSS class + `data-selected` attribute — an inline style always wins over a stylesheet `:hover` rule regardless of specificity, so hover could never have worked while those properties stayed inline. `role`/`aria-checked`/`aria-pressed` semantics untouched (pinned by existing tests).
- **Continue gating (P1, the one logic touch)**: the `disabled`-until-answered logic (`canContinue`/`isAnswered`) was already wired from the original Studio ship (`87a6a6c05`, 2026-08-19) but had zero test coverage. Added guilt/innocence tests: unanswered step → disabled; answered → enabled; gating resets per-step (not sticky); family step (always-answered) is never disabled; a disabled Continue is a true no-op on click.
- **Consent banner localization (P1)**: added `common.consent.*` keys to `en.json`/`it.json`/`id.json` (faithful translation of the current English sentence, no new claims). `ConsentBanner` now uses a new `useOptionalTranslation()` hook (`src/i18n/index.tsx`) that returns `null` instead of throwing when there's no `<I18nProvider>` ancestor — verified `/visa` itself has none anywhere in its layout chain, while `/visa/second-home/*` does via that route's `layout.tsx`. So it renders localized on the Studio/landing (including `/it` and `/id`) and falls back to the existing English strings everywhere else, with zero provider restructuring. fr/ru fall back to EN automatically via the existing `t()` fallback (no fr/ru keys added).
- **Desktop layout balance (P2)**: the memo rail (`<aside>`) is now `position: sticky` at ≥900px so it doesn't scroll away and leave a dead column next to a tall question card. The wizard grid was already constrained to `1120px` (within the requested 1100–1200px range).
- **Styled "Why we ask" disclosure (P2)**: rotating chevron (lucide `ChevronRight`, CSS `transform: rotate(90deg)` on `[open]`), `list-style: none` on the summary.
- **Custody list markers (P2)**: the plain "1." "2." "3." text markers in `CustodyMap` become small accent-bordered circle badges, matching `TimelineView`'s rounded/bordered "owner chip" visual language.

All decorative affordances (radio dot, check box, chevron, custody badges) are `aria-hidden` — accessible names are unchanged from before this diff.

## Test plan

- [x] `npx vitest run src/app/visa/second-home src/i18n --root .` — 8 test files, 83 tests, all passing (includes the new Continue-gating guilt/innocence block and both landing test files — EN + it/id).
- [x] `npx tsc --noEmit -p .` — clean.
- [x] `npx eslint src/app/visa/second-home src/components --no-error-on-unmatched-pattern` — 0 errors (31 pre-existing warnings elsewhere in the repo, none in the changed files).
- [x] `python3 scripts/docs_sync.py` — `DOCSYNC OK (no changes)`.
- [x] `secondhome-forbidden-claims.test.ts` (W82 sweep) still green — new consent strings live under `common.*`, outside the `secondHome` subtree it scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)