### PR TITLE
fix(wr2): agy has no stdin path — pass prompt as -p argv, not piped

### DIFF
--- a/.claude/agents/wr2-external-bench.md
+++ b/.claude/agents/wr2-external-bench.md
@@ -60,7 +60,7 @@ If a brand's IG handle has changed or account no longer active, log in output fi
 
 For each brand in Tier 1+2:
 
-- Use Antigravity CLI `agy` (Gemini 3.1 Pro, Google AI Ultra sub): `printf '%s' "$PROMPT" | agy -p --print-timeout 5m` to fetch IG profile recent 12 posts.
+- Use Antigravity CLI `agy` (Gemini 3.1 Pro, Google AI Ultra sub): `agy -p "$PROMPT" --print-timeout 5m` to fetch IG profile recent 12 posts. agy has NO stdin path — piping the prompt in (`printf ... | agy -p`) binds the next flag as the literal prompt and returns RC 0 with empty output, silently burning quota (measured 2026-08-15). Pass the prompt as `-p`'s own argv value.
 - Extract: cover image description, caption first 200 chars, slides_count if visible, likes/comments/saves if scraped.
 - For Tier 3 (trend reports): fetch URL via WebFetch, summarize key metrics + design recommendations.
 

--- a/.claude/agents/wr2-ig-metrics-analyst.md
+++ b/.claude/agents/wr2-ig-metrics-analyst.md
@@ -56,8 +56,13 @@ Bundle the filtered data into a single Gemini 3.1 Pro prompt:
 
 ```bash
 # agy = Antigravity CLI Gemini 3.1 Pro (Google AI Ultra sub, 1M ctx).
-# Takes prompt + corpus on stdin combined.
-{ printf '%s\n\n--- CORPUS ---\n' "$PROMPT"; cat /tmp/wr2-metrics-corpus.json; } | agy -p --print-timeout 5m
+# agy v1.1.12+ has NO stdin path — `-p` MUST get the prompt as its own argv
+# value. A pipe into `agy -p --print-timeout 5m` binds "--print-timeout" as
+# the literal prompt and never reads stdin: RC 0, empty output, quota spent
+# for nothing (measured 2026-08-15, matches the fix already live in
+# infra/launchagents/wrappers/*.sh and scripts/ai-dispatch.sh since 2026-08-13).
+FULL_PROMPT="$(printf '%s\n\n--- CORPUS ---\n' "$PROMPT"; cat /tmp/wr2-metrics-corpus.json)"
+agy -p "$FULL_PROMPT" --print-timeout 5m
 ```
 
 Where `/tmp/wr2-metrics-corpus.json` contains:


### PR DESCRIPTION
## Summary
- `.claude/agents/wr2-ig-metrics-analyst.md` and `.claude/agents/wr2-external-bench.md` still documented the pre-2026-08-13 broken `... | agy -p --print-timeout 5m` form.
- `agy` has no stdin path: the pipe binds `--print-timeout` as the literal prompt, agy exits 0 with empty output — quota consumed, nothing delivered.
- The shell wrappers (`regulatory-watcher-run.sh`, `claude-cascade.sh`, `nb-curator-daily.sh`, `ai-dispatch.sh`) were already fixed to the argv form on 2026-08-13 (visible in their comments); these two subagent-spec `.md` files, read verbatim by the Sonnet subagent at its Step 2/Step 1, were not — so `wr2-ig-metrics-analyst` (weekly) and `wr2-external-bench` (monthly) were silently burning one dead agy call per run.

## Test plan
- [x] Grepped repo-wide for `| agy` and `agy -p` — confirmed these were the only two remaining broken call-sites (all shell wrappers already fixed).
- [x] Pre-commit hooks pass (no code path, docs-only change to agent instruction files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)