### PR TITLE
fix(s7): restrict S4 yield segment to clients with a documented relationship

### DIFF
--- a/scripts/s7_yield_draft_local.py
+++ b/scripts/s7_yield_draft_local.py
@@ -89,6 +89,22 @@ SEGMENTS: dict[str, dict] = {
     "S4": {
         "label": "Active client, no contact 120d+ (relationship health)",
         "pitch": "a quick check-in on their current status and any pending needs",
+        # RESTRICTED 2026-08-21 (team-lead mandate, S7 segment-4 review): the pitch text
+        # says "a quick check-in", which presupposes a relationship that has gone quiet —
+        # but `last_interaction_date` is written in exactly one place
+        # (backend/.../crm_interactions.py, "UPDATE clients SET last_interaction_date =
+        # NOW()") ONLY when a team member manually logs an interaction. It is never
+        # touched by inbound WhatsApp, client creation, or practice activity. So NULL
+        # here does not mean "we have gone quiet on them" — it means "nobody on the team
+        # has ever clicked that button", which is true for clients we may never have
+        # actually served. Measured 2026-08-21: of 501 clients the un-restricted clause
+        # matched, only 124 (25%) had ever had a practice on file. Sending the "check-in"
+        # pitch to the other 376 would be a first-ever contact disguised as a follow-up.
+        # The EXISTS clause below requires at least one practice (any status — open,
+        # completed, or cancelled all prove a service relationship actually existed) so
+        # this segment only reaches clients the pitch's own premise is true for. DO NOT
+        # remove this clause to "simplify" the query — it is the entire point of the
+        # segment restriction, not incidental filtering.
         "sql": """
             SELECT c.id, c.full_name, c.nationality, c.assigned_to,
                    'last_contact' AS document_type, NULL::int AS days_until_expiry,
@@ -96,6 +112,7 @@ SEGMENTS: dict[str, dict] = {
             FROM clients c
             WHERE c.deleted_at IS NULL AND c.status='active'
               AND (c.last_interaction_date IS NULL OR c.last_interaction_date < now()-interval '120 days')
+              AND EXISTS (SELECT 1 FROM practices p WHERE p.client_id = c.id)
             ORDER BY c.last_interaction_date ASC NULLS FIRST
         """,
     },

--- a/scripts/tests/test_s7_yield_draft_s4_segment.py
+++ b/scripts/tests/test_s7_yield_draft_s4_segment.py
@@ -1,0 +1,177 @@
+"""scripts/s7_yield_draft_local.py -- S4 segment restriction (relationship-history
+gate for the "quick check-in" pitch).
+
+Team-lead mandate 2026-08-21: S4 ("active client, no contact 120d+") pulled 501
+clients with the un-restricted clause, but only 124 of them (25%) had ever had a
+practice on file. `last_interaction_date` is written in one place only
+(crm_interactions.py, on a manual team-member log) -- NULL means "nobody logged
+an interaction", not "we went quiet on a relationship that existed". Sending the
+"a quick check-in on their current status" pitch to a client with zero practice
+history would be a first-ever contact disguised as a follow-up. The fix adds
+`AND EXISTS (SELECT 1 FROM practices p WHERE p.client_id = c.id)` -- ANY practice
+status counts (open/completed/cancelled all prove a service relationship existed).
+
+Test strategy -- CTE-shadow against the live read-only role, ZERO real data touched:
+Postgres lets a `WITH clients AS (...)` / `WITH practices AS (...)` clause SHADOW
+the real tables for the scope of one query. We take SEGMENTS["S4"]["sql"]
+byte-for-byte from the module (no re-derivation -- W114-class bug: two sides that
+never agreed on the same logic is its own cicatrix) and wrap it with a fixture of
+two literal, non-existent client rows (id 1 = no practice, id 2 = one closed
+practice). The query never reads a single row of `clients` or `practices` --
+`nuzantara_readonly` only ever needs SELECT on literals here, and the fixture
+carries no PII (synthetic ids only). Skips cleanly if the DB/Keychain is
+unreachable (CI has neither) -- this is an integration proof, not a unit test
+duplicating the SQL in Python (duplicating it would drift from the real query,
+exactly the class of bug this file exists to avoid).
+
+Mutation proof (team-lead mandate step 4, performed live 2026-08-21, see PR body):
+the SAME fixture run against the SQL with the EXISTS clause stripped returns BOTH
+client 1 and client 2 -- i.e. the guilt test below (client 1 must be absent) goes
+red the moment the restriction is removed. Not re-encoded as a permanent pytest
+mutant (a standing mutant would defeat the real gate, matching the documented
+convention in test_yield_optimizer_pitch_gate.py) -- verified once, by hand,
+before shipping, and recorded here in prose per that same convention.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO / "scripts" / "s7_yield_draft_local.py"
+PG_SH = REPO / "scripts" / "pg.sh"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("s7_yield_draft_local", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+s7 = _load_module()
+
+# Synthetic fixture -- ids 1/2 never exist in the real table (client ids are
+# sequential from a live production sequence, and these two rows are shadowed
+# CTEs, never inserted anywhere). No name/contact/PII: literal placeholders only.
+_FIXTURE = """
+    WITH clients AS (
+        SELECT * FROM (VALUES
+            (1, 'Client A'::varchar, 'Test'::varchar, 'owner@balizero.com'::varchar,
+             'active'::varchar, NULL::timestamptz, (now() - interval '200 days')::timestamptz),
+            (2, 'Client B'::varchar, 'Test'::varchar, 'owner@balizero.com'::varchar,
+             'active'::varchar, NULL::timestamptz, (now() - interval '200 days')::timestamptz)
+        ) AS t(id, full_name, nationality, assigned_to, status, deleted_at, last_interaction_date)
+    ),
+    practices AS (
+        SELECT * FROM (VALUES
+            (100, 2, 'completed'::varchar, 'paid'::varchar)
+        ) AS t(id, client_id, status, payment_status)
+    )
+"""
+
+
+def _run_sql(sql: str) -> list[str]:
+    """Execute `sql` via scripts/pg.sh against the live READ-ONLY role and
+    return the returned client ids (col 1) as strings. Raises RuntimeError if
+    the DB/Keychain is unreachable -- callers translate that into a skip."""
+    proc = subprocess.run(
+        [str(PG_SH), "-tA", "-c", sql],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "pg.sh failed")
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+@pytest.fixture(scope="module")
+def s4_ids_with_restriction() -> list[str]:
+    """The REAL S4 query (SEGMENTS["S4"]["sql"], untouched) run against the
+    synthetic fixture. Skips if the readonly DB/Keychain isn't reachable."""
+    sql = _FIXTURE + s7.SEGMENTS["S4"]["sql"]
+    try:
+        rows = _run_sql(sql)
+    except (RuntimeError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+        pytest.skip(f"readonly Postgres unreachable, skipping integration proof: {e}")
+    # pg.sh -tA on a multi-column SELECT prints '|'-joined rows; the id is the
+    # first field.
+    return [row.split("|", 1)[0] for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# Guilt: silent 200d, ZERO practices -> excluded from S4.
+# ---------------------------------------------------------------------------
+
+
+def test_client_with_no_practice_never_ever_contacted_is_excluded(
+    s4_ids_with_restriction,
+):
+    assert "1" not in s4_ids_with_restriction, (
+        "client_id=1 (active, silent 200d, NO practice on file) must NOT enter "
+        "S4 -- the 'quick check-in' pitch presupposes a relationship the CRM "
+        "cannot document for this client"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Innocence: silent 200d, WITH a (closed) practice -> still included.
+# ---------------------------------------------------------------------------
+
+
+def test_client_with_a_closed_practice_still_enters_s4(s4_ids_with_restriction):
+    assert "2" in s4_ids_with_restriction, (
+        "client_id=2 (active, silent 200d, ONE completed practice) must still "
+        "enter S4 -- the restriction proves a relationship existed, it must not "
+        "additionally require the practice to be currently OPEN"
+    )
+
+
+def test_only_the_documented_relationship_survives(s4_ids_with_restriction):
+    """Exact-membership guard: the fixture has exactly one client that should
+    survive the restriction. If a future edit widens the EXISTS clause (e.g.
+    to also implicitly admit undocumented clients via an OR), this catches it
+    even if the two tests above would individually still pass."""
+    assert s4_ids_with_restriction == ["2"]
+
+
+# ---------------------------------------------------------------------------
+# Mutation-proof scaffold (not run automatically -- see module docstring):
+# the same fixture against the SQL with the EXISTS clause stripped. Kept here,
+# skipped by default, so a future session can re-verify the mutation without
+# hand-editing the shipped module (which would itself be the mutant the repo's
+# guard-conformance doctrine warns never to leave standing).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(
+    reason=(
+        "manual mutation-proof, not a standing CI mutant (see module "
+        "docstring / test_yield_optimizer_pitch_gate.py precedent) -- run "
+        "with `-m ''` to re-verify by hand"
+    )
+)
+def test_mutation_without_exists_clause_both_clients_appear():
+    unrestricted_sql = s7.SEGMENTS["S4"]["sql"].replace(
+        "AND EXISTS (SELECT 1 FROM practices p WHERE p.client_id = c.id)\n", ""
+    )
+    try:
+        rows = _run_sql(_FIXTURE + unrestricted_sql)
+    except (RuntimeError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+        pytest.skip(f"readonly Postgres unreachable: {e}")
+    ids = sorted(row.split("|", 1)[0] for row in rows)
+    assert ids == ["1", "2"], (
+        "with the restriction stripped, BOTH the undocumented client (1) and "
+        "the documented one (2) must reappear -- proving the guilt test above "
+        "is actually exercising the EXISTS clause, not a coincidence of the "
+        "fixture"
+    )


### PR DESCRIPTION
## Summary
- S4 ("active client, no contact 120d+") of `scripts/s7_yield_draft_local.py` matched **501** clients on the un-restricted `last_interaction_date` clause, but only **124** (25%) ever had a practice on file — `last_interaction_date` is written in exactly one place (`crm_interactions.py`, on a manual team-member log), so `NULL` means "nobody logged an interaction," not "we went quiet on an existing relationship." The pitch text ("a quick check-in on their current status") presupposes a relationship the CRM cannot document for 3/4 of the un-restricted set.
- Adds `AND EXISTS (SELECT 1 FROM practices p WHERE p.client_id = c.id)` to S4 — any practice status counts (open/completed/cancelled all prove a service relationship existed). A comment in the module explains the invariant so a future edit doesn't "simplify" the clause away.
- **Re-measured counts (2026-08-21, read-only role, matches team-lead's original numbers exactly):** `total_active=761` · `s4_no_cap(before)=501` (`null_branch=376`, `stale_branch=125`) · `s4_with_any_practice=124` · `s4_with_open_practice=4`.
- **S4 count: 501 → 124.**

## Test plan
- [x] `scripts/tests/test_s7_yield_draft_s4_segment.py` — CTE-shadow guilt/innocence against the live read-only role, executing the real `SEGMENTS["S4"]["sql"]` string byte-for-byte (no logic duplicated in Python). Skips cleanly if DB/Keychain unreachable.
  - Guilt: synthetic client with silent 200d + **zero** practices → excluded.
  - Innocence: synthetic client with silent 200d + **one completed** practice → still included.
  - Exact-membership: only the documented client survives.
- [x] Mutation-verified live: stripped the `EXISTS` clause and re-ran the same fixture — both synthetic clients reappeared, confirming the guilt test goes red without the restriction. Restored before commit; not left as a standing CI mutant (same convention as `test_yield_optimizer_pitch_gate.py`).
- [x] Module imports clean, `SEGMENTS["S4"]["sql"]` contains the `EXISTS` clause.
- [x] No DB writes — read-only query change only. No PII in code/tests/PR body (client_id + aggregate counts only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)