### PR TITLE
feat(health): report the commit SHA the image was built from

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -181,7 +181,8 @@ jobs:
               --app nuzantara-rag \
               --remote-only \
               --dockerfile apps/backend-rag/Dockerfile \
-              --config apps/backend-rag/fly.toml 2>&1 | tee fly-deploy.log
+              --config apps/backend-rag/fly.toml \
+              --build-arg GIT_SHA=${{ github.sha }} 2>&1 | tee fly-deploy.log
             status=${PIPESTATUS[0]}
             set -e
 

--- a/apps/backend-rag/Dockerfile
+++ b/apps/backend-rag/Dockerfile
@@ -92,6 +92,15 @@ FROM node:22-trixie-slim AS node22
 # ========================================
 FROM python:3.11-slim
 
+# Build identity (2026-08-20): bake the deploying commit SHA into the image so
+# /health can say WHICH version is actually running, not just that a process
+# answers. Set via `flyctl deploy --build-arg GIT_SHA=<sha>` in
+# .github/workflows/fly-deploy.yml (${{ github.sha }}). A build that omits the
+# arg (e.g. local `docker build`) gets the empty default below; the health
+# router (backend/app/routers/health.py::_resolve_build_sha) normalizes that
+# to the explicit "unknown" marker at import time — never a fabricated SHA.
+ARG GIT_SHA=""
+
 # Install runtime dependencies:
 # - curl + ca-certificates: healthcheck
 # - nodejs + npm: required by the `claude` CLI (Claude Code), used by
@@ -237,6 +246,9 @@ ENV PYTHONPATH=/app:/app/backend:/app/packages/cell-core:/app/apps/crm-cell:/hom
 ENV PATH=/home/nuzantara/.local/bin:$PATH
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+# Build identity: promote the ARG declared above to a runtime ENV var so
+# backend/app/routers/health.py can read it via os.getenv at import time.
+ENV GIT_SHA=${GIT_SHA}
 
 # Aggressive cleanup to reduce image size
 RUN find /home/nuzantara/.local -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true \

--- a/apps/backend-rag/backend/app/models/__init__.py
+++ b/apps/backend-rag/backend/app/models/__init__.py
@@ -115,6 +115,13 @@ class HealthResponse(BaseModel):
 
     status: str
     version: str
+    # Build identity (2026-08-20): the commit SHA actually running in this
+    # process, baked in at `docker build --build-arg GIT_SHA=<sha>` (see
+    # health.py::BUILD_SHA). `version` above is a hand-maintained label and
+    # says nothing about WHICH commit is live — this field is the answer to
+    # that question. Defaults to "unknown" only as a safety net; every call
+    # site in health.py passes the real resolved value explicitly.
+    build_sha: str = "unknown"
     database: dict[str, Any]
     embeddings: dict[str, Any]
 

--- a/apps/backend-rag/backend/app/routers/health.py
+++ b/apps/backend-rag/backend/app/routers/health.py
@@ -29,6 +29,29 @@ logger = logging.getLogger(__name__)
 STARTUP_WARMUP_DEADLINE_S = float(os.getenv("STARTUP_WARMUP_DEADLINE_S", "180"))
 
 
+def _resolve_build_sha() -> str:
+    """Read the git commit SHA baked into this image at build time.
+
+    Cicatrix family #2 (esiste != armato): before this, /health could say
+    the process was alive but never WHICH commit was actually running — the
+    `version` field below is a hand-maintained label, not a build identity.
+    `GIT_SHA` is set via `docker build --build-arg GIT_SHA=<sha>` from
+    `.github/workflows/fly-deploy.yml` (`${{ github.sha }}`) and baked into
+    the image as an ENV var (Dockerfile) — read ONCE here at import time.
+    No subprocess, no request-time `git` shell-out, no latency added.
+
+    Local dev / any build that did not pass the arg reads as the explicit
+    "unknown" marker, on purpose — never a fabricated or silently-omitted
+    SHA. A health endpoint that guesses its own identity is worse than one
+    that admits it does not know.
+    """
+    raw = os.getenv("GIT_SHA", "").strip()
+    return raw if raw else "unknown"
+
+
+BUILD_SHA = _resolve_build_sha()
+
+
 _qdrant_client: httpx.AsyncClient | None = None
 
 
@@ -273,6 +296,7 @@ async def health_check(request: Request, response: Response) -> HealthResponse:
             return HealthResponse(
                 status="unhealthy",
                 version="v100-qdrant",
+                build_sha=BUILD_SHA,
                 database={
                     "status": "unknown",
                     "type": "postgresql",
@@ -294,6 +318,7 @@ async def health_check(request: Request, response: Response) -> HealthResponse:
             return HealthResponse(
                 status="unhealthy",
                 version="v100-qdrant",
+                build_sha=BUILD_SHA,
                 database={
                     "status": "unknown",
                     "type": "postgresql",
@@ -322,6 +347,7 @@ async def health_check(request: Request, response: Response) -> HealthResponse:
                 return HealthResponse(
                     status=status_override or "healthy",
                     version="v100-qdrant",
+                    build_sha=BUILD_SHA,
                     database={"status": "connected", "type": "postgresql"},
                     embeddings={
                         "status": "operational",
@@ -334,6 +360,7 @@ async def health_check(request: Request, response: Response) -> HealthResponse:
             return HealthResponse(
                 status="initializing",
                 version="v100-qdrant",
+                build_sha=BUILD_SHA,
                 database={"status": "initializing", "message": "Warming up Qdrant connections"},
                 embeddings={"status": "initializing", "message": "Loading embedding model"},
             )
@@ -376,6 +403,7 @@ async def health_check(request: Request, response: Response) -> HealthResponse:
             return HealthResponse(
                 status=status_override or "healthy",
                 version="v100-qdrant",
+                build_sha=BUILD_SHA,
                 database={
                     "status": "connected",
                     "type": "qdrant",
@@ -396,6 +424,7 @@ async def health_check(request: Request, response: Response) -> HealthResponse:
             return HealthResponse(
                 status="initializing",
                 version="v100-qdrant",
+                build_sha=BUILD_SHA,
                 database={"status": "partial", "message": "Services starting"},
                 embeddings={"status": "loading", "message": str(ae)},
             )
@@ -406,6 +435,7 @@ async def health_check(request: Request, response: Response) -> HealthResponse:
         return HealthResponse(
             status="degraded",
             version="v100-qdrant",
+            build_sha=BUILD_SHA,
             database={"status": "error", "error": str(e)},
             embeddings={"status": "error", "error": str(e)},
         )

--- a/apps/backend-rag/backend/tests/routers/test_health.py
+++ b/apps/backend-rag/backend/tests/routers/test_health.py
@@ -204,3 +204,119 @@ class TestHealthEndpoints:
         assert semantic["hits"] == sem_hits_before + 1
         assert semantic["misses"] == sem_misses_before + 1
         assert semantic["hits_by_match_type"]["match_type=semantic"] >= 1
+
+
+class TestBuildSha:
+    """build_sha (2026-08-20): the git commit SHA baked into the image via
+    GIT_SHA at `docker build --build-arg` time (see
+    .github/workflows/fly-deploy.yml + Dockerfile). Before this, /health's
+    `version` field was a frozen literal ("v100-qdrant") that could not say
+    WHICH commit was actually running — cicatrix family #2 (esiste != armato).
+
+    Two behaviors are load-bearing here: build_sha reflects the resolved
+    value when GIT_SHA was set at build time, and it reads as the explicit
+    "unknown" marker -- never a fabricated or silently-omitted SHA -- when
+    the build never received one (local dev, a build that skipped the arg).
+    """
+
+    @pytest.mark.unit
+    def test_resolve_build_sha_reads_env_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GIT_SHA", "abc1234def5678")
+        assert health_module._resolve_build_sha() == "abc1234def5678"
+
+    @pytest.mark.unit
+    def test_resolve_build_sha_is_unknown_when_env_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GIT_SHA", raising=False)
+        assert health_module._resolve_build_sha() == "unknown"
+
+    @pytest.mark.unit
+    def test_resolve_build_sha_is_unknown_when_env_blank(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A Docker build arg default of "" (never passed at deploy time)
+        # must normalize the same as a fully-absent env var — never surface
+        # an empty string as if it were a real identity.
+        monkeypatch.setenv("GIT_SHA", "   ")
+        assert health_module._resolve_build_sha() == "unknown"
+
+    @pytest.mark.integration
+    def test_health_surfaces_resolved_build_sha(
+        self, app: FastAPI, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pins the WIRING: every HealthResponse(...) call site in
+        health_check() must pass build_sha=BUILD_SHA through to the JSON
+        payload, and the pre-existing `version` field must stay untouched
+        (other consumers read it — see health.py module docstring)."""
+        monkeypatch.setattr(health_module, "BUILD_SHA", "deadbeefcafe")
+        app.state.process_mode = "light"
+        app.state.search_service = None
+
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["build_sha"] == "deadbeefcafe"
+        assert body["version"] == "v100-qdrant"
+
+    @pytest.mark.integration
+    def test_health_surfaces_unknown_build_sha_when_unresolved(
+        self, app: FastAPI, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A health payload that guesses its own identity is worse than one
+        that admits it does not know -- pin the unresolved case end-to-end,
+        not just at the resolver-function level above."""
+        monkeypatch.setattr(health_module, "BUILD_SHA", "unknown")
+        app.state.process_mode = "light"
+        app.state.search_service = None
+
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json()["build_sha"] == "unknown"
+
+    @pytest.mark.unit
+    def test_build_sha_constant_is_bound_to_the_resolver(self) -> None:
+        """Pin the BINDING, not just the two ends of it.
+
+        `BUILD_SHA = _resolve_build_sha()` is the one line no other test in
+        this class can see: the unit tests call the resolver directly and the
+        integration tests monkeypatch the constant, so both stay green if the
+        module were changed to `BUILD_SHA = "v100-qdrant"` — re-contracting
+        the exact frozen-literal disease this feature exists to cure.
+        """
+        assert health_module.BUILD_SHA == health_module._resolve_build_sha()
+
+    @pytest.mark.unit
+    def test_every_health_response_construction_passes_build_sha(self) -> None:
+        """All SEVEN HealthResponse(...) sites, not just the one branch an
+        integration test happens to walk.
+
+        Measured 2026-08-20: dropping `build_sha=BUILD_SHA` from a single
+        call site left the whole suite green, because only the `light`
+        process-mode path is exercised end-to-end. Six of the seven could
+        silently lose the field. Read the wiring structurally instead of
+        hoping a request routes through it (cicatrix W107: cure the class,
+        not the instance that bit you).
+        """
+        import ast
+        import pathlib
+
+        source = pathlib.Path(health_module.__file__).read_text()
+        sites = [
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "HealthResponse"
+        ]
+        # Anti-vacuity (W84): zero sites traversed is not a clean verdict.
+        assert len(sites) >= 7, f"expected >=7 HealthResponse sites, found {len(sites)}"
+
+        missing = [
+            node.lineno
+            for node in sites
+            if "build_sha" not in {kw.arg for kw in node.keywords if kw.arg}
+        ]
+        assert not missing, f"HealthResponse without build_sha at lines {missing}"


### PR DESCRIPTION
## What

`/health` could say the process was alive but never **which commit was running**. `version` is a hand-maintained literal (`"v100-qdrant"`, 7 call sites) that has not changed across deploys — cicatrix family #2, *esiste ≠ armato*: a stale image and a fresh one are indistinguishable to every consumer.

Adds a separate `build_sha` field fed by `GIT_SHA`, passed at `docker build --build-arg` time from `fly-deploy.yml` and baked into the image as an ENV var. Read once at import — no subprocess, no request-time `git` shell-out, no added latency.

- `version` keeps its exact value and shape. Other consumers read it; this does not touch them.
- **Fails honest**: a build that never received the arg (local dev, any path that skips it) reads the explicit `"unknown"` marker — never a fabricated or silently-omitted SHA. A blank/whitespace arg normalizes the same way.
- `fly.toml` is off-limits and is **not** touched; the route runs entirely through the Dockerfile and the workflow.

## Adversarial review

Mutation-verified, baseline RC=0:

| mutation | result |
|---|---|
| resolver stops normalizing a blank `GIT_SHA` | RC=1 |
| one of the seven call sites drops `build_sha=` | RC=1, failure names the line |
| `BUILD_SHA` rebound to a frozen literal | RC=1 |

The **last two survived the first corpus** — that is why two tests were added rather than declaring the corpus adequate:

- The integration tests `monkeypatch` the constant and the unit tests call the resolver directly, so **nothing saw the binding between them**: the module could have been changed to `BUILD_SHA = "v100-qdrant"` and stayed green, re-contracting the exact frozen-literal disease this PR exists to cure.
- Only the `light` process-mode branch is walked end-to-end, so **six of the seven call sites could silently lose the field** (W107: cure the class, not the instance that bit you). The wiring is now read structurally over the AST, with an anti-vacuity floor (W84) so zero sites traversed cannot read as clean.

Generator ≠ grader: the diff was produced by an implementer lane; the mutation testing and the two added tests came from an independent pass that set out to break it.