### PR TITLE
fix(wr2): stop the vision loop from re-probing a quota window it already proved dead

### DIFF
--- a/apps/backend-rag/backend/db/migrations_v2/275_war_room_vision_circuit_breaker.sql
+++ b/apps/backend-rag/backend/db/migrations_v2/275_war_room_vision_circuit_breaker.sql
@@ -1,0 +1,45 @@
+-- Migration 275: war_room_drafts vision-quota circuit-breaker columns.
+--
+-- Purpose (WR2 vision-quota-burn fix, 2026-08-20):
+--   The HTML render apply-worker (scripts/wr2_html_render_apply.py) releases a
+--   draft WITHOUT burning html_render_attempts whenever the vision critic/
+--   verifier chain hits a TRANSIENT infra failure (rate-limit / endpoint
+--   timeout — VisionTransient in claude_vision.py). That "no attempt burned"
+--   contract is correct (a quota window is not a defect of the draft) but had
+--   NO ceiling: a draft landing on a dead quota window bounced
+--   status='drafts_imaged_checked' -> 'rendering' -> released, forever, every
+--   launchd tick. Measured: ~1,262 `claude --print` vision sessions/day,
+--   ~690M cache-write tokens/7d, while every OAuth seat in the chain was
+--   rate-limited for hours.
+--
+--   Two additive columns give the worker a per-draft cap independent of (and
+--   a backstop for) the process-wide vision cooldown added in the same
+--   change (claude_vision.py's on-disk circuit breaker):
+--     html_vision_transient_streak — consecutive VisionTransient releases on
+--       this draft; reset to 0 the moment a non-transient outcome (success OR
+--       a real render failure) breaks the streak.
+--     html_vision_parked_until — set, once the streak reaches
+--       WR2_VISION_MAX_TRANSIENT (default 3), to NOW() + WR2_VISION_COOLDOWN_S;
+--       NULL means not parked. The HTML-lane fetch
+--       (_pg.fetch_pending_html_draft_ids) excludes a draft while
+--       parked_until is in the future, so a draft that keeps landing on a
+--       dead quota window stops being re-picked every tick WITHOUT ever
+--       reaching the existing, terminal 'parked' STATUS value (that value
+--       means "no usable source content, needs a human" — a vision-quota
+--       window recovers on its own, so this draft must resume automatically
+--       once parked_until passes, never wait for a manual re-queue).
+--
+-- Pure additive nullable/defaulted columns — same shape as migration 228
+-- (html_render_attempts). No backfill: existing rows read streak=0,
+-- parked_until=NULL (not parked), which is the correct historical value (the
+-- circuit breaker did not exist before this migration).
+
+ALTER TABLE war_room_drafts
+    ADD COLUMN IF NOT EXISTS html_vision_transient_streak INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE war_room_drafts
+    ADD COLUMN IF NOT EXISTS html_vision_parked_until TIMESTAMPTZ;
+
+-- === ROLLBACK ===
+ALTER TABLE war_room_drafts DROP COLUMN IF EXISTS html_vision_parked_until;
+ALTER TABLE war_room_drafts DROP COLUMN IF EXISTS html_vision_transient_streak;

--- a/apps/backend-rag/backend/services/canva_renderer_v2/_pg.py
+++ b/apps/backend-rag/backend/services/canva_renderer_v2/_pg.py
@@ -74,6 +74,13 @@ async def fetch_pending_html_draft_ids(conn: asyncpg.Connection, limit: int = 3)
     on it (as the Canva-lane fetch does) starves them forever in
     drafts_imaged_checked while the supervisor reconcile keeps kicking them.
     Mirrors the guard already used by acquire_html_lease_and_fetch.
+
+    Excludes a draft while html_vision_parked_until is still in the future —
+    the vision-quota circuit breaker (2026-08-20) parks a draft here after
+    WR2_VISION_MAX_TRANSIENT consecutive transient (rate-limit/timeout)
+    releases so it stops being re-picked every tick against a proven-dead
+    quota window; it becomes fetchable again on its own once the timestamp
+    passes (see migrations_v2/275_war_room_vision_circuit_breaker.sql).
     """
     rows = await conn.fetch(
         """
@@ -81,6 +88,7 @@ async def fetch_pending_html_draft_ids(conn: asyncpg.Connection, limit: int = 3)
          WHERE status = 'drafts_imaged_checked'
            AND drive_url IS NULL
            AND lease_owner IS NULL
+           AND (html_vision_parked_until IS NULL OR html_vision_parked_until <= NOW())
          ORDER BY created_at ASC
          LIMIT $1
         """,
@@ -107,6 +115,11 @@ async def requeue_draft_for_rerender(conn: asyncpg.Connection, draft_id: UUID | 
       without this, a draft that previously exhausted its attempts (or spent
       some) re-enters with a burned circuit breaker and the first transient
       error of the new cycle goes terminal (Codex review 2026-07-13).
+    - `html_vision_transient_streak` resets to 0 / `html_vision_parked_until`
+      resets to NULL (2026-08-20): same reasoning as html_render_attempts —
+      without this a draft parked by the vision-quota circuit breaker would
+      re-enter the lane but stay INVISIBLE to fetch_pending_html_draft_ids
+      until the stale parked_until from the PREVIOUS cycle happened to pass.
 
     Returns True when the draft re-entered the lane, False otherwise.
     """
@@ -115,7 +128,9 @@ async def requeue_draft_for_rerender(conn: asyncpg.Connection, draft_id: UUID | 
         UPDATE war_room_drafts
            SET status = 'drafts_imaged_checked',
                drive_url = NULL,
-               html_render_attempts = 0
+               html_render_attempts = 0,
+               html_vision_transient_streak = 0,
+               html_vision_parked_until = NULL
          WHERE id = $1
            AND lease_owner IS NULL
            AND status IN ('rendered', 'render_failed', 'drafts_imaged_checked')
@@ -213,6 +228,8 @@ async def rebrief_draft(conn: asyncpg.Connection, draft_id: UUID | str) -> bool:
                fact_check_at = NULL,
                drive_url = NULL,
                html_render_attempts = 0,
+               html_vision_transient_streak = 0,
+               html_vision_parked_until = NULL,
                canva_design_id = NULL,
                canva_edit_url = NULL,
                canva_view_url = NULL,
@@ -531,7 +548,9 @@ async def persist_html_result_and_enqueue_notifications(
                    lease_owner = NULL,
                    lease_acquired_at = NULL,
                    lease_heartbeat_at = NULL,
-                   updated_at = NOW()
+                   updated_at = NOW(),
+                   html_vision_transient_streak = 0,
+                   html_vision_parked_until = NULL
              WHERE id = $1 AND lease_owner = $2 AND status = 'rendering'
             """,
             draft_id,

--- a/apps/backend-rag/backend/tests/conftest.py
+++ b/apps/backend-rag/backend/tests/conftest.py
@@ -144,10 +144,22 @@ def _wr2_runtime_isolation(tmp_path, monkeypatch):
     Control app this way. Redirect both to tmp_path unconditionally; a test
     that needs its own root still wins by monkeypatching the env itself
     (test-body setenv runs after this autouse fixture).
+
+    Same reasoning, added 2026-08-20: claude_vision.py's chain-wide rate-limit
+    cooldown + no-op fingerprint cache default to ~/.agent/state/*.json — an
+    unmocked test that trips a "rate-limited" path would otherwise write a
+    REAL cooldown file that then blocks the PRODUCTION vision loop for up to
+    WR2_VISION_COOLDOWN_S (default 1h), discovered live when the existing
+    _run_claude_json test battery (rate-limit/timeout/rotation cases) started
+    failing each other in file order via the shared default path.
     """
     monkeypatch.setenv("WR2_OUTPUT_ROOT", str(tmp_path / "wr2-output"))
     monkeypatch.setenv("TG_DRY_RUN", "1")
     monkeypatch.setenv("TG_SPOOL_DIR", str(tmp_path / "tg-spool"))
+    monkeypatch.setenv("WR2_VISION_COOLDOWN_STATE", str(tmp_path / "wr2-vision-cooldown.json"))
+    monkeypatch.setenv(
+        "WR2_VISION_FINGERPRINT_CACHE", str(tmp_path / "wr2-vision-fingerprints.json")
+    )
 
 
 @pytest.fixture

--- a/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
+++ b/apps/backend-rag/backend/tests/unit/scripts/test_wr2_html_render_apply.py
@@ -550,6 +550,84 @@ async def test_apply_one_rate_limit_does_not_burn_attempt(monkeypatch):
     assert "drafts_imaged_checked" in sqls
 
 
+async def _run_apply_one_vision_transient(monkeypatch, *, prior_streak: int):
+    """Shared scaffold (mirrors test_apply_one_rate_limit_does_not_burn_attempt
+    above): drives _apply_one through a VisionRateLimited render failure, with
+    conn.fetchval standing in for the current html_vision_transient_streak
+    read. Returns (result, streak_update_call) where streak_update_call is the
+    conn.execute() call whose SQL wrote html_vision_transient_streak."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import scripts.wr2_html_render_apply as html
+    from wr2_html_renderer.claude_vision import VisionRateLimited
+
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    conn.fetchval = AsyncMock(return_value=prior_streak)
+    conn.close = AsyncMock()
+    monkeypatch.setattr(html.asyncpg, "connect", AsyncMock(return_value=conn))
+    monkeypatch.setattr(
+        html._pg, "acquire_html_lease_and_fetch",
+        AsyncMock(return_value={"slides_json": {"slides": [{"headline": "H"}]}}),
+    )
+    monkeypatch.setattr(html, "_heartbeat_loop", AsyncMock())
+    monkeypatch.setattr(html, "_normalize_heroes", lambda slides, *a, **k: slides)
+
+    class _Srv:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    monkeypatch.setattr(html, "_HeroServer", lambda *a, **k: _Srv())
+    monkeypatch.setattr(
+        html, "_render_carousel",
+        AsyncMock(side_effect=VisionRateLimited("429")),
+    )
+    monkeypatch.setenv("WR2_VISION_REQUIRED", "1")
+
+    import uuid as _uuid
+    result = await html._apply_one("postgres://x", _uuid.uuid4(), "owner-1")
+
+    streak_call = next(
+        c for c in conn.execute.call_args_list
+        if "html_vision_transient_streak" in str(c.args[0])
+    )
+    return result, streak_call
+
+
+@pytest.mark.asyncio
+async def test_apply_one_vision_transient_streak_increments_without_parking(monkeypatch):
+    """INNOCENCE: below WR2_VISION_MAX_TRANSIENT the draft is released for a
+    normal retry — status stays effectively 'rate_limited', the streak column
+    is written as fetched-value + 1, and NO park timestamp is set."""
+    monkeypatch.setenv("WR2_VISION_MAX_TRANSIENT", "3")
+    result, streak_call = await _run_apply_one_vision_transient(monkeypatch, prior_streak=1)
+
+    assert result.startswith("rate_limited")
+    assert not result.startswith("parked:vision_quota")
+    draft_id, owner, streak, parked_until = streak_call.args[1:5]
+    assert streak == 2  # prior 1 + this release
+    assert parked_until is None
+
+
+@pytest.mark.asyncio
+async def test_apply_one_fourth_consecutive_transient_parks_draft(monkeypatch):
+    """GUILT: the 4th consecutive VisionTransient release (prior streak 3,
+    WR2_VISION_MAX_TRANSIENT=3) parks the draft — html_vision_parked_until set
+    ~WR2_VISION_COOLDOWN_S in the future, and the reported outcome is
+    'parked:vision_quota', not a plain 'rate_limited' retry."""
+    import datetime
+
+    monkeypatch.setenv("WR2_VISION_MAX_TRANSIENT", "3")
+    monkeypatch.setenv("WR2_VISION_COOLDOWN_S", "1800")
+    result, streak_call = await _run_apply_one_vision_transient(monkeypatch, prior_streak=3)
+
+    assert result.startswith("parked:vision_quota")
+    draft_id, owner, streak, parked_until = streak_call.args[1:5]
+    assert streak == 4
+    assert parked_until is not None
+    delta_s = (parked_until - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
+    assert 1700 < delta_s < 1900  # ~1800s, generous margin for test wall-clock
+
+
 # ── take_label hard gate through _apply_one — integration (2026-07-16
 #    red-team finding #1 coverage gap): confirm the tri-state PrepublishStatus
 #    actually drives release_lease_permanent() correctly at the real call

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pg.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer_v2/test_pg.py
@@ -196,6 +196,20 @@ async def test_fetch_pending_html_selects_on_drive_url_not_canva_url():
 
 
 @pytest.mark.asyncio
+async def test_fetch_pending_html_excludes_parked_drafts():
+    """GUILT+INNOCENCE (vision-quota circuit breaker, 2026-08-20): a draft
+    parked by WR2_VISION_MAX_TRANSIENT consecutive VisionTransient releases
+    (html_vision_parked_until set in the future) must be excluded from the
+    fetch; a never-parked draft (NULL) or one whose park window already
+    elapsed (<= NOW()) is fetchable with no extra query."""
+    conn = AsyncMock()
+    conn.fetch.return_value = []
+    await fetch_pending_html_draft_ids(conn, limit=2)
+    sql = conn.fetch.call_args[0][0]
+    assert "html_vision_parked_until IS NULL OR html_vision_parked_until <= NOW()" in sql
+
+
+@pytest.mark.asyncio
 async def test_acquire_html_lease_sets_heartbeat_and_guards_drive_url():
     conn = AsyncMock()
     fake_row = {"id": "abc", "topic": "T", "tone": "analitico", "slides_json": "{}"}
@@ -279,6 +293,29 @@ async def test_persist_html_enqueues_per_recipient_and_skips_duplicate():
 
 
 @pytest.mark.asyncio
+async def test_persist_html_result_resets_vision_circuit_breaker_on_success():
+    """A successful render proves the vision chain is not (fully) dead — the
+    terminal promote-to-'rendered' UPDATE must clear both circuit-breaker
+    columns so a past transient streak never outlives a real success."""
+    conn = _conn_with_txn()
+    conn.execute.return_value = "UPDATE 1"
+    conn.fetchrow.side_effect = [
+        {"thread_id": 1, "window_open": True},
+        {"id": 10},
+    ]
+    await persist_html_result_and_enqueue_notifications(
+        conn, draft_id="abc", lease_owner="w1", drive_url="https://d/x",
+        recipients=["+62A"], message_body="link",
+    )
+    # first execute() call is the promote UPDATE (wa_outbox INSERTs follow, per
+    # recipient, inside the transaction loop below it)
+    sql = conn.execute.call_args_list[0][0][0]
+    assert "SET status = 'rendered'" in sql
+    assert "html_vision_transient_streak = 0" in sql
+    assert "html_vision_parked_until = NULL" in sql
+
+
+@pytest.mark.asyncio
 async def test_requeue_rerender_resets_gate_fields_with_guards():
     """GUILT (W82): the requeue verb must clear BOTH re-entry gates (status +
     drive_url) and carry the lease CAS + status whitelist in the same statement."""
@@ -291,6 +328,19 @@ async def test_requeue_rerender_resets_gate_fields_with_guards():
     assert "html_render_attempts = 0" in sql  # fresh retry budget on re-entry
     assert "lease_owner IS NULL" in sql
     assert "status IN ('rendered', 'render_failed', 'drafts_imaged_checked')" in sql
+
+
+@pytest.mark.asyncio
+async def test_requeue_rerender_resets_vision_circuit_breaker_fields():
+    """A draft previously parked by the vision-quota circuit breaker must not
+    stay invisible to fetch_pending_html_draft_ids forever after a manual
+    re-queue — both breaker columns reset alongside html_render_attempts."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {"id": "abc"}
+    assert await requeue_draft_for_rerender(conn, "abc") is True
+    sql = conn.fetchrow.call_args[0][0]
+    assert "html_vision_transient_streak = 0" in sql
+    assert "html_vision_parked_until = NULL" in sql
 
 
 @pytest.mark.asyncio
@@ -345,6 +395,19 @@ async def test_rebrief_resets_status_and_gate_trio_atomically():
     ):
         assert excluded not in sql
     assert conn.fetchrow.call_args[0][1] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_rebrief_resets_vision_circuit_breaker_fields():
+    """Same reasoning as the requeue verb: a rebriefed draft must not stay
+    invisible to fetch_pending_html_draft_ids because of a stale park window
+    from a PREVIOUS generation of this draft."""
+    conn = AsyncMock()
+    conn.fetchrow.return_value = {"id": "abc"}
+    assert await rebrief_draft(conn, "abc") is True
+    sql = conn.fetchrow.call_args[0][0]
+    assert "html_vision_transient_streak = 0" in sql
+    assert "html_vision_parked_until = NULL" in sql
 
 
 @pytest.mark.asyncio

--- a/scripts/wr2_html_render_apply.py
+++ b/scripts/wr2_html_render_apply.py
@@ -33,12 +33,19 @@ vision fail-closed), WR2_HTML_MAX_ATTEMPTS (circuit breaker, default 3),
 WR2_NOTIFY_RECIPIENTS (comma phones; default the two below), WR2_HTML_HEARTBEAT_SECS (60),
 WR2_RUNTIME_SHA_GATE (C2 deploy-fork content-gate: off|warn|strict, default warn —
 warn logs provenance problems and proceeds; strict refuses impure boots and aborts
-pre-Drive when HEAD moves mid-run, releasing the lease without burning an attempt).
+pre-Drive when HEAD moves mid-run, releasing the lease without burning an attempt),
+WR2_VISION_MAX_TRANSIENT (2026-08-20 vision-quota circuit breaker: consecutive
+transient VisionTransient releases on the SAME draft before it is parked —
+html_vision_parked_until — instead of immediately requeued, default 3),
+WR2_VISION_COOLDOWN_S (shared with claude_vision.py's process-wide rate-limit
+cooldown; also the per-draft park duration once WR2_VISION_MAX_TRANSIENT is hit,
+default 3600).
 """
 
 from __future__ import annotations
 
 import asyncio
+import datetime
 import logging
 import os
 import re
@@ -1327,7 +1334,9 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
                     UPDATE war_room_drafts
                        SET status = 'rendered_shadow', drive_url_shadow = $2,
                            lease_owner = NULL, lease_acquired_at = NULL,
-                           lease_heartbeat_at = NULL, updated_at = NOW()
+                           lease_heartbeat_at = NULL, updated_at = NOW(),
+                           html_vision_transient_streak = 0,
+                           html_vision_parked_until = NULL
                      WHERE id = $1 AND lease_owner = $3 AND status = 'rendering'
                     """,
                     draft_id, web, owner,
@@ -1413,16 +1422,56 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
             # this release path records its status instead of crashing on a closed
             # connection and leaving the draft stuck in 'rendering'.
             main_conn = await _ensure_live(main_conn, pool_conn_dsn)
+            # "No attempt burned" had no CEILING (2026-08-20 SCAR): a draft that
+            # kept landing on a dead quota window bounced status='rendering' ->
+            # released, forever, every launchd tick, with html_render_attempts
+            # never incrementing. html_vision_transient_streak is a SEPARATE
+            # counter, independent of (and a backstop for) the process-wide
+            # cooldown in claude_vision.py — once it reaches
+            # WR2_VISION_MAX_TRANSIENT consecutive releases, the draft is parked
+            # (html_vision_parked_until) instead of being immediately requeued,
+            # so fetch_pending_html_draft_ids skips it until the window plausibly
+            # resets. This is NOT the terminal status='parked' value (that means
+            # "no usable source, needs a human") — status stays
+            # 'drafts_imaged_checked' so the draft resumes on its OWN once
+            # parked_until passes.
+            max_transient = int(os.environ.get("WR2_VISION_MAX_TRANSIENT", "3"))
+            streak = (
+                await main_conn.fetchval(
+                    "SELECT COALESCE(html_vision_transient_streak, 0) "
+                    "FROM war_room_drafts WHERE id=$1",
+                    draft_id,
+                )
+                or 0
+            ) + 1
+            parked_until: datetime.datetime | None = None
+            if streak >= max_transient:
+                cooldown_s = float(os.environ.get("WR2_VISION_COOLDOWN_S", "3600"))
+                parked_until = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+                    seconds=cooldown_s
+                )
             await main_conn.execute(
                 """
                 UPDATE war_room_drafts
                    SET status='drafts_imaged_checked', lease_owner=NULL,
-                       lease_acquired_at=NULL, lease_heartbeat_at=NULL, updated_at=NOW()
+                       lease_acquired_at=NULL, lease_heartbeat_at=NULL, updated_at=NOW(),
+                       html_vision_transient_streak=$3,
+                       html_vision_parked_until=$4
                  WHERE id=$1 AND lease_owner=$2 AND status='rendering'
                 """,
-                draft_id, owner,
+                draft_id, owner, streak, parked_until,
             )
-            logger.warning("draft %s vision transient (%s) — no attempt burned: %s", draft_id, type(exc).__name__, exc)
+            if parked_until is not None:
+                logger.warning(
+                    "draft %s parked:vision_quota after %d consecutive transient "
+                    "releases (no attempt burned) — resumes at %s: %s",
+                    draft_id, streak, parked_until.isoformat(), exc,
+                )
+                return f"parked:vision_quota:{exc}"
+            logger.warning(
+                "draft %s vision transient (%s) — no attempt burned (streak %d/%d): %s",
+                draft_id, type(exc).__name__, streak, max_transient, exc,
+            )
             return f"rate_limited:{exc}"
         except Exception as exc:
             # transient render/Drive failure OR an unexpected bug — either way the
@@ -1463,12 +1512,17 @@ async def _apply_one(pool_conn_dsn: str, draft_id: uuid.UUID, owner: str) -> str
                 )
                 return f"render_failed:{exc}"
             # record attempt + release for retry (ownership-gated so a stolen lease doesn't count)
+            # A real (non-vision) failure breaks any consecutive-transient streak
+            # the draft was building — reset it so an unrelated render/Drive
+            # hiccup doesn't count toward the vision-quota park threshold.
             await main_conn.execute(
                 """
                 UPDATE war_room_drafts
                    SET html_render_attempts = $3::int,
                        status='drafts_imaged_checked', lease_owner=NULL,
-                       lease_acquired_at=NULL, lease_heartbeat_at=NULL, updated_at=NOW()
+                       lease_acquired_at=NULL, lease_heartbeat_at=NULL, updated_at=NOW(),
+                       html_vision_transient_streak = 0,
+                       html_vision_parked_until = NULL
                  WHERE id=$1 AND lease_owner=$2 AND status='rendering'
                 """,
                 draft_id, owner, attempts,
@@ -1608,10 +1662,13 @@ async def run(dry_run: bool = False, draft_id: str | None = None) -> int:
                 logger.info("draft %s -> %s", did, result)
                 if result.startswith("rendered") or result == "shadow_done":
                     successes += 1
-                elif result.startswith("rate_limited"):
+                elif result.startswith("rate_limited") or result.startswith("parked:vision_quota"):
                     # quota is exhausted account-wide — further drafts this run
-                    # would hit the same 429. Stop draining; the draft stays
-                    # queued (no attempt burned) and renders on a later tick.
+                    # would hit the same 429 (or the process-wide cooldown in
+                    # claude_vision.py, which now makes that check itself
+                    # zero-cost). Stop draining anyway to skip the redundant
+                    # DB lease claim/release round-trip; the draft stays queued
+                    # (no attempt burned) and renders on a later tick.
                     logger.warning("drain-loop halting early: vision quota rate-limited")
                     rate_limited_halt = True
                     break

--- a/scripts/wr2_html_renderer/claude_vision.py
+++ b/scripts/wr2_html_renderer/claude_vision.py
@@ -22,6 +22,7 @@ is permitted (CLAUDE.md cost rule: PII boundary, not a flat cloud ban).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -340,7 +341,127 @@ def _vision_token_chain(env: dict[str, str]) -> list[tuple[str, str]]:
     return chain
 
 
-def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | None = None) -> dict[str, Any] | None:
+# ── chain-wide rate-limit circuit breaker (persists across launchd re-fires) ────
+# Motivation (2026-08-20, measured): when EVERY OAuth seat in the token chain is
+# rate-limited, the one-shot apply-worker correctly released the draft without
+# burning an attempt — but launchd re-fires the WHOLE process on a fixed
+# schedule, so the next tick walked the full seat chain again against a quota
+# window already known dead. Measured cost: ~1,262 `claude --print` vision
+# sessions/day, ~690M cache-write tokens/7d, while every seat was rate-limited
+# for hours. The breaker persists to disk (survives the process exiting between
+# ticks) so a proven-dead window is never re-probed until it plausibly resets.
+_STATE_DIR_DEFAULT = Path.home() / ".agent" / "state"
+_FINGERPRINT_CACHE_MAX_ENTRIES = 500
+
+
+def _cooldown_state_path() -> Path:
+    override = os.environ.get("WR2_VISION_COOLDOWN_STATE", "").strip()
+    return Path(override) if override else _STATE_DIR_DEFAULT / "wr2_vision_cooldown.json"
+
+
+def _fingerprint_cache_path() -> Path:
+    override = os.environ.get("WR2_VISION_FINGERPRINT_CACHE", "").strip()
+    return Path(override) if override else _STATE_DIR_DEFAULT / "wr2_vision_fingerprint_cache.json"
+
+
+def _cooldown_remaining_s() -> float:
+    """Seconds left in an active chain-wide rate-limit cooldown, or 0.0 when
+    there is none — expired, never set, OR the state file is missing/corrupt.
+    Fail-OPEN by design (cicatrix #2 antidote — a bookkeeping file that cannot
+    be read must never read as "cooldown forever"; only a genuinely fresh,
+    readable cooldown blocks a call)."""
+    try:
+        raw = json.loads(_cooldown_state_path().read_text())
+        until = float(raw["cooldown_until"])
+    except Exception:  # noqa: BLE001 — any read/parse failure = no cooldown
+        return 0.0
+    remaining = until - time.time()
+    return remaining if remaining > 0 else 0.0
+
+
+def _set_cooldown(seconds: float, reason: str) -> None:
+    path = _cooldown_state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "cooldown_until": time.time() + seconds,
+            "set_at": time.time(),
+            "reason": reason,
+        }))
+    except Exception as exc:  # noqa: BLE001 — bookkeeping must never block the release
+        logger.warning("claude vision: could not persist rate-limit cooldown: %s", exc)
+
+
+def _clear_cooldown() -> None:
+    """Best-effort hygiene: a call that actually SUCCEEDED proves the chain is
+    no longer fully dead, so drop any stale cooldown instead of waiting out
+    its full remaining duration."""
+    try:
+        _cooldown_state_path().unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _fingerprint_key(png_path: Path, prompt_template: str, discriminator: str) -> str | None:
+    """Content-addressed no-op key: a role+slide discriminator + the prompt
+    TEMPLATE (not the interpolated string, which always differs because it
+    embeds a volatile per-run tmp-dir path) + the actual rendered PIXELS. A real
+    prompt-wording edit still busts the cache; a re-render into a fresh tmpdir
+    that reproduces byte-identical pixels does not. Returns None (never
+    cacheable) if the PNG can't be read — the caller then always calls through."""
+    try:
+        image_bytes = png_path.read_bytes()
+    except OSError:
+        return None
+    digest = hashlib.sha256()
+    for part in (discriminator, prompt_template):
+        digest.update(part.encode("utf-8"))
+        digest.update(b"\0")
+    digest.update(image_bytes)
+    return digest.hexdigest()
+
+
+def _fingerprint_lookup(key: str) -> dict[str, Any] | None:
+    try:
+        cache = json.loads(_fingerprint_cache_path().read_text())
+        entry = cache.get(key)
+    except Exception:  # noqa: BLE001 — fail open: a corrupt/missing cache is a miss
+        return None
+    return entry.get("verdict") if isinstance(entry, dict) else None
+
+
+def _fingerprint_store(key: str, verdict: dict[str, Any]) -> None:
+    """Only ever called on a genuinely SUCCESSFUL parse (see the _succeed()
+    call sites in _run_claude_json below) — a failed/unavailable/rate-limited
+    call must never seed the cache, or a legitimately-broken slide would be
+    skipped forever instead of re-checked."""
+    path = _fingerprint_cache_path()
+    try:
+        try:
+            cache = json.loads(path.read_text())
+            if not isinstance(cache, dict):
+                cache = {}
+        except Exception:  # noqa: BLE001
+            cache = {}
+        cache[key] = {"verdict": verdict, "ts": time.time()}
+        if len(cache) > _FINGERPRINT_CACHE_MAX_ENTRIES:
+            for stale_key, _ in sorted(
+                cache.items(), key=lambda kv: kv[1].get("ts", 0)
+            )[: len(cache) - _FINGERPRINT_CACHE_MAX_ENTRIES]:
+                cache.pop(stale_key, None)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(cache))
+    except Exception as exc:  # noqa: BLE001 — bookkeeping must never block the caller
+        logger.warning("claude vision: could not persist fingerprint cache: %s", exc)
+
+
+def _run_claude_json(
+    prompt: str,
+    schema: dict[str, Any],
+    *,
+    timeout_s: int | None = None,
+    fingerprint_key: str | None = None,
+) -> dict[str, Any] | None:
     """Call the claude CLI with a JSON schema, return the parsed object or None.
 
     Strips ANTHROPIC_API_KEY from the env (defense-in-depth: force OAuth path,
@@ -351,6 +472,28 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | No
     """
     if timeout_s is None:
         timeout_s = int(os.environ.get("WR2_VISION_TIMEOUT_S", "180"))
+
+    cooldown_remaining = _cooldown_remaining_s()
+    if cooldown_remaining > 0:
+        logger.warning(
+            "claude vision: chain-wide rate-limit cooldown active (%.0fs remaining) "
+            "— skipping call, no subprocess spawned",
+            cooldown_remaining,
+        )
+        raise VisionRateLimited(
+            f"claude vision cooldown active ({cooldown_remaining:.0f}s remaining) — "
+            "the full OAuth chain was rate-limited on a previous call"
+        )
+
+    if fingerprint_key is not None:
+        cached = _fingerprint_lookup(fingerprint_key)
+        if cached is not None:
+            logger.info(
+                "claude vision: fingerprint hit — identical slide/prompt/image "
+                "already verified, skipping call"
+            )
+            return cached
+
     base_env = dict(os.environ)
     # Pin the vision model (default sonnet: vision-capable + solid editorial
     # judgment, lighter/cheaper than opus so it neither burns the MAX-plan quota
@@ -428,16 +571,25 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | No
             logger.warning("claude vision: stdout not JSON: %s", out[:200])
             return None
 
+        def _succeed(obj: dict[str, Any]) -> dict[str, Any]:
+            # A real success proves the chain is not (fully) dead — drop any
+            # stale cooldown instead of waiting out its full duration, and seed
+            # the no-op cache so an identical re-render doesn't re-verify.
+            _clear_cooldown()
+            if fingerprint_key is not None:
+                _fingerprint_store(fingerprint_key, obj)
+            return obj
+
         # CLI json envelope: schema output lives in `structured_output`.
         structured = envelope.get("structured_output")
         if isinstance(structured, dict):
-            return structured
+            return _succeed(structured)
         result = envelope.get("result")
         if isinstance(result, dict):
-            return result
+            return _succeed(result)
         if isinstance(result, str):
             try:
-                return json.loads(result)
+                return _succeed(json.loads(result))
             except json.JSONDecodeError:
                 logger.warning(
                     "claude vision: no structured_output and result not JSON: %s",
@@ -448,7 +600,12 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | No
         return None
 
     if saw_rate_limit:
-        raise VisionRateLimited("claude vision rate-limited across all OAuth accounts")
+        cooldown_s = float(os.environ.get("WR2_VISION_COOLDOWN_S", "3600"))
+        _set_cooldown(cooldown_s, "rate_limit")
+        raise VisionRateLimited(
+            f"claude vision rate-limited across all OAuth accounts — cooldown "
+            f"armed for {cooldown_s:.0f}s"
+        )
     if saw_timeout:
         raise VisionTimeout(f"vision call exceeded its {timeout_s}s global budget")
     return None
@@ -456,7 +613,10 @@ def _run_claude_json(prompt: str, schema: dict[str, Any], *, timeout_s: int | No
 
 def claude_design_critic(png_path: Path, slide: dict[str, Any], context: dict[str, Any]) -> Critique:
     """Claude-vision design critic (Tier 3). Returns a Critique with levers."""
-    obj = _run_claude_json(_CRITIC_PROMPT.format(png_path=png_path), _CRITIC_SCHEMA)
+    fp_key = _fingerprint_key(png_path, _CRITIC_PROMPT, f"critic:{png_path.parent.name}")
+    obj = _run_claude_json(
+        _CRITIC_PROMPT.format(png_path=png_path), _CRITIC_SCHEMA, fingerprint_key=fp_key
+    )
     if obj is None:
         # vision unavailable. Default: soft-pass (don't block — historical behavior).
         # WR2_VISION_REQUIRED=1 (v4 condition E / GO#3 c1): FAIL-CLOSED — a carousel
@@ -503,7 +663,10 @@ def claude_design_critic(png_path: Path, slide: dict[str, Any], context: dict[st
 
 def claude_brand_verifier(png_path: Path, slide: dict[str, Any], context: dict[str, Any]) -> Critique:
     """Claude-vision brand verifier (autonomy guardrail). passed=brand intact."""
-    obj = _run_claude_json(_VERIFIER_PROMPT.format(png_path=png_path), _VERIFIER_SCHEMA)
+    fp_key = _fingerprint_key(png_path, _VERIFIER_PROMPT, f"brand:{png_path.parent.name}")
+    obj = _run_claude_json(
+        _VERIFIER_PROMPT.format(png_path=png_path), _VERIFIER_SCHEMA, fingerprint_key=fp_key
+    )
     if obj is None:
         # if the verifier can't run, FAIL CLOSED — don't let an unverified change
         # through (the critic's autonomy must be gated).

--- a/scripts/wr2_html_renderer/tests/test_vision_circuit_breaker.py
+++ b/scripts/wr2_html_renderer/tests/test_vision_circuit_breaker.py
@@ -1,0 +1,198 @@
+"""Vision quota-burn circuit breaker (2026-08-20): persistent chain-wide
+rate-limit cooldown + content-addressed no-op fingerprint cache in
+claude_vision.py::_run_claude_json.
+
+Ground truth measured the same day: with every OAuth seat rate-limited, the
+one-shot apply-worker correctly released each draft without burning an
+attempt, but launchd re-fired the WHOLE process on a schedule and walked the
+full seat chain again every tick — ~1,262 `claude --print` vision sessions/
+day, ~690M cache-write tokens/7d, against a quota window already known dead.
+
+These tests exercise `_run_claude_json` directly (private, but the intended
+unit-test surface per its own module docstring / test_critic_calibration_
+rubric.py precedent) with `_run_process_group` mocked out — no real
+subprocess, no real Claude CLI, no network.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import wr2_html_renderer.claude_vision as cv  # noqa: E402
+
+_SCHEMA = {"type": "object", "properties": {}}
+
+
+def _success_proc(payload: dict) -> subprocess.CompletedProcess[str]:
+    envelope = {"type": "result", "subtype": "success", "structured_output": payload}
+    return subprocess.CompletedProcess(["claude"], 0, json.dumps(envelope), "")
+
+
+def _rate_limited_proc() -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["claude"], 1, "", "rate limit exceeded")
+
+
+def _isolate_state(monkeypatch, tmp_path: Path) -> None:
+    """Point both state files at a fresh tmp dir and give the token chain a
+    predictable, fixed length (2 numbered seats + the always-present keychain
+    fallback) regardless of what's configured on the machine running the test."""
+    monkeypatch.setenv("WR2_VISION_COOLDOWN_STATE", str(tmp_path / "cooldown.json"))
+    monkeypatch.setenv("WR2_VISION_FINGERPRINT_CACHE", str(tmp_path / "fingerprints.json"))
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_1", "tok1")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN_2", "tok2")
+    for key in (
+        "CLAUDE_CODE_OAUTH_TOKEN_3", "CLAUDE_CODE_OAUTH_TOKEN_4",
+        "CLAUDE_CODE_OAUTH_TOKEN_5", "CLAUDE_CODE_OAUTH_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── chain-wide cooldown: GUILT ───────────────────────────────────────────────
+
+
+def test_full_chain_rate_limited_arms_cooldown_and_next_call_spawns_nothing(
+    monkeypatch, tmp_path
+):
+    """GUILT: every seat in the chain (token_1, token_2, keychain) reports
+    rate-limit -> VisionRateLimited raised AND a cooldown is persisted. The
+    VERY NEXT call, while the cooldown is active, must raise immediately
+    WITHOUT invoking _run_process_group at all (zero subprocess spawned)."""
+    _isolate_state(monkeypatch, tmp_path)
+    monkeypatch.setenv("WR2_VISION_COOLDOWN_S", "3600")
+
+    with patch.object(cv, "_run_process_group", side_effect=[
+        _rate_limited_proc(), _rate_limited_proc(), _rate_limited_proc(),
+    ]) as mocked:
+        with pytest.raises(cv.VisionRateLimited):
+            cv._run_claude_json("prompt", _SCHEMA)
+        assert mocked.call_count == 3  # walked the whole chain once to prove it's dead
+
+    assert cv._cooldown_remaining_s() > 0
+
+    # second call: cooldown is armed — must short-circuit before any subprocess
+    with patch.object(cv, "_run_process_group") as mocked_second:
+        with pytest.raises(cv.VisionRateLimited):
+            cv._run_claude_json("prompt", _SCHEMA)
+        mocked_second.assert_not_called()
+
+
+def test_cooldown_expired_resumes_normal_calls(monkeypatch, tmp_path):
+    """A cooldown whose window has already elapsed must not block — the call
+    proceeds and spawns a subprocess exactly like a fresh (never-cooled-down)
+    call would."""
+    _isolate_state(monkeypatch, tmp_path)
+    # write an ALREADY-EXPIRED cooldown directly (simulates "tick N later")
+    cv._cooldown_state_path().parent.mkdir(parents=True, exist_ok=True)
+    cv._cooldown_state_path().write_text(json.dumps({
+        "cooldown_until": time.time() - 10,
+        "set_at": time.time() - 3610,
+        "reason": "rate_limit",
+    }))
+    assert cv._cooldown_remaining_s() == 0.0
+
+    with patch.object(cv, "_run_process_group", return_value=_success_proc({"ok": True})) as mocked:
+        out = cv._run_claude_json("prompt", _SCHEMA)
+        assert out == {"ok": True}
+        mocked.assert_called_once()
+
+
+# ── chain-wide cooldown: INNOCENCE ───────────────────────────────────────────
+
+
+def test_single_seat_rate_limited_fails_over_without_arming_cooldown(monkeypatch, tmp_path):
+    """INNOCENCE: seat 1 is rate-limited, seat 2 succeeds — normal failover,
+    the call returns the successful verdict, and NO cooldown is armed (the
+    chain was never proven fully dead)."""
+    _isolate_state(monkeypatch, tmp_path)
+
+    with patch.object(cv, "_run_process_group", side_effect=[
+        _rate_limited_proc(), _success_proc({"passes": True}),
+    ]) as mocked:
+        out = cv._run_claude_json("prompt", _SCHEMA)
+        assert out == {"passes": True}
+        assert mocked.call_count == 2
+
+    assert cv._cooldown_remaining_s() == 0.0
+
+
+# ── fingerprint no-op cache ───────────────────────────────────────────────────
+
+
+def test_identical_slide_prompt_image_skips_second_call(monkeypatch, tmp_path):
+    """GUILT: same fingerprint_key + a prior SUCCESSFUL parse -> the second
+    call is served from cache, no subprocess spawned."""
+    _isolate_state(monkeypatch, tmp_path)
+
+    with patch.object(cv, "_run_process_group", return_value=_success_proc({"passes": True})) as mocked:
+        first = cv._run_claude_json("prompt", _SCHEMA, fingerprint_key="fp-1")
+        assert first == {"passes": True}
+        mocked.assert_called_once()
+
+    with patch.object(cv, "_run_process_group") as mocked_second:
+        second = cv._run_claude_json("prompt", _SCHEMA, fingerprint_key="fp-1")
+        assert second == {"passes": True}
+        mocked_second.assert_not_called()
+
+
+def test_changed_input_does_not_skip_from_fingerprint(monkeypatch, tmp_path):
+    """INNOCENCE: a DIFFERENT fingerprint_key (input changed — different slide,
+    prompt template, or rendered pixels) must always call through."""
+    _isolate_state(monkeypatch, tmp_path)
+
+    with patch.object(cv, "_run_process_group", side_effect=[
+        _success_proc({"passes": True}), _success_proc({"passes": False}),
+    ]) as mocked:
+        first = cv._run_claude_json("prompt", _SCHEMA, fingerprint_key="fp-1")
+        second = cv._run_claude_json("prompt", _SCHEMA, fingerprint_key="fp-2")
+        assert first == {"passes": True}
+        assert second == {"passes": False}
+        assert mocked.call_count == 2
+
+
+def test_failed_call_never_seeds_the_fingerprint_cache(monkeypatch, tmp_path):
+    """A call that never produces a parsed verdict (rate-limited, here) must
+    NOT populate the cache — the next call with the SAME fingerprint_key
+    still calls through instead of permanently reusing the missing verdict."""
+    _isolate_state(monkeypatch, tmp_path)
+
+    with patch.object(cv, "_run_process_group", side_effect=[
+        _rate_limited_proc(), _rate_limited_proc(), _rate_limited_proc(),
+    ]):
+        with pytest.raises(cv.VisionRateLimited):
+            cv._run_claude_json("prompt", _SCHEMA, fingerprint_key="fp-1")
+
+    # cooldown is now active — clear it so this second call isn't short-circuited
+    # by the (correctly-armed) cooldown instead of the fingerprint cache, which
+    # is the specific thing this test is isolating.
+    cv._cooldown_state_path().unlink(missing_ok=True)
+
+    with patch.object(cv, "_run_process_group", return_value=_success_proc({"passes": True})) as mocked:
+        out = cv._run_claude_json("prompt", _SCHEMA, fingerprint_key="fp-1")
+        assert out == {"passes": True}
+        mocked.assert_called_once()  # NOT a cache hit — the failed run never cached
+
+
+# ── caller wiring: claude_design_critic / claude_brand_verifier fingerprints ──
+
+
+def test_critic_and_verifier_fingerprints_differ_for_same_png(monkeypatch, tmp_path):
+    """The critic and verifier use different prompt templates against the same
+    PNG — their fingerprint keys must differ (role-scoped), else the verifier
+    could be served the critic's cached verdict (wrong schema/shape)."""
+    from wr2_html_renderer.claude_vision import _fingerprint_key
+    png = tmp_path / "loop-01" / "iter-01.png"
+    png.parent.mkdir(parents=True)
+    png.write_bytes(b"\x89PNG-fake-bytes")
+    critic_key = _fingerprint_key(png, cv._CRITIC_PROMPT, f"critic:{png.parent.name}")
+    verifier_key = _fingerprint_key(png, cv._VERIFIER_PROMPT, f"brand:{png.parent.name}")
+    assert critic_key != verifier_key


### PR DESCRIPTION
**Measured on Pro, 2026-08-20:** ~1,262 `claude --print` vision sessions/day, ~690M cache-write tokens/7d, while `wr2-html-apply.log` read *"claude vision rate-limited across all OAuth accounts"* for hours. The WR2 metronome alone was 7,004 of Pro's 8,676 sessions/7d.

## Root cause

"No attempt burned" on a transient vision failure is correct — a dead quota window is not a defect of the draft — but it had **no ceiling**. The apply-worker released the draft without incrementing `html_render_attempts`, launchd re-fired the whole process on the next tick, and it walked the full seat chain again against a window already known dead. Forever.

## Three independent brakes, each failing OPEN

**1. Process-wide cooldown** (`claude_vision.py`) — a chain-wide rate-limit persists `cooldown_until` to disk, so the next launchd tick returns *before spawning any subprocess*. Surviving process exit is the whole point. An unreadable or corrupt state file reads as "no cooldown", never "blocked forever" (cicatrix #2 antidote); a successful call clears it.

**2. Per-draft park** (migration 275) — `html_vision_transient_streak` counts consecutive transient releases on the same draft; at `WR2_VISION_MAX_TRANSIENT` (default 3) the draft gets `html_vision_parked_until` and the HTML-lane fetch skips it. Status stays `drafts_imaged_checked`, **not** the terminal `parked` (which means "needs a human") — it resumes on its own. Any non-transient outcome resets the streak.

**3. No-op fingerprint** — keyed on role+slide discriminator + prompt **template** + rendered **pixels**, not the interpolated prompt (which always differs: it embeds a volatile tmp-dir path). A prompt-wording edit still busts the cache; an unreadable PNG is never cacheable; only successful runs are recorded.

## Deliberately untouched

The three critic iterations + brand verifier in `designer_loop` are design, not retry — measured, not assumed (the ~3.2 sessions/prompt multiplier is iterations + verifier + seat failover + outer rerun, per the Codex panel review). Model, prompt, and review semantics unchanged. The unconditional Fable final on-disk gate is not in this path and gains no classifier in front of it.

## Verification

- `test_vision_circuit_breaker.py` — 7 passed
- `test_wr2_html_render_apply.py` + `test_pg.py` — 181 passed
- Migration 275 is additive (two nullable columns), Squawk-gated

## Live state

The three WR2 launchd jobs plus their `plist-watchdog` resurrector are `launchctl disable`d on Pro right now (verified: 0 sessions, 0 processes, no re-arm over two independent 4- and 10-minute windows). Re-arm with `launchctl enable` **after this merges** — not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)