### PR TITLE
security(actions): SHA-pin third-party GitHub Actions + write-permission first-party jobs

### DIFF
--- a/.github/workflows/auto-merge-whitelist.yml
+++ b/.github/workflows/auto-merge-whitelist.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repo (read-only for diff inspection)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codex-autofix-reaper.yml
+++ b/.github/workflows/codex-autofix-reaper.yml
@@ -46,12 +46,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout (full history for blob-per-file merge check)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           filter: blob:none
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/cron-fly-cost-alert.yml
+++ b/.github/workflows/cron-fly-cost-alert.yml
@@ -24,7 +24,7 @@ jobs:
       MAX_TOTAL_VOLUME_GB: "60"
       MAX_DEDICATED_IPV4: "1"
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Inventory billable Fly.io resources
         id: check

--- a/.github/workflows/cron-fly-restart-detector.yml
+++ b/.github/workflows/cron-fly-restart-detector.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Restore cooldown state
         id: cache

--- a/.github/workflows/cron-fly-watcher.yml
+++ b/.github/workflows/cron-fly-watcher.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Test alert (channel liveness probe)
         if: github.event_name == 'workflow_dispatch' && inputs.test_alert

--- a/.github/workflows/cron-kg-staging-promotion.yml
+++ b/.github/workflows/cron-kg-staging-promotion.yml
@@ -40,7 +40,7 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       FLY_ACCESS_TOKEN: ${{ secrets.FLY_API_TOKEN }} # flyctl ≥0.3 reads this name
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Run promotion job via fly ssh (api group — asyncpg lives there)
         timeout-minutes: 10

--- a/.github/workflows/cron-llm-credit-sentinel.yml
+++ b/.github/workflows/cron-llm-credit-sentinel.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Probe the LLM credit inside prod
         id: probe

--- a/.github/workflows/cron-sentry-quota-check.yml
+++ b/.github/workflows/cron-sentry-quota-check.yml
@@ -22,7 +22,7 @@ jobs:
       APP: nuzantara-rag
       MAX_TRACES: "0.02"
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Read runtime env from Fly machine
         id: read

--- a/.github/workflows/fly-api-diagnostics.yml
+++ b/.github/workflows/fly-api-diagnostics.yml
@@ -46,7 +46,7 @@ jobs:
       LOG_LINES: ${{ github.event.inputs.log_lines }}
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Snapshot Fly status and select machine
         id: status

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -147,7 +147,7 @@ jobs:
       FLY_ACCESS_TOKEN: ${{ secrets.FLY_API_TOKEN }} # flyctl ≥0.3 reads this name
 
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Run DB migrations via flyctl console
         timeout-minutes: 3 # step-level timeout (flyctl ssh no longer supports --timeout)
@@ -169,7 +169,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Deploy (rolling strategy, monorepo context)
         run: |
@@ -227,7 +227,7 @@ jobs:
       FLY_ACCESS_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Pin migration to a fresh-image machine in the api group (sentinel)
         id: sentinel
@@ -352,7 +352,7 @@ jobs:
       FLY_ACCESS_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Wait for new image to be serving
         run: |
@@ -501,7 +501,7 @@ jobs:
       FLY_ACCESS_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
     steps:
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Health check (10 tentativi × 30s = 5min max)
         id: health_check

--- a/.github/workflows/fly-secrets-check.yml
+++ b/.github/workflows/fly-secrets-check.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Install flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: Check Fly.io token validity
         id: fly_check

--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -107,7 +107,7 @@ jobs:
       # -----------------------------------------------------------------
       - name: Checkout base ref
         if: steps.kill_switch.outputs.disabled != 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
 
       - name: Set up Python
         if: steps.kill_switch.outputs.disabled != 'true'
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/migration-lint.yml
+++ b/.github/workflows/migration-lint.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           # blob:none — partial clone: every commit and tree, no file contents (fetched on
@@ -119,7 +119,7 @@ jobs:
 
       - name: Setup Node
         if: steps.changed.outputs.files != ''
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Generate SBOM (SPDX format)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: .
           format: spdx-json
@@ -54,7 +54,7 @@ jobs:
           upload-artifact: false
 
       - name: Generate SBOM (CycloneDX format)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: .
           format: cyclonedx-json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -331,7 +331,7 @@ jobs:
           python scripts/check_cve_exceptions.py
 
       - name: Run Snyk (Python, JSON for exception filtering)
-        uses: snyk/actions/python@master
+        uses: snyk/actions/python@12140f4059e244892ae643824a95459a102120dd # master
         continue-on-error: true # we make the decision in the next step
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -477,7 +477,7 @@ jobs:
             -f apps/backend-rag/Dockerfile .
 
       - name: Run Snyk (Docker)
-        uses: snyk/actions/docker@master
+        uses: snyk/actions/docker@12140f4059e244892ae643824a95459a102120dd # master
         continue-on-error: true # vulnerability findings stay advisory (see job comment)
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -620,11 +620,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
         if: env.RUN_THIS_LANGUAGE == 'true'
-        uses: github/codeql-action/init@v4.37.7
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -632,11 +632,11 @@ jobs:
 
       - name: Autobuild
         if: env.RUN_THIS_LANGUAGE == 'true'
-        uses: github/codeql-action/autobuild@v4.37.7
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
       - name: Perform CodeQL Analysis
         if: env.RUN_THIS_LANGUAGE == 'true'
-        uses: github/codeql-action/analyze@v4.37.7
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -159,13 +159,13 @@ jobs:
         # individual failed steps still surface red on the PR rollup; this
         # if-guard prevents that visual noise without changing policy.
         if: ${{ env.SONAR_TOKEN != '' }}
-        uses: sonarsource/sonarqube-scan-action@master
+        uses: sonarsource/sonarqube-scan-action@ad8210318ac8bb816e41990d5af2b304f7a6c213 # master
         env:
           SONAR_HOST_URL: https://sonarcloud.io
 
       - name: SonarQube Quality Gate Check
         if: ${{ env.SONAR_TOKEN != '' }}
-        uses: sonarsource/sonarqube-quality-gate-action@master
+        uses: sonarsource/sonarqube-quality-gate-action@7a5fffe8e523c40e0c740b6bc2712ab503e52efa # master
         timeout-minutes: 5
         continue-on-error: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -663,7 +663,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ env.HAS_CODECOV_TOKEN == 'true' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -733,7 +733,7 @@ jobs:
 
       - name: Upload MCP coverage to Codecov
         if: ${{ env.HAS_CODECOV_TOKEN == 'true' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -798,7 +798,7 @@ jobs:
 
       - name: Upload evaluator coverage to Codecov
         if: ${{ env.HAS_CODECOV_TOKEN == 'true' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1017,7 +1017,7 @@ jobs:
 
       - name: Upload coverage
         if: ${{ matrix.coverage && env.HAS_CODECOV_TOKEN == 'true' && steps.decide.outputs.run == 'true' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -1071,7 +1071,7 @@ jobs:
 
       - name: Upload shared core coverage to Codecov
         if: ${{ env.HAS_CODECOV_TOKEN == 'true' }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
## Problem

`gh api repos/Bali-Zero/Teman2/actions/permissions` shows `allowed_actions: "all"` and `sha_pinning_required: false`. All third-party actions across the 93 workflow files were pinned to mutable tags (e.g. `@v7`, `@master`) — whoever controls that tag ref can push arbitrary code that our CI executes, and several affected jobs carry write-scoped `GITHUB_TOKEN` permissions.

## What this PR does

**Census**: 227 real `uses:` directives across 93 workflow files (2 grep false-positives excluded: `statuses: write` and prose "...independent causes:" — both just contain the substring `uses:`, neither is an action reference). No local composite actions (`./.github/...`), no reusable-workflow calls.

**24 of 24 third-party action references pinned** (100%), resolved via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha`, tag kept as a trailing `# <tag>` comment so Dependabot keeps bumping them:

| Action | Tag | SHA | Count |
|---|---|---|---|
| `superfly/flyctl-actions/setup-flyctl` | `master` | `ed8efb3...` | 13 |
| `codecov/codecov-action` | `v7` | `fb8b358...` | 5 |
| `anchore/sbom-action` | `v0` | `e22c389...` | 2 |
| `sonarsource/sonarqube-scan-action` | `master` | `ad82103...` | 1 |
| `sonarsource/sonarqube-quality-gate-action` | `master` | `7a5fffe...` | 1 |
| `snyk/actions/python` | `master` | `12140f4...` | 1 |
| `snyk/actions/docker` | `master` | `12140f4...` | 1 |

**First-party `actions/*` / `github/*` (GitHub-owned)**: left on their tag by default — GitHub's own actions are a different trust boundary than an arbitrary third party. Criterion applied: pin only in jobs whose *effective* `GITHUB_TOKEN` permissions (job-level override, else workflow-level, else the repo's `default_workflow_permissions: "read"`) grant **any `write` scope** — because a compromised action there can abuse a token that can actually mutate the repo/PRs/security events. Verified with a small script that computes effective per-job permissions from each workflow's YAML (no `write-all` anywhere in the corpus). That surfaced exactly 5 jobs:

| Workflow : job | Write scope | Actions pinned |
|---|---|---|
| `auto-merge-whitelist.yml` : `evaluate` | `contents`, `pull-requests` | `actions/checkout` |
| `codex-autofix-reaper.yml` : `reap` | `contents`, `pull-requests` | `actions/checkout`, `actions/setup-python` |
| `harness-floor.yml` : `harness-floor` | `statuses` | `actions/checkout`, `actions/setup-python` |
| `migration-lint.yml` : `lint` | `pull-requests` | `actions/checkout`, `actions/setup-node` |
| `security.yml` : `codeql` | `security-events` | `actions/checkout`, `github/codeql-action/{init,autobuild,analyze}` |

11 lines pinned there. All other `actions/checkout`/`setup-python`/`setup-node`/`upload-artifact`/`cache`/`github-script`/`codeql-action/upload-sarif` occurrences (in read-only jobs) were left on tag — pinning every one of the ~200 occurrences repo-wide would be a much larger, lower-signal diff for jobs that hold no exploitable token scope.

**Totals**: 35 `uses:` lines changed across 17 files, 24/24 third-party pinned, 0 left on a mutable tag among third-party actions.

## Verification

`actionlint 1.7.12` (same pinned version + build the repo's own `actionlint.yml` CI job uses) run against the full modified tree: **clean, 0 findings**.

## Out of scope

`allowed_actions` and `sha_pinning_required` are repo Actions-permission settings, not workflow-file content — left untouched per the mandate; that's the orchestrator's call.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>