### PR TITLE
fix(organism): exempt non-primary arsenal_probe heartbeats from 7-day staleness

### DIFF
--- a/scripts/organism_stale_detector.py
+++ b/scripts/organism_stale_detector.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -64,6 +65,22 @@ def _core_organs_expected_here() -> tuple[str, ...]:
 DEFAULT_SIDECAR_DIR = os.path.expanduser("~/.organism/last_seen")
 DEFAULT_ALERTS_FILE = os.path.expanduser("~/.organism/alerts/open.jsonl")
 DEFAULT_STALE_DAYS = 7
+
+# arsenal_probe's AUTOMATED recurring heartbeat is a promise only on its primary
+# node (docs/runbooks/arsenal-probe.md §How it is armed: "Mini (primary)"). Any
+# other node's `<machine>.arsenal_probe.json` is a one-time on-demand stamp from
+# a manual `--table`/VCR-triggered run there (infra/vcr/cli.py check) — its
+# staleness is expected, not a silent outage. Sibling fix to
+# organism_digest.py::stale_heartbeats() (same exemption, same constant name):
+# that module got this exemption, this detector reads the same sidecar dir and
+# had the identical bug (same class as the .worktrees/ runtime-stamp fix a few
+# lines below) — found live 2026-08-21 when a dispatch went out to "revive"
+# m5.arsenal_probe as a dead cron when no cron for it has ever existed on M5
+# (CLAUDE.md: M5 = no daemon/cron H24; the probe is on-demand only there). This
+# detector's blanket 7-day scan flagged the 8.7-day-old on-demand stamp as if
+# it were a broken recurring promise.
+_ARSENAL_PROBE_STEM_RE = re.compile(r"^(?P<machine>[a-z][a-z0-9]*)\.arsenal_probe$")
+ARSENAL_PROBE_PRIMARY_NODE = "mini"
 
 # Cross-host visibility gap (found 2026-07-17, PENDING-ARMS "infra.eventbus_redis_mini
 # heartbeat frozen"): a handful of organ_ids are TCP-probed and written by a cron that
@@ -339,6 +356,9 @@ def scan_sidecars(
             continue
         organ_id = fname[: -len(".json")]
         seen.add(organ_id)
+        m = _ARSENAL_PROBE_STEM_RE.match(organ_id)
+        if m and m.group("machine") != ARSENAL_PROBE_PRIMARY_NODE:
+            continue  # on-demand elsewhere; no recurring promise here, never "silent"
         if _is_foreign_jurisdiction(organ_id, here):
             continue
         path = os.path.join(sidecar_dir, fname)

--- a/scripts/tests/test_organism_stale_detector.py
+++ b/scripts/tests/test_organism_stale_detector.py
@@ -150,6 +150,64 @@ def test_guilt_canonical_checkout_stamp_still_flags_stale(tmp_path):
     assert findings[0].kind == "stale"
 
 
+# ---------------------------------------------------------------------------
+# arsenal_probe non-primary-node exemption (sibling fix to organism_digest.py::
+# stale_heartbeats()'s existing ARSENAL_PROBE_PRIMARY_NODE check — same class
+# as the .worktrees/ exemption above). docs/runbooks/arsenal-probe.md §How it
+# is armed: only Mini has a recurring healer-armed refresh; M5/Pro reports are
+# on-demand only (a manual `--table` run or infra/vcr/cli.py's `check` path).
+# organism_digest.py already skips m5/pro's arsenal_probe stamp when computing
+# its "silent Nh" digest line; this detector read the SAME sidecar dir with the
+# SAME blanket 7-day rule and had no such exemption — found live 2026-08-21 when
+# m5.arsenal_probe.json (last refreshed 2026-08-12, 8.7d old) was reported as a
+# dead cron even though no cron for it has ever existed on M5 (CLAUDE.md: M5 has
+# no daemon/cron H24 by design).
+# ---------------------------------------------------------------------------
+
+
+def test_innocence_m5_arsenal_probe_stamp_not_flagged_stale(tmp_path):
+    """M5's arsenal_probe heartbeat has no recurring promise — an old stamp is
+    an unrefreshed on-demand snapshot, not a broken cron, and must NOT flag."""
+    d = str(tmp_path)
+    old = time.time() - 9 * 86400
+    _write(d, "m5.arsenal_probe", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7)
+    assert findings == [], f"m5 arsenal_probe stamp wrongly flagged stale: {findings}"
+
+
+def test_guilt_mini_arsenal_probe_stamp_still_flags_stale(tmp_path):
+    """Mini IS the primary/healer-armed node — its stamp going stale for 9 days
+    IS a broken promise and must still flag. Proves the exemption is scoped to
+    the non-primary machine, not to the arsenal_probe organ family at large."""
+    d = str(tmp_path)
+    old = time.time() - 9 * 86400
+    _write(d, "mini.arsenal_probe", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7, host="mini-pro2")
+    assert len(findings) == 1
+    assert findings[0].organ_id == "mini.arsenal_probe"
+    assert findings[0].kind == "stale"
+
+
+def test_innocence_pro_arsenal_probe_stamp_not_flagged_stale(tmp_path):
+    """Pro is also non-primary per the runbook — same exemption applies."""
+    d = str(tmp_path)
+    old = time.time() - 9 * 86400
+    _write(d, "pro.arsenal_probe", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7, host="nuzantara")
+    assert findings == [], f"pro arsenal_probe stamp wrongly flagged stale: {findings}"
+
+
+def test_innocence_unrelated_organ_named_like_arsenal_probe_prefix_still_flags(tmp_path):
+    """The stem regex is anchored (^...$) — an unrelated organ that merely
+    starts with a machine label must not accidentally match and get exempted."""
+    d = str(tmp_path)
+    old = time.time() - 9 * 86400
+    _write(d, "m5.arsenal_probe_extra", {"ts": old, "status": "ok"})
+    findings = scan_sidecars(d, stale_days=7)
+    assert len(findings) == 1
+    assert findings[0].organ_id == "m5.arsenal_probe_extra"
+
+
 def test_finding_is_serializable(tmp_path):
     d = str(tmp_path)
     _write(d, "pro.x", {"ts": time.time() - 30 * 86400, "status": "ok"})
@@ -475,13 +533,19 @@ def test_innocence_cross_host_allowlisted_organ_still_flags_on_m5(tmp_path):
 
 def test_innocence_m5_own_sidecar_still_flags_on_m5(tmp_path):
     """INNOCENCE: an m5.* sidecar scanned on M5 is squarely in-jurisdiction —
-    the new skip must never suppress a machine's own organs."""
+    the new skip must never suppress a machine's own organs.
+
+    Deliberately NOT named "m5.arsenal_probe" here: that specific organ_id
+    is now exempt on its own separate grounds (the arsenal_probe
+    non-primary-node exemption above, 2026-08-21) regardless of jurisdiction
+    — using it would conflate two independent exemptions in one assertion.
+    """
     d = str(tmp_path)
     old = time.time() - 30 * 86400
-    _write(d, "m5.arsenal_probe", {"ts": old, "status": "ok"})
+    _write(d, "m5.some_other_organ", {"ts": old, "status": "ok"})
     findings = scan_sidecars(d, stale_days=7, host="air-m5")
     assert len(findings) == 1
-    assert findings[0].organ_id == "m5.arsenal_probe"
+    assert findings[0].organ_id == "m5.some_other_organ"
 
 
 def test_innocence_unrecognised_prefix_keeps_reporting(tmp_path):


### PR DESCRIPTION
## Summary
- `organism_stale_detector.py` scanned `~/.organism/last_seen/*.json` with a blanket 7-day staleness rule that never knew M5/Pro's `arsenal_probe` heartbeat has no recurring promise (only Mini is healer-armed per `docs/runbooks/arsenal-probe.md`).
- `organism_digest.py::stale_heartbeats()` already carries this exact exemption (`ARSENAL_PROBE_PRIMARY_NODE`); this detector reads the same sidecar dir and had the identical gap — the same bug class its own comments already document for a sibling case (`.worktrees/` runtime stamps, PR #3486).
- Found live 2026-08-21: an 8.7-day-old `m5.arsenal_probe.json` (last refreshed 2026-08-12) was reported as a dead cron during a dispatch — investigation showed no cron for this probe has ever existed on M5 (CLAUDE.md: no daemon/cron H24 by design; the probe is on-demand only there).

## Fix
Mirrors `organism_digest.py`'s exemption exactly — same regex (`_ARSENAL_PROBE_STEM_RE`), same constant (`ARSENAL_PROBE_PRIMARY_NODE = "mini"`) — so both receptors agree on which machine's `arsenal_probe` heartbeat carries a recurring freshness promise. Non-primary nodes (m5, pro) are exempt from the staleness scan; Mini's own stamp still flags if it goes silent.

## Test plan
- [x] `test_innocence_m5_arsenal_probe_stamp_not_flagged_stale` / `test_innocence_pro_arsenal_probe_stamp_not_flagged_stale` — non-primary stamps 9 days old are NOT flagged.
- [x] `test_guilt_mini_arsenal_probe_stamp_still_flags_stale` — Mini's own 9-day-old stamp IS still flagged (proves the exemption is scoped, not blanket).
- [x] `test_innocence_unrelated_organ_named_like_arsenal_probe_prefix_still_flags` — regex is anchored, no accidental prefix match.
- [x] Updated a pre-existing test (`test_innocence_m5_own_sidecar_still_flags_on_m5`) that happened to name its fixture organ `m5.arsenal_probe` for an unrelated jurisdiction check — renamed to avoid colliding with the new exemption's semantics.
- [x] Full suite: `python3 -m pytest scripts/tests/test_organism_stale_detector.py -q` → 36 passed.
- [x] Live re-probe on M5 (`arsenal_probe.py --seats claude,glm,agy,codex,kimi --timeout 3`) confirms today's true verdict and refreshes the heartbeat — `organism_digest.py` banner now shows fresh seat statuses with no stale-report annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)