### PR TITLE
chore(gitignore): ignore .trash/ — a renamed .next cache escaped the rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,10 @@ testsprite_tests/tmp/
 
 # Next.js / Frontend
 .next/
+# a renamed .next build cache (.trash/.next-verify3210/...) escaped the .next/
+# rule above and cost 135 MB in a quarantine commit on 2026-08-20 — ignore the
+# rename target too.
+.trash/
 out/
 build/
 dist/


### PR DESCRIPTION
## Summary
- While cleaning 612 `refs/agent-quarantine/` refs, we found a worktree (`mouth-visa-experience`, on Pro) that had swept a Next.js dev-build cache into a quarantine commit — **135 MB across 92 blobs**, all under `.trash/.next-verify3210/dev/...` (webpack packs, vendor chunks, static chunks).
- `.next/` is already in `.gitignore` (2 entries), but `.trash/` was not — so something renamed a `.next` cache to `.trash/.next-verify3210` and the rename walked it straight past the ignore rule.
- No script in this repo creates `.trash/` as an automated tool. It's a documented manual "safe delete" convention — `docs/plans/2026-07-19-mini-regia-conoscenza.md:119,125` instructs: "MAI rm (mv in .trash/)" ("never rm, mv into .trash/ instead") for corpse-reconciliation / cleanup work. Someone following that convention by hand is the likely producer here.
- Verified `origin/main` currently tracks **nothing** under `.trash/` (`git ls-tree -r origin/main | grep '^\.trash/'` → 0 hits), so adding this rule is safe — no tracked files would be silently orphaned by it.

## Test plan
- [x] `git status --porcelain` on a probe file at `.trash/probe.txt` shows nothing (only the `.gitignore` edit itself is dirty)
- [x] `git check-ignore -v .trash/probe.txt` → `.gitignore:116:.trash/	.../.trash/probe.txt` — confirms the new rule matches
- [x] Probe file deleted after verification
- [x] Confirmed 0 tracked paths under `.trash/` on `origin/main` before adding the rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)