### PR TITLE
fix(trust): retire the reply-time claim across six surfaces

### DIFF
--- a/apps/mouth/src/app/(tax-calendar)/tax-calendar/page.tsx
+++ b/apps/mouth/src/app/(tax-calendar)/tax-calendar/page.tsx
@@ -1,4 +1,5 @@
 import { FunnelFrame } from "@balizero/core";
+import { GOOGLE_RATING, GOOGLE_REVIEW_COUNT } from "@/lib/trust-figures";
 import { TaxCalendarBody } from "@/components/funnel/TaxCalendarBody";
 import { TAX_DEADLINES, getRegencies } from "@/app/api/tax-calendar/deadlines";
 
@@ -9,7 +10,11 @@ export default function TaxCalendarPage() {
     <FunnelFrame
       funnel="tax"
       sessionId="SSR"
-      trust={{ clientCount: 5000, rating: 4.9, responseMinutes: 15 }}
+      trust={{
+        clientCount: 5000,
+        rating: GOOGLE_RATING,
+        reviewCount: GOOGLE_REVIEW_COUNT,
+      }}
     >
       <header style={{ marginBottom: "var(--space-6)" }}>
         <h1 style={{ fontSize: "2rem", fontWeight: 700, margin: 0 }}>

--- a/apps/mouth/src/app/kbli/[code]/page.tsx
+++ b/apps/mouth/src/app/kbli/[code]/page.tsx
@@ -52,6 +52,7 @@ import { KBLIPageTracker } from "@/components/kbli/KBLIPageTracker";
 import { KBLIConsultationCTA } from "@/components/kbli/KBLIConsultationCTA";
 import { KBLICommonQuestions } from "@/components/kbli/KBLICommonQuestions";
 import { FunnelFrame } from "@balizero/core";
+import { GOOGLE_RATING, GOOGLE_REVIEW_COUNT } from "@/lib/trust-figures";
 
 const ZantaraChat = lazy(() =>
   import("@/components/kbli/ZantaraChat").then((mod) => ({
@@ -188,7 +189,11 @@ export default async function KBLICodePage({
       <FunnelFrame
         funnel="kbli"
         sessionId="SSR"
-        trust={{ clientCount: 5000, rating: 4.9, responseMinutes: 15 }}
+        trust={{
+          clientCount: 5000,
+          rating: GOOGLE_RATING,
+          reviewCount: GOOGLE_REVIEW_COUNT,
+        }}
       >
         <article className="pb-28">
           {/* BREADCRUMB */}

--- a/apps/mouth/src/app/kbli/page.tsx
+++ b/apps/mouth/src/app/kbli/page.tsx
@@ -8,6 +8,7 @@ import { KBLISectorGrid } from "@/components/kbli/KBLISectorGrid";
 import { ZantaraChat } from "@/components/kbli/ZantaraChat";
 import { KBLIPersonaDoors } from "@/components/kbli/KBLIPersonaDoors";
 import { FunnelFrame } from "@balizero/core";
+import { GOOGLE_RATING, GOOGLE_REVIEW_COUNT } from "@/lib/trust-figures";
 
 export const metadata: Metadata = {
   title: "KBLI 2025 Navigator — Indonesia Business Classification Guide",
@@ -41,7 +42,11 @@ export default async function KBLIHomePage({
     <FunnelFrame
       funnel="kbli"
       sessionId="SSR"
-      trust={{ clientCount: 5000, rating: 4.9, responseMinutes: 15 }}
+      trust={{
+        clientCount: 5000,
+        rating: GOOGLE_RATING,
+        reviewCount: GOOGLE_REVIEW_COUNT,
+      }}
     >
       <div className="space-y-16">
         {/* ── HERO ── */}

--- a/apps/mouth/src/app/property/eligibility/page.tsx
+++ b/apps/mouth/src/app/property/eligibility/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { FunnelFrame } from "@balizero/core";
+import { GOOGLE_RATING, GOOGLE_REVIEW_COUNT } from "@/lib/trust-figures";
 import { PropertyEligibilityBody } from "@/components/funnel/PropertyEligibilityBody";
 
 export const metadata: Metadata = {
@@ -11,7 +12,11 @@ export default function PropertyPage() {
     <FunnelFrame
       funnel="property"
       sessionId="SSR"
-      trust={{ clientCount: 5000, rating: 4.9, responseMinutes: 15 }}
+      trust={{
+        clientCount: 5000,
+        rating: GOOGLE_RATING,
+        reviewCount: GOOGLE_REVIEW_COUNT,
+      }}
     >
       <header style={{ marginBottom: "var(--space-6)" }}>
         <h1 style={{ fontSize: "2rem", fontWeight: 700, margin: 0 }}>

--- a/apps/mouth/src/app/visa/clock/page.tsx
+++ b/apps/mouth/src/app/visa/clock/page.tsx
@@ -92,7 +92,6 @@ export default function VisaClockPage() {
           items={[
             { value: "5,021", label: "visas filed since 2019" },
             { value: "5", label: "checkpoints (D-60 → D-1)" },
-            { value: "4.8h", label: "avg first-reply on WhatsApp" },
           ]}
         />
       }

--- a/apps/mouth/src/app/visa/page.tsx
+++ b/apps/mouth/src/app/visa/page.tsx
@@ -22,7 +22,6 @@ export default function VisaEntryPage() {
           items={[
             { value: "5,021", label: "visas filed since 2019" },
             { value: "24+", label: "visa categories supported" },
-            { value: "4.8h", label: "avg first-reply on WhatsApp" },
           ]}
         />
       }

--- a/apps/mouth/src/components/trust/response-time-claim.test.ts
+++ b/apps/mouth/src/components/trust/response-time-claim.test.ts
@@ -76,8 +76,23 @@ const FILES = SCANNED.flatMap((d) => walk(join(SRC, d)));
 //   - `AVG_REPLY_MINUTES = 2` — an identifier, no space to match.
 // The patterns below were chosen AFTER the innocence corpus was fixed, and each
 // was run against all of it. Widening any of them means re-running both lists.
+//
+// Third round (2026-08-20). `packages/core` was opened, so the two shapes the
+// DECLARED GAP block used to hold are now removable, and the block is gone —
+// what it described no longer exists. Two changes, both re-run against the
+// whole innocence list:
+//   - Pattern 1: `\s+` -> `\.?[^.\n]{0,16}?`, so a hyphenated infix lands
+//     ("avg first-reply"). The literal `\.?` is KEPT: `[^.\n]` excludes the
+//     period, and dropping it would have silently un-caught "Avg. reply: 2 min",
+//     which is in the guilt list. The recipe left in the old block omitted it.
+//     "Avg Latency" survives because `\brepl(y|ies)\b` needs a whole word
+//     within 16 chars, and "replace" is not one.
+//   - Pattern 9 (new): the `responseMinutes` prop, by name and by its snake and
+//     hyphen spellings. It is deliberately narrow — `responseTime` is a real
+//     variable in this app (innocence list) and any pattern reaching it would
+//     fire on machine latency, which is not a promise to a reader.
 const CLAIMS: RegExp[] = [
-  /\b(avg|average|typical)\.?\s+repl(y|ies)\b/i,
+  /\b(avg|average|typical)\.?[^.\n]{0,16}?\brepl(y|ies)\b/i,
   /\b(avg|average|typical)\.?\s+response\s*[:=]?\s*(under\s+|less\s+than\s+)?\d/i,
   /\brepl(y|ies|ying)\b[^.\n]{0,20}?\b(in|within)\s+(under\s+|less\s+than\s+)?\d/i,
   /\b(we|our\s+team|balizero)\s+(repl(y|ies)|responds?)\s+(in|within)\s+(under\s+)?\d/i,
@@ -85,41 +100,8 @@ const CLAIMS: RegExp[] = [
   /\brepl(y|ies)\s+time\s*[:=]\s*\d/i,
   /\bavg[_\s-]*repl(y|ies)(?![a-z])/i,
   /\busually\s+(?:within|under)\s+\d+\s*(?:min|hour|hr)[a-z]*\b/i,
+  /\b(response|repl(?:y|ies))[_\s-]*minutes\b/i,
 ];
-
-// ---------------------------------------------------------------------------
-// DECLARED GAP — two live claims this guard deliberately does NOT catch yet.
-//
-// Both are on pages right now, both are unmeasured, and neither can be removed
-// without editing `packages/core`, which this PR is not allowed to touch:
-//
-//   1. `{ value: "4.8h", label: "avg first-reply on WhatsApp" }`
-//      apps/mouth/src/app/visa/page.tsx:25 and app/visa/clock/page.tsx:95.
-//      `AppTrustStripProps.items` is a fixed-length tuple
-//      (packages/core/components/apps/AppTrustStrip.tsx:11), so dropping the
-//      third item is a compile error. Measured, `tsc --noEmit`:
-//        TS2322: Source has 2 element(s) but target requires 3.
-//      The CSS grid is auto-fit and handles two items fine — it is the TYPE,
-//      not the layout, that blocks it.
-//
-//   2. `responseMinutes: 15`
-//      app/kbli/page.tsx:44, app/kbli/[code]/page.tsx:191,
-//      app/(tax-calendar)/tax-calendar/page.tsx:12,
-//      app/property/eligibility/page.tsx:14.
-//      `TrustBandProps.responseMinutes` is a REQUIRED prop rendered as
-//      `~{responseMinutes} min` inside a hard `repeat(3, …)` grid
-//      (packages/core/components/TrustBand.tsx:6,43).
-//
-// A pattern that caught either would turn this suite red on main, so what is
-// scoped is the PATTERN — never a filename exception, which would hide the
-// claim instead of declaring it. Neither string is in the innocence corpus
-// below: they are not innocent, they are unreachable from here.
-//
-// When packages/core is opened: delete both claims, then widen pattern 1 to
-// allow a hyphenated infix (e.g. `(avg|average)\b[^.\n]{0,16}?\brepl(y|ies)`)
-// and add one for `responseMinutes`, and re-run the innocence corpus —
-// "Avg Latency" and `{ l: "Avg response" }` are the two that will fight you.
-// ---------------------------------------------------------------------------
 
 describe("no page claims a response time nobody measured", () => {
   it("scans a plausible number of files", () => {
@@ -147,11 +129,17 @@ describe("no page claims a response time nobody measured", () => {
       // identifier forms — no space for a word-spaced pattern to land on
       "export const AVG_REPLY_MINUTES = 2;",
       "export const AVG_REPLY = '2 min';",
-      // removed by this PR, at the file:line each was measured at
+      // removed 2026-08-18 (PR #4178), at the file:line each was measured at
       "Typical first reply on WhatsApp in under 5 hours.",
       "<span>Usually within 15 minutes.</span>",
       'note: "Fastest response — usually under 15 minutes.",',
       "Messages are typically responded to within 24 hours",
+      // removed 2026-08-20, once packages/core was opened. They sat in a
+      // DECLARED GAP block until now because the tuple arity and a required
+      // prop made them unremovable from apps/mouth alone.
+      '            { value: "4.8h", label: "avg first-reply on WhatsApp" },',
+      "      trust={{ clientCount: 5000, rating: 4.9, responseMinutes: 15 }}",
+      "  responseMinutes: number;",
       // caught by the first version, must not regress
       "  <p>We reply within 5 minutes</p>",
       "  <p>Our team responds in 2 minutes</p>",

--- a/docs/design/components-catalog.md
+++ b/docs/design/components-catalog.md
@@ -110,8 +110,8 @@
 - **source**: `packages/core/components/apps/AppTrustStrip.tsx`
 - **use when**: trust, social proof
 - **props**:
-  - `items`: `[TrustNumber, TrustNumber, TrustNumber]`
-- **example**: `<AppTrustStrip items={/* [TrustNumber, TrustNumber, TrustNumber] */} />`
+  - `items`: `[TrustNumber, TrustNumber] | [TrustNumber, TrustNumber, TrustNumber]`
+- **example**: `<AppTrustStrip items={/* [TrustNumber, TrustNumber] | [TrustNumber, TrustNumber, TrustNumber] */} />`
 
 ## `AppWhatsAppCTA`
 
@@ -382,9 +382,9 @@
 - **use when**: trust, social proof
 - **props**:
   - `clientCount`: `number`
-  - `rating`: `number`
-  - `responseMinutes`: `number`
-- **example**: `<TrustBand clientCount={/* number */} rating={/* number */} responseMinutes={/* number */} />`
+  - `rating`: `string`
+  - `reviewCount`: `number`
+- **example**: `<TrustBand clientCount={/* number */} rating={/* string */} reviewCount={/* number */} />`
 
 ## `WhatsAppFAB`
 

--- a/packages/core/components/FunnelFrame.test.tsx
+++ b/packages/core/components/FunnelFrame.test.tsx
@@ -9,7 +9,7 @@ describe("FunnelFrame", () => {
         funnel="visa"
         sessionId="abc"
         step={{ current: 2, total: 5 }}
-        trust={{ clientCount: 5000, rating: 4.9, responseMinutes: 15 }}
+        trust={{ clientCount: 5000, rating: "4.9", reviewCount: 693 }}
       >
         <div>QUIZ_BODY</div>
       </FunnelFrame>,

--- a/packages/core/components/TrustBand.test.tsx
+++ b/packages/core/components/TrustBand.test.tsx
@@ -5,10 +5,12 @@ import { TrustBand } from "./TrustBand";
 describe("TrustBand", () => {
   it("renders three stat tiles with labels", () => {
     const { getByText } = render(
-      <TrustBand clientCount={5000} rating={4.9} responseMinutes={15} />,
+      <TrustBand clientCount={5000} rating="4.9" reviewCount={1234} />,
     );
     expect(getByText(/5,?000\+|5k\+/)).toBeTruthy();
     expect(getByText(/4\.9/)).toBeTruthy();
-    expect(getByText(/15 min/)).toBeTruthy();
+    // 1234, not 693: the real count has no thousands separator yet, so a
+    // literal 693 here would let `toLocaleString` be deleted without failing.
+    expect(getByText("1,234")).toBeTruthy();
   });
 });

--- a/packages/core/components/TrustBand.tsx
+++ b/packages/core/components/TrustBand.tsx
@@ -1,9 +1,25 @@
 import type { FC } from "react";
 
+/**
+ * The third column used to read `~15 min` — a response-time promise nobody
+ * had measured (see apps/mouth/src/components/trust/response-time-claim.test.ts
+ * for the measurement that retired it). It now carries the Google review
+ * count, which IS measured and carries a MEASURED_ON date.
+ *
+ * `rating` and `reviewCount` are INJECTED, not imported. Their source of
+ * truth is apps/mouth/src/lib/trust-figures.ts, and packages/core cannot
+ * reach into an app: this package declares zero dependencies, has no tsconfig
+ * of its own, and its vitest config carries no path alias — an `@/lib/...`
+ * import here resolves in apps/mouth and fails under `cd packages/core &&
+ * npx vitest --run`, which is an armed step of a required check. Pass them
+ * from the call site; do not "fix" this into a cross-package import.
+ */
 export interface TrustBandProps {
   clientCount: number;
-  rating: number;
-  responseMinutes: number;
+  /** Star rating, verbatim from the measured source (e.g. "4.9"). */
+  rating: string;
+  /** Review count, verbatim from the measured source. */
+  reviewCount: number;
 }
 
 function formatK(n: number): string {
@@ -13,7 +29,7 @@ function formatK(n: number): string {
 export const TrustBand: FC<TrustBandProps> = ({
   clientCount,
   rating,
-  responseMinutes,
+  reviewCount,
 }) => (
   <section
     aria-label="Trust signals"
@@ -33,16 +49,14 @@ export const TrustBand: FC<TrustBandProps> = ({
       <div style={{ color: "var(--color-text-secondary)" }}>Clients</div>
     </div>
     <div>
-      <strong style={{ fontSize: "var(--font-size-2xl)" }}>
-        ★ {rating.toFixed(1)}
-      </strong>
-      <div style={{ color: "var(--color-text-secondary)" }}>Reviews</div>
+      <strong style={{ fontSize: "var(--font-size-2xl)" }}>★ {rating}</strong>
+      <div style={{ color: "var(--color-text-secondary)" }}>Rating</div>
     </div>
     <div>
       <strong style={{ fontSize: "var(--font-size-2xl)" }}>
-        ~{responseMinutes} min
+        {reviewCount.toLocaleString("en-US")}
       </strong>
-      <div style={{ color: "var(--color-text-secondary)" }}>Response</div>
+      <div style={{ color: "var(--color-text-secondary)" }}>Google reviews</div>
     </div>
   </section>
 );

--- a/packages/core/components/apps/AppFrame.tsx
+++ b/packages/core/components/apps/AppFrame.tsx
@@ -7,7 +7,7 @@ export interface AppFrameProps {
   subtitle?: string;
   /** Optional right-sidebar (desktop ≥900px). */
   sidebar?: ReactNode;
-  /** 3-number trust strip (AppTrustStrip) rendered above the main content. */
+  /** Trust strip (AppTrustStrip) rendered above the main content. */
   trustStrip?: ReactNode;
   children: ReactNode;
   /** Footer content (disclaimers, last-updated, etc.). */

--- a/packages/core/components/apps/AppTrustStrip.tsx
+++ b/packages/core/components/apps/AppTrustStrip.tsx
@@ -8,11 +8,14 @@ export interface TrustNumber {
 }
 
 export interface AppTrustStripProps {
-  items: [TrustNumber, TrustNumber, TrustNumber];
+  items: [TrustNumber, TrustNumber] | [TrustNumber, TrustNumber, TrustNumber];
 }
 
-/** 3-number strip: concrete metrics only. X_BRAND_VOICE — never
- * "5k+ clients ★4.9"; prefer "5,021 visas filed since 2019". */
+/** Two or three concrete metrics. Three was once the only shape; the tuple
+ * accepts two because a strip is better short than padded with a number
+ * nobody measured. X_BRAND_VOICE — never "5k+ clients ★4.9", and a rating
+ * or a review count is not a substitute for a retired claim; prefer
+ * "5,021 visas filed since 2019". */
 export const AppTrustStrip: FC<AppTrustStripProps> = ({ items }) => {
   return (
     <ul

--- a/packages/design-system/brand-api/components.json
+++ b/packages/design-system/brand-api/components.json
@@ -144,13 +144,13 @@
       "import": "@balizero/core/components/apps/AppTrustStrip",
       "source": "packages/core/components/apps/AppTrustStrip.tsx",
       "props": {
-        "items": "[TrustNumber, TrustNumber, TrustNumber]"
+        "items": "[TrustNumber, TrustNumber] | [TrustNumber, TrustNumber, TrustNumber]"
       },
       "useWhen": [
         "trust",
         "social proof"
       ],
-      "example": "<AppTrustStrip items={/* [TrustNumber, TrustNumber, TrustNumber] */} />"
+      "example": "<AppTrustStrip items={/* [TrustNumber, TrustNumber] | [TrustNumber, TrustNumber, TrustNumber] */} />"
     },
     {
       "name": "AppWhatsAppCTA",
@@ -515,14 +515,14 @@
       "source": "packages/core/components/TrustBand.tsx",
       "props": {
         "clientCount": "number",
-        "rating": "number",
-        "responseMinutes": "number"
+        "rating": "string",
+        "reviewCount": "number"
       },
       "useWhen": [
         "trust",
         "social proof"
       ],
-      "example": "<TrustBand clientCount={/* number */} rating={/* number */} responseMinutes={/* number */} />"
+      "example": "<TrustBand clientCount={/* number */} rating={/* string */} reviewCount={/* number */} />"
     },
     {
       "name": "WhatsAppFAB",


### PR DESCRIPTION
## 1. Insight
SCOPE — Retire response-time claim (TrustBand + AppTrustStrip)
GOAL        : responseMinutes removed from TrustBandProps; TrustBand's third
              column carries Google figures; the 4.8h literal is gone from two
              visa pages; the guard catches both shapes.
NON-GOAL    : SCANNED is NOT widened (owner ruling, separate decision).
              No rating/review substitution inside AppTrustStrip.
              visa/voa and visa/match keep three legitimate items.
              clientCount: 5000 is untouched — tracked separately.
FILES       : 14, listed in section 3.
MEASURED BY : tsc --noEmit = 0 · brand_api_gen.py --check = exit 0 · guard 4/4
ROLLBACK    : revert this PR — no migration, no DB.
DONE WHEN   : state 6 — prove-live.

## 2. Studio
WHAT CHANGES FOR THE USER
- /visa and /visa/clock: the trust strip drops from three tiles to two. The
  removed tile read "4.8h — avg first-reply on WhatsApp". Grid is auto-fit and
  reflows without CSS changes.
- /property/eligibility, /tax-calendar, /kbli, /kbli/[code]: the trust band
  keeps three columns. The third column changes from "~15 min" to the Google
  review count; the second now reads the rating from the measured source
  instead of a hardcoded 4.9.

WHERE
- packages/core/components/TrustBand.tsx — GIALLO, packages/core non-token
- packages/core/components/apps/AppTrustStrip.tsx — GIALLO
- packages/core/components/apps/AppFrame.tsx — GIALLO (docstring only)
- apps/mouth/src/app/** (6 call sites) — VERDE
- apps/mouth/src/components/trust/response-time-claim.test.ts — VERDE

Written GO for the GIALLO surfaces: owner's ruling of 2026-08-20, per component.

## 3. Source
Owner ruling, 2026-08-20:
  1. TrustBand → option (c): drop responseMinutes from the type, fill the third
     column from trust-figures (which carries MEASURED_ON = 2026-08-14).
  2. AppTrustStrip → widen the tuple, do not force two. The component docstring
     closes the rating+review shape, so (c) does not apply there.
  3. One PR covering packages/core, the call sites, and the guard pattern.
  4. SCANNED stays as it is — separate decision, out of this PR.

Data behind the retirement: 189 inbound→outbound pairs (meta_inbox_messages,
3 Jun–30 Jul) → mean 548.8 min, median 4.9 min, p90 411.2. No framing produces
4.8 hours.

Files changed (14):
  packages/core/components/TrustBand.tsx
  packages/core/components/TrustBand.test.tsx
  packages/core/components/FunnelFrame.test.tsx
  packages/core/components/apps/AppTrustStrip.tsx
  packages/core/components/apps/AppFrame.tsx
  apps/mouth/src/app/visa/page.tsx
  apps/mouth/src/app/visa/clock/page.tsx
  apps/mouth/src/app/(tax-calendar)/tax-calendar/page.tsx
  apps/mouth/src/app/property/eligibility/page.tsx
  apps/mouth/src/app/kbli/page.tsx
  apps/mouth/src/app/kbli/[code]/page.tsx
  apps/mouth/src/components/trust/response-time-claim.test.ts
  packages/design-system/brand-api/components.json   (generated)
  docs/design/components-catalog.md                  (generated)

## 4. Methodology
Two read-only phases before the first edit: surface inventory, then worktree
triage, generator discovery, and a pre-change baseline. Two stale worktrees
carrying earlier attempts were inspected and left untouched — one is an
ancestor of main with zero commits ahead, the other's content is already in
main (7/7 blobs identical, squash-merged as #4178).

## 5. Raw Observations
Live surfaces before the change: 2 × "4.8h" literal, 4 × responseMinutes: 15.

Baseline on this machine, 2026-08-20, before the change:
  npx tsc --noEmit                 → exit 0, 0 errors, empty output
  guard test                       → exit 0, 4/4 passing

After the change, rebased onto c1f89677c, re-measured on that base:
  npx tsc --noEmit                 → exit 0, 0 errors
  guard test                       → exit 0, 4/4 passing
  python3 scripts/brand_api_gen.py --check → exit 0, "32 components, artifacts fresh"
  prettier --check (changed files) → exit 0
  packages/core suite              → NOT MEASURED on this machine (see Risk)

Final grep for "4.8h|responseMinutes" across apps/ and packages/: 5 hits, all
inside the guard file — 2 comments, 3 guilt-corpus entries. Zero live claims.

## 6. Reasoning Path
The literal instruction was to import GOOGLE_RATING and GOOGLE_REVIEW_COUNT
into TrustBand. That import cannot exist: packages/core has no dependencies, no
tsconfig of its own, and no resolve.alias in its vitest config, and CI runs
`cd packages/core && npx vitest --run` as part of a required leg. A shared
package reaching into one app resolves under apps/mouth and fails there. The
figures still originate from trust-figures; they are injected from the call
sites, which already live in apps/mouth. The reason is written inside
TrustBand.tsx so the next reader does not "fix" it into a cross-package import.

The DECLARED GAP block inside the guard prescribed the pattern rewrite. Its
recipe excluded periods, which would have silently dropped an existing guilt
case ("Avg. reply: 2 min"). The original optional-period token was kept. One
rewrite round only; 4/4 green, so no limitation needed recording.

## 7. Risk
NOT MEASURED ON THIS MACHINE: `cd packages/core && npx vitest --run` fails at
config load — Cannot find module '@vitejs/plugin-react', vitest.config.ts:24 —
before any test file is read. The comment at tests.yml:965-968 states the
plugin hoists to the root node_modules and that nothing is nested under
apps/mouth. Measured today: node_modules/@vitejs/* → no matches;
apps/mouth/node_modules/@vitejs/plugin-react → present. Whether the CI runner
still hoists as the comment claims cannot be measured from here. The failure is
pre-existing and independent of this diff, which touches no config and no
package.json.

The packages/core assertions in TrustBand.test.tsx and FunnelFrame.test.tsx are
therefore unmeasured here. Type-side coverage is closed (tsc resolves
@balizero/core to source, exit 0), and the 14 files are bit-identical before and
after the rebase, but neither is a substitute for running the suite. CI measures it.

DECISION NEEDED — brand voice. With the third column now carrying the review
count and the second the rating, the band reads, literally, "5k+ clients ★4.9".
That is the exact string AppTrustStrip's X_BRAND_VOICE docstring forbids. The
prohibition is scoped to AppTrustStrip and this shape follows directly from
ruling #1, so it was implemented as instructed and is flagged rather than
resolved. If TrustBand should be held to the same voice rule, say so and the
second column reverts to a plain client figure.

Touching packages/core/components/** always arms the p8-brand-api gate
(on: pull_request, no paths filter). Both generated artifacts were regenerated
by running the generator, not edited by hand.

## 8. Implication
The claim is retired on both surfaces in the same PR, so no half-retired state
reaches main. Every figure that survives now carries a MEASURED_ON date, which
is what stops someone restoring the third column in six months because the
layout "looks empty". The guard now fails on both the literal and the prop
name, so the shape cannot return through either door.

## 9. Recommendation
Rekomendasi: Tinggi — merge as one unit. Splitting it leaves either a widened
type with no consumer or a retired claim with a red type-check.

## 10. Next Action
Author stops here per the standing rule. Review, arm, merge, and prove-live are
owner-side. When measuring the served layer: wait for /api/health to show this
commit, and use a probe that normalises the HTML comment separator — React SSR
splits text nodes, so interpolated prose never exists as one string in the HTML.
Follow-up already filed separately: clientCount: 5000 is still hardcoded at
four call sites and trust-figures declines to hold it.
