### PR TITLE
feat(ci): path-aware gating for security.yml — skip scanners a diff can't need

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,14 @@
 /scripts/ci/ring_gating_override.sh                  @Balizero1987
 /scripts/ci/test_ring_gating_override.py             @Balizero1987
 
+# security.yml path-aware gating (2026-08-20) — the flag math that decides
+# which of the seven security scanners a PR actually runs. Same trust
+# boundary as change_map.py above and extracted from BASE_SHA alongside it
+# in security.yml's own `changes` job: a PR could otherwise bypass gating
+# by editing THIS file's rules directly, leaving change_map.py untouched.
+/scripts/ci/security_gate_flags.py                   @Balizero1987
+/scripts/ci/test_security_gate_flags.py              @Balizero1987
+
 # ---------------------------------------------------------------------------
 # Deploy / infra config — TIER 1
 # ---------------------------------------------------------------------------

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -69,8 +69,246 @@ concurrency:
   cancel-in-progress: ${{ (github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 jobs:
+  # Path-aware gating (2026-08-20). Before this job existed, all 8 jobs below
+  # ran on EVERY pull_request and EVERY merge_group entry, unconditionally —
+  # measured live over a 70-minute window at 424.7 runner-minutes total,
+  # 364 min/h, ~39.84 min/run, and merge_group alone was 47.5% of all minutes
+  # this workflow burns. A PR touching only a .md file paid the full bill.
+  #
+  # This job does NOT invent a second classifier. It reuses the exact
+  # `scripts/ci/change_map.py` domain model + `scripts/ci/hotzone_changed_files.sh`
+  # enumerator that tests.yml's own `changes` job (promoted to enforcing
+  # 2026-08-14, PR #4181) already runs in production — same root-of-trust
+  # extraction, same corpus self-test, same manual override, same fail-open
+  # polarity on every layer. GitHub Actions `needs.*.outputs` are scoped to a
+  # single workflow file, so a literal second `changes` job is unavoidable —
+  # but the JUDGING LOGIC (change_map.py) is the identical file, not a fork of it.
+  #
+  # What differs from tests.yml's job is only the DERIVED FLAGS: six test
+  # suites there, seven security scanners here, each with its own trigger
+  # rationale (see the per-job `if:` comments below). detect-secrets is
+  # deliberately absent from every flag here — see its own job for why.
+  changes:
+    name: Change map (security)
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      map: ${{ steps.classify.outputs.map }}
+      # Fail-open defaults (superscar #2 "esiste ≠ armato"): any failure of
+      # the override probe, the classifier corpus, the trusted-extraction
+      # step, the enumerator, or this step's own JSON parsing leaves
+      # steps.classify.outputs.* unset, and every `|| 'true'` below then
+      # makes the corresponding scanner run. There is no path from a broken
+      # classifier to a silently-skipped scan.
+      run_all: ${{ steps.classify.outputs.run_all || 'true' }}
+      run_codeql_python: ${{ steps.classify.outputs.run_codeql_python || 'true' }}
+      run_codeql_js: ${{ steps.classify.outputs.run_codeql_js || 'true' }}
+      run_bandit: ${{ steps.classify.outputs.run_bandit || 'true' }}
+      run_snyk_python: ${{ steps.classify.outputs.run_snyk_python || 'true' }}
+      run_safety: ${{ steps.classify.outputs.run_safety || 'true' }}
+      run_snyk_docker: ${{ steps.classify.outputs.run_snyk_docker || 'true' }}
+      run_snyk_node: ${{ steps.classify.outputs.run_snyk_node || 'true' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Same discretionary manual lever as tests.yml (Merge-OS round-2 Cure
+      # #1) — ONE operator switch forces the full suite on BOTH workflows
+      # during an incident, rather than two separate variables to remember.
+      # Truth table lives in scripts/ci/ring_gating_override.sh: only the
+      # exact literal "true" activates; every other value (unset, "false",
+      # typo) leaves the classifier deciding, i.e. today's behavior.
+      - name: Manual override — force full suite (Merge-OS round-2 Cure #1)
+        id: override
+        env:
+          MERGEOS_RING_GATING_DISABLED: ${{ vars.MERGEOS_RING_GATING_DISABLED }}
+        run: bash scripts/ci/ring_gating_override.sh >> "$GITHUB_OUTPUT"
+
+      - name: Self-test ring-gating override (guilt + innocence)
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 scripts/ci/test_ring_gating_override.py
+
+      # ROOT OF TRUST — identical rationale to tests.yml's own extraction
+      # step: a PR that breaks something CodeQL/Bandit/Snyk would have
+      # caught could, in the same commit, edit change_map.py (or
+      # security_gate_flags.py — see its own module docstring) to
+      # misclassify itself away from the scanner that would have caught it.
+      # Extract all five classifier files from BASE_SHA (main's tip for a
+      # PR, the queue's base for merge_group) and judge with ONLY those
+      # copies — a PR can propose a change to the classifier, but that
+      # change judges every OTHER PR first and only starts judging PRs once
+      # merged. `.github/` and `scripts/ci/` are already PREFIX_RULES
+      # entries mapped to security_sensitive, so a PR editing the classifier
+      # is itself classified run-everything by the OLD copy doing the judging.
+      - name: Extract trusted classifier (base ref)
+        id: extract
+        if: steps.override.outputs.active != 'true'
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          CLASSIFIER_DIR="$RUNNER_TEMP/trusted-classifier"
+          mkdir -p "$CLASSIFIER_DIR"
+          OK=true
+          for f in scripts/ci/change_map.py scripts/ci/test_change_map.py scripts/ci/hotzone_changed_files.sh scripts/ci/security_gate_flags.py scripts/ci/test_security_gate_flags.py; do
+            if ! git show "${BASE_SHA}:${f}" > "$CLASSIFIER_DIR/$(basename "$f")" 2>/dev/null; then
+              echo "::warning::could not extract $f from base ref $BASE_SHA — treating classifier as untrusted for this run"
+              OK=false
+            fi
+          done
+          chmod +x "$CLASSIFIER_DIR/hotzone_changed_files.sh" 2>/dev/null || true
+          echo "dir=$CLASSIFIER_DIR" >> "$GITHUB_OUTPUT"
+          echo "ok=$OK" >> "$GITHUB_OUTPUT"
+
+      - name: Verify change-map guilt and innocence corpus
+        id: classifier-tests
+        if: steps.override.outputs.active != 'true'
+        continue-on-error: true
+        env:
+          CLASSIFIER_DIR: ${{ steps.extract.outputs.dir }}
+          EXTRACT_OK: ${{ steps.extract.outputs.ok }}
+        run: |
+          set -uo pipefail
+          if [ "$EXTRACT_OK" != "true" ]; then
+            echo "::error::base-ref classifier extraction failed — refusing to trust a corpus that didn't run"
+            exit 1
+          fi
+          python3 "$CLASSIFIER_DIR/test_change_map.py"
+          python3 "$CLASSIFIER_DIR/test_security_gate_flags.py"
+
+      # merge_group base/head SHAs — same established pattern as
+      # hot-zone-pr-gate.yml / tests.yml / harness-floor.yml.
+      - name: Enumerate and classify this PR's files
+        id: classify
+        if: steps.override.outputs.active != 'true'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+          CLASSIFIER_TEST_OUTCOME: ${{ steps.classifier-tests.outcome }}
+          CLASSIFIER_DIR: ${{ steps.extract.outputs.dir }}
+          EXTRACT_OK: ${{ steps.extract.outputs.ok }}
+        run: |
+          set -uo pipefail
+          CHANGED_FILE="$RUNNER_TEMP/change-map-changed-files.txt"
+
+          if [ "$EXTRACT_OK" != "true" ] || [ "$CLASSIFIER_TEST_OUTCOME" != "success" ]; then
+            echo "::warning::classifier untrusted or corpus failed; recommendation defaults to all scanners"
+            printf '%s\n' '__CHANGE_MAP_ENUMERATION_ERROR__' > "$CHANGED_FILE"
+          elif ! bash "$CLASSIFIER_DIR/hotzone_changed_files.sh" \
+            "$BASE_SHA" "$HEAD_SHA" "$PR_NUMBER" > "$CHANGED_FILE"; then
+            echo "::warning::changed-file enumeration failed; recommendation defaults to all scanners"
+            printf '%s\n' '__CHANGE_MAP_ENUMERATION_ERROR__' > "$CHANGED_FILE"
+          fi
+
+          if ! MAP_JSON="$(python3 "$CLASSIFIER_DIR/change_map.py" < "$CHANGED_FILE")"; then
+            echo "::warning::change_map.py exited non-zero; forcing conservative fallback"
+            MAP_JSON='{"schema_version":1,"mode":"enforcing","reason":"classifier_runtime_failure","changed_file_count":0,"domains":{},"unknown_paths":[],"run_all":true,"suggested_jobs":[],"would_skip":[]}'
+          fi
+          RUN_ALL="$(MAP_JSON="$MAP_JSON" python3 -c 'import json, os; print(str(json.loads(os.environ["MAP_JSON"])["run_all"]).lower())')"
+          echo "map=$MAP_JSON" >> "$GITHUB_OUTPUT"
+          echo "run_all=$RUN_ALL" >> "$GITHUB_OUTPUT"
+
+          # Per-scanner flags, delegated to security_gate_flags.py (the SAME
+          # trusted, BASE_SHA-extracted copy as change_map.py above — root
+          # of trust applies to the flag math too, not just the domain
+          # classification: a PR editing this file's rules directly, leaving
+          # change_map.py untouched, is a distinct bypass this extraction
+          # also closes). See that module for the per-scanner rationale
+          # (docstring + FLAG_DOMAINS table) and
+          # scripts/ci/test_security_gate_flags.py for its guilt/innocence
+          # corpus (run above, alongside test_change_map.py). It also owns
+          # the JS-manifest predicate that closes a verified gap in
+          # change_map.py's own JS-manifest rule (EXACT_RULES matches only
+          # the literal root-level "package.json"/"package-lock.json" —
+          # apps/wa-mirror/package-lock.json, this repo's own nested
+          # lockfile outside the root npm-workspaces tree, falls through to
+          # PREFIX_RULES and is tagged only "wa_mirror", never
+          # "security_sensitive"). Deliberately NOT fixed inside
+          # change_map.py itself: that file is under active review in
+          # another PR the same day (#4441, adding a fleet_ops domain to
+          # unrelated scripts/ subdirectories) — flagged as a worthwhile
+          # upstream follow-up, not fixed here, to avoid two PRs touching
+          # the same CODEOWNERS-tier1 file in parallel.
+          JOB_FLAGS="$(MAP_JSON="$MAP_JSON" python3 "$CLASSIFIER_DIR/security_gate_flags.py" < "$CHANGED_FILE")"
+          echo "$JOB_FLAGS" >> "$GITHUB_OUTPUT"
+          echo "::notice::security change-map: $MAP_JSON"
+          echo "::notice::security gate flags: $JOB_FLAGS"
+
+      - name: Publish change-map decision
+        if: always()
+        env:
+          MAP_JSON: ${{ steps.classify.outputs.map }}
+          CLASSIFIER_TEST_OUTCOME: ${{ steps.classifier-tests.outcome }}
+          CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
+          OVERRIDE_ACTIVE: ${{ steps.override.outputs.active }}
+          JS_MANIFEST_TOUCHED: ${{ steps.classify.outputs.js_manifest_touched }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          raw = os.environ.get("MAP_JSON", "")
+          if raw:
+              result = json.loads(raw)
+          elif os.environ.get("OVERRIDE_ACTIVE") == "true":
+              result = {"reason": "manual_override_disabled", "run_all": True, "unknown_paths": []}
+          else:
+              result = {"reason": "classifier_runtime_failure", "run_all": True, "unknown_paths": []}
+
+          lines = [
+              "## Security change map",
+              "",
+              f"- Classifier corpus: `{os.environ['CLASSIFIER_TEST_OUTCOME']}`",
+              f"- Classification step: `{os.environ['CLASSIFY_OUTCOME']}`",
+              f"- Conservative fallback (run everything): `{str(result['run_all']).lower()}`",
+              f"- Reason: `{result['reason']}`",
+              f"- JS manifest touched (any path): `{os.environ.get('JS_MANIFEST_TOUCHED', 'unknown')}`",
+          ]
+          if result.get("unknown_paths"):
+              lines.extend(
+                  ["", "Unclassified paths (therefore all scanners run):", ""]
+                  + [f"- `{path}`" for path in result["unknown_paths"]]
+              )
+          lines.append("")
+          lines.append(
+              "detect-secrets always runs regardless of this map — see its own job comment."
+          )
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("\n".join(lines) + "\n")
+          PY
+
   snyk-python:
     name: Snyk Python Security
+    needs: [changes]
+    # Path-aware skip (2026-08-20) — see the `changes` job comment for the
+    # full rationale. `!cancelled()` overrides the inherited skip from
+    # `changes` being pull_request/merge_group-only; the event-name branch
+    # makes this job unconditional on push/schedule/workflow_dispatch;
+    # `needs.changes.result != 'success'` covers a stale published output
+    # surviving a later failure in that job; `!= 'false'` is fail-open on
+    # every other path (unset/malformed output never skips a scan).
+    # Snyk-python scans apps/backend-rag/requirements.txt only — gated on
+    # security_sensitive (which already covers any requirements*.txt /
+    # pyproject.toml / uv.lock change, globally, via change_map.py's
+    # basename rule), not on backend_python: a code-only change cannot
+    # alter the declared dependency set this scanner evaluates.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_snyk_python != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Blocking gate — HIGH/CRITICAL CVEs fail the job unless the finding is
@@ -121,6 +359,21 @@ jobs:
 
   snyk-node:
     name: Snyk Node.js Security
+    needs: [changes]
+    # Path-aware skip — see snyk-python's comment for the shared rationale.
+    # Gated on the JS-manifest predicate (any package.json/package-lock.json
+    # anywhere in the tree, not just the root ones change_map.py's
+    # EXACT_RULES literally matches — closes a verified nested-lockfile gap,
+    # e.g. apps/wa-mirror/package-lock.json, its own lockfile outside the
+    # root npm-workspaces tree this job's `npm ci` installs) in addition to
+    # security_sensitive.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_snyk_node != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Blocking gate — see snyk-python. Exceptions honoured via
@@ -173,6 +426,19 @@ jobs:
 
   snyk-docker:
     name: Snyk Docker Security
+    needs: [changes]
+    # Path-aware skip — see snyk-python's comment for the shared rationale.
+    # backend_python is included here (unlike snyk-python/safety) because
+    # this job also validates that the production Dockerfile still BUILDS
+    # (see the job's own comment below) — application code, not just the
+    # Dockerfile or requirements.lock.txt, can break that build.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_snyk_docker != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # This job does TWO different things and they deserve different verdicts:
@@ -287,6 +553,34 @@ jobs:
 
   codeql:
     name: CodeQL Analysis
+    needs: [changes]
+    # Path-aware skip — TWO LAYERS, because actionlint refuses `matrix.*` in
+    # a job-level `if:` (verified live 2026-08-20 — "context matrix is not
+    # allowed here", schema only permits github/inputs/needs/vars there; an
+    # earlier draft of this gate assumed otherwise and actionlint caught it
+    # before merge). Layer 1 (this `if:`, job-level, union of both
+    # languages): the whole job — both matrix legs, i.e. both
+    # "CodeQL Analysis (python)" and "CodeQL Analysis (javascript)" required
+    # contexts — skips only when NEITHER language's domain matched (measured
+    # on 120 sampled merged PRs: 38% of PRs, vs. 43%/52% skip individually —
+    # the union is necessarily smaller than either leg alone). Layer 2 (step
+    # `if:` below, where `matrix.*` IS legal) then skips the three EXPENSIVE
+    # steps — Initialize/Autobuild/Analyze, ~14.6min for python alone — for
+    # whichever single language this run didn't need, while the job itself
+    # still reports a clean `success` (not merely `skipped`) for that leg,
+    # which satisfies its required context unambiguously. The only residual
+    # cost on a python-only PR is the JS leg's runner spin-up + checkout —
+    # not the analysis. Domains verified live by extension count
+    # (2026-08-20): apps/evaluator, packages/cell-core, apps/nuzantara-mcp
+    # are Python; packages/core is TSX/TS.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_codeql_python != 'false' ||
+        needs.changes.outputs.run_codeql_js != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -299,11 +593,24 @@ jobs:
       matrix:
         language: ["python", "javascript"]
 
+    # Per-leg gate (Layer 2 — see job `if:` comment above). Same fail-open
+    # polarity as every other gate in this workflow: only the exact literal
+    # 'false' skips; unset/malformed/any-other-value runs.
+    env:
+      RUN_THIS_LANGUAGE: >-
+        ${{
+          (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+          needs.changes.result != 'success' ||
+          (matrix.language == 'python' && needs.changes.outputs.run_codeql_python != 'false') ||
+          (matrix.language == 'javascript' && needs.changes.outputs.run_codeql_js != 'false')
+        }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
+        if: env.RUN_THIS_LANGUAGE == 'true'
         uses: github/codeql-action/init@v4.37.6
         with:
           languages: ${{ matrix.language }}
@@ -311,15 +618,28 @@ jobs:
           config-file: ./.github/codeql-config.yml
 
       - name: Autobuild
+        if: env.RUN_THIS_LANGUAGE == 'true'
         uses: github/codeql-action/autobuild@v4.37.6
 
       - name: Perform CodeQL Analysis
+        if: env.RUN_THIS_LANGUAGE == 'true'
         uses: github/codeql-action/analyze@v4.37.6
         with:
           category: "/language:${{matrix.language}}"
 
   bandit:
     name: Bandit Python Security
+    needs: [changes]
+    # Path-aware skip — see snyk-python's comment for the shared rationale.
+    # Bandit's scan target is fixed to apps/backend-rag/backend/ only, so
+    # backend_python (or security_sensitive) is the correct gate.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_bandit != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Blocking gate (A1 fix 2026-06-13): this job is in the merge-blocking
@@ -388,6 +708,16 @@ jobs:
 
   safety:
     name: Safety Dependency Check
+    needs: [changes]
+    # Path-aware skip — see snyk-python's comment for the shared rationale
+    # (Safety scans apps/backend-rag/requirements.txt only; same gate).
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_safety != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Blocking gate — HIGH/CRITICAL CVEs fail the job unless the finding is
@@ -432,6 +762,14 @@ jobs:
 
   detect-secrets:
     name: Detect Secrets
+    # Deliberately NOT gated by the `changes` job (2026-08-20 path-aware
+    # gating pass) — unlike every other job in this workflow. A secret can
+    # land in ANY file, including a .md, a JSON test fixture, or a docs
+    # page that change_map.py classifies as docs_content_data — there is no
+    # domain a leaked credential is structurally confined to. This is the
+    # one scanner in this file where "better ten unnecessary scans than one
+    # skipped wrongly" has no exception, and it always runs on every
+    # pull_request/merge_group/push/schedule trigger, exactly as before.
     runs-on: ubuntu-latest
     # Run 31312661093 measured 19m34s in the scan alone and was cancelled at
     # the 20m job limit after every gating step had succeeded. Keep this gate
@@ -514,18 +852,32 @@ jobs:
     if: always()
 
     steps:
+      # Path-aware gating (2026-08-20) means the seven jobs below no longer
+      # always run — a static "✅ ran" list would misreport a skip as a scan
+      # (the exact "message inventories mutable state" failure mode this
+      # repo already has a cicatrix about, W114/W106). List each job's ACTUAL
+      # `needs.<job>.result` instead of asserting it.
       - name: Create security summary
         uses: actions/github-script@v9
         with:
           script: |
+            const jobs = [
+              ["Snyk Python", "${{ needs.snyk-python.result }}"],
+              ["Snyk Node.js", "${{ needs.snyk-node.result }}"],
+              ["Snyk Docker", "${{ needs.snyk-docker.result }}"],
+              ["CodeQL", "${{ needs.codeql.result }}"],
+              ["Bandit", "${{ needs.bandit.result }}"],
+              ["Safety", "${{ needs.safety.result }}"],
+              ["Detect Secrets (never skipped)", "${{ needs.detect-secrets.result }}"],
+            ];
+            const icon = (r) => r === "success" ? "✅ ran" : r === "skipped" ? "⏭️ skipped (path-aware gate)" : r === "failure" ? "❌ FAILED" : `⚠️ ${r}`;
+            const scanLines = jobs.map(([name, result]) => `- **${name}**: ${icon(result)}`).join("\n            ");
+
             const summary = `
             ## 🔒 Security Scan Complete
 
-            ### Scans Performed
-            - ✅ Snyk (Python, Node.js, Docker)
-            - ✅ CodeQL (Python, JavaScript)
-            - ✅ Bandit (Python security linter)
-            - ✅ Safety (Python dependency checker)
+            ### Scans
+            ${scanLines}
 
             ### Results
             View detailed results in:

--- a/scripts/ci/security_gate_flags.py
+++ b/scripts/ci/security_gate_flags.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Derive per-scanner run/skip flags for security.yml from a change_map.py map.
+
+Companion to change_map.py (2026-08-20 path-aware gating of
+.github/workflows/security.yml). This module does NOT re-classify paths — it
+consumes the map `classify()` already produced (same domain vocabulary,
+same run_all fallback) and answers one narrower question per scanner:
+"given these domains, does THIS security job need to run?"
+
+Kept as its own file, extracted from BASE_SHA alongside change_map.py /
+test_change_map.py / hotzone_changed_files.sh in security.yml's `changes`
+job (root-of-trust: a PR could otherwise bypass gating by editing THIS
+file's flag math directly, leaving change_map.py's domain classification
+untouched — a distinct attack surface from gaming the classifier itself).
+Also CODEOWNERS-TIER1 alongside the other three (see .github/CODEOWNERS).
+
+Fail-open by construction: every flag is `run_all OR <domain match>` — never
+a bare domain match — so a run_all=True map (classifier failure, enumeration
+failure, unclassified path, or genuinely broad diff) forces every flag True
+regardless of what follows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Iterable
+
+# Each entry: which change_map.py domains make this scanner necessary.
+# Rationale for each mapping lives in security.yml's per-job `if:` comments,
+# not duplicated here — this table is the single place the actual policy
+# is expressed; test_security_gate_flags.py pins it with named cases.
+FLAG_DOMAINS: dict[str, tuple[str, ...]] = {
+    # Source-code analyzers: gated on the domains whose PREFIX_RULES trees
+    # are that language (apps/evaluator, packages/cell-core,
+    # apps/nuzantara-mcp are Python; packages/core is TSX/TS — verified live
+    # by extension count 2026-08-20).
+    "run_codeql_python": ("backend_python", "mcp", "evaluator", "security_sensitive"),
+    "run_codeql_js": ("mouth", "admin_dashboard", "wa_mirror", "packages_core", "security_sensitive"),
+    # Bandit's scan target is fixed to apps/backend-rag/backend/ only.
+    "run_bandit": ("backend_python", "security_sensitive"),
+    # Snyk-python / Safety scan apps/backend-rag/requirements.txt ONLY. A
+    # backend_python-only change (no manifest edit) cannot alter the
+    # declared dependency set these two evaluate — change_map.py's
+    # PYTHON_MANIFEST_NAMES rule already tags any requirements*.txt /
+    # pyproject.toml / uv.lock change as security_sensitive, globally,
+    # regardless of directory, so security_sensitive alone is sufficient.
+    "run_snyk_python": ("security_sensitive",),
+    "run_safety": ("security_sensitive",),
+    # Snyk-docker also validates the production Dockerfile still BUILDS
+    # (fly deploy builds this same file) — backend_python is included here,
+    # unlike snyk-python/safety, because application code can break that
+    # build even with the Dockerfile/manifest untouched.
+    "run_snyk_docker": ("backend_python", "security_sensitive"),
+}
+
+# run_snyk_node is handled separately below: it needs the JS-manifest
+# predicate (see js_manifest_touched), not just a domain lookup, because
+# change_map.py's own JS-manifest rule has a verified gap (nested lockfiles
+# like apps/wa-mirror/package-lock.json fall through to PREFIX_RULES and are
+# never tagged security_sensitive — see security.yml's `changes` job
+# comment for the full writeup).
+
+
+def js_manifest_touched(paths: Iterable[str]) -> bool:
+    """True if any changed path's basename is a JS dependency manifest.
+
+    Deliberately basename-only, anywhere in the tree — not routed through
+    change_map.py's domain model. Closes the exact gap change_map.py has
+    today: EXACT_RULES only matches the literal root-level "package.json" /
+    "package-lock.json" paths, so a nested manifest is tagged only its app
+    domain (e.g. "wa_mirror"), never "security_sensitive".
+    """
+    for raw in paths:
+        if not raw or not raw.strip():
+            continue
+        base = raw.rsplit("/", 1)[-1]
+        if base in ("package.json", "package-lock.json"):
+            return True
+    return False
+
+
+def compute_flags(map_result: dict, js_manifest: bool) -> dict[str, bool]:
+    """Return {flag_name: bool} for every gated security.yml job.
+
+    `map_result` is change_map.py's classify() output (or an
+    equivalent dict — schema_version/domains/run_all keys). Fail-open: a
+    malformed or missing "domains"/"run_all" key raises, which the caller
+    (security.yml's classify step) treats the same as any other classifier
+    failure — force every flag True — never silently defaults to False.
+    """
+    run_all = bool(map_result["run_all"])
+    domains = map_result["domains"]
+
+    flags: dict[str, bool] = {}
+    for name, needed_domains in FLAG_DOMAINS.items():
+        flags[name] = run_all or any(domains.get(d, False) for d in needed_domains)
+
+    flags["run_snyk_node"] = (
+        run_all or domains.get("security_sensitive", False) or js_manifest
+    )
+    return flags
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: MAP_JSON=<json> security_gate_flags.py < <changed-files-list>
+
+    Mirrors change_map.py's own CLI conventions in this same caller
+    (security.yml): the JSON blob travels through an env var (as the
+    caller already does for MAP_JSON, avoiding argv-length/quoting
+    concerns for a payload whose size — unknown_paths can be long — isn't
+    bounded), and the changed-file list travels over stdin (exactly how
+    change_map.py itself reads paths). No positional args.
+
+    Prints `name=true`/`name=false` lines, one per flag, suitable for
+    `>> "$GITHUB_OUTPUT"`. Any error here is a caller-visible non-zero exit —
+    security.yml's classify step treats a non-zero exit as classifier
+    failure and forces the conservative fallback, never swallows it.
+    """
+    del argv  # no positional args; kept for test-call symmetry with change_map.main()
+    map_json = os.environ.get("MAP_JSON", "")
+    if not map_json:
+        print("security_gate_flags: MAP_JSON env var is required and was empty", file=sys.stderr)
+        return 2
+
+    map_result = json.loads(map_json)
+    paths = [line.rstrip("\n") for line in sys.stdin]
+
+    js_manifest = js_manifest_touched(paths)
+    flags = compute_flags(map_result, js_manifest)
+
+    print(f"js_manifest_touched={'true' if js_manifest else 'false'}")
+    for name, value in flags.items():
+        print(f"{name}={'true' if value else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_security_gate_flags.py
+++ b/scripts/ci/test_security_gate_flags.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Guilt + innocence corpus for security_gate_flags.py.
+
+Companion to test_change_map.py. Fixtures build minimal domain dicts
+directly (not via change_map.classify()) — this test is about the FLAG
+MATH, not the path classifier, and should not regress if change_map.py's
+own PREFIX_RULES change shape.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import security_gate_flags as sgf
+
+ALL_DOMAINS = (
+    "backend_python",
+    "mouth",
+    "admin_dashboard",
+    "wa_mirror",
+    "mcp",
+    "evaluator",
+    "packages_core",
+    "infra_workflows",
+    "docs_content_data",
+    "security_sensitive",
+)
+
+
+def _map(run_all: bool = False, **true_domains: bool) -> dict:
+    domains = dict.fromkeys(ALL_DOMAINS, False)
+    for name in true_domains:
+        assert name in ALL_DOMAINS, f"unknown domain in fixture: {name}"
+        domains[name] = True
+    return {"run_all": run_all, "domains": domains}
+
+
+ALL_FLAGS = (
+    "run_codeql_python",
+    "run_codeql_js",
+    "run_bandit",
+    "run_snyk_python",
+    "run_safety",
+    "run_snyk_docker",
+    "run_snyk_node",
+)
+
+
+class SecurityGateFlagsTests(unittest.TestCase):
+    # --- run_all / fail-open ------------------------------------------------
+
+    def test_guilt_run_all_forces_every_flag_true(self) -> None:
+        flags = sgf.compute_flags(_map(run_all=True), js_manifest=False)
+        for name in ALL_FLAGS:
+            self.assertTrue(flags[name], f"{name} should be true under run_all")
+
+    def test_innocence_no_domains_no_run_all_skips_everything_but_node(self) -> None:
+        # snyk-node has a THIRD trigger (js_manifest) independent of domains
+        # — this case pins that it does NOT fire spuriously when that flag
+        # is also false.
+        flags = sgf.compute_flags(_map(), js_manifest=False)
+        for name in ALL_FLAGS:
+            self.assertFalse(flags[name], f"{name} should be false on an empty map")
+
+    # --- docs-only innocence (the mandate's required proof) -----------------
+
+    def test_innocence_docs_content_data_only_skips_every_scanner(self) -> None:
+        flags = sgf.compute_flags(_map(docs_content_data=True), js_manifest=False)
+        for name in ALL_FLAGS:
+            self.assertFalse(flags[name], f"{name} should be false for docs-only")
+
+    # --- security_sensitive is the universal override -----------------------
+
+    def test_guilt_security_sensitive_forces_every_flag_true(self) -> None:
+        flags = sgf.compute_flags(_map(security_sensitive=True), js_manifest=False)
+        for name in ALL_FLAGS:
+            self.assertTrue(flags[name], f"{name} should be true under security_sensitive")
+
+    # --- codeql-python -------------------------------------------------------
+
+    def test_guilt_backend_python_runs_codeql_python_only(self) -> None:
+        flags = sgf.compute_flags(_map(backend_python=True), js_manifest=False)
+        self.assertTrue(flags["run_codeql_python"])
+        self.assertTrue(flags["run_bandit"])
+        self.assertTrue(flags["run_snyk_docker"])
+        self.assertFalse(flags["run_codeql_js"])
+        self.assertFalse(flags["run_snyk_python"])
+        self.assertFalse(flags["run_safety"])
+        self.assertFalse(flags["run_snyk_node"])
+
+    def test_guilt_mcp_and_evaluator_run_codeql_python_only(self) -> None:
+        for domain in ("mcp", "evaluator"):
+            with self.subTest(domain=domain):
+                flags = sgf.compute_flags(_map(**{domain: True}), js_manifest=False)
+                self.assertTrue(flags["run_codeql_python"])
+                self.assertFalse(flags["run_codeql_js"])
+                # mcp/evaluator do NOT gate bandit (fixed target dir) or the
+                # dependency scanners (no manifest coupling of their own).
+                self.assertFalse(flags["run_bandit"])
+                self.assertFalse(flags["run_snyk_python"])
+                self.assertFalse(flags["run_snyk_docker"])
+
+    # --- codeql-js -------------------------------------------------------
+
+    def test_guilt_mouth_runs_codeql_js_only(self) -> None:
+        flags = sgf.compute_flags(_map(mouth=True), js_manifest=False)
+        self.assertTrue(flags["run_codeql_js"])
+        self.assertFalse(flags["run_codeql_python"])
+        self.assertFalse(flags["run_bandit"])
+
+    def test_guilt_admin_wa_packages_core_run_codeql_js_only(self) -> None:
+        for domain in ("admin_dashboard", "wa_mirror", "packages_core"):
+            with self.subTest(domain=domain):
+                flags = sgf.compute_flags(_map(**{domain: True}), js_manifest=False)
+                self.assertTrue(flags["run_codeql_js"])
+                self.assertFalse(flags["run_codeql_python"])
+
+    # --- bandit --------------------------------------------------------------
+
+    def test_innocence_bandit_not_triggered_by_frontend_domains(self) -> None:
+        for domain in ("mouth", "admin_dashboard", "wa_mirror", "packages_core"):
+            with self.subTest(domain=domain):
+                flags = sgf.compute_flags(_map(**{domain: True}), js_manifest=False)
+                self.assertFalse(flags["run_bandit"])
+
+    # --- snyk-python / safety: manifest-gated only, NOT by backend_python ---
+
+    def test_innocence_snyk_python_and_safety_not_triggered_by_code_only(self) -> None:
+        # The mandate's central finding: a backend_python-only change (no
+        # requirements.txt/pyproject.toml/uv.lock edit) cannot alter the
+        # dependency set these two evaluate.
+        flags = sgf.compute_flags(_map(backend_python=True), js_manifest=False)
+        self.assertFalse(flags["run_snyk_python"])
+        self.assertFalse(flags["run_safety"])
+
+    def test_guilt_security_sensitive_runs_snyk_python_and_safety(self) -> None:
+        # change_map.py's PYTHON_MANIFEST_NAMES rule tags any
+        # requirements*.txt/pyproject.toml/uv.lock change as
+        # security_sensitive globally — this is the shape that reaches here.
+        flags = sgf.compute_flags(_map(security_sensitive=True), js_manifest=False)
+        self.assertTrue(flags["run_snyk_python"])
+        self.assertTrue(flags["run_safety"])
+
+    # --- snyk-docker: backend_python is a DELIBERATE extra trigger ----------
+
+    def test_guilt_snyk_docker_also_triggered_by_backend_python(self) -> None:
+        # Unlike snyk-python/safety, snyk-docker also validates the
+        # production Dockerfile still BUILDS — application code alone can
+        # break that build.
+        flags = sgf.compute_flags(_map(backend_python=True), js_manifest=False)
+        self.assertTrue(flags["run_snyk_docker"])
+
+    # --- snyk-node: JS-manifest predicate is independent of domains --------
+
+    def test_guilt_js_manifest_touched_runs_snyk_node_even_with_empty_map(self) -> None:
+        # The whole point of this predicate: change_map.py itself may not
+        # have tagged security_sensitive (nested-lockfile gap) but snyk-node
+        # must still run.
+        flags = sgf.compute_flags(_map(), js_manifest=True)
+        self.assertTrue(flags["run_snyk_node"])
+        # Nothing else should be pulled in by this predicate alone.
+        for name in ALL_FLAGS:
+            if name != "run_snyk_node":
+                self.assertFalse(flags[name], f"{name} should stay false")
+
+    def test_innocence_no_js_manifest_and_no_domains_skips_snyk_node(self) -> None:
+        flags = sgf.compute_flags(_map(wa_mirror=True), js_manifest=False)
+        # wa_mirror alone (e.g. a .ts source edit, no manifest touched)
+        # does NOT need a dependency re-scan.
+        self.assertFalse(flags["run_snyk_node"])
+
+
+class JsManifestTouchedTests(unittest.TestCase):
+    def test_guilt_root_lockfile(self) -> None:
+        self.assertTrue(sgf.js_manifest_touched(["package-lock.json"]))
+
+    def test_guilt_root_manifest(self) -> None:
+        self.assertTrue(sgf.js_manifest_touched(["package.json"]))
+
+    def test_guilt_nested_lockfile_outside_workspaces(self) -> None:
+        # apps/wa-mirror/package-lock.json is its OWN lockfile, outside the
+        # root npm-workspaces tree (verified live 2026-08-20: `workspaces`
+        # in the root package.json does not list apps/wa-mirror) — this is
+        # the exact gap change_map.py's EXACT_RULES (literal root-path
+        # match only) does not close.
+        self.assertTrue(
+            sgf.js_manifest_touched(["apps/wa-mirror/package-lock.json"])
+        )
+
+    def test_guilt_nested_manifest_without_a_lockfile(self) -> None:
+        # Several apps/*/package.json in this repo have no lockfile at all
+        # (verified live 2026-08-20) — Snyk still reads declared ranges from
+        # package.json in that case, so the manifest alone must trigger.
+        self.assertTrue(
+            sgf.js_manifest_touched(["apps/kbli-navigator/package.json"])
+        )
+
+    def test_innocence_js_source_edit_does_not_touch_manifest(self) -> None:
+        self.assertFalse(
+            sgf.js_manifest_touched(["apps/wa-mirror/src/index.ts"])
+        )
+
+    def test_innocence_similarly_named_file_is_not_a_manifest(self) -> None:
+        # Entity, not substring (superscar #3) — a file that merely
+        # CONTAINS "package.json" in its name must not match.
+        self.assertFalse(
+            sgf.js_manifest_touched(["docs/research/old-package.json.bak"])
+        )
+
+    def test_innocence_empty_and_blank_entries_are_skipped(self) -> None:
+        self.assertFalse(sgf.js_manifest_touched(["", "   ", "\n"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`security.yml` ran all 8 jobs unconditionally on every `pull_request` and
`merge_group` entry — measured live over a 70min window: 424.7 runner-min
total (364 min/h), avg 39.84 min/run, and `merge_group` alone was 47.5% of
all minutes this workflow burns. A docs-only PR paid the full bill.

Adds a `changes` job that reuses `scripts/ci/change_map.py` +
`hotzone_changed_files.sh` — the exact classifier `tests.yml`'s own
enforcing `changes` job already runs in production (#4181/#4302) — with
the same root-of-trust BASE_SHA extraction, corpus self-test, manual
override, and fail-open `!= 'false'` polarity. New
`scripts/ci/security_gate_flags.py` derives one flag per scanner from the
map (its own guilt+innocence corpus, mutation-verified 3/3), and closes a
verified gap in `change_map.py`'s own JS-manifest rule: nested lockfiles
like `apps/wa-mirror/package-lock.json` (outside the root npm-workspaces
tree) were never tagged `security_sensitive`.

## What's gated, and why

| Job | Trigger | Why |
|---|---|---|
| `detect-secrets` | **never gated** | a secret can land in any file — no domain confines it |
| `codeql` (python leg) | `backend_python`/`mcp`/`evaluator`/`security_sensitive` | source-code analyzer; domains verified Python by extension count |
| `codeql` (js leg) | `mouth`/`admin_dashboard`/`wa_mirror`/`packages_core`/`security_sensitive` | same, verified TS/TSX |
| `bandit` | `backend_python`/`security_sensitive` | scan target fixed to `apps/backend-rag/backend/` |
| `snyk-python`, `safety` | `security_sensitive` only | scan `requirements.txt` — a code-only change can't alter the declared dependency set |
| `snyk-docker` | `backend_python`/`security_sensitive` | also validates the production Dockerfile still *builds* |
| `snyk-node` | `security_sensitive` OR JS-manifest-touched-anywhere | closes the nested-lockfile gap above |

CodeQL uses a two-layer gate (job-level union across both legs, then
step-level per-language `if: matrix.language == ...`) because actionlint
rejects `matrix.*` context in a job-level `if:` — caught before merge, not
assumed.

## Proof

**Innocence** (real merged PR #4434, docs-only,
`.claude/skills/modus/PENDING-ARMS.md`): all 7 gated scanners skip,
`detect-secrets` still runs.

**Guilt** (real merged PR #4423, backend Python only,
`apps/backend-rag/backend/services/portal/...`): `codeql-python` +
`bandit` + `snyk-docker` run; `codeql-js`/`snyk-python`/`safety`/`snyk-node`
correctly skip (no JS, no manifest touched).

**Security-sensitive escalation** (real merged PR #4348, touches
`apps/backend-rag/backend/app/auth/public_endpoints.py`): the `auth`
path segment forces `security_sensitive` → all 7 flags true.

**Mutation-verified**: 3 independent mutations against
`security_gate_flags.py` (drop `security_sensitive` from bandit's domains;
narrow the JS-manifest match to only `package-lock.json`; drop the
`js_manifest` OR-term from `run_snyk_node`) — each caught by exactly the
expected test, file restored byte-identical after each (`diff` confirmed).

**Measured on 120 real merged PRs** with the actual module: 32% average
runner-minute reduction per PR (39.11 → 26.67 min), ~53 runner-hours/week
saved at this repo's stated PR volume (255/week).

## What's NOT gated (and why that's a deliberate answer, not a gap)

- `detect-secrets` — see table above.
- A PR touching `.github/workflows/security.yml` itself, or `scripts/ci/`,
  is tagged `security_sensitive` by `change_map.py`'s existing
  `PREFIX_RULES` → forces every flag true. No self-approval gap.
- `scripts/ci/security_gate_flags.py` + its test are extracted from
  BASE_SHA alongside `change_map.py` (same root-of-trust step) and added
  to CODEOWNERS-TIER1 — editing the flag math directly, leaving
  `change_map.py` untouched, is closed the same way gaming the classifier
  itself is.

## Deliberately NOT touched

`scripts/ci/change_map.py` / `test_change_map.py` — PR #4441 is adding a
`fleet_ops` domain to those files the same day. This PR reuses them
unmodified to avoid two PRs colliding on a CODEOWNERS-tier1 file. The
verified JS-manifest gap is flagged as a worthwhile upstream follow-up in
`security_gate_flags.py`'s own docstring, not fixed there.

## Test plan

- [x] `actionlint .github/workflows/security.yml` — clean (caught and fixed
      one real error: `matrix` context is not legal in job-level `if:`)
- [x] `python3 scripts/ci/test_security_gate_flags.py` — 21/21 passing
- [x] `python3 scripts/ci/test_change_map.py` — 26/26 passing (untouched,
      re-verified)
- [x] 3 independent mutations, each caught, file restored clean
- [x] Simulated against 120 real merged PRs via the actual module
- [ ] Live: this PR's own CI run is the first live proof — required checks
      (`CodeQL Analysis (python)`, `CodeQL Analysis (javascript)`,
      `Detect Secrets`, `Bandit Python Security`) should all report
      `success` since this diff touches `.github/`/`scripts/ci/`
      (`security_sensitive` → run_all-equivalent for every flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)