### PR TITLE
fix(portal): show clients the part of the bill they have already paid

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/billing.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/billing.py
@@ -68,7 +68,9 @@ class PortalBillingMixin:
                     i.practice_id,
                     pt.name AS practice_name,
                     pt.category AS practice_category,
+                    i.paid_amount_idr,
                     p.payment_status,
+                    p.paid_amount,
                     p.quoted_price
                 FROM invoices i
                 JOIN practices p ON p.id = i.practice_id
@@ -81,14 +83,34 @@ class PortalBillingMixin:
 
         invoices = []
         total_invoiced = 0.0
-        total_paid = 0.0
+
+        # Money received is tracked on the PRACTICE (`practices.paid_amount`,
+        # incremented by the operator's reconciliation in the same transaction
+        # that moves payment_status). Crediting `amount_idr` on status == "paid"
+        # — as this did until 2026-08-20 — cannot see a partial payment: the
+        # operator's lifecycle is unpaid -> partial -> paid, and every invoice
+        # under a partial practice contributed 0 to Paid and its full amount to
+        # Outstanding. A client who had paid half was shown the whole bill.
+        #
+        # paid_amount is per PRACTICE while this list is per INVOICE, and a
+        # practice can carry several invoices (the unique constraint was
+        # dropped), so credit each practice ONCE. It is capped at what that
+        # practice was actually invoiced: these three figures answer "of what we
+        # billed you, how much is settled", so a payment running ahead of
+        # invoicing must not make Outstanding negative. Nothing is hidden by the
+        # cap — the raw per-invoice figure is returned as `paid_amount_idr`.
+        invoiced_by_practice: dict[int, float] = {}
+        paid_by_practice: dict[int, float] = {}
 
         for row in rows:
             amount = float(row["amount_idr"] or 0)
-            payment_status = row["payment_status"] or "pending"
+            # "unpaid", not "pending": pending is not a state this system emits.
+            payment_status = row["payment_status"] or "unpaid"
             total_invoiced += amount
-            if payment_status == "paid":
-                total_paid += amount
+
+            practice_id = row["practice_id"]
+            invoiced_by_practice[practice_id] = invoiced_by_practice.get(practice_id, 0.0) + amount
+            paid_by_practice[practice_id] = float(row["paid_amount"] or 0)
 
             invoices.append(
                 {
@@ -107,14 +129,24 @@ class PortalBillingMixin:
                     "practice_name": row["practice_name"],
                     "practice_category": row["practice_category"],
                     "payment_status": payment_status,
+                    "paid_amount_idr": float(row["paid_amount_idr"])
+                    if row["paid_amount_idr"] is not None
+                    else None,
                 }
             )
+
+        total_paid = sum(
+            min(paid, invoiced_by_practice[practice_id])
+            for practice_id, paid in paid_by_practice.items()
+        )
 
         return {
             "invoices": invoices,
             "summary": {
                 "total_invoiced": total_invoiced,
                 "total_paid": total_paid,
+                # Non-negative by construction: every practice's credit is
+                # capped at what that same practice was invoiced.
                 "total_pending": total_invoiced - total_paid,
                 "count": len(invoices),
             },

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal_billing.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal_billing.py
@@ -49,7 +49,9 @@ async def test_get_billing_returns_invoices():
             "practice_id": 10,
             "practice_name": "KITAS B211A",
             "practice_category": "visa",
-            "payment_status": "pending",
+            "payment_status": "unpaid",
+            "paid_amount_idr": None,
+            "paid_amount": 0,
             "quoted_price": 20000000.0,
         },
         {
@@ -66,6 +68,8 @@ async def test_get_billing_returns_invoices():
             "practice_name": "PT PMA Setup",
             "practice_category": "company",
             "payment_status": "paid",
+            "paid_amount_idr": 35000000,
+            "paid_amount": 35000000,
             "quoted_price": 35000000.0,
         },
     ]
@@ -86,6 +90,138 @@ async def test_get_billing_returns_invoices():
     assert result["summary"]["total_pending"] == 20000000.0
     assert result["summary"]["count"] == 2
     assert all(invoice["drive_web_link"] is None for invoice in result["invoices"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Partial payments (2026-08-20)
+#
+# The operator's lifecycle is unpaid -> partial -> paid and the money lands in
+# `practices.paid_amount` (and `invoices.paid_amount_idr`) in the same
+# transaction that moves the status. The summary used to credit `amount_idr`
+# only when the status read exactly "paid", so a client who had paid part of a
+# bill was shown Paid = 0 and the FULL amount Outstanding, in warning colour.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _billing_row(**overrides: object) -> dict[str, object]:
+    """One row shaped exactly like the get_billing SELECT."""
+    row: dict[str, object] = {
+        "id": 1,
+        "invoice_number": "INV-202608-00001",
+        "amount_idr": 10000000.0,
+        "invoice_source": "local_pdf",
+        "drive_file_id": None,
+        "drive_web_link": None,
+        "email_sent_to_client": False,
+        "generated_at": None,
+        "created_at": None,
+        "practice_id": 10,
+        "practice_name": "KITAS B211A",
+        "practice_category": "visa",
+        "paid_amount_idr": None,
+        "payment_status": "unpaid",
+        "paid_amount": 0,
+        "quoted_price": 10000000.0,
+    }
+    row.update(overrides)
+    return row
+
+
+async def _billing_for(rows: list[dict[str, object]]) -> dict[str, object]:
+    mock_conn = AsyncMock()
+    mock_conn.fetch.return_value = rows
+    mock_pool = MagicMock()
+    mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    return await PortalService(mock_pool).get_billing(
+        client_id=1,
+        current_user={"client_id": 1, "email": "c1@example.com"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_payment_is_credited_not_reported_as_fully_outstanding() -> None:
+    """GUILT: the regression this fix exists for. Half paid must read half paid."""
+    result = await _billing_for(
+        [_billing_row(payment_status="partial", paid_amount=4000000, paid_amount_idr=4000000)]
+    )
+
+    assert result["summary"]["total_invoiced"] == 10000000.0
+    assert result["summary"]["total_paid"] == 4000000.0
+    assert result["summary"]["total_pending"] == 6000000.0
+
+
+@pytest.mark.asyncio
+async def test_a_practice_with_two_invoices_is_credited_once() -> None:
+    """GUILT: paid_amount is per PRACTICE, the list is per INVOICE. Summing it
+    per row would double-count a practice that carries two invoices."""
+    result = await _billing_for(
+        [
+            _billing_row(id=1, amount_idr=6000000.0, practice_id=10, paid_amount=5000000),
+            _billing_row(id=2, amount_idr=4000000.0, practice_id=10, paid_amount=5000000),
+        ]
+    )
+
+    assert result["summary"]["total_invoiced"] == 10000000.0
+    assert result["summary"]["total_paid"] == 5000000.0
+    assert result["summary"]["total_pending"] == 5000000.0
+
+
+@pytest.mark.asyncio
+async def test_payment_ahead_of_invoicing_never_makes_outstanding_negative() -> None:
+    """A practice can be paid beyond what has been invoiced so far. Outstanding
+    is 'of what we billed you, what is left' — it must not go negative."""
+    result = await _billing_for(
+        [_billing_row(amount_idr=3000000.0, paid_amount=10000000, payment_status="paid")]
+    )
+
+    assert result["summary"]["total_paid"] == 3000000.0
+    assert result["summary"]["total_pending"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_fully_paid_still_reads_fully_paid() -> None:
+    """INNOCENCE: the case that already worked must keep working."""
+    result = await _billing_for(
+        [_billing_row(paid_amount=10000000, payment_status="paid", paid_amount_idr=10000000)]
+    )
+
+    assert result["summary"]["total_paid"] == 10000000.0
+    assert result["summary"]["total_pending"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_unpaid_reads_nothing_paid() -> None:
+    """INNOCENCE: an untouched invoice must not be credited by the new path."""
+    result = await _billing_for([_billing_row()])
+
+    assert result["summary"]["total_paid"] == 0.0
+    assert result["summary"]["total_pending"] == 10000000.0
+
+
+@pytest.mark.asyncio
+async def test_null_payment_status_reads_unpaid_not_pending() -> None:
+    """'pending' is not a state this system emits — invoice_service.py says so
+    verbatim, and the client's StatusBadge has no entry for it either."""
+    result = await _billing_for([_billing_row(payment_status=None)])
+
+    assert result["invoices"][0]["payment_status"] == "unpaid"
+
+
+@pytest.mark.asyncio
+async def test_per_invoice_paid_amount_is_exposed_including_when_unrecorded() -> None:
+    """The per-invoice figure is passed through raw (None when a payment was
+    reconciled against the practice without naming an invoice), so the capped
+    summary hides nothing."""
+    result = await _billing_for(
+        [
+            _billing_row(id=1, practice_id=10, paid_amount_idr=4000000),
+            _billing_row(id=2, practice_id=11, paid_amount_idr=None),
+        ]
+    )
+
+    assert result["invoices"][0]["paid_amount_idr"] == 4000000.0
+    assert result["invoices"][1]["paid_amount_idr"] is None
 
 
 @pytest.mark.asyncio

--- a/apps/mouth/src/app/portal/(authenticated)/billing/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/billing/page.test.tsx
@@ -226,6 +226,32 @@ describe("BillingPage", () => {
     expect(mockRefetch).toHaveBeenCalledOnce();
   });
 
+  // The operator's lifecycle is unpaid -> partial -> paid. STATUS_MAP knew only
+  // "paid" and "pending", so both "unpaid" and "partial" fell through to the
+  // `?? STATUS_MAP.none` fallback and the client saw a grey "None" badge on a
+  // bill they had partly settled.
+  it("names the operator's real payment states instead of falling back to None", () => {
+    mockState({
+      data: {
+        summary: {
+          total_invoiced: 10_000_000,
+          total_paid: 4_000_000,
+          total_pending: 6_000_000,
+          count: 2,
+        },
+        invoices: [
+          { ...BILLING.invoices[0], id: 3, payment_status: "partial" },
+          { ...BILLING.invoices[1], id: 4, payment_status: "unpaid" },
+        ],
+      },
+    });
+    render(<BillingPage />);
+
+    expect(screen.getByText("Partially paid")).toBeInTheDocument();
+    expect(screen.getByText("Unpaid")).toBeInTheDocument();
+    expect(screen.queryByText("None")).not.toBeInTheDocument();
+  });
+
   it("renders the empty state when there are no invoices", () => {
     mockState({
       data: {

--- a/apps/mouth/src/components/portal/StatusBadge.tsx
+++ b/apps/mouth/src/components/portal/StatusBadge.tsx
@@ -53,6 +53,8 @@ const STATUS_MAP: Record<
   submitted: { icon: CheckCircle, label: "Submitted", tone: "success" },
   filed: { icon: CheckCircle, label: "Filed", tone: "success" },
   paid: { icon: CheckCircle, label: "Paid", tone: "success" },
+  unpaid: { icon: Clock, label: "Unpaid", tone: "warning" },
+  partial: { icon: Clock, label: "Partially paid", tone: "warning" },
   // Amber group
   applied: { icon: Clock, label: "Applied", tone: "warning" },
   pending: { icon: Clock, label: "Pending", tone: "warning" },

--- a/apps/mouth/src/lib/api/portal/portal.types.ts
+++ b/apps/mouth/src/lib/api/portal/portal.types.ts
@@ -510,6 +510,11 @@ export interface PortalInvoice {
   practice_name: string;
   practice_category: string;
   payment_status: string;
+  /** Amount reconciled against THIS invoice. `null` when a payment was
+   *  recorded on the practice without naming an invoice — the summary's
+   *  `total_paid` reads the practice-level figure, so it can be non-zero
+   *  while this is null. */
+  paid_amount_idr: number | null;
 }
 
 export interface BillingSummary {


### PR DESCRIPTION
## The intoppo

Operator ↔ client handoff simulation, billing axis. A client who had paid **half** a bill saw on `my.balizero.com/portal/billing`:

| card | showed | operator's truth |
|---|---|---|
| **Paid** | `0` | `practices.paid_amount` = half |
| **Outstanding** | the **full** invoiced amount, in warning colour | half |
| invoice badge | grey **"None"** | `partial` |

The money was recorded correctly the whole time.

## The source of the cause

Not three bugs — one un-shared vocabulary across the boundary. `practices.payment_status` runs `unpaid → partial → paid` (asserted in `crm_practices.py:242` and `reconcile_service.py:28`; `invoice_service.py:481` says verbatim *"FE ciclo is unpaid→partial→paid (no 'pending' state)"*), and `confirm_payment` moves the money into `practices.paid_amount` **and** `invoices.paid_amount_idr` in the same transaction as the status.

Across the handoff:

- the summary credited `amount_idr` only when the status read exactly `"paid"` — so every invoice under a `partial` practice contributed 0 to Paid and its full amount to Outstanding. `paid_amount` had **zero** references anywhere in `backend/services/portal/`;
- `row["payment_status"] or "pending"` produced a label nothing in the system emits;
- `STATUS_MAP` carried `paid` and `pending` but neither `unpaid` nor `partial`, so both fell through `?? STATUS_MAP.none`.

## The fix

The summary reads the money. Two shapes had to be right, each with its own test because each is a distinct way to be wrong:

- **credit each practice once.** `paid_amount` is per practice, the list is per invoice, and a practice can carry several invoices (the unique constraint was dropped in m125). Summing per row double-counts.
- **cap each practice's credit at what that practice was invoiced.** A practice can be paid ahead of invoicing; these three cards answer *"of what we billed you, how much is settled"*. The cap makes `total_pending >= 0` true **by construction** rather than by a clamp that would hide the anomaly — and nothing is lost, the raw per-invoice figure ships as `paid_amount_idr` (`null` when a payment was reconciled against the practice without naming an invoice).

Plus `"unpaid"` as the fallback label, and the two missing badge entries.

## Verification

Both existing fixtures did not emit the columns the query selects, and one asserted the fabricated `"pending"` — aligned (W114: a fake sharing the code's imagination confirms nothing).

Mutation-verified with guaranteed restore; each mutant killed by the test that owns the property:

| mutation | killed by |
|---|---|
| restore the status-only rule | `test_partial_payment_is_credited_not_reported_as_fully_outstanding` + `test_a_practice_with_two_invoices_is_credited_once` |
| sum `paid_amount` per row (no dedup) | `test_a_practice_with_two_invoices_is_credited_once` |
| drop the cap | `test_payment_ahead_of_invoicing_never_makes_outstanding_negative` |
| restore `"pending"` | `test_null_payment_status_reads_unpaid_not_pending` |
| remove the two badge entries | the frontend test — its failure output prints the two grey `None` badges verbatim |

31 backend + 7 frontend tests green; `tsc --noEmit` clean.

**Cross-family refutation** (Alibaba seat, instructed to refute, default-to-wrong): **STANDS**, and narrowed the claim — `total_paid` is exactly `0` only when *all* of a client's practices are partial; the invariant that always held is that every partial payment contributed 0 to Paid and its full invoiced amount to Outstanding. That narrower statement is the one the commit uses.

## Measured, deliberately NOT fixed here

The billing page fixture also carries `payment_status: "overdue"` — a fourth label outside `{unpaid, partial, paid}` that the backend cannot emit and `STATUS_MAP` does not know. Same root; left alone rather than changed silently under an assertion that does not cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)