### PR TITLE
perf(ci): make security.yml path-aware via the existing change-map classifier

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -184,7 +184,21 @@ jobs:
             echo "::warning::change_map.py exited non-zero; forcing conservative fallback"
             MAP_JSON='{"schema_version":1,"mode":"enforcing","reason":"classifier_runtime_failure","changed_file_count":0,"domains":{},"unknown_paths":[],"run_all":true,"security_suggested_jobs":["snyk-python","snyk-node","snyk-docker","codeql-python","codeql-javascript","bandit","safety"],"security_would_skip":[]}'
           fi
-          RUN_ALL="$(MAP_JSON="$MAP_JSON" python3 -c 'import json, os; print(str(json.loads(os.environ["MAP_JSON"])["run_all"]).lower())')"
+          # BOOTSTRAP GAP (found live on this PR's own first run, 2026-08-20):
+          # the extracted classifier is always the BASE-ref copy (root of
+          # trust, see above) — the one PR that ADDS security_suggested_jobs
+          # to change_map.py necessarily extracts a base copy that doesn't
+          # have it yet, and a bare `result["security_suggested_jobs"]` threw
+          # KeyError and hard-failed this job (every downstream job still ran
+          # correctly, via the `needs.changes.result != 'success'` fail-open
+          # branch on their own `if:` — but the failure itself was an
+          # unnecessary, confusing crash for something the fail-open contract
+          # was already handling). `.get(...)` + treating a missing key as
+          # its own reason to force run_all covers both this one-time
+          # bootstrap case AND any future PR that similarly edits
+          # change_map.py's schema and security.yml's consumption of it in
+          # the same commit.
+          RUN_ALL="$(MAP_JSON="$MAP_JSON" python3 -c 'import json, os; r = json.loads(os.environ["MAP_JSON"]); print(str(bool(r.get("run_all", True)) or "security_suggested_jobs" not in r).lower())')"
           echo "map=$MAP_JSON" >> "$GITHUB_OUTPUT"
           echo "run_all=$RUN_ALL" >> "$GITHUB_OUTPUT"
 
@@ -195,8 +209,8 @@ jobs:
           import json, os
 
           result = json.loads(os.environ["MAP_JSON"])
-          run_all = bool(result["run_all"])
-          suggested = set(result["security_suggested_jobs"])
+          run_all = bool(result.get("run_all", True)) or "security_suggested_jobs" not in result
+          suggested = set(result.get("security_suggested_jobs", []))
           jobs = [
               "snyk-python",
               "snyk-node",
@@ -229,8 +243,16 @@ jobs:
           raw = os.environ.get("MAP_JSON", "")
           if raw:
               result = json.loads(raw)
-              skipped = result["security_would_skip"]
-              run_all = result["run_all"]
+              # .get(...), not bare indexing (bootstrap gap, found live on
+              # this PR's own first run — see the "Enumerate and classify"
+              # step's comment above): the base-ref classifier this job
+              # extracts can predate security_suggested_jobs existing at
+              # all.
+              schema_has_security_jobs = "security_suggested_jobs" in result
+              skipped = result.get("security_would_skip", [])
+              run_all = bool(result.get("run_all", True)) or not schema_has_security_jobs
+              if not schema_has_security_jobs:
+                  result["reason"] = "base_ref_classifier_schema_too_old"
           else:
               result = {"reason": "classifier_runtime_failure"}
               skipped = []

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -69,8 +69,218 @@ concurrency:
   cancel-in-progress: ${{ (github.ref != 'refs/heads/main') && github.event_name != 'merge_group' }}
 
 jobs:
+  changes:
+    name: Change map (security)
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      # Fail-open defaults (superscar #2 "esiste ≠ armato"): any failure of
+      # the classifier corpus, the enumerator, or this step's own JSON
+      # parsing leaves steps.classify.outputs.* unset, and every `|| 'true'`
+      # below then makes the corresponding job run. There is no path from a
+      # broken classifier to a silently-skipped security scan.
+      #
+      # `detect-secrets` deliberately has NO output/flag here — it is never
+      # gated on this job's decision (superscar #4 "secret in the clear": a
+      # secret can land via any file type, so that job stays unconditional
+      # in its own `if:`-free job definition below).
+      run_all: ${{ steps.classify.outputs.run_all || 'true' }}
+      run_snyk_python: ${{ steps.classify.outputs.run_snyk_python || 'true' }}
+      run_snyk_node: ${{ steps.classify.outputs.run_snyk_node || 'true' }}
+      run_snyk_docker: ${{ steps.classify.outputs.run_snyk_docker || 'true' }}
+      run_codeql_python: ${{ steps.classify.outputs.run_codeql_python || 'true' }}
+      run_codeql_javascript: ${{ steps.classify.outputs.run_codeql_javascript || 'true' }}
+      run_bandit: ${{ steps.classify.outputs.run_bandit || 'true' }}
+      run_safety: ${{ steps.classify.outputs.run_safety || 'true' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # ROOT OF TRUST (mirrors tests.yml's `changes` job, CRITICAL-1
+      # 2026-08-14): a PR that weakens which security jobs get selected could,
+      # in the SAME commit, edit change_map.py to under-report its own
+      # domain — self-approving a skip of e.g. CodeQL or Bandit. Extract the
+      # classifier from BASE_SHA (main's tip for a PR, the queue's base for
+      # merge_group) and run ONLY that copy for the rest of this job — a PR
+      # can propose a change to the classifier, but that change judges every
+      # OTHER PR first and only starts judging PRs once merged. `scripts/ci/`
+      # is CODEOWNERS TIER 1 (defense in depth) and is itself mapped to
+      # security_sensitive in change_map.py, so a PR editing the classifier
+      # is classified run_all=true by the OLD copy doing the judging.
+      - name: Extract trusted classifier (base ref)
+        id: extract
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          CLASSIFIER_DIR="$RUNNER_TEMP/trusted-classifier"
+          mkdir -p "$CLASSIFIER_DIR"
+          OK=true
+          for f in scripts/ci/change_map.py scripts/ci/test_change_map.py scripts/ci/hotzone_changed_files.sh; do
+            if ! git show "${BASE_SHA}:${f}" > "$CLASSIFIER_DIR/$(basename "$f")" 2>/dev/null; then
+              echo "::warning::could not extract $f from base ref $BASE_SHA — treating classifier as untrusted for this run"
+              OK=false
+            fi
+          done
+          chmod +x "$CLASSIFIER_DIR/hotzone_changed_files.sh" 2>/dev/null || true
+          echo "dir=$CLASSIFIER_DIR" >> "$GITHUB_OUTPUT"
+          echo "ok=$OK" >> "$GITHUB_OUTPUT"
+
+      - name: Verify change-map guilt and innocence corpus
+        id: classifier-tests
+        continue-on-error: true
+        env:
+          CLASSIFIER_DIR: ${{ steps.extract.outputs.dir }}
+          EXTRACT_OK: ${{ steps.extract.outputs.ok }}
+        run: |
+          set -uo pipefail
+          if [ "$EXTRACT_OK" != "true" ]; then
+            echo "::error::base-ref classifier extraction failed — refusing to trust a corpus that didn't run"
+            exit 1
+          fi
+          python3 "$CLASSIFIER_DIR/test_change_map.py"
+
+      # merge_group base/head SHAs (established pattern — see tests.yml,
+      # hot-zone-pr-gate.yml, harness-floor.yml): under a merge queue entry
+      # github.event.pull_request.* is unset, so the merge_group.* SHAs take
+      # priority via `||`. hotzone_changed_files.sh resolves the merge-base
+      # with pure git and only falls back to the PR files API (which needs
+      # PR_NUMBER) if that fails.
+      - name: Enumerate and classify this PR's files
+        id: classify
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+          CLASSIFIER_TEST_OUTCOME: ${{ steps.classifier-tests.outcome }}
+          CLASSIFIER_DIR: ${{ steps.extract.outputs.dir }}
+          EXTRACT_OK: ${{ steps.extract.outputs.ok }}
+        run: |
+          set -uo pipefail
+          CHANGED_FILE="$RUNNER_TEMP/security-change-map-changed-files.txt"
+
+          if [ "$EXTRACT_OK" != "true" ] || [ "$CLASSIFIER_TEST_OUTCOME" != "success" ]; then
+            echo "::warning::classifier untrusted or corpus failed; recommendation defaults to all jobs"
+            printf '%s\n' '__CHANGE_MAP_ENUMERATION_ERROR__' > "$CHANGED_FILE"
+          elif ! bash "$CLASSIFIER_DIR/hotzone_changed_files.sh" \
+            "$BASE_SHA" "$HEAD_SHA" "$PR_NUMBER" > "$CHANGED_FILE"; then
+            echo "::warning::changed-file enumeration failed; recommendation defaults to all jobs"
+            printf '%s\n' '__CHANGE_MAP_ENUMERATION_ERROR__' > "$CHANGED_FILE"
+          fi
+
+          # HIGH-4 (mirrors tests.yml): capture the classifier's own exit
+          # code explicitly rather than trusting a bare command-substitution
+          # under `set -uo pipefail` (no `-e` — see W101 in
+          # cicatrix-superscar.md).
+          if ! MAP_JSON="$(python3 "$CLASSIFIER_DIR/change_map.py" < "$CHANGED_FILE")"; then
+            echo "::warning::change_map.py exited non-zero; forcing conservative fallback"
+            MAP_JSON='{"schema_version":1,"mode":"enforcing","reason":"classifier_runtime_failure","changed_file_count":0,"domains":{},"unknown_paths":[],"run_all":true,"security_suggested_jobs":["snyk-python","snyk-node","snyk-docker","codeql-python","codeql-javascript","bandit","safety"],"security_would_skip":[]}'
+          fi
+          RUN_ALL="$(MAP_JSON="$MAP_JSON" python3 -c 'import json, os; print(str(json.loads(os.environ["MAP_JSON"])["run_all"]).lower())')"
+          echo "map=$MAP_JSON" >> "$GITHUB_OUTPUT"
+          echo "run_all=$RUN_ALL" >> "$GITHUB_OUTPUT"
+
+          # Per-job explicit booleans (superscar #3 "guard-over-match"): exact
+          # membership against the parsed security_suggested_jobs list, never
+          # a substring check on the raw JSON.
+          JOB_FLAGS="$(MAP_JSON="$MAP_JSON" python3 -c '
+          import json, os
+
+          result = json.loads(os.environ["MAP_JSON"])
+          run_all = bool(result["run_all"])
+          suggested = set(result["security_suggested_jobs"])
+          jobs = [
+              "snyk-python",
+              "snyk-node",
+              "snyk-docker",
+              "codeql-python",
+              "codeql-javascript",
+              "bandit",
+              "safety",
+          ]
+          for job in jobs:
+              flag = run_all or job in suggested
+              output_name = "run_" + job.replace("-", "_")
+              value = "true" if flag else "false"
+              print(f"{output_name}={value}")
+          ')"
+          echo "$JOB_FLAGS" >> "$GITHUB_OUTPUT"
+          echo "::notice::security change-map: $MAP_JSON"
+
+      - name: Publish change-map decision
+        if: always()
+        env:
+          MAP_JSON: ${{ steps.classify.outputs.map }}
+          CLASSIFIER_TEST_OUTCOME: ${{ steps.classifier-tests.outcome }}
+          CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          raw = os.environ.get("MAP_JSON", "")
+          if raw:
+              result = json.loads(raw)
+              skipped = result["security_would_skip"]
+              run_all = result["run_all"]
+          else:
+              result = {"reason": "classifier_runtime_failure"}
+              skipped = []
+              run_all = True
+
+          lines = [
+              "## Change map (security) — enforcing",
+              "",
+              f"- Classifier corpus: `{os.environ['CLASSIFIER_TEST_OUTCOME']}`",
+              f"- Classification step: `{os.environ['CLASSIFY_OUTCOME']}`",
+              f"- Reason: `{result.get('reason', 'unknown')}`",
+              f"- Conservative fallback (run everything): `{str(run_all).lower()}`",
+              "",
+              "`detect-secrets` is never gated — it always runs regardless of this map.",
+              "",
+          ]
+          if skipped:
+              lines.append("Jobs this run will SKIP:")
+              lines.extend(f"- {job}" for job in skipped)
+          else:
+              lines.append("No security job is being skipped for this run.")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fh:
+                  fh.write("\n".join(lines) + "\n")
+          PY
+
   snyk-python:
     name: Snyk Python Security
+    needs: [changes]
+    # Path-aware skip (change-map, 2026-08-20 — see `changes` job above and
+    # scripts/ci/change_map.py::_suggested_security_jobs). Not a required
+    # branch-protection context (verified against
+    # `gh api repos/.../branches/main/protection` 2026-08-20 — absent from
+    # the contexts list, unlike CodeQL/Bandit/Detect Secrets below), so a
+    # `skipped` conclusion here has no merge-blocking effect either way.
+    # `!cancelled()` + the event-name branch + `needs.changes.result` check
+    # follow the exact pattern tests.yml uses for its own path-aware jobs —
+    # see backend-tests there for the full rationale (HIGH-3: a stale
+    # run_*=false published before a later `changes` step fails must not
+    # survive; `!cancelled()`: a cancelled workflow run gets no verdict, not
+    # a false pass).
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_snyk_python != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Blocking gate — HIGH/CRITICAL CVEs fail the job unless the finding is
@@ -121,6 +331,16 @@ jobs:
 
   snyk-node:
     name: Snyk Node.js Security
+    needs: [changes]
+    # Path-aware skip — see snyk-python above for the full rationale. Not a
+    # required context.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_snyk_node != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Blocking gate — see snyk-python. Exceptions honoured via
@@ -173,6 +393,21 @@ jobs:
 
   snyk-docker:
     name: Snyk Docker Security
+    needs: [changes]
+    # Path-aware skip — see snyk-python above for the full rationale. Not a
+    # required context. Trigger is the backend_python domain (see
+    # change_map.py::_suggested_security_jobs): the Dockerfile's COPY
+    # instructions pull apps/backend-rag/backend, packages/cell-core,
+    # apps/crm-cell (CLAUDE.md §11 deploy) — all three are inside that
+    # domain, so an edit to any of them (Dockerfile included, tagged both
+    # backend_python and security_sensitive) reruns this job.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_snyk_docker != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # This job does TWO different things and they deserve different verdicts:
@@ -285,19 +520,43 @@ jobs:
             "${RUN_URL}")"
           bash scripts/ci/telegram_notify.sh --parse-mode HTML --text "$TEXT"
 
-  codeql:
-    name: CodeQL Analysis
+  # CodeQL used to be one `strategy.matrix` job ("CodeQL Analysis", legs
+  # ["python", "javascript"]) generating the two required contexts below by
+  # GitHub's own `<job name> (<matrix value>)` naming. Split into two plain
+  # jobs 2026-08-20 SOLELY to make path-aware skipping possible: a job's
+  # top-level `if:` does not have access to the `matrix` context (only
+  # `github`, `needs`, `vars`, `inputs` — confirmed live via actionlint and
+  # GitHub's own context-availability table), so a per-language skip
+  # decision cannot be expressed inside a matrix job's `if:`. `name:` is set
+  # literally to the exact required-context strings the matrix used to
+  # generate, so branch protection needs no change.
+  codeql-python:
+    name: CodeQL Analysis (python)
+    needs: [changes]
+    # Path-aware skip. REQUIRED context (branch protection context
+    # "CodeQL Analysis (python)" — verified 2026-08-20 via
+    # `gh api repos/.../branches/main/protection`), so a `skipped` conclusion
+    # here is what satisfies the merge gate for a PR with no Python file in
+    # its diff — the same skip-satisfies-required pattern tests.yml's own
+    # required contexts (e.g. "Backend Tests (Python)") already rely on.
+    #
+    # Language-shaped, not domain-shaped (see change_map.py::PYTHON_SUFFIXES):
+    # CodeQL's autobuild compiles whatever Python source exists anywhere in
+    # the checkout, so this is gated on "does the diff contain a .py/.pyi
+    # file", independent of which product domain it nominally belongs to.
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_codeql_python != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["python", "javascript"]
 
     steps:
       - name: Checkout code
@@ -306,7 +565,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.37.6
         with:
-          languages: ${{ matrix.language }}
+          languages: python
           queries: security-extended,security-and-quality
           config-file: ./.github/codeql-config.yml
 
@@ -316,10 +575,66 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4.37.6
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:python"
+
+  codeql-javascript:
+    name: CodeQL Analysis (javascript)
+    needs: [changes]
+    # Path-aware skip — see codeql-python above for the full rationale.
+    # REQUIRED context "CodeQL Analysis (javascript)" (verified 2026-08-20).
+    # Gated on "does the diff contain a .js/.jsx/.ts/.tsx/.mjs/.cjs file"
+    # (change_map.py::JS_TS_SUFFIXES).
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_codeql_javascript != 'false'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4.37.6
+        with:
+          languages: javascript
+          queries: security-extended,security-and-quality
+          config-file: ./.github/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4.37.6
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4.37.6
+        with:
+          category: "/language:javascript"
 
   bandit:
     name: Bandit Python Security
+    needs: [changes]
+    # Path-aware skip. REQUIRED context (branch protection context
+    # "Bandit Python Security" — verified 2026-08-20), so a `skipped`
+    # conclusion satisfies the merge gate, mirroring the CodeQL job above and
+    # tests.yml's own required contexts. Trigger is a direct path check
+    # (apps/backend-rag/backend/ — bandit's exact `-r` target — or
+    # apps/backend-rag/pyproject.toml, its `-c` config), narrower than the
+    # full backend_python domain (see change_map.py::_suggested_security_jobs
+    # docstring for why).
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_bandit != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Blocking gate (A1 fix 2026-06-13): this job is in the merge-blocking
@@ -388,6 +703,17 @@ jobs:
 
   safety:
     name: Safety Dependency Check
+    needs: [changes]
+    # Path-aware skip — see snyk-python above for the full rationale. Not a
+    # required context. Same trigger as snyk-python (both scan exactly
+    # apps/backend-rag/requirements.txt).
+    if: >-
+      !cancelled() &&
+      (
+        (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.run_safety != 'false'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Blocking gate — HIGH/CRITICAL CVEs fail the job unless the finding is
@@ -433,6 +759,13 @@ jobs:
   detect-secrets:
     name: Detect Secrets
     runs-on: ubuntu-latest
+    # DELIBERATELY UNCONDITIONAL (2026-08-20): every other job in this
+    # workflow gates on the `changes` job's path-aware recommendation
+    # (scripts/ci/change_map.py::_suggested_security_jobs) — this one never
+    # will. A secret can land via any file type (a .md, a fixture, a
+    # generated .json), so cicatrix-superscar #4 "secret in the clear" bars
+    # any path filter here, no exceptions. No `needs: [changes]`, no `if:`.
+    #
     # Run 31312661093 measured 19m34s in the scan alone and was cancelled at
     # the 20m job limit after every gating step had succeeded. Keep this gate
     # blocking, but give runner variance enough headroom to report its verdict.
@@ -506,7 +839,8 @@ jobs:
         snyk-python,
         snyk-node,
         snyk-docker,
-        codeql,
+        codeql-python,
+        codeql-javascript,
         bandit,
         safety,
         detect-secrets,

--- a/scripts/ci/change_map.py
+++ b/scripts/ci/change_map.py
@@ -12,6 +12,12 @@ shadow-measurement audit that found and closed one real false-skip (see
 EXACT_RULES' PricingTool-canonical entry below) — see that workflow's
 ``changes`` job for the fail-open contract every consumer of this module's
 output must honor.
+
+Second consumer added 2026-08-20: .github/workflows/security.yml gates six of
+its seven heavy jobs on ``security_suggested_jobs``/``run_all`` (the seventh,
+``detect-secrets``, is unconditional by design — see SECURITY_JOBS below).
+Same fail-open contract, same root-of-trust extraction pattern (this file is
+pulled from the PR's BASE ref before it judges the PR).
 """
 
 from __future__ import annotations
@@ -45,6 +51,31 @@ TEST_JOBS = (
     "packages-core-tests",
     "e2e-tests",
 )
+
+# security.yml's heavy jobs (2026-08-20). `detect-secrets` is deliberately
+# ABSENT — cicatrix-superscar #4 "secret in the clear": a secret can land via
+# any file type (a .md, a fixture, a .json), so that job stays unconditional
+# in the workflow itself and never consults this map. Two of the six are the
+# CodeQL matrix legs; they get their own reason below (language-shaped, not
+# path-shaped).
+SECURITY_JOBS = (
+    "snyk-python",
+    "snyk-node",
+    "snyk-docker",
+    "codeql-python",
+    "codeql-javascript",
+    "bandit",
+    "safety",
+)
+
+# CodeQL's autobuild compiles whatever source of a given language exists
+# anywhere in the checkout — it is language-shaped, not domain-shaped, so the
+# correct trigger is "does this diff contain a file of that language" rather
+# than a domain lookup. This also robustly covers paths with no domain route
+# at all (e.g. root-level scripts/*.py), which would otherwise depend on the
+# unknown-path fail-closed branch to be caught.
+PYTHON_SUFFIXES = (".py", ".pyi")
+JS_TS_SUFFIXES = (".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
 
 PRODUCT_DOMAINS = frozenset(
     {
@@ -167,6 +198,26 @@ EXACT_RULES: dict[str, set[str] | frozenset[str]] = {
         "mouth",
         "backend_python",
     },
+    # security.yml's CVE-exception / secrets-baseline honour scripts live at
+    # repo-root `scripts/`, not `scripts/ci/` (that prefix rule below does not
+    # reach them) — an unqualified `scripts/` prefix rule would be far too
+    # wide (hundreds of unrelated cron/ops scripts live there). Named
+    # explicitly instead so an edit here is routed to security_sensitive
+    # rather than falling through to the unknown-path fail-closed branch —
+    # same observable outcome (run everything), but documented intent rather
+    # than an accident of an unmapped path.
+    "scripts/check_cve_exceptions.py": {"infra_workflows", "security_sensitive"},
+    "scripts/filter_snyk_findings.py": {"infra_workflows", "security_sensitive"},
+    "scripts/filter_safety_findings.py": {"infra_workflows", "security_sensitive"},
+    "scripts/detect_secrets_auto_triage.py": {
+        "infra_workflows",
+        "security_sensitive",
+    },
+    "scripts/detect_secrets_check_unaudited.py": {
+        "infra_workflows",
+        "security_sensitive",
+    },
+    ".secrets.baseline": {"infra_workflows", "security_sensitive"},
 }
 
 # Filename-pattern coupling (red-team HIGH-8, 2026-08-14): the visa-engine
@@ -335,6 +386,71 @@ def _suggested_jobs(domains: set[str], run_all: bool) -> list[str]:
     return jobs
 
 
+def _suggested_security_jobs(
+    domains: set[str], changed: list[str], run_all: bool
+) -> list[str]:
+    """Domain/path -> security.yml job routing (2026-08-20).
+
+    Evidence for every rule below is the job's own `run:`/`args:` in
+    security.yml, re-verified in this same PR — not guessed from domain
+    names:
+
+    - snyk-python / safety both scan exactly
+      ``apps/backend-rag/requirements.txt`` (``--file=`` / ``--file``). A
+      manifest edit anywhere already tags `security_sensitive`
+      (PYTHON_MANIFEST_NAMES) and is caught by the run_all branch below;
+      `backend_python` domain is kept as the trigger here (not narrowed to
+      the one file) because CVE-exception plumbing
+      (`.security/exceptions.yaml`, `scripts/check_cve_exceptions.py`,
+      `scripts/filter_snyk_findings.py`, `scripts/filter_safety_findings.py`)
+      also gates these jobs and already routes through security_sensitive.
+    - snyk-docker builds `apps/backend-rag/Dockerfile`, whose COPY
+      instructions pull `apps/backend-rag/backend`, `packages/cell-core`,
+      `apps/crm-cell` (CLAUDE.md SS11 deploy) — all three are already inside
+      the `backend_python` domain via PREFIX_RULES.
+    - snyk-node runs `npm ci` + `snyk test --all-projects` from the repo
+      root, whose workspace (package.json `workspaces`) is backend-rag,
+      mouth, admin-dashboard, packages/core, packages/ts-schemas — i.e. the
+      same domain set frontend-tests already gates on.
+    - bandit recursively scans `apps/backend-rag/backend/` (`-r` flag,
+      Python-only by nature of the tool) and reads its config from
+      `apps/backend-rag/pyproject.toml` (`-c` flag) — narrower than the full
+      `backend_python` domain on two axes: directory (excludes
+      apps/crm-cell, packages/cell-core, the manifest itself, none of which
+      `-r` touches) AND language (a non-.py file inside that directory, e.g.
+      a JSON fixture, changes nothing bandit would report), so this one is a
+      direct path+suffix check rather than a domain lookup.
+    - codeql-python / codeql-javascript: see PYTHON_SUFFIXES/JS_TS_SUFFIXES
+      above — language-shaped, not path-shaped.
+    """
+
+    # Same fail-closed contract as _suggested_jobs: CI infrastructure and
+    # security-sensitive surfaces are known paths but never candidates for
+    # selective execution, and an unclassified/empty/failed enumeration
+    # (run_all) always means "run everything".
+    if run_all or domains.intersection({"infra_workflows", "security_sensitive"}):
+        return list(SECURITY_JOBS)
+
+    jobs: list[str] = []
+    if "backend_python" in domains:
+        jobs.append("snyk-python")
+        jobs.append("safety")
+        jobs.append("snyk-docker")
+    if domains.intersection({"mouth", "admin_dashboard", "wa_mirror", "packages_core"}):
+        jobs.append("snyk-node")
+    if any(
+        p == "apps/backend-rag/pyproject.toml"
+        or (p.startswith("apps/backend-rag/backend/") and p.endswith(PYTHON_SUFFIXES))
+        for p in changed
+    ):
+        jobs.append("bandit")
+    if any(p.endswith(PYTHON_SUFFIXES) for p in changed):
+        jobs.append("codeql-python")
+    if any(p.endswith(JS_TS_SUFFIXES) for p in changed):
+        jobs.append("codeql-javascript")
+    return jobs
+
+
 def classify(paths: Iterable[str]) -> dict[str, object]:
     """Build the deterministic change-map recommendation for ``paths``."""
 
@@ -375,15 +491,21 @@ def classify(paths: Iterable[str]) -> dict[str, object]:
         reason = "classified"
 
     suggested = _suggested_jobs(domains, run_all)
+    # security.yml's own `changes` job (2026-08-20) is the second consumer of
+    # this module — the fields below are additive to the schema tests.yml has
+    # relied on since promotion, so this stays backward compatible for that
+    # caller (it reads suggested_jobs/would_skip by key and ignores the rest).
+    security_suggested = _suggested_security_jobs(domains, changed, run_all)
     return {
         "schema_version": 1,
         # Promoted 2026-08-14 (cicatrix superscar #2, "esiste ≠ armato": a
         # status field that keeps saying "shadow" after the caller starts
         # enforcing it is exactly the false-green this family warns about —
         # the next person to debug a skipped job would read this and assume
-        # nothing gates on it). Literal, not derived: this module has exactly
-        # one caller (.github/workflows/tests.yml's `changes` job) and it is
-        # enforcing; there is no second "shadow" consumer to parametrize for.
+        # nothing gates on it). Both callers of this module
+        # (.github/workflows/tests.yml and .github/workflows/security.yml
+        # `changes` jobs) are enforcing; there is no "shadow" consumer left
+        # to parametrize for.
         "mode": "enforcing",
         "reason": reason,
         "changed_file_count": len(changed),
@@ -392,6 +514,10 @@ def classify(paths: Iterable[str]) -> dict[str, object]:
         "run_all": run_all,
         "suggested_jobs": suggested,
         "would_skip": [job for job in TEST_JOBS if job not in suggested],
+        "security_suggested_jobs": security_suggested,
+        "security_would_skip": [
+            job for job in SECURITY_JOBS if job not in security_suggested
+        ],
     }
 
 

--- a/scripts/ci/test_change_map.py
+++ b/scripts/ci/test_change_map.py
@@ -314,6 +314,129 @@ class ChangeMapTests(unittest.TestCase):
             ["backend-tests", "frontend-tests", "e2e-tests"],
         )
 
+    # -- security.yml routing (security_suggested_jobs / security_would_skip) --
+
+    def test_guilt_backend_change_runs_python_dep_and_sast_security_jobs(
+        self,
+    ) -> None:
+        result = cm.classify(["apps/backend-rag/backend/app/main.py"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(
+            result["security_suggested_jobs"],
+            ["snyk-python", "safety", "snyk-docker", "bandit", "codeql-python"],
+        )
+        self.assertEqual(
+            result["security_would_skip"], ["snyk-node", "codeql-javascript"]
+        )
+
+    def test_innocence_frontend_only_change_skips_python_security_jobs(
+        self,
+    ) -> None:
+        # mouth is JS/TS -- none of snyk-python/safety/snyk-docker/bandit
+        # scan anything under apps/mouth/, and codeql-python has no python
+        # file to react to.
+        result = cm.classify(["apps/mouth/src/app.tsx"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(
+            result["security_suggested_jobs"], ["snyk-node", "codeql-javascript"]
+        )
+        for job in ("snyk-python", "safety", "snyk-docker", "bandit", "codeql-python"):
+            self.assertIn(job, result["security_would_skip"])
+
+    def test_innocence_docs_only_skips_every_security_job(self) -> None:
+        result = cm.classify(["docs/runbooks/ci.md", "research/operations/note.json"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["security_suggested_jobs"], [])
+        self.assertEqual(result["security_would_skip"], list(cm.SECURITY_JOBS))
+
+    def test_guilt_bandit_target_directory_runs_bandit_only_python_job(self) -> None:
+        # apps/backend-rag/backend/ is bandit's exact `-r` target -- distinct
+        # from the broader backend_python domain, which also covers
+        # apps/crm-cell/ and packages/cell-core/ (neither bandit-scanned).
+        result = cm.classify(["apps/backend-rag/backend/services/foo.py"])
+        self.assertIn("bandit", result["security_suggested_jobs"])
+
+    def test_innocence_backend_domain_outside_bandit_target_skips_bandit(self) -> None:
+        for path in (
+            "apps/crm-cell/crm_cell/main.py",
+            "packages/cell-core/cell_core/base.py",
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertFalse(result["run_all"])
+                self.assertNotIn("bandit", result["security_suggested_jobs"])
+                self.assertIn("bandit", result["security_would_skip"])
+                # still a backend_python change -- the dependency/build scans
+                # DO apply (snyk-docker's Dockerfile COPYs both trees).
+                self.assertIn("snyk-python", result["security_suggested_jobs"])
+                self.assertIn("snyk-docker", result["security_suggested_jobs"])
+
+    def test_guilt_bandit_config_edit_reruns_bandit(self) -> None:
+        result = cm.classify(["apps/backend-rag/pyproject.toml"])
+        self.assertIn("bandit", result["security_suggested_jobs"])
+
+    def test_innocence_non_python_file_under_bandit_target_skips_bandit(self) -> None:
+        # Live case, 2026-08-20 sample (PR #4413): a signed rulepack .json
+        # under apps/backend-rag/backend/ changes nothing `bandit -r`
+        # (python-only by nature of the tool) would report.
+        result = cm.classify(
+            [
+                "apps/backend-rag/backend/services/visa_engine/contracts/packs/rulepack-prod-012.signed.json"
+            ]
+        )
+        self.assertFalse(result["run_all"])
+        self.assertNotIn("bandit", result["security_suggested_jobs"])
+        self.assertIn("bandit", result["security_would_skip"])
+        # still backend_python -- the dependency/build scans DO apply.
+        self.assertIn("snyk-python", result["security_suggested_jobs"])
+
+    def test_guilt_codeql_reacts_to_language_not_domain(self) -> None:
+        # apps/nuzantara-mcp/ has no snyk-python/bandit/safety route (those
+        # scan apps/backend-rag/ specifically) but IS python source, so
+        # CodeQL's python leg must still see it.
+        result = cm.classify(["apps/nuzantara-mcp/server.py"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["security_suggested_jobs"], ["codeql-python"])
+
+    def test_guilt_manifest_edit_runs_every_security_job(self) -> None:
+        # A dependency-manifest edit is tagged security_sensitive
+        # (PYTHON_MANIFEST_NAMES) regardless of directory -- the coarse
+        # catch-all applies, matching the existing TEST_JOBS behaviour for
+        # the same input.
+        result = cm.classify(["apps/backend-rag/requirements.txt"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["security_suggested_jobs"], list(cm.SECURITY_JOBS))
+
+    def test_guilt_cve_exception_honour_scripts_run_everything(self) -> None:
+        for path in (
+            "scripts/check_cve_exceptions.py",
+            "scripts/filter_snyk_findings.py",
+            "scripts/filter_safety_findings.py",
+            "scripts/detect_secrets_auto_triage.py",
+            "scripts/detect_secrets_check_unaudited.py",
+            ".secrets.baseline",
+        ):
+            with self.subTest(path=path):
+                result = cm.classify([path])
+                self.assertFalse(result["run_all"])
+                self.assertTrue(result["domains"]["security_sensitive"])
+                self.assertEqual(
+                    result["security_suggested_jobs"], list(cm.SECURITY_JOBS)
+                )
+
+    def test_guilt_unclassified_path_runs_every_security_job(self) -> None:
+        # Same fail-closed contract as TEST_JOBS: an unknown path forces
+        # run_all, which forces every security job too.
+        result = cm.classify(["apps/new-product/runtime.rs"])
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["security_suggested_jobs"], list(cm.SECURITY_JOBS))
+        self.assertEqual(result["security_would_skip"], [])
+
+    def test_guilt_security_workflow_self_edit_runs_everything(self) -> None:
+        result = cm.classify([".github/workflows/security.yml"])
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["security_suggested_jobs"], list(cm.SECURITY_JOBS))
+
     def test_cli_stdout_is_one_compact_json_line(self) -> None:
         script = Path(__file__).with_name("change_map.py")
         completed = subprocess.run(


### PR DESCRIPTION
## Summary

`security.yml` ran all 8 jobs unconditionally on every `pull_request`
(`opened`/`synchronize`/`reopened`) and `merge_group` — no `paths:` filter,
no `needs.changes` gate. Measured average: **39.84 runner-minutes/run**, the
single largest CI time sink in the fleet, most of it spent on PRs that never
touch what a given job analyzes (e.g. a docs-only PR still ran CodeQL on
every language).

This makes 6 of the 8 jobs path-aware by reusing the infrastructure the repo
already has — `scripts/ci/change_map.py` + `scripts/ci/hotzone_changed_files.sh`
+ tests.yml's `changes`-job pattern — rather than inventing a second
classifier.

## The 8 jobs, evidence, and filter

| Job | What it actually scans | Filter |
|---|---|---|
| **Detect Secrets** | Every file in the repo (`detect-secrets scan`) | **NEVER filtered.** No `needs`, no `if:`. A secret can land via a `.md`, a fixture, a `.json` — cicatrix-superscar #4. |
| Snyk Python | `apps/backend-rag/requirements.txt` (`--file=`) | `backend_python` domain (also covers the CVE-exception plumbing that gates it) |
| Safety | Same file, same reason | Same as Snyk Python |
| Snyk Docker | Builds `apps/backend-rag/Dockerfile`, whose `COPY` pulls `apps/backend-rag/backend`, `packages/cell-core`, `apps/crm-cell` | `backend_python` domain (covers all three COPY sources) |
| Snyk Node | `npm ci` + `snyk test --all-projects` from repo root (workspace = backend-rag, mouth, admin-dashboard, packages/core, packages/ts-schemas) | any of `mouth`/`admin_dashboard`/`wa_mirror`/`packages_core` domains |
| Bandit | `bandit -r apps/backend-rag/backend/` (`.py` only) + `-c apps/backend-rag/pyproject.toml` | direct path+suffix check: `.py` file under that dir, or the pyproject.toml itself — narrower than the `backend_python` domain (excludes `apps/crm-cell`, `packages/cell-core`, non-`.py` files) |
| **CodeQL (python)** — required | Autobuild compiles whatever Python source exists anywhere | any `.py`/`.pyi` in the diff — language-shaped, not domain-shaped |
| **CodeQL (javascript)** — required | Same, for JS/TS | any `.js`/`.jsx`/`.ts`/`.tsx`/`.mjs`/`.cjs` in the diff |
| **Bandit** — required (see above) | | |

`Bandit Python Security`, `CodeQL Analysis (python)`, `CodeQL Analysis
(javascript)`, `Detect Secrets` are the 4 required branch-protection
contexts this workflow owns (`gh api repos/.../branches/main/protection`,
verified). Snyk×3 and Safety are not required — they're blocking-but-advisory
at the job level, unaffected either way by a `skipped` conclusion.

## Mechanics

- **New `changes` job** in security.yml, mirroring tests.yml's proven
  pattern: extracts `change_map.py`/`test_change_map.py`/
  `hotzone_changed_files.sh` from `BASE_SHA` (root-of-trust — a PR editing
  the classifier can't judge itself), runs the guilt+innocence corpus,
  enumerates changed files anchored at the **merge-base** (never two-dot —
  W102), classifies, and publishes per-job `run_<job>` outputs with a hard
  `|| 'true'` fail-open default at every layer.
- **`scripts/ci/change_map.py`** gets a new `_suggested_security_jobs()`
  (additive — `suggested_jobs`/`would_skip` for tests.yml's 6 jobs are
  untouched) plus a handful of new `EXACT_RULES` entries for the root-level
  CVE-exception/secrets-baseline scripts (`scripts/check_cve_exceptions.py`
  etc.) so they're explicitly `security_sensitive` instead of silently
  falling into the unknown-path fail-closed branch (same observable
  behavior, clearer intent).
- **CodeQL matrix → 2 standalone jobs.** A job's top-level `if:` has no
  `matrix` context (`github`, `needs`, `vars`, `inputs` only — confirmed via
  actionlint against GitHub's own context-availability table), so a
  per-language skip can't live inside a matrix job's `if:`. Split into
  `codeql-python`/`codeql-javascript`, each `name:`'d to the exact literal
  string the matrix used to generate (`CodeQL Analysis (python)` /
  `(javascript)`), so branch protection needs zero changes.
- `merge_group` gets the **same** path-aware treatment as `pull_request` —
  this mirrors what tests.yml's own required contexts (`Backend Tests
  (Python)`, etc.) already do under merge_group (verified by reading that
  `if:` condition), not a literal "run everything under merge_group"
  reading. Flagging this explicitly since it's a legitimate judgment call:
  I chose consistency with the established, red-teamed pattern for the same
  required-check *class* over a fresh policy for this workflow.

## Measured savings (20 most recently merged PRs, 2026-08-20)

```
run_all (unclassified path present, nothing skipped): 2/20
  snyk-python:        skipped in 5/20 PRs
  snyk-node:           skipped in 8/20 PRs
  snyk-docker:         skipped in 5/20 PRs
  codeql-python:       skipped in 6/20 PRs
  codeql-javascript:   skipped in 8/20 PRs
  bandit:              skipped in 6/20 PRs
  safety:              skipped in 5/20 PRs
Total job-slots: 140, skipped: 43 (30.7%)
```

Weighted by real per-job durations from a live run (job 32375452507):
CodeQL-python ~12.4min, CodeQL-js ~3.7min, Snyk-node ~2.7min, Snyk-docker
~2.3min, Snyk-python ~1.3min, Bandit ~1.1min, Safety ~0.8min, Detect Secrets
~10.4min (never skipped) → **~7.7 of ~34.7 runner-minutes/run saved on
average (~22%)**, dominated by CodeQL-python being the single biggest lever.

## What is explicitly NOT filtered, and why

- **Detect Secrets** — never, by design (see table above).
- Any path `change_map.py` can't classify (e.g. `apps/mata-garuda/**`,
  root-level `scripts/*.py` outside the small explicit list added here) —
  `run_all=True`, every job runs. This is the pre-existing classifier's
  fail-closed contract (unrelated to this PR, inherited as-is); 2/20 PRs in
  the sample hit it.
- `.github/`, `.husky/`, `.security/`, `scripts/ci/`, `infra/`, `config/`,
  and anything tagged `security_sensitive` — coarse catch-all, every job
  runs (same philosophy tests.yml already uses for its own 6 jobs).
- `security-summary` — decorative (`if: always()`, writes a static success
  message regardless of `needs.*.result`, not a required context) — untouched,
  out of scope for a path-awareness PR.

## Test plan

- [x] `python3 scripts/ci/test_change_map.py` — 38/38 pass (26 pre-existing
      + 12 new guilt/innocence/fail-closed cases for security-job routing)
- [x] `actionlint .github/workflows/security.yml` — clean
- [x] `actionlint` repo-wide — zero new findings attributable to this file
- [x] Verified `jobs.<id>.if` cannot see `matrix` (hence the CodeQL split) —
      confirmed live via actionlint + GitHub docs, not assumed
- [x] `bash -n` + `compile()` on every extracted run-script/heredoc in the
      new `changes` job
- [x] Measured skip rate against 20 real merged PRs (table above)
- [ ] Live PR/merge_group run of this very branch will exercise the new
      `changes` job end-to-end — first real signal before merge

**Not auto-merging** — this touches the security-scanning surface, leaving
it for direct review per the mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>