### PR TITLE
feat(organism): give the flowkit-pro-tunnel launchd job a heartbeat

### DIFF
--- a/scripts/check_flowkit_tunnel.py
+++ b/scripts/check_flowkit_tunnel.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""check_flowkit_tunnel.py — liveness probe for the FlowKit SSH tunnel
+(launchd job `com.balizero.flowkit-pro-tunnel`, M5-only: `ssh -N -T
+-L 127.0.0.1:8100:127.0.0.1:8100 -L 127.0.0.1:9222:127.0.0.1:9222 pro`).
+
+THE DISEASE IT KILLS (scar family #2, Esiste!=Armato): the launchd job existed
+and even self-recovered on its own (KeepAlive + ThrottleInterval=10s correctly
+retry an ssh tunnel through Tailscale flaps -- family #8 network-flap, not a
+KeepAlive misconfig), but NOTHING watched it. Its stderr log accumulated 800+
+"Operation timed out" lines across 5+ days (born 2026-08-15 04:25, last
+failure 2026-08-21 00:55) with zero heartbeat sidecar, zero proprioception
+registry entry, zero alert anywhere in the repo -- the only reason anyone
+noticed was a manual `launchctl list` during an unrelated dispatch.
+
+`launchctl list`'s own STATUS column is itself a trap: it prints the LAST
+exit code even while the job is CURRENTLY RUNNING (measured live 2026-08-21:
+PID alive 2h20m, tunnel forwarding real HTTP traffic, `launchctl list` still
+read "255" from the prior failed attempt). This script never trusts that
+column -- it judges a REAL process (`ps -p <pid>`) AND a REAL HTTP reply
+through the forwarded port (scar W104: judge the reply, never the exit code
+or PID-presence alone).
+
+WR2 image-gen degrades gracefully when this tunnel is down
+(WR2_IMAGE_BACKEND default "auto" silently falls back to Playwright --
+scripts/wr2_image_generator.py) -- DOWN here is a cost/latency finding
+(FlowKit ~5-15s/image vs Playwright's 30-90s), never a data-loss one.
+
+Blind-scan guard (W84 "green-but-dead"): a run on a machine that has never
+heard of this launchd job is NOT_CONFIGURED, not "clean" -- distinct from
+DOWN (configured but unreachable). Exit 0 either way (this organ is M5-only
+by design; NOT_CONFIGURED elsewhere is expected, not an alarm), but the JSON
+`status` field always distinguishes the two.
+
+Usage:
+    python3 scripts/check_flowkit_tunnel.py            # human line, writes heartbeat
+    python3 scripts/check_flowkit_tunnel.py --json      # machine-readable
+    python3 scripts/check_flowkit_tunnel.py --quiet     # one summary line
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Callable, Optional
+
+LABEL = "com.balizero.flowkit-pro-tunnel"
+DEFAULT_PROBE_URL = "http://127.0.0.1:8100/"
+DEFAULT_TIMEOUT_S = 3.0
+HEARTBEAT_DIR = Path.home() / ".organism" / "last_seen"
+
+LIVE = "LIVE"
+DOWN = "DOWN"
+NOT_CONFIGURED = "NOT_CONFIGURED"
+
+
+def machine_label() -> str:
+    """Mirrors organism_stale_detector._machine_label / arsenal_probe.machine_label
+    (small, deliberately duplicated -- these sibling receptors already carry
+    their own copy each rather than a cross-module import, scripts/ is not a
+    package)."""
+    host = socket.gethostname().split(".")[0].lower()
+    if "air-m5" in host:
+        return "m5"
+    if "mini" in host:
+        return "mini"
+    if host == "nuzantara":
+        return "pro"
+    return host
+
+
+def plist_path(label: str = LABEL) -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
+
+
+def _launchctl_pid(
+    label: str,
+    run: Optional[Callable[[list[str]], subprocess.CompletedProcess]] = None,
+) -> Optional[int]:
+    """Returns the PID launchd currently reports for `label`, or None if not
+    running / not loaded. Never trusts the STATUS column (see module
+    docstring) -- only the PID column, which ps then independently verifies."""
+    run = run or (lambda cmd: subprocess.run(cmd, capture_output=True, text=True, timeout=10))
+    try:
+        res = run(["launchctl", "list"])
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    for line in res.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 3 and parts[2] == label:
+            pid_str = parts[0].strip()
+            if pid_str.isdigit():
+                return int(pid_str)
+            return None
+    return None
+
+
+def _pid_alive(
+    pid: int,
+    run: Optional[Callable[[list[str]], subprocess.CompletedProcess]] = None,
+) -> bool:
+    run = run or (lambda cmd: subprocess.run(cmd, capture_output=True, text=True, timeout=5))
+    try:
+        res = run(["ps", "-p", str(pid)])
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+    return res.returncode == 0
+
+
+def _http_probe(
+    url: str,
+    timeout: float,
+    fetch: Optional[Callable[[str, float], tuple[Optional[int], str]]] = None,
+) -> tuple[bool, str]:
+    """Any HTTP response (even a 404) proves the tunnel forwards real bytes
+    end-to-end. Only a connection-level failure (refused/timeout/DNS) is DOWN
+    -- this is the same "judge the reply" contract arsenal_probe.py uses."""
+    def _default(u: str, t: float) -> tuple[Optional[int], str]:
+        req = urllib.request.Request(u, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=t) as resp:
+                return resp.status, f"HTTP {resp.status}"
+        except urllib.error.HTTPError as e:
+            return e.code, f"HTTP {e.code}"  # a real HTTP error status IS a live reply
+        except urllib.error.URLError as e:
+            return None, f"{type(e).__name__}: {e.reason}"
+        except TimeoutError:
+            return None, "timed out"
+        except Exception as e:  # a probe must never crash the whole run
+            return None, f"{type(e).__name__}: {e}"
+
+    fetch = fetch or _default
+    status, evidence = fetch(url, timeout)
+    return status is not None, evidence
+
+
+def check(
+    label: str = LABEL,
+    probe_url: str = DEFAULT_PROBE_URL,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    plist_exists: Optional[Callable[[], bool]] = None,
+    launchctl_pid_fn: Callable[[str], Optional[int]] = _launchctl_pid,
+    pid_alive_fn: Callable[[int], bool] = _pid_alive,
+    http_probe_fn: Callable[[str, float], tuple[bool, str]] = _http_probe,
+) -> dict:
+    """Pure-ish (all IO injectable) so tests never touch a real launchd/socket."""
+    plist_exists = plist_exists or (lambda: plist_path(label).is_file())
+    if not plist_exists():
+        return {
+            "organ": "flowkit_tunnel",
+            "status": NOT_CONFIGURED,
+            "healthy": True,  # not an alarm -- this machine doesn't run this job
+            "evidence": f"{plist_path(label)} not present -- this machine has no flowkit tunnel job",
+        }
+
+    pid = launchctl_pid_fn(label)
+    if pid is None:
+        return {
+            "organ": "flowkit_tunnel",
+            "status": DOWN,
+            "healthy": False,
+            "evidence": "launchd job not running (no PID in `launchctl list`)",
+        }
+    if not pid_alive_fn(pid):
+        return {
+            "organ": "flowkit_tunnel",
+            "status": DOWN,
+            "healthy": False,
+            "evidence": f"launchctl reports PID {pid} but `ps -p {pid}` finds no live process",
+        }
+
+    reachable, http_evidence = http_probe_fn(probe_url, timeout_s)
+    if not reachable:
+        return {
+            "organ": "flowkit_tunnel",
+            "status": DOWN,
+            "healthy": False,
+            "evidence": f"PID {pid} alive but {probe_url} unreachable through the tunnel: {http_evidence}",
+        }
+    return {
+        "organ": "flowkit_tunnel",
+        "status": LIVE,
+        "healthy": True,
+        "evidence": f"PID {pid} alive, {probe_url} answered ({http_evidence})",
+    }
+
+
+def _atomic_write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=1, ensure_ascii=False))
+    tmp.rename(path)
+
+
+def write_heartbeat(result: dict, machine: Optional[str] = None) -> Path:
+    """Skips the write entirely for NOT_CONFIGURED (scar #2 sibling lesson,
+    2026-08-21: a heartbeat file that exists everywhere-but-means-nothing on
+    most machines is exactly the collocation-not-entity trap family #3
+    warns about -- only write a sidecar where this organ actually runs)."""
+    machine = machine or machine_label()
+    path = HEARTBEAT_DIR / f"{machine}.flowkit_tunnel.json"
+    if result["status"] == NOT_CONFIGURED:
+        return path
+    heartbeat = {
+        "organ": f"{machine}.flowkit_tunnel",
+        "status": "ok" if result["healthy"] else "error",
+        "degraded": not result["healthy"],
+        "note": result["evidence"],
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    _atomic_write_json(path, heartbeat)
+    return path
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--quiet", action="store_true")
+    ap.add_argument("--probe-url", default=DEFAULT_PROBE_URL)
+    ap.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_S)
+    ap.add_argument("--no-heartbeat", action="store_true", help="skip the sidecar write (testing)")
+    args = ap.parse_args(argv)
+
+    result = check(probe_url=args.probe_url, timeout_s=args.timeout)
+
+    if not args.no_heartbeat:
+        try:
+            write_heartbeat(result)
+        except OSError as e:
+            sys.stderr.write(f"check_flowkit_tunnel: heartbeat write FAILED: {e}\n")
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False))
+    elif args.quiet:
+        print(f"flowkit_tunnel: {result['status']}")
+    else:
+        print(f"flowkit_tunnel: {result['status']} -- {result['evidence']}")
+
+    if result["status"] == NOT_CONFIGURED:
+        return 0
+    return 0 if result["healthy"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/proprioception.py
+++ b/scripts/proprioception.py
@@ -74,6 +74,7 @@ KNOWN_BOUNDARY_CLASSES = [
     "process<->process",        # e.g. /health/detailed provenance — NO PROBE in v1 (A2)
     "seat<->armed",             # AI-seat credential/quota vs live probe (arsenal, #2)
     "worktree<->gate",          # does git actually invoke a pre-push hook in this worktree (#2)
+    "tunnel<->reachable",       # declared network tunnel/forward vs live reachability (2026-08-21)
 ]
 
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=15",
@@ -1030,6 +1031,26 @@ DEFAULT_REGISTRY: list[dict] = [
         "verdict_key": "status",
         "ok_values": [],
         "fix_hint": "python3 infra/vcr/cli.py check --seat <s> --host m5 --auth-context interactive (drafts/2026-08-03-vcr-pilot-v2.1-and-build-workflow.md)",
+    },
+    {
+        # M5-only launchd SSH tunnel (com.balizero.flowkit-pro-tunnel) that
+        # WR2 image-gen depends on for FlowKit reachability. Found live
+        # 2026-08-21 (dispatch "revive dead organs") with ZERO coverage
+        # anywhere: no heartbeat sidecar, no proprioception entry, no alert —
+        # its stderr log accumulated 800+ "Operation timed out" lines across
+        # 5+ days while nothing watched. This entry is the cure: on-demand
+        # (no M5 daemon per CLAUDE.md §1), piggybacking on whatever already
+        # triggers a proprioception sweep each session, same pattern as
+        # arsenal_seats_vcr_m5 above. Severity P2, not P1: WR2_IMAGE_BACKEND
+        # "auto" (default) silently falls back to Playwright when this tunnel
+        # is down — a cost/latency finding, never data loss.
+        "id": "flowkit_tunnel", "type": "wrap",
+        "target": ["python3", "{repo}/scripts/check_flowkit_tunnel.py", "--quiet"],
+        "class": "tunnel<->reachable",
+        "boundary": "flowkit ssh tunnel (M5->Pro, 127.0.0.1:8100/9222) <-> live HTTP reachability",
+        "machines": ["m5"], "tags": ["fast", "wr2"], "timeout_sec": 15,
+        "severity": "P2", "parse": "exit_code",
+        "fix_hint": "launchctl print gui/$(id -u)/com.balizero.flowkit-pro-tunnel; tail ~/Library/Logs/flowkit-pro-tunnel.err — WR2 falls back to Playwright automatically (auto backend), no data loss while down",
     },
 ]
 

--- a/scripts/tests/test_check_flowkit_tunnel.py
+++ b/scripts/tests/test_check_flowkit_tunnel.py
@@ -1,0 +1,177 @@
+"""Tests for check_flowkit_tunnel — the FlowKit SSH tunnel liveness probe.
+
+Born 2026-08-21: the launchd job com.balizero.flowkit-pro-tunnel existed and
+even self-recovered from a multi-day Tailscale flap, but had zero heartbeat,
+zero proprioception coverage, zero alert (scar family #2, Esiste!=Armato).
+This module gives it a heartbeat sidecar wired into the existing
+~/.organism/last_seen/ ecosystem so the NEXT outage is loud, not silent.
+
+Contract (guilt + innocence, per cicatrix-superscar #3 antidote):
+  - GUILT: no plist -> NOT_CONFIGURED (never an alarm; M5-only organ).
+  - GUILT: plist present but no PID in `launchctl list` -> DOWN.
+  - GUILT: PID reported by launchctl but `ps -p <pid>` finds nothing -> DOWN
+    (never trust launchctl's word alone -- W104: judge the reply).
+  - GUILT: PID alive but the forwarded HTTP port is unreachable -> DOWN.
+  - INNOCENCE: PID alive AND the forwarded port answers (even a 404/500 IS a
+    live reply through the tunnel) -> LIVE.
+  - `launchctl list`'s STATUS column is never consulted at all -- only the
+    PID column plus two independent real checks (ps, HTTP).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from check_flowkit_tunnel import (  # noqa: E402
+    DOWN,
+    LIVE,
+    NOT_CONFIGURED,
+    check,
+    write_heartbeat,
+)
+
+
+def _cp(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_guilt_not_configured_when_no_plist():
+    result = check(plist_exists=lambda: False)
+    assert result["status"] == NOT_CONFIGURED
+    assert result["healthy"] is True  # not an alarm on a machine that never runs this job
+
+
+def test_guilt_down_when_no_pid_in_launchctl_list():
+    result = check(
+        plist_exists=lambda: True,
+        launchctl_pid_fn=lambda label: None,
+    )
+    assert result["status"] == DOWN
+    assert result["healthy"] is False
+    assert "not running" in result["evidence"]
+
+
+def test_guilt_down_when_pid_reported_but_process_actually_dead():
+    """The exact gotcha this organ exists for: launchctl SAYS a PID, but the
+    process is not real. Never trust launchctl's word alone."""
+    result = check(
+        plist_exists=lambda: True,
+        launchctl_pid_fn=lambda label: 99999,
+        pid_alive_fn=lambda pid: False,
+    )
+    assert result["status"] == DOWN
+    assert result["healthy"] is False
+    assert "99999" in result["evidence"]
+    assert "no live process" in result["evidence"]
+
+
+def test_guilt_down_when_pid_alive_but_port_unreachable():
+    result = check(
+        plist_exists=lambda: True,
+        launchctl_pid_fn=lambda label: 12345,
+        pid_alive_fn=lambda pid: True,
+        http_probe_fn=lambda url, timeout: (False, "Connection refused"),
+    )
+    assert result["status"] == DOWN
+    assert result["healthy"] is False
+    assert "Connection refused" in result["evidence"]
+
+
+def test_innocence_live_when_pid_alive_and_port_answers():
+    result = check(
+        plist_exists=lambda: True,
+        launchctl_pid_fn=lambda label: 12345,
+        pid_alive_fn=lambda pid: True,
+        http_probe_fn=lambda url, timeout: (True, "HTTP 404"),
+    )
+    assert result["status"] == LIVE
+    assert result["healthy"] is True
+    assert "12345" in result["evidence"]
+
+
+def test_innocence_live_even_on_http_error_status():
+    """A 404/500 through the tunnel IS a live reply -- only a connection-level
+    failure (refused/timeout) is DOWN, never an HTTP status code."""
+    result = check(
+        plist_exists=lambda: True,
+        launchctl_pid_fn=lambda label: 12345,
+        pid_alive_fn=lambda pid: True,
+        http_probe_fn=lambda url, timeout: (True, "HTTP 500"),
+    )
+    assert result["status"] == LIVE
+
+
+def test_launchctl_pid_never_reads_the_status_column():
+    """The exact live gotcha (2026-08-21): `launchctl list` showed PID 99968
+    alongside a STALE status "255" from a prior failed attempt while the
+    tunnel was healthy and running for 2h20m. _launchctl_pid must extract
+    the PID column only and never even look at column 2."""
+    from check_flowkit_tunnel import _launchctl_pid
+
+    stdout = "99968\t255\tcom.balizero.flowkit-pro-tunnel\n69445\t-9\tcom.apple.WorkflowKit.ShortcutsViewService\n"
+    pid = _launchctl_pid("com.balizero.flowkit-pro-tunnel", run=lambda cmd: _cp(0, stdout=stdout))
+    assert pid == 99968
+
+
+def test_launchctl_pid_dash_means_not_running():
+    stdout = "-\t78\tcom.balizero.flowkit-pro-tunnel\n"
+    from check_flowkit_tunnel import _launchctl_pid
+
+    pid = _launchctl_pid("com.balizero.flowkit-pro-tunnel", run=lambda cmd: _cp(0, stdout=stdout))
+    assert pid is None
+
+
+def test_heartbeat_not_written_for_not_configured(tmp_path, monkeypatch):
+    import check_flowkit_tunnel as mod
+
+    monkeypatch.setattr(mod, "HEARTBEAT_DIR", tmp_path)
+    result = {"organ": "flowkit_tunnel", "status": NOT_CONFIGURED, "healthy": True, "evidence": "no plist"}
+    path = write_heartbeat(result, machine="pro")
+    assert not path.exists(), "NOT_CONFIGURED must never write a sidecar on a foreign machine"
+
+
+def test_heartbeat_written_ok_when_live(tmp_path, monkeypatch):
+    import check_flowkit_tunnel as mod
+
+    monkeypatch.setattr(mod, "HEARTBEAT_DIR", tmp_path)
+    result = {"organ": "flowkit_tunnel", "status": LIVE, "healthy": True, "evidence": "PID 1 alive, HTTP 404"}
+    path = write_heartbeat(result, machine="m5")
+    assert path.exists()
+    data = json.loads(path.read_text())
+    assert data["status"] == "ok"
+    assert data["degraded"] is False
+    assert data["organ"] == "m5.flowkit_tunnel"
+
+
+def test_heartbeat_written_error_when_down(tmp_path, monkeypatch):
+    import check_flowkit_tunnel as mod
+
+    monkeypatch.setattr(mod, "HEARTBEAT_DIR", tmp_path)
+    result = {"organ": "flowkit_tunnel", "status": DOWN, "healthy": False, "evidence": "unreachable"}
+    path = write_heartbeat(result, machine="m5")
+    data = json.loads(path.read_text())
+    assert data["status"] == "error"
+    assert data["degraded"] is True
+
+
+def test_heartbeat_feeds_organism_stale_detector_as_unhealthy_when_down(tmp_path, monkeypatch):
+    """End-to-end wiring proof: a DOWN heartbeat, once written, is picked up
+    by organism_stale_detector.scan_sidecars_status as unhealthy -- this is
+    what makes the next outage loud instead of silent."""
+    import check_flowkit_tunnel as mod
+
+    monkeypatch.setattr(mod, "HEARTBEAT_DIR", tmp_path)
+    result = {"organ": "flowkit_tunnel", "status": DOWN, "healthy": False, "evidence": "unreachable"}
+    write_heartbeat(result, machine="m5")
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    from organism_stale_detector import scan_sidecars_status
+
+    findings = scan_sidecars_status(str(tmp_path), now=time.time(), host="air-m5")
+    assert len(findings) == 1
+    assert findings[0].organ_id == "m5.flowkit_tunnel"
+    assert findings[0].kind == "unhealthy"


### PR DESCRIPTION
## Summary
- `com.balizero.flowkit-pro-tunnel` (M5's SSH port-forward: WR2 image-gen on M5 -> FlowKit hosted on Pro, `127.0.0.1:8100`/`9222`) had ZERO observability — no heartbeat sidecar, no proprioception entry, no alert.
- Found live 2026-08-21: stderr log accumulated 800+ `Operation timed out` lines across 5+ days (born 2026-08-15 04:25, last failure 2026-08-21 00:55) while the job silently self-recovered each time (KeepAlive + `ThrottleInterval=10s` correctly retrying through a Tailscale flap to Pro — family #8 network-flap, not a KeepAlive misconfig). Nobody noticed until an unrelated dispatch happened to `launchctl list` it.
- `launchctl list`'s own STATUS column is a trap: it prints the **last exit code even while the job is currently running** — measured live: PID alive 2h20m, tunnel forwarding real HTTP traffic, `launchctl list` still read `255` from the prior failed attempt.

## Fix
New `scripts/check_flowkit_tunnel.py`:
- Never trusts the launchctl STATUS column — only the PID column, cross-checked with a real `ps -p <pid>`.
- Then does a real HTTP GET through the forwarded port; any HTTP reply (even a 404/500) proves the tunnel forwards bytes end-to-end — only a connection-level failure is DOWN.
- Writes `~/.organism/last_seen/m5.flowkit_tunnel.json` (skipped entirely on machines without the plist — `NOT_CONFIGURED`, never a false alarm elsewhere).
- Wired into `proprioception.py`'s registry as an M5-only, on-demand wrap probe (new boundary class `tunnel<->reachable`) — no new daemon, consistent with CLAUDE.md's no-cron/no-daemon-H24 rule for M5; piggybacks on whatever already triggers a session's proprioception sweep (same pattern as the existing `arsenal_seats_vcr_m5` entry).
- Severity **P2**, not P1: `WR2_IMAGE_BACKEND=auto` (default) silently falls back to Playwright when this tunnel is down — a cost/latency finding (5-15s/image vs 30-90s), never data loss.

## Test plan
- [x] Guilt: no plist -> `NOT_CONFIGURED`; no PID -> `DOWN`; PID reported but `ps` finds nothing -> `DOWN` (the exact live gotcha); PID alive but port unreachable -> `DOWN`.
- [x] Innocence: PID alive + port answers (even HTTP 4xx/5xx) -> `LIVE`.
- [x] `_launchctl_pid` unit test reproduces the live 2026-08-21 output verbatim (`99968\t255\t...`) and proves only the PID column is read.
- [x] Heartbeat write/skip tests + end-to-end wiring test proving a DOWN heartbeat is picked up by `organism_stale_detector.scan_sidecars_status` as unhealthy.
- [x] `python3 -m pytest scripts/tests/test_check_flowkit_tunnel.py scripts/tests/test_proprioception*.py -q` → 96 passed.
- [x] `proprioception.validate_registry(DEFAULT_REGISTRY)` → `[]` (schema-valid, no dup ids).
- [x] Live smoke test on M5: tunnel currently `LIVE` (PID alive, FlowKit answers HTTP 404 through the forward) — heartbeat now reflects today's true state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)