### PR TITLE
feat(ci): map 10 provably-decoupled scripts/ directories to fleet_ops

### DIFF
--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -35,6 +35,7 @@ DOMAIN_NAMES = (
     "infra_workflows",
     "docs_content_data",
     "security_sensitive",
+    "fleet_ops",
 )
 
 TEST_JOBS = (
@@ -217,6 +218,55 @@ PREFIX_RULES: tuple[tuple[str, frozenset[str]], ...] = (
     ("config/", frozenset({"infra_workflows", "security_sensitive"})),
     ("data/", frozenset({"backend_python", "docs_content_data"})),
     ("public/", frozenset({"mouth", "docs_content_data"})),
+    # fleet_ops (2026-08-20): top-level scripts/ (outside scripts/ci/, already
+    # mapped above) is NOT mapped as a whole — a per-file coupling census this
+    # PR ran found 19+ scripts/*.py modules silently imported into
+    # apps/backend-rag/backend/tests/{scripts,unit/scripts}/ via a sys.path
+    # shim in that tree's own conftest.py (`from scripts.X import Y` resolves
+    # to the repo-root scripts/ package once the CI job's pytest invocation
+    # has collected any file under it — see scripts/bot/test_*.py, which are
+    # listed as explicit pytest targets in tests.yml and are what actually
+    # puts the repo root on sys.path for every other test in the same run).
+    # The coupled set has NO naming or directory pattern an automated rule
+    # could detect — scripts/drive_token_watchdog.py, scripts/fix_lkpm_q1_
+    # 2026_client_ids.py and scripts/wr2_html_render_apply.py (the last one
+    # is what forced run_all=true, correctly, on PR #4431 the same day this
+    # was written) are all individually imported by backend-tests despite
+    # none of their names suggesting it; one, scripts/sentinel_lib/alerter.py,
+    # is even imported by PRODUCTION backend application code. Mapping scripts/
+    # by directory or prefix at that granularity would be an under-match
+    # (cicatrix #3) waiting to happen. These ten directories are the ONLY
+    # scripts/ subtrees mapped, because each is verified BOTH ways: (a)
+    # contains zero .py files anywhere in its tree, so it is structurally
+    # impossible for the sys.path-import mechanism above to reach it (Python
+    # cannot `import` a .sh/.json/.plist/.md file), and (b) a literal grep for
+    # each directory's own path (trailing slash, to avoid a prefix collision
+    # like "scripts/pro" matching "scripts/probes/…") across every file tree
+    # any of the six tests.yml jobs execute — apps/backend-rag/, apps/
+    # nuzantara-mcp/, apps/evaluator/, apps/mouth/, apps/admin-dashboard/,
+    # apps/wa-mirror/, packages/core/, and tests.yml itself — returns zero
+    # hits, so no job subprocess-invokes anything in them either. All ten are
+    # pure per-machine/per-person fleet-ops payloads (Mini/Pro git-pull
+    # wrappers, Codex overnight cron scripts, Damar/Krisna/Ruslana node
+    # bootstrap installers, LaunchAgent plists, a CLI dispatcher, one static
+    # JSON snapshot, one JSON routing config) with their own narrower CI where
+    # they need it (e.g. scripts/codex/ and scripts/pro/ are swept by
+    # immune-enforcement.yml and guard-conformance.yml — unrelated to and
+    # unaffected by this domain, which only governs tests.yml's six jobs).
+    # `fleet_ops` intentionally maps to ZERO entries in `_suggested_jobs()` —
+    # a change confined to these directories needs none of the six heavy
+    # jobs to verify it, and a change combined with anything else keeps
+    # whatever job set that other path already earns.
+    ("scripts/cli/", frozenset({"fleet_ops"})),
+    ("scripts/codex/", frozenset({"fleet_ops"})),
+    ("scripts/damar-node/", frozenset({"fleet_ops"})),
+    ("scripts/data/", frozenset({"fleet_ops"})),
+    ("scripts/krisna-node/", frozenset({"fleet_ops"})),
+    ("scripts/launchd/", frozenset({"fleet_ops"})),
+    ("scripts/mini/", frozenset({"fleet_ops"})),
+    ("scripts/pro/", frozenset({"fleet_ops"})),
+    ("scripts/review_routes/", frozenset({"fleet_ops"})),
+    ("scripts/ruslana-node/", frozenset({"fleet_ops"})),
 )
 
 DOC_PREFIXES = (

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -314,6 +314,104 @@ class ChangeMapTests(unittest.TestCase):
             ["backend-tests", "frontend-tests", "e2e-tests"],
         )
 
+    def test_innocence_fleet_ops_directories_skip_every_test_job(self) -> None:
+        # 2026-08-20: PR #4428 touched only scripts/mini/*.sh (a Mini-machine
+        # git-pull wrapper) and still paid the full ~28min backend suite,
+        # because top-level scripts/ (outside scripts/ci/) has no domain rule
+        # at all and unclassified paths fail closed to run_all=true — correct
+        # by design, but this specific directory is provably safe (see the
+        # fleet_ops block in change_map.py for the two-sided proof: zero .py
+        # files anywhere in the tree, so nothing can import it; zero
+        # references anywhere in the six gated jobs' own code trees or in
+        # tests.yml, so nothing subprocess-invokes it either). This is the
+        # exact PR #4428 diff shape.
+        result = cm.classify(
+            [
+                "scripts/mini/mini-git-pull.sh",
+                "scripts/mini/test-mini-git-pull-self-update-atomic.sh",
+                "scripts/mini/test-mini-git-pull-symlink-typechange-clean.sh",
+            ]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["reason"], "classified")
+        self.assertTrue(result["domains"]["fleet_ops"])
+        self.assertEqual(result["suggested_jobs"], [])
+        self.assertEqual(result["would_skip"], list(cm.TEST_JOBS))
+
+    def test_innocence_every_fleet_ops_directory_skips_every_test_job(self) -> None:
+        # One representative path per mapped directory — guards against a
+        # future edit narrowing one prefix's trailing slash or typo-ing a
+        # directory name in a way a single spot-check on scripts/mini/ alone
+        # would not catch.
+        for path in (
+            "scripts/cli/nz",
+            "scripts/codex/codex-nightly-autofix-ci.sh",
+            "scripts/damar-node/install.sh",
+            "scripts/data/nb_decomm_audit_2026-05-07.json",
+            "scripts/krisna-node/install.sh",
+            "scripts/launchd/com.nuzantara.fly-pg-tunnel.plist",
+            "scripts/mini/mini-git-pull.sh",
+            "scripts/pro/pro-git-pull.sh",
+            "scripts/review_routes/worker-plane-council-v3.json",
+            "scripts/ruslana-node/install.sh",
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertFalse(result["run_all"])
+                self.assertTrue(result["domains"]["fleet_ops"])
+                self.assertEqual(result["suggested_jobs"], [])
+
+    def test_guilt_hidden_backend_test_coupled_scripts_stay_unclassified(
+        self,
+    ) -> None:
+        # Regression tripwire for the census this PR ran: these top-level
+        # scripts/*.py files are silently `from scripts.X import Y`-imported
+        # by apps/backend-rag/backend/tests/{scripts,unit/scripts}/ (verified
+        # live, 2026-08-20 — a sys.path shim in that tree's own conftest.py
+        # resolves `scripts` to the repo-root package once ANY file under it
+        # has been pytest-collected in the same run). None of their names
+        # hint at the coupling — this is exactly the shape a naive
+        # directory/prefix rule on all of scripts/ would have missed, and
+        # exactly why fleet_ops only covers directories proven to contain no
+        # .py at all. If any of these ever starts reporting run_all=false,
+        # something either mapped a domain over it directly or widened an
+        # existing fleet_ops prefix to swallow it — both are a live
+        # under-match on a file backend-tests actually needs to run for.
+        for path in (
+            "scripts/wr2_html_render_apply.py",  # forced run_all=true on PR #4431, same day
+            "scripts/drive_token_watchdog.py",
+            "scripts/fix_lkpm_q1_2026_client_ids.py",
+            "scripts/sentinel_lib/alerter.py",  # imported by PRODUCTION backend code, not just tests
+            "scripts/bot/wa_blind_bench.py",  # scripts/bot/ is pytest-collected directly by tests.yml
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertTrue(result["run_all"])
+                self.assertEqual(result["reason"], "unclassified_paths")
+                self.assertEqual(result["suggested_jobs"], list(cm.TEST_JOBS))
+
+    def test_innocence_loose_top_level_script_outside_mapped_dirs_stays_unclassified(
+        self,
+    ) -> None:
+        # A file living directly in scripts/ (not under any of the ten
+        # fleet_ops directories) must not inherit the exemption just for
+        # sharing the scripts/ prefix — the rule is per-directory, not
+        # repo-wide on scripts/.
+        result = cm.classify(["scripts/pro-mini-healthcheck.sh"])
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["reason"], "unclassified_paths")
+
+    def test_guilt_fleet_ops_combined_with_backend_change_still_runs_backend(
+        self,
+    ) -> None:
+        # fleet_ops must contribute nothing to the job set, but must not
+        # SUPPRESS what a co-changed backend_python path already earns.
+        result = cm.classify(
+            ["scripts/pro/pro-git-pull.sh", "apps/backend-rag/backend/app/main.py"]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["suggested_jobs"], ["backend-tests", "e2e-tests"])
+
     def test_cli_stdout_is_one_compact_json_line(self) -> None:
         script = Path(__file__).with_name("change_map.py")
         completed = subprocess.run(


### PR DESCRIPTION
## Summary

PR #4428 touched only `scripts/mini/*.sh` and still paid the full ~28min
backend suite: top-level `scripts/` (outside `scripts/ci/`, already
mapped) has no domain rule, so an unclassified path correctly fails
closed to `run_all=true`.

A per-file coupling census — not a naming/directory heuristic — found
this is **not** safe to fix by mapping `scripts/` broadly:
`apps/backend-rag/backend/tests/{scripts,unit/scripts}/` silently
imports 19+ top-level `scripts/*.py` modules via a `sys.path` shim in
that tree's own `conftest.py`, with zero naming or directory pattern —
`scripts/drive_token_watchdog.py`, `scripts/fix_lkpm_q1_2026_client_ids.py`,
`scripts/wr2_html_render_apply.py` (the last one forced `run_all=true`,
correctly, on PR #4431 the same day this was written) are all
individually imported by backend-tests despite none of their names
suggesting it. One, `scripts/sentinel_lib/alerter.py`, is imported by
**production** backend application code.

Mapped only the 10 directories verified both ways: (a) zero `.py` files
anywhere in the tree — Python cannot `import` a `.sh`/`.json`/`.plist`/`.md`
file, so the coupling mechanism above is structurally impossible; (b) a
literal grep for each directory's own path (trailing slash, to avoid a
prefix collision like `scripts/pro` matching `scripts/probes/…`) across
every file tree any of the six `tests.yml` jobs execute, plus `tests.yml`
itself, returns zero hits — nothing subprocess-invokes them either. All
ten are per-machine/per-person fleet-ops payloads: Mini/Pro git-pull
wrappers, Codex overnight cron scripts, Damar/Krisna/Ruslana node
bootstrap installers, LaunchAgent plists, a CLI dispatcher, and two
static JSON files.

The new `fleet_ops` domain contributes **zero** jobs in `_suggested_jobs()`
by design — a change confined to these directories now needs none of the
six heavy jobs; a change combined with anything else still earns whatever
job set that other path already earns.

## Test plan

- [x] `python3 scripts/ci/test_change_map.py` — 31/31 green (26 existing + 5 new)
- [x] Manually reproduced PR #4428's exact diff shape → `run_all=false, suggested_jobs=[]`
- [x] Manually confirmed the known hidden-coupled files (`wr2_html_render_apply.py`,
      `drive_token_watchdog.py`) still correctly force `run_all=true`
- [x] Mutation-verified: widening `scripts/mini/` to bare `scripts/` fails 6 tests
      (the exact hidden-coupled-file guilt cases + the loose-file boundary test)
- [x] Mutation-verified: removing all 10 `fleet_ops` rules fails 12 tests (every
      mapped directory's innocence case + the mixed-domain guilt case)
- [x] `ruff check` + `ruff format --check` clean on both changed files
- [x] `python3 -m py_compile` clean
- [x] Root-of-trust (base-SHA classifier extraction, PR #4181) and CODEOWNERS
      TIER1 protection are unchanged — both already cover `scripts/ci/change_map.py`
      and `scripts/ci/test_change_map.py`

Not auto-merge-armed — this PR touches gate/job selection logic, reviewed
and merged by the codeowner per their own request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)