### PR TITLE
fix(pii): deterministic Ollama-only fail-closed gate for yield-optimizer

### DIFF
--- a/.github/workflows/yield-optimizer-pii-gate-tests.yml
+++ b/.github/workflows/yield-optimizer-pii-gate-tests.yml
@@ -1,0 +1,51 @@
+name: yield-optimizer PII gate tests
+
+# Guilt+innocence+class-guard for scripts/yield_optimizer_pitch_gate.py — the
+# deterministic PII fail-closed gate for yield-optimizer's Step 3 (draft
+# pitch). yield-optimizer is a Claude Sonnet-5 AGENT with unrestricted Bash
+# access (~/.claude/agents/yield-optimizer.md, cron Sunday 04:00 WITA on
+# Pro); its "Ollama unreachable: STOP, no fallback to cloud" rule used to
+# live only as prose an LLM has to remember every run. This file is the
+# per-PR consumer of the test suite that proves the code-level gate holds —
+# without a workflow naming it, scripts/tests/*.py only runs in the nightly
+# report-only sweep (scripts-tests-sweep.yml), which is cicatrix superscar #2
+# ("exists != armed") for a guardrail whose whole point is to be armed.
+#
+# `paths:` filtered to just the gate + its test (small, well-scoped surface,
+# unlike asyncpg-lint's deliberate full-repo scan) — safe because this
+# workflow is NOT added to branch-protection required checks here (that is a
+# repo-settings action, operator-gated per CLAUDE.md §13); it runs informationally
+# on every PR that touches the gate, same as most workflows in this repo.
+
+on:
+  pull_request:
+    paths:
+      - "scripts/yield_optimizer_pitch_gate.py"
+      - "scripts/tests/test_yield_optimizer_pitch_gate.py"
+      - ".github/workflows/yield-optimizer-pii-gate-tests.yml"
+  merge_group:
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/yield_optimizer_pitch_gate.py"
+      - "scripts/tests/test_yield_optimizer_pitch_gate.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: yield-optimizer-pii-gate-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
+jobs:
+  gate-tests:
+    name: yield-optimizer PII gate tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run guilt + innocence + class-guard + CLI tests
+        run: |
+          python3 -m pip install --quiet --disable-pip-version-check pytest
+          python3 -m pytest scripts/tests/test_yield_optimizer_pitch_gate.py -v

--- a/infra/launchagents/wrappers/yield-optimizer-run.sh
+++ b/infra/launchagents/wrappers/yield-optimizer-run.sh
@@ -25,7 +25,16 @@ echo "[$(date)] yield-optimizer run starting for $WEEK" >> "$LOG"
 PROMPT="Run yield-optimizer agent for week $WEEK ($DATE).
 Read ~/.claude/agents/yield-optimizer.md for full spec.
 - Pull CRM via Postgres (apply 6 opportunity rules R1-R6, cap 20)
-- Generate WhatsApp pitches via Ollama qwen3.5:9b LOCAL (NEVER cloud LLM for CRM PII)
+- Generate WhatsApp pitches by piping a JSON payload (client_id, name, language,
+  fact, pitch_goal) on STDIN to \`python3 ~/nuzantara/scripts/yield_optimizer_pitch_gate.py\`
+  for EVERY opportunity, one call per opportunity. This is the ONLY sanctioned way to
+  draft a pitch — it is the deterministic PII fail-closed gate (2026-08-20 hardening):
+  it talks to local Ollama qwen3.5:9b ONLY and NEVER falls back to a cloud model. Never
+  call \`ollama run\` directly and never improvise another way to draft a pitch.
+  Exit 0 = pitch text on stdout, use it verbatim. Exit 2 = SKIPPED_OLLAMA_FAIL (Ollama is
+  down) — skip that opportunity, do NOT retry it with any other model/tool/CLI, and note
+  it as skipped in the report. If most/all calls return exit 2, stop and report Ollama is
+  down instead of continuing.
 - Output to ~/nuzantara/research/commercial/${WEEK}-yield-opportunities.md
 - Telegram digest to TELEGRAM_OWNER_CHAT_ID
 - Emit eventbus learning.updated event

--- a/scripts/tests/test_yield_optimizer_pitch_gate.py
+++ b/scripts/tests/test_yield_optimizer_pitch_gate.py
@@ -1,0 +1,363 @@
+"""scripts/yield_optimizer_pitch_gate.py -- the deterministic PII fail-closed
+cancello for yield-optimizer's Step 3 (draft pitch).
+
+yield-optimizer (~/.claude/agents/yield-optimizer.md) is a Claude Sonnet-5
+AGENT with unrestricted Bash access, not a Python daemon -- its "Ollama
+unreachable: STOP, no fallback to cloud" rule used to live only as prose an
+LLM has to remember every run. This module is the code-level gate; this test
+file is the guilt+innocence+mutation proof the org's guard-conformance
+doctrine (cicatrix-superscar.md #3) requires before a guard like this ships.
+
+Four required proofs (team-lead mandate, 2026-08-20):
+  1. Guilt: Ollama unreachable -> a PII-marked payload produces no cloud call
+     and a named terminal outcome (SKIPPED_OLLAMA_FAIL), logged.
+  2. Innocence: Ollama healthy -> the lane drafts exactly as before.
+  3. Innocence-2 (adapted -- see class docstring on `TestNoNonSensitiveClass`):
+     this lane has NO non-sensitive payload shape, so instead of "a
+     non-sensitive payload keeps its normal cascade" the proof is that no
+     dormant cloud branch exists AT ALL to leak through, structurally (static
+     class-guard) and behaviourally (choose_tier(False) raises rather than
+     degrading anywhere).
+  4. Mutation: manually verified by commenting out the `ollama_up()` gate in
+     a scratch copy of this file and re-running the guilt test against it --
+     it goes red (documented in the shipping PR body, not re-run here, since
+     a permanent mutant would defeat the real gate).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "scripts" / "yield_optimizer_pitch_gate.py"
+
+from scripts import yield_optimizer_pitch_gate as gate  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolated_gate_log(tmp_path, monkeypatch):
+    """Never touch the real ~/logs/yield-optimizer-pii-gate.jsonl (W96 class)."""
+    monkeypatch.setattr(gate, "GATE_LOG", tmp_path / "gate.jsonl")
+    yield
+
+
+def _log_lines() -> list[dict]:
+    if not gate.GATE_LOG.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in gate.GATE_LOG.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. Guilt -- Ollama unreachable
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_down_produces_no_cloud_call_and_a_named_terminal_outcome(monkeypatch):
+    monkeypatch.setattr(gate, "ollama_up", lambda timeout=3.0: False)
+
+    called = {"n": 0}
+
+    def _poison(*a, **k):
+        called["n"] += 1
+        raise AssertionError(
+            "draft_pitch must never call the model when ollama_up() is False"
+        )
+
+    monkeypatch.setattr(gate, "_call_ollama", _poison)
+
+    outcome, text = gate.draft_pitch("C_TEST_1", "irrelevant prompt")
+
+    assert outcome == gate.SKIPPED_OLLAMA_FAIL
+    assert text is None
+    assert called["n"] == 0
+
+    lines = _log_lines()
+    assert len(lines) == 1
+    assert lines[0]["client_id"] == "C_TEST_1"
+    assert lines[0]["outcome"] == gate.SKIPPED_OLLAMA_FAIL
+    assert lines[0]["detail"] == "ollama_unreachable"
+
+
+def test_ollama_reachable_but_generate_call_fails_is_also_terminal_not_a_retry(
+    monkeypatch,
+):
+    """Guilt, second failure branch: ollama_up() says True (tags endpoint
+    answers) but the actual generate call blows up (timeout / connection
+    reset mid-request). Must still be terminal, never a cloud fallback."""
+    monkeypatch.setattr(gate, "ollama_up", lambda timeout=3.0: True)
+
+    def _boom(prompt, timeout=180.0):
+        raise urllib.error.URLError("connection reset")
+
+    monkeypatch.setattr(gate, "_call_ollama", _boom)
+
+    outcome, text = gate.draft_pitch("C_TEST_2", "prompt")
+
+    assert outcome == gate.SKIPPED_OLLAMA_FAIL
+    assert text is None
+    assert _log_lines()[0]["detail"] == "URLError"
+
+
+def test_empty_ollama_response_is_terminal_not_a_blank_pitch(monkeypatch):
+    monkeypatch.setattr(gate, "ollama_up", lambda timeout=3.0: True)
+    monkeypatch.setattr(gate, "_call_ollama", lambda prompt, timeout=180.0: "")
+
+    outcome, text = gate.draft_pitch("C_TEST_3", "prompt")
+
+    assert outcome == gate.SKIPPED_OLLAMA_FAIL
+    assert text is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Innocence -- Ollama healthy, unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_healthy_drafts_exactly_as_before(monkeypatch):
+    monkeypatch.setattr(gate, "ollama_up", lambda timeout=3.0: True)
+    seen_prompts = []
+
+    def _fake_call(prompt, timeout=180.0):
+        seen_prompts.append(prompt)
+        return "Pak Budi, KITAS bapak akan expire 23 hari lagi. Boleh kita jadwalkan call minggu ini?"
+
+    monkeypatch.setattr(gate, "_call_ollama", _fake_call)
+
+    prompt = gate.build_prompt(
+        name="Budi",
+        language="Indonesian (Bahasa Indonesia)",
+        fact="Their KITAS expires in 23 days (2026-09-12).",
+        pitch_goal="renewal + KITAP eligibility check",
+    )
+    outcome, text = gate.draft_pitch("C_TEST_4", prompt)
+
+    assert outcome == gate.OLLAMA_LOCAL
+    assert text and "expire" in text
+    assert seen_prompts == [prompt]
+
+    lines = _log_lines()
+    assert len(lines) == 1
+    assert lines[0]["outcome"] == gate.OLLAMA_LOCAL
+    assert lines[0]["client_id"] == "C_TEST_4"
+
+
+def test_cli_end_to_end_ollama_healthy(monkeypatch, capsys):
+    monkeypatch.setattr(gate, "ollama_up", lambda timeout=3.0: True)
+    monkeypatch.setattr(
+        gate,
+        "_call_ollama",
+        lambda prompt, timeout=180.0: "Hi there, quick call this week?",
+    )
+
+    payload = {
+        "client_id": "C_TEST_5",
+        "name": "Ari",
+        "language": "English",
+        "fact": "Their passport expires in 90 days.",
+        "pitch_goal": "early passport renewal",
+    }
+    monkeypatch.setattr(sys, "stdin", _StdinStub(json.dumps(payload)))
+
+    exit_code = gate.main()
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert out.strip() == "Hi there, quick call this week?"
+
+
+def test_cli_end_to_end_ollama_down_exits_2_prints_nothing_on_stdout(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(gate, "ollama_up", lambda timeout=3.0: False)
+
+    payload = {"client_id": "C_TEST_6", "name": "Ari"}
+    monkeypatch.setattr(sys, "stdin", _StdinStub(json.dumps(payload)))
+
+    exit_code = gate.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert (
+        captured.out == ""
+    )  # nothing on stdout -- caller cannot mistake this for a draft
+    assert "SKIPPED_OLLAMA_FAIL" in captured.err
+
+
+class _StdinStub:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def read(self) -> str:
+        return self._text
+
+
+# ---------------------------------------------------------------------------
+# 3. No non-sensitive payload class exists in this lane -- structural +
+#    behavioural proof there is no dormant cloud branch to leak through.
+# ---------------------------------------------------------------------------
+
+
+class TestNoNonSensitiveClass:
+    """This lane processes ONLY CRM client records; unlike
+    mos-plus-compression-worker.py (which legitimately has a cloud tier for
+    non-sensitive traffic), there is no non-sensitive payload shape here to
+    exercise a 'normal cascade' against. The equivalent proof for a
+    mono-purpose lane is: (a) the boolean is live code, not a tautology --
+    both branches are reachable and behave differently -- and (b) there is no
+    cloud call anywhere in the file for a future 'handle sensitive=False'
+    edit to quietly wake up.
+    """
+
+    def test_choose_tier_sensitive_true_returns_ollama_local(self):
+        assert gate.choose_tier(True) == gate.OLLAMA_LOCAL
+
+    def test_choose_tier_sensitive_false_raises_rather_than_degrading(self):
+        with pytest.raises(ValueError, match="no non-sensitive payload class"):
+            gate.choose_tier(False)
+
+    def test_draft_pitch_refuses_a_non_sensitive_call_before_touching_ollama(
+        self, monkeypatch
+    ):
+        """Guilt for the caller-bug shape: a hypothetical future call site
+        that passes sensitive=False must never reach ollama_up()/the network
+        -- it must raise first."""
+        monkeypatch.setattr(
+            gate,
+            "ollama_up",
+            lambda timeout=3.0: (_ for _ in ()).throw(
+                AssertionError("ollama_up must not be reached when sensitive=False")
+            ),
+        )
+
+        with pytest.raises(ValueError):
+            gate.draft_pitch("C_TEST_7", "prompt", sensitive=False)
+
+
+def test_no_cloud_references_in_file():
+    """Static class-guard (cicatrix-superscar.md #2/#3 antidote pattern): the
+    gate's EXECUTABLE source must never mention a cloud LLM CLI/SDK/host. If a
+    future edit adds a fallback to claude/agy/kimi/codex/anthropic/openai/
+    gemini or any non-localhost URL, this test goes red BEFORE the edit ships
+    -- an unenforceable prose rule needs a code backstop (CLAUDE.md §7).
+
+    Scanned on CODE only, not the module docstring: the docstring legitimately
+    NAMES those providers to explain their absence (over-match on prose would
+    be the exact guard-over-match bug this repo has scarred on repeatedly --
+    cicatrix-superscar.md #3). Guilt for that framing is
+    `test_over_matching_the_docstring_would_be_wrong` below.
+    """
+    hits = _forbidden_hits_outside_docstring(SRC.read_text())
+    assert not hits, f"forbidden cloud references found in {SRC.name} CODE: {hits}"
+
+    # Every literal http(s):// URL anywhere in the file (docstring examples
+    # included -- a usage example pointed at a cloud host would still be a
+    # real defect) must target localhost/127.0.0.1.
+    import re
+
+    urls = re.findall(r"https?://[^\s\"'{}]+", SRC.read_text())
+    non_local = [u for u in urls if "localhost" not in u and "127.0.0.1" not in u]
+    assert not non_local, f"non-localhost URL literal found: {non_local}"
+
+
+def _strip_module_docstring(source: str) -> str:
+    """Remove the leading module docstring using `ast` (never a hand-rolled
+    quote scanner -- that class of bug is its own cicatrix, W99: "check != action",
+    a strip that silently fails to strip is worse than no strip at all).
+    Uses the exact literal `ast.get_docstring(..., clean=False)` text so the
+    single `.replace()` below cannot partially match."""
+    import ast
+
+    tree = ast.parse(source)
+    doc = ast.get_docstring(tree, clean=False)
+    if doc is None:
+        return source
+    module_body = tree.body
+    if not module_body or not isinstance(module_body[0], ast.Expr):
+        return source
+    doc_node = module_body[0]
+    lines = source.splitlines(keepends=True)
+    # doc_node.lineno/end_lineno are 1-indexed and inclusive.
+    before = lines[: doc_node.lineno - 1]
+    after = lines[doc_node.end_lineno :]
+    blank = ["\n"] * (doc_node.end_lineno - doc_node.lineno + 1)
+    return "".join(before) + "".join(blank) + "".join(after)
+
+
+_FORBIDDEN_TOKENS = [
+    "claude ",
+    "claude-cascade",
+    '"claude"',
+    "'claude'",
+    "anthropic",
+    "openai",
+    "chatgpt",
+    "codex exec",
+    '"codex"',
+    " agy ",
+    'agy"',
+    "kimi-code",
+    "kimi ",
+    "gemini",
+    "moonshot",
+]
+
+
+def _forbidden_hits_outside_docstring(source: str) -> list[str]:
+    code_only = _strip_module_docstring(source).lower()
+    return [token for token in _FORBIDDEN_TOKENS if token in code_only]
+
+
+def test_over_matching_the_docstring_would_be_wrong():
+    """Innocence for the class-guard above: the real module docstring (which
+    legitimately names claude/anthropic/openai/agy/kimi/codex/gemini to
+    explain their absence) must NOT trip the guard once the docstring is
+    stripped -- proving the strip actually removes the prose, not just
+    shifting where the false positive lands."""
+    source = SRC.read_text()
+    assert "anthropic" in source.lower(), (
+        "fixture assumption broke: docstring no longer names it"
+    )
+    assert not _forbidden_hits_outside_docstring(source)
+
+
+def test_docstring_stripper_still_catches_a_real_cloud_call():
+    """Guilt for the stripper itself: a forbidden token placed AFTER the
+    docstring (i.e. in real code) must still be caught."""
+    mutated = (
+        SRC.read_text() + '\nimport subprocess\nsubprocess.run(["claude", "-p", "x"])\n'
+    )
+    assert _forbidden_hits_outside_docstring(mutated)
+
+
+# ---------------------------------------------------------------------------
+# Privacy: only client_id ever reaches the log, never name/contact/facts.
+# ---------------------------------------------------------------------------
+
+
+def test_log_never_contains_name_or_facts(monkeypatch):
+    monkeypatch.setattr(gate, "ollama_up", lambda timeout=3.0: True)
+    monkeypatch.setattr(
+        gate, "_call_ollama", lambda prompt, timeout=180.0: "some drafted pitch text"
+    )
+
+    prompt = gate.build_prompt(
+        name="Siti Rahayu",
+        language="Indonesian (Bahasa Indonesia)",
+        fact="Their KITAS expires in 5 days -- URGENT, passport AB1234567.",
+        pitch_goal="renewal",
+    )
+    gate.draft_pitch("C_TEST_8", prompt)
+
+    raw_log_text = gate.GATE_LOG.read_text()
+    assert "Siti Rahayu" not in raw_log_text
+    assert "AB1234567" not in raw_log_text
+    assert "C_TEST_8" in raw_log_text

--- a/scripts/yield_optimizer_pitch_gate.py
+++ b/scripts/yield_optimizer_pitch_gate.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""yield-optimizer PII fail-closed gate — deterministic Ollama-only pitch drafting.
+
+`yield-optimizer` (`~/.claude/agents/yield-optimizer.md`, cron Sunday 04:00 WITA
+on Pro via `infra/launchagents/wrappers/yield-optimizer-run.sh` ->
+`claude-cascade.sh --agent yield-optimizer`) is a Claude Sonnet-5 AGENT, not a
+Python daemon. Its own hard rule #1 — "CRM data NEVER to cloud LLM... Ollama
+LOCAL only" — and its Failure-modes rule — "Ollama unreachable: STOP, no
+fallback to cloud" — used to live ONLY as prose an LLM has to remember every
+run: compliance for an autonomous agent, not a cancello in code (CLAUDE.md §14:
+"il fail-closed e' la condotta richiesta, non uno stato gia' implementato").
+
+This script IS that cancello. It is the ONLY sanctioned way for the agent's
+Step 3 (draft pitch) to turn a CRM opportunity into WhatsApp pitch text:
+
+  - The only model this file EVER calls is local Ollama, over its LOCAL HTTP
+    API (127.0.0.1 by default). Nothing else is imported or shelled out to --
+    no `claude`/`agy`/`kimi`/`codex` CLI, no `anthropic`/`openai`/
+    `google.generativeai` SDK, no request to any non-localhost host.
+    `test_no_cloud_references_in_file` in the paired test module pins this as
+    a class-guard: any future edit that adds one of those tokens to THIS file
+    goes red.
+  - On Ollama failure (down, timeout, empty/bad response) the outcome is a
+    named TERMINAL state, `SKIPPED_OLLAMA_FAIL` -- never a silent retry on a
+    different backend, and no pitch text is ever returned for that
+    opportunity. There is no cloud branch in this file to fall through to.
+    Unlike `mos-plus-compression-worker.py`'s `choose_tier()` (which
+    legitimately routes non-sensitive traffic to cloud tiers), this lane has
+    no non-sensitive traffic at all -- every payload is a CRM client record --
+    so `choose_tier()` below has nowhere to degrade a non-sensitive call TO;
+    it raises instead (see its docstring).
+  - Every call is logged to `YIELD_OPTIMIZER_GATE_LOG` with `client_id` +
+    outcome ONLY -- client name/contact/case facts are never written to the
+    log (yield-optimizer.md hard rule #5: "log only client_id, not name").
+    This makes a rejection auditable rather than a silent no-op (cicatrix
+    W114/W116: an astensione muta e' indistinguibile da "non e' mai partito").
+
+Same shape as the three other hardened local-only PII lanes (censimento
+2026-08-20):
+  - wa-mirror-attention-classifier.py: exception -> default MEDIUM tagged
+    `ollama_fail:*`, never cloud.
+  - mos-plus-compression-worker.py::choose_tier(): `osint_sensitive` ->
+    "ollama_local" hard-coded; retry stays local ("ollama_fallback").
+  - wa-mirror-strategic-recap-updater.py: failure -> `action =
+    "SKIPPED_OLLAMA_FAIL"`.
+
+The Ollama HTTP-API pattern (`ollama_up()` / generate call) is reused from
+`scripts/s7_yield_draft_local.py` (reuse-first) rather than re-derived --
+that script is a separate, ALREADY-DETERMINISTIC, schema-correct rebuild of
+this whole lane (real CRM schema, hard `sys.exit` before any PII read if
+Ollama is down) that currently sits unarmed (no plist/cron references it).
+Whether to retire the agent-based lane in favor of it is a business-logic
+call outside this PR's scope: this file touches only the drafting boundary
+of the lane that is actually scheduled today.
+
+CLI usage -- payload via STDIN ONLY, never argv (a client fact on argv is
+readable by any other user on the machine via `ps`; cicatrix W115 GOTCHA-3
+caught exactly this in a sibling script):
+
+    echo '{"client_id": "C123", "name": "Budi",
+           "language": "Indonesian (Bahasa Indonesia)",
+           "fact": "Their KITAS expires in 23 days (2026-09-12).",
+           "pitch_goal": "renewal + KITAP eligibility check"}' \\
+        | python3 scripts/yield_optimizer_pitch_gate.py
+
+Exit codes: 0 = drafted (pitch text on stdout) · 2 = SKIPPED_OLLAMA_FAIL
+(terminal -- nothing on stdout, the caller MUST skip this opportunity, never
+retry on another backend) · 1 = bad input (malformed JSON / missing
+client_id).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+OLLAMA_HOST = os.environ.get("YIELD_OPTIMIZER_OLLAMA_HOST", "http://localhost:11434")
+OLLAMA_TAGS_URL = f"{OLLAMA_HOST}/api/tags"
+OLLAMA_GENERATE_URL = f"{OLLAMA_HOST}/api/generate"
+OLLAMA_MODEL = os.environ.get("YIELD_OPTIMIZER_OLLAMA_MODEL", "qwen3.5:9b")
+GATE_LOG = Path(
+    os.environ.get(
+        "YIELD_OPTIMIZER_GATE_LOG",
+        str(Path.home() / "logs" / "yield-optimizer-pii-gate.jsonl"),
+    )
+)
+
+SKIPPED_OLLAMA_FAIL = "SKIPPED_OLLAMA_FAIL"
+OLLAMA_LOCAL = "ollama_local"
+
+
+def choose_tier(sensitive: bool) -> str:
+    """Return the tier for drafting a yield-optimizer pitch.
+
+    yield-optimizer processes ONLY CRM client records (name, contact info,
+    case facts) -- there is no non-sensitive payload shape in this lane,
+    unlike mos-plus-compression-worker's mixed traffic. `sensitive` exists so
+    this function has the same guilt+innocence surface as the other hardened
+    lanes' tier-choice functions; every real call site in this file passes
+    sensitive=True. `sensitive=False` RAISES rather than degrading anywhere --
+    there is no cloud tier wired into this script to degrade TO, so a False
+    here is a caller bug, not a policy choice.
+    """
+    if not sensitive:
+        raise ValueError(
+            "yield-optimizer pitch drafting has no non-sensitive payload "
+            "class -- this call site is a bug, not a policy choice"
+        )
+    return OLLAMA_LOCAL
+
+
+def ollama_up(timeout: float = 3.0) -> bool:
+    try:
+        urllib.request.urlopen(OLLAMA_TAGS_URL, timeout=timeout).read()
+        return True
+    except Exception:
+        return False
+
+
+def _log_outcome(client_id: str, outcome: str, detail: str = "") -> None:
+    """Append one JSONL line. `client_id` ONLY -- never name/contact/facts
+    (yield-optimizer.md hard rule #5)."""
+    GATE_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with GATE_LOG.open("a", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "client_id": client_id,
+                    "outcome": outcome,
+                    "detail": detail,
+                }
+            )
+            + "\n"
+        )
+
+
+def build_prompt(name: str, language: str, fact: str, pitch_goal: str) -> str:
+    return (
+        "You are a Bali Zero account executive writing a WhatsApp message to a client.\n"
+        f"Client first name: {name}. Write in {language}.\n"
+        f"Context: {fact}\n"
+        f"Goal: invite them to discuss {pitch_goal}.\n"
+        "Rules: 40-80 words. Warm but professional. NO marketing buzzwords, NO emoji, "
+        "NO 'exciting opportunity'. Reference the specific fact above. End with a concrete "
+        "next step (a suggested 20-30 min call this week). Output ONLY the message text.\n/no_think"
+    )
+
+
+def _call_ollama(prompt: str, timeout: float = 180.0) -> str:
+    """The ONLY model call in this file. Talks to the local Ollama HTTP API
+    exclusively -- see the module docstring's class-guard note."""
+    body = json.dumps(
+        {
+            "model": OLLAMA_MODEL,
+            "prompt": prompt,
+            "stream": False,
+            "think": False,
+            "options": {"temperature": 0.4},
+        }
+    ).encode()
+    req = urllib.request.Request(
+        OLLAMA_GENERATE_URL, data=body, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        resp = json.loads(r.read())
+    text = (resp.get("response") or "").strip()
+    if "</think>" in text:
+        text = text.split("</think>", 1)[1].strip()
+    return text
+
+
+def draft_pitch(
+    client_id: str, prompt: str, sensitive: bool = True
+) -> tuple[str, str | None]:
+    """Returns (outcome, pitch_text_or_None).
+
+    Never raises on an Ollama failure -- that IS the terminal outcome, not an
+    exception for the caller to interpret or retry around. Never falls
+    through to any other model on any failure branch.
+    """
+    tier = choose_tier(sensitive)  # raises if sensitive=False -- see docstring
+    assert tier == OLLAMA_LOCAL
+
+    if not ollama_up():
+        _log_outcome(client_id, SKIPPED_OLLAMA_FAIL, "ollama_unreachable")
+        return SKIPPED_OLLAMA_FAIL, None
+
+    try:
+        text = _call_ollama(prompt)
+    except Exception as exc:  # noqa: BLE001 -- any failure here is terminal, never a cloud retry
+        _log_outcome(client_id, SKIPPED_OLLAMA_FAIL, type(exc).__name__)
+        return SKIPPED_OLLAMA_FAIL, None
+
+    if not text:
+        _log_outcome(client_id, SKIPPED_OLLAMA_FAIL, "empty_response")
+        return SKIPPED_OLLAMA_FAIL, None
+
+    _log_outcome(client_id, OLLAMA_LOCAL)
+    return OLLAMA_LOCAL, text
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as exc:
+        print(f"[yield-optimizer-gate] bad JSON on stdin: {exc}", file=sys.stderr)
+        return 1
+
+    client_id = payload.get("client_id")
+    if not client_id:
+        print("[yield-optimizer-gate] missing client_id", file=sys.stderr)
+        return 1
+
+    prompt = build_prompt(
+        name=payload.get("name", "there"),
+        language=payload.get("language", "English"),
+        fact=payload.get("fact", ""),
+        pitch_goal=payload.get("pitch_goal", ""),
+    )
+    outcome, text = draft_pitch(client_id, prompt)
+    if outcome == OLLAMA_LOCAL:
+        print(text)
+        return 0
+
+    print(
+        f"[yield-optimizer-gate] {SKIPPED_OLLAMA_FAIL} client_id={client_id}",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- yield-optimizer (`~/.claude/agents/yield-optimizer.md`, cron Sun 04:00 WITA on Pro) is a Claude Sonnet-5 **agent** with unrestricted Bash access, not a Python daemon — its "Ollama unreachable: STOP, no fallback to cloud" rule lived only as prose an LLM has to remember every run, unlike the other 3 hardened local-only PII lanes.
- Adds `scripts/yield_optimizer_pitch_gate.py`: the only sanctioned way to draft a WhatsApp pitch from a CRM opportunity. Talks to local Ollama qwen3.5:9b ONLY (127.0.0.1 HTTP API); on any failure returns a named terminal outcome (`SKIPPED_OLLAMA_FAIL`) instead of falling through to any cloud model. No cloud branch exists in the file to wake up later — pinned by a static class-guard test. Every call logs `client_id` only, never name/contact/facts.
- Updates `infra/launchagents/wrappers/yield-optimizer-run.sh`'s prompt to mandate the gate script for every opportunity and forbid calling `ollama run`/any other CLI directly.
- New CI workflow (`yield-optimizer-pii-gate-tests.yml`) runs the 13-test suite on every PR touching the gate — otherwise `scripts/tests/*.py` only runs in the nightly report-only sweep (cicatrix-superscar.md #2, "exists != armed").

## NOT included — needs an operator step

`~/.claude/agents/yield-optimizer.md`'s own Step 3 text (the freeform `ollama run qwen3.5:9b '...'` Bash example) is **blocked by the `host_boundary` pre-tool hook** as agent control plane — operator-only by design, and I did not override it. The wrapper's prompt (edited in this PR) already instructs the agent explicitly not to call `ollama run` directly and to use the gate script instead, which the agent reads at every invocation — so the fix is live in practice even without this edit — but the `.md` file itself is now stale relative to that instruction. Exact patch to apply (or authorize) on every machine that owns a copy — confirmed **Pro-only** via `infra/home-fork/declared-pairs.json`, no Mini/M5 copy needs it:

```diff
--- a/yield-optimizer.md (Step 3 section)
+++ b/yield-optimizer.md (Step 3 section)
-### Step 3 — Draft pitch (Ollama qwen3.5:9b LOCAL)
-
-For each opportunity, generate a 3-5 sentence WhatsApp pitch via:
-
-```bash
-ollama run qwen3.5:9b 'You are Bali Zero account exec. Client context: <name=X, service=visa, KITAS expires in N days>.
-Draft a WhatsApp message (40-80 words, casual but professional, in <client_preferred_language>) inviting
-them to discuss <upgrade_path>. NO marketing buzzwords. NO "exciting opportunity". Reference SPECIFIC facts
-from their case. End with concrete next-step (suggested 30-min call this week).
-Output ONLY the message text, no preamble.'
-```
-
-Validate output:
-- 40-80 words ✓ (else re-prompt)
-- Language matches client preference ✓
-- Mentions specific case fact ✓
-- Has concrete next-step ✓
+### Step 3 — Draft pitch (deterministic PII gate — 2026-08-20 hardening)
+
+**Do NOT call `ollama run` directly, and do NOT improvise any other way to draft a
+pitch.** For each opportunity, pipe a JSON payload on STDIN (never argv — a client
+fact on argv is readable by any other user on the machine via `ps`) to the
+deterministic gate script:
+
+```bash
+echo '{"client_id": "<id>", "name": "<first name>", "language": "<client_preferred_language>",
+       "fact": "<specific case fact, e.g. KITAS expires in 23 days (2026-09-12)>",
+       "pitch_goal": "<upgrade_path>"}' \
+    | python3 ~/nuzantara/scripts/yield_optimizer_pitch_gate.py
+```
+
+This script IS the privacy boundary, not a suggestion: it talks to local Ollama
+qwen3.5:9b ONLY (127.0.0.1 HTTP API), never imports or shells out to any cloud
+LLM CLI/SDK, and it is what enforces the "Ollama unreachable: STOP, no fallback
+to cloud" rule below in code rather than in your judgement. Repo copy + tests:
+`scripts/yield_optimizer_pitch_gate.py` / `scripts/tests/test_yield_optimizer_pitch_gate.py`.
+
+- **Exit 0**: pitch text on stdout. Validate: 40-80 words, language matches
+  client preference, mentions the specific case fact, has a concrete next-step
+  (else re-prompt with a refined `fact`/`pitch_goal`, still through the script).
+- **Exit 2** (`SKIPPED_OLLAMA_FAIL`, nothing on stdout): Ollama is down or the
+  call failed. Skip THIS opportunity — mark it skipped in the report, do NOT
+  retry it with `claude`/`agy`/`codex`/`kimi`/any other CLI, curl, or your own
+  judgement about what would be "close enough". If most/all calls in the run
+  return exit 2, stop early and report that Ollama is down instead of grinding
+  through the rest of the list.
```

## Separate finding, out of this PR's scope (flagged, not fixed)

`research/crm/S7-yield-signals-spec.md` (2026-06-02) already documented that the agent's Step 1 SQL references a `crm_clients` table + columns (`engagement_score`, `total_spend_ytd`, `kitap_expiry_date`) that **do not exist** in production, and built `scripts/s7_yield_draft_local.py` as a schema-correct, fully deterministic replacement (real CRM tables, hard `sys.exit` fail-closed before any PII read if Ollama is down — stricter than this PR's gate, which only guards the drafting call). That script is **not wired to any plist/cron** — built but never armed (cicatrix-superscar.md #2). Whether to retire the agent-based lane in favor of it is a business-logic call for Zero/team-lead, not something I changed here.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_yield_optimizer_pitch_gate.py -q` — 13 passed
- [x] Guilt: Ollama unreachable → no model call, `SKIPPED_OLLAMA_FAIL`, logged (client_id only)
- [x] Guilt: Ollama reachable but generate call fails / returns empty → also terminal, never a retry
- [x] Innocence: Ollama healthy → drafts exactly as before (CLI end-to-end + function-level)
- [x] No-non-sensitive-payload-class proof (this lane's equivalent of "innocence 2" — see PR discussion): `choose_tier(False)` raises rather than degrading anywhere; static class-guard confirms zero cloud references outside the docstring and zero non-localhost URLs
- [x] Mutation (manual, not committed): removed the `ollama_up()` gate in a scratch copy — the first guilt test (`test_ollama_down_produces_no_cloud_call_and_a_named_terminal_outcome`) went red (`assert called["n"] == 0` failed, 1 == 0), 12/13 others stayed green
- [x] `ruff check` + `ruff format` clean on both new files
- [x] `actionlint` clean on the new workflow
- [x] `bash -n` clean on the wrapper edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)