### PR TITLE
fix(ci): register yield-optimizer-pii-gate-tests.yml with the push-failure watcher

### DIFF
--- a/.github/workflows/main-push-failure-watch.yml
+++ b/.github/workflows/main-push-failure-watch.yml
@@ -221,6 +221,17 @@ on:
       # reachability (see its own docstring); caught by that gate on this
       # PR's own first CI run, exactly the self-conformance it exists for.
       - Harness floor & gate publisher
+      # Added 2026-08-21: yield-optimizer-pii-gate-tests.yml (built PR #4449,
+      # scripts/yield_optimizer_pitch_gate.py's guilt+innocence+class-guard
+      # suite) triggers on pull_request with a `paths:` filter only — same
+      # non-reachable-but-still-required-for-coverage shape as actionlint /
+      # hot-zone-enforcement / Prettier (changed files) / Harness floor above.
+      # check_watcher_coverage.py's contract is name-set membership against
+      # this file's `name:`, not alert-path reachability (see its own
+      # docstring); the workflow shipped without this entry, which is exactly
+      # the drift check_watcher_coverage.py exists to catch — caught here on
+      # main-push-failure-watch's own run 32395393032, 2026-08-20.
+      - yield-optimizer PII gate tests
     types: [completed]
     # 2026-08-20 CI-churn cure — see the matching GOTCHA above for the
     # measurement and the empirical proof this narrows run CREATION, never


### PR DESCRIPTION
## Summary
- `check_watcher_coverage.py` has been failing on `origin/main` since PR #4449 (`f1de0b792`) added `yield-optimizer-pii-gate-tests.yml` without registering its `name:` in `main-push-failure-watch.yml`'s `workflows:` list — the "exists != armed" gap this meta-guard exists to catch (cicatrix superscar #2).
- Confirmed pre-existing and unrelated to #4456: same failure reproduces at `origin/main`'s current tip (`2f7e485e3`) and on every push-to-main run since `5929044e9` (`gh run list --branch main --workflow watcher-coverage.yml` shows `failure` at both SHAs).
- Adds the missing entry with the same non-reachable-but-still-required-for-coverage justification already used for `actionlint` / `hot-zone-enforcement` / `Prettier (changed files)` / `Harness floor & gate publisher` — this workflow also only triggers on `pull_request` with a `paths:` filter.

## Verification
- `python3 scripts/check_watcher_coverage.py`: `1 violation(s)` -> `✓ watcher-coverage: all 93 live workflow(s) covered`, RC=0.
- `actionlint .github/workflows/main-push-failure-watch.yml`: RC=0.

## Test plan
- [x] `check_watcher_coverage.py` passes locally
- [x] `actionlint` passes locally
- [ ] CI green on this PR

Adversarial review: exempt-single-line-ci-config-registration (mechanical name-list registration, no logic change; verified locally with the same script the CI check runs).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>