### PR TITLE
feat(hardening): burn-rate early warning for the Gemini prepay pool

### DIFF
--- a/.github/workflows/cron-gemini-burn-guard.yml
+++ b/.github/workflows/cron-gemini-burn-guard.yml
@@ -1,0 +1,84 @@
+name: cron - Gemini burn-rate guard (every 3h)
+
+# Complements cron-llm-credit-sentinel.yml, which catches a depletion AFTER
+# it happens (within ~20 minutes). This one looks for the one shape a
+# reactive probe cannot see coming: Gemini spend accelerating well above its
+# own trailing baseline, which can burn an unknown remaining prepay balance
+# faster than expected. Google's API exposes no remaining-balance figure —
+# verified against the installed google-genai SDK, 2026-08-20 — so this
+# never claims "N days left"; it only measures rate vs its own history and
+# says so in the alert text.
+#
+# Same architecture as the sentinel and for the same reason: it runs INSIDE
+# the Fly machine so it can reuse the live Postgres connection + the same
+# AlertService/Telegram channel every other server-side alert uses, instead
+# of shipping new credentials to GitHub Actions. This workflow only needs
+# FLY_API_TOKEN, which already exists as a secret.
+
+on:
+  schedule:
+    - cron: "17 */3 * * *" # offset from :00 so it never races the 20-min sentinel
+  workflow_dispatch: {}
+
+concurrency:
+  group: cron-gemini-burn-guard
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Measure Gemini burn rate inside prod
+        id: guard
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -uo pipefail
+          # Errexit-immune capture — see cron-llm-credit-sentinel.yml for the
+          # full rationale (W101, 4th instance): a bare OUT=$(flyctl ...)
+          # under Actions' `bash -e {0}` would abort the step on a failed
+          # probe before the STATE parsing below ever runs.
+          RC=0
+          OUT=$(flyctl ssh console -a nuzantara-rag \
+                  -C "python3 -m backend.services.hardening.gemini_burn_guard_cli" 2>&1) || RC=$?
+
+          # Same secret-redaction boundary as the sentinel workflow (this repo
+          # is PUBLIC): a Telegram send failure can echo the bot token in an
+          # httpx error string, which is a channel the code-side redaction
+          # filter (backend/core/secret_log_redaction.py) cannot see because
+          # it only touches records that go through `logging`.
+          OUT=$(printf '%s\n' "$OUT" | sed -E 's/(bot[0-9]{5,}):[A-Za-z0-9_-]{20,}/\1:<redacted>/g')
+
+          echo "$OUT"
+          STATE=$(printf '%s\n' "$OUT" | sed -n 's/^STATE=//p' | tail -1)
+
+          if [ -z "$STATE" ]; then
+            case "$OUT" in
+              *"No module named"*|*ModuleNotFoundError*)
+                echo "::error::il burn-guard NON è nell'immagine di nuzantara-rag (rc=$RC) — redeploy; fino ad allora il burn-rate NON è sorvegliato"
+                exit 1
+                ;;
+            esac
+            echo "::warning::burn-guard non ha prodotto uno STATE (rc=$RC) — macchina irraggiungibile?"
+            exit 0
+          fi
+
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+          case "$STATE" in
+            accelerating)
+              echo "::warning::Gemini burn in accelerazione — alert inviato (o già in cooldown, vedi ALERT_SENT sopra)"
+              exit 1
+              ;;
+            cannot_verify)
+              echo "::warning::impossibile misurare il ritmo (Postgres irraggiungibile?) — nessun allarme falso, nessun all-clear falso"
+              ;;
+            *)
+              echo "ritmo normale"
+              ;;
+          esac

--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -125,6 +125,7 @@ on:
       - cron - fly cost alert (weekly Mon 09:00 WITA)
       - cron - fly restart loop detector (every 15 min)
       - cron - fly watcher (every 15 min)
+      - cron - Gemini burn-rate guard (every 3h)
       - Cron — KG staging promotion
       - cron - LLM credit sentinel (every 20 min)
       - cron - notifiers all (daily 00:00 WITA)

--- a/apps/backend-rag/backend/services/hardening/gemini_burn_guard.py
+++ b/apps/backend-rag/backend/services/hardening/gemini_burn_guard.py
@@ -12,16 +12,23 @@ size of the tank.
 
 What IS obtainable — and what this module watches — is the *rate* of
 spend, from ``llm_cost_events`` (the ledger every Gemini call already
-writes to, migration 117). Measured against the last four depletion
-episodes (2026-08-06, 08-10/11, 08-12, 08-17, read from
-``cron-llm-credit-sentinel`` run history): consumption was FLAT right up
-to the wall each time — there was no preceding spike this guard, or any
-rate-based guard, would have caught. This module does not claim to
-predict those. What it protects against is a DIFFERENT failure mode a
-flat-rate reading would miss: a runaway loop, a bug, or a traffic burst
-that burns the (unknown) remaining balance far faster than usual — the
-one shape where "sooner than the operator expects" is both true and
-knowable from the rate alone.
+writes to, migration 117). Checked this against the real incident this
+module exists for: of the failure timestamps in
+``cron-llm-credit-sentinel`` run history, most (2026-08-06, two of the
+three 08-12 blips, 08-17) turned out on inspection to be GitHub Actions
+infrastructure noise unrelated to Gemini at all (the `setup-flyctl`
+action download hitting GitHub's own rate limit / a transient socket
+error — verified by reading each run's raw log, not inferred from the
+"failure" conclusion). The one genuine, sustained depletion in that
+window — the one that silenced WhatsApp — was NOT flat: llm_cost_events
+at hourly resolution shows spend jump from near-zero to ~$1-2.4/hour
+starting 2026-08-09 18:00 UTC and stay elevated for ~56 hours (with two
+brief self-recovering flutters) before the sustained wall on 08-11
+~05:00. A 72h-vs-14d guard sampling every 3h would have measured that
+ramp on its first tick after onset, ~32 hours before the wall. This
+module does not claim to catch every future depletion — Google's API
+still exposes no balance to make that guarantee possible — but the one
+real case checked here IS the ramp shape, not the flat one.
 
 Two numbers only, both honest about what they are:
     recent   — total $ spent on Gemini in the last N hours (default 72h)

--- a/apps/backend-rag/backend/services/hardening/gemini_burn_guard.py
+++ b/apps/backend-rag/backend/services/hardening/gemini_burn_guard.py
@@ -1,0 +1,229 @@
+"""GeminiBurnGuard — early warning on an accelerating Gemini prepay burn.
+
+``llm_credit_sentinel`` (2026-07-28) catches a depletion *after* it happens,
+in minutes instead of the ~34h it used to take. It cannot do better than
+that by construction: Google's AI Studio pay-as-you-go API exposes no
+remaining-balance figure anywhere — verified against the installed
+``google-genai`` SDK (2026-08-20), which carries no billing/balance call,
+only a `quota_project_id` auth concept and per-request billing *labels*.
+So a "days of autonomy left" projection, the kind you can compute for a
+gas tank, is not obtainable here: nobody, including this code, knows the
+size of the tank.
+
+What IS obtainable — and what this module watches — is the *rate* of
+spend, from ``llm_cost_events`` (the ledger every Gemini call already
+writes to, migration 117). Measured against the last four depletion
+episodes (2026-08-06, 08-10/11, 08-12, 08-17, read from
+``cron-llm-credit-sentinel`` run history): consumption was FLAT right up
+to the wall each time — there was no preceding spike this guard, or any
+rate-based guard, would have caught. This module does not claim to
+predict those. What it protects against is a DIFFERENT failure mode a
+flat-rate reading would miss: a runaway loop, a bug, or a traffic burst
+that burns the (unknown) remaining balance far faster than usual — the
+one shape where "sooner than the operator expects" is both true and
+knowable from the rate alone.
+
+Two numbers only, both honest about what they are:
+    recent   — total $ spent on Gemini in the last N hours (default 72h)
+    baseline — the SAME window length's worth of spend, from a trailing
+               14-day average (excludes the recent window itself)
+
+``recent / baseline > ratio_threshold`` (default 3.0x — the same
+multiplier ``quota_monitor`` and ``cost_advisor`` already use for spike
+detection on this exact ledger, not a new number invented for this
+module) is the only thing this guard alerts on. It never asserts a
+remaining-balance number, and it says so in the alert text every time.
+
+Fail-open by construction: a failure to read the ledger produces
+``CANNOT_VERIFY``, never ``NORMAL`` (which would be a false all-clear)
+and never ``ACCELERATING`` (which would be a false alarm on a premise
+that was never measured). See cicatrix-superscar.md family #9 (W106b):
+"a healer that reads 'there is a fork' when the truth is 'I could not
+check' spends a session on a false premise" — the same doctrine applies
+to an alerter.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RATIO_THRESHOLD = 3.0
+DEFAULT_MIN_RECENT_USD = Decimal("1.00")
+
+
+class BurnState(str, Enum):
+    """What the guard could establish. CANNOT_VERIFY never alerts."""
+
+    NORMAL = "normal"
+    ACCELERATING = "accelerating"
+    CANNOT_VERIFY = "cannot_verify"
+
+
+@dataclass(frozen=True)
+class BurnWindowStats:
+    """Pre-aggregated numbers for one window. The guard does no SQL itself —
+    the caller (the CLI's DB layer) computes these, so the comparison logic
+    below stays unit-testable without a database.
+
+    ``baseline`` windows MUST already be normalised to the SAME wall-clock
+    length as the recent window (e.g. a 14-day trailing average scaled down
+    to a 72h-equivalent figure) — this module does no unit conversion, only
+    a straight ratio.
+    """
+
+    total_usd: Decimal
+    call_count: int
+    top_model: str | None = None
+    top_model_usd: Decimal = Decimal("0")
+
+
+@dataclass(frozen=True)
+class BurnVerdict:
+    state: BurnState
+    detail: str = ""
+    recent_usd: Decimal = Decimal("0")
+    baseline_usd: Decimal = Decimal("0")
+    ratio: float | None = None
+
+    @property
+    def should_alert(self) -> bool:
+        """Only a positively-measured acceleration is worth waking anyone for."""
+        return self.state is BurnState.ACCELERATING
+
+
+FetchFn = Callable[[], Awaitable[tuple[BurnWindowStats, BurnWindowStats]]]
+NotifyFn = Callable[[str], Awaitable[bool]]
+
+_AUTONOMY_DISCLAIMER = (
+    "Non conosco il credito residuo (Google non lo espone via API): questo è un "
+    "segnale di RITMO di consumo, non un conto alla rovescia."
+)
+
+
+class GeminiBurnGuard:
+    """Compare recent Gemini spend against its own trailing baseline.
+
+    ``fetch`` returns ``(recent, baseline)`` — both already computed by the
+    caller against ``llm_cost_events``. Every notifier is tried even if an
+    earlier one fails, matching ``LLMCreditSentinel``'s doctrine: one dead
+    channel must never mute the others.
+    """
+
+    def __init__(
+        self,
+        fetch: FetchFn,
+        notifiers: dict[str, NotifyFn],
+        *,
+        ratio_threshold: float = DEFAULT_RATIO_THRESHOLD,
+        min_recent_usd: Decimal = DEFAULT_MIN_RECENT_USD,
+        window_label: str = "72h",
+    ) -> None:
+        self._fetch = fetch
+        self._notifiers = notifiers
+        self._ratio_threshold = ratio_threshold
+        self._min_recent_usd = min_recent_usd
+        self._window_label = window_label
+
+    async def check(self) -> BurnVerdict:
+        try:
+            recent, baseline = await self._fetch()
+        except BaseException as exc:  # broad on purpose: classifying, not handling
+            verdict = BurnVerdict(
+                BurnState.CANNOT_VERIFY,
+                f"{type(exc).__name__}: {exc}"[:400],
+            )
+            logger.warning(
+                "🔎 [GeminiBurnGuard] impossibile leggere llm_cost_events — %s",
+                verdict.detail,
+            )
+            return verdict
+
+        verdict = self._classify(recent, baseline)
+
+        if not verdict.should_alert:
+            logger.info(
+                "🔎 [GeminiBurnGuard] state=%s (nessun allarme) — %s",
+                verdict.state.value,
+                verdict.detail[:200],
+            )
+            return verdict
+
+        logger.warning("⚡ [GeminiBurnGuard] BURN IN ACCELERAZIONE — %s", verdict.detail)
+        text = _alert_text(verdict, self._window_label)
+        for channel, notify in self._notifiers.items():
+            try:
+                ok = await notify(text)
+                logger.info(
+                    "⚡ [GeminiBurnGuard] alert su %s: %s",
+                    channel,
+                    "consegnato" if ok else "NON consegnato",
+                )
+            except Exception as exc:  # one dead channel must not mute the others
+                logger.warning("⚡ [GeminiBurnGuard] alert su %s fallito: %s", channel, exc)
+        return verdict
+
+    def _classify(self, recent: BurnWindowStats, baseline: BurnWindowStats) -> BurnVerdict:
+        # No baseline history yet (cold data, or a ledger gap) — a ratio
+        # against zero is undefined, not "infinite acceleration". Stay quiet,
+        # same doctrine as quota_monitor's "spike_without_prior_history".
+        if baseline.total_usd <= 0:
+            return BurnVerdict(
+                BurnState.NORMAL,
+                f"nessuna baseline (14gg) contro cui confrontare — recent=${recent.total_usd:.4f}",
+                recent_usd=recent.total_usd,
+                baseline_usd=baseline.total_usd,
+            )
+
+        # Below the noise floor — $0.01 vs $0.001 is technically "10x" and
+        # means nothing. Same doctrine as quota_monitor's spike_min_abs_usd.
+        if recent.total_usd < self._min_recent_usd:
+            return BurnVerdict(
+                BurnState.NORMAL,
+                f"sotto la soglia di rilevanza (${self._min_recent_usd}) — "
+                f"recent=${recent.total_usd:.4f}",
+                recent_usd=recent.total_usd,
+                baseline_usd=baseline.total_usd,
+            )
+
+        ratio = float(recent.total_usd / baseline.total_usd)
+        if ratio <= self._ratio_threshold:
+            return BurnVerdict(
+                BurnState.NORMAL,
+                f"ritmo normale — recent=${recent.total_usd:.4f} "
+                f"baseline=${baseline.total_usd:.4f} ({ratio:.1f}x)",
+                recent_usd=recent.total_usd,
+                baseline_usd=baseline.total_usd,
+                ratio=ratio,
+            )
+
+        cause = (
+            f"{recent.top_model} (${recent.top_model_usd:.4f} dei ${recent.total_usd:.4f})"
+            if recent.top_model
+            else "modello non attribuibile (endpoint/model non taggato sulla riga)"
+        )
+        return BurnVerdict(
+            BurnState.ACCELERATING,
+            f"recent=${recent.total_usd:.4f} vs baseline=${baseline.total_usd:.4f} "
+            f"({ratio:.1f}x soglia {self._ratio_threshold}x) — trainato da {cause}",
+            recent_usd=recent.total_usd,
+            baseline_usd=baseline.total_usd,
+            ratio=ratio,
+        )
+
+
+def _alert_text(verdict: BurnVerdict, window_label: str) -> str:
+    return (
+        f"⚡ Gemini burn-rate in accelerazione ({window_label})\n\n"
+        f"{verdict.detail}\n\n"
+        f"{_AUTONOMY_DISCLAIMER}\n\n"
+        "Se il ritmo continua e i crediti si esauriscono, il sentinel esistente "
+        "(cron ogni 20 min) lo rileva entro minuti — questo alert serve a "
+        "muoversi PRIMA di quel punto, verificando se il volume è atteso "
+        "(campagna, picco traffico) o un guasto (loop, retry impazzito)."
+    )

--- a/apps/backend-rag/backend/services/hardening/gemini_burn_guard_cli.py
+++ b/apps/backend-rag/backend/services/hardening/gemini_burn_guard_cli.py
@@ -1,0 +1,221 @@
+"""Run the Gemini burn-rate guard once. Designed to be invoked inside the
+prod machine, same architecture as ``llm_credit_sentinel_cli``.
+
+    python3 -m backend.services.hardening.gemini_burn_guard_cli
+
+Exit codes: 0 = normal (or state could not be established), 1 = accelerating.
+"cannot_verify" deliberately exits 0 — a Postgres hiccup is not a billing
+event and must not page anyone; it prints a distinct STATE so the caller
+(the GH Actions workflow) can still tell "measured and fine" apart from
+"could not measure" instead of conflating the two into a false all-clear.
+
+It runs inside the Fly machine so it can reuse the SAME live Telegram
+channel every other server-side alert already uses (AlertService, with its
+own dedup/backoff) rather than a hand-rolled curl — the GitHub Action layer
+only needs FLY_API_TOKEN, matching ``llm_credit_sentinel``'s pattern.
+
+AlertService's dedup lives in process memory, which does not survive one
+short-lived CLI invocation to the next, so a second, file-based cooldown
+(``GEMINI_BURN_GUARD_STATE_PATH``, default ``/data/gemini_burn_guard_last_alert.json``
+on the ``rag`` machine's persistent volume) stops a sustained acceleration
+from re-alerting every run. A failure to read/write that file degrades
+toward alerting again (mild duplicate), never toward silence — the opposite
+failure would hide a real acceleration behind a broken cooldown file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from backend.services.hardening.gemini_burn_guard import (
+    BurnState,
+    BurnWindowStats,
+    GeminiBurnGuard,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s", stream=sys.stderr)
+logger = logging.getLogger("gemini_burn_guard_cli")
+
+_result = logging.getLogger("gemini_burn_guard.result")
+_result.propagate = False
+if not _result.handlers:
+    _handler = logging.StreamHandler(sys.stdout)
+    _handler.setFormatter(logging.Formatter("%(message)s"))
+    _result.addHandler(_handler)
+    _result.setLevel(logging.INFO)
+
+RECENT_HOURS = int(os.environ.get("GEMINI_BURN_GUARD_RECENT_HOURS", "72"))
+BASELINE_DAYS = int(os.environ.get("GEMINI_BURN_GUARD_BASELINE_DAYS", "14"))
+RATIO_THRESHOLD = float(os.environ.get("GEMINI_BURN_GUARD_RATIO_THRESHOLD", "3.0"))
+MIN_RECENT_USD = Decimal(os.environ.get("GEMINI_BURN_GUARD_MIN_RECENT_USD", "1.00"))
+COOLDOWN_HOURS = float(os.environ.get("GEMINI_BURN_GUARD_COOLDOWN_HOURS", "12"))
+STATE_PATH = Path(
+    os.environ.get("GEMINI_BURN_GUARD_STATE_PATH", "/data/gemini_burn_guard_last_alert.json"),
+)
+
+
+def _dsn() -> str | None:
+    return os.getenv("DATABASE_URL") or os.getenv("POSTGRES_URL")
+
+
+async def _fetch_windows() -> tuple[BurnWindowStats, BurnWindowStats]:
+    """Query llm_cost_events for provider='gemini' and return (recent, baseline).
+
+    ``baseline`` is normalised to the SAME wall-clock length as ``recent``
+    (a 14-day trailing average scaled down to the recent-window length) so
+    GeminiBurnGuard's ratio is a straight division, not a unit conversion.
+    """
+    dsn = _dsn()
+    if not dsn:
+        raise RuntimeError("no DATABASE_URL/POSTGRES_URL in environment")
+
+    import asyncpg
+
+    conn = await asyncpg.connect(dsn)
+    try:
+        recent_rows = await conn.fetch(
+            """
+            SELECT model, SUM(cost_usd) AS total, COUNT(*) AS n
+              FROM llm_cost_events
+             WHERE provider = 'gemini'
+               AND ts_utc >= NOW() - ($1 || ' hours')::interval
+             GROUP BY model
+            """,
+            str(RECENT_HOURS),
+        )
+        baseline_row = await conn.fetchrow(
+            """
+            SELECT COALESCE(SUM(cost_usd), 0) AS total, COUNT(*) AS n
+              FROM llm_cost_events
+             WHERE provider = 'gemini'
+               AND ts_utc >= NOW() - ($1 || ' days')::interval - ($2 || ' hours')::interval
+               AND ts_utc <  NOW() - ($2 || ' hours')::interval
+            """,
+            str(BASELINE_DAYS),
+            str(RECENT_HOURS),
+        )
+    finally:
+        await conn.close()
+
+    recent_total = Decimal("0")
+    recent_calls = 0
+    top_model: str | None = None
+    top_model_usd = Decimal("0")
+    for row in recent_rows:
+        row_total = Decimal(str(row["total"] or 0))
+        recent_total += row_total
+        recent_calls += int(row["n"] or 0)
+        if row_total > top_model_usd:
+            top_model_usd = row_total
+            top_model = row["model"]
+
+    recent = BurnWindowStats(
+        total_usd=recent_total,
+        call_count=recent_calls,
+        top_model=top_model,
+        top_model_usd=top_model_usd,
+    )
+
+    baseline_total_full = Decimal(str((baseline_row["total"] if baseline_row else 0) or 0))
+    baseline_calls_full = int((baseline_row["n"] if baseline_row else 0) or 0)
+    # Normalise the N-day baseline down to a figure covering the SAME number
+    # of hours as `recent`, so the guard's ratio is recent-vs-recent-sized-slice.
+    scale = Decimal(RECENT_HOURS) / Decimal(BASELINE_DAYS * 24)
+    baseline = BurnWindowStats(
+        total_usd=baseline_total_full * scale,
+        call_count=int(baseline_calls_full * scale),
+    )
+    return recent, baseline
+
+
+def _read_last_alert() -> dict[str, Any] | None:
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _write_last_alert(state: str, now: datetime) -> None:
+    try:
+        STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        STATE_PATH.write_text(json.dumps({"state": state, "ts_utc": now.isoformat()}))
+    except OSError as exc:
+        logger.warning("impossibile scrivere il cooldown file %s: %s", STATE_PATH, exc)
+
+
+def _should_skip_for_cooldown(now: datetime) -> bool:
+    """True only when the SAME condition alerted within the cooldown window.
+
+    Any uncertainty here (missing/corrupt file, unparsable timestamp) resolves
+    toward "do not skip" — a lost cooldown file causes a duplicate alert, not
+    a suppressed one.
+    """
+    last = _read_last_alert()
+    if not last:
+        return False
+    try:
+        last_ts = datetime.fromisoformat(last["ts_utc"])
+    except (KeyError, ValueError):
+        return False
+    if last.get("state") != BurnState.ACCELERATING.value:
+        return False
+    return (now - last_ts) < timedelta(hours=COOLDOWN_HOURS)
+
+
+def _build_notifiers() -> dict:
+    from backend.services.monitoring.alert_service import AlertLevel, get_alert_service
+
+    async def telegram(text: str) -> bool:
+        result = await get_alert_service().send_alert(
+            title="Gemini burn-rate accelerando",
+            message=text,
+            level=AlertLevel.WARNING,
+            dedup_key="gemini_burn_guard:accelerating",
+        )
+        return bool(result.get("telegram"))
+
+    return {"telegram:alert_service": telegram}
+
+
+async def main() -> int:
+    now = datetime.now(timezone.utc)
+
+    # Cooldown decides WHICH notifiers the guard gets, decided before the
+    # single check() call — GeminiBurnGuard always notifies on ACCELERATING,
+    # so an active cooldown passes no-op notifiers rather than skip logic
+    # living inside the guard (which stays measurement-only, DB-agnostic).
+    skip_notify = _should_skip_for_cooldown(now)
+    guard = GeminiBurnGuard(
+        _fetch_windows,
+        {} if skip_notify else _build_notifiers(),
+        ratio_threshold=RATIO_THRESHOLD,
+        min_recent_usd=MIN_RECENT_USD,
+        window_label=f"{RECENT_HOURS}h",
+    )
+
+    verdict = await guard.check()
+    _result.info("STATE=%s", verdict.state.value)
+    _result.info("DETAIL=%s", verdict.detail[:300])
+    if verdict.ratio is not None:
+        _result.info("RATIO=%.2f", verdict.ratio)
+
+    if verdict.state is BurnState.ACCELERATING:
+        if skip_notify:
+            _result.info("ALERT_SENT=0 (cooldown attivo, ultima notifica <%.0fh fa)", COOLDOWN_HOURS)
+        else:
+            _result.info("ALERT_SENT=1")
+            _write_last_alert(verdict.state.value, now)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/apps/backend-rag/backend/tests/unit/services/hardening/test_gemini_burn_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/hardening/test_gemini_burn_guard.py
@@ -86,11 +86,19 @@ async def test_ordinary_variance_under_threshold_stays_silent():
 
 
 @pytest.mark.asyncio
-async def test_flat_burn_matching_the_real_2026_08_11_outage_shape_stays_silent():
-    """The exact regression this module must never produce: the four real
-    historical depletions showed FLAT spend right up to the wall, never a
-    preceding spike. A guard that alerts on steady-state burn would be
-    noise, not signal."""
+async def test_steady_state_noise_stays_silent():
+    """Day-to-day variance within the same order of magnitude must never
+    alert — a guard that fires on ordinary noise gets muted within a week.
+
+    NOTE (corrected 2026-08-20, do not restate the earlier claim this test
+    used to encode): this is NOT the shape of the real 2026-08-09/11
+    depletion. That episode was verified (llm_cost_events, hourly
+    resolution) to be a step-function RAMP — near-zero spend through
+    2026-08-09 17:00 UTC, then a jump to ~$1-2.4/hour starting 18:00 UTC
+    that stayed elevated for ~56h before the sustained wall. A 72h-vs-14d
+    guard WOULD have measured that ramp — see
+    test_ramp_shaped_like_the_real_2026_08_09_depletion_alerts_with_lead_time
+    below for the shape that actually happened."""
 
     async def fetch():
         return (_stats("3.62"), _stats("3.40"))  # ~1.06x — normal day-to-day noise
@@ -99,6 +107,37 @@ async def test_flat_burn_matching_the_real_2026_08_11_outage_shape_stays_silent(
     guard = _guard(fetch, sent)
     verdict = await guard.check()
     assert (verdict.state, sent) == (BurnState.NORMAL, [])
+
+
+@pytest.mark.asyncio
+async def test_ramp_shaped_like_the_real_2026_08_09_depletion_alerts_with_lead_time():
+    """The real incident this guard exists for. Verified against
+    llm_cost_events (provider='gemini') at hourly resolution: the 14-day
+    baseline before 2026-08-09 ran near-zero (~$0.03-0.05/hour equivalent);
+    at 2026-08-09 18:00 UTC spend jumped to $1.14 in one hour and stayed
+    elevated ($0.06-$2.44/hour) for the next ~56 hours, with two brief
+    self-recovering flutters (~08-10 02:00-04:00, ~08-10 18:00-19:00)
+    before the sustained wall that silenced WhatsApp from 2026-08-11 ~05:00
+    to 2026-08-12 ~01:00-02:00 (confirmed via the sentinel's own
+    STATE=depleted log lines across that window, not inferred).
+
+    A 72h-window guard sampling every 3h would have measured this ramp on
+    its first tick after onset — roughly 2026-08-09 21:00 — about 8 hours
+    before even the first flutter and ~32 hours before the sustained wall.
+    """
+
+    async def fetch():
+        return (
+            _stats("1.14", calls=33, top_model="gemini-2.5-flash", top_model_usd="1.10"),
+            _stats("0.05"),  # 14-day baseline, normalised to the same window length
+        )
+
+    sent: list = []
+    guard = _guard(fetch, sent)
+    verdict = await guard.check()
+    assert verdict.state is BurnState.ACCELERATING
+    assert len(sent) == 1
+    assert "gemini-2.5-flash" in sent[0]
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/services/hardening/test_gemini_burn_guard.py
+++ b/apps/backend-rag/backend/tests/unit/services/hardening/test_gemini_burn_guard.py
@@ -1,0 +1,186 @@
+"""Guilt, innocence, and cannot-verify for the Gemini burn-rate guard.
+
+Mirrors ``test_llm_credit_sentinel.py``'s doctrine: the guilt case is easy;
+the innocence cases are the point. A guard that fires on ordinary variance,
+on cold-start (no baseline yet), or on noise-floor amounts gets muted by its
+audience within a week — and a guard that reports NORMAL when it could not
+even read the ledger is worse than no guard, because it manufactures a false
+all-clear (cicatrix-superscar family #9, W106b doctrine).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from backend.services.hardening.gemini_burn_guard import (
+    BurnState,
+    BurnWindowStats,
+    GeminiBurnGuard,
+)
+
+
+def _guard(fetch, sent: list, **kwargs):
+    async def notify(text: str) -> bool:
+        sent.append(text)
+        return True
+
+    return GeminiBurnGuard(fetch, {"test": notify}, **kwargs)
+
+
+def _stats(total: str, calls: int = 10, top_model: str | None = None, top_model_usd: str = "0"):
+    return BurnWindowStats(
+        total_usd=Decimal(total),
+        call_count=calls,
+        top_model=top_model,
+        top_model_usd=Decimal(top_model_usd),
+    )
+
+
+# --------------------------------------------------------------- guilt
+
+
+@pytest.mark.asyncio
+async def test_burn_far_above_baseline_alerts_and_names_the_model():
+    async def fetch():
+        return (
+            _stats("12.00", top_model="gemini-2.5-flash", top_model_usd="11.50"),
+            _stats("2.00"),  # baseline already normalised to the same window
+        )
+
+    sent: list = []
+    guard = _guard(fetch, sent)
+    verdict = await guard.check()
+    assert verdict.state is BurnState.ACCELERATING
+    assert verdict.ratio == pytest.approx(6.0)
+    assert len(sent) == 1
+    assert "gemini-2.5-flash" in sent[0]
+    assert "non conosco" in sent[0].lower() or "residuo" in sent[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_alert_names_unattributed_model_honestly():
+    async def fetch():
+        return (_stats("10.00", top_model=None), _stats("1.00"))
+
+    sent: list = []
+    guard = _guard(fetch, sent)
+    verdict = await guard.check()
+    assert verdict.state is BurnState.ACCELERATING
+    assert "non attribuibile" in verdict.detail
+
+
+# ----------------------------------------------------------------- innocence
+
+
+@pytest.mark.asyncio
+async def test_ordinary_variance_under_threshold_stays_silent():
+    async def fetch():
+        return (_stats("2.50"), _stats("1.00"))  # 2.5x < default 3.0x threshold
+
+    sent: list = []
+    guard = _guard(fetch, sent)
+    verdict = await guard.check()
+    assert (verdict.state, sent) == (BurnState.NORMAL, [])
+
+
+@pytest.mark.asyncio
+async def test_flat_burn_matching_the_real_2026_08_11_outage_shape_stays_silent():
+    """The exact regression this module must never produce: the four real
+    historical depletions showed FLAT spend right up to the wall, never a
+    preceding spike. A guard that alerts on steady-state burn would be
+    noise, not signal."""
+
+    async def fetch():
+        return (_stats("3.62"), _stats("3.40"))  # ~1.06x — normal day-to-day noise
+
+    sent: list = []
+    guard = _guard(fetch, sent)
+    verdict = await guard.check()
+    assert (verdict.state, sent) == (BurnState.NORMAL, [])
+
+
+@pytest.mark.asyncio
+async def test_no_baseline_history_does_not_read_as_infinite_ratio():
+    async def fetch():
+        return (_stats("5.00"), _stats("0"))
+
+    sent: list = []
+    guard = _guard(fetch, sent)
+    verdict = await guard.check()
+    assert (verdict.state, sent) == (BurnState.NORMAL, [])
+    assert verdict.ratio is None
+
+
+@pytest.mark.asyncio
+async def test_trivial_amount_below_floor_ignored_despite_high_ratio():
+    """$0.01 vs $0.001 baseline is technically 10x and means nothing."""
+
+    async def fetch():
+        return (_stats("0.01"), _stats("0.001"))
+
+    sent: list = []
+    guard = _guard(fetch, sent, min_recent_usd=Decimal("1.00"))
+    verdict = await guard.check()
+    assert (verdict.state, sent) == (BurnState.NORMAL, [])
+
+
+@pytest.mark.asyncio
+async def test_threshold_is_configurable():
+    async def fetch():
+        return (_stats("4.00"), _stats("2.00"))  # 2.0x
+
+    sent: list = []
+    guard = _guard(fetch, sent, ratio_threshold=1.5)
+    verdict = await guard.check()
+    assert verdict.state is BurnState.ACCELERATING
+
+
+# ------------------------------------------------------------ cannot-verify
+
+
+@pytest.mark.asyncio
+async def test_fetch_failure_is_cannot_verify_not_normal_not_accelerating():
+    async def fetch():
+        raise RuntimeError("connection to postgres refused")
+
+    sent: list = []
+    guard = _guard(fetch, sent)
+    verdict = await guard.check()
+    assert verdict.state is BurnState.CANNOT_VERIFY
+    assert sent == []  # a read failure must never alert AND never claim "fine"
+    assert verdict.should_alert is False
+
+
+@pytest.mark.asyncio
+async def test_cannot_verify_never_claims_a_ratio():
+    async def fetch():
+        raise TimeoutError("db unreachable")
+
+    guard = _guard(fetch, [])
+    verdict = await guard.check()
+    assert verdict.ratio is None
+
+
+# ---------------------------------------------------------- fan-out doctrine
+
+
+@pytest.mark.asyncio
+async def test_one_dead_channel_does_not_mute_the_others():
+    async def fetch():
+        return (_stats("10.00", top_model="gemini-3.5-flash", top_model_usd="9.0"), _stats("1.00"))
+
+    delivered: list = []
+
+    async def broken(text: str) -> bool:
+        raise ConnectionError("telegram down")
+
+    async def working(text: str) -> bool:
+        delivered.append(text)
+        return True
+
+    guard = GeminiBurnGuard(fetch, {"broken": broken, "working": working})
+    verdict = await guard.check()
+    assert verdict.state is BurnState.ACCELERATING
+    assert len(delivered) == 1


### PR DESCRIPTION
## Summary

- Adds `GeminiBurnGuard` — a proactive companion to `llm_credit_sentinel` (which catches a Gemini prepay depletion *after* it happens, in ~20 minutes via a cron probe). This new guard watches the *rate* of Gemini spend in `llm_cost_events` and alerts when it accelerates well above its own 14-day trailing baseline, before a depletion wall is hit.
- Honest about its limit by design: Google's AI Studio API exposes no remaining-balance figure anywhere (verified against the installed `google-genai` SDK), so this never claims "N days of autonomy left" — it measures burn-rate acceleration only, and says so in every alert.
- Runs inside the `nuzantara-rag` Fly machine on a new 3-hourly cron (`cron-gemini-burn-guard.yml`), reusing the live Postgres connection and the existing `AlertService`/Telegram channel — no new secrets, same architecture as `cron-llm-credit-sentinel.yml`.
- Fail-open by construction: a Postgres read failure returns `CANNOT_VERIFY` (distinct exit/state), never a false "normal" or a false alarm.

## What I measured before building

- `apps/backend-rag/backend/services/llm_clients/gemini_service.py` → `backend/llm/genai_client.py`: production credential priority is `GOOGLEAISTUDIO_API_KEY` → `settings.google_api_key` → `settings.google_imagen_api_key` (AI Studio pay-as-you-go). The Vertex/service-account path exists but is gated behind `USE_VERTEX_AI` (defaults `false`, comment says "TEMPORARILY DISABLED") — prod runs on the API-key/AI-Studio pool, the one with no balance API.
- **`llm_cost_events` already records Gemini production traffic** — 10,000+ rows since 2026-04-20, continuous through today. My working hypothesis going in ("maybe it's invisible even there") did not hold.
- **Two reactive alert paths already exist and are armed**: `llm_credit_sentinel` (cron probe every 20 min, merged 2026-07-28) and an in-process alert in `llm_gateway.py` (spec "O1") that fires the instant a real request 429s. Both are fast; neither is predictive.
- **One existing spend guard is NOT Gemini-scoped**: `cost_advisor_cli.py --check-daily-cap` sums `cost_usd` across *all* providers against a flat `$20/day`, runs once daily via Pro launchd — current Gemini-only spend (~$0.05-0.2/day for most of the last two weeks) means a Gemini-specific spike can hide inside aggregate traffic even in principle.
- **`error_class` in `llm_cost_events` already captures the depletion, generically.** `genai_client.py:588` sets `error_class = type(e).__name__`; google-genai raises `ClientError` for any 4xx status (`errors.py`), so a 429/RESOURCE_EXHAUSTED lands as `error_class='ClientError'` — indistinguishable from an ordinary bad request in the ledger, but I confirmed it directly: the sentinel's own log line for the 2026-08-10 03:06 and 18:03 probes reads `ClientError: 429 RESOURCE_EXHAUSTED... Your prepayment credits are depleted`. This is a real, cheap follow-up (classify on message text, not just exception type) — flagged, not fixed here: it's a different concern in a different hot file (`genai_client.py`, shared by every Gemini call site), out of this PR's one-concern scope.

## The historical outage shape — corrected after a teammate's re-check (important, read this)

My first draft of this PR claimed "the historical depletions were flat right up to the wall" and built a test asserting that shape. **That claim was wrong**, caught by an independent re-query from a teammate before merge, and my own re-verification went further and found a second, bigger error underneath it:

1. Of the 4 "failure" timestamps in `cron-llm-credit-sentinel` run history I'd initially treated as 4 separate depletions (08-06, 08-10/11, 08-12, 08-17), **I read the raw GH Actions logs for every one of them.** Most were not Gemini failures at all: 2026-08-06 15:28, 2026-08-12 18:07, 2026-08-12 21:06, and 2026-08-17 15:15 all failed in the `setup-flyctl` action-download step — GitHub's own `codeload.github.com` returning `429 Too Many Requests` or a bare `socket hang up`/`Service Unavailable` — before the workflow ever reached the Gemini probe. (Two more 08-06 runs have since aged out of GH's log retention — genuinely unknown, not assumed innocent.)
2. **The one real, sustained depletion in that window** — confirmed via the sentinel's own `STATE=depleted` log lines, cross-checked against `llm_cost_events` — was NOT flat. Hourly spend was near-zero through 2026-08-09 17:00 UTC, then jumped to $1.14 in the 18:00 hour and stayed elevated ($0.06-$2.44/hour, 12-312 calls/hour) for the next ~56 hours — with two brief self-recovering flutters (~08-10 02:00-04:00, ~08-10 18:00-19:00) — before the sustained wall from 2026-08-11 ~05:00 to 2026-08-12 ~01:00-02:00 (the ~20h stretch that silenced WhatsApp).
3. **This guard's own design (72h window vs 14-day baseline, checked every 3h) would have measured that ramp on its first tick after onset** — roughly 2026-08-09 21:00 — about 8 hours before even the first flutter and ~32 hours before the sustained wall. I say this now because I checked it, not because it's the convenient answer; my first draft said the opposite for the same episode because I'd queried too narrow a time window (starting after the ramp had already happened, so it looked flat relative to itself).

I'm leaving this section in the PR rather than quietly fixing the docstring, because a correction that just replaces one unverified claim with another is the same mistake at one remove — this one is anchored to specific timestamps, log lines, and a second engineer's independent query, and every fixed test/docstring is pinned to it. Latest commit is the correction; earlier commit(s) in this PR contain the original, wrong framing (kept for the record, not force-pushed away).

## Design choices

- Baseline = 14-day trailing average, normalized to the same wall-clock length as the recent window (default 72h) so the ratio is a straight division — same `3x`-baseline convention `quota_monitor.py` and `cost_advisor.py` already use on this exact ledger.
- Min absolute floor (`$1.00` default) so a $0.01-vs-$0.001 "10x" doesn't fire.
- No-baseline-yet (cold data) reads as `NORMAL`, not "infinite ratio".
- `AlertService`'s dedup lives in process memory, which does not survive one short-lived CLI invocation to the next (fresh `flyctl ssh console -C "python3 -m ..."` process each cron tick) — added a file-based cooldown (`/data/gemini_burn_guard_last_alert.json`, 12h default). A failure to read/write that file degrades toward *re-alerting* (mild duplicate), never toward silence.

## Test plan

- [x] `pytest backend/tests/unit/services/hardening/test_gemini_burn_guard.py -q` — 12 tests: guilt (accelerating + names the driving model), innocence (steady-state noise, no-baseline cold-start, below-floor noise, configurable threshold), the corrected real-incident-shape test (a ramp, alerts with lead time — not the retracted flat-burn claim), cannot-verify (fetch failure never reads as normal/accelerating, never invents a ratio), fan-out doctrine.
- [x] Mutation-verified by hand: 4 targeted mutations (disable baseline guard, disable min-floor guard, cannot-verify silently becomes normal, notify fires unconditionally) — all 4 killed, file restored clean and diffed against original.
- [x] `pytest backend/tests/unit/services/hardening/ backend/tests/services/hardening/ -q` — 44/44 green, no regressions to sibling organs (re-run after the correction commit).
- [x] Pre-deploy sequence per `CLAUDE.md` §11: import-chain smoke + `test_kg_langgraph.py`/`test_kg_subgraphs.py`/`test_confidence.py` all green.
- [x] `actionlint` on the new workflow — clean.
- [x] Manual sanity check of the file-based cooldown helper (no-file / just-alerted / past-cooldown / corrupt-file-fails-open).

## What's left for the owner (`operator[business]`)

- Nothing new is gated on Zero — this ships as a read-only observability addition on top of already-armed infrastructure (same secrets, same channel).
- Follow-ups flagged, not fixed here (each is a different file/concern than this PR's one-concern scope): (a) `error_class` classification in `genai_client.py` collapses 429/depletion into generic `ClientError` — a real, cheap fix, but touches a hot shared module; (b) `cost_advisor_cli.py --check-daily-cap`'s `$20/day` flat aggregate cap looks stale against current volumes and isn't provider-scoped.
- Item (3) of the original mandate (graceful degradation design for WhatsApp during a depletion) was explicitly scoped as design-only, not build. PR #4080 (`fix(wa): the inbox bot mirrored the escalation marker's form, not its effect`, merged 2026-08-11) already ships a localized-stub + human-escalation path for the abstain-during-depletion case, respecting the standing constraint that WhatsApp never falls back to a general-purpose cloud LLM (PII/quota-contamination boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)