### PR TITLE
fix(ci): stop main-push-failure-watch firing on every PR/queue completion

### DIFF
--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -19,9 +19,13 @@ name: Main-push Failure Watch
 # workflow_dispatch runs (operator-initiated; the operator is already
 # watching). The `workflows:` list below is DELIBERATELY over-inclusive
 # (every workflow in the repo, this file's own name excluded) so listing it
-# never requires a push:main/schedule:main judgment call — real filtering
-# happens in the job `if:` below, on the actual event + branch of the run
-# that just completed.
+# never requires a push:main/schedule:main judgment call — the trigger's
+# own `branches: [main]` filter (added 2026-08-20, see GOTCHA below) drops
+# the pull_request/merge_group completions of that over-inclusive list
+# before a run is even CREATED, so most of the noise never shows up in the
+# Actions run list at all; the job `if:` below still does the real event +
+# conclusion judgment (push-vs-schedule-vs-dispatch, failure-vs-success) on
+# the same `head_branch` field, unchanged, as the backstop.
 #
 # Widened to `schedule` 2026-07-26 (task #37): task #37 added the first
 # schedule-triggered workflow that targets main (`Tests & Coverage`'s
@@ -53,6 +57,39 @@ name: Main-push Failure Watch
 #    a WATCHED workflow (a newer push lands mid-run) is routine, not a silent
 #    failure — alerting on it would itself be the noise this design exists to
 #    avoid.
+#  - 2026-08-20 (CI-churn finding): a 100-run sample of one day's Actions
+#    activity found 47 were this workflow's own reactive runs. Re-measured
+#    directly against the live API the same day: `gh api
+#    repos/Bali-Zero/Teman2/actions/workflows/320576288/runs?created=>=2026-
+#    08-20` returned 4,138 runs of THIS workflow alone, against ~8,266
+#    repo-wide — essentially all `conclusion: skipped` or `cancelled`. The
+#    `alert` job's `if:` below already correctly no-ops on everything but a
+#    push/schedule failure, but GitHub still CREATES a run for every
+#    completion of every workflow in the over-inclusive list below —
+#    `pull_request` and `merge_group` completions included — and a
+#    created-then-skipped run still counts, still shows up in the Actions
+#    list, still costs a scheduling round-trip. Added `branches: [main]` to
+#    the trigger below (cuts run CREATION, not coverage — see SCOPE note
+#    above). Verified empirically against this repo's live run history,
+#    not assumed from docs: `workflow_run.head_branch` is the PR's own
+#    head-branch name for `pull_request`-triggered completions of a
+#    watched workflow (e.g. actionlint run 32364422455, head_branch
+#    `agent/air-m5/ops/quarantine-index-2026-08-20`) and
+#    `gh-readonly-queue/main/pr-<n>-<sha>` for `merge_group`-triggered ones
+#    (e.g. actionlint run 32357549625) — NEVER the literal string `main` —
+#    while `push`-to-main and `schedule` completions of a watched workflow
+#    both report `head_branch: main` (tests.yml schedule run 32360788806;
+#    Frontend Live Sentinel push-FAILURE run 32359844277, confirming a real
+#    push-to-main failure keeps `head_branch: main`). The trigger's new
+#    `branches:` filter and the job's `if:` below both gate on that
+#    identical field against that identical value, so the filter can only
+#    additionally exclude runs the job would have skipped anyway — it
+#    cannot silently drop a real push/schedule failure, by construction,
+#    with the job `if:` left completely unchanged as the backstop should
+#    the filter ever behave unexpectedly. `types:` was deliberately NOT
+#    touched: GitHub's docs confirm `workflow_run` only supports
+#    `completed`/`requested`/`in_progress` there — conclusion can only be
+#    filtered inside a job, which is what the `if:` below already does.
 
 on:
   workflow_run:
@@ -185,6 +222,17 @@ on:
       # PR's own first CI run, exactly the self-conformance it exists for.
       - Harness floor & gate publisher
     types: [completed]
+    # 2026-08-20 CI-churn cure — see the matching GOTCHA above for the
+    # measurement and the empirical proof this narrows run CREATION, never
+    # coverage: filters on the triggering workflow's own head_branch, the
+    # identical field (and identical target value) the `alert` job's `if:`
+    # below already requires — so this can only additionally exclude runs
+    # that job would have skipped anyway (pull_request/merge_group
+    # completions, whose head_branch is never literally `main`), never one
+    # it would have alerted on. `push`-to-main and `schedule` completions
+    # (the only two the job ever acts on) both report head_branch `main`
+    # and pass through unaffected.
+    branches: [main]
   # Task #41 (2026-07-26): see the `verdict-liveness` job below for why this
   # exists — a reactive workflow_run watcher structurally cannot see the
   # absence of an event, only events themselves.


### PR DESCRIPTION
## Summary

Measured 2026-08-20: `Main-push Failure Watch` accounted for ~4,138 of the
repo's ~8,266 Actions runs in one day (~50%), essentially all `conclusion:
skipped` or `cancelled`. The `alert` job's `if:` already correctly no-ops on
anything but a push/schedule failure on `main`, but GitHub still **creates**
a run for every completion of every workflow in the (deliberately
over-inclusive) `workflows:` list — pull_request and merge_group
completions included, which dominate this repo's CI volume (2,323
pull_request + 1,378 merge_group vs 292 push + 147 schedule completions
today).

Adds `branches: [main]` to the `on.workflow_run:` trigger. This filters on
`workflow_run.head_branch` — the identical field the `alert` job's `if:`
already requires to equal `main` — so it can only additionally exclude runs
the job would have skipped anyway; it cannot drop a real push/schedule
failure. The job `if:` is left completely unchanged as the backstop.

## Coverage proof (per cicatrix-superscar.md #3 guard discipline)

Verified empirically against this repo's live run history, not assumed from
docs:

- `pull_request`-triggered completions of a watched workflow report
  `head_branch` = the PR's own head branch (e.g. actionlint run
  [32364422455](https://github.com/Bali-Zero/Teman2/actions/runs/32364422455),
  head_branch `agent/air-m5/ops/quarantine-index-2026-08-20`) — never `main`.
- `merge_group`-triggered completions report `head_branch` =
  `gh-readonly-queue/main/pr-<n>-<sha>` (e.g. actionlint run
  [32357549625](https://github.com/Bali-Zero/Teman2/actions/runs/32357549625))
  — never the literal string `main`.
- `push`-to-main and `schedule` completions both report `head_branch: main`,
  including on a **real push-triggered failure**: `Frontend Live Sentinel`
  run [32359844277](https://github.com/Bali-Zero/Teman2/actions/runs/32359844277)
  (event=push, head_branch=main, conclusion=failure) — under today's
  unmodified `if:`, this is exactly the shape that fires the Telegram alert;
  under the new `branches: [main]` filter it still passes through
  unaffected, since its head_branch is `main`.
- Also cross-checked on `tests.yml`: schedule run
  [32360788806](https://github.com/Bali-Zero/Teman2/actions/runs/32360788806)
  reports head_branch `main`.

`types:` was not touched — GitHub's `workflow_run` trigger only supports
`completed`/`requested`/`in_progress`; conclusion-level filtering is only
possible inside a job (which the `if:` already does).

## Estimated reduction

Repo-wide completions today by event: pull_request 2,323, merge_group
1,378, push 292, schedule 147, workflow_dispatch 2 (total non-workflow_run
≈ 4,142) — closely matching the 4,138 reactive runs this watcher itself
fired today (all 93 live workflows are in its watched list, so completion
count ≈ reactive-trigger count 1:1). After this filter, only push/schedule/
dispatch completions (441/day) will still create a reactive run — an
**~89% cut in this workflow's own run creation**, and roughly a **45% cut
in the repo's total daily Actions run volume** (8,266 → ~4,565/day at
today's rate).

## Test plan

- [x] `python3 scripts/check_watcher_coverage.py` — still green locally (93/93
      workflows covered; this check only asserts `workflows:` list
      membership, untouched by this PR).
- [x] `actionlint .github/workflows/main-push-failure-watch.yml` — clean.
- [x] Coverage proof above, against real run history (not simulated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)