### PR TITLE
fix(portal): close two client-side messaging guard gaps vs the operator twin

### DIFF
--- a/apps/backend-rag/backend/services/portal/_mixins/messaging.py
+++ b/apps/backend-rag/backend/services/portal/_mixins/messaging.py
@@ -108,6 +108,8 @@ class PortalMessagingMixin:
                 "SELECT email FROM clients WHERE id = $1 AND deleted_at IS NULL",
                 client_id,
             )
+            if not client:
+                raise ValueError(f"Client {client_id} not found")
 
             message = await conn.fetchrow(
                 """
@@ -149,13 +151,21 @@ class PortalMessagingMixin:
         *,
         current_user: ClientContext,
     ) -> dict[str, Any]:
-        """Mark a message as read."""
+        """Mark a message as read.
+
+        Only `team_to_client` messages can be marked read by the client —
+        mirrors the operator-side guard in `crm_portal_integration.py`
+        (`mark_client_message_read`, which restricts to `client_to_team`).
+        Without this, a client could mark one of their OWN outbound
+        messages read and forge a "the team has read this" signal.
+        """
         async with self.pool.acquire() as conn:
             result = await conn.execute(
                 """
                 UPDATE portal_messages
                 SET read_at = NOW()
-                WHERE id = $1 AND client_id = $2 AND read_at IS NULL
+                WHERE id = $1 AND client_id = $2
+                AND direction = 'team_to_client' AND read_at IS NULL
                 """,
                 message_id,
                 client_id,

--- a/apps/backend-rag/backend/tests/unit/routers/test_portal.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_portal.py
@@ -475,6 +475,22 @@ class TestMessages:
         mock_portal_service.send_message.assert_awaited_once()
         assert mock_portal_service.send_message.await_args.kwargs["practice_id"] == 603
 
+    def test_send_message_client_not_found_returns_404_not_500(
+        self, client, mock_portal_service
+    ):
+        """DEFECT 1: if the portal account is linked to a soft-deleted
+        client, send_message raises ValueError('Client X not found') —
+        same not-found shape as get_dashboard (BUG C) — and must surface
+        as 404, not a 500."""
+        mock_portal_service.send_message.side_effect = ValueError("Client 42 not found")
+
+        response = client.post(
+            "/api/portal/messages",
+            json={"content": "hello"},
+        )
+
+        assert response.status_code == 404
+
     def test_mark_message_read(self, client, mock_portal_service):
         """Mark message as read."""
         mock_portal_service.mark_message_read.return_value = {"success": True}

--- a/apps/backend-rag/backend/tests/unit/services/portal/test_portal_service.py
+++ b/apps/backend-rag/backend/tests/unit/services/portal/test_portal_service.py
@@ -500,6 +500,104 @@ class TestPortalServiceDashboard:
         assert result["documents"]["total"] == 5
 
 
+class TestPortalServiceMessages:
+    """send_message / mark_message_read guards.
+
+    DEFECT 1: send_message must reject a soft-deleted client with a
+    ValueError (mirrors get_dashboard's "not found" shape) instead of
+    letting `client["email"]` raise a bare TypeError on a None row.
+
+    DEFECT 2: mark_message_read must only flip read_at on `team_to_client`
+    messages — a client marking read a `client_to_team` message they sent
+    themselves would forge a "the team has read this" signal. Mirrors the
+    operator-side guard in `crm_portal_integration.mark_client_message_read`
+    (direction = 'client_to_team').
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_message_soft_deleted_client_raises_value_error(
+        self, mock_pool: tuple
+    ) -> None:
+        from backend.services.portal.portal_service import PortalService
+
+        pool, conn = mock_pool
+        # `deleted_at IS NULL` filter in the SQL means fetchrow returns None
+        # for a soft-deleted client — exactly what the router's ValueError
+        # -> 404 handler expects.
+        conn.fetchrow = AsyncMock(return_value=None)
+
+        service = PortalService(pool)
+        with pytest.raises(ValueError, match="not found"):
+            await service.send_message(
+                999,
+                content="hello",
+                current_user=_ctx(999),
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_message_success_uses_client_email(self, mock_pool: tuple) -> None:
+        from backend.services.portal.portal_service import PortalService
+
+        pool, conn = mock_pool
+        client_row = {"email": "client-1@example.com"}
+        message_row = {
+            "id": 5,
+            "subject": None,
+            "content": "hello",
+            "direction": "client_to_team",
+            "sent_by": "client-1@example.com",
+            "read_at": None,
+            "created_at": datetime.now(timezone.utc),
+            "practice_id": None,
+        }
+        conn.fetchrow = AsyncMock(side_effect=[client_row, message_row])
+
+        service = PortalService(pool)
+        result = await service.send_message(1, content="hello", current_user=_ctx(1))
+
+        assert result["id"] == 5
+        assert result["sent_by"] == "client-1@example.com"
+
+    @pytest.mark.asyncio
+    async def test_mark_message_read_rejects_client_to_team_message(
+        self, mock_pool: tuple
+    ) -> None:
+        """Guilt: a client_to_team message (the client's own outbound
+        message) must NOT be marked read via this path — the SQL guard
+        (direction = 'team_to_client') means the UPDATE matches zero rows
+        even if the id/client_id are otherwise correct."""
+        from backend.services.portal.portal_service import PortalService
+
+        pool, conn = mock_pool
+        # The UPDATE's WHERE clause (direction='team_to_client') excludes
+        # a client_to_team row, so asyncpg reports zero rows touched.
+        conn.execute = AsyncMock(return_value="UPDATE 0")
+
+        service = PortalService(pool)
+        result = await service.mark_message_read(1, 42, current_user=_ctx(1))
+
+        assert result == {"success": False}
+        # Assert the guard is actually IN the SQL, not just that the
+        # mocked return value happens to be zero.
+        executed_sql = conn.execute.await_args.args[0]
+        assert "direction = 'team_to_client'" in executed_sql
+
+    @pytest.mark.asyncio
+    async def test_mark_message_read_accepts_team_to_client_message(
+        self, mock_pool: tuple
+    ) -> None:
+        """Innocence: a genuine team_to_client message is still markable."""
+        from backend.services.portal.portal_service import PortalService
+
+        pool, conn = mock_pool
+        conn.execute = AsyncMock(return_value="UPDATE 1")
+
+        service = PortalService(pool)
+        result = await service.mark_message_read(1, 42, current_user=_ctx(1))
+
+        assert result == {"success": True}
+
+
 class TestPortalServiceVisaStatus:
     @pytest.mark.asyncio
     async def test_get_visa_status_client_not_found(self, mock_pool: tuple) -> None:


### PR DESCRIPTION
## Summary

`_mixins/messaging.py` (client-side portal messaging) had partial copies of two guards the operator-side `crm_portal_integration.py` already converged on. Both are closed here, mirroring the existing operator-side shape.

**Defect 1 — `send_message` 500 instead of 404 for a soft-deleted client.**
The auth dependency `get_current_client` (router `portal.py`) resolves `client_id` from `team_members.linked_client_id` and never joins/checks `clients.deleted_at` — so a soft-deleted client whose `team_members` row is still `active`/`portal_access=true` reaches `send_message` unblocked. There, the client row was fetched with `deleted_at IS NULL` but never null-checked before `client["email"]` — a missing row raised a bare `TypeError`, which the router's `except ValueError -> 404` (comment: "Client soft-deleted / gone ... -> not-found, not a 500") doesn't catch, so it fell through to `except Exception -> 500`. Fixed by raising `ValueError(f"Client {client_id} not found")` on a missing row — the same pattern `dashboard.py::get_dashboard` already uses.

**Defect 2 — `mark_message_read` had no `direction` filter, letting a client forge a read receipt.**
A client could call `mark_message_read` on one of their own outbound `client_to_team` messages and flip `read_at`, faking "the team has read this." The operator-side twin (`mark_client_message_read` in `crm_portal_integration.py`) already guards with `direction = 'client_to_team'`; added the mirror-image `direction = 'team_to_client'` on the client side. The current frontend (`chat/page.tsx`) only ever calls this endpoint for `team_to_client` messages, so this closes a server-side hole rather than changing any behaviour observed in production today.

## Verification

- Confirmed `get_current_client` does **not** reject a soft-deleted client upstream (no `clients.deleted_at` check anywhere in it) — Defect 1 is live-reachable, not just defense-in-depth.
- New tests, mutation-verified (guard removed → RED with the exact failure mode; guard restored → GREEN):
  - `test_send_message_soft_deleted_client_raises_value_error` / `test_send_message_success_uses_client_email`
  - `test_mark_message_read_rejects_client_to_team_message` (asserts the SQL clause itself, not just the mocked return) / `test_mark_message_read_accepts_team_to_client_message`
  - Router-level: `test_send_message_client_not_found_returns_404_not_500` (mirrors the existing `test_dashboard_client_not_found_returns_404_not_500` pattern)

```
PYTHONPATH=. pytest backend/tests/unit/services/portal backend/tests/unit/routers/test_portal.py -q
128 passed
```

## Test plan

- [x] `send_message` with a soft-deleted client raises `ValueError`, router surfaces 404 not 500
- [x] `mark_message_read` rejects `client_to_team` (guilt) and still accepts `team_to_client` (innocence)
- [x] Both guards mutation-verified (removed → RED, restored → GREEN)
- [x] Full portal unit suite green (128 passed)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01659shze7K4ypUoEkU5ixZq