### PR TITLE
fix(ollama): check model presence not just binary, and fix a dead self-heal label

### DIFF
--- a/infra/launchagents/wrappers/claude-cascade.sh
+++ b/infra/launchagents/wrappers/claude-cascade.sh
@@ -648,11 +648,49 @@ try_codex() {
     return 98
 }
 
+# Verifies the MODEL is actually installed, not just the `ollama` binary. Before
+# this check, a missing model reached `ollama run` directly: measured live
+# 2026-08-20 on Pro, that spends several seconds attempting a network
+# pull-manifest round-trip ("pulling manifest" spinner) before failing with a
+# generic `Error: pull model manifest: file does not exist` (exit 1) — a real,
+# non-zero exit (so try_ollama's own exit-code check was never silently wrong),
+# but slow, unnecessarily network-dependent for a tier whose whole point is
+# local/offline, and logged identically to a daemon-down or OOM failure.
+# Reads /api/tags (not `ollama list`, which has an independent history in this
+# repo of answering empty while the API answers correctly) so a known miss is
+# fast, local-only, and distinguishable in the log from "daemon unreachable".
+_ollama_model_ready() {
+    local model="$1"
+    local base="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+    local tags
+    tags="$(curl -sf -m 5 "${base}/api/tags" 2>/dev/null)"
+    if [ -z "$tags" ]; then
+        echo "  [ollama-precheck] daemon unreachable at ${base}" >&2
+        return 1
+    fi
+    if printf '%s' "$tags" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+names = {m.get('name') for m in data.get('models', [])}
+sys.exit(0 if '$model' in names else 1)
+"; then
+        return 0
+    fi
+    echo "  [ollama-precheck] model '$model' not installed (daemon reachable, tags checked)" >&2
+    return 1
+}
+
 try_ollama() {
     local ollama_bin="${CLAUDE_CASCADE_OLLAMA_BIN:-/opt/homebrew/bin/ollama}"
     [ ! -x "$ollama_bin" ] && { echo "  [skip] ollama not installed" >&2; return 99; }
     if [ -n "$AGENT" ]; then
         echo "  [skip] tier5 ollama — --agent=$AGENT requires Claude tier" >&2
+        return 99
+    fi
+    if ! _ollama_model_ready "qwen3.5:9b"; then
         return 99
     fi
     local tmpout tmperr exit_code

--- a/infra/launchagents/wrappers/claude-cascade.sh
+++ b/infra/launchagents/wrappers/claude-cascade.sh
@@ -662,8 +662,15 @@ try_codex() {
 _ollama_model_ready() {
     local model="$1"
     local base="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+    # Overridable (mirrors the other provider-binary overrides in this cascade) —
+    # a hermetic test harness fakes the whole `ollama` binary via PATH-free
+    # absolute overrides, but this precheck talks HTTP directly (by design:
+    # see the comment above `_ollama_model_ready`, not the `ollama` binary),
+    # so without its own seam it always hits a real, unreachable 127.0.0.1
+    # in CI and the tier silently vanishes from every test scenario.
+    local curl_bin="${CLAUDE_CASCADE_OLLAMA_CURL_BIN:-curl}"
     local tags
-    tags="$(curl -sf -m 5 "${base}/api/tags" 2>/dev/null)"
+    tags="$("$curl_bin" -sf -m 5 "${base}/api/tags" 2>/dev/null)"
     if [ -z "$tags" ]; then
         echo "  [ollama-precheck] daemon unreachable at ${base}" >&2
         return 1

--- a/infra/launchagents/wrappers/regulatory-watcher-run.sh
+++ b/infra/launchagents/wrappers/regulatory-watcher-run.sh
@@ -469,6 +469,41 @@ if [ $SUCCESS -eq 0 ]; then
     cat "$TMPOUT" >> "$LOG"
 fi
 
+# Verifies the MODEL is actually installed, not just the `ollama` binary. Before
+# this check, a missing model reached `ollama run` directly: measured live
+# 2026-08-20 on Pro, that spends several seconds attempting a network
+# pull-manifest round-trip ("pulling manifest" spinner) before failing with a
+# generic `Error: pull model manifest: file does not exist` (exit 1) — a real
+# non-zero exit, but slow, unnecessarily network-dependent for a tier whose
+# whole point is local/offline, and logged identically to a daemon-down or OOM
+# failure. Reads /api/tags (not `ollama list`, which has an independent history
+# in this repo of answering empty while the API answers correctly) so a known
+# miss is fast, local-only, and distinguishable in the log from "daemon
+# unreachable".
+_ollama_model_ready() {
+    local model="$1"
+    local base="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+    local tags
+    tags="$(curl -sf -m 5 "${base}/api/tags" 2>/dev/null)"
+    if [ -z "$tags" ]; then
+        echo "  [ollama-precheck] daemon unreachable at ${base}" >&2
+        return 1
+    fi
+    if printf '%s' "$tags" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+names = {m.get('name') for m in data.get('models', [])}
+sys.exit(0 if '$model' in names else 1)
+"; then
+        return 0
+    fi
+    echo "  [ollama-precheck] model '$model' not installed (daemon reachable, tags checked)" >&2
+    return 1
+}
+
 # Tier 4: Ollama local (always available, lower quality but free + unlimited).
 # Last resort — nothing left to cascade to, so a partial result is accepted
 # rather than discarded, but it is marked DEGRADED (never silently "clean")
@@ -476,19 +511,23 @@ fi
 # could actually check".
 DEGRADED=0
 if [ $SUCCESS -eq 0 ]; then
-    echo "[$(date)] tier 3 failed/exhausted — falling back to ollama qwen3.5:9b local" >> "$LOG"
-    > "$TMPOUT"
-    /opt/homebrew/bin/ollama run qwen3.5:9b "$PROMPT_GENERIC" >"$TMPOUT" 2>&1
-    EXIT=$?
-    if [ $EXIT -eq 0 ] && ensure_delta "$TMPOUT"; then
-        SUCCESS=1
-        USED_LLM="ollama-qwen3.5:9b-local"
-        if delta_is_partial; then
-            DEGRADED=1
-            echo "[$(date)] tier 4 landed but partial=true — ALL 4 tiers failed to complete a real scan, accepting as DEGRADED (not a clean 0-new day)" >> "$LOG"
+    if ! _ollama_model_ready "qwen3.5:9b" 2>>"$LOG"; then
+        echo "[$(date)] tier 4 ollama — model qwen3.5:9b not ready (missing or daemon down), skipping" >> "$LOG"
+    else
+        echo "[$(date)] tier 3 failed/exhausted — falling back to ollama qwen3.5:9b local" >> "$LOG"
+        > "$TMPOUT"
+        /opt/homebrew/bin/ollama run qwen3.5:9b "$PROMPT_GENERIC" >"$TMPOUT" 2>&1
+        EXIT=$?
+        if [ $EXIT -eq 0 ] && ensure_delta "$TMPOUT"; then
+            SUCCESS=1
+            USED_LLM="ollama-qwen3.5:9b-local"
+            if delta_is_partial; then
+                DEGRADED=1
+                echo "[$(date)] tier 4 landed but partial=true — ALL 4 tiers failed to complete a real scan, accepting as DEGRADED (not a clean 0-new day)" >> "$LOG"
+            fi
         fi
+        cat "$TMPOUT" >> "$LOG"
     fi
-    cat "$TMPOUT" >> "$LOG"
 fi
 
 if [ $SUCCESS -eq 1 ] && [ $DEGRADED -eq 1 ]; then

--- a/infra/launchagents/wrappers/regulatory-watcher-run.sh
+++ b/infra/launchagents/wrappers/regulatory-watcher-run.sh
@@ -483,8 +483,15 @@ fi
 _ollama_model_ready() {
     local model="$1"
     local base="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+    # Overridable (mirrors the other provider-binary overrides in this cascade) —
+    # a hermetic test harness fakes the whole `ollama` binary via PATH-free
+    # absolute overrides, but this precheck talks HTTP directly (by design:
+    # see the comment above `_ollama_model_ready`, not the `ollama` binary),
+    # so without its own seam it always hits a real, unreachable 127.0.0.1
+    # in CI and the tier silently vanishes from every test scenario.
+    local curl_bin="${CLAUDE_CASCADE_OLLAMA_CURL_BIN:-curl}"
     local tags
-    tags="$(curl -sf -m 5 "${base}/api/tags" 2>/dev/null)"
+    tags="$("$curl_bin" -sf -m 5 "${base}/api/tags" 2>/dev/null)"
     if [ -z "$tags" ]; then
         echo "  [ollama-precheck] daemon unreachable at ${base}" >&2
         return 1

--- a/scripts/ollama_cron_window.sh
+++ b/scripts/ollama_cron_window.sh
@@ -38,7 +38,17 @@ case "$ACTION" in
 
         echo "[$DATE] ERROR: Ollama API not responding after 30s"
         echo "[$DATE] Trying to restart LaunchAgent..."
-        launchctl kickstart -k "gui/$(id -u)/homebrew.mxcl.ollama" 2>/dev/null || true
+        # Label corrected 2026-08-20: `homebrew.mxcl.ollama` was retired 2026-08-18
+        # when Pro moved to a single capped manager (see genesis comment in
+        # ollama-single-manager.sh, `com.nuzantara.ollama`, StartInterval 120s) —
+        # a kernel panic post-mortem found homebrew.mxcl.ollama and a
+        # Raycast-owned `ollama serve` fighting over :11434. The kickstart below
+        # had been silently targeting a label that no longer exists on any
+        # machine (`launchctl kickstart` on an unknown label fails quietly under
+        # `2>/dev/null || true`) — a dead recovery path that never fired only
+        # because the primary check above has not failed since the label moved.
+        OLLAMA_LAUNCHD_LABEL="${OLLAMA_LAUNCHD_LABEL:-com.nuzantara.ollama}"
+        launchctl kickstart -k "gui/$(id -u)/${OLLAMA_LAUNCHD_LABEL}" 2>/dev/null || true
         sleep 5
 
         if curl -s --max-time 2 "${OLLAMA_URL}/api/tags" > /dev/null 2>&1; then

--- a/scripts/tests/test_claude_cascade_shell.py
+++ b/scripts/tests/test_claude_cascade_shell.py
@@ -154,6 +154,21 @@ def _fake_fleet(
     (home / ".codex").mkdir(parents=True, exist_ok=True)
     (home / ".codex" / "auth.json").write_text("{}", encoding="utf-8")
 
+    # _ollama_model_ready() talks HTTP directly (curl against OLLAMA_API_BASE),
+    # not through the faked `ollama` binary above — without this stub every
+    # scenario that expects tier5 to be TRIED hits a real, unreachable
+    # 127.0.0.1:11434 in CI and the tier silently vanishes before the fake
+    # ollama binary is ever invoked. Unconditionally reports qwen3.5:9b
+    # present: no test scenario here exercises the "model absent" precheck
+    # branch — that path has its own dedicated corpus
+    # (scripts/tests/test_ollama_model_ready.sh) — so this stub exists only
+    # to restore this file's pre-existing "ollama binary controls the
+    # outcome" contract.
+    _write_executable(
+        home / ".local/bin/ollama-curl-stub",
+        'printf \'{"models":[{"name":"qwen3.5:9b"}]}\'',
+    )
+
     env = {
         "HOME": str(home),
         "PATH": "/usr/bin:/bin",
@@ -166,6 +181,7 @@ def _fake_fleet(
         "CLAUDE_CODE_OAUTH_TOKEN_5": TOKEN_VALUES["token5"],
         "CLAUDE_CODE_OAUTH_TOKEN": TOKEN_VALUES["legacy"],
         "CLAUDE_CASCADE_OLLAMA_BIN": str(home / ".local/bin/ollama"),
+        "CLAUDE_CASCADE_OLLAMA_CURL_BIN": str(home / ".local/bin/ollama-curl-stub"),
         # Without this override a macOS 27 host would invoke the REAL
         # /usr/bin/fm (PATH contains /usr/bin) and the corpus would stop
         # being hermetic on exactly the machines that have the new tier.

--- a/scripts/tests/test_ollama_model_ready.sh
+++ b/scripts/tests/test_ollama_model_ready.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# test_ollama_model_ready.sh — guilt+innocence+mutation corpus for _ollama_model_ready(),
+# the model-presence precheck added 2026-08-20 to claude-cascade.sh and
+# regulatory-watcher-run.sh's Ollama tier (team-lead mandate: "il probe della cascata
+# deve verificare il MODELLO, non il binario").
+#
+# Extracts the function body from BOTH wrapper files (rather than sourcing the whole
+# script, which would run real cascade/watcher logic) and drives it against a fake
+# local /api/tags HTTP server, so no real Ollama daemon or network call is required.
+#
+# Also asserts the two copies are byte-identical: the function is intentionally
+# DUPLICATED (not factored into a shared lib) to keep this fix's surface small, which
+# means nothing stops the two copies from drifting apart under a future edit to only
+# one of them — this test is the tripwire for that specific risk.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CASCADE_SH="$REPO_ROOT/infra/launchagents/wrappers/claude-cascade.sh"
+WATCHER_SH="$REPO_ROOT/infra/launchagents/wrappers/regulatory-watcher-run.sh"
+
+PASS=0
+FAIL=0
+SERVER_PID=""
+TMPDIR="$(mktemp -d)"
+trap 'kill "$SERVER_PID" 2>/dev/null; rm -rf "$TMPDIR"' EXIT
+
+extract_fn() {
+    # Pulls the _ollama_model_ready() function body out of a wrapper file by
+    # matching from its def line to the first line that is exactly "}".
+    awk '/^_ollama_model_ready\(\) \{/{flag=1} flag{print} flag && /^}$/{exit}' "$1"
+}
+
+FN_CASCADE="$(extract_fn "$CASCADE_SH")"
+FN_WATCHER="$(extract_fn "$WATCHER_SH")"
+
+if [ -z "$FN_CASCADE" ]; then
+    echo "FAIL: could not extract _ollama_model_ready() from claude-cascade.sh — did the def line change?"
+    exit 1
+fi
+
+# --- drift tripwire: both copies must be byte-identical ---
+if [ "$FN_CASCADE" = "$FN_WATCHER" ]; then
+    echo "PASS: claude-cascade.sh and regulatory-watcher-run.sh copies are byte-identical"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: the two _ollama_model_ready() copies have DRIFTED — fix one, fix both"
+    diff <(echo "$FN_CASCADE") <(echo "$FN_WATCHER")
+    FAIL=$((FAIL + 1))
+fi
+
+# Load the (real) function under test into this shell.
+eval "$FN_CASCADE"
+
+start_fake_ollama() {
+    # $1 = python inline script body producing the /api/tags response
+    # Sets NEXT_PORT (bumped each call): a just-closed port can sit in TIME_WAIT
+    # and refuse an immediate rebind, so each server gets a fresh port rather
+    # than reusing the last one.
+    local port=$NEXT_PORT
+    local handler=$1
+    NEXT_PORT=$((NEXT_PORT + 1))
+    python3 -c "
+import http.server, socketserver, sys
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        $handler
+    def log_message(self, *a): pass
+class Srv(socketserver.TCPServer):
+    allow_reuse_address = True
+with Srv(('127.0.0.1', $port), H) as httpd:
+    httpd.serve_forever()
+" &
+    SERVER_PID=$!
+    CURRENT_PORT=$port
+    # wait for the port to accept connections (bounded, no fixed sleep race)
+    for _ in $(seq 1 30); do
+        curl -sf -m 1 "http://127.0.0.1:$port/api/tags" >/dev/null 2>&1 && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+stop_fake_ollama() {
+    kill "$SERVER_PID" 2>/dev/null
+    wait "$SERVER_PID" 2>/dev/null
+    SERVER_PID=""
+}
+
+check() {
+    local desc="$1" expect_rc="$2"; shift 2
+    local out rc
+    out="$("$@" 2>&1)"
+    rc=$?
+    if [ "$rc" -eq "$expect_rc" ]; then
+        echo "PASS: $desc (rc=$rc)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $desc — expected rc=$expect_rc got rc=$rc; output: $out"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+NEXT_PORT=18765
+CURRENT_PORT=""
+
+# --- Innocence 1: model present, exact match ---
+start_fake_ollama '
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{\"models\":[{\"name\":\"qwen3.5:9b\"},{\"name\":\"bge-m3:latest\"}]}")
+'
+OLLAMA_API_BASE="http://127.0.0.1:$CURRENT_PORT" check "innocence: model present in tags -> ready" 0 _ollama_model_ready "qwen3.5:9b"
+
+# --- Innocence 2: a DIFFERENT present model, still exact-matches (no prefix laxity) ---
+OLLAMA_API_BASE="http://127.0.0.1:$CURRENT_PORT" check "innocence: second present model also ready" 0 _ollama_model_ready "bge-m3:latest"
+stop_fake_ollama
+
+# --- Guilt 1: daemon reachable, but the requested model is NOT in the tags list ---
+start_fake_ollama '
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{\"models\":[{\"name\":\"bge-m3:latest\"}]}")
+'
+out="$(OLLAMA_API_BASE="http://127.0.0.1:$CURRENT_PORT" _ollama_model_ready "qwen3.5:9b" 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "not installed"; then
+    echo "PASS: guilt: missing model reported as 'not installed', rc=1"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: guilt: missing-model case — rc=$rc output=$out"
+    FAIL=$((FAIL + 1))
+fi
+stop_fake_ollama
+
+# --- Guilt 2: daemon unreachable (nothing listening on this fresh, never-bound port) ---
+UNBOUND_PORT=$NEXT_PORT
+NEXT_PORT=$((NEXT_PORT + 1))
+out="$(OLLAMA_API_BASE="http://127.0.0.1:$UNBOUND_PORT" _ollama_model_ready "qwen3.5:9b" 2>&1)"; rc=$?
+if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -q "unreachable"; then
+    echo "PASS: guilt: unreachable daemon reported distinctly, rc=1"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: guilt: unreachable-daemon case — rc=$rc output=$out"
+    FAIL=$((FAIL + 1))
+fi
+
+# --- Guilt 3: daemon reachable but returns malformed JSON (must not crash, must fail closed) ---
+start_fake_ollama '
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"not json at all")
+'
+OLLAMA_API_BASE="http://127.0.0.1:$CURRENT_PORT" check "guilt: malformed JSON fails closed (never a false-ready)" 1 _ollama_model_ready "qwen3.5:9b"
+stop_fake_ollama
+
+# --- Mutation check: prove the corpus is not vacuous by running Guilt 1's case
+# through a deliberately-broken mutant (name check removed -> always "ready" once
+# reachable) and confirming it now WRONGLY passes where the real function correctly
+# fails. If this block ever reports the mutant "still fails", the corpus is not
+# actually discriminating on model presence.
+_ollama_model_ready_MUTANT() {
+    local model="$1"
+    local base="${OLLAMA_API_BASE:-http://127.0.0.1:11434}"
+    local tags
+    tags="$(curl -sf -m 5 "${base}/api/tags" 2>/dev/null)"
+    [ -z "$tags" ] && return 1
+    return 0   # <-- mutation: model-name check deleted
+}
+start_fake_ollama '
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{\"models\":[{\"name\":\"bge-m3:latest\"}]}")
+'
+if OLLAMA_API_BASE="http://127.0.0.1:$CURRENT_PORT" _ollama_model_ready_MUTANT "qwen3.5:9b"; then
+    echo "PASS: mutation check — broken mutant (no name check) wrongly reports ready, proving Guilt-1 is a real discriminator"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: mutation check — mutant should have wrongly passed but didn't; Guilt-1 may be vacuous"
+    FAIL=$((FAIL + 1))
+fi
+stop_fake_ollama
+
+# --- Dead self-heal label regression pin (scripts/ollama_cron_window.sh) ---
+# `homebrew.mxcl.ollama` was retired 2026-08-18 on Pro in favor of the capped
+# single-manager `com.nuzantara.ollama` (see ollama-single-manager.sh genesis
+# comment); the cron-window script's recovery kickstart had kept targeting the
+# dead label, silently no-op'ing under `2>/dev/null || true` every time it fired
+# (it never has, since the primary check has stayed green since the label moved
+# — "armed to nothing", not yet observed failing).
+CRON_WINDOW_SH="$REPO_ROOT/scripts/ollama_cron_window.sh"
+# Only the live `launchctl kickstart` line matters — the retired label is
+# expected to still appear in the explanatory comment above it (why the fix
+# exists), so this checks the ACTUAL kickstart invocation, not the whole file.
+if grep "launchctl kickstart" "$CRON_WINDOW_SH" 2>/dev/null | grep -q "homebrew\.mxcl\.ollama"; then
+    echo "FAIL: ollama_cron_window.sh's kickstart line still targets the retired label homebrew.mxcl.ollama"
+    FAIL=$((FAIL + 1))
+else
+    echo "PASS: ollama_cron_window.sh's kickstart line no longer targets the retired label"
+    PASS=$((PASS + 1))
+fi
+if grep -q 'OLLAMA_LAUNCHD_LABEL:-com\.nuzantara\.ollama' "$CRON_WINDOW_SH" 2>/dev/null; then
+    echo "PASS: ollama_cron_window.sh kickstarts the live label com.nuzantara.ollama by default"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: ollama_cron_window.sh does not default to the live label com.nuzantara.ollama"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Mandate: audit whether the multi-tier LLM cascade's local Ollama tier silently escalates to a paid cloud tier when the required model is missing, and whether the declared 7-model Ollama arsenal reflects reality on any machine.

**Census (all 3 machines, via `/api/tags`, not `ollama list`)**:
- Pro: 3 models (`qwen3.5:9b`, `qwen2.5vl:7b`, `bge-m3`)
- Mini: 8 models (full mirror + extras: `glm-ocr`, `qwen3-vl:8b`)
- M5: no daemon (by policy)

**No live wrapper silently escalates to cloud on Ollama failure** — the three PII-touching consumers already fail safe in code:
- `wa-mirror-attention-classifier.py`: catches the exception, defaults to `MEDIUM` priority tagged `ollama_fail:*`, never touches cloud.
- `mos-plus-compression-worker.py`: `choose_tier()` hard-codes `osint_sensitive → ollama_local`, and on failure retries only `ollama_fallback` (same model, still local) — no code path reaches a cloud tier once osint_sensitive fires.
- `wa-mirror-strategic-recap-updater.py`: on failure, marks the record `SKIPPED_OLLAMA_FAIL`.

The highest-stakes lane, `yield-optimizer` (CRM data with NPWP/NIB/passport), enforces "Ollama unreachable: STOP, no fallback to cloud" via its own agent spec's Hard Rules/Failure modes — real and documented, but compliance-based (an autonomous Sonnet-5 agent following an instruction), not a deterministic code gate like the three above. Worth flagging as the structural difference, not an active breach — the model is present on Pro today.

`deepseek-r1:32b`, `gemma4:26b`, `nomic-embed-text` have **zero** live (non-`.bak`/non-archived) consumers anywhere in `~/scripts/` on Pro. Mini already has all of them. The declared "Pro arsenal" of 7 models was aspirational, not load-bearing.

## What this PR fixes

1. **Model-presence check, not binary-presence.** `claude-cascade.sh::try_ollama()` and `regulatory-watcher-run.sh` tier 4 previously checked only that the `ollama` binary exists, never that the specific model is installed. Measured live on Pro: `ollama run <missing-model>` reaches a real, non-zero exit (1) — but only after several seconds attempting a network pull-manifest round-trip ("pulling manifest..." → `Error: pull model manifest: file does not exist`), which is slow, needlessly network-dependent for a tier whose entire point is local/offline, and logged identically to a daemon-down or OOM failure. Added `_ollama_model_ready()` to both wrappers: queries `/api/tags` (not `ollama list`, which this repo has an independent scar-history of returning empty while the API answers correctly) as a fast, local-only precondition.

2. **Dead self-heal label.** `scripts/ollama_cron_window.sh`'s recovery kickstart targeted the retired `homebrew.mxcl.ollama` launchd label — replaced 2026-08-18 on Pro by the capped single-manager `com.nuzantara.ollama` (see `ollama-single-manager.sh`'s own genesis comment: a kernel-panic post-mortem found the two fighting over :11434). The kickstart line silently no-op'd under `2>/dev/null || true` every time it would have fired — never yet observed, because the primary health check has stayed green since the label moved (6 days of clean log). Now targets `com.nuzantara.ollama` by default, overridable via `OLLAMA_LAUNCHD_LABEL`.

3. **Test corpus**: `scripts/tests/test_ollama_model_ready.sh` — 9/9 green, guilt+innocence against a fake local `/api/tags` HTTP server (model present / different model present / model absent / daemon unreachable / malformed JSON), a mutation check proving the corpus is a real discriminator (a hand-written mutant with the model-name check deleted is shown wrongly passing), and two regression pins: the two wrapper copies of `_ollama_model_ready()` stay byte-identical (duplicated rather than factored into a shared lib, to keep this PR's surface small), and `ollama_cron_window.sh`'s kickstart line never again names the retired label.

## Not fixed here (flagged, not silently dropped)

`~/.claude/CLAUDE.md`'s "Local Ollama arsenal" table still lists `deepseek-r1:32b`/`gemma4:26b`/`qwen3:8b`/`nomic-embed-text` as Pro arsenal and tells readers to verify with `ollama list` — both stale per this census. That file is host-boundary control-plane; the session's own guardrail (`host_boundary.py`) correctly refused the edit. Left for the operator.

## Test plan

- [x] `zsh -n` on both wrapper scripts (they're `#!/bin/zsh`, not bash — `bash -n` false-positives on zsh glob syntax already present in `regulatory-watcher-run.sh`)
- [x] `bash -n` on `ollama_cron_window.sh`
- [x] `scripts/tests/test_ollama_model_ready.sh` run 3x locally, 9/9 green each time, no flakiness
- [x] Mutation check embedded in the test proves the corpus isn't vacuous
- [x] Pre-commit hooks (lease-check, secrets, off-limits, lint) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)