### PR TITLE
feat(seats): qwen coding-plan seat armed fleet-wide

### DIFF
--- a/FLEET_TOPOLOGY.json
+++ b/FLEET_TOPOLOGY.json
@@ -144,6 +144,50 @@
             "operational_notes": [
               "qwen3.8-max carries a Limited-time Night 50% Off discount per the console — schedule future TP1-heavy H24 batch lanes at night to exploit this."
             ]
+          },
+          "models_measured_2026_08_21": {
+            "_doc": "Empirical qwen-seat-fleet arming probe (qwen -p 'PONG-<id>' --model <id>, judged by output content, watchdog-guarded, ssh -n remote recipe on Pro/Mini). NOT a re-audit of TP1 billing/console truth above — flags a contradiction with console_verified_2026_08_14.roster.NOT_in_plan for kimi-k2/k2.7/k3 and MiniMax-M2.7/M3 (those returned live PONG here, under the same BAILIAN_TOKEN_PLAN_API_KEY, while the dated kimi-k2.5/2.6 and MiniMax-M2.5 snapshots the console marked PHANTOM correctly 403'd). Open question NOT resolved by this probe: whether the PASS-ing kimi/MiniMax calls draw from the flat TP1 quota or fall through to metered billing outside the plan. See MODEL_ROSTER.md Alibaba TP1 section, dated sub-table, for full detail.",
+            "method": "qwen -p \"Reply with exactly: PONG-<id>\" --model <id>, 60-90s watchdog, judged by stdout content never exit code",
+            "pass_all_three_machines": [
+              "qwen3-coder-plus",
+              "qwen3-coder",
+              "qwen3-coder-flash",
+              "qwen3-coder-next",
+              "qwen3-max-2026-01-23",
+              "qwen3-max",
+              "qwen3.5-plus",
+              "qwen3.6-flash",
+              "qwen3.7-plus",
+              "qwen3.7-max",
+              "qwen3.8-max",
+              "qwen3.8-max-preview",
+              "qwen3-vl-plus",
+              "qwen3-asr-flash",
+              "glm-4",
+              "glm-4.5",
+              "glm-4.7",
+              "glm-5.2",
+              "kimi-k2",
+              "kimi-k2.7",
+              "kimi-k3",
+              "MiniMax-M2.7",
+              "MiniMax-M3",
+              "deepseek-v3",
+              "deepseek-v4",
+              "deepseek-v4-pro"
+            ],
+            "fail_403_access_denied_m5_measured": [
+              "kimi-k2.5",
+              "kimi-k2.6",
+              "glm-5",
+              "glm-5.1",
+              "MiniMax-M2.5",
+              "qwen3.6-plus",
+              "deepseek-v4-flash"
+            ],
+            "fail_not_reprobed_on_pro_mini": "denial is a token-scope property (account-level), not a machine property — not re-run per machine",
+            "machines_probed": ["M5", "Pro", "Mini"],
+            "pro_mini_probe_gotcha": "first attempt used ssh without -n inside a while-read loop — ssh consumed the loop's own stdin and only 1 of 26 models ran per machine; fixed with ssh -n, then 26/26 completed on both"
           }
         }
       }

--- a/MODEL_ROSTER.md
+++ b/MODEL_ROSTER.md
@@ -146,6 +146,53 @@ API-confirmed): MiniMax M2.5, kimi-k2.5/2.6/2.7. PROBE-4 (the planned MiniMax sa
 verification) is moot — there is nothing on this account to probe. Using either requires adding
 it to this plan or sourcing a different account, a Zero decision, not a probe.
 
+### Coding-plan models measured 2026-08-21 (qwen-seat-fleet arming, empirical CLI probe)
+
+**⚠️ Contradicts the 2026-08-14 PHANTOM line above — flagged, NOT auto-resolved here.** This
+session's task was arming the seat + wrapper fleet-wide, not re-auditing TP1 billing; the
+discrepancy below needs a console-side check (which underlying balance a call draws from) before
+either classification is trusted blindly. Two independent measurements, both empirical, disagree
+with each other AND with the 2026-08-14 console read:
+
+1. `GET /v1/models` on both DashScope base URLs (`coding-intl` and `coding`, identical response)
+   returned exactly 10 ids: `qwen3-coder-plus`, `qwen3-max-2026-01-23`, `qwen3-coder-next`,
+   `glm-4.7`, `kimi-k2.5`, `qwen3.5-plus`, `glm-5`, `MiniMax-M2.5`, `qwen3.6-plus`,
+   `qwen3.7-plus`.
+2. Live `qwen -p "..." --model <id>` calls (the thing that actually matters) show **4 of those
+   10 listed ids return `403 Access to model denied`** (`kimi-k2.5`, `glm-5`, `MiniMax-M2.5`,
+   `qwen3.6-plus`) — the listing endpoint is not a reliable access oracle (own W-class: judge the
+   reply, never a name/listing proxy) — while **16 ids NOT in that listing return PONG**,
+   including `kimi-k2`, `kimi-k2.7`, `kimi-k3`, `MiniMax-M2.7`, `MiniMax-M3` — i.e. the specific
+   _dated_ kimi/MiniMax snapshots the 2026-08-14 census marked PHANTOM fail, but _other_ numbered
+   snapshots of the same model families succeed live, under the same `BAILIAN_TOKEN_PLAN_API_KEY`.
+   Open question this session did not resolve: do the PASS-ing kimi/MiniMax calls draw from the
+   flat TP1 quota, or silently fall through to metered pay-as-you-go billing outside the plan? A
+   console spend-ledger check is needed before routing any real traffic to them.
+
+**PASS (26/26 on M5, Pro, AND Mini — probed once per model per machine, `qwen -p "Reply with
+exactly: PONG-<id>" --model <id>`, judged by output content, watchdog-guarded)**:
+`qwen3-coder-plus` · `qwen3-coder` · `qwen3-coder-flash` · `qwen3-coder-next` ·
+`qwen3-max-2026-01-23` · `qwen3-max` · `qwen3.5-plus` · `qwen3.6-flash` · `qwen3.7-plus` ·
+`qwen3.7-max` · `qwen3.8-max` · `qwen3.8-max-preview` · `qwen3-vl-plus` · `qwen3-asr-flash` ·
+`glm-4` · `glm-4.5` · `glm-4.7` · `glm-5.2` · `kimi-k2` · `kimi-k2.7` · `kimi-k3` ·
+`MiniMax-M2.7` · `MiniMax-M3` · `deepseek-v3` · `deepseek-v4` · `deepseek-v4-pro`.
+
+**FAIL (M5 only, `403 Access to model denied` — plan-account-level, so presumed identical on
+Pro/Mini; not re-probed there since the denial is a token-scope property, not a machine
+property)**: `kimi-k2.5` · `kimi-k2.6` · `glm-5` · `glm-5.1` · `MiniMax-M2.5` · `qwen3.6-plus` ·
+`deepseek-v4-flash` (note: distinct from the ARMED `deepseek-v4-flash-0731` above — a bare
+`deepseek-v4-flash` alias without the date suffix is denied; the dated one that's in production
+use is unaffected by this finding).
+
+Remote-probe recipe used (avoids the ssh-eats-the-loop trap, W-class: `ssh` without `-n` inside a
+`while read` loop consumes the loop's own stdin — first attempt silently ran only 1 of 26 models
+per machine before this was caught and fixed):
+
+```bash
+ssh -n -o BatchMode=yes -o ConnectTimeout=15 <pro|mini> \
+  "export PATH=/opt/homebrew/bin:\$PATH; perl -e 'alarm 150; exec @ARGV' qwen -p '<prompt>' --model '<id>' < /dev/null"
+```
+
 **Hard NOs, whole wing** (spec §2.5): client PII (Law 2 — PII intake is SEA-LION/local, never this
 wing), client-facing outputs, merge/deploy, final gates, NUZANTARA/infra credentials in the
 model-visible env.

--- a/scripts/qwen-cloud-code.sh
+++ b/scripts/qwen-cloud-code.sh
@@ -20,6 +20,13 @@
 #     neither flag; appending would break them). Their transcript retention remains
 #     harness state — the one declared residual, now scoped precisely.
 #
+# v4 (2026-08-21): fleet-arming — Keychain access over non-interactive ssh (Pro/Mini) fails
+# with "User interaction is not allowed" (locked, not absent). Credential gate now falls
+# back to ~/.qwen/settings.json IFF its mode is exactly 0600 AS FOUND (before step 0's own
+# chmod runs — else the fallback's own mode check would be neutered by step 0) and
+# env.BAILIAN_TOKEN_PLAN_API_KEY is non-empty; logs which source was accepted (never the
+# value — W106 class).
+#
 set -euo pipefail
 
 KEYCHAIN_SERVICE="qwen-cloud-code-token"
@@ -28,7 +35,16 @@ SETTINGS="$HOME/.qwen/settings.json"
 die() { printf '❌ qwen-cloud-code: %s\n' "$*" >&2; exit 1; }
 
 # ---------------------------------------------------------------- 0. Durable perms re-assertion (first, so refused paths also re-assert)
-[ -f "$SETTINGS" ] && chmod 0600 "$SETTINGS" 2>/dev/null || true
+# Capture the mode as FOUND before tightening it: step 4's settings.json fallback must
+# judge the state a caller actually left it in, not the state we just silently fixed —
+# a file discovered 0644 has an untrusted disclosure history (family #4, "secret in the
+# clear") even after this chmod hardens it going forward. Fixing before judging would
+# make the "only if exactly 0600" gate below vacuous (check≠action, W99/W109 class).
+SETTINGS_FOUND_MODE=""
+if [ -f "$SETTINGS" ]; then
+  SETTINGS_FOUND_MODE="$(stat -f '%Lp' "$SETTINGS" 2>/dev/null || stat -c '%a' "$SETTINGS" 2>/dev/null || true)"
+  chmod 0600 "$SETTINGS" 2>/dev/null || true
+fi
 
 # ---------------------------------------------------------------- 1. Legge 5 verb/flag scan
 for arg in "$@"; do
@@ -60,13 +76,46 @@ if [ "$REVIEW_MODE" = "1" ]; then
   ARGS+=("--approval-mode=plan" "--chat-recording=false")
 fi
 
-# ---------------------------------------------------------------- 4. Credential gate (Keychain only)
-if ! TOKEN="$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null)"; then
-  die "Keychain service '$KEYCHAIN_SERVICE' absent — seat UNARMED.
-    Operator cure (value-preserving, no rotation needed):
-      security add-generic-password -s '$KEYCHAIN_SERVICE' -a qwen-cloud-code -w '<credential>'"
+# ---------------------------------------------------------------- 4. Credential gate (Keychain, settings.json fallback when Keychain is locked)
+# Over ssh (Pro/Mini non-interactive), `security find-generic-password` fails with
+# "User interaction is not allowed" — a locked-Keychain state, not an absent-secret
+# state. Both must arm the seat if a usable ~/.qwen/settings.json exists. The `if
+# TOKEN="$(...)"` form is errexit-safe (condition context is exempt from `set -e`,
+# W101 class) — no `|| true` needed here.
+TOKEN=""
+TOKEN_SOURCE=""
+if TOKEN="$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null)" && [ -n "$TOKEN" ]; then
+  TOKEN_SOURCE="keychain"
+else
+  TOKEN=""
+  if [ -f "$SETTINGS" ]; then
+    if [ "$SETTINGS_FOUND_MODE" = "600" ]; then
+      SETTINGS_TOKEN="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        d = json.load(f)
+    print(d.get("env", {}).get("BAILIAN_TOKEN_PLAN_API_KEY", ""))
+except Exception:
+    print("")
+' "$SETTINGS" 2>/dev/null || true)"
+      if [ -n "$SETTINGS_TOKEN" ]; then
+        TOKEN="$SETTINGS_TOKEN"
+        TOKEN_SOURCE="settings.json"
+      fi
+    fi
+  fi
 fi
-[ -n "$TOKEN" ] || die "Keychain entry '$KEYCHAIN_SERVICE' is empty"
+
+if [ -z "$TOKEN" ]; then
+  die "Keychain service '$KEYCHAIN_SERVICE' absent or locked (e.g. non-interactive ssh) AND
+    '$SETTINGS' fallback unavailable (missing / not exactly 0600 / no env.BAILIAN_TOKEN_PLAN_API_KEY) — seat UNARMED.
+    Operator cure (value-preserving, no rotation needed):
+      security add-generic-password -s '$KEYCHAIN_SERVICE' -a qwen-cloud-code -w '<credential>'
+    or ensure '$SETTINGS' is chmod 0600 with env.BAILIAN_TOKEN_PLAN_API_KEY set."
+fi
+# Log WHICH source was accepted, never the value (W106 class: name the source, not the secret).
+printf 'qwen-cloud-code: token source accepted: %s\n' "$TOKEN_SOURCE" >&2
 
 # ---------------------------------------------------------------- 5. Binary
 QWEN_BIN="$(command -v qwen || true)"

--- a/scripts/tests/test_qwen_cloud_code_token_source.sh
+++ b/scripts/tests/test_qwen_cloud_code_token_source.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test_qwen_cloud_code_token_source.sh — the qwen-cloud-code wrapper's credential gate
+# must accept a Keychain token (locked in every case here — simulated, matching the real
+# non-interactive-ssh failure "User interaction is not allowed") OR fall back to
+# ~/.qwen/settings.json ONLY when its mode is exactly 0600 AS FOUND and
+# env.BAILIAN_TOKEN_PLAN_API_KEY is non-empty; die otherwise. It must log WHICH source was
+# accepted, NEVER the value (W106 class: name the source, not the secret).
+# 2026-08-21, qwen-seat-fleet arming (fleet-wide over ssh where Keychain is locked).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/qwen-cloud-code.sh"
+[ -f "$WRAPPER" ] || { echo "FAIL: wrapper not found at $WRAPPER"; exit 2; }
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/qwentoken.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+FAILED=0
+DUMMY="sk-test-000"
+
+ok()  { echo "  ok   — $1"; }
+bad() { echo "  FAIL — $1"; FAILED=1; }
+
+# Fake `security`: always simulates a LOCKED Keychain (the real non-interactive-ssh
+# failure mode), forcing every case through the settings.json fallback under test.
+# Fake `qwen`: proves the wrapper reached exec, without ever printing the token value.
+mkfakebin() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "$dir/security" <<'FAKE'
+#!/usr/bin/env bash
+echo "security: User interaction is not allowed." >&2
+exit 1
+FAKE
+    chmod +x "$dir/security"
+    cat > "$dir/qwen" <<'FAKE'
+#!/usr/bin/env bash
+if [ -n "${BAILIAN_TOKEN_PLAN_API_KEY:-}" ]; then
+    echo "FAKE_QWEN_INVOKED token_set=yes"
+else
+    echo "FAKE_QWEN_INVOKED token_set=no"
+fi
+exit 0
+FAKE
+    chmod +x "$dir/qwen"
+}
+
+run_wrapper() {  # $1 = fake HOME; prints "rc|combined stdout+stderr"
+    local home="$1" bindir="$SANDBOX/bin" out
+    mkfakebin "$bindir"
+    out="$SANDBOX/out.$$"
+    ( HOME="$home" PATH="$bindir:$PATH" bash "$WRAPPER" --help ) > "$out" 2>&1
+    local rc=$?
+    printf '%s|%s' "$rc" "$(cat "$out")"
+    rm -f "$out"
+}
+
+write_settings() {  # $1=home $2=mode ("600"/"644") $3=value ("" to omit the key)
+    local home="$1" mode="$2" val="$3"
+    mkdir -p "$home/.qwen"
+    if [ -n "$val" ]; then
+        printf '{"env": {"BAILIAN_TOKEN_PLAN_API_KEY": "%s"}}\n' "$val" > "$home/.qwen/settings.json"
+    else
+        printf '{"env": {}}\n' > "$home/.qwen/settings.json"
+    fi
+    chmod "$mode" "$home/.qwen/settings.json"
+}
+
+# ── 1. settings.json 0600 + value → ACCEPTED, source=settings.json, exec reached ─────
+H1="$SANDBOX/home1"; mkdir -p "$H1"
+write_settings "$H1" 600 "$DUMMY"
+R="$(run_wrapper "$H1")"
+RC="${R%%|*}"; OUT="${R#*|}"
+if [ "$RC" = "0" ] && echo "$OUT" | grep -q "token source accepted: settings.json" \
+   && echo "$OUT" | grep -q "FAKE_QWEN_INVOKED token_set=yes"; then
+    ok "0600 settings.json with value → accepted, source logged, exec reached"
+else
+    bad "0600 settings.json with value: got rc=$RC out=[$OUT]"
+fi
+if echo "$OUT" | grep -qF "$DUMMY"; then
+    bad "0600 case leaked the dummy token value into output"
+else
+    ok "0600 case never printed the dummy token value"
+fi
+
+# ── 2. settings.json 0644 (wrong mode, AS FOUND) → REFUSED, die, no leak ─────────────
+#    (proves step-0's own chmod-0600-reassert does NOT retroactively launder the file
+#    into passing this gate — the mode captured is the mode the caller left it in)
+H2="$SANDBOX/home2"; mkdir -p "$H2"
+write_settings "$H2" 644 "$DUMMY"
+R="$(run_wrapper "$H2")"
+RC="${R%%|*}"; OUT="${R#*|}"
+if [ "$RC" != "0" ] && echo "$OUT" | grep -qi "UNARMED"; then
+    ok "0644 settings.json (wrong mode as found) → refused (seat UNARMED)"
+else
+    bad "0644 settings.json: got rc=$RC out=[$OUT] (want non-zero + UNARMED)"
+fi
+if echo "$OUT" | grep -qF "$DUMMY"; then
+    bad "0644 case leaked the dummy token value into output"
+else
+    ok "0644 case never printed the dummy token value"
+fi
+
+# ── 3. no Keychain (locked) + no settings.json at all → die, no leak ─────────────────
+H3="$SANDBOX/home3"; mkdir -p "$H3"
+R="$(run_wrapper "$H3")"
+RC="${R%%|*}"; OUT="${R#*|}"
+if [ "$RC" != "0" ] && echo "$OUT" | grep -qi "UNARMED"; then
+    ok "no keychain + no settings.json → refused (seat UNARMED)"
+else
+    bad "no-settings case: got rc=$RC out=[$OUT] (want non-zero + UNARMED)"
+fi
+if echo "$OUT" | grep -qF "$DUMMY"; then
+    bad "no-settings case leaked the dummy token value"
+else
+    ok "no-settings case never printed the dummy token value"
+fi
+
+# ── 4. settings.json 0600 but the key is EMPTY → refused (non-empty required) ────────
+H4="$SANDBOX/home4"; mkdir -p "$H4"
+write_settings "$H4" 600 ""
+R="$(run_wrapper "$H4")"
+RC="${R%%|*}"; OUT="${R#*|}"
+if [ "$RC" != "0" ] && echo "$OUT" | grep -qi "UNARMED"; then
+    ok "0600 settings.json with EMPTY value → refused (seat UNARMED)"
+else
+    bad "0600-empty case: got rc=$RC out=[$OUT] (want non-zero + UNARMED)"
+fi
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+    echo "PASS — qwen_cloud_code_token_source"; exit 0
+else
+    echo "FAIL — qwen_cloud_code_token_source"; exit 1
+fi


### PR DESCRIPTION
## Why

The Qwen coding-plan seat needed to be armed on all three machines (M5, Pro, Mini) for every
model the plan grants, with the repo wrapper (`scripts/qwen-cloud-code.sh`) working over ssh.
Keychain access over non-interactive ssh (Pro/Mini) fails with `User interaction is not
allowed` — a locked-Keychain state, not an absent-secret state — and the wrapper had no
fallback for it.

## What

- `scripts/qwen-cloud-code.sh`: credential gate falls back to `~/.qwen/settings.json` when
  Keychain access fails, ONLY if the file's mode is exactly 0600 **as found** (captured before
  step 0's own `chmod 0600` re-assertion runs — otherwise the mode check would be neutered by
  that same re-assertion, a check≠action interaction bug fixed in the same diff) and
  `env.BAILIAN_TOKEN_PLAN_API_KEY` is non-empty. Logs which source was accepted
  (`keychain`/`settings.json`), never the value.
- `scripts/tests/test_qwen_cloud_code_token_source.sh`: 7 assertions in a fake HOME with a
  dummy token, fake `security` (always simulates a locked Keychain) and fake `qwen` (proves
  exec was reached without ever printing the token). Covers: 0600+value accepted, 0644 (wrong
  mode as found) refused, no-keychain+no-settings refused, 0600+empty-value refused; each
  refusal/acceptance path checked for zero leakage of the dummy value.
- `MODEL_ROSTER.md` / `FLEET_TOPOLOGY.json`: recorded the measured coding-plan model roster
  (26 models probed once per machine on M5/Pro/Mini via `qwen -p "PONG-<id>" --model <id>`,
  judged by output content, watchdog-guarded).

## Probe matrix (2026-08-21)

**PASS on all 3 machines (26/26 M5, 26/26 Pro, 26/26 Mini)**: qwen3-coder-plus, qwen3-coder,
qwen3-coder-flash, qwen3-coder-next, qwen3-max-2026-01-23, qwen3-max, qwen3.5-plus,
qwen3.6-flash, qwen3.7-plus, qwen3.7-max, qwen3.8-max, qwen3.8-max-preview, qwen3-vl-plus,
qwen3-asr-flash, glm-4, glm-4.5, glm-4.7, glm-5.2, kimi-k2, kimi-k2.7, kimi-k3, MiniMax-M2.7,
MiniMax-M3, deepseek-v3, deepseek-v4, deepseek-v4-pro.

**FAIL — 403 Access to model denied (M5-measured; account-level, not re-probed per machine)**:
kimi-k2.5, kimi-k2.6, glm-5, glm-5.1, MiniMax-M2.5, qwen3.6-plus, deepseek-v4-flash (bare, no
date suffix — distinct from the ARMED `deepseek-v4-flash-0731`).

**Finding worth flagging**: the DashScope `/v1/models` listing endpoint is not a reliable
access oracle — it lists 10 ids, 4 of which 403 live (kimi-k2.5, glm-5, MiniMax-M2.5,
qwen3.6-plus), while 16 ids it never lists return PONG, including kimi-k2/k2.7/k3 and
MiniMax-M2.7/M3. This contradicts `MODEL_ROSTER.md`'s 2026-08-14 PHANTOM classification for
those model families (the specific *dated* snapshots kimi-k2.5/2.6 and MiniMax-M2.5 do 403,
matching that census — but *other* numbered snapshots of the same families succeed live).
Recorded as an open question in both files, **not resolved here** — whether the passing
kimi/MiniMax calls draw on the flat TP1 quota or fall through to metered billing outside the
plan needs a console-side spend-ledger check, out of this PR's scope.

No HOME-fork copy of the wrapper exists outside git-tracked checkouts on Pro/Mini (`~/scripts/`
has no copy on either machine) — nothing to propagate manually once this merges.

## Adversarial review

Probe matrix measured live on three machines by this lane (M5 direct CLI + ssh -n remote
recipe on Pro/Mini, fixed mid-run after discovering the classic ssh-eats-the-while-read-loop
bug on the first attempt — verified 26/26 on the second). Wrapper fallback mutation-checked by
the test's own refusal cases (wrong mode, missing file, empty value all independently
exercised, each asserted to never leak the dummy token). Orchestrating session 3563604c
re-verifies.