### PR TITLE
fix(llm): distinguish Gemini quota exhaustion from other 4xx in error_class

### DIFF
--- a/apps/backend-rag/backend/llm/genai_client.py
+++ b/apps/backend-rag/backend/llm/genai_client.py
@@ -155,6 +155,45 @@ def _clamp_error_class(value: str) -> str:
     return value[:ERROR_CLASS_MAX_LEN]
 
 
+def _gemini_error_label(exc: BaseException) -> str:
+    """Compose a PII-safe, quota-distinguishing ``error_class`` from a raised
+    exception.
+
+    google-genai's ``APIError`` (base of ``ClientError``/``ServerError``,
+    ``google/genai/errors.py``, verified live against the installed
+    google-genai==2.7.0) carries a structured HTTP ``code`` (int) and a
+    structured API ``status`` string (e.g. ``RESOURCE_EXHAUSTED``,
+    ``INVALID_ARGUMENT``) alongside the bare exception message. Before this,
+    every write site here recorded only ``type(e).__name__``, so a 429
+    quota-exhaustion event (``ClientError``) was indistinguishable in the
+    ledger from an ordinary 400 malformed-request event (also
+    ``ClientError``) — the 2026-08-11 WhatsApp-silent-for-hours outage read
+    only as an anonymous ``ClientError`` count.
+
+    Reads ONLY the structured ``code``/``status`` attributes — never
+    ``str(exc)`` or ``exc.message``, both of which can echo prompt fragments
+    back out (same PII boundary ``_structured_failure_reason`` already
+    follows). Never decides by substring on the message text (cicatrix
+    family #3, guard-over-match has bitten this repo repeatedly on exactly
+    that pattern — see ``llm_gateway._classify_quota_exhaustion``, which
+    reads the same two structured attributes for its own, independent,
+    quota alert). And never CLAIMS a code/status it did not actually read:
+    an exception without these attributes, or carrying the wrong type on
+    them (e.g. a ``bool`` — an ``int`` subclass in Python — on ``code``),
+    degrades to the bare class name, which is exactly the previous
+    behaviour for non-API exceptions (``TimeoutError``, ``ConnectionError``,
+    …) and therefore never turns a successful label into a failed call.
+    """
+    parts = [type(exc).__name__]
+    code = getattr(exc, "code", None)
+    if isinstance(code, int) and not isinstance(code, bool):
+        parts.append(str(code))
+    status = getattr(exc, "status", None)
+    if isinstance(status, str) and status:
+        parts.append(status)
+    return _clamp_error_class(":".join(parts))
+
+
 def _structured_failure_reason(
     response: object,
     raw_text: str,
@@ -584,7 +623,7 @@ class GenAIClient:
             }
         except Exception as e:
             latency_ms = round((time.perf_counter() - t0) * 1000)
-            error_class = type(e).__name__
+            error_class = _gemini_error_label(e)
             logger.error(
                 "LLM call failed",
                 extra={
@@ -822,7 +861,7 @@ class GenAIClient:
         except LLMStructuredOutputError:
             raise
         except Exception as e:
-            error_class = type(e).__name__
+            error_class = _gemini_error_label(e)
             logger.error(
                 "LLM structured call failed",
                 extra={

--- a/apps/backend-rag/backend/tests/unit/llm/test_gemini_error_label.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_gemini_error_label.py
@@ -1,0 +1,171 @@
+"""`error_class` must distinguish a quota/credit exhaustion from any other
+Gemini 4xx.
+
+`google-genai` raises `ClientError` for *every* 4xx, so recording only
+`type(e).__name__` put a 429 RESOURCE_EXHAUSTED (prepay credits depleted —
+the failure that left WhatsApp silent on 2026-08-11) in the same bucket as
+an ordinary 400 malformed request. Interrogating the ledger for the outage
+read only `ClientError 44` — registered, but anonymous.
+
+Guilt: a simulated 429/RESOURCE_EXHAUSTED produces a label that names both,
+within the column. Innocence: an ordinary 400 stays distinguishable and is
+never mislabelled as quota. Robustness: an exception without the structured
+attributes (or with the wrong type on them) degrades to the bare class name
+— never raises, never claims a code/status it did not read. Truncation: an
+absurd exception-type name cannot blow the 64-char column.
+"""
+
+import pytest
+
+from backend.llm.genai_client import ERROR_CLASS_MAX_LEN, _gemini_error_label
+
+try:
+    from google.genai.errors import ClientError, ServerError
+
+    GENAI_ERRORS_AVAILABLE = True
+except ImportError:  # pragma: no cover - SDK always installed in this repo's venv
+    GENAI_ERRORS_AVAILABLE = False
+
+requires_genai_errors = pytest.mark.skipif(
+    not GENAI_ERRORS_AVAILABLE, reason="google-genai SDK not installed"
+)
+
+
+class _FakeAPIError(Exception):
+    """Duck-typed stand-in for google-genai's APIError shape (`.code` int
+    HTTP status, `.status` API status string) — used where the test does not
+    need the real SDK class, only the structured attributes it exposes."""
+
+    def __init__(self, code: object, status: object, message: str = "boom") -> None:
+        self.code = code
+        self.status = status
+        self.message = message
+        super().__init__(message)
+
+
+class TestGuilt:
+    """A real 429/RESOURCE_EXHAUSTED is named as both, inside the column."""
+
+    def test_fake_quota_exhaustion_names_the_code_and_the_status(self):
+        exc = _FakeAPIError(429, "RESOURCE_EXHAUSTED")
+        label = _gemini_error_label(exc)
+        assert "429" in label
+        assert "RESOURCE_EXHAUSTED" in label
+        assert len(label) <= ERROR_CLASS_MAX_LEN
+
+    @requires_genai_errors
+    def test_real_sdk_client_error_names_the_code_and_the_status(self):
+        # This is exactly the shape google-genai==2.7.0 raises for a 429:
+        # ClientError.__init__(code, response_json, response=None) reads
+        # `status`/`message` off response_json onto `.status`/`.message`.
+        exc = ClientError(
+            429,
+            {"status": "RESOURCE_EXHAUSTED", "message": "prepayment credits are depleted"},
+        )
+        label = _gemini_error_label(exc)
+        assert label == "ClientError:429:RESOURCE_EXHAUSTED"
+        assert len(label) <= ERROR_CLASS_MAX_LEN
+
+
+class TestInnocence:
+    """An ordinary 400 stays distinguishable and is never called quota."""
+
+    def test_ordinary_400_is_not_labelled_as_quota(self):
+        exc = _FakeAPIError(400, "INVALID_ARGUMENT")
+        label = _gemini_error_label(exc)
+        assert "RESOURCE_EXHAUSTED" not in label
+        assert "429" not in label
+
+    def test_400_and_429_produce_different_labels(self):
+        quota = _gemini_error_label(_FakeAPIError(429, "RESOURCE_EXHAUSTED"))
+        bad_request = _gemini_error_label(_FakeAPIError(400, "INVALID_ARGUMENT"))
+        assert quota != bad_request
+
+    @requires_genai_errors
+    def test_real_sdk_server_error_is_not_confused_with_client_error(self):
+        client_exc = ClientError(429, {"status": "RESOURCE_EXHAUSTED"})
+        server_exc = ServerError(503, {"status": "UNAVAILABLE"})
+        assert _gemini_error_label(client_exc) != _gemini_error_label(server_exc)
+        assert _gemini_error_label(client_exc).startswith("ClientError:")
+        assert _gemini_error_label(server_exc).startswith("ServerError:")
+
+
+class TestPIIBoundary:
+    """The raw message never enters the label — only enum-shaped fields do."""
+
+    LEAKY = "CLIENT_TEXT_SENTINEL_MUST_NOT_APPEAR"
+
+    def test_message_text_never_leaks_into_the_label(self):
+        exc = _FakeAPIError(429, "RESOURCE_EXHAUSTED", message=self.LEAKY)
+        assert self.LEAKY not in _gemini_error_label(exc)
+
+    @requires_genai_errors
+    def test_real_sdk_message_never_leaks_into_the_label(self):
+        exc = ClientError(429, {"status": "RESOURCE_EXHAUSTED", "message": self.LEAKY})
+        assert self.LEAKY not in _gemini_error_label(exc)
+
+
+class TestRobustness:
+    """A labelling bug must never turn a successful call into a failed one,
+    and must never claim a code/status it did not actually read."""
+
+    def test_exception_without_structured_attributes_degrades_to_bare_class_name(self):
+        assert _gemini_error_label(TimeoutError("slow")) == "TimeoutError"
+
+    def test_exception_without_structured_attributes_matches_prior_behaviour(self):
+        # Pre-enrichment, every write site recorded `type(e).__name__`. For
+        # exceptions that never carry `.code`/`.status` (network/timeout
+        # errors, not API 4xx/5xx), that must still be exactly what lands.
+        exc = ConnectionError("reset")
+        assert _gemini_error_label(exc) == type(exc).__name__
+
+    def test_wrong_type_on_code_is_not_trusted(self):
+        exc = RuntimeError("boom")
+        exc.code = "not-an-int"  # type: ignore[attr-defined]
+        exc.status = "RESOURCE_EXHAUSTED"  # type: ignore[attr-defined]
+        # `.status` alone, without a real `.code`, still degrades safely —
+        # the label must not silently assert an int it never had.
+        label = _gemini_error_label(exc)
+        assert "not-an-int" not in label
+
+    def test_wrong_type_on_status_is_not_trusted(self):
+        exc = RuntimeError("boom")
+        exc.code = 429  # type: ignore[attr-defined]
+        exc.status = 12345  # type: ignore[attr-defined] - wrong type, must not be trusted
+        label = _gemini_error_label(exc)
+        assert label == "RuntimeError:429"
+
+    def test_bool_code_is_never_mistaken_for_a_status_code(self):
+        # bool is an int subclass in Python; True/False are never real HTTP
+        # status codes and must not be printed as one.
+        exc = RuntimeError("boom")
+        exc.code = True  # type: ignore[attr-defined]
+        assert _gemini_error_label(exc) == "RuntimeError"
+
+    def test_empty_status_string_is_not_appended(self):
+        exc = RuntimeError("boom")
+        exc.code = 429  # type: ignore[attr-defined]
+        exc.status = ""  # type: ignore[attr-defined]
+        assert _gemini_error_label(exc) == "RuntimeError:429"
+
+    def test_none_attributes_degrade_cleanly(self):
+        exc = RuntimeError("boom")
+        exc.code = None  # type: ignore[attr-defined]
+        exc.status = None  # type: ignore[attr-defined]
+        assert _gemini_error_label(exc) == "RuntimeError"
+
+
+class TestLedgerFit:
+    """`llm_cost_events.error_class` is varchar(64) — see `_clamp_error_class`."""
+
+    def test_absurdly_long_exception_type_name_is_clamped_not_a_crash(self):
+        absurd_type = type("X" * 300, (Exception,), {})
+        exc = absurd_type()
+        exc.code = 429  # type: ignore[attr-defined]
+        exc.status = "RESOURCE_EXHAUSTED"  # type: ignore[attr-defined]
+        label = _gemini_error_label(exc)
+        assert len(label) == ERROR_CLASS_MAX_LEN
+
+    def test_normal_labels_are_well_under_the_column_limit(self):
+        label = _gemini_error_label(_FakeAPIError(429, "RESOURCE_EXHAUSTED"))
+        assert len(label) < ERROR_CLASS_MAX_LEN

--- a/apps/backend-rag/backend/tests/unit/llm/test_genai_client.py
+++ b/apps/backend-rag/backend/tests/unit/llm/test_genai_client.py
@@ -102,3 +102,64 @@ class TestGenAIClient:
             client1 = get_genai_client()
             client2 = get_genai_client()
             assert client1 is client2
+
+    @pytest.mark.asyncio
+    async def test_generate_content_failure_records_enriched_error_class(self, genai_client):
+        """Wiring test: a real ClientError raised from the SDK call must
+        reach `record_llm_call`'s `error_class` kwarg through the enriched
+        label, not the bare `type(e).__name__` this replaced. The helper
+        function is unit-tested in isolation in test_gemini_error_label.py;
+        this proves the write site actually calls it."""
+        from google.genai.errors import ClientError
+
+        quota_exc = ClientError(429, {"status": "RESOURCE_EXHAUSTED", "message": "depleted"})
+        genai_client._client.aio.models.generate_content = AsyncMock(side_effect=quota_exc)
+
+        with patch(
+            "backend.services.observability.record_llm_call", new=AsyncMock()
+        ) as mock_record:
+            with pytest.raises(ClientError):
+                await genai_client.generate_content("test prompt")
+
+        mock_record.assert_awaited_once()
+        recorded_error_class = mock_record.await_args.kwargs["error_class"]
+        assert recorded_error_class == "ClientError:429:RESOURCE_EXHAUSTED"
+
+    @pytest.mark.asyncio
+    async def test_generate_content_ordinary_400_is_not_recorded_as_quota(self, genai_client):
+        """Innocence at the wiring level: a 400 must never land in the
+        ledger under a label that names quota/RESOURCE_EXHAUSTED."""
+        from google.genai.errors import ClientError
+
+        bad_request_exc = ClientError(400, {"status": "INVALID_ARGUMENT", "message": "bad"})
+        genai_client._client.aio.models.generate_content = AsyncMock(side_effect=bad_request_exc)
+
+        with patch(
+            "backend.services.observability.record_llm_call", new=AsyncMock()
+        ) as mock_record:
+            with pytest.raises(ClientError):
+                await genai_client.generate_content("test prompt")
+
+        recorded_error_class = mock_record.await_args.kwargs["error_class"]
+        assert "RESOURCE_EXHAUSTED" not in recorded_error_class
+        assert recorded_error_class == "ClientError:400:INVALID_ARGUMENT"
+
+    @pytest.mark.asyncio
+    async def test_generate_content_success_never_touched_by_error_labelling(self, genai_client):
+        """Robustness at the wiring level: a successful call records
+        `error_class=None` and is never put at risk by the labelling path."""
+        mock_response = MagicMock()
+        mock_response.text = "ok"
+        mock_response.usage_metadata = MagicMock()
+        mock_response.usage_metadata.prompt_token_count = 5
+        mock_response.usage_metadata.candidates_token_count = 5
+        genai_client._client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "backend.services.observability.record_llm_call", new=AsyncMock()
+        ) as mock_record:
+            result = await genai_client.generate_content("test prompt")
+
+        assert result["text"] == "ok"
+        assert mock_record.await_args.kwargs["error_class"] is None
+        assert mock_record.await_args.kwargs["success"] is True


### PR DESCRIPTION
## Summary
- `google-genai` raises `ClientError` for every 4xx, so the 429 RESOURCE_EXHAUSTED prepay-credit depletion that left WhatsApp silent for hours on 2026-08-11 landed in `llm_cost_events` as the bare `ClientError` label — indistinguishable from an ordinary 400.
- New `_gemini_error_label()` in `genai_client.py` reads the SDK's structured `APIError.code` (int HTTP status) and `.status` (API status string, e.g. `RESOURCE_EXHAUSTED`) — never the message text — composing e.g. `ClientError:429:RESOURCE_EXHAUSTED`, clamped through the existing `_clamp_error_class` to stay inside the `varchar(64)` column.
- Applied at both write sites in `genai_client.py` (`generate_content`, `generate_structured`'s generic-exception branch). `generate_content_stream` has no cost-recorder call, so no third site exists.
- Exceptions without the structured attributes (or wrong types on them) degrade to the bare class name — identical to prior behavior for `TimeoutError`/`ConnectionError`/etc, never at risk of failing a successful call.

## Consumers of `error_class`
Grepped the whole repo for `llm_cost_events`/`error_class` readers. No consumer anywhere filters/matches on an exact Gemini-produced `error_class` string (only writers exist for this column; the one other structured-attribute reader, `llm_gateway._classify_quota_exhaustion`'s O1 quota alert, reads `.code`/`.status` directly off the raw exception, independent of this ledger column, and is unaffected). `wa_broker`'s `error_class` is an unrelated closed-vocabulary column on a different table, untouched.

## Test plan
- [x] New `test_gemini_error_label.py`: guilt (429/RESOURCE_EXHAUSTED named, fits 64 chars) + innocence (400 stays distinguishable, never mislabeled quota) + PII boundary (message text never leaks) + robustness (missing/wrong-typed attrs degrade safely, bool `code` never mistaken for a status) + truncation (absurd type name clamped, no crash) — both against a duck-typed fake and the real `google.genai.errors.ClientError`/`ServerError`.
- [x] New wiring tests in `test_genai_client.py`: `generate_content` failure path actually records the enriched label via `record_llm_call`, a 400 is never recorded as quota, and a successful call is untouched (`error_class=None`).
- [x] Mutation check: reverted both write sites to `type(e).__name__`, confirmed the two wiring guilt tests go red, restored (`git status` clean before commit).
- [x] `PYTHONPATH=. pytest backend/tests/unit/llm/` — all green (61 in the touched files + full `llm/` dir).
- [x] Pre-deploy targeted RAG suite (`test_kg_langgraph.py`, `test_kg_subgraphs.py`, `test_confidence.py`) — green.
- [x] Import-chain smoke test — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)