### PR TITLE
fix(codex): arm seat rotation on every real codex-invoking call site

### DIFF
--- a/apps/backend-rag/backend/services/federation_alerts/actions/_codex_seat.py
+++ b/apps/backend-rag/backend/services/federation_alerts/actions/_codex_seat.py
@@ -1,0 +1,68 @@
+"""Shared door onto scripts/lib/codex_seat.py for the federation_alerts codex
+actions (codex_xhigh_fix, codex_image_gen).
+
+NOT duplicated per-action. Both actions spawn `codex` as a subprocess; a
+second copy of this root-finder + importlib glue per action is exactly the
+defect scripts/lib/codex_seat.sh's own docstring warns against reproducing
+(W106b: "a duplicated list is the very defect codex_seat.sh exists to kill" —
+applies equally to the glue that reaches it, not just the seat list itself).
+
+Measured 2026-08-12 on Pro (the machine that runs the federation_alerts
+daemon): the default `~/.codex` answers 401 Unauthorized while a paid,
+logged-in second seat (`~/.codex-acct2`) sits one environment variable away.
+Neither codex_xhigh_fix nor codex_image_gen ever touched CODEX_HOME before
+this file existed — every HITL-approved fix/image-gen action was silently
+pinned to whichever seat happened to be the CLI's own default.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    """Resolve the repo root in worktrees, CI, and the canonical Pro checkout.
+
+    Independent of codex_xhigh_fix._default_project_root() (used there for
+    `cwd`, a different concern) — this one only needs to find
+    scripts/lib/codex_seat.py, so it is allowed to answer differently without
+    the two ever needing to agree.
+    """
+    env_root = os.environ.get("NUZANTARA_REPO_ROOT")
+    if env_root:
+        return Path(env_root).expanduser()
+
+    legacy_root = Path(os.path.expanduser("~/nuzantara"))
+    if legacy_root.exists():
+        return legacy_root
+
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "apps" / "backend-rag").exists():
+            return parent
+
+    return legacy_root
+
+
+def codex_seat_home() -> str | None:
+    """A logged-in CODEX_HOME, via scripts/lib/codex_seat.py, or None.
+
+    Loaded by path (this package may run without the repo root on
+    sys.path). Never raises: a missing helper, a missing repo root, or a
+    shell that misbehaves all degrade to None — callers must leave
+    CODEX_HOME unset in that case, which is codex's own default seat, i.e.
+    exactly the behaviour every caller had before seat rotation existed.
+    """
+    helper = _repo_root() / "scripts" / "lib" / "codex_seat.py"
+    if not helper.is_file():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("_codex_seat_lib", helper)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.codex_seat_pick()
+    except Exception:  # broad on purpose — a seat hint may never break an action
+        return None

--- a/apps/backend-rag/backend/services/federation_alerts/actions/codex_image_gen.py
+++ b/apps/backend-rag/backend/services/federation_alerts/actions/codex_image_gen.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from backend.services.federation_alerts.actions._codex_seat import codex_seat_home
 from backend.services.federation_alerts.actions.registry import (
     ActionResult,
     register_action,
@@ -56,13 +57,21 @@ _STRIPPED_ENV_KEYS: frozenset[str] = frozenset(
 
 
 def _safe_env() -> dict[str, str]:
-    """Strip provider API keys before spawning Codex subprocess.
+    """Strip provider API keys before spawning Codex subprocess, pin a seat.
 
     Mirrors codex_xhigh_fix._safe_env. The backend-rag parent process
     legitimately holds OPENAI_API_KEY for text-embedding-3-small, but
     image generation must run via Codex OAuth — never per-call billing.
+
+    CODEX_HOME (2026-08-20): see codex_xhigh_fix._safe_env for why — same
+    daemon, same dead-default-seat risk, same fix via the shared
+    _codex_seat.codex_seat_home() door.
     """
-    return {k: v for k, v in os.environ.items() if k not in _STRIPPED_ENV_KEYS}
+    env = {k: v for k, v in os.environ.items() if k not in _STRIPPED_ENV_KEYS}
+    seat = codex_seat_home()
+    if seat:
+        env["CODEX_HOME"] = seat
+    return env
 
 
 def _safe_name(s: str, default: str = "asset") -> str:

--- a/apps/backend-rag/backend/services/federation_alerts/actions/codex_xhigh_fix.py
+++ b/apps/backend-rag/backend/services/federation_alerts/actions/codex_xhigh_fix.py
@@ -29,6 +29,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from backend.services.federation_alerts.actions._codex_seat import codex_seat_home
 from backend.services.federation_alerts.actions.registry import (
     ActionResult,
     register_action,
@@ -60,14 +61,25 @@ _STRIPPED_ENV_KEYS: frozenset[str] = frozenset(
 
 
 def _safe_env() -> dict[str, str]:
-    """Strip provider API keys from subprocess env.
+    """Strip provider API keys from subprocess env, then pin a live seat.
 
     Codex CLI uses OAuth (Pro $200 quota); embedding-only OPENAI_API_KEY
     must stay scoped to backend-rag and NEVER leak into Codex subprocess
     which could open a non-embedding billing path. Defense-in-depth for
     Anthropic, OpenAI, Google providers.
+
+    CODEX_HOME (2026-08-20): without this, every HITL-approved xhigh fix ran
+    against whichever seat the codex CLI defaults to — on Pro that is the
+    dead ~/.codex (401), one env var away from the live ~/.codex-acct2. A
+    missing/unresolvable seat leaves CODEX_HOME untouched (codex's own
+    default), never an empty string (empty reads to codex as "use the
+    default", the opposite of "no seat found").
     """
-    return {k: v for k, v in os.environ.items() if k not in _STRIPPED_ENV_KEYS}
+    env = {k: v for k, v in os.environ.items() if k not in _STRIPPED_ENV_KEYS}
+    seat = codex_seat_home()
+    if seat:
+        env["CODEX_HOME"] = seat
+    return env
 
 
 def _default_project_root() -> Path:

--- a/apps/backend-rag/backend/tests/services/federation_alerts/test_codex_actions.py
+++ b/apps/backend-rag/backend/tests/services/federation_alerts/test_codex_actions.py
@@ -18,6 +18,8 @@ from typing import Any
 
 import pytest
 
+import backend.services.federation_alerts.actions.codex_image_gen as _codex_image_gen_mod
+import backend.services.federation_alerts.actions.codex_xhigh_fix as _codex_xhigh_fix_mod
 from backend.services.federation_alerts.actions.codex_image_gen import (
     codex_image_gen_action,
 )
@@ -307,3 +309,63 @@ async def test_no_anthropic_key_in_xhigh_prompt() -> None:
     # by checking that the dry_run reports a framed_prompt larger than
     # the raw user prompt would imply.
     assert result.metadata["framed_prompt_bytes"] > len("Do work")
+
+
+# ---------------------------------------------------------------------------
+# Seat rotation (2026-08-20) — codex_xhigh_fix and codex_image_gen both spawn
+# `codex` directly; before this, neither ever set CODEX_HOME, so both were
+# silently pinned to whichever seat the CLI defaults to (dead ~/.codex on
+# Pro, per scripts/lib/codex_seat.sh's own measurement). Guilt: a live seat
+# lands in the subprocess env. Innocence: no seat found degrades to "leave
+# CODEX_HOME untouched", never a forced-empty override (which codex reads as
+# "use the default" — the opposite of "no seat") and never a raised
+# exception (a seat hint must not be able to break a HITL-approved action).
+# ---------------------------------------------------------------------------
+
+
+def test_xhigh_fix_safe_env_carries_a_live_seat(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        _codex_xhigh_fix_mod, "codex_seat_home", lambda: "/Users/nuzantara/.codex-acct2"
+    )
+    env = _codex_xhigh_fix_mod._safe_env()
+    assert env["CODEX_HOME"] == "/Users/nuzantara/.codex-acct2"
+
+
+def test_xhigh_fix_safe_env_degrades_cleanly_with_no_seat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_codex_xhigh_fix_mod, "codex_seat_home", lambda: None)
+    env = _codex_xhigh_fix_mod._safe_env()  # must not raise
+    assert "CODEX_HOME" not in env
+
+
+def test_image_gen_safe_env_carries_a_live_seat(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        _codex_image_gen_mod, "codex_seat_home", lambda: "/Users/nuzantara/.codex-acct2"
+    )
+    env = _codex_image_gen_mod._safe_env()
+    assert env["CODEX_HOME"] == "/Users/nuzantara/.codex-acct2"
+
+
+def test_image_gen_safe_env_degrades_cleanly_with_no_seat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_codex_image_gen_mod, "codex_seat_home", lambda: None)
+    env = _codex_image_gen_mod._safe_env()  # must not raise
+    assert "CODEX_HOME" not in env
+
+
+def test_safe_env_still_strips_provider_keys_with_a_seat_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The seat wiring must not reopen the Golden Rule #13 hole it sits next
+    to — CODEX_HOME added, ANTHROPIC_API_KEY/OPENAI_API_KEY still gone."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-never-reach-codex")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-embedding-only-should-not-leak")
+    monkeypatch.setattr(
+        _codex_xhigh_fix_mod, "codex_seat_home", lambda: "/Users/nuzantara/.codex-acct2"
+    )
+    env = _codex_xhigh_fix_mod._safe_env()
+    assert env["CODEX_HOME"] == "/Users/nuzantara/.codex-acct2"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env

--- a/scripts/codex/codex-daily-research-actor.sh
+++ b/scripts/codex/codex-daily-research-actor.sh
@@ -29,6 +29,23 @@ mkdir -p "$STATE_DIR" "$LOG_DIR" "$OVERNIGHT_BACKLOG_DIR"
 # shellcheck source=/Users/nuzantara/scripts/codex-automation-lib.sh
 [ -f "$CODEX_AUTOMATION_LIB" ] && source "$CODEX_AUTOMATION_LIB"
 
+# Seat rotation (2026-08-20): alternate between the ChatGPT Pro subscriptions
+# instead of pinning to whichever CODEX_HOME the codex CLI defaults to.
+# scripts/lib/codex_seat.sh is the single source for the seat list and the
+# rotation counter — do not re-derive either here (W106b: a duplicated list
+# is the very defect that file exists to kill). Judged by REPLY at call time,
+# never by this script's own exit code (W104).
+CODEX_SEAT_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)/codex_seat.sh"
+if [ -f "$CODEX_SEAT_LIB" ]; then
+    # shellcheck disable=SC1090
+    . "$CODEX_SEAT_LIB"
+    CODEX_SEAT="$(codex_seat_pick 2>/dev/null || true)"
+    if [ -n "$CODEX_SEAT" ]; then
+        export CODEX_HOME="$CODEX_SEAT"
+        echo "[$(basename "$0")] codex seat: $CODEX_SEAT" >&2
+    fi
+fi
+
 CODEX_TIMEOUT=2400  # 40min per finding
 DAILY_PR_CAP=3
 

--- a/scripts/codex/codex-nightly-autofix-ci.sh
+++ b/scripts/codex/codex-nightly-autofix-ci.sh
@@ -39,6 +39,25 @@ mkdir -p "$STATE_DIR" "$LOG_DIR"
 # shellcheck source=/Users/nuzantara/scripts/codex/automation-lib.sh
 [ -f "$CODEX_AUTOMATION_LIB" ] && source "$CODEX_AUTOMATION_LIB"
 
+# Seat rotation (2026-08-20): alternate between the ChatGPT Pro subscriptions
+# instead of pinning to whichever CODEX_HOME the codex CLI defaults to.
+# scripts/lib/codex_seat.sh is the single source for the seat list and the
+# rotation counter — do not re-derive either here (W106b: a duplicated list
+# is the very defect that file exists to kill). Judged by REPLY at call time,
+# never by this script's own exit code (W104). Exported here so the later
+# `env -u ... codex ...` invocation inherits it — `env -u` only strips the
+# names it is told to strip.
+CODEX_SEAT_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)/codex_seat.sh"
+if [ -f "$CODEX_SEAT_LIB" ]; then
+    # shellcheck disable=SC1090
+    . "$CODEX_SEAT_LIB"
+    CODEX_SEAT="$(codex_seat_pick 2>/dev/null || true)"
+    if [ -n "$CODEX_SEAT" ]; then
+        export CODEX_HOME="$CODEX_SEAT"
+        echo "[$(basename "$0")] codex seat: $CODEX_SEAT" >&2
+    fi
+fi
+
 # Cap: max 3 autofix attempts per rolling 24h
 DAILY_CAP=3
 RECENT_WINDOW_HOURS=24

--- a/scripts/codex/codex-nightly-coverage-improver.sh
+++ b/scripts/codex/codex-nightly-coverage-improver.sh
@@ -22,6 +22,23 @@ mkdir -p "$STATE_DIR" "$LOG_DIR"
 # shellcheck source=/Users/nuzantara/scripts/codex-automation-lib.sh
 [ -f "$CODEX_AUTOMATION_LIB" ] && source "$CODEX_AUTOMATION_LIB"
 
+# Seat rotation (2026-08-20): alternate between the ChatGPT Pro subscriptions
+# instead of pinning to whichever CODEX_HOME the codex CLI defaults to.
+# scripts/lib/codex_seat.sh is the single source for the seat list and the
+# rotation counter — do not re-derive either here (W106b: a duplicated list
+# is the very defect that file exists to kill). Judged by REPLY at call time,
+# never by this script's own exit code (W104).
+CODEX_SEAT_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)/codex_seat.sh"
+if [ -f "$CODEX_SEAT_LIB" ]; then
+    # shellcheck disable=SC1090
+    . "$CODEX_SEAT_LIB"
+    CODEX_SEAT="$(codex_seat_pick 2>/dev/null || true)"
+    if [ -n "$CODEX_SEAT" ]; then
+        export CODEX_HOME="$CODEX_SEAT"
+        echo "[$(basename "$0")] codex seat: $CODEX_SEAT" >&2
+    fi
+fi
+
 CODEX_TIMEOUT=2400  # 40 min
 COVERAGE_THRESHOLD=50  # files below this get prioritized
 MAX_NEW_LOC=200

--- a/scripts/codex/codex-overnight-runner.sh
+++ b/scripts/codex/codex-overnight-runner.sh
@@ -25,6 +25,25 @@ mkdir -p "$LOG_DIR" "$STATE_DIR" "$QUEUE_DIR" "$DONE_DIR" "$FAILED_DIR"
 # shellcheck source=/Users/nuzantara/scripts/codex-automation-lib.sh
 [ -f "$CODEX_AUTOMATION_LIB" ] && source "$CODEX_AUTOMATION_LIB"
 
+# Seat rotation (2026-08-20): alternate between the ChatGPT Pro subscriptions
+# instead of pinning to whichever CODEX_HOME the codex CLI defaults to.
+# scripts/lib/codex_seat.sh is the single source for the seat list and the
+# rotation counter — do not re-derive either here (W106b: a duplicated list
+# is the very defect that file exists to kill). Judged by REPLY at call time,
+# never by this script's own exit code (W104). NOTE: this cron's plist is
+# disabled (W81, since 2026-06-15) — this fix has no live effect today, kept
+# so it does not need rediscovering if the job is ever re-armed.
+CODEX_SEAT_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" 2>/dev/null && pwd)/codex_seat.sh"
+if [ -f "$CODEX_SEAT_LIB" ]; then
+    # shellcheck disable=SC1090
+    . "$CODEX_SEAT_LIB"
+    CODEX_SEAT="$(codex_seat_pick 2>/dev/null || true)"
+    if [ -n "$CODEX_SEAT" ]; then
+        export CODEX_HOME="$CODEX_SEAT"
+        echo "[$(basename "$0")] codex seat: $CODEX_SEAT" >&2
+    fi
+fi
+
 OVERNIGHT_TIMEOUT="${CODEX_OVERNIGHT_TIMEOUT:-28800}"  # 8h hard cap
 LOCK_FILE="${STATE_DIR}/codex_overnight.lock"
 

--- a/scripts/codex_visual_orchestrator.py
+++ b/scripts/codex_visual_orchestrator.py
@@ -43,6 +43,7 @@ import json
 import logging
 import os
 import subprocess
+import sys
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -57,6 +58,11 @@ for forbidden in ("ANTHROPIC_API_KEY", "AWS_BEDROCK_ANTHROPIC_KEY", "VERTEX_AI_A
 REPO_ROOT = Path(os.environ.get("NUZANTARA_REPO_ROOT") or
                  Path(__file__).resolve().parent.parent)
 DISPATCH_ROOT = REPO_ROOT / "research" / "dispatch"
+
+# Add repo root to sys.path so `from scripts...` resolves regardless of how
+# this file was invoked (direct path, -m, or from a worktree).
+sys.path.insert(0, str(REPO_ROOT))
+from scripts.lib.codex_seat import codex_seat_env  # noqa: E402
 LOG_DIR = Path.home() / "logs" / "codex-visual-orchestrator"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -229,6 +235,12 @@ async def generate_one(asset: AssetRequest, topic: str, output_dir: Path, slot_i
     logger.info("Generating %s (size=%s)...", asset.name, asset.size)
 
     try:
+        # Seat rotation (2026-08-20): without env=, this subprocess inherits
+        # the parent's full os.environ, which never sets CODEX_HOME — every
+        # generation pinned to whichever seat the codex CLI defaults to.
+        # scripts/lib/codex_seat.codex_seat_env() is the single source for
+        # the seat list; a missing/unresolvable seat leaves CODEX_HOME
+        # exactly as inherited, never forces an empty override.
         proc = await asyncio.create_subprocess_exec(
             "codex",
             "--profile",
@@ -238,6 +250,7 @@ async def generate_one(asset: AssetRequest, topic: str, output_dir: Path, slot_i
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(output_dir),
+            env=codex_seat_env(),
         )
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
         duration = time.time() - start

--- a/scripts/tests/test_codex_seat_lib.py
+++ b/scripts/tests/test_codex_seat_lib.py
@@ -16,10 +16,26 @@ from pathlib import Path
 import pytest
 
 # `["codex", "exec", ...]` in either quote style — an argv element, not prose.
-_ARGV_CODEX_EXEC = re.compile(r"""(['"])codex\1\s*,\s*(['"])exec\2""")
+# Up to 6 intervening quoted tokens are tolerated between "codex" and "exec"
+# (2026-08-20, W-class under-match found while arming seat rotation on the
+# nightly cron trio: `create_subprocess_exec("codex", "--profile", "xhigh",
+# "exec", ...)` has "--profile", "xhigh" between them — the old adjacency-only
+# pattern missed codex_xhigh_fix.py and codex_visual_orchestrator.py, both
+# real spawns with no seat).
+_ARGV_CODEX_EXEC = re.compile(
+    r"""(['"])codex\1\s*,\s*(?:['"][^'"]*['"]\s*,\s*){0,6}(['"])exec\2"""
+)
 # `codex exec` as a command word: start of line/pipe/`&&`/`$(`, optionally with
-# a leading path, an `env VAR=…` prefix, or a `timeout N` prefix.
-_SHELL_CODEX_EXEC = re.compile(r"(^|[|&;(]|\s)(\S*/)?codex\s+exec\b")
+# a leading path, an `env VAR=…` prefix, or a `timeout N` prefix. Up to 6
+# `--flag [value]` tokens are tolerated between "codex" and "exec" for the
+# same reason as the argv pattern above — `codex --profile xhigh exec "$P"`
+# and `codex --ignore-user-config --sandbox workspace-write --ephemeral --cd
+# "$ROOT" exec "$P"` are both real invocations the bare-adjacency pattern
+# missed (all three nightly codex/*.sh crons, live on Pro, none seat-aware
+# until this fix).
+_SHELL_CODEX_EXEC = re.compile(
+    r"(^|[|&;(]|\s)(\S*/)?codex(\s+--?[\w][\w-]*(=\S+)?(\s+\S+)?){0,6}\s+exec\b"
+)
 
 LIB = Path(__file__).resolve().parents[2] / "scripts" / "lib" / "codex_seat.sh"
 
@@ -270,10 +286,17 @@ def test_no_call_site_invokes_codex_without_choosing_a_seat() -> None:
         if path.suffix == ".py":
             real = bool(_ARGV_CODEX_EXEC.search(body))
         else:
+            # Join `\`-newline continuations into their logical line first —
+            # the real codex-nightly-autofix-ci.sh invocation puts `codex
+            # --ignore-user-config ... \` and `exec "$PROMPT" ...` on two
+            # separate physical lines; scanning physical lines alone can
+            # never see them as one command (same class of miss as the
+            # adjacency-only pattern above, one line up the stack).
+            logical_body = re.sub(r"\\\n[ \t]*", " ", body)
             real = any(
                 _SHELL_CODEX_EXEC.search(line)
                 and not line.lstrip().startswith("#")
-                for line in body.splitlines()
+                for line in logical_body.splitlines()
             )
         if not real:
             continue
@@ -298,3 +321,112 @@ def test_the_search_list_is_overridable(tmp_path: Path) -> None:
     ).split()
 
     assert [Path(p).name for p in out] == ["custom-seat", ".codex"]
+
+
+# ---------------------------------------------------------------------------
+# Per-call-site: the four scripts/codex/*.sh nightly crons (2026-08-20 arming)
+#
+# Each guilt case proves the wrapper ITSELF — not just the lib in isolation
+# above — now resolves and exports a seat before it would spawn codex. Each
+# innocence case proves the opposite direction: with no live seat anywhere
+# under HOME, the wrapper degrades to codex's own default (no CODEX_HOME
+# forced empty, no crash, no seat line printed) rather than failing loud or
+# silently on a class of input the guilt case doesn't cover.
+#
+# All four are run with their own DRY_RUN escape hatch so no `codex`
+# subprocess, no GitHub API, and no runtime-worktree git checkout ever
+# fires — CODEX_AUTOMATION_LIB is pointed at a nonexistent path so the real
+# ~/scripts/codex/automation-lib.sh (which does a real `git fetch` before its
+# own dry-run gate — codex-nightly-autofix-ci.sh only) never loads either.
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[2]
+
+_SEAT_LINE_RE = re.compile(r"codex seat: (\S+)")
+
+
+def _cron_case(
+    script: str, dry_run_var: str, *, extra_env: dict[str, str] | None = None
+) -> dict[str, str]:
+    return {"script": script, "dry_run_var": dry_run_var, "extra": extra_env or {}}
+
+
+CRON_CASES = [
+    _cron_case("codex-daily-research-actor.sh", "CODEX_RESEARCH_DRY_RUN"),
+    _cron_case("codex-nightly-coverage-improver.sh", "CODEX_COVERAGE_DRY_RUN"),
+    _cron_case("codex-overnight-runner.sh", "CODEX_OVERNIGHT_DRY_RUN"),
+    _cron_case(
+        "codex-nightly-autofix-ci.sh",
+        "CODEX_AUTOFIX_DRY_RUN",
+        # Short-circuits at "No failed runs found" before ever reaching its
+        # own dry-run gate — same clean, codex-free exit, no `gh` call.
+        extra_env={"CODEX_AUTOFIX_FAILED_RUNS_JSON": "[]"},
+    ),
+]
+
+
+def _run_cron(tmp_path: Path, case: dict[str, str], *, seat: bool) -> subprocess.CompletedProcess[str]:
+    home = tmp_path / "home"
+    if seat:
+        _seat(home, ".codex-o2")
+    else:
+        home.mkdir(parents=True, exist_ok=True)
+    # Every *_STATE_DIR / *_LOG_DIR / *_REPO_ROOT env var this family of
+    # scripts reads shares one prefix per script — set the ones each script
+    # actually consults to keep every side effect inside tmp_path.
+    prefix = case["dry_run_var"].removesuffix("_DRY_RUN")
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        case["dry_run_var"]: "1",
+        f"{prefix}_STATE_DIR": str(tmp_path / "state"),
+        f"{prefix}_LOG_DIR": str(tmp_path / "log"),
+        f"{prefix}_REPO_ROOT": str(tmp_path / "repo"),
+        "CODEX_AUTOMATION_LIB": str(tmp_path / "no-such-lib.sh"),
+        **case["extra"],
+    }
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    if prefix == "CODEX_RESEARCH":
+        env["CODEX_RESEARCH_OVERNIGHT_BACKLOG_DIR"] = str(tmp_path / "backlog")
+    return subprocess.run(
+        ["bash", str(ROOT / "scripts" / "codex" / case["script"])],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+
+@pytest.mark.parametrize("case", CRON_CASES, ids=[c["script"] for c in CRON_CASES])
+def test_guilt_the_cron_wrapper_now_resolves_a_seat_before_running(
+    tmp_path: Path, case: dict[str, str]
+) -> None:
+    proc = _run_cron(tmp_path, case, seat=True)
+    assert proc.returncode == 0, proc.stderr
+    m = _SEAT_LINE_RE.search(proc.stderr)
+    assert m, f"no seat line in stderr:\n{proc.stderr}"
+    assert m.group(1).endswith(".codex-o2")
+
+
+@pytest.mark.parametrize("case", CRON_CASES, ids=[c["script"] for c in CRON_CASES])
+def test_innocence_the_cron_wrapper_degrades_cleanly_with_no_live_seat(
+    tmp_path: Path, case: dict[str, str]
+) -> None:
+    """No seat anywhere under HOME must NOT crash the wrapper and must NOT
+    print a seat line — CODEX_HOME stays unset (codex's own default), the
+    fail-open this class of fix must keep, never a silent wrong seat."""
+    proc = _run_cron(tmp_path, case, seat=False)
+    assert proc.returncode == 0, proc.stderr
+    assert "codex seat:" not in proc.stderr, proc.stderr
+
+
+def test_all_four_cron_wrappers_source_the_one_true_seat_lib() -> None:
+    """Static shape check, cheap and specific: every wrapper's seat block
+    sources scripts/lib/codex_seat.sh by its real relative path and calls
+    codex_seat_pick — not a hand-rolled re-derivation of the seat list
+    (W106b), and not a typo'd path that would silently no-op every run."""
+    for case in CRON_CASES:
+        body = (ROOT / "scripts" / "codex" / case["script"]).read_text(encoding="utf-8")
+        assert "../lib" in body and "codex_seat.sh" in body, case["script"]
+        assert "codex_seat_pick" in body, case["script"]
+        assert "export CODEX_HOME=" in body, case["script"]


### PR DESCRIPTION
## Summary

`scripts/lib/codex_seat.sh` (2026-08-12) alternates between the two ChatGPT
Pro subscriptions so a cron doesn't silently pin to a dead default seat
(`~/.codex` answers 401 on Pro while `~/.codex-acct2` is live). Only 7 call
sites sourced it. This PR censuses the rest and arms the real ones.

**Armed:**
- `scripts/codex/codex-{daily-research-actor,nightly-autofix-ci,nightly-coverage-improver}.sh`
  — confirmed live on Pro today (fresh logs, launchd plists present).
- `scripts/codex/codex-overnight-runner.sh` — same fix for consistency, but
  its plist has been **disabled since 2026-06-15** (W81 disable, moved to
  `_archive-panic-diet-20260818/`) — no live effect today, kept so the fix
  isn't rediscovered if the job is ever re-armed. (Correction to the initial
  "4 live crons" assumption — measured, not assumed.)
- `apps/backend-rag/.../actions/codex_xhigh_fix.py` + `codex_image_gen.py` —
  both HITL_ONLY federation_alerts actions spawning `codex` directly with
  their own duplicated `_safe_env()`; now share one door
  (`actions/_codex_seat.py`) onto `scripts/lib/codex_seat.py` instead of a
  third re-derivation (W106b — a duplicated list is the defect the lib
  exists to kill).
- `scripts/codex_visual_orchestrator.py` — spawned `codex --profile image
  exec` with no `env=` override at all (full inherited `os.environ`).

**Guard extended, not just call sites patched:** the repo already had a
census test (`test_no_call_site_invokes_codex_without_choosing_a_seat`) meant
to catch exactly this class going forward — but its detector regexes
required `"codex"` and `"exec"` adjacent, which is why it never caught any of
the above: every real invocation here inserts flags (`--profile xhigh`,
`--ignore-user-config --sandbox workspace-write --ephemeral --cd "$ROOT"`)
between them. Fixed both regexes to tolerate bounded flag/token runs, and
made the shell scanner join backslash-continued lines first (the autofix-ci
invocation splits `codex ... \` / `exec ...` across two physical lines — a
line-by-line scan can't see it as one command). Added per-call-site
guilt+innocence tests for the 4 cron wrappers and the 2 backend-rag actions.

**Deliberately not touched:** `wr2_image_generator.py`'s
`_acquire_bytes_via_codex_once` also bypasses seat rotation, but spawns via
a `CODEX_BIN` variable, not the literal `"codex"` string — outside what the
improved census detector can prove without risking new false positives
across the whole tree. Flagging as a known follow-up rather than silently
declaring the class closed (W107: curing one wrapper and calling the disease
closed).

## Two scars specifically guarded against
- **W104**: seat liveness is judged by the codex CLI's reply, never by this
  script's own exit code — unchanged, `codex_seat_pick()` already does this.
- **W106**: no hardcoded "seat X is dead" constant anywhere — every wrapper
  probes live (`[ -f "$seat/auth.json" ]`) on every run and logs which PATH
  it accepted (never file contents, never `env`).

## Test plan
- [x] `scripts/tests/test_codex_seat_lib.py` — 23/23 passed (14 pre-existing
      + 9 new guilt/innocence/shape tests for the 4 cron wrappers)
- [x] `apps/backend-rag` `backend/tests/services/federation_alerts/` — full
      suite green (63 tests incl. 5 new seat-wiring unit tests)
- [x] Import chain smoke test (`get_current_user`) — OK
- [x] `ruff check` clean on every touched/new Python file
- [x] `shellcheck` clean on every touched shell script (no new findings)
- [x] Manual dry-run of all 3 live crons — seat line printed, correct path,
      exit 0, no side effects
- [x] Pre-commit + pre-push hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)