### PR TITLE
chore(home-fork): declare the 3 eventbus subscriber HOME-fork pairs

### DIFF
--- a/infra/home-fork/declared-pairs.json
+++ b/infra/home-fork/declared-pairs.json
@@ -842,6 +842,24 @@
       "live": "~/Library/LaunchAgents/com.nuzantara.visa-freshness-sentinel.plist",
       "repo": "infra/launchagents/com.nuzantara.visa-freshness-sentinel.plist",
       "machines": ["pro"]
+    },
+    {
+      "live": "~/scripts/eventbus/meta_dispatcher.py",
+      "repo": "infra/eventbus/meta_dispatcher.py",
+      "machines": ["pro"],
+      "_note": "UNDECLARED live payload found 2026-08-20 (family #1): plist com.balizero.meta-dispatcher execs this HOME copy directly (ProgramArguments greps /Users/nuzantara/scripts/eventbus/meta_dispatcher.py), running (launchctl list shows a live PID). Verified byte-identical to repo/origin-main sha256 0cf1d3e5... on Pro. NOT widened to m5: M5 also carries a real file at the same path, but it is dormant (0 launchd/crontab references — M5 has no daemon/cron per CLAUDE.md) AND it DIVERGES from repo (stale — missing the REDISCLI_AUTH/BZ_REDIS_HOST env-driven Redis fix and the claude-sonnet-5 model-pin migration). Declaring it here would immediately fail --check on someone else's pre-existing drift rather than catch new drift — same call as the codex/nightly-autofix-ci.sh precedent above. Mini has no ~/scripts/eventbus/ at all (confirmed via ssh, its repo checkout also lives at ~/nuzantara not ~/Desktop/nuzantara)."
+    },
+    {
+      "live": "~/scripts/eventbus/intel_dedup_gateway.py",
+      "repo": "infra/eventbus/intel_dedup_gateway.py",
+      "machines": ["pro", "m5"],
+      "_note": "UNDECLARED live payload found 2026-08-20 (family #1): plist com.balizero.intel-dedup-gateway execs this HOME copy directly, running on Pro. Verified byte-identical to repo/origin-main sha256 52871616... on BOTH Pro and M5. M5 included even though inert there (0 launchd/crontab references — M5 has no daemon/cron per CLAUDE.md): same reasoning as wr2-external-bench-run.sh/codex-automation-lib.sh above — declaring an inert-but-identical copy makes a future drift on it visible instead of silent. Mini has no ~/scripts/eventbus/ at all — not declared."
+    },
+    {
+      "live": "~/scripts/eventbus/research_sentinel.py",
+      "repo": "infra/eventbus/research_sentinel.py",
+      "machines": ["pro", "m5"],
+      "_note": "UNDECLARED live payload found 2026-08-20 (family #1): plist com.balizero.research-sentinel execs this HOME copy directly, running on Pro. Verified byte-identical to repo/origin-main sha256 858c17c6... on BOTH Pro and M5. M5 included even though inert there (0 launchd/crontab references): same reasoning as the sibling intel_dedup_gateway.py entry above. Mini has no ~/scripts/eventbus/ at all — not declared. Sibling plist com.balizero.observatory was investigated in the same sweep and is NOT part of this family: its ProgramArguments execs /Users/nuzantara/agents/.observatory/observatory.py, a structurally different directory (agents/.observatory/, not scripts/eventbus/) — left undeclared here, own ledger row if ever promoted."
     }
   ],
   "allow": [


### PR DESCRIPTION
## Summary
- Declares the three Pro-side eventbus subscriber HOME-fork pairs (`meta_dispatcher.py`, `intel_dedup_gateway.py`, `research_sentinel.py` under `~/scripts/eventbus/`) in `infra/home-fork/declared-pairs.json` — launchd-driven (`com.balizero.meta-dispatcher`/`.intel-dedup-gateway`/`.research-sentinel`), running, and previously UNDECLARED (superscar family #1: `lint_home_fork.py --check` could not catch a future drift on them).
- All three verified byte-identical sha256 live-vs-repo on Pro.
- `intel_dedup_gateway.py`/`research_sentinel.py` also byte-identical on M5 (present but inert — no launchd/cron reference there) → declared `machines:["pro","m5"]`.
- `meta_dispatcher.py`'s M5 copy exists but DIVERGES (stale — predates the REDISCLI_AUTH/BZ_REDIS_HOST fix and the claude-sonnet-5 model pin) and is dormant → kept `machines:["pro"]` only, matching the existing `codex/nightly-autofix-ci.sh` precedent in the same file (declaring a diverging dormant copy would immediately paint this PR red for someone else's pre-existing drift).
- Mini has no `~/scripts/eventbus/` at all — not declared for mini.
- `com.balizero.observatory` (investigated in the same sweep, same day) is confirmed NOT part of this family: its plist execs `/Users/nuzantara/agents/.observatory/observatory.py`, a structurally different directory — left out, own ledger row if ever promoted.

## Test plan
- [x] `python3 -c "import json; json.load(open('infra/home-fork/declared-pairs.json'))"` — valid JSON
- [x] `python3 scripts/lint_home_fork.py --check --config <worktree>/infra/home-fork/declared-pairs.json --repo-root <worktree>` on M5 — exit 1, but the ONLY breach is a pre-existing, unrelated `~/.claude/hooks/worktree_isolation.py` divergence (confirmed pre-existing via `git stash` A/B); the 3 new eventbus pairs report clean
- [x] Same check on Pro (`ssh pro`) — clean, no new breach
- [x] Same check on Mini (`ssh mini`) — pre-existing unrelated `mini-git-pull.sh` DIVERGED failure (exit 1) is untouched by this change; no new breach introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)