### PR TITLE
fix(usage): G1/K1 seat telemetry — identity-verified invocation counts

### DIFF
--- a/scripts/usage/seat_usage_collector.py
+++ b/scripts/usage/seat_usage_collector.py
@@ -16,7 +16,17 @@ Sorgenti (tutte best-effort, stdlib only):
     input_tokens/output_tokens | prompt_tokens/completion_tokens).
   - Cost-ledger locale: ~/.agent/cost-ledger/*.jsonl (output dell'exporter PG
     già armato) → per confronto/offline mirror della parte API.
-  - agy / kimi: conteggio invocazioni dai log se le dir esistono (no token).
+  - agy: ~/.gemini/antigravity-cli/log/cli-*.log (un file per invocazione CLI,
+    verificato "logging before google.Init" in testa al file) → conteggio
+    invocazioni, no token. Identità confermata da `installation_id` nella
+    stessa dir (2026-08-20: fissato un bug per cui il collettore contava file
+    ESTRANEI in ~/.openclaw/logs, la dir del bridge OpenClaw, e li pubblicava
+    come "agy logs").
+  - kimi: ~/.kimi-code/sessions/**/session_* (una dir per sessione, pinnata
+    da session_index.jsonl) → conteggio invocazioni, no token. Identità
+    confermata da `session_index.jsonl` nella dir base.
+  - Entrambi: senza il marcatore d'identità la dir NON viene contata —
+    status "unknown", mai un numero inventato da una dir non verificata.
 
 Output: JSON snapshot (default ~/.agent/cost-ledger/seat_usage_snapshot.json)
 con schema {generated_at, seats:[{id, source, status, days:{...}, metrics}]}.
@@ -194,13 +204,47 @@ def collect_codex(codex_home: str, since: datetime) -> dict:
     return out
 
 
-def collect_invocations(log_dir: str, since: datetime) -> dict:
-    """Best-effort: conta file di log recenti (agy, kimi) — nessun token."""
-    p = Path(os.path.expanduser(log_dir))
+def collect_invocations(base_dir: str, since: datetime, *, identity_marker: str, entity_glob: str) -> dict:
+    """Best-effort: conta le ENTITÀ (file o dir) che sono davvero un'invocazione
+    della CLI — mai un conteggio cieco di TUTTO ciò che sta nella home della
+    CLI. Nessun token qui, solo conteggio invocazioni.
+
+    Bug reale (2026-08-20): il chiamante G1 puntava a `~/.openclaw/logs` —
+    la home del bridge OpenClaw (git-sync.log, t4_monitor.log, pipeline nb),
+    che non ha NULLA a che fare con `agy`/Antigravity — e un `rglob("*")`
+    cieco su quella dir tornava un numero plausibile (11) di file altrui,
+    pubblicato come "id": "G1", "source": "agy logs". Uno zero sarebbe
+    saltato all'occhio; un piccolo numero plausibile no.
+
+    Antidoto: prova d'identità PRIMA di contare. `identity_marker` è un file
+    caratteristico che esiste SOLO nella home reale di quella CLI (es.
+    `installation_id` per Antigravity, `session_index.jsonl` per Kimi) — se
+    `base_dir` esiste ma il marcatore manca, la dir potrebbe essere estranea:
+    status "unknown", MAI un conteggio. Solo col marcatore presente si conta
+    via `entity_glob` (relativo a `base_dir`, `glob.glob(..., recursive=True)`
+    — supporta `**`), filtrato per mtime >= since. Il glob stesso è già
+    scoping-per-entità (es. `log/cli-*.log`, non l'intero albero) così cache/
+    telemetry/updater/scratch della CLI non si sommano come se fossero
+    invocazioni.
+    """
+    base = os.path.expanduser(base_dir)
+    p = Path(base)
     if not p.is_dir():
         return {"status": "absent"}
-    n = sum(1 for f in p.rglob("*") if f.is_file() and f.stat().st_mtime >= since.timestamp())
-    return {"status": "ok", "recent_files": n}
+    if not (p / identity_marker).exists():
+        return {
+            "status": "unknown",
+            "note": (f"marcatore d'identita' '{identity_marker}' assente in {p} — "
+                     "non verificabile che questa dir appartenga al seat atteso, nessun conteggio"),
+        }
+    n = 0
+    for fp in glob.glob(os.path.join(base, entity_glob), recursive=True):
+        try:
+            if os.path.getmtime(fp) >= since.timestamp():
+                n += 1
+        except OSError:
+            continue
+    return {"status": "ok", "recent_invocations": n}
 
 
 def collect_api_mirror(export_dir: str, since: datetime) -> dict:
@@ -260,8 +304,16 @@ def main() -> int:
                       "metrics": fmt_metrics(r.get("days", {})) if r.get("days") else None,
                       "note": r.get("note")})
 
-    seats.append({"id": "G1", "source": "agy logs", **collect_invocations("~/.openclaw/logs", since)})
-    seats.append({"id": "K1", "source": "kimi logs", **collect_invocations("~/.kimi-code", since)})
+    seats.append({"id": "G1", "source": "agy (antigravity-cli) invocation logs", **collect_invocations(
+        "~/.gemini/antigravity-cli", since,
+        identity_marker="installation_id",
+        entity_glob="log/cli-*.log",
+    )})
+    seats.append({"id": "K1", "source": "kimi-code session dirs", **collect_invocations(
+        "~/.kimi-code", since,
+        identity_marker="session_index.jsonl",
+        entity_glob="sessions/**/session_*",
+    )})
     seats.append({"id": "TP1", "source": "dashscope", "status": "pending_probe1",
                   "note": "crediti Token Plan: endpoint da individuare in PROBE-1"})
 

--- a/scripts/usage/test_seat_usage_collector.py
+++ b/scripts/usage/test_seat_usage_collector.py
@@ -20,6 +20,7 @@ test pins the ACTUAL shape, not an invented one.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -182,3 +183,105 @@ def test_collect_codex_ignores_lines_without_token_keyword(tmp_path):
     day = next(iter(result["days"].values()))
     assert day["in"] == 10
     assert day["out"] == 2
+
+
+# ------------------------------------------------------ collect_invocations
+#
+# Regression pin for the 2026-08-20 "G1 counts OpenClaw's files as agy
+# invocations" bug: seat_usage_collector.py::main() had G1 pointed at
+# ~/.openclaw/logs (the OpenClaw bridge home — git-sync.log, t4_monitor.log,
+# nlm pipeline logs, nothing to do with agy/Antigravity) and a blind
+# `rglob("*")` file count over it published a plausible-looking number
+# ("recent_files": 11) as if it were agy invocations. A zero would have been
+# noticed; a small plausible number was not. The fix requires an identity
+# marker (a file characteristic of the seat's real home dir) to exist BEFORE
+# any count is trusted — absent marker => status "unknown", never a number.
+
+
+def test_collect_invocations_wrong_directory_reports_unknown_not_a_count(tmp_path):
+    """Guilt: point the collector at a directory that is real, non-empty,
+    and recently touched — but has NOTHING to do with the claimed seat (no
+    identity marker). This is exactly the shape of the live 2026-08-20 bug
+    (an existing, populated, foreign directory). Must report status
+    "unknown" and must NOT emit any invocation count."""
+    foreign = tmp_path / "openclaw-logs"
+    (foreign / "log").mkdir(parents=True)
+    # foreign files that would have been miscounted by the old blind rglob
+    for name in ("git-sync.log", "t4_monitor.log", "nlm_nb4_pipeline.log"):
+        (foreign / name).write_text("noise")
+    # even a file that happens to MATCH the entity_glob shape must not save it —
+    # identity is checked first, independent of what the glob would find
+    (foreign / "log" / "cli-20260101_000000.log").write_text("not really antigravity")
+
+    result = suc.collect_invocations(
+        str(foreign), SINCE,
+        identity_marker="installation_id",
+        entity_glob="log/cli-*.log",
+    )
+    assert result["status"] == "unknown"
+    assert "recent_invocations" not in result
+    assert "installation_id" in result["note"]
+
+
+def test_collect_invocations_real_source_with_marker_counts_correctly(tmp_path):
+    """Innocence: a directory that DOES carry the identity marker is counted
+    normally — entity_glob scoped to the real invocation-log shape, filtered
+    by mtime, cache/scratch/telemetry siblings ignored because the glob
+    never reaches them."""
+    home = tmp_path / "antigravity-cli"
+    (home / "log").mkdir(parents=True)
+    (home / "cache").mkdir()
+    (home / "installation_id").write_text("fake-id-not-a-secret")
+    # 2 recent invocation logs + 1 stale (outside window) + 1 non-matching cache file
+    (home / "log" / "cli-20260820_120000.log").write_text("logging before google.Init")
+    (home / "log" / "cli-20260820_130000.log").write_text("logging before google.Init")
+    stale = home / "log" / "cli-20200101_000000.log"
+    stale.write_text("logging before google.Init")
+    old_time = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
+    os.utime(stale, (old_time, old_time))
+    (home / "cache" / "onboarding.json").write_text("{}")  # must NOT be counted
+
+    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    result = suc.collect_invocations(
+        str(home), since,
+        identity_marker="installation_id",
+        entity_glob="log/cli-*.log",
+    )
+    assert result["status"] == "ok"
+    assert result["recent_invocations"] == 2
+
+
+def test_collect_invocations_kimi_session_dirs_still_counted_correctly(tmp_path):
+    """Innocence 2: K1 (kimi-code) gets the same treatment — session_*
+    directories nested under sessions/<workdir>/ are the real per-session
+    unit, must still be counted after the shared function was hardened."""
+    home = tmp_path / "kimi-code"
+    (home / "sessions" / "wd_nuzantara_abc123").mkdir(parents=True)
+    (home / "sessions" / "wd_scratchpad_def456").mkdir(parents=True)
+    (home / "session_index.jsonl").write_text('{"sessionId":"x"}\n')
+    (home / "sessions" / "wd_nuzantara_abc123" / "session_11111111").mkdir()
+    (home / "sessions" / "wd_nuzantara_abc123" / "session_22222222").mkdir()
+    (home / "sessions" / "wd_scratchpad_def456" / "session_33333333").mkdir()
+    (home / "cache").mkdir()
+    (home / "cache" / "query-store").mkdir()  # must NOT be counted
+
+    since = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    result = suc.collect_invocations(
+        str(home), since,
+        identity_marker="session_index.jsonl",
+        entity_glob="sessions/**/session_*",
+    )
+    assert result["status"] == "ok"
+    assert result["recent_invocations"] == 3
+
+
+def test_collect_invocations_absent_dir_unaffected_by_identity_check(tmp_path):
+    """Innocence: a seat whose CLI was never installed on this machine keeps
+    reporting "absent" (not "unknown") — the identity check only applies
+    once the base dir exists."""
+    result = suc.collect_invocations(
+        str(tmp_path / "never-installed"), SINCE,
+        identity_marker="installation_id",
+        entity_glob="log/cli-*.log",
+    )
+    assert result["status"] == "absent"


### PR DESCRIPTION
## Summary
- `collect_invocations` for G1 was pointed at `~/.openclaw/logs` (the OpenClaw bridge home — git-sync.log, t4_monitor.log, nlm pipeline logs), which has nothing to do with `agy`/Antigravity. A blind `rglob("*")` file count over that foreign dir produced a plausible-looking number (11) published as `"id": "G1", "source": "agy logs"`. A zero would have been noticed; a small plausible number was not.
- Fixed G1 to point at the real source: `~/.gemini/antigravity-cli/log/cli-*.log` — one file per CLI invocation (verified: each file starts with `logging before google.Init`), confirmed present with the same shape on M5/Pro/Mini.
- Structural fix, not just a path swap: `collect_invocations` now requires an **identity marker** (a file characteristic of the seat's real home dir — `installation_id` for antigravity-cli, `session_index.jsonl` for kimi-code) to exist before trusting any count. Missing marker → `status: "unknown"`, never a fabricated number.
- Same treatment applied to K1 (kimi-code), which had the same class of risk even though it was pointed at the right top-level dir: it counted *every file* under `~/.kimi-code` (cache/telemetry/updater/search-index included), not real invocations. Narrowed to `sessions/**/session_*` — one directory per real session.
- `recent_files` renamed to `recent_invocations` (K1 counts directories, not files); grepped for other consumers of the old field name — none exist.

## Verified on all 3 machines
- `~/.gemini/antigravity-cli/{log,installation_id}` — present on M5, Pro, Mini
- `~/.kimi-code/{sessions,session_index.jsonl}` — present on M5, Pro, Mini
- `Path.home()`-based paths already resolve correctly per-machine (`~` expands to the right user home), so this was never a HOME-fork path bug — purely a wrong-directory bug.

## Test plan
- [x] `pytest scripts/usage/test_seat_usage_collector.py -v` — 10/10 pass
- [x] Guilt: pointing the collector at a populated, recently-touched, but foreign directory (no identity marker) → `status: "unknown"`, no count emitted
- [x] Innocence: real antigravity-cli dir with marker → correct count, cache/ siblings excluded
- [x] Innocence 2: kimi-code session dirs still counted correctly (K1 unaffected)
- [x] Mutation: disabled the identity-marker guard → guilt test goes red (fabricated `"ok"` count instead of `"unknown"`) — restored, tests green again
- [x] `py_compile` on both changed files
- [x] End-to-end run against real M5 data: G1=165, K1=129 (8-day window) — plausible, non-fabricated

🤖 Generated with [Claude Code](https://claude.com/claude-code)