### PR TITLE
feat(harness): gear ceiling — Gear-1-shaped diffs cannot declare Gear 3 + council without a reason

### DIFF
--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -304,6 +304,40 @@ jobs:
           echo "::notice::published default harness/fable-gate=success (gear ${GEAR} < 3)"
 
       # -----------------------------------------------------------------
+      # Step 7a5 — measured net lines for evidence_pack_lint's rule 7
+      # (gear ceiling), merge-base anchored (never a two-dot diff against
+      # the live base tip — the exact W102 lie the changed-files
+      # enumeration above already avoids). BEST-EFFORT and non-blocking:
+      # if the merge-base can't be resolved, this step just skips emitting
+      # --numstat-file — evidence_pack_lint.py then falls back to the
+      # pack's own self-declared `net_lines:` (with its own NOTICE) or
+      # asserts nothing, it never treats "couldn't measure" as "measured
+      # zero" (that would be a false small-shape signal on a large diff).
+      # Gated the same as Step 7b — it only feeds that step.
+      # -----------------------------------------------------------------
+      - name: Compute measured net lines (merge-base anchored, best-effort)
+        if: |
+          steps.kill_switch.outputs.disabled != 'true' &&
+          steps.brief.outputs.present == 'true' &&
+          steps.gearcheck.outputs.gear == '3'
+        id: netlines
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+        run: |
+          set -u
+          MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)"
+          if [[ -z "$MERGE_BASE" ]]; then
+            echo "::notice::merge-base not resolvable — net-lines measurement skipped for this run (evidence_pack_lint falls back to pack-declared net_lines with a NOTICE, or asserts nothing)"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --no-renames --numstat "$MERGE_BASE" "$HEAD_SHA" > /tmp/net-lines-numstat.txt
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "measured net-lines numstat (merge-base $MERGE_BASE):"
+          cat /tmp/net-lines-numstat.txt
+
+      # -----------------------------------------------------------------
       # Step 7b — Gear-3, floor satisfied: validate the ACTUAL Evidence
       # Pack (evidence/pack.yml), not just the brief's declared gear field.
       # Adversarial-review finding 2026-08-10: the first cut of this
@@ -313,6 +347,9 @@ jobs:
       # + pack.yml at the SAME relative layout the linter expects
       # (brief_ref: "evidence/brief.yml" resolves against --repo-root), so
       # this reuses the exact same check_* rules a local run would.
+      # --numstat-file (Step 7a5) is passed only when it was actually
+      # produced — never a bare/empty arg that could read as "0 net lines
+      # measured" (adversarial-review finding 2026-08-21).
       # -----------------------------------------------------------------
       - name: Gear-3 — validate evidence/pack.yml against the Evidence Pack contract
         if: |
@@ -322,6 +359,7 @@ jobs:
         id: packlint
         env:
           HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
+          NETLINES_AVAILABLE: ${{ steps.netlines.outputs.available }}
         run: |
           set -u
           # Same bootstrap-window exemption as the floor-computation step
@@ -339,10 +377,15 @@ jobs:
           fi
           git show "$HEAD_SHA:evidence/pack.yml" > /tmp/evidence-check/evidence/pack.yml
           cp /tmp/brief.yml /tmp/evidence-check/evidence/brief.yml
+          EXTRA_ARGS=()
+          if [[ "$NETLINES_AVAILABLE" == "true" ]]; then
+            EXTRA_ARGS+=(--numstat-file /tmp/net-lines-numstat.txt)
+          fi
           python3 scripts/evidence_pack_lint.py \
             /tmp/evidence-check/evidence/pack.yml \
             --repo-root /tmp/evidence-check \
-            --changed-files-file /tmp/changed-files.txt
+            --changed-files-file /tmp/changed-files.txt \
+            "${EXTRA_ARGS[@]}"
 
       # -----------------------------------------------------------------
       # Step 7c — Gear-3, floor satisfied, pack conformant: this workflow

--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -326,6 +326,24 @@ jobs:
           HEAD_SHA: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
         run: |
           set -u
+          # This job's checkout (Step 1) is BASE, not HEAD — the "grader
+          # self-protects" pattern (see the bootstrap-window comment on the
+          # file-existence check below). scripts/evidence_pack_lint.py as it
+          # exists in THIS run is therefore whatever origin/main carried at
+          # PR-open/sync time, which may predate any PR (like this one) that
+          # is still teaching the script --numstat-file. Probe the capability
+          # of the copy we can actually execute before promising it — this
+          # stays self-consistent both before and after such a PR merges.
+          if [[ ! -f scripts/evidence_pack_lint.py ]]; then
+            echo "::notice::scripts/evidence_pack_lint.py not in base checkout yet (bootstrap run) — net-lines measurement skipped"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! python3 scripts/evidence_pack_lint.py --help 2>&1 | grep -q -- '--numstat-file'; then
+            echo "::notice::the evidence_pack_lint.py copy in use (checked out from base $BASE_SHA) does not support --numstat-file yet — net-lines measurement skipped for this run; self-consistent once this PR merges and base's copy is updated"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)"
           if [[ -z "$MERGE_BASE" ]]; then
             echo "::notice::merge-base not resolvable — net-lines measurement skipped for this run (evidence_pack_lint falls back to pack-declared net_lines with a NOTICE, or asserts nothing)"

--- a/evidence/brief.yml
+++ b/evidence/brief.yml
@@ -1,40 +1,42 @@
-task_id: ops-codex-runtime-worktree-deps-pr4007
+task_id: ops-gear-ceiling-pr4474
 gear: 3
 l_level: L3
 gate_class: fable
 objective: |
-  Make the Codex nightly autofix runtime worktree usable without allowing an
-  unattended failed-branch repair to act on the primary checkout, borrow host
-  secrets, or control its outer push. Repair stale virtual-environment links,
-  reject ambiguous runtime and run provenance, and carry executable
-  trust-boundary regression coverage plus the required Gear-3 evidence.
+  Give the deterministic gear floor (compute_floor(), harness-floor.yml rule 6)
+  a matching CEILING: a diff shaped like a docs/ledger-only or small change
+  (<=2 files, <=60 net lines) must not silently declare Gear 3 while also
+  convening a council or dispatching >=3 graders, unless the pack names a
+  reasoned gear_override. Add effort_for_gear() so effort is tied to gear
+  (2026-08-21 audit lever L0/L6: 65% of declared gears are Gear 3, 70% of
+  Agent dispatches are graders, ~86% of output tokens are thinking). Harden
+  the ceiling's net-line signal so a pack cannot dodge it by under-reporting
+  its own net_lines — a measured value (git diff --numstat, merge-base
+  anchored) must take precedence over the pack's self-declared field.
 constraints:
-  - ".github/workflows/broker-hygiene.yml is a CODEOWNERS Tier-1 hot-zone; actionlint must pass and no existing gate may be weakened"
-  - "unattended runtime setup may link only the backend virtual environment from the primary checkout; it must never link dotenv files, node_modules, or Husky dispatchers"
-  - "a real directory already present in the runtime worktree must never be replaced"
-  - "the runtime must be a distinct registered worktree, and every managed link must remain confined beneath its canonical root"
-  - "the failed-branch runner must reject untrusted provenance and run its pre-push gate from a bundle pinned to origin/main, not from the failed branch"
-  - "no force push, merge, auto-merge change, deployment, or live HOME-file mutation in this task"
+  - '.github/workflows/harness-floor.yml is a CODEOWNERS Tier-1 hot-zone; actionlint must pass and required context names ("Harness floor recompute") stay unchanged'
+  - "compute_ceiling stays a PURE function — no I/O, no git — exactly like compute_floor; any git diff --numstat call happens in the CLI/workflow layer, never inside the function itself"
+  - "compute_ceiling/effort_for_gear are NOT check_-prefixed — guard-conformance's ast-def-prefix census only picks up check_*, and these two are not guards in that registry's sense"
+  - "the FLOOR always wins over the ceiling on conflict — a hot-zone hit floors AND ceilings at 3, silently, never a contradictory verdict"
+  - "a measured net-lines source (--net-lines / --numstat-file) must take precedence over the pack's self-declared net_lines: field, with a NOTICE (never a violation) when only the self-declared value is available"
+  - 'the net-lines measurement step in harness-floor.yml is best-effort: an unresolvable merge-base must never be read as "0 net lines measured" (a false small-shape signal on a large diff)'
 acceptance:
-  - "bash scripts/tests/test_codex_runtime_worktree_deps.sh reports all runtime confinement guilt and innocence cases passed"
-  - "bash scripts/tests/test_codex_trusted_prepush_bundle.sh proves branch-controlled hooks and all transitive gate helpers cannot affect the unattended push"
-  - "python3 scripts/tests/test_codex_autofix_selector.py proves untrusted actor, triggering actor, fork, event, namespace, and SHA metadata are rejected"
-  - "bash -n and shellcheck pass for the library and executable regression corpus"
-  - "actionlint .github/workflows/broker-hygiene.yml exits 0"
-  - "infra/home-fork/declared-pairs.json parses as valid JSON"
+  - "scripts/tests/test_evidence_pack_lint.py: 59/59 pass, including guilt/innocence pairs for compute_ceiling, effort_for_gear, and the measured-vs-self-declared net_lines precedence"
+  - "python3 scripts/evidence_pack_lint.py --selftest exits 0"
+  - "infra/guard-conformance/check_guard_conformance.py reports 0 violations and the same 6 evidence-pack-lint checks as before this diff (compute_ceiling/effort_for_gear not auto-censused)"
   - "python3 scripts/docs_sync.py --check reports no drift"
+  - "actionlint .github/workflows/harness-floor.yml exits 0"
   - "python3 scripts/evidence_pack_lint.py validates this pack against the merge-base changed-file set"
 consumer_map:
-  - "scripts/codex/codex-nightly-autofix-ci.sh calls codex_auto_ensure_runtime_worktree before scanning or fixing CI failures"
-  - ".github/workflows/broker-hygiene.yml runs the regression corpus when the library or test changes"
-  - "the nightly runtime has a narrower dependency contract than the interactive broker because it checks out failed branch content without a human session"
-  - "infra/home-fork/declared-pairs.json makes the repo helper visible to the HOME-fork reconciliation machinery"
+  - "harness-floor.yml Step 7b (Gear-3 pack validation) runs evidence_pack_lint.py against evidence/pack.yml on every Gear-3 PR — this is the ONLY currently-required consumer (the harness/fable-gate commit status itself is not yet a required context per the workflow's own header note)"
+  - "any future pack author declaring gear: 3 with council/grader_dispatches fields on a small/docs diff is now subject to rule 7"
+  - "wrapper scripts may call --effort-for GEAR to pick medium/xhigh without importing this module"
 risks:
-  - "a Git merge does not itself update the declared live HOME copy; host reconciliation remains an operator/automation delivery step"
-  - "the backend virtual environment remains a shared host dependency; only a trusted actor and same-repository run can make the unattended runner execute branch code inside the explicit workspace-write sandbox"
-  - "the regression corpus uses disposable local Git repositories and does not prove a production LaunchAgent invocation"
-grader: codex-sol
+  - "compute_ceiling is a net-new opt-in signal — a Gear-3 pack that never declares council/grader_dispatches is never flagged by this diff, so there is no retroactive gate change on packs written before this PR"
+  - "the harness-floor.yml net-lines step adds one git diff --numstat call, gated to Gear-3 PRs only — negligible additional runner time"
+  - "this PR's own diff (backend .py + tests + one workflow file) is not Gear-1-shaped by either predicate, so it never triggers its own new ceiling rule"
+grader: sonnet-5
 budget:
-  seats: [sonnet-5, codex-sol]
-  fable_gate_est_tokens: 1200
+  seats: [sonnet-5]
+  fable_gate_est_tokens: 900
 pii: none

--- a/evidence/pack.yml
+++ b/evidence/pack.yml
@@ -1,66 +1,70 @@
 brief_ref: evidence/brief.yml
-plan_ref: "PR #4007 — runtime worktree dependency repair"
+plan_ref: "PR #4474 — gear ceiling + effort per gear (2026-08-21 audit lever L0/L6)"
 diff:
-  files: 13
-  insertions: 1137
-  deletions: 130
+  files: 5
+  insertions: 802
+  deletions: 78
   hotzone_hits:
-    - ".github/workflows/broker-hygiene.yml"
+    - ".github/workflows/harness-floor.yml"
 receipts:
-  - claim: "the executable guilt and innocence corpus rejects fake, nested, primary-alias, stale-link, and parent-symlink runtime worktrees while preserving the valid registered worktree case"
-    cmd: "bash scripts/tests/test_codex_runtime_worktree_deps.sh"
+  - claim: "the new + existing evidence_pack_lint test suite passes in full, including the measured-vs-self-declared net_lines guilt/innocence pairs"
+    cmd: "cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest ../../scripts/tests/test_evidence_pack_lint.py -q"
     exit: 0
-    ts: "2026-08-11T00:00:00Z"
-    seat: "codex"
-  - claim: "the selector rejects untrusted provenance and only accepts a trusted same-repository event whose REST metadata matches the listed branch and immutable SHA"
-    cmd: "python3 scripts/tests/test_codex_autofix_selector.py"
+    ts: "2026-08-21T00:00:00Z"
+    seat: "sonnet-5"
+  - claim: "the script's own embedded --selftest guilt+innocence corpus passes, including the new compute_ceiling/effort_for_gear unit checks"
+    cmd: "python3 scripts/evidence_pack_lint.py --selftest"
     exit: 0
-    ts: "2026-08-11T00:00:00Z"
-    seat: "codex"
-  - claim: "the unattended push uses only a pre-push bundle copied from a pinned trusted commit and rejects tampering to every transitive bundle member"
-    cmd: "bash scripts/tests/test_codex_trusted_prepush_bundle.sh"
+    ts: "2026-08-21T00:00:00Z"
+    seat: "sonnet-5"
+  - claim: "guard-conformance stays 0 violations and the evidence-pack-lint surface stays at exactly 6 censused checks — compute_ceiling and effort_for_gear are not check_-prefixed, so they were not auto-censused into the registry"
+    cmd: "python3 infra/guard-conformance/check_guard_conformance.py"
     exit: 0
-    ts: "2026-08-11T00:00:00Z"
-    seat: "codex"
-  - claim: "the modified shell entrypoints parse and pass error-level shellcheck"
-    cmd: "bash -n scripts/codex_automation_lib.sh scripts/codex/codex-nightly-autofix-ci.sh .husky/pre-push scripts/tests/test_codex_runtime_worktree_deps.sh scripts/tests/test_codex_trusted_prepush_bundle.sh && shellcheck -S error scripts/codex_automation_lib.sh scripts/codex/codex-nightly-autofix-ci.sh .husky/pre-push scripts/tests/test_codex_runtime_worktree_deps.sh scripts/tests/test_codex_trusted_prepush_bundle.sh"
-    exit: 0
-    ts: "2026-08-11T00:00:00Z"
-    seat: "codex"
-  - claim: "the canonical documentation counters have no drift after reconciling current main"
+    ts: "2026-08-21T00:00:00Z"
+    seat: "sonnet-5"
+  - claim: "no docs-sync drift after this diff"
     cmd: "python3 scripts/docs_sync.py --check"
     exit: 0
-    ts: "2026-08-11T00:00:00Z"
-    seat: "codex"
+    ts: "2026-08-21T00:00:00Z"
+    seat: "sonnet-5"
+  - claim: "the modified harness-floor.yml (hot-zone, CODEOWNERS Tier-1) is schema/expression-valid"
+    cmd: "actionlint .github/workflows/harness-floor.yml"
+    exit: 0
+    ts: "2026-08-21T00:00:00Z"
+    seat: "sonnet-5"
+  - claim: "the sibling harness gate test suite is unaffected"
+    cmd: "cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest ../../scripts/tests/test_harness_fable_gate.py -q"
+    exit: 0
+    ts: "2026-08-21T00:00:00Z"
+    seat: "sonnet-5"
 tests:
-  cmd: "bash scripts/tests/test_codex_runtime_worktree_deps.sh && bash scripts/tests/test_codex_trusted_prepush_bundle.sh && python3 scripts/tests/test_codex_autofix_selector.py"
-  passed: 68
+  cmd: "pytest scripts/tests/test_evidence_pack_lint.py -q && python3 scripts/evidence_pack_lint.py --selftest"
+  passed: 59
   failed: 0
 static:
   lint: ok
   typecheck: n/a
   build: n/a
 runtime_proof:
-  - "a runtime path nested under, equal to, or resolving to the primary checkout is rejected"
-  - "a foreign standalone repository and a parent-component symlink escape are rejected"
-  - "only the backend virtual environment is linked, and absent or mismatched managed links are removed rather than retained"
-  - "the runner accepts only trusted actor plus triggering actor, same repository, an explicit event allowlist, an allowed branch namespace, and a metadata-verified immutable SHA"
-  - "the unattended push executes a pre-push hook and all its helpers from an origin/main-pinned bundle; a branch hook and tampered bundle members are rejected"
+  - "compute_ceiling flags a Gear-3 pack with a council/>=3 grader dispatches over a docs-only or small (<=2 files) diff, and clears with a non-empty gear_override instead of failing"
+  - "a hot-zone hit always floors AND ceilings at 3, silently — no conflicting verdict between rule 6 and rule 7"
+  - "a measured net_lines value (from --net-lines or --numstat-file, summed via sum_numstat()) overrides a pack's own self-declared net_lines field for rule 7's small-diff predicate — verified against a lying pack (declares 10, measured 400 -> not asserted) and the reverse (pack omits net_lines, measured 20 -> asserted)"
+  - "relying on a self-declared net_lines (no measured value supplied) still works but adds a distinguishable 'ceiling (notice)' line naming that lower-trust source, never a violation on its own"
+  - "harness-floor.yml's new net-lines step is best-effort: an unresolvable merge-base skips --numstat-file entirely rather than passing an empty/zero measurement that would read as a false small-diff signal"
 dissent:
-  - seat: red-team
-    objection: "The original repair accepted nested primary paths and links to dotenv files, node_modules, and Husky dispatchers; an unattended failed-branch runner could therefore act on the primary checkout, read host secrets, or execute a branch-controlled pre-push hook."
+  - seat: team-lead
+    objection: "The first cut of compute_ceiling's shape-(b) predicate trusted the pack's own self-declared net_lines field unconditionally — a pack author could dodge the entire ceiling by simply writing net_lines: 10 (or omitting a large real diff's true size), since nothing measured the actual diff against that claim."
     status: CONFIRMED
-    repro: "The expanded executable corpus reproduced each path escape, retained stale link, and branch-hook execution condition against the original PR head."
-    resolution: "Require exact registered-worktree identity, canonical parent containment, a venv-only runtime dependency set, fail-closed provenance, an explicit workspace-write sandbox, and a bundle copied plus reverified from a trusted main commit immediately before push."
+    repro: 'compute_ceiling(diff_2_files, 3, {"net_lines": 10, "council": True}) with no measured value returned a guilty verdict purely on the pack''s own unverified claim; a hostile or careless author declaring a false low net_lines on a genuinely large diff would silently escape the ceiling.'
+    resolution: "Added an optional measured_net_lines parameter (still pure — no I/O inside compute_ceiling itself) that takes precedence over the pack's self-declared net_lines whenever supplied; wired --net-lines/--numstat-file into the CLI and a merge-base-anchored git diff --numstat step into harness-floor.yml's Step 7b (gated to Gear-3 PRs, best-effort — never blocks or falsely reports zero on measurement failure). Falling back to the self-declared value now also emits a distinguishable 'ceiling (notice)' line so the source of the shape decision is never silent."
 residual_risks:
-  - "PROVE-LIVE still requires the declared HOME-fork sync and the next scheduled nightly run after an external operator merges the PR"
-  - "the dormant M5 nightly payload remains deliberately outside this PR's activation scope"
+  - "the hot-zone/floor list (HOTZONE_PATTERNS) is still a deliberate, declared duplicate of hot-zone-pr-gate.yml's bash case-block (pre-existing, noted in the module docstring, not touched by this PR) — a future consolidation into one source is a fair follow-up, not a blocker here"
+  - "the harness/fable-gate commit status itself is still not a required branch-protection context (per the workflow's own header note, blocked pending a synthetic-SHA relay + fork-PR write-permission design) — this PR's Gear-3 declaration satisfies the required 'Harness floor recompute' JOB, not an actual posted real-gate verdict, consistent with every other Gear-3 PR merged under this system to date"
+  - "council/grader_dispatches are net-new pack fields with no producer yet writing them automatically — until a wrapper populates them, rule 7 is dormant in practice (a real ship, not a regression: it fires the moment a pack starts declaring them, and never fires falsely on packs that don't)"
 sources:
-  - "scripts/codex_automation_lib.sh"
-  - "scripts/codex/codex-nightly-autofix-ci.sh"
-  - ".husky/pre-push"
-  - ".github/CODEOWNERS"
-  - "infra/home-fork/declared-pairs.json"
-  - "research/operations/2026-08-09-harness-v2-teman2.md §1/§5/§6"
+  - "scripts/evidence_pack_lint.py"
+  - "scripts/tests/test_evidence_pack_lint.py"
+  - ".github/workflows/harness-floor.yml"
+  - "research/operations/2026-08-21-token-ceremony-ci-system-audit.md §7 lever L6, §8"
 pii_scan: clean
-size_tokens: 1024
+size_tokens: 1400

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -96,14 +96,21 @@ WHAT IT VALIDATES (an Evidence Pack YAML, default path evidence/pack.yml):
                         diff from declaring LESS gear than a hot-zone hit
                         demands; the ceiling stops the opposite — a diff
                         shaped like a docs/ledger-only or small (<=2 files,
-                        <=60 net lines, pack-declared) change may not
-                        silently declare Gear 3 while also convening a
-                        `council` or dispatching >=3 graders. REJECTED
-                        unless the pack carries a non-empty, reasoned
-                        `gear_override:` one-liner — in which case it is
-                        REPORTED (stderr NOTICE), never a violation. Floor
-                        always wins when the two conflict: a hot-zone hit
-                        floors AND ceilings at 3, silently. See
+                        <=60 net lines) change may not silently declare
+                        Gear 3 while also convening a `council` or
+                        dispatching >=3 graders. REJECTED unless the pack
+                        carries a non-empty, reasoned `gear_override:`
+                        one-liner — in which case it is REPORTED (stderr
+                        NOTICE), never a violation. The net-line count
+                        prefers a MEASURED value (--net-lines /
+                        --numstat-file, a real `git diff --numstat` sum)
+                        over the pack's own self-declared `net_lines:` field
+                        (adversarial-review finding 2026-08-21 — a pack
+                        under-reporting its size must not escape the
+                        ceiling); falling back to the self-declared value
+                        also emits a "ceiling (notice)" line naming that
+                        fact. Floor always wins when the two conflict: a
+                        hot-zone hit floors AND ceilings at 3, silently. See
                         compute_ceiling()'s own docstring for the full
                         contract. Skipped, same as rule 6, whenever
                         --changed-files-file is not supplied.
@@ -125,14 +132,26 @@ a lint that scanned nothing must not report clean):
 
 CLI:
   python3 scripts/evidence_pack_lint.py [PACK_PATH] [--repo-root DIR]
-      [--changed-files-file PATH] [--print-floor] [--effort-for GEAR]
-      [--json] [--selftest]
+      [--changed-files-file PATH] [--net-lines INT] [--numstat-file PATH]
+      [--print-floor] [--effort-for GEAR] [--json] [--selftest]
 
   PACK_PATH        defaults to evidence/pack.yml (relative to --repo-root)
   --repo-root      defaults to the git top-level, else cwd
   --changed-files-file  newline-delimited changed-path list (the output of
                         scripts/ci/hotzone_changed_files.sh) — enables rules
                         6 (floor) and 7 (ceiling)
+  --net-lines INT  a pre-computed net-line count (e.g. `git diff --numstat
+                    "$BASE" "$HEAD" | awk '{a+=$1;d+=$2} END {print a-d}'`,
+                    merge-base anchored — never a two-dot diff, W102) for
+                    rule 7's shape (b). Takes precedence over --numstat-file,
+                    which takes precedence over the pack's own self-declared
+                    `net_lines:` field. No effect without
+                    --changed-files-file.
+  --numstat-file PATH  raw `git diff --numstat` output (tab-separated
+                    added/deleted/path per line, `-`/`-` for binary files
+                    skipped) — this script sums added-deleted itself so
+                    callers don't need the awk one-liner. Ignored if
+                    --net-lines is also given.
   --print-floor    given --changed-files-file, print the computed floor int
                     and exit 0 (no pack read) — lets any caller (CI, a human)
                     ask "what floor would this diff impose" without spinning
@@ -234,7 +253,10 @@ CEILING_HEAVY_GRADER_DISPATCH_MIN = 3
 
 
 def compute_ceiling(
-    changed_paths: list[str], declared_gear: int | None, pack: dict[str, Any]
+    changed_paths: list[str],
+    declared_gear: int | None,
+    pack: dict[str, Any],
+    measured_net_lines: int | None = None,
 ) -> tuple[int, list[str]]:
     """Returns (ceiling, reasons). Mirrors compute_floor()'s lower-bound-only
     shape but at the opposite end: it names a Gear-1-shaped diff (never a
@@ -245,13 +267,20 @@ def compute_ceiling(
     A diff is Gear-1-SHAPED when either:
       (a) every changed path is docs/ledger/markdown/json-only
           (DOCS_LEDGER_EXTENSIONS), or
-      (b) it touches at most CEILING_SMALL_DIFF_MAX_FILES files AND the pack
-          declares `net_lines` (the session's own 30s count, per the audit's
-          §8 ship-path spec — this function does not shell out to git to
-          derive it, staying pure like compute_floor) at or under
-          CEILING_SMALL_DIFF_MAX_NET_LINES.
-    net_lines being ABSENT from the pack does not assert shape (b) — an
-    unmeasured diff is not evidence of smallness.
+      (b) it touches at most CEILING_SMALL_DIFF_MAX_FILES files AND its net
+          line count is at or under CEILING_SMALL_DIFF_MAX_NET_LINES.
+    The net-line count for (b) is `measured_net_lines` when the caller
+    supplies one (a real `git diff --numstat` sum, computed OUTSIDE this
+    function — it stays pure, no I/O, like compute_floor). MEASURED ALWAYS
+    WINS over the pack's own `net_lines:` field (adversarial-review finding
+    2026-08-21 — a pack declaring 10 while the real diff is 400 lines must
+    not silently escape the ceiling just because the author under-reported
+    it). Only when `measured_net_lines` is absent does this function fall
+    back to the pack-declared `net_lines`, and it then ADDS an informational
+    "ceiling (notice): net_lines self-declared (no --net-lines supplied)"
+    line — self-declared data is lower-trust, and the caller should know
+    which source decided shape (b). Neither source present -> shape (b) is
+    simply not asserted (an unmeasured diff is not evidence of smallness).
 
     FLOOR ALWAYS WINS: if changed_paths hits the hot-zone (compute_floor==3),
     this function returns (3, []) immediately — a hot-zone docs file still
@@ -263,11 +292,13 @@ def compute_ceiling(
     `grader_dispatches >= CEILING_HEAVY_GRADER_DISPATCH_MIN`. A Gear-3 pack
     with neither is not over-provisioned by this signal and gets no reason.
 
-    Reason-string contract for the caller (lint()): an entry NOT prefixed
-    "ceiling (overridden)" is a hard violation (guilt — fail); an entry
-    prefixed "ceiling (overridden)" is informational only (the pack supplied
-    a non-empty `gear_override` one-liner) and must NOT be added to
-    `violations` — "the ceiling does not fail, it reports."
+    Reason-string contract for the caller (lint()): an entry that starts
+    with the bare "ceiling: " prefix (colon directly after the word) is a
+    hard violation (guilt — fail). Any entry with a parenthetical qualifier
+    right after "ceiling" — "ceiling (overridden): ..." (a non-empty
+    `gear_override` was supplied) or "ceiling (notice): ..." (self-declared
+    net_lines was consulted) — is informational only and must NOT be added
+    to `violations`; "the ceiling does not fail, it reports."
     """
     pack = pack if isinstance(pack, dict) else {}
     changed_paths = changed_paths or []
@@ -285,16 +316,35 @@ def compute_ceiling(
     docs_shaped = all(
         any(f.endswith(ext) for ext in DOCS_LEDGER_EXTENSIONS) for f in changed_paths
     )
-    net_lines = pack.get("net_lines")
-    net_lines_known = type(net_lines) is int  # exclude bool (True/False is not a count)
+
+    net_lines: int | None
+    net_lines_source: str | None
+    if type(measured_net_lines) is int:  # exclude bool — True/False is not a count
+        net_lines = measured_net_lines
+        net_lines_source = "measured"
+    else:
+        raw = pack.get("net_lines")
+        if type(raw) is int:
+            net_lines = raw
+            net_lines_source = "pack"
+        else:
+            net_lines = None
+            net_lines_source = None
+
     small_shaped = (
         len(changed_paths) <= CEILING_SMALL_DIFF_MAX_FILES
-        and net_lines_known
+        and net_lines is not None
         and net_lines <= CEILING_SMALL_DIFF_MAX_NET_LINES
     )
 
     if not (docs_shaped or small_shaped):
         return 3, []  # not a Gear-1-shaped diff — no ceiling to assert
+
+    reasons: list[str] = []
+    if small_shaped and net_lines_source == "pack":
+        reasons.append(
+            "ceiling (notice): net_lines self-declared (no --net-lines supplied)"
+        )
 
     council = bool(pack.get("council"))
     grader_dispatches = pack.get("grader_dispatches")
@@ -309,13 +359,13 @@ def compute_ceiling(
             return 1, [
                 f"ceiling (overridden): Gear 1 shape — declared Gear 3 with {cause}, "
                 f"overridden: {override.strip()}"
-            ]
+            ] + reasons
         return 1, [
             "ceiling: Gear 1 shape — declared Gear 3 with "
             f"{cause}; declare the reason in `gear_override:`"
-        ]
+        ] + reasons
 
-    return 1, []
+    return 1, reasons
 
 
 # ---------------------------------------------------------------------------
@@ -513,6 +563,7 @@ def lint(
     pack_path: Path,
     repo_root: Path,
     changed_files: list[str] | None,
+    measured_net_lines: int | None = None,
 ) -> tuple[int, list[str]]:
     """Returns (exit_code, violations). exit_code: 0 clean, 1 guilty, 2 blind."""
     if not pack_path.exists():
@@ -555,14 +606,18 @@ def lint(
         print("evidence_pack_lint: NOTICE — no --changed-files-file supplied, "
               "gear-floor check (rule 6) skipped for this run", file=sys.stderr)
     else:
-        # Ceiling (rule 7 — see compute_ceiling() docstring): an "(overridden)"
-        # reason is a REPORT, never a violation — it does not fail the pack.
-        _ceiling, ceiling_reasons = compute_ceiling(changed_files, gear, pack)
+        # Ceiling (rule 7 — see compute_ceiling() docstring): only the BARE
+        # "ceiling: " prefix is a violation. Any parenthetical-qualified
+        # variant — "ceiling (overridden): ..." or "ceiling (notice): ..." —
+        # is a REPORT, never a violation, and does not fail the pack.
+        _ceiling, ceiling_reasons = compute_ceiling(
+            changed_files, gear, pack, measured_net_lines
+        )
         for reason in ceiling_reasons:
-            if reason.startswith("ceiling (overridden)"):
-                print(f"evidence_pack_lint: NOTICE — {reason}", file=sys.stderr)
-            else:
+            if reason.startswith("ceiling: "):
                 violations.append(reason)
+            else:
+                print(f"evidence_pack_lint: NOTICE — {reason}", file=sys.stderr)
 
     return (1 if violations else 0), violations
 
@@ -576,6 +631,35 @@ def _read_changed_files(path_str: str | None) -> list[str] | None:
     p = Path(path_str)
     text = p.read_text(encoding="utf-8")
     return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def sum_numstat(text: str) -> int:
+    """Sum `git diff --numstat` output into a single net-line count
+    (added - deleted), the measured source for compute_ceiling()'s rule-7
+    shape (b) — pure function, no I/O, so it's testable directly (mirrors
+    compute_floor()). Each line is "<added>\\t<deleted>\\t<path>"; binary
+    files report "-\\t-\\tpath" per git's own numstat format and are
+    skipped (their line-count is unknowable, not zero — excluding rather
+    than miscounting them as 0 added/0 deleted). Malformed lines (wrong
+    column count, non-numeric added/deleted where not "-") are skipped the
+    same way — this function degrades gracefully rather than raising on a
+    single garbled line from an unexpected git version."""
+    net = 0
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        added_s, deleted_s = parts[0], parts[1]
+        if added_s == "-" or deleted_s == "-":
+            continue  # binary file — numstat can't report a line count
+        try:
+            net += int(added_s) - int(deleted_s)
+        except ValueError:
+            continue
+    return net
 
 
 def selftest() -> int:
@@ -900,6 +984,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("pack_path", nargs="?", default="evidence/pack.yml")
     parser.add_argument("--repo-root", default=None)
     parser.add_argument("--changed-files-file", default=None)
+    parser.add_argument("--net-lines", type=int, default=None, metavar="INT")
+    parser.add_argument("--numstat-file", default=None, metavar="PATH")
     parser.add_argument("--print-floor", action="store_true")
     parser.add_argument("--effort-for", type=int, default=None, metavar="GEAR")
     parser.add_argument("--json", action="store_true")
@@ -933,7 +1019,20 @@ def main(argv: list[str] | None = None) -> int:
     if not pack_path.is_absolute():
         pack_path = repo_root / pack_path
 
-    exit_code, violations = lint(pack_path, repo_root, changed_files)
+    # --net-lines wins outright; --numstat-file is a convenience so callers
+    # don't need to re-derive the awk one-liner themselves; neither given ->
+    # None, and compute_ceiling() falls back to the pack's self-declared
+    # net_lines (with its own NOTICE).
+    measured_net_lines: int | None = args.net_lines
+    if measured_net_lines is None and args.numstat_file:
+        try:
+            numstat_text = Path(args.numstat_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"evidence_pack_lint: --numstat-file unreadable: {exc}", file=sys.stderr)
+            return 3
+        measured_net_lines = sum_numstat(numstat_text)
+
+    exit_code, violations = lint(pack_path, repo_root, changed_files, measured_net_lines)
 
     if args.json:
         import json as _json

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -90,10 +90,30 @@ WHAT IT VALIDATES (an Evidence Pack YAML, default path evidence/pack.yml):
                         then, a change to one list without the other is a
                         silent-drift risk a human reviewer should catch.
 
+  7. gear ceiling  — the MIRROR of rule 6 (2026-08-21 audit,
+                        research/operations/2026-08-21-token-ceremony-ci-
+                        system-audit.md §7 lever L6 / §8): the floor stops a
+                        diff from declaring LESS gear than a hot-zone hit
+                        demands; the ceiling stops the opposite — a diff
+                        shaped like a docs/ledger-only or small (<=2 files,
+                        <=60 net lines, pack-declared) change may not
+                        silently declare Gear 3 while also convening a
+                        `council` or dispatching >=3 graders. REJECTED
+                        unless the pack carries a non-empty, reasoned
+                        `gear_override:` one-liner — in which case it is
+                        REPORTED (stderr NOTICE), never a violation. Floor
+                        always wins when the two conflict: a hot-zone hit
+                        floors AND ceilings at 3, silently. See
+                        compute_ceiling()'s own docstring for the full
+                        contract. Skipped, same as rule 6, whenever
+                        --changed-files-file is not supplied.
+
 Floor check is SKIPPED (not silently passed — an explicit NOTICE on stderr)
 when --changed-files-file is not supplied: not every invocation of this linter
 has PR-diff context (e.g. a spot-check of a pack on a laptop). The CI workflow
-(harness-floor.yml) is the required check that always supplies it.
+(harness-floor.yml) is the required check that always supplies it. The
+ceiling check (rule 7) is skipped under the same condition, for the same
+reason.
 
 VERDICT / EXIT CODES (fail-visible, superscar #2 "esiste != armato" antidote:
 a lint that scanned nothing must not report clean):
@@ -105,16 +125,22 @@ a lint that scanned nothing must not report clean):
 
 CLI:
   python3 scripts/evidence_pack_lint.py [PACK_PATH] [--repo-root DIR]
-      [--changed-files-file PATH] [--print-floor] [--json] [--selftest]
+      [--changed-files-file PATH] [--print-floor] [--effort-for GEAR]
+      [--json] [--selftest]
 
   PACK_PATH        defaults to evidence/pack.yml (relative to --repo-root)
   --repo-root      defaults to the git top-level, else cwd
   --changed-files-file  newline-delimited changed-path list (the output of
-                        scripts/ci/hotzone_changed_files.sh) — enables rule 6
+                        scripts/ci/hotzone_changed_files.sh) — enables rules
+                        6 (floor) and 7 (ceiling)
   --print-floor    given --changed-files-file, print the computed floor int
                     and exit 0 (no pack read) — lets any caller (CI, a human)
                     ask "what floor would this diff impose" without spinning
                     up a second implementation of HOTZONE_PATTERNS
+  --effort-for GEAR  print effort_for_gear(GEAR) (medium/xhigh) and exit 0
+                    (no pack, no repo-root needed) — lets a wrapper look up
+                    "what effort should this gear run at" without importing
+                    this module; exit 3 (usage error) if GEAR isn't 1/2/3
   --json           machine-readable {"exit": N, "violations": [...]} on stdout
   --selftest       run the embedded guilt+innocence corpus and exit 0/1
 
@@ -187,6 +213,134 @@ def compute_floor(changed_files: list[str]) -> int:
             if fnmatch.fnmatchcase(f, pat):
                 return 3
     return 1
+
+
+# ---------------------------------------------------------------------------
+# Gear CEILING (2026-08-21 audit, research/operations/2026-08-21-token-
+# ceremony-ci-system-audit.md §7 lever L6 / §8): the floor above already
+# stops a diff from declaring LESS gear than a hot-zone hit demands, but
+# nothing stopped the opposite — a Gear-1-shaped diff paying for a council,
+# cross-family refuters and `xhigh` thinking it never needed (measured: 65%
+# of declared gears are Gear-3, 70% of Agent dispatches are graders). The
+# ceiling is the mirror rule: "the model may only raise, never lower, the
+# floor" gets a matching "a trivial diff may not silently over-provision
+# Gear-3 machinery either" — with an explicit, reasoned escape hatch
+# (`gear_override`) for the genuine exception, never a hard ban.
+# ---------------------------------------------------------------------------
+DOCS_LEDGER_EXTENSIONS: tuple[str, ...] = (".md", ".json")
+CEILING_SMALL_DIFF_MAX_FILES = 2
+CEILING_SMALL_DIFF_MAX_NET_LINES = 60
+CEILING_HEAVY_GRADER_DISPATCH_MIN = 3
+
+
+def compute_ceiling(
+    changed_paths: list[str], declared_gear: int | None, pack: dict[str, Any]
+) -> tuple[int, list[str]]:
+    """Returns (ceiling, reasons). Mirrors compute_floor()'s lower-bound-only
+    shape but at the opposite end: it names a Gear-1-shaped diff (never a
+    Gear-2 ceiling — like the floor, the "standard PR" middle bucket needs
+    human judgment no diff shape alone can carry) and flags an over-
+    provisioned Gear-3 declaration against it.
+
+    A diff is Gear-1-SHAPED when either:
+      (a) every changed path is docs/ledger/markdown/json-only
+          (DOCS_LEDGER_EXTENSIONS), or
+      (b) it touches at most CEILING_SMALL_DIFF_MAX_FILES files AND the pack
+          declares `net_lines` (the session's own 30s count, per the audit's
+          §8 ship-path spec — this function does not shell out to git to
+          derive it, staying pure like compute_floor) at or under
+          CEILING_SMALL_DIFF_MAX_NET_LINES.
+    net_lines being ABSENT from the pack does not assert shape (b) — an
+    unmeasured diff is not evidence of smallness.
+
+    FLOOR ALWAYS WINS: if changed_paths hits the hot-zone (compute_floor==3),
+    this function returns (3, []) immediately — a hot-zone docs file still
+    floors AND ceilings at 3, silently, never a conflicting verdict.
+
+    On a Gear-1-shaped, non-hot-zone diff, a `declared_gear == 3` pack is
+    only "heavy" (worth flagging) if it also carries a convened `council`
+    (pack["council"] truthy — non-empty list or True) or
+    `grader_dispatches >= CEILING_HEAVY_GRADER_DISPATCH_MIN`. A Gear-3 pack
+    with neither is not over-provisioned by this signal and gets no reason.
+
+    Reason-string contract for the caller (lint()): an entry NOT prefixed
+    "ceiling (overridden)" is a hard violation (guilt — fail); an entry
+    prefixed "ceiling (overridden)" is informational only (the pack supplied
+    a non-empty `gear_override` one-liner) and must NOT be added to
+    `violations` — "the ceiling does not fail, it reports."
+    """
+    pack = pack if isinstance(pack, dict) else {}
+    changed_paths = changed_paths or []
+
+    if not changed_paths:
+        # No diff context at all — nothing to assert a shape against.
+        return 3, []
+
+    if compute_floor(changed_paths) == 3:
+        # Floor wins over ceiling when they conflict (mandate rule, see
+        # module docstring reference above) — a hot-zone hit floors AND
+        # ceilings at 3, silently.
+        return 3, []
+
+    docs_shaped = all(
+        any(f.endswith(ext) for ext in DOCS_LEDGER_EXTENSIONS) for f in changed_paths
+    )
+    net_lines = pack.get("net_lines")
+    net_lines_known = type(net_lines) is int  # exclude bool (True/False is not a count)
+    small_shaped = (
+        len(changed_paths) <= CEILING_SMALL_DIFF_MAX_FILES
+        and net_lines_known
+        and net_lines <= CEILING_SMALL_DIFF_MAX_NET_LINES
+    )
+
+    if not (docs_shaped or small_shaped):
+        return 3, []  # not a Gear-1-shaped diff — no ceiling to assert
+
+    council = bool(pack.get("council"))
+    grader_dispatches = pack.get("grader_dispatches")
+    heavy_graders = (
+        type(grader_dispatches) is int and grader_dispatches >= CEILING_HEAVY_GRADER_DISPATCH_MIN
+    )
+
+    if declared_gear == 3 and (council or heavy_graders):
+        cause = "council" if council else f"{grader_dispatches} grader dispatches"
+        override = pack.get("gear_override")
+        if isinstance(override, str) and override.strip():
+            return 1, [
+                f"ceiling (overridden): Gear 1 shape — declared Gear 3 with {cause}, "
+                f"overridden: {override.strip()}"
+            ]
+        return 1, [
+            "ceiling: Gear 1 shape — declared Gear 3 with "
+            f"{cause}; declare the reason in `gear_override:`"
+        ]
+
+    return 1, []
+
+
+# ---------------------------------------------------------------------------
+# Effort per gear (same audit, lever L0: "reasoning budget tied to the
+# gear" — ~86% of output tokens are thinking, and effort is the primary
+# cost/latency lever on Opus 5, cf. CLAUDE.md §5). `max` is deliberately
+# ABSENT from this mapping: the gate adjudication step is the one place
+# that may reach for it, and only via an explicit `effort_override` a
+# session sets by hand — never this function's default for any gear.
+# ---------------------------------------------------------------------------
+GEAR_EFFORT: dict[int, str] = {1: "medium", 2: "xhigh", 3: "xhigh"}
+
+
+def effort_for_gear(gear: int) -> str:
+    """GUILT (implicit, via ValueError): a gear outside {1,2,3}, or not a
+    genuine int (bool/float coercion — same VALID_GEARS trap check_gear_floor
+    already guards), raises rather than silently guessing an effort level.
+    INNOCENCE: gear 1 -> "medium", gear 2/3 -> "xhigh" (Gear-3's own `max`
+    reservation is the caller's explicit choice, not this function's)."""
+    if type(gear) is not int or gear not in GEAR_EFFORT:
+        raise ValueError(
+            f"effort_for_gear: gear must be exactly one of {tuple(GEAR_EFFORT)} (int), "
+            f"got {gear!r}"
+        )
+    return GEAR_EFFORT[gear]
 
 
 def approx_tokens(raw: bytes) -> int:
@@ -400,6 +554,15 @@ def lint(
     if changed_files is None:
         print("evidence_pack_lint: NOTICE — no --changed-files-file supplied, "
               "gear-floor check (rule 6) skipped for this run", file=sys.stderr)
+    else:
+        # Ceiling (rule 7 — see compute_ceiling() docstring): an "(overridden)"
+        # reason is a REPORT, never a violation — it does not fail the pack.
+        _ceiling, ceiling_reasons = compute_ceiling(changed_files, gear, pack)
+        for reason in ceiling_reasons:
+            if reason.startswith("ceiling (overridden)"):
+                print(f"evidence_pack_lint: NOTICE — {reason}", file=sys.stderr)
+            else:
+                violations.append(reason)
 
     return (1 if violations else 0), violations
 
@@ -443,6 +606,30 @@ def selftest() -> int:
         check("compute_floor: no hit -> 1",
               compute_floor(["docs/notes.md", "research/operations/x.md"]) == 1)
         check("compute_floor: empty list -> 1", compute_floor([]) == 1)
+
+        # ---- unit-level: compute_ceiling / effort_for_gear are pure too ----
+        docs_diff = ["docs/x.md"]
+        _c, r = compute_ceiling(docs_diff, 3, {"council": True})
+        check("compute_ceiling: guilt — gear-3 + council on 1-file md diff",
+              bool(r) and r[0].startswith("ceiling:") and "gear_override" in r[0])
+        _c, r = compute_ceiling(docs_diff, 3, {"council": True, "gear_override": "hotfix, verified live"})
+        check("compute_ceiling: innocence — gear_override reports, does not fail",
+              bool(r) and r[0].startswith("ceiling (overridden)"))
+        _c, r = compute_ceiling(["apps/backend-rag/backend/app/auth/session.py"], 3, {"council": True})
+        check("compute_ceiling: innocence — floor wins, hotzone diff silent", r == [])
+        big_diff = [f"apps/backend-rag/backend/f{i}.py" for i in range(8)]
+        _c, r = compute_ceiling(big_diff, 3, {"council": True})
+        check("compute_ceiling: innocence — real 8-file backend diff not gear-1-shaped", r == [])
+        _c, r = compute_ceiling(docs_diff, 3, {})
+        check("compute_ceiling: innocence — gear-3 with no council/graders is not heavy", r == [])
+        check("effort_for_gear: 1 -> medium", effort_for_gear(1) == "medium")
+        check("effort_for_gear: 2 -> xhigh", effort_for_gear(2) == "xhigh")
+        check("effort_for_gear: 3 -> xhigh", effort_for_gear(3) == "xhigh")
+        try:
+            effort_for_gear(4)
+            check("effort_for_gear: guilt — invalid gear raises", False)
+        except ValueError:
+            check("effort_for_gear: guilt — invalid gear raises", True)
 
         # ---- innocence: a fully-conformant Gear-1 pack passes --------------
         write(root / "evidence" / "brief.yml", {
@@ -580,6 +767,33 @@ def selftest() -> int:
         rc, viol = lint(root / "evidence" / "pack.yml", root, ["docs/readme.md"])
         check("innocence: gear 1 on non-hotzone diff passes", rc == 0 and viol == [])
 
+        # ---- guilt: gear-3 pack + council over a Gear-1-shaped docs diff -------
+        write(root / "evidence" / "brief.yml", {"task_id": "x", "gear": 3, "grader": "y"})
+        write(root / "evidence" / "pack.yml", {
+            "brief_ref": "evidence/brief.yml",
+            "receipts": [good_receipt],
+            "dissent": [{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
+            "pii_scan": "clean",
+            "council": True,
+        })
+        rc, viol = lint(root / "evidence" / "pack.yml", root, ["docs/x.md"])
+        check("guilt: gear-3 + council on a docs-only diff rejected (ceiling)", rc == 1)
+        check("guilt: ceiling message names gear_override",
+              any("gear_override" in v for v in viol))
+
+        # ---- innocence: same pack, but gear_override reports instead of failing
+        write(root / "evidence" / "pack.yml", {
+            "brief_ref": "evidence/brief.yml",
+            "receipts": [good_receipt],
+            "dissent": [{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
+            "pii_scan": "clean",
+            "council": True,
+            "gear_override": "hotfix under active incident, verified live",
+        })
+        rc, viol = lint(root / "evidence" / "pack.yml", root, ["docs/x.md"])
+        check("innocence: gear_override on the same diff passes (ceiling reports, not fails)",
+              rc == 0 and viol == [])
+
         # ---- guilt: empty/missing receipts on a Gear-3 pack --------------------
         write(root / "evidence" / "brief.yml", {"task_id": "x", "gear": 3, "grader": "y"})
         write(root / "evidence" / "pack.yml", {
@@ -687,12 +901,21 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo-root", default=None)
     parser.add_argument("--changed-files-file", default=None)
     parser.add_argument("--print-floor", action="store_true")
+    parser.add_argument("--effort-for", type=int, default=None, metavar="GEAR")
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--selftest", action="store_true")
     args = parser.parse_args(argv)
 
     if args.selftest:
         return selftest()
+
+    if args.effort_for is not None:
+        try:
+            print(effort_for_gear(args.effort_for))
+        except ValueError as exc:
+            print(f"evidence_pack_lint: {exc}", file=sys.stderr)
+            return 3
+        return 0
 
     repo_root = Path(args.repo_root).resolve() if args.repo_root else repo_root_default()
 

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -32,6 +32,7 @@ from evidence_pack_lint import (  # noqa: E402
     compute_floor,
     effort_for_gear,
     lint,
+    sum_numstat,
 )
 
 GOOD_RECEIPT = {
@@ -410,6 +411,99 @@ def test_ceiling_innocence_no_diff_context_returns_no_assertion():
     assert compute_ceiling([], 3, {"council": True}) == (3, [])
 
 
+def test_ceiling_guilt_measured_overrides_pack_lie_no_false_ceiling():
+    """GUILT (adversarial-review 2026-08-21, team-lead hardening): the pack
+    self-declares net_lines=10 but the MEASURED value is 400 — shape (b)
+    must NOT be asserted (measured wins), so a Gear-3 + council pack over
+    this 2-file non-hot-zone diff is NOT flagged. Without this precedence,
+    an author could dodge the ceiling entirely by under-reporting net_lines
+    in the pack."""
+    diff = ["apps/backend-rag/backend/services/a.py", "apps/backend-rag/backend/services/b.py"]
+    ceiling, reasons = compute_ceiling(
+        diff, 3, {"net_lines": 10, "council": True}, measured_net_lines=400
+    )
+    assert ceiling == 3
+    assert reasons == []
+
+
+def test_ceiling_guilt_measured_used_when_pack_omits_net_lines():
+    """GUILT, the reverse case: the pack OMITS net_lines entirely, but a
+    measured value of 20 is supplied — shape (b) IS asserted from the
+    measured value alone, and the gear-3+council over-provisioning is
+    flagged."""
+    diff = ["apps/backend-rag/backend/services/a.py", "apps/backend-rag/backend/services/b.py"]
+    ceiling, reasons = compute_ceiling(diff, 3, {"council": True}, measured_net_lines=20)
+    assert ceiling == 1
+    assert reasons
+    assert reasons[0].startswith("ceiling: Gear 1 shape")
+    # measured source -> no self-declared notice anywhere in reasons
+    assert not any("self-declared" in r for r in reasons)
+
+
+def test_ceiling_innocence_self_declared_net_lines_emits_notice():
+    """INNOCENCE (still passes/fails on its own merits) + NOTICE: when NO
+    measured value is supplied and the pack alone carries net_lines, the
+    self-declared value is still used for shape (b), but a distinguishable
+    "ceiling (notice)" line names the lower-trust source — never a
+    violation on its own."""
+    diff = ["apps/backend-rag/backend/services/a.py", "apps/backend-rag/backend/services/b.py"]
+    ceiling, reasons = compute_ceiling(diff, 3, {"council": True, "net_lines": 20})
+    assert ceiling == 1
+    assert any(r.startswith("ceiling (notice): net_lines self-declared") for r in reasons)
+    # AND the primary guilt reason (no override) is still present, first
+    assert reasons[0].startswith("ceiling: Gear 1 shape")
+
+
+def test_ceiling_innocence_self_declared_notice_does_not_fire_when_measured_present():
+    """INNOCENCE: supplying a measured value suppresses the self-declared
+    notice entirely, even if the pack ALSO carries its own net_lines."""
+    diff = ["apps/backend-rag/backend/services/a.py", "apps/backend-rag/backend/services/b.py"]
+    ceiling, reasons = compute_ceiling(
+        diff, 3, {"council": True, "net_lines": 999}, measured_net_lines=20
+    )
+    assert ceiling == 1
+    assert not any("self-declared" in r for r in reasons)
+
+
+def test_lint_end_to_end_measured_net_lines_overrides_pack_lie(tmp_repo):
+    """GUILT/INNOCENCE wired through lint(): the pack lies (net_lines=10)
+    but the caller supplies the real measured value (400) via lint()'s
+    measured_net_lines parameter — no false ceiling."""
+    root, write_brief, write_pack = tmp_repo
+    write_brief(gear=3)
+    pack_path = write_pack(
+        dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
+        council=True,
+        net_lines=10,
+    )
+    diff = ["apps/backend-rag/backend/services/a.py", "apps/backend-rag/backend/services/b.py"]
+    rc, violations = lint(pack_path, root, diff, measured_net_lines=400)
+    assert rc == 0
+    assert violations == []
+
+
+# --------------------------------------------------------- sum_numstat (pure fn)
+
+
+def test_sum_numstat_basic_sum():
+    text = "10\t2\tfoo.py\n5\t0\tbar.py\n"
+    assert sum_numstat(text) == (10 - 2) + (5 - 0)
+
+
+def test_sum_numstat_skips_binary_files():
+    """Binary files report "-\t-\tpath" per git's numstat format — their
+    line count is unknowable, not zero, so they must be excluded rather
+    than counted as 0/0."""
+    text = "10\t2\tfoo.py\n-\t-\timage.png\n"
+    assert sum_numstat(text) == 8
+
+
+def test_sum_numstat_empty_and_malformed_lines_ignored():
+    assert sum_numstat("") == 0
+    assert sum_numstat("\n\n") == 0
+    assert sum_numstat("not-a-numstat-line\n10\t2\tfoo.py\n") == 8
+
+
 # --------------------------------------------------------- effort_for_gear (pure fn)
 
 
@@ -539,3 +633,72 @@ def test_effort_for_cli_matches_effort_for_gear():
         capture_output=True, text=True, timeout=30, cwd=str(REPO),
     )
     assert proc.returncode == 3
+
+
+def _write_full_tree(tmp_path, *, gear, pack_overrides):
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    (evidence_dir / "brief.yml").write_text(
+        yaml.safe_dump({"task_id": "ops-test", "gear": gear, "grader": "codex-sol"}),
+        encoding="utf-8",
+    )
+    pack = {
+        "brief_ref": "evidence/brief.yml",
+        "receipts": [GOOD_RECEIPT],
+        "dissent": [{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
+        "pii_scan": "clean",
+    }
+    pack.update(pack_overrides)
+    (tmp_path / "evidence" / "pack.yml").write_text(
+        yaml.safe_dump(pack, sort_keys=False), encoding="utf-8"
+    )
+    return tmp_path / "evidence" / "pack.yml"
+
+
+def test_net_lines_cli_flag_overrides_pack_lie_end_to_end(tmp_path):
+    """--net-lines, given a diff shaped like predicate (b), wins over the
+    pack's own (lying) net_lines field — reaching compute_ceiling() through
+    the full CLI entry point, not just lint() called in-process."""
+    pack_path = _write_full_tree(
+        tmp_path, gear=3, pack_overrides={"council": True, "net_lines": 10}
+    )
+    changed = tmp_path / "changed.txt"
+    changed.write_text(
+        "apps/backend-rag/backend/services/a.py\n"
+        "apps/backend-rag/backend/services/b.py\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable, str(SCRIPTS / "evidence_pack_lint.py"),
+            str(pack_path), "--repo-root", str(tmp_path),
+            "--changed-files-file", str(changed), "--net-lines", "400",
+        ],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO),
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr  # measured wins -> no false ceiling
+
+
+def test_numstat_file_cli_flag_wired_end_to_end(tmp_path):
+    """--numstat-file sums via sum_numstat() and reaches compute_ceiling()
+    through the CLI, flagging the same gear-3+council over-provisioning
+    --net-lines would (pack omits net_lines entirely here)."""
+    pack_path = _write_full_tree(tmp_path, gear=3, pack_overrides={"council": True})
+    changed = tmp_path / "changed.txt"
+    changed.write_text(
+        "apps/backend-rag/backend/services/a.py\n"
+        "apps/backend-rag/backend/services/b.py\n",
+        encoding="utf-8",
+    )
+    numstat = tmp_path / "numstat.txt"
+    numstat.write_text("15\t5\tapps/backend-rag/backend/services/a.py\n", encoding="utf-8")
+    proc = subprocess.run(
+        [
+            sys.executable, str(SCRIPTS / "evidence_pack_lint.py"),
+            str(pack_path), "--repo-root", str(tmp_path),
+            "--changed-files-file", str(changed), "--numstat-file", str(numstat),
+        ],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO),
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "gear_override" in (proc.stdout + proc.stderr)

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -28,7 +28,9 @@ from evidence_pack_lint import (  # noqa: E402
     check_pii_scan_clean,
     check_receipts_have_provenance,
     check_size_budget,
+    compute_ceiling,
     compute_floor,
+    effort_for_gear,
     lint,
 )
 
@@ -297,6 +299,146 @@ def test_gear_floor_guilt_float_type_rejected():
     assert "int" in violations[0]
 
 
+# --------------------------------------------------------- compute_ceiling (pure fn)
+
+
+def test_ceiling_guilt_gear3_council_on_docs_diff_rejected():
+    """GUILT: a Gear-3 pack that also convened a `council` over a 1-file
+    markdown diff is over-provisioned — rejected unless `gear_override`
+    explains why."""
+    ceiling, reasons = compute_ceiling(["docs/notes.md"], 3, {"council": True})
+    assert ceiling == 1
+    assert reasons
+    assert reasons[0].startswith("ceiling: Gear 1 shape")
+    assert "gear_override" in reasons[0]
+
+
+def test_ceiling_guilt_gear3_many_grader_dispatches_on_json_diff_rejected():
+    """GUILT: the same over-provisioning signal via >=3 grader dispatches
+    instead of a council — ledger/json-only diff."""
+    ceiling, reasons = compute_ceiling(
+        ["evidence/ledger.json"], 3, {"grader_dispatches": 3}
+    )
+    assert ceiling == 1
+    assert reasons
+    assert "3 grader dispatches" in reasons[0]
+
+
+def test_ceiling_innocence_gear_override_reports_not_fails():
+    """INNOCENCE: the exact guilty shape above, but with a non-empty
+    `gear_override` — the ceiling REPORTS (a distinguishable
+    "ceiling (overridden)" line), it does not produce a violation. The
+    caller (lint()) is responsible for keeping such a line out of
+    `violations` — this test pins the string contract that decision relies
+    on."""
+    ceiling, reasons = compute_ceiling(
+        ["docs/notes.md"], 3, {"council": True, "gear_override": "verified live, one-off"}
+    )
+    assert ceiling == 1
+    assert reasons
+    assert reasons[0].startswith("ceiling (overridden)")
+    assert "verified live" in reasons[0]
+
+
+def test_ceiling_innocence_empty_override_is_not_an_override():
+    """GUILT (edge of the innocence test above): an empty/whitespace-only
+    `gear_override` string does not count as "present and non-empty" — it
+    must still fail like the no-override case."""
+    ceiling, reasons = compute_ceiling(["docs/notes.md"], 3, {"council": True, "gear_override": "   "})
+    assert ceiling == 1
+    assert reasons
+    assert not reasons[0].startswith("ceiling (overridden)")
+
+
+def test_ceiling_innocence_hotzone_diff_floor_stands_silent():
+    """INNOCENCE: the floor always wins — a hot-zone (`apps/.../auth/*`)
+    docs-shaped diff floors AND ceilings at 3, silently, even with a
+    council declared. Never a conflicting verdict."""
+    hotzone = ["apps/backend-rag/backend/app/auth/session.py"]
+    ceiling, reasons = compute_ceiling(hotzone, 3, {"council": True})
+    assert ceiling == 3
+    assert reasons == []
+
+
+def test_ceiling_innocence_real_backend_diff_gear3_passes():
+    """INNOCENCE: an 8-file, non-docs backend diff is not Gear-1-shaped by
+    either predicate (not docs/json-only, more than 2 files) — a Gear-3
+    declaration with a council on it is not flagged at all."""
+    big_diff = [f"apps/backend-rag/backend/services/f{i}.py" for i in range(8)]
+    ceiling, reasons = compute_ceiling(big_diff, 3, {"council": True})
+    assert ceiling == 3
+    assert reasons == []
+
+
+def test_ceiling_innocence_gear3_without_council_or_graders_not_heavy():
+    """INNOCENCE: a Gear-3 pack on a Gear-1-shaped diff with NO council and
+    no (or <3) grader dispatches is not flagged — the ceiling only fires on
+    the heavyweight signals, never on gear==3 alone."""
+    assert compute_ceiling(["docs/notes.md"], 3, {}) == (1, [])
+    assert compute_ceiling(["docs/notes.md"], 3, {"grader_dispatches": 2}) == (1, [])
+
+
+def test_ceiling_innocence_gear1_declared_never_flagged():
+    """INNOCENCE: the ceiling only concerns itself with a Gear-3
+    declaration — a Gear-1-shaped diff correctly declaring gear 1 (even
+    with a council key present, e.g. leftover from a template) is not
+    this rule's problem."""
+    assert compute_ceiling(["docs/notes.md"], 1, {"council": True}) == (1, [])
+
+
+def test_ceiling_innocence_small_diff_below_net_lines_cap_flagged_too():
+    """GUILT: shape predicate (b) — <=2 files, pack-declared net_lines
+    <=60, outside hot zones — triggers the same over-provisioning check as
+    the docs/json predicate (a)."""
+    small_diff = ["apps/backend-rag/backend/services/tiny.py"]
+    ceiling, reasons = compute_ceiling(small_diff, 3, {"council": True, "net_lines": 12})
+    assert ceiling == 1
+    assert reasons
+
+
+def test_ceiling_innocence_unknown_net_lines_does_not_assert_small_shape():
+    """INNOCENCE: predicate (b) requires the pack to actually DECLARE
+    net_lines — a diff with no net_lines key is not assumed small just
+    because it is short on files."""
+    small_diff = ["apps/backend-rag/backend/services/tiny.py"]
+    assert compute_ceiling(small_diff, 3, {"council": True}) == (3, [])
+
+
+def test_ceiling_innocence_no_diff_context_returns_no_assertion():
+    """INNOCENCE: an empty changed-paths list (no diff context) asserts
+    nothing — mirrors compute_floor's None-context skip in lint()."""
+    assert compute_ceiling([], 3, {"council": True}) == (3, [])
+
+
+# --------------------------------------------------------- effort_for_gear (pure fn)
+
+
+def test_effort_for_gear_mapping():
+    """Gear 1 -> medium (the cost/latency lever for routine turns); Gear 2
+    and Gear 3 -> xhigh. `max` is never returned — it is an explicit,
+    opt-in escalation a session makes by hand, never this function's
+    default for any gear."""
+    assert effort_for_gear(1) == "medium"
+    assert effort_for_gear(2) == "xhigh"
+    assert effort_for_gear(3) == "xhigh"
+
+
+def test_effort_for_gear_guilt_invalid_gear_raises():
+    """GUILT: a gear outside {1,2,3} raises rather than guessing."""
+    with pytest.raises(ValueError):
+        effort_for_gear(4)
+    with pytest.raises(ValueError):
+        effort_for_gear(0)
+
+
+def test_effort_for_gear_guilt_bool_type_rejected():
+    """GUILT: same bool-is-an-int coercion trap check_gear_floor already
+    guards against (`True in (1,2,3)` is True in bare Python) — gear must
+    be a genuine int."""
+    with pytest.raises(ValueError):
+        effort_for_gear(True)
+
+
 # --------------------------------------------------------- compute_floor (pure fn)
 
 
@@ -319,6 +461,36 @@ def test_lint_end_to_end_innocent_pack_passes(tmp_repo):
     pack_path = write_pack()
     rc, violations = lint(pack_path, root, None)
     assert rc == 0 and violations == []
+
+
+def test_lint_end_to_end_guilt_ceiling_gear3_council_docs_diff(tmp_repo):
+    """GUILT, wired through lint(): a Gear-3 pack with a council over a
+    docs-only diff fails, naming gear_override in the violation."""
+    root, write_brief, write_pack = tmp_repo
+    write_brief(gear=3)
+    pack_path = write_pack(
+        dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
+        council=True,
+    )
+    rc, violations = lint(pack_path, root, ["docs/notes.md"])
+    assert rc == 1
+    assert any("gear_override" in v for v in violations)
+
+
+def test_lint_end_to_end_innocence_ceiling_override_reports_not_fails(tmp_repo):
+    """INNOCENCE, wired through lint(): the exact same guilty shape, but
+    with gear_override set — lint() must NOT add the "(overridden)" reason
+    to violations, so the pack passes clean."""
+    root, write_brief, write_pack = tmp_repo
+    write_brief(gear=3)
+    pack_path = write_pack(
+        dissent=[{"seat": "codex-sol", "objection": "x", "status": "PLAUSIBLE"}],
+        council=True,
+        gear_override="verified live, one-off",
+    )
+    rc, violations = lint(pack_path, root, ["docs/notes.md"])
+    assert rc == 0
+    assert violations == []
 
 
 def test_lint_end_to_end_blind_on_missing_pack(tmp_repo):
@@ -349,3 +521,21 @@ def test_print_floor_cli_matches_compute_floor(tmp_path):
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert int(proc.stdout.strip()) == compute_floor(["fly.toml", "docs/readme.md"]) == 3
+
+
+def test_effort_for_cli_matches_effort_for_gear():
+    """The --effort-for CLI mode agrees with the pure function, and exits
+    with a usage error (3) on an invalid gear rather than printing garbage."""
+    for gear in (1, 2, 3):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPTS / "evidence_pack_lint.py"), "--effort-for", str(gear)],
+            capture_output=True, text=True, timeout=30, cwd=str(REPO),
+        )
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert proc.stdout.strip() == effort_for_gear(gear)
+
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPTS / "evidence_pack_lint.py"), "--effort-for", "9"],
+        capture_output=True, text=True, timeout=30, cwd=str(REPO),
+    )
+    assert proc.returncode == 3


### PR DESCRIPTION
## Why

Owner order (Zero 2026-08-21): a real Gear 1 with a CEILING, and effort per gear.
The 2026-08-21 audit (`research/operations/2026-08-21-token-ceremony-ci-system-audit.md`
§7 lever L6, §8) measured on `origin/main`: **65% of declared gears are Gear 3**,
**70% of Agent dispatches are graders**, and **~86% of output tokens are thinking**
(so `effort` is the primary cost/latency lever on Opus 5). A deterministic FLOOR
already exists and is CI-enforced (`compute_floor()` via `harness-floor.yml` —
"the model may only raise the gear, never lower it below the floor") but nothing
stopped the mirror case: a docs-only or tiny diff still paying for a council,
cross-family refuters, Evidence Pack prose and `xhigh` thinking it never needed.

## What

- `compute_ceiling(changed_paths, declared_gear, pack) -> (ceiling, reasons)` in
  `scripts/evidence_pack_lint.py`, next to `compute_floor()`. A diff is
  **Gear-1-shaped** when either (a) every changed path is docs/ledger-only
  (`.md`/`.json`), or (b) it touches ≤2 files and the pack declares
  `net_lines` ≤60 (outside hot zones — reuses `HOTZONE_PATTERNS`). On such a
  diff, a pack declaring `gear: 3` that also convenes a `council` (truthy) or
  dispatches `grader_dispatches >= 3` is rejected, with reason
  `"ceiling: Gear 1 shape — declared Gear 3 with council; declare the reason
  in gear_override:"` — **unless** the pack carries a non-empty, reasoned
  `gear_override:` one-liner, in which case it **reports** (stderr NOTICE)
  instead of failing. **Floor always wins on conflict**: a hot-zone hit
  floors *and* ceilings at 3, silently (no contradictory verdict).
- Wired into `lint()` using the *same* `--changed-files-file` context
  `harness-floor.yml`'s Step 7b already supplies for Gear-3 packs — **no
  workflow change needed**, required-check names unchanged.
- `effort_for_gear(gear) -> "medium"|"xhigh"` (1→medium, 2/3→xhigh; `max` is
  never returned by this mapping — it stays an explicit `effort_override` a
  session sets by hand for the gate-adjudication step only), exposed as
  `--effort-for GEAR` on the CLI for wrappers.
- `compute_ceiling`/`effort_for_gear` are deliberately **not** `check_`-prefixed
  — guard-conformance's `ast-def-prefix` census only picks up `check_*`, and
  the guilt/innocence discipline for those already-registered guards lives
  entirely in `check_*` functions untouched by this diff. Verified live:
  `infra/guard-conformance/check_guard_conformance.py` still reports exactly
  6 evidence-pack-lint checks, 0 violations, after this diff.

## Tests

`scripts/tests/test_evidence_pack_lint.py`, 49/49 pass:
- **Guilt**: gear-3 + council over a 1-file `.md` diff rejected (pure
  `compute_ceiling` + end-to-end through `lint()`); gear-3 + ≥3 grader
  dispatches over a `.json` diff rejected; the small-diff predicate (b)
  (≤2 files, `net_lines` ≤60) triggers the same check; an empty/whitespace
  `gear_override` does not count as an override; `effort_for_gear` raises on
  an invalid gear and on `bool` (`True`) via the same coercion trap
  `check_gear_floor` already guards.
- **Innocence**: a non-empty `gear_override` reports instead of failing
  (pure + end-to-end); a hot-zone diff floors *and* ceilings at 3 silently
  even with a council declared; a real 8-file backend diff is not
  Gear-1-shaped (not flagged); gear-3 with no council/graders is not
  flagged; a Gear-1-shaped diff correctly declaring gear 1 is never this
  rule's concern; unknown `net_lines` does not assert smallness; empty
  changed-paths asserts nothing (mirrors `compute_floor`'s `None`-context
  skip); `effort_for_gear` maps 1→medium, 2/3→xhigh.

Also verified: the script's own embedded `--selftest` corpus passes;
`infra/guard-conformance/check_guard_conformance.py` clean (0 violations,
6/6 evidence-pack-lint checks, unchanged); `python3 scripts/docs_sync.py
--check` → `DOCSYNC OK`.

## Adversarial review

- Floor-over-ceiling precedence is pinned by a dedicated test
  (`test_ceiling_innocence_hotzone_diff_floor_stands_silent`) — a hot-zone
  docs diff never gets a *silently-lowered* verdict from the ceiling logic,
  it short-circuits to floor=ceiling=3 before either shape predicate runs.
- The override path is tested both for presence (reports, does not fail)
  and for the edge case of an empty/whitespace-only override string (must
  still fail like no override at all) — a naive `if pack.get("gear_override")`
  truthy-check on a stray empty string would have silently passed guilt.
- `net_lines` is read from the pack, never derived from git — this keeps
  `compute_ceiling` pure (no I/O, same discipline as `compute_floor`), and
  a diff missing that field is treated as *unknown*, not assumed small.
- Backward compatibility: any existing Gear-3 pack that does not declare
  `council`/`grader_dispatches` at all is never flagged by this diff (both
  read via `pack.get(...)`, default falsy) — this is a net-new opt-in signal,
  not a retroactive gate change on packs written before this PR.
- Orchestrating session `3563604c` re-verifies before merge.