### PR TITLE
fix(admin-dashboard): stop shelling out to gog for calendar events (CodeQL critical)

### DIFF
--- a/apps/admin-dashboard/app/api/calendar/events/route.ts
+++ b/apps/admin-dashboard/app/api/calendar/events/route.ts
@@ -17,12 +17,47 @@ const GOG_PATH = "/opt/homebrew/bin/gog";
 const TEAM_CALENDAR_ID =
   "ec0863e7c14ac6bf414ec23e2aab81960ecb26823c6a8f397c664fc64901d617@group.calendar.google.com";
 
+// Argument-injection guard (argv flag smuggling — CodeQL follow-up, 2026-08-21).
+// execFile stops shell metacharacter injection (no shell is ever spawned), but
+// it does NOT stop a value that starts with `-`/`--` from being read as a FLAG
+// by gog's own parser once it lands in argv (gog is built on alecthomas/kong,
+// which — like effectively every CLI-parsing library — recognizes a `-`-led
+// token as a flag candidate regardless of which array slot it occupies). A
+// calendarId of `--upload-file=/etc/passwd` or an eventId of `--force` carries
+// no shell risk but could still be reinterpreted by gog itself. Defense: allow-
+// list every field to the shape it MUST have, never a blocklist of "dangerous"
+// characters — and reject anything starting with `-`, which none of these
+// fields ever legitimately do.
+const CALENDAR_ID_RE =
+  /^(?:primary|[A-Za-z0-9](?:[A-Za-z0-9._%+-]*[A-Za-z0-9])?@[A-Za-z0-9.-]+\.[A-Za-z]{2,})$/;
+const DIGITS_RE = /^\d{1,4}$/;
+const EVENT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,1023}$/;
+const ISO_DATETIME_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2}|[+-]\d{4})?)?$/;
+
+function badRequest(field: string): NextResponse {
+  return NextResponse.json(
+    { success: false, error: `Invalid ${field}` },
+    { status: 400 },
+  );
+}
+
+// Free-text fields (summary/description/location/attendees): no fixed shape,
+// but a legitimate value never begins with `-` and has a sane length cap.
+function isSafeFreeText(value: string, maxLen: number): boolean {
+  return value.length > 0 && value.length <= maxLen && !value.startsWith("-");
+}
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
     const calendarId = searchParams.get("calendarId") || TEAM_CALENDAR_ID;
     const days = searchParams.get("days") || "30";
     const max = searchParams.get("max") || "50";
+
+    if (!CALENDAR_ID_RE.test(calendarId)) return badRequest("calendarId");
+    if (!DIGITS_RE.test(days)) return badRequest("days");
+    if (!DIGITS_RE.test(max)) return badRequest("max");
 
     const { stdout } = await execFileAsync(GOG_PATH, [
       "calendar",
@@ -103,16 +138,35 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const calId = String(calendarId);
+    const summaryStr = String(summary);
+    const fromStr = String(from);
+    const toStr = String(to);
+
+    if (!CALENDAR_ID_RE.test(calId)) return badRequest("calendarId");
+    if (!isSafeFreeText(summaryStr, 500)) return badRequest("summary");
+    if (!ISO_DATETIME_RE.test(fromStr)) return badRequest("from");
+    if (!ISO_DATETIME_RE.test(toStr)) return badRequest("to");
+    if (description && !isSafeFreeText(String(description), 5000)) {
+      return badRequest("description");
+    }
+    if (location && !isSafeFreeText(String(location), 500)) {
+      return badRequest("location");
+    }
+    if (attendees && !isSafeFreeText(String(attendees), 2000)) {
+      return badRequest("attendees");
+    }
+
     const args = [
       "calendar",
       "create",
-      String(calendarId),
+      calId,
       "--summary",
-      String(summary),
+      summaryStr,
       "--from",
-      String(from),
+      fromStr,
       "--to",
-      String(to),
+      toStr,
     ];
 
     if (description) args.push("--description", String(description));
@@ -150,6 +204,9 @@ export async function DELETE(request: NextRequest) {
         { status: 400 },
       );
     }
+
+    if (!CALENDAR_ID_RE.test(calendarId)) return badRequest("calendarId");
+    if (!EVENT_ID_RE.test(eventId)) return badRequest("eventId");
 
     await execFileAsync(GOG_PATH, [
       "calendar",

--- a/apps/admin-dashboard/app/api/calendar/events/route.ts
+++ b/apps/admin-dashboard/app/api/calendar/events/route.ts
@@ -1,8 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+import { logger } from "@/lib/logger";
+
+// execFile (not exec) — argv is passed as an array straight to the binary,
+// never through a shell. calendarId/days/max/summary/etc. are user-provided
+// (query params or JSON body); with `exec` + a template string they could
+// break out of the intended argument via shell metacharacters (CodeQL
+// js/command-line-injection #2311/#2312/#2313, 2026-08-21). execFile makes
+// that class of injection structurally impossible — each array element
+// becomes exactly one argv token, no matter what characters it contains.
+const execFileAsync = promisify(execFile);
 
 const GOG_PATH = "/opt/homebrew/bin/gog";
 const TEAM_CALENDAR_ID =
@@ -15,9 +24,16 @@ export async function GET(request: NextRequest) {
     const days = searchParams.get("days") || "30";
     const max = searchParams.get("max") || "50";
 
-    const { stdout } = await execAsync(
-      `${GOG_PATH} calendar events "${calendarId}" --days ${days} --max ${max} --json`,
-    );
+    const { stdout } = await execFileAsync(GOG_PATH, [
+      "calendar",
+      "events",
+      calendarId,
+      "--days",
+      days,
+      "--max",
+      max,
+      "--json",
+    ]);
 
     const data = JSON.parse(stdout || '{"events":[]}');
     interface CalendarEvent {
@@ -58,7 +74,7 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    console.error("Calendar API error:", error);
+    logger.error("Calendar API error:", error);
     return NextResponse.json(
       { success: false, error: message },
       { status: 500 },
@@ -87,23 +103,36 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    let cmd = `${GOG_PATH} calendar create "${calendarId}" --summary "${summary}" --from "${from}" --to "${to}"`;
+    const args = [
+      "calendar",
+      "create",
+      String(calendarId),
+      "--summary",
+      String(summary),
+      "--from",
+      String(from),
+      "--to",
+      String(to),
+    ];
 
-    if (description) cmd += ` --description "${description}"`;
-    if (location) cmd += ` --location "${location}"`;
-    if (attendees) cmd += ` --attendees "${attendees}"`;
-    if (withMeet) cmd += ` --with-meet`;
+    if (description) args.push("--description", String(description));
+    if (location) args.push("--location", String(location));
+    if (attendees) args.push("--attendees", String(attendees));
+    if (withMeet) args.push("--with-meet");
 
-    cmd += " --json";
+    args.push("--json");
 
-    const { stdout } = await execAsync(cmd);
+    const { stdout } = await execFileAsync(GOG_PATH, args);
     const event = JSON.parse(stdout || "{}");
 
     return NextResponse.json({ success: true, event });
   } catch (error) {
-    console.error("Calendar create error:", error);
+    logger.error("Calendar create error:", error);
     return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : String(error) },
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
       { status: 500 },
     );
   }
@@ -122,15 +151,22 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    await execAsync(
-      `${GOG_PATH} calendar delete "${calendarId}" "${eventId}" --force`,
-    );
+    await execFileAsync(GOG_PATH, [
+      "calendar",
+      "delete",
+      calendarId,
+      eventId,
+      "--force",
+    ]);
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error("Calendar delete error:", error);
+    logger.error("Calendar delete error:", error);
     return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : String(error) },
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
       { status: 500 },
     );
   }

--- a/apps/admin-dashboard/tests/calendar-events-route.test.ts
+++ b/apps/admin-dashboard/tests/calendar-events-route.test.ts
@@ -2,15 +2,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 /**
- * CodeQL js/command-line-injection #2311/#2312/#2313 (2026-08-21):
- * GET/POST/DELETE built a `gog` shell command with a template string and ran
- * it via `child_process.exec`, which spawns `/bin/sh -c <string>`. A
- * `calendarId`/`summary`/`eventId` containing shell metacharacters (`;`,
- * `$(...)`, backticks, a stray `"`) could break out of its quoted slot and
- * run arbitrary shell. The fix swaps `exec` + string concatenation for
- * `execFile` + an argv array — no shell is ever spawned, so each array
- * element reaches the `gog` binary as exactly one argument no matter what
- * characters it contains.
+ * Two distinct vulnerability classes on this route, both from CodeQL
+ * (js/command-line-injection #2311/#2312/#2313, 2026-08-21) and a follow-up
+ * security review on the first fix:
+ *
+ * 1. SHELL injection (CWE-78) — the original bug. GET/POST/DELETE built a
+ *    `gog` shell command with a template string and ran it via
+ *    `child_process.exec`, which spawns `/bin/sh -c <string>`. Fixed by
+ *    switching to `execFile` + an argv array: no shell is ever spawned, so
+ *    shell metacharacters in a value are inert wherever they reach `gog` at
+ *    all.
+ * 2. ARGUMENT injection / flag smuggling (CWE-88) — execFile's own residual
+ *    risk. gog is built on alecthomas/kong, which (like effectively every
+ *    CLI-parsing library) reads any `-`-prefixed argv token as a candidate
+ *    FLAG regardless of which array slot it lands in. A calendarId of
+ *    `--upload-file=/etc/passwd` carries no shell risk but could still be
+ *    reinterpreted by gog itself. Fixed by allow-listing every field to the
+ *    shape it must have (never a blocklist), explicitly rejecting anything
+ *    that starts with `-`.
  *
  * `child_process` is mocked at the module the route imports, so `exec` and
  * `execFile` resolve to the same spies the route calls.
@@ -36,6 +45,7 @@ vi.mock("child_process", () => ({
 const { GET, POST, DELETE } = await import("@/app/api/calendar/events/route");
 
 const SHELL_PAYLOAD = '"; touch /tmp/pwned; echo "';
+const VALID_CAL_ID = "team@balizero.com";
 
 function getReq(search: string): NextRequest {
   return new NextRequest(
@@ -58,23 +68,43 @@ beforeEach(() => {
   );
 });
 
-describe("/api/calendar/events GET — command injection", () => {
-  it("GUILT: a calendarId with shell metacharacters never reaches a shell", async () => {
+describe("/api/calendar/events GET", () => {
+  it("GUILT (shell): a calendarId with shell metacharacters is rejected by shape validation, never reaches a process", async () => {
     const res = await GET(
       getReq(`?calendarId=${encodeURIComponent(SHELL_PAYLOAD)}`),
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     expect(execMock).not.toHaveBeenCalled();
-    expect(execFileMock).toHaveBeenCalledTimes(1);
-    const [file, args] = execFileMock.mock.calls[0];
-    expect(file).toBe("/opt/homebrew/bin/gog");
-    // The whole payload must survive as ONE argv element — never split,
-    // never interpreted, never used to grow the args array.
-    expect(args).toContain(SHELL_PAYLOAD);
-    expect(args.filter((a: string) => a === SHELL_PAYLOAD)).toHaveLength(1);
+    expect(execFileMock).not.toHaveBeenCalled();
   });
 
-  it("INNOCENCE: a normal request resolves the parsed events", async () => {
+  it("GUILT (argv flag smuggling): a calendarId starting with '-' is rejected, not passed to gog", async () => {
+    const res = await GET(
+      getReq(`?calendarId=${encodeURIComponent("--upload-file=/etc/passwd")}`),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): a days value starting with '-' is rejected", async () => {
+    const res = await GET(
+      getReq(
+        `?calendarId=${VALID_CAL_ID}&days=${encodeURIComponent("--evil")}`,
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): a max value starting with '-' is rejected", async () => {
+    const res = await GET(
+      getReq(`?calendarId=${VALID_CAL_ID}&max=${encodeURIComponent("--evil")}`),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("INNOCENCE: a normal request resolves the parsed events with the exact argv", async () => {
     execFileMock.mockImplementation((_file, _args, cb) =>
       cb(null, {
         stdout: JSON.stringify({
@@ -83,7 +113,7 @@ describe("/api/calendar/events GET — command injection", () => {
         stderr: "",
       }),
     );
-    const res = await GET(getReq("?calendarId=team-cal&days=7&max=10"));
+    const res = await GET(getReq(`?calendarId=${VALID_CAL_ID}&days=7&max=10`));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.success).toBe(true);
@@ -93,7 +123,7 @@ describe("/api/calendar/events GET — command injection", () => {
     expect(args).toEqual([
       "calendar",
       "events",
-      "team-cal",
+      VALID_CAL_ID,
       "--days",
       "7",
       "--max",
@@ -101,18 +131,29 @@ describe("/api/calendar/events GET — command injection", () => {
       "--json",
     ]);
   });
+
+  it("INNOCENCE: 'primary' is an accepted calendarId shape", async () => {
+    const res = await GET(getReq("?calendarId=primary"));
+    expect(res.status).toBe(200);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
 });
 
-describe("/api/calendar/events POST — command injection", () => {
-  it("GUILT: a summary with shell metacharacters never reaches a shell", async () => {
+describe("/api/calendar/events POST", () => {
+  const validBody = {
+    summary: "Team sync",
+    from: "2026-08-21T10:00:00Z",
+    to: "2026-08-21T11:00:00Z",
+  };
+
+  it("GUILT (shell): a summary with shell metacharacters survives as one inert argv element (execFile, not exec)", async () => {
     execFileMock.mockImplementation((_file, _args, cb) =>
       cb(null, { stdout: "{}", stderr: "" }),
     );
     const res = await POST(
       postReq({
+        ...validBody,
         summary: SHELL_PAYLOAD,
-        from: "2026-08-21T10:00:00Z",
-        to: "2026-08-21T11:00:00Z",
         description: "`whoami`",
       }),
     );
@@ -120,8 +161,6 @@ describe("/api/calendar/events POST — command injection", () => {
     expect(execMock).not.toHaveBeenCalled();
     const [file, args] = execFileMock.mock.calls[0];
     expect(file).toBe("/opt/homebrew/bin/gog");
-    expect(args).toContain(SHELL_PAYLOAD);
-    expect(args).toContain("`whoami`");
     // Injected content must not have grown the argv beyond the fields
     // actually supplied (summary/from/to/description + fixed flags + --json).
     expect(args).toEqual([
@@ -140,17 +179,53 @@ describe("/api/calendar/events POST — command injection", () => {
     ]);
   });
 
+  it("GUILT (argv flag smuggling): a summary starting with '-' is rejected, not passed to gog", async () => {
+    const res = await POST(
+      postReq({ ...validBody, summary: "--upload-file=/etc/passwd" }),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): a description starting with '-' is rejected", async () => {
+    const res = await POST(
+      postReq({ ...validBody, description: "--evil-flag" }),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): a location starting with '-' is rejected", async () => {
+    const res = await POST(postReq({ ...validBody, location: "--evil-flag" }));
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): an attendees value starting with '-' is rejected", async () => {
+    const res = await POST(postReq({ ...validBody, attendees: "--evil-flag" }));
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): a calendarId starting with '-' is rejected", async () => {
+    const res = await POST(
+      postReq({ ...validBody, calendarId: "--upload-file=/etc/passwd" }),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT: a non-ISO 'from'/'to' (including a flag-shaped one) is rejected", async () => {
+    const res = await POST(postReq({ ...validBody, from: "--evil" }));
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
   it("INNOCENCE: a legitimate create still works and rejects incomplete payloads", async () => {
     execFileMock.mockImplementation((_file, _args, cb) =>
       cb(null, { stdout: JSON.stringify({ id: "evt1" }), stderr: "" }),
     );
-    const res = await POST(
-      postReq({
-        summary: "Team sync",
-        from: "2026-08-21T10:00:00Z",
-        to: "2026-08-21T11:00:00Z",
-      }),
-    );
+    const res = await POST(postReq(validBody));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json).toEqual({ success: true, event: { id: "evt1" } });
@@ -160,32 +235,82 @@ describe("/api/calendar/events POST — command injection", () => {
     expect(bad.status).toBe(400);
     expect(execFileMock).not.toHaveBeenCalled();
   });
+
+  it("INNOCENCE: description/location/attendees with ordinary hyphens still work", async () => {
+    execFileMock.mockImplementation((_file, _args, cb) =>
+      cb(null, { stdout: "{}", stderr: "" }),
+    );
+    const res = await POST(
+      postReq({
+        ...validBody,
+        description: "Q3 planning - budget review",
+        location: "Meeting Room - 2nd floor",
+        attendees: "a@balizero.com,b@balizero.com",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const [, args] = execFileMock.mock.calls[0];
+    expect(args).toContain("--description");
+    expect(args).toContain("Q3 planning - budget review");
+    expect(args).toContain("--attendees");
+    expect(args).toContain("a@balizero.com,b@balizero.com");
+  });
 });
 
-describe("/api/calendar/events DELETE — command injection", () => {
-  it("GUILT: an eventId with shell metacharacters never reaches a shell", async () => {
+describe("/api/calendar/events DELETE", () => {
+  it("GUILT (shell): an eventId with shell metacharacters is rejected by shape validation, never reaches a process", async () => {
+    const res = await DELETE(
+      getReq(
+        `?eventId=${encodeURIComponent(SHELL_PAYLOAD)}&calendarId=${VALID_CAL_ID}`,
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): an eventId starting with '-' is rejected, not passed to gog", async () => {
+    const res = await DELETE(
+      getReq(
+        `?eventId=${encodeURIComponent("--force")}&calendarId=${VALID_CAL_ID}`,
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("GUILT (argv flag smuggling): a calendarId starting with '-' is rejected", async () => {
+    const res = await DELETE(
+      getReq(
+        `?eventId=abc123&calendarId=${encodeURIComponent("--upload-file=/etc/passwd")}`,
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("INNOCENCE: missing eventId is rejected before any process spawns", async () => {
+    const res = await DELETE(getReq(`?calendarId=${VALID_CAL_ID}`));
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("INNOCENCE: a valid eventId+calendarId deletes with the exact argv", async () => {
     execFileMock.mockImplementation((_file, _args, cb) =>
       cb(null, { stdout: "", stderr: "" }),
     );
     const res = await DELETE(
-      getReq(`?eventId=${encodeURIComponent(SHELL_PAYLOAD)}&calendarId=cal1`),
+      getReq(`?eventId=abc123XYZ&calendarId=${VALID_CAL_ID}`),
     );
     expect(res.status).toBe(200);
-    expect(execMock).not.toHaveBeenCalled();
     const [file, args] = execFileMock.mock.calls[0];
     expect(file).toBe("/opt/homebrew/bin/gog");
     expect(args).toEqual([
       "calendar",
       "delete",
-      "cal1",
-      SHELL_PAYLOAD,
+      VALID_CAL_ID,
+      "abc123XYZ",
       "--force",
     ]);
-  });
-
-  it("INNOCENCE: missing eventId is rejected before any process spawns", async () => {
-    const res = await DELETE(getReq("?calendarId=cal1"));
-    expect(res.status).toBe(400);
-    expect(execFileMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/admin-dashboard/tests/calendar-events-route.test.ts
+++ b/apps/admin-dashboard/tests/calendar-events-route.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * CodeQL js/command-line-injection #2311/#2312/#2313 (2026-08-21):
+ * GET/POST/DELETE built a `gog` shell command with a template string and ran
+ * it via `child_process.exec`, which spawns `/bin/sh -c <string>`. A
+ * `calendarId`/`summary`/`eventId` containing shell metacharacters (`;`,
+ * `$(...)`, backticks, a stray `"`) could break out of its quoted slot and
+ * run arbitrary shell. The fix swaps `exec` + string concatenation for
+ * `execFile` + an argv array — no shell is ever spawned, so each array
+ * element reaches the `gog` binary as exactly one argument no matter what
+ * characters it contains.
+ *
+ * `child_process` is mocked at the module the route imports, so `exec` and
+ * `execFile` resolve to the same spies the route calls.
+ */
+const execFileMock = vi.fn(
+  (
+    _file: string,
+    _args: string[],
+    cb: (err: Error | null, res: { stdout: string; stderr: string }) => void,
+  ) => {
+    cb(null, { stdout: '{"events":[]}', stderr: "" });
+  },
+);
+const execMock = vi.fn();
+
+vi.mock("child_process", () => ({
+  execFile: (...args: unknown[]) =>
+    (execFileMock as (...a: unknown[]) => unknown)(...args),
+  exec: (...args: unknown[]) =>
+    (execMock as (...a: unknown[]) => unknown)(...args),
+}));
+
+const { GET, POST, DELETE } = await import("@/app/api/calendar/events/route");
+
+const SHELL_PAYLOAD = '"; touch /tmp/pwned; echo "';
+
+function getReq(search: string): NextRequest {
+  return new NextRequest(
+    new URL(`https://admin.balizero.com/api/calendar/events${search}`),
+  );
+}
+
+function postReq(body: Record<string, unknown>): NextRequest {
+  return new NextRequest(
+    new URL("https://admin.balizero.com/api/calendar/events"),
+    { method: "POST", body: JSON.stringify(body) },
+  );
+}
+
+beforeEach(() => {
+  execFileMock.mockClear();
+  execMock.mockClear();
+  execFileMock.mockImplementation((_file, _args, cb) =>
+    cb(null, { stdout: '{"events":[]}', stderr: "" }),
+  );
+});
+
+describe("/api/calendar/events GET — command injection", () => {
+  it("GUILT: a calendarId with shell metacharacters never reaches a shell", async () => {
+    const res = await GET(
+      getReq(`?calendarId=${encodeURIComponent(SHELL_PAYLOAD)}`),
+    );
+    expect(res.status).toBe(200);
+    expect(execMock).not.toHaveBeenCalled();
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [file, args] = execFileMock.mock.calls[0];
+    expect(file).toBe("/opt/homebrew/bin/gog");
+    // The whole payload must survive as ONE argv element — never split,
+    // never interpreted, never used to grow the args array.
+    expect(args).toContain(SHELL_PAYLOAD);
+    expect(args.filter((a: string) => a === SHELL_PAYLOAD)).toHaveLength(1);
+  });
+
+  it("INNOCENCE: a normal request resolves the parsed events", async () => {
+    execFileMock.mockImplementation((_file, _args, cb) =>
+      cb(null, {
+        stdout: JSON.stringify({
+          events: [{ id: "e1", summary: "Kickoff" }],
+        }),
+        stderr: "",
+      }),
+    );
+    const res = await GET(getReq("?calendarId=team-cal&days=7&max=10"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.events).toEqual([{ id: "e1", summary: "Kickoff" }]);
+    const [file, args] = execFileMock.mock.calls[0];
+    expect(file).toBe("/opt/homebrew/bin/gog");
+    expect(args).toEqual([
+      "calendar",
+      "events",
+      "team-cal",
+      "--days",
+      "7",
+      "--max",
+      "10",
+      "--json",
+    ]);
+  });
+});
+
+describe("/api/calendar/events POST — command injection", () => {
+  it("GUILT: a summary with shell metacharacters never reaches a shell", async () => {
+    execFileMock.mockImplementation((_file, _args, cb) =>
+      cb(null, { stdout: "{}", stderr: "" }),
+    );
+    const res = await POST(
+      postReq({
+        summary: SHELL_PAYLOAD,
+        from: "2026-08-21T10:00:00Z",
+        to: "2026-08-21T11:00:00Z",
+        description: "`whoami`",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(execMock).not.toHaveBeenCalled();
+    const [file, args] = execFileMock.mock.calls[0];
+    expect(file).toBe("/opt/homebrew/bin/gog");
+    expect(args).toContain(SHELL_PAYLOAD);
+    expect(args).toContain("`whoami`");
+    // Injected content must not have grown the argv beyond the fields
+    // actually supplied (summary/from/to/description + fixed flags + --json).
+    expect(args).toEqual([
+      "calendar",
+      "create",
+      "ec0863e7c14ac6bf414ec23e2aab81960ecb26823c6a8f397c664fc64901d617@group.calendar.google.com",
+      "--summary",
+      SHELL_PAYLOAD,
+      "--from",
+      "2026-08-21T10:00:00Z",
+      "--to",
+      "2026-08-21T11:00:00Z",
+      "--description",
+      "`whoami`",
+      "--json",
+    ]);
+  });
+
+  it("INNOCENCE: a legitimate create still works and rejects incomplete payloads", async () => {
+    execFileMock.mockImplementation((_file, _args, cb) =>
+      cb(null, { stdout: JSON.stringify({ id: "evt1" }), stderr: "" }),
+    );
+    const res = await POST(
+      postReq({
+        summary: "Team sync",
+        from: "2026-08-21T10:00:00Z",
+        to: "2026-08-21T11:00:00Z",
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ success: true, event: { id: "evt1" } });
+
+    execFileMock.mockClear();
+    const bad = await POST(postReq({ summary: "No dates" }));
+    expect(bad.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("/api/calendar/events DELETE — command injection", () => {
+  it("GUILT: an eventId with shell metacharacters never reaches a shell", async () => {
+    execFileMock.mockImplementation((_file, _args, cb) =>
+      cb(null, { stdout: "", stderr: "" }),
+    );
+    const res = await DELETE(
+      getReq(`?eventId=${encodeURIComponent(SHELL_PAYLOAD)}&calendarId=cal1`),
+    );
+    expect(res.status).toBe(200);
+    expect(execMock).not.toHaveBeenCalled();
+    const [file, args] = execFileMock.mock.calls[0];
+    expect(file).toBe("/opt/homebrew/bin/gog");
+    expect(args).toEqual([
+      "calendar",
+      "delete",
+      "cal1",
+      SHELL_PAYLOAD,
+      "--force",
+    ]);
+  });
+
+  it("INNOCENCE: missing eventId is rejected before any process spawns", async () => {
+    const res = await DELETE(getReq("?calendarId=cal1"));
+    expect(res.status).toBe(400);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- CodeQL flagged 3 `js/command-line-injection` critical alerts (#2311/#2312/#2313) in `apps/admin-dashboard/app/api/calendar/events/route.ts`: GET/POST/DELETE built a `gog` shell command via template-string interpolation and ran it through `child_process.exec` (spawns `/bin/sh -c`). Confirmed real (VERA) — the route is behind admin JWT auth, but `exec` + string concat is a genuine shell-injection primitive regardless, and local dev bypasses auth entirely.
- Fix (commit 1): swap `exec` for `execFile` with an argv array on all three handlers. No shell is ever spawned, so a malicious `calendarId`/`summary`/`eventId` reaches the `gog` binary as exactly one argv token no matter what characters it contains — shell injection (CWE-78) is structurally eliminated.
- Fix (commit 2, follow-up from a security review of commit 1): `execFile` does **not** close argument/flag injection (CWE-88) — `gog` is built on `alecthomas/kong`, which (like effectively every CLI-parsing library) reads any `-`-prefixed argv token as a candidate flag regardless of which array slot it occupies. A `calendarId` of `--upload-file=/etc/passwd` or a `description` of `--with-meet` carries no shell risk but could still be reinterpreted by `gog` itself. Fixed by allow-listing every user-controlled field to the shape it must have (`calendarId`, `days`/`max`, `eventId`, ISO `from`/`to`) and explicitly rejecting any free-text field (`summary`/`description`/`location`/`attendees`) that starts with `-` — never a blocklist.
- Two other CodeQL critical alerts on this repo were investigated and dismissed as **false positive** (not touched by this PR, closed directly via the code-scanning API with an evidence-based comment):
  - `#7585` (`py/command-line-injection`, `skills/bali-zero-brand/_damar-queue-server.py:721`) — sink is `subprocess.Popen(list)`, no `shell=True` anywhere in the file; every user value is joined into a single `--flag=value` argv token (the "#1708 Argument-injection guard", already in the code), which structurally prevents CWE-88 flag injection; server also binds `127.0.0.1`-only with an Origin-based CSRF gate.
  - `#8474` (`py/partial-ssrf`, `apps/backend-rag/backend/app/routers/documents_proxy.py:447`) — `file_id` is validated by `_assert_file_id_shape` (regex `^[A-Za-z0-9_-]{10,256}$`) before every network call in both call sites; the same guard already closed sibling alerts #791/#792 on this exact file as false positive.

## Deliberately not done
- **`--` flag-parsing terminator, not added.** `gog`'s CLI library (`alecthomas/kong`) does support the POSIX `--` convention to stop flag parsing (confirmed by reading kong's README). It was evaluated and skipped here: our current argv **interleaves** flags and positionals (`calendar events <calendarId> --days X --max Y --json`), so using `--` safely would require reordering the invocation to put every flag before a trailing `--` and the positional args after it. That is a change to how a real external binary is invoked, and `gog` is not installed in this environment and needs an interactive OAuth setup — there is no way to smoke-test a reorder here. A wrong reorder risks silently breaking a live admin tool (calendar create/delete), which is a worse outcome than the residual risk the allow-list already closes. The allow-list is the primary, fully-tested defense and makes the argument-injection vulnerability unreachable on its own, independent of `gog`'s exact parsing behavior.
  - **Reopen condition:** if `gog` becomes available to test against locally (installed + authenticated), add `--` as a defense-in-depth belt on top of the allow-list — reorder each invocation to `[...flags, "--", ...positionals]` and verify with a real `gog` call (not a mock) that legitimate create/list/delete still work before shipping.
- **Sibling file, measured and not touched.** `apps/admin-dashboard/app/api/calendar/calendars/route.ts` still uses `exec` + a template string (same pre-fix style as this route). Measured: it is the *only* other file under `apps/admin-dashboard` that touches `child_process` (`grep -rl child_process apps/admin-dashboard/app apps/admin-dashboard/lib`), and its handler is `export async function GET()` — **zero parameters, zero request input** — the command is the hardcoded literal `` `${GOG_PATH} calendar calendars --json}` ``. There is no tainted source reaching it, so it is not a CodeQL finding and not a real vulnerability; it is left as-is because fixing it here would be scope creep on a file with nothing to secure. Flagged for whoever next touches that file, since the same `exec`→`execFile` swap would be a trivial, zero-risk consistency change if the file is ever extended to take a parameter.

## Test plan
- [x] `apps/admin-dashboard/tests/calendar-events-route.test.ts`: 20 tests (GUILT + INNOCENCE for GET/POST/DELETE), covering both vulnerability classes — shell metacharacters surviving as one inert argv element via `execFile` (never `exec`), and a dedicated GUILT test per field proving a leading `-`/`--` value is rejected (400) before any process spawns.
- [x] Mutation-verified twice:
  - Commit 1: reverted the route to the original `exec`+template-string version — 5/6 tests went red.
  - Commit 2: reverted only the allow-list (kept `execFile`) — 13/20 tests went red, exactly the new argument-injection GUILT tests; the 7 survivors are the ones already covered by `execFile` alone.
- [x] `npx vitest run tests/calendar-events-route.test.ts` — 20/20 green with both fixes in place.
- [x] `npx tsc --noEmit` — no new type errors (one pre-existing, unrelated error in `app/api/rag/search/route.ts`).
- [x] `npx eslint` on changed files — clean.
- [x] Pre-commit/pre-push hooks passed (no `--no-verify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
