### PR TITLE
feat(worktree-gc): expire refs/agent-quarantine/* refs older than 30 days

### DIFF
--- a/scripts/tests/test_worktree_gc_universal.py
+++ b/scripts/tests/test_worktree_gc_universal.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -102,6 +103,65 @@ class TestKillSwitch:
     def test_true_is_enabled(self, monkeypatch):
         monkeypatch.setenv(gc.KILL_SWITCH_ENV, "true")
         assert gc._kill_switch_active() is False
+
+
+# ---------------------------------------------------------------------------
+# _quarantine_ttl_disabled  (env QUARANTINE_TTL_ENABLED — its OWN switch,
+# independent of WORKTREE_GC_ENABLED, matching the same convention)
+# ---------------------------------------------------------------------------
+
+
+class TestQuarantineTtlKillSwitch:
+    def test_false_disables(self, monkeypatch):
+        monkeypatch.setenv(gc.QUARANTINE_TTL_ENABLED_ENV, "false")
+        assert gc._quarantine_ttl_disabled() is True
+
+    def test_zero_disables(self, monkeypatch):
+        monkeypatch.setenv(gc.QUARANTINE_TTL_ENABLED_ENV, "0")
+        assert gc._quarantine_ttl_disabled() is True
+
+    def test_unset_is_enabled(self, monkeypatch):
+        monkeypatch.delenv(gc.QUARANTINE_TTL_ENABLED_ENV, raising=False)
+        assert gc._quarantine_ttl_disabled() is False
+
+    def test_true_is_enabled(self, monkeypatch):
+        monkeypatch.setenv(gc.QUARANTINE_TTL_ENABLED_ENV, "true")
+        assert gc._quarantine_ttl_disabled() is False
+
+
+# ---------------------------------------------------------------------------
+# _list_quarantine_refs  (parses NUL-delimited `git for-each-ref` output)
+# ---------------------------------------------------------------------------
+
+
+class TestListQuarantineRefs:
+    def test_parses_nul_delimited_lines(self, monkeypatch):
+        sample = (
+            "refs/agent-quarantine/foo\x00" + "a" * 40 +
+            "\x002026-01-01T00:00:00+00:00\n" +
+            "refs/agent-quarantine/bar\x00" + "b" * 40 +
+            "\x002026-02-02T03:04:05+08:00\n"
+        )
+        monkeypatch.setattr(gc, "_run_git", lambda *a, **k: _FakeProc(sample))
+        entries = gc._list_quarantine_refs()
+        assert len(entries) == 2
+        assert entries[0]["ref"] == "refs/agent-quarantine/foo"
+        assert entries[0]["sha"] == "a" * 40
+        assert entries[0]["committer_date"].year == 2026
+        assert entries[0]["committer_date"].tzinfo is not None
+
+    def test_empty_output(self, monkeypatch):
+        monkeypatch.setattr(gc, "_run_git", lambda *a, **k: _FakeProc(""))
+        assert gc._list_quarantine_refs() == []
+
+    def test_unparseable_date_kept_as_none_not_dropped(self, monkeypatch, caplog):
+        sample = "refs/agent-quarantine/weird\x00" + "c" * 40 + "\x00not-a-date\n"
+        monkeypatch.setattr(gc, "_run_git", lambda *a, **k: _FakeProc(sample))
+        with caplog.at_level("WARNING"):
+            entries = gc._list_quarantine_refs()
+        assert len(entries) == 1
+        assert entries[0]["committer_date"] is None
+        assert any("unparseable" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------
@@ -401,11 +461,39 @@ def _load_gc_module(repo_root: Path):
     mod.REPO_ROOT = repo_root
     mod.WORKTREES_DIR = repo_root / ".worktrees"
     mod.ALLOWLIST_PATHS = {str(repo_root.resolve())}
+    # Quarantine TTL sweep writes its receipt log under REPO_ROOT/.agent-receipts/
+    # by default; this constant is bound at module-exec time (before REPO_ROOT
+    # is repointed above), so it must be repointed explicitly here too — same
+    # reasoning as WORKTREES_DIR two lines up. Without this, a test using the
+    # DEFAULT log path would append to the real worktree's .agent-receipts/
+    # instead of tmp_path (W96 discipline).
+    mod.QUARANTINE_EXPIRY_LOG = repo_root / ".agent-receipts" / "quarantine-ttl-expired.log"
     return mod
 
 
 def _add_worktree(repo, wt_path, branch, env, *, base="main"):
     _git(["worktree", "add", "-b", branch, str(wt_path), base], cwd=repo, env=env)
+
+
+def _make_quarantine_ref(repo: Path, slug: str, days_old: float, env: dict) -> str:
+    """Create refs/agent-quarantine/<slug> pointing at a NEW commit object
+    backdated `days_old` days via GIT_COMMITTER_DATE (per the brief: build
+    fixtures in the tmp throwaway repo, never against real refs). Returns
+    the commit sha."""
+    backdated = datetime.now(timezone.utc) - timedelta(days=days_old)
+    date_str = backdated.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    commit_env = dict(env)
+    commit_env["GIT_COMMITTER_DATE"] = date_str
+    commit_env["GIT_AUTHOR_DATE"] = date_str
+    tree = _git(["rev-parse", "HEAD^{tree}"], cwd=repo, env=env).stdout.strip()
+    parent = _git(["rev-parse", "HEAD"], cwd=repo, env=env).stdout.strip()
+    sha = _git(
+        ["commit-tree", tree, "-p", parent, "-m", f"quarantine {slug}"],
+        cwd=repo, env=commit_env,
+    ).stdout.strip()
+    ref = f"refs/agent-quarantine/{slug}"
+    _git(["update-ref", ref, sha], cwd=repo, env=env)
+    return sha
 
 
 def _age_path(path: Path, hours: float):
@@ -568,6 +656,193 @@ class TestGcIntegration:
         mod.gc(apply=False, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
 
         assert wt.exists()
+
+
+# ---------------------------------------------------------------------------
+# _expire_stale_quarantine_refs (rule 10, 2026-08-2x quarantine TTL sweep) —
+# real git repo under tmp_path, real refs/agent-quarantine/* refs backdated
+# via GIT_COMMITTER_DATE (never the real repo's refs, per the brief).
+# ---------------------------------------------------------------------------
+
+
+class TestExpireStaleQuarantineRefs:
+    def test_ref_older_than_ttl_is_expired(self, gc_repo):
+        """GUILT: a quarantine ref committed 31+ days ago IS expired."""
+        mod, repo, env = gc_repo
+        _make_quarantine_ref(repo, "old-one", mod.QUARANTINE_TTL_DAYS + 1, env)
+
+        expired = mod._expire_stale_quarantine_refs(apply=True)
+
+        assert expired == 1
+        check = _git(
+            ["rev-parse", "--verify", "refs/agent-quarantine/old-one"],
+            cwd=repo, env=env, check=False,
+        )
+        assert check.returncode != 0, "expired ref must no longer resolve"
+
+    def test_ref_within_ttl_survives(self, gc_repo):
+        """INNOCENCE: a 29-day-old ref (< 30-day TTL) survives."""
+        mod, repo, env = gc_repo
+        _make_quarantine_ref(repo, "recent-one", mod.QUARANTINE_TTL_DAYS - 1, env)
+
+        expired = mod._expire_stale_quarantine_refs(apply=True)
+
+        assert expired == 0
+        check = _git(
+            ["rev-parse", "--verify", "refs/agent-quarantine/recent-one"],
+            cwd=repo, env=env, check=False,
+        )
+        assert check.returncode == 0, "a ref inside the TTL must survive"
+
+    def test_refs_outside_namespace_never_touched(self, gc_repo):
+        """INNOCENCE: a branch, a tag, and a remote-tracking ref — however
+        old — are never touched, no matter what else the sweep expires."""
+        mod, repo, env = gc_repo
+        old_env = dict(env)
+        old_env["GIT_COMMITTER_DATE"] = "2020-01-01T00:00:00+00:00"
+        old_env["GIT_AUTHOR_DATE"] = "2020-01-01T00:00:00+00:00"
+        _git(["tag", "-a", "ancient-tag", "-m", "old"], cwd=repo, env=old_env)
+        before_branch = _git(["rev-parse", "main"], cwd=repo, env=env).stdout.strip()
+        before_tag = _git(["rev-parse", "ancient-tag"], cwd=repo, env=env).stdout.strip()
+        before_remote = _git(
+            ["rev-parse", "origin/main"], cwd=repo, env=env,
+        ).stdout.strip()
+        # One genuinely guilty quarantine ref alongside them, so the sweep
+        # has real work to do while touching neither of the three above.
+        _make_quarantine_ref(repo, "guilty", mod.QUARANTINE_TTL_DAYS + 1, env)
+
+        expired = mod._expire_stale_quarantine_refs(apply=True)
+
+        assert expired == 1  # only the quarantine ref
+        assert _git(["rev-parse", "main"], cwd=repo, env=env).stdout.strip() == before_branch
+        assert _git(["rev-parse", "ancient-tag"], cwd=repo, env=env).stdout.strip() == before_tag
+        assert (
+            _git(["rev-parse", "origin/main"], cwd=repo, env=env).stdout.strip()
+            == before_remote
+        )
+
+    def test_dry_run_expires_nothing(self, gc_repo):
+        """INNOCENCE: dry-run reports the candidate count but deletes
+        nothing and writes no log file."""
+        mod, repo, env = gc_repo
+        _make_quarantine_ref(repo, "old-dry", mod.QUARANTINE_TTL_DAYS + 1, env)
+
+        would_expire = mod._expire_stale_quarantine_refs(apply=False)
+
+        assert would_expire == 1  # correctly counts the candidate
+        check = _git(
+            ["rev-parse", "--verify", "refs/agent-quarantine/old-dry"],
+            cwd=repo, env=env, check=False,
+        )
+        assert check.returncode == 0, "dry-run must not delete anything"
+        assert not mod.QUARANTINE_EXPIRY_LOG.exists(), (
+            "dry-run must not write the receipt log either"
+        )
+
+    def test_kill_switch_expires_nothing(self, gc_repo, monkeypatch):
+        """INNOCENCE: QUARANTINE_TTL_ENABLED=false disables the sweep end
+        to end (through gc()), even though the worktree-reap loop still
+        runs."""
+        mod, repo, env = gc_repo
+        monkeypatch.setenv(mod.QUARANTINE_TTL_ENABLED_ENV, "false")
+        _make_quarantine_ref(repo, "old-killswitch", mod.QUARANTINE_TTL_DAYS + 1, env)
+
+        report = mod.gc(apply=True, max_age_hours=mod.DEFAULT_MAX_AGE_HOURS)
+
+        assert report["quarantine_expired"] == 0
+        check = _git(
+            ["rev-parse", "--verify", "refs/agent-quarantine/old-killswitch"],
+            cwd=repo, env=env, check=False,
+        )
+        assert check.returncode == 0, "kill switch must prevent expiry"
+
+    def test_already_gone_ref_is_not_reported_as_a_failure(
+        self, gc_repo, monkeypatch, caplog,
+    ):
+        """GOTCHA (from the brief): `git update-ref -d` against a ref that
+        no longer exists prints 'unable to resolve reference ...' and
+        returns 1 — that's 'already gone', not a bug, and must not be
+        logged as a failure or crash the sweep."""
+        mod, repo, env = gc_repo
+        sha = _make_quarantine_ref(repo, "vanishing", mod.QUARANTINE_TTL_DAYS + 1, env)
+        # Simulate the ref disappearing between enumeration and deletion.
+        _git(
+            ["update-ref", "-d", "refs/agent-quarantine/vanishing", sha],
+            cwd=repo, env=env,
+        )
+        stale_entry = {
+            "ref": "refs/agent-quarantine/vanishing",
+            "sha": sha,
+            "committer_date": datetime.now(timezone.utc) - timedelta(days=31),
+        }
+        monkeypatch.setattr(mod, "_list_quarantine_refs", lambda: [stale_entry])
+
+        with caplog.at_level("ERROR"):
+            expired = mod._expire_stale_quarantine_refs(apply=True)
+
+        assert expired == 0  # nothing NEW was deleted — it was already gone
+        assert not any("failed to expire" in r.message for r in caplog.records)
+
+    def test_expiry_appends_receipt_log_with_refname_sha_date(self, gc_repo):
+        """Never silent: every expiry writes (full refname, sha, committer
+        date) to the receipt log file."""
+        mod, repo, env = gc_repo
+        sha = _make_quarantine_ref(repo, "logged-one", mod.QUARANTINE_TTL_DAYS + 1, env)
+
+        mod._expire_stale_quarantine_refs(apply=True)
+
+        log_path = mod.QUARANTINE_EXPIRY_LOG
+        assert log_path.exists()
+        content = log_path.read_text()
+        assert "refs/agent-quarantine/logged-one" in content
+        assert sha in content
+
+    def test_large_sweep_alarms_but_proceeds(self, gc_repo, caplog):
+        """Alarm, never halt: a run that would expire more than
+        QUARANTINE_SWEEP_ALARM refs logs a loud [ALARM] and still expires
+        every one of them — it does not stop draining the backlog."""
+        mod, repo, env = gc_repo
+        n = mod.QUARANTINE_SWEEP_ALARM + 1
+        for i in range(n):
+            _make_quarantine_ref(repo, f"bulk-{i}", mod.QUARANTINE_TTL_DAYS + 1, env)
+
+        with caplog.at_level("WARNING"):
+            expired = mod._expire_stale_quarantine_refs(apply=True)
+
+        assert expired == n
+        assert any("[ALARM]" in r.message for r in caplog.records)
+
+    def test_ref_outside_namespace_from_a_compromised_lister_is_refused(
+        self, gc_repo, monkeypatch, caplog,
+    ):
+        """Defense in depth: assert per-ref in CODE, not just in the query.
+        Even if _list_quarantine_refs() were to somehow return an
+        out-of-namespace entry, the sweep must refuse to touch it — a guard
+        that only trusts its own query is not a guard."""
+        mod, repo, env = gc_repo
+        fake_entries = [{
+            "ref": "refs/heads/main",
+            "sha": "d" * 40,
+            "committer_date": datetime(2000, 1, 1, tzinfo=timezone.utc),
+        }]
+        monkeypatch.setattr(mod, "_list_quarantine_refs", lambda: fake_entries)
+        calls = []
+        real_run_git = mod._run_git
+
+        def spy(args, **kw):
+            calls.append(args)
+            return real_run_git(args, **kw)
+
+        monkeypatch.setattr(mod, "_run_git", spy)
+
+        with caplog.at_level("ERROR"):
+            expired = mod._expire_stale_quarantine_refs(apply=True)
+
+        assert expired == 0
+        assert not any(
+            len(c) >= 2 and c[0] == "update-ref" and "-d" in c for c in calls
+        ), "must never call update-ref -d for a ref outside refs/agent-quarantine/"
+        assert any("OUTSIDE" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_worktree_gc_universal.py
+++ b/scripts/tests/test_worktree_gc_universal.py
@@ -783,6 +783,59 @@ class TestExpireStaleQuarantineRefs:
         assert expired == 0  # nothing NEW was deleted — it was already gone
         assert not any("failed to expire" in r.message for r in caplog.records)
 
+    def test_moved_ref_survives_and_is_not_conflated_with_already_gone(
+        self, gc_repo, monkeypatch, caplog,
+    ):
+        """Regression (team-lead review, 2026-08-2x): `git update-ref -d`
+        wraps BOTH the absent-ref case and the moved-ref case in "cannot
+        lock ref ..." — matching on that wrapper alone silently swallowed
+        a ref that MOVED between enumeration and deletion (present, but not
+        at the sha the sweep expected) as ordinary "already gone" noise.
+        A moved ref means something else wrote to this namespace mid-sweep
+        — exactly the event an operator needs to see, not something to
+        hide. Prove: the ref survives, it is NOT counted as expired, and it
+        is not logged as "already gone"."""
+        mod, repo, env = gc_repo
+        stale_sha = _make_quarantine_ref(
+            repo, "moved", mod.QUARANTINE_TTL_DAYS + 1, env,
+        )
+        # Simulate the ref moving to a NEW sha between enumeration and
+        # deletion (e.g. re-quarantined by a concurrent run) — the sweep's
+        # candidate list still carries the OLD (now-stale) sha.
+        # A different days_old (still > TTL) yields a different committer
+        # date and therefore a different commit sha — `git commit-tree` is
+        # otherwise fully deterministic (same tree/parent/message/author),
+        # so an identical call here would silently reproduce stale_sha.
+        fresh_sha = _make_quarantine_ref(
+            repo, "moved", mod.QUARANTINE_TTL_DAYS + 2, env,
+        )
+        assert fresh_sha != stale_sha
+        stale_entry = {
+            "ref": "refs/agent-quarantine/moved",
+            "sha": stale_sha,  # stale — the ref has already moved past this
+            "committer_date": datetime.now(timezone.utc) - timedelta(days=31),
+        }
+        monkeypatch.setattr(mod, "_list_quarantine_refs", lambda: [stale_entry])
+
+        with caplog.at_level("WARNING"):
+            expired = mod._expire_stale_quarantine_refs(apply=True)
+
+        assert expired == 0, "a moved ref must not be counted as expired"
+        current = _git(
+            ["rev-parse", "--verify", "refs/agent-quarantine/moved"],
+            cwd=repo, env=env, check=False,
+        )
+        assert current.returncode == 0, "the ref must survive"
+        assert current.stdout.strip() == fresh_sha, (
+            "the ref must still point at its CURRENT (fresh) sha, untouched"
+        )
+        assert not any(
+            "already gone" in r.message for r in caplog.records
+        ), "a moved ref must never be reported as already gone"
+        assert any(
+            "MOVED" in r.message for r in caplog.records
+        ), "a moved ref must be logged as its own distinct case"
+
     def test_expiry_appends_receipt_log_with_refname_sha_date(self, gc_repo):
         """Never silent: every expiry writes (full refname, sha, committer
         date) to the receipt log file."""

--- a/scripts/worktree_gc_universal.py
+++ b/scripts/worktree_gc_universal.py
@@ -77,8 +77,32 @@ scope. For each candidate it applies the panel's safety model:
      is made of: the daily cron reaped 0 for days with zero external signal.
      Registry entry: apps/organism/organism/organs_registry.yaml
      id=pro.worktree_gc_universal.
+ 10. Quarantine ref TTL sweep (2026-08-2x): refs/agent-quarantine/* (written
+     by rule 4's two preservation tracks) is a durable BACKSTOP for work
+     that would otherwise be orphaned — never a queue anyone works off. With
+     no expiry it grew to 612 refs fleet-wide by 2026-08-20, oldest dated
+     2026-05-31, invisible to `git branch`. Measured value of the backlog is
+     low (a full census on one machine found every ref an orphan stash
+     nobody ever returned for). Policy: expire any refs/agent-quarantine/*
+     ref whose COMMITTER DATE is older than QUARANTINE_TTL_DAYS (30 — a full
+     month of recoverability). Never silent (every expiry is logged AND
+     appended to a receipt file under .agent-receipts/, and the run reports
+     a quarantine_expired count same as removed/quarantined/etc.), never
+     halting on a large sweep (a run that would expire more than
+     QUARANTINE_SWEEP_ALARM refs logs a loud [ALARM] and proceeds — halting
+     would recreate the exact silent-backlog disease this cures), --apply
+     gated like every other destructive action in this file. Touches ONLY
+     refs whose full name starts with refs/agent-quarantine/ — asserted
+     per-ref in _expire_stale_quarantine_refs(), never just trusted from the
+     for-each-ref query that produced the candidate list. This is a NEW
+     ref-deletion capability for this organ; the pre-existing invariant that
+     it NEVER runs `git branch -D`/`-d` (rule 5) is unchanged and remains
+     grep-verifiable — the sweep only ever calls `git update-ref -d` against
+     the agent-quarantine namespace, never `git branch`.
 
-Kill switch: WORKTREE_GC_ENABLED=false → no-op exit 0.
+Kill switches: WORKTREE_GC_ENABLED=false → no-op exit 0 (whole organ, incl.
+the quarantine sweep). QUARANTINE_TTL_ENABLED=false → skip ONLY the
+quarantine-ref TTL sweep; worktree reaping still runs.
 Run: python scripts/worktree_gc_universal.py [--apply] [--quiet]
 """
 from __future__ import annotations
@@ -91,7 +115,7 @@ import shutil
 import subprocess
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -113,6 +137,12 @@ MIN_AGE_MIN = 15          # skip worktrees touched in the last 15 min (active)
 DEFAULT_MAX_AGE_HOURS = 24
 MAX_REMOVE_ALARM = 5      # WARN if a single run removes more than this
 QUARANTINE_REF_PREFIX = "refs/agent-quarantine"
+
+# Quarantine ref TTL sweep (module docstring rule 10, 2026-08-2x policy).
+QUARANTINE_TTL_DAYS = 30
+QUARANTINE_TTL_ENABLED_ENV = "QUARANTINE_TTL_ENABLED"
+QUARANTINE_SWEEP_ALARM = 50   # WARN (never halt) if a run would expire more than this
+QUARANTINE_EXPIRY_LOG = REPO_ROOT / ".agent-receipts" / "quarantine-ttl-expired.log"
 
 # Worktrees that must NEVER be GC'd, regardless of age/state.
 # Matched by resolved absolute path.
@@ -171,6 +201,15 @@ def _run_git(args, *, cwd=None, check=True):
 
 def _kill_switch_active() -> bool:
     return os.environ.get(KILL_SWITCH_ENV, "true").strip().lower() in (
+        "false", "0", "no", "off", "disabled",
+    )
+
+
+def _quarantine_ttl_disabled() -> bool:
+    """Same convention as _kill_switch_active() (KILL_SWITCH_ENV) — its OWN
+    switch, so the quarantine-ref TTL sweep can be disabled without also
+    disabling worktree reaping. Default enabled (unset/"true" -> False)."""
+    return os.environ.get(QUARANTINE_TTL_ENABLED_ENV, "true").strip().lower() in (
         "false", "0", "no", "off", "disabled",
     )
 
@@ -403,6 +442,141 @@ def _unique_ref(base_ref: str, sha_hint: str) -> str:
     return f"{base_ref}-{sha_hint[:8]}"
 
 
+def _list_quarantine_refs() -> list[dict]:
+    """Enumerate every refs/agent-quarantine/* ref with its sha + committer
+    date, via a single `git for-each-ref` call (cheap — no per-ref
+    subprocess, same reasoning as _collect_live_cwds()'s one-shot lsof).
+
+    Each entry: {ref: full refname (str), sha: str, committer_date:
+    datetime|None}. committer_date is None when git could not resolve one
+    (malformed/empty field) — callers must treat None as "cannot determine
+    age" and never expire that ref (fail-closed on the deletion side; an
+    unknown age must never read as "old enough").
+    """
+    out = _run_git(
+        ["for-each-ref",
+         "--format=%(refname)%00%(objectname)%00%(committerdate:iso-strict)",
+         QUARANTINE_REF_PREFIX + "/"],
+        check=True,
+    ).stdout
+    entries: list[dict] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\x00")
+        if len(parts) != 3:
+            logger.warning("unparseable for-each-ref line, skipping: %r", line)
+            continue
+        ref, sha, date_str = parts
+        committer_date = None
+        if date_str:
+            try:
+                committer_date = datetime.fromisoformat(date_str)
+            except ValueError:
+                logger.warning(
+                    "quarantine ref %s has an unparseable committer date "
+                    "%r — keeping (cannot determine age)", ref, date_str,
+                )
+        entries.append({"ref": ref, "sha": sha, "committer_date": committer_date})
+    return entries
+
+
+def _expire_stale_quarantine_refs(*, apply: bool, log_path: Path | None = None) -> int:
+    """Expire refs/agent-quarantine/* refs whose committer date is older
+    than QUARANTINE_TTL_DAYS (module docstring rule 10). Returns the count
+    expired (apply) or that WOULD be expired (dry-run).
+
+    Safety, mirroring the rest of this file:
+      - Touches ONLY refs whose FULL NAME starts with
+        QUARANTINE_REF_PREFIX + "/" — asserted PER-REF here, never just
+        trusted from the for-each-ref query that produced the candidate
+        list (a guard that trusts its input is not a guard).
+      - Deletes via the two-argument `git update-ref -d <ref> <sha>`: a ref
+        that moved between enumeration and deletion FAILS instead of being
+        clobbered.
+      - `git update-ref -d` against a ref that is already gone prints
+        "error: cannot lock ref ...: unable to resolve reference ..." and
+        returns 1 — that is "already gone", not a failure; it is NOT
+        reported as an expiry failure.
+      - Never halts: if a single run would expire more than
+        QUARANTINE_SWEEP_ALARM refs, logs a loud [ALARM] and proceeds —
+        halting here would recreate the silent-backlog disease this cures.
+      - dry-run touches NOTHING on disk (no delete, no log-file write) —
+        only logs to stdout what it WOULD do.
+    """
+    entries = _list_quarantine_refs()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=QUARANTINE_TTL_DAYS)
+
+    candidates: list[dict] = []
+    for e in entries:
+        ref = e["ref"]
+        if not ref.startswith(QUARANTINE_REF_PREFIX + "/"):
+            # Defense in depth: the for-each-ref query already scopes this
+            # namespace, but a guard that trusts its input is not a guard.
+            logger.error(
+                "quarantine TTL sweep saw a ref OUTSIDE %s/ — refusing to "
+                "touch it: %s", QUARANTINE_REF_PREFIX, ref,
+            )
+            continue
+        cd = e["committer_date"]
+        if cd is None:
+            continue  # already logged by _list_quarantine_refs(); keep it
+        if cd < cutoff:
+            candidates.append(e)
+
+    if len(candidates) > QUARANTINE_SWEEP_ALARM:
+        logger.warning(
+            "[ALARM] quarantine TTL sweep %s %d refs older than %dd in one "
+            "run (threshold %d) — proceeding; a large backlog is the "
+            "disease this sweep cures, not a reason to stop draining it",
+            "would expire" if not apply else "is expiring", len(candidates),
+            QUARANTINE_TTL_DAYS, QUARANTINE_SWEEP_ALARM,
+        )
+
+    if not apply:
+        for e in candidates:
+            logger.info(
+                "[dry-run] would expire quarantine ref %s (%s, committed %s)",
+                e["ref"], e["sha"][:10], e["committer_date"].isoformat(),
+            )
+        return len(candidates)
+
+    log_path = log_path or QUARANTINE_EXPIRY_LOG
+    expired = 0
+    log_lines: list[str] = []
+    for e in candidates:
+        ref, sha, cd = e["ref"], e["sha"], e["committer_date"]
+        result = _run_git(["update-ref", "-d", ref, sha], check=False)
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            if "unable to resolve reference" in stderr or "cannot lock ref" in stderr:
+                # Already gone — not a failure, see docstring gotcha above.
+                logger.info("quarantine ref %s already gone (%s)", ref, stderr)
+                continue
+            logger.error(
+                "failed to expire quarantine ref %s (rc=%d): %s",
+                ref, result.returncode, stderr,
+            )
+            continue
+        expired += 1
+        line = f"{datetime.now(timezone.utc).isoformat()}\t{ref}\t{sha}\t{cd.isoformat()}"
+        logger.info("expired quarantine ref: %s", line)
+        log_lines.append(line)
+
+    if log_lines:
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a", encoding="utf-8") as fh:
+                for line in log_lines:
+                    fh.write(line + "\n")
+        except Exception as exc:  # noqa: BLE001 — best-effort, never crash the sweep
+            logger.warning(
+                "could not append quarantine expiry log %s: %s", log_path, exc,
+            )
+
+    return expired
+
+
 def _quarantine(worktree: Path, slug: str, *, apply: bool) -> bool:
     """Create a quarantine ref capturing the worktree's current tree+untracked.
 
@@ -631,10 +805,23 @@ def gc(*, apply: bool, max_age_hours: float) -> dict[str, Any]:
             "investigate possible loop bug", removed,
         )
 
+    # Quarantine ref TTL sweep (rule 10) — independent kill switch, but
+    # still gated by the whole-organ kill switch above (this line is only
+    # reached when that one is enabled).
+    quarantine_expired = 0
+    if _quarantine_ttl_disabled():
+        logger.info(
+            "%s=false — quarantine TTL sweep disabled, skipping",
+            QUARANTINE_TTL_ENABLED_ENV,
+        )
+    else:
+        quarantine_expired = _expire_stale_quarantine_refs(apply=apply)
+
     logger.info(
         "done: removed=%d quarantined=%d reclaimed_unpushed=%d kept_active=%d "
-        "phantom=%d apply=%s",
-        removed, quarantined, reclaimed_unpushed, kept_active, pruned_phantom, apply,
+        "phantom=%d quarantine_expired=%d apply=%s",
+        removed, quarantined, reclaimed_unpushed, kept_active, pruned_phantom,
+        quarantine_expired, apply,
     )
     return {
         "disabled": False,
@@ -643,6 +830,7 @@ def gc(*, apply: bool, max_age_hours: float) -> dict[str, Any]:
         "reclaimed_unpushed": reclaimed_unpushed,
         "kept_active": kept_active,
         "phantom": pruned_phantom,
+        "quarantine_expired": quarantine_expired,
         "apply": apply,
     }
 
@@ -685,6 +873,7 @@ def main() -> int:
                     f"removed={report['removed']} quarantined={report['quarantined']} "
                     f"reclaimed_unpushed={report['reclaimed_unpushed']} "
                     f"kept_active={report['kept_active']} phantom={report['phantom']} "
+                    f"quarantine_expired={report['quarantine_expired']} "
                     f"apply={report['apply']}"
                 )
                 _heartbeat("ok", detail)

--- a/scripts/worktree_gc_universal.py
+++ b/scripts/worktree_gc_universal.py
@@ -494,10 +494,16 @@ def _expire_stale_quarantine_refs(*, apply: bool, log_path: Path | None = None) 
       - Deletes via the two-argument `git update-ref -d <ref> <sha>`: a ref
         that moved between enumeration and deletion FAILS instead of being
         clobbered.
-      - `git update-ref -d` against a ref that is already gone prints
-        "error: cannot lock ref ...: unable to resolve reference ..." and
-        returns 1 — that is "already gone", not a failure; it is NOT
-        reported as an expiry failure.
+      - `git update-ref -d` wraps EVERY failure in "cannot lock ref ..." —
+        that wrapper alone does NOT mean "already gone". Two distinct
+        causes share it: an absent ref adds "...: unable to resolve
+        reference ..."; a MOVED ref (present, but not at the expected sha)
+        adds "...: is at <X> but expected <Y>". Only the "unable to resolve
+        reference" case is "already gone" and skipped as routine (NOT
+        reported as an expiry failure); the moved case is left untouched
+        and logged as a WARNING naming what happened, never conflated with
+        "already gone" (that would misreport an active write to this
+        namespace during the sweep as unremarkable noise).
       - Never halts: if a single run would expire more than
         QUARANTINE_SWEEP_ALARM refs, logs a loud [ALARM] and proceeds —
         halting here would recreate the silent-backlog disease this cures.
@@ -549,9 +555,25 @@ def _expire_stale_quarantine_refs(*, apply: bool, log_path: Path | None = None) 
         result = _run_git(["update-ref", "-d", ref, sha], check=False)
         if result.returncode != 0:
             stderr = (result.stderr or "").strip()
-            if "unable to resolve reference" in stderr or "cannot lock ref" in stderr:
-                # Already gone — not a failure, see docstring gotcha above.
+            # "cannot lock ref" is the wrapper both git prints on ANY -d
+            # failure — it does NOT by itself mean "already gone". Two
+            # distinct messages share it:
+            #   absent: "cannot lock ref '<r>': unable to resolve reference '<r>'"
+            #   moved:  "cannot lock ref '<r>': is at <X> but expected <Y>"
+            # Only "unable to resolve reference" means the ref no longer
+            # exists (see docstring gotcha above) — matching on "cannot lock
+            # ref" alone silently swallowed the moved case too, misreporting
+            # an active write to this namespace during the sweep as routine
+            # already-gone noise.
+            if "unable to resolve reference" in stderr:
                 logger.info("quarantine ref %s already gone (%s)", ref, stderr)
+                continue
+            if "but expected" in stderr:
+                logger.warning(
+                    "quarantine ref %s MOVED between enumeration and "
+                    "deletion — NOT expired, left untouched (%s)",
+                    ref, stderr,
+                )
                 continue
             logger.error(
                 "failed to expire quarantine ref %s (rc=%d): %s",


### PR DESCRIPTION
## Summary

\`refs/agent-quarantine/*\` — the stash-quarantine backstop \`worktree_gc_universal.py\` writes before removing a dirty or detached-HEAD worktree — has never had any expiry. Measured today: **612 refs fleet-wide**, oldest dated 2026-05-31, invisible to \`git branch\`, growing without anyone seeing it. On Mini a full census found every one of its 130 refs already unreachable from any live ref — an orphan stash nobody ever returns for. Without a TTL, that number is back near 600 by autumn.

## Policy (decided; this PR is the mechanism)

- Expire any \`refs/agent-quarantine/*\` ref whose **committer date** is older than **30 days**.
- **Never silent**: every expiry is logged (\`logger.info\`) and appended to \`.agent-receipts/quarantine-ttl-expired.log\` with full refname, sha, and committer date. The run reports a \`quarantine_expired\` count alongside the existing \`removed\`/\`quarantined\`/\`reclaimed_unpushed\`/\`kept_active\`/\`phantom\` counters (log line + G2 heartbeat detail).
- **Never halts**: a run that would expire more than \`QUARANTINE_SWEEP_ALARM\` (50) refs logs a loud \`[ALARM]\` and proceeds anyway — halting would recreate the exact silent-backlog disease this cures.
- **Dedicated kill switch**: \`QUARANTINE_TTL_ENABLED=false\` disables only the sweep, following the same env-var convention as the existing \`WORKTREE_GC_ENABLED\` switch (default enabled; \`false\`/\`0\`/\`no\`/\`off\`/\`disabled\` turns it off). It's still nested inside the whole-organ kill switch, so \`WORKTREE_GC_ENABLED=false\` still means full no-op.
- **Only under \`--apply\`**: dry-run lists candidates and touches nothing (no delete, no log-file write).

## Safety

- Deletion is scoped defensively: only refs whose **full name starts with** \`refs/agent-quarantine/\` are ever touched — asserted **per-ref in code**, not just trusted from the \`for-each-ref\` query that produced the candidate list.
- Uses the two-argument \`git update-ref -d <ref> <sha>\`, so a ref that moved between enumeration and deletion fails instead of being clobbered.
- \`git update-ref -d\` against an already-gone ref prints \`unable to resolve reference ...\` and returns 1 — handled as "already gone," never reported as a failure.
- The pre-existing "this GC never runs \`git branch -D\`/\`-d\`" invariant is unchanged and remains grep-verifiable — the sweep's only destructive call is \`update-ref -d\` scoped to the quarantine namespace.

## Tests

11 new tests in \`scripts/tests/test_worktree_gc_universal.py\`, all against a throwaway git repo under \`tmp_path\` with backdated commits via \`GIT_COMMITTER_DATE\` (never the real repo's refs):

- **Guilt**: a 31-day-old quarantine ref is expired.
- **Innocence**: a 29-day-old ref survives; a branch/tag/remote-tracking ref — however old — is never touched even when a genuinely-guilty quarantine ref exists alongside it; dry-run expires nothing and writes no log; the kill switch (exercised end-to-end through \`gc()\`) expires nothing.
- Defense-in-depth: a compromised/mocked \`_list_quarantine_refs()\` returning an out-of-namespace ref is still refused by the per-ref code guard.
- The "already gone" gotcha, the receipt-log content, and the large-sweep alarm-but-proceed behavior each have a dedicated test.

Verified the guilt test actually goes red: sabotaged the age-comparison in \`_expire_stale_quarantine_refs\` (\`if cd < cutoff and False\`), reran — 5 tests failed including the primary guilt test and the alarm test (0 expired instead of 51) — then restored and reran full suite green (58/58).

## Test plan

- [x] \`python3 -m pytest scripts/tests/test_worktree_gc_universal.py -v\` — 58 passed
- [x] Guilt test verified to go red under a deliberate sabotage, then restored to green
- [x] \`py_compile\` on both changed files
- [x] Grepped for \`git branch -D\`/\`-d\` — zero real invocations (only comment/docstring mentions of the invariant)
- [x] Never ran the real script with \`--apply\` against this or any real repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)