### PR TITLE
fix(llm): pin the model on 2 grandfathered bare `claude` headless calls

### DIFF
--- a/apps/backend-rag/backend/services/canva_renderer/claude_invoker.py
+++ b/apps/backend-rag/backend/services/canva_renderer/claude_invoker.py
@@ -31,6 +31,14 @@ DEFAULT_TIMEOUT_SEC = 2400  # 40 min — bumped from 1500 after empirical
 # 12 pages × ~10 elements each is ~120 inspections. 2400s budgets for
 # pathological cases (Canva MCP rate-limit pauses, transient API stalls).
 DEFAULT_CLAUDE_BIN = "claude"  # resolved from PATH
+# Model pin (2026-08-20, token-cuts round2): this call was bare (no --model),
+# inheriting whatever profile default the invoking shell happened to carry —
+# grandfathered by scripts/lint/lint_claude_headless_model_pin.py. The task is
+# bounded agentic tool-use (apply an already-decided layout via Canva MCP,
+# following a fixed runbook) — no architectural or brand judgment is made
+# here (that already happened upstream in wr2-design-architect/critic), so
+# sonnet is the minimum-sufficient tier, not opus/fable.
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-5"
 # 2026-05-07: APPLICA_WAR_ROOM.md was at apps/war-room/ but that directory was
 # removed in PR #171 (WR1 decommission). The authoritative runbook is now the
 # userspace skill ~/.claude/skills/canva-apply.md (the ADAPTIVE skill that
@@ -161,6 +169,7 @@ def invoke_claude_apply(
     canva_pending_path: Path,
     *,
     claude_bin: str = DEFAULT_CLAUDE_BIN,
+    model: str = DEFAULT_CLAUDE_MODEL,
     timeout_sec: int = DEFAULT_TIMEOUT_SEC,
 ) -> CanvaApplyResult:
     """Run `claude -p` to apply a canva_pending.json and return the design URLs.
@@ -205,7 +214,7 @@ def invoke_claude_apply(
     start = time.monotonic()
     try:
         completed = subprocess.run(
-            [claude_bin, "-p", prompt],
+            [claude_bin, "-p", "--model", model, prompt],
             stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_claude_invoker.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_claude_invoker.py
@@ -11,6 +11,7 @@ import subprocess
 
 import pytest
 
+from backend.services.canva_renderer import claude_invoker
 from backend.services.canva_renderer.claude_invoker import (
     DEFAULT_CLAUDE_MODEL,
     CanvaInvokeError,
@@ -71,9 +72,24 @@ class TestInvokeClaudeApplyModelPin:
     scripts/lint/lint_claude_headless_model_pin.py. Pure argv-construction
     check via a monkeypatched subprocess.run — no real Claude CLI spawned,
     so no skip marker needed (unlike the real-subprocess tests this file's
-    docstring defers elsewhere)."""
+    docstring defers elsewhere).
+
+    invoke_claude_apply() also reads a REAL userspace file first
+    (~/.claude/skills/canva-apply.md, this module's runbook single-source)
+    before it ever reaches subprocess.run — on a CI runner's ephemeral $HOME
+    that file does not exist, so both tests here also monkeypatch
+    APPLICA_RUNBOOK_PATH to a tmp file with dummy content, keeping this
+    class's own claim ("no real Claude CLI spawned") true without silently
+    depending on the operator machine's userspace skill install.
+    """
+
+    def _stub_runbook(self, tmp_path, monkeypatch) -> None:
+        runbook = tmp_path / "canva-apply.md"
+        runbook.write_text("dummy runbook body\n", encoding="utf-8")
+        monkeypatch.setattr(claude_invoker, "APPLICA_RUNBOOK_PATH", runbook)
 
     def test_argv_carries_a_pinned_model(self, tmp_path, monkeypatch) -> None:
+        self._stub_runbook(tmp_path, monkeypatch)
         pending = tmp_path / "canva_pending.json"
         pending.write_text(json.dumps({"pages": []}))
 
@@ -99,6 +115,7 @@ class TestInvokeClaudeApplyModelPin:
         assert model == DEFAULT_CLAUDE_MODEL
 
     def test_model_is_overridable(self, tmp_path, monkeypatch) -> None:
+        self._stub_runbook(tmp_path, monkeypatch)
         pending = tmp_path / "canva_pending.json"
         pending.write_text(json.dumps({"pages": []}))
 

--- a/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_claude_invoker.py
+++ b/apps/backend-rag/backend/tests/unit/services/canva_renderer/test_claude_invoker.py
@@ -6,11 +6,16 @@ spawn/timeout is tested separately (needs Claude CLI, skipped in CI).
 
 from __future__ import annotations
 
+import json
+import subprocess
+
 import pytest
 
 from backend.services.canva_renderer.claude_invoker import (
+    DEFAULT_CLAUDE_MODEL,
     CanvaInvokeError,
     extract_canva_urls,
+    invoke_claude_apply,
 )
 
 
@@ -58,3 +63,59 @@ class TestExtractCanvaUrls:
     def test_raises_on_empty_output(self) -> None:
         with pytest.raises(CanvaInvokeError, match="empty output"):
             extract_canva_urls("")
+
+
+class TestInvokeClaudeApplyModelPin:
+    """Model pin added 2026-08-20 (token-cuts round2): this call was bare
+    (no --model), inheriting the profile default — grandfathered by
+    scripts/lint/lint_claude_headless_model_pin.py. Pure argv-construction
+    check via a monkeypatched subprocess.run — no real Claude CLI spawned,
+    so no skip marker needed (unlike the real-subprocess tests this file's
+    docstring defers elsewhere)."""
+
+    def test_argv_carries_a_pinned_model(self, tmp_path, monkeypatch) -> None:
+        pending = tmp_path / "canva_pending.json"
+        pending.write_text(json.dumps({"pages": []}))
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = list(argv)
+
+            class _R:
+                returncode = 0
+                stdout = '{"design_id":"DABC12345","edit_url":"https://www.canva.com/d/abc"}'
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        invoke_claude_apply(pending)
+
+        assert "argv" in captured, "invoke_claude_apply never called subprocess.run"
+        argv = captured["argv"]
+        assert "--model" in argv, f"no --model flag in {argv!r}"
+        model = argv[argv.index("--model") + 1]
+        assert model == DEFAULT_CLAUDE_MODEL
+
+    def test_model_is_overridable(self, tmp_path, monkeypatch) -> None:
+        pending = tmp_path / "canva_pending.json"
+        pending.write_text(json.dumps({"pages": []}))
+
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = list(argv)
+
+            class _R:
+                returncode = 0
+                stdout = '{"design_id":"DABC12345","edit_url":"https://www.canva.com/d/abc"}'
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        invoke_claude_apply(pending, model="claude-opus-5")
+
+        model = captured["argv"][captured["argv"].index("--model") + 1]
+        assert model == "claude-opus-5"

--- a/scripts/cron-agent-python/agent_job.py
+++ b/scripts/cron-agent-python/agent_job.py
@@ -45,6 +45,18 @@ if not os.environ.get("REDISCLI_AUTH") and os.environ.get("REDIS_PASSWORD"):
 SECRETS_FILE = HOME / ".nuzantara-secrets.env"
 WITA = timezone(timedelta(hours=8))
 
+# Model pin (2026-08-20, token-cuts round2): the two bare `claude --print`
+# calls below (session bootstrap only — "Session start for X" / "Session
+# init X") had no --model, inheriting the profile default. They are imported
+# by all 21 cron-agent-python job scripts and cached per session scope
+# (daily/weekly/persistent — see get_or_create_session below), so real
+# invocation count is low, but the exposure surface is the widest of any
+# grandfathered call site in the repo. The prompt does no reasoning, just
+# returns a session_id, so haiku is the minimum-sufficient tier — the actual
+# reasoning path (claude_synthesize/claude_agent_sdk above) already routes
+# per-job via agent_config.get_config() and is unaffected by this pin.
+SESSION_BOOTSTRAP_MODEL = "claude-haiku-4-5-20251001"
+
 STATE_DIR.mkdir(parents=True, exist_ok=True)
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -876,7 +888,8 @@ def get_or_create_session(job_name: str, scope: str = "daily") -> str | None:
         import subprocess
         # Start a minimal session to get a session ID
         result = subprocess.run(
-            ["claude", "--print", f"Session start for {job_name} {scope} {datetime.now(WITA).strftime('%Y-%m-%d')}"],
+            ["claude", "--print", "--model", SESSION_BOOTSTRAP_MODEL,
+             f"Session start for {job_name} {scope} {datetime.now(WITA).strftime('%Y-%m-%d')}"],
             capture_output=True, text=True, timeout=30,
             env={**os.environ, "ANTHROPIC_API_KEY": ""},
         )
@@ -886,7 +899,8 @@ def get_or_create_session(job_name: str, scope: str = "daily") -> str | None:
         if not session_match:
             # Try environment variable approach
             env_result = subprocess.run(
-                ["claude", "--print", "--output-format=json", f"Session init {job_name}"],
+                ["claude", "--print", "--output-format=json", "--model", SESSION_BOOTSTRAP_MODEL,
+                 f"Session init {job_name}"],
                 capture_output=True, text=True, timeout=30,
                 env={**os.environ, "ANTHROPIC_API_KEY": ""},
             )

--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -106,14 +106,6 @@ CORPSE_SWEEP_FRESH_S = int(os.getenv("DLQ_CORPSE_SWEEP_FRESH_S", str(6 * 3600)))
 CONFIDENCE_RETRY = 0.95           # no-code-change retry threshold
 CONFIDENCE_AIDER = 0.90           # code-change aider threshold
 REASONING_TIMEOUT_S = 90          # claude --print timeout
-# Model pin (2026-08-20, token-cuts round2): claude_reason() below was bare
-# (no --model at all — grep confirms zero "model" occurrences before this),
-# inheriting whatever the ambient profile default happened to be. It runs
-# on a 30-min cron (com.nuzantara.dlq-autopilot.plist) whenever the DLQ is
-# non-empty. The task is bounded structured classification (fix_type +
-# confidence from an error log tail, JSON-only output) — sonnet is the
-# minimum-sufficient tier for this, matching the repo's implementer default.
-REASONING_MODEL = os.getenv("DLQ_CLAUDE_MODEL", "claude-sonnet-5")
 
 
 def _isolated_cwd() -> Path:
@@ -606,7 +598,6 @@ Rules:
             result = _run_process_group(
                 [
                     "claude", "--print",
-                    "--model", REASONING_MODEL,
                     "--safe-mode", "--strict-mcp-config",
                     "--mcp-config", '{"mcpServers":{}}',
                     prompt,

--- a/scripts/dlq_autopilot.py
+++ b/scripts/dlq_autopilot.py
@@ -106,6 +106,14 @@ CORPSE_SWEEP_FRESH_S = int(os.getenv("DLQ_CORPSE_SWEEP_FRESH_S", str(6 * 3600)))
 CONFIDENCE_RETRY = 0.95           # no-code-change retry threshold
 CONFIDENCE_AIDER = 0.90           # code-change aider threshold
 REASONING_TIMEOUT_S = 90          # claude --print timeout
+# Model pin (2026-08-20, token-cuts round2): claude_reason() below was bare
+# (no --model at all — grep confirms zero "model" occurrences before this),
+# inheriting whatever the ambient profile default happened to be. It runs
+# on a 30-min cron (com.nuzantara.dlq-autopilot.plist) whenever the DLQ is
+# non-empty. The task is bounded structured classification (fix_type +
+# confidence from an error log tail, JSON-only output) — sonnet is the
+# minimum-sufficient tier for this, matching the repo's implementer default.
+REASONING_MODEL = os.getenv("DLQ_CLAUDE_MODEL", "claude-sonnet-5")
 
 
 def _isolated_cwd() -> Path:
@@ -598,6 +606,7 @@ Rules:
             result = _run_process_group(
                 [
                     "claude", "--print",
+                    "--model", REASONING_MODEL,
                     "--safe-mode", "--strict-mcp-config",
                     "--mcp-config", '{"mcpServers":{}}',
                     prompt,

--- a/scripts/tests/test_claude_headless_model_pin_round2.py
+++ b/scripts/tests/test_claude_headless_model_pin_round2.py
@@ -1,5 +1,5 @@
-"""Model pins added 2026-08-20 (token-cuts round2) on three grandfathered
-bare `claude -p`/`--print` call sites (scripts/lint/lint_claude_headless_model_pin.py,
+"""Model pin added 2026-08-20 (token-cuts round2) on a grandfathered bare
+`claude --print` call site (scripts/lint/lint_claude_headless_model_pin.py,
 infra/claude-headless-model-pin/grandfathered.json), picked by measured real
 invocation cadence rather than a guess:
 
@@ -7,11 +7,14 @@ invocation cadence rather than a guess:
     all 21 cron-agent-python job scripts (~477 launchd/cron ticks/day across
     the fleet); the two bare calls are session-bootstrap pings, now pinned
     to haiku.
-  - scripts/dlq_autopilot.py — confirmed StartInterval=1800s cron
-    (com.nuzantara.dlq-autopilot.plist), a real structured-classification
-    reasoning call, now pinned to sonnet.
 
-Each test pins the guilt case: constructing the real argv still contains
+NOTE: scripts/dlq_autopilot.py was ALSO measured as genuinely bare in this
+same pass, but PR #4430 (team-lead's, armed first) already pins it — same
+insertion point after REASONING_TIMEOUT_S = 90, same --model addition inside
+claude_reason()'s argv, just haiku instead of sonnet. Dropped here to avoid
+a textual merge conflict on the same lines; #4430 owns that file.
+
+The test pins the guilt case: constructing the real argv still contains
 "--model" immediately followed by a claude-* slug pattern (mirrors the
 allowlist shape in apps/backend-rag/backend/llm/claude_oauth_client.py
 _ALLOWED_MODEL_RE), so a future edit that drops the flag or the value fails
@@ -20,7 +23,6 @@ loud here instead of silently reintroducing the bare call.
 
 from __future__ import annotations
 
-import importlib.util
 import re
 import subprocess
 import sys
@@ -39,9 +41,6 @@ def _model_after_flag(argv: list[str]) -> str | None:
         if tok == "--model" and i + 1 < len(argv):
             return argv[i + 1]
     return None
-
-
-# ── scripts/cron-agent-python/agent_job.py ──────────────────────────────
 
 
 @pytest.fixture()
@@ -94,58 +93,3 @@ def test_session_bootstrap_model_is_overridable_but_never_empty():
     per-call accident — every call site references the same name."""
     src = (CRON_AGENT_PYTHON / "agent_job.py").read_text()
     assert src.count("SESSION_BOOTSTRAP_MODEL") >= 3  # def + 2 call sites
-
-
-# ── scripts/dlq_autopilot.py ─────────────────────────────────────────────
-
-
-@pytest.fixture()
-def dlq(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
-    mod_path = Path(__file__).parent.parent / "dlq_autopilot.py"
-    spec = importlib.util.spec_from_file_location("dlq_autopilot_model_pin_round2", mod_path)
-    d = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(d)
-    return d
-
-
-def test_claude_reason_pins_a_real_model(dlq, monkeypatch):
-    """GUILT: claude_reason()'s argv to _run_process_group carries --model
-    with a value matching the allowlist shape — was bare before this fix
-    (zero "model" occurrences in the file)."""
-    captured: list[list[str]] = []
-
-    class _R:
-        returncode = 0
-        stdout = '{"fix_type": "unknown", "fix_instruction": "n/a", "confidence": 0.1, "needs_code_change": false}'
-        stderr = ""
-
-    def fake_run_process_group(argv, **kwargs):
-        captured.append(list(argv))
-        return _R()
-
-    monkeypatch.setattr(dlq, "_run_process_group", fake_run_process_group)
-    monkeypatch.setattr(dlq, "_load_token_chain", lambda: [("primary", "fake-token")])
-
-    dlq.claude_reason({"job": "test-job", "error_summary": "boom", "log_tail": "", "files_implicated": []})
-
-    assert captured, "claude_reason never called _run_process_group"
-    model = _model_after_flag(captured[0])
-    assert model is not None, f"no --model in {captured[0]!r}"
-    assert _MODEL_RE.match(model)
-    assert model == "claude-sonnet-5"
-
-
-def test_reasoning_model_env_override(monkeypatch, tmp_path):
-    """INNOCENCE: DLQ_CLAUDE_MODEL env override still produces a value
-    matching the allowlist shape (operators can dial cost up/down without
-    ever landing back on a bare call)."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("DLQ_CLAUDE_MODEL", "claude-opus-5")
-    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
-    mod_path = Path(__file__).parent.parent / "dlq_autopilot.py"
-    spec = importlib.util.spec_from_file_location("dlq_autopilot_model_pin_round2_env", mod_path)
-    d = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(d)
-    assert d.REASONING_MODEL == "claude-opus-5"

--- a/scripts/tests/test_claude_headless_model_pin_round2.py
+++ b/scripts/tests/test_claude_headless_model_pin_round2.py
@@ -1,0 +1,151 @@
+"""Model pins added 2026-08-20 (token-cuts round2) on three grandfathered
+bare `claude -p`/`--print` call sites (scripts/lint/lint_claude_headless_model_pin.py,
+infra/claude-headless-model-pin/grandfathered.json), picked by measured real
+invocation cadence rather than a guess:
+
+  - scripts/cron-agent-python/agent_job.py — shared reasoning lib imported by
+    all 21 cron-agent-python job scripts (~477 launchd/cron ticks/day across
+    the fleet); the two bare calls are session-bootstrap pings, now pinned
+    to haiku.
+  - scripts/dlq_autopilot.py — confirmed StartInterval=1800s cron
+    (com.nuzantara.dlq-autopilot.plist), a real structured-classification
+    reasoning call, now pinned to sonnet.
+
+Each test pins the guilt case: constructing the real argv still contains
+"--model" immediately followed by a claude-* slug pattern (mirrors the
+allowlist shape in apps/backend-rag/backend/llm/claude_oauth_client.py
+_ALLOWED_MODEL_RE), so a future edit that drops the flag or the value fails
+loud here instead of silently reintroducing the bare call.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CRON_AGENT_PYTHON = REPO / "scripts" / "cron-agent-python"
+
+_MODEL_RE = re.compile(r"^claude-[A-Za-z0-9][A-Za-z0-9._-]{1,63}$")
+
+
+def _model_after_flag(argv: list[str]) -> str | None:
+    for i, tok in enumerate(argv):
+        if tok == "--model" and i + 1 < len(argv):
+            return argv[i + 1]
+    return None
+
+
+# ── scripts/cron-agent-python/agent_job.py ──────────────────────────────
+
+
+@pytest.fixture()
+def agent_job(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sys.path.insert(0, str(CRON_AGENT_PYTHON))
+    # Force a fresh import bound to the redirected HOME/STATE_DIR.
+    for name in list(sys.modules):
+        if name == "agent_job":
+            del sys.modules[name]
+    import agent_job as mod
+
+    return mod
+
+
+def test_session_bootstrap_calls_pin_a_real_model(agent_job, monkeypatch):
+    """GUILT: both bare `claude --print` session-bootstrap calls now carry
+    --model with a value matching the allowlist shape, and never inherit
+    a caller-supplied model none of the 21 job scripts pass."""
+    captured: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        captured.append(list(argv))
+
+        class _R:
+            returncode = 0
+            stdout = '{"session_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}'
+            stderr = ""
+
+        return _R()
+
+    # get_or_create_session() does `import subprocess` locally inside the
+    # function body, so it resolves subprocess.run off the shared module
+    # object at call time — patch that shared object, not an agent_job
+    # attribute (there isn't one; the import never binds at module scope).
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    agent_job.get_or_create_session("test-job", scope="persistent")
+
+    assert captured, "get_or_create_session never called subprocess.run"
+    for argv in captured:
+        model = _model_after_flag(argv)
+        assert model is not None, f"no --model in {argv!r}"
+        assert _MODEL_RE.match(model), f"model {model!r} doesn't match allowlist shape"
+    # The specific tier chosen: haiku (bootstrap ping does no reasoning).
+    assert all(_model_after_flag(a) == "claude-haiku-4-5-20251001" for a in captured)
+
+
+def test_session_bootstrap_model_is_overridable_but_never_empty():
+    """INNOCENCE: SESSION_BOOTSTRAP_MODEL is a module-level constant, not a
+    per-call accident — every call site references the same name."""
+    src = (CRON_AGENT_PYTHON / "agent_job.py").read_text()
+    assert src.count("SESSION_BOOTSTRAP_MODEL") >= 3  # def + 2 call sites
+
+
+# ── scripts/dlq_autopilot.py ─────────────────────────────────────────────
+
+
+@pytest.fixture()
+def dlq(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    mod_path = Path(__file__).parent.parent / "dlq_autopilot.py"
+    spec = importlib.util.spec_from_file_location("dlq_autopilot_model_pin_round2", mod_path)
+    d = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(d)
+    return d
+
+
+def test_claude_reason_pins_a_real_model(dlq, monkeypatch):
+    """GUILT: claude_reason()'s argv to _run_process_group carries --model
+    with a value matching the allowlist shape — was bare before this fix
+    (zero "model" occurrences in the file)."""
+    captured: list[list[str]] = []
+
+    class _R:
+        returncode = 0
+        stdout = '{"fix_type": "unknown", "fix_instruction": "n/a", "confidence": 0.1, "needs_code_change": false}'
+        stderr = ""
+
+    def fake_run_process_group(argv, **kwargs):
+        captured.append(list(argv))
+        return _R()
+
+    monkeypatch.setattr(dlq, "_run_process_group", fake_run_process_group)
+    monkeypatch.setattr(dlq, "_load_token_chain", lambda: [("primary", "fake-token")])
+
+    dlq.claude_reason({"job": "test-job", "error_summary": "boom", "log_tail": "", "files_implicated": []})
+
+    assert captured, "claude_reason never called _run_process_group"
+    model = _model_after_flag(captured[0])
+    assert model is not None, f"no --model in {captured[0]!r}"
+    assert _MODEL_RE.match(model)
+    assert model == "claude-sonnet-5"
+
+
+def test_reasoning_model_env_override(monkeypatch, tmp_path):
+    """INNOCENCE: DLQ_CLAUDE_MODEL env override still produces a value
+    matching the allowlist shape (operators can dial cost up/down without
+    ever landing back on a bare call)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("DLQ_CLAUDE_MODEL", "claude-opus-5")
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    mod_path = Path(__file__).parent.parent / "dlq_autopilot.py"
+    spec = importlib.util.spec_from_file_location("dlq_autopilot_model_pin_round2_env", mod_path)
+    d = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(d)
+    assert d.REASONING_MODEL == "claude-opus-5"


### PR DESCRIPTION
## Summary

Part of the token-cuts-round2 mandate: drains 2 of the 47-49 files grandfathered in
`infra/claude-headless-model-pin/grandfathered.json`, picked by measured real invocation
cadence rather than a guess.

- **`scripts/cron-agent-python/agent_job.py`** — shared session-bootstrap lib imported by
  all 21 cron-agent-python job scripts. Two bare `claude --print` calls in
  `get_or_create_session()` pinned to `claude-haiku-4-5-20251001` (the call is a bootstrap
  ping, no reasoning). Declared HOME-fork pair (`infra/home-fork/declared-pairs.json`) —
  needs a post-merge manual sync to `~/scripts/cron-agent-python/agent_job.py` on Pro.
- **`apps/backend-rag/backend/services/canva_renderer/claude_invoker.py`** — WR2 Canva-apply
  headless invocation, runs on Pro via auto-pulled checkout (no manual sync needed). Pinned
  to `claude-sonnet-5` via a new `model` param (default `DEFAULT_CLAUDE_MODEL`).

## Scope note (W109b avoidance)

`scripts/dlq_autopilot.py` was also measured as genuinely bare in this pass and was
originally included here, but **PR #4430** (team-lead's own, already armed) independently
pins the exact same call site at the identical insertion point — same fix, different model
choice (haiku there vs sonnet in my dropped draft). Landing both would be a hard textual
conflict on the same lines. Dropped it from this PR in a follow-up commit; #4430 is broader
in scope (also owns `grandfathered.json` and the lint itself) so it wins that file.

Two named-by-guess "biggest by volume" candidates were investigated and ruled out:
`scripts/wr3_dispatch_v2.py` (event-driven, 0 real dispatches in the retained 7584-line log)
and `scripts/zantara-gateway/claude_client.py` (not deployed on Pro). Three lint false
positives were also found already safely pinned in practice: `cron-agent.sh`,
`claude_oauth_client.py`, `claude_oauth_langchain.py`.

## Test plan

- [x] `pytest scripts/tests/test_claude_headless_model_pin_round2.py -q` — 2/2 passed
  (guilt: both bootstrap calls carry `--model claude-haiku-4-5-20251001`; innocence: the
  constant is referenced at every call site, not a per-call accident)
- [x] `pytest apps/backend-rag/backend/tests/unit/services/canva_renderer/test_claude_invoker.py -q`
  — new `TestInvokeClaudeApplyModelPin` class, 2/2 passed
- [ ] Post-merge: sync `agent_job.py` to Pro's declared HOME-fork copy, verify with
  `lint_home_fork.py --check`