### PR TITLE
feat(ci-ops): pr_watch.sh — deterministic PR terminal-state watcher

### DIFF
--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -228,6 +228,42 @@ becomes visible.
 
 ---
 
+## After arming: watch, don't poll
+
+Measured 2026-08-21: 54% of a PR-session's output tokens were spent AFTER `gh pr create` — hand-polling
+CI — and 14% of all Bash calls were `gh pr checks/view/run`. **The rule: arm `gh pr merge --auto N`
+(nude, per §Session discipline above), then hand it to `scripts/pr_watch.sh N` in a background task or
+`Monitor`, and move on.** Never loop `gh pr checks` by hand waiting for green.
+
+```bash
+gh pr merge --auto 4321          # arm, nude
+scripts/pr_watch.sh 4321         # background/Monitor — do the next thing meanwhile
+```
+
+It emits one line per event (`#N MERGED <ts>`, `#N CLOSED`, `#N REQUIRED-FAILING: <names>` once per
+new failing set, `#N MISSING-REQUIRED: <contexts>`, `#N EJECTED-FROM-QUEUE`) and a final `ALL_DONE` /
+`TIMEOUT`. Multiple PRs in one call are watched together; it exits only once every one of them is
+terminal.
+
+**Never read `autoMergeRequest` to decide "still armed" (W118)** — it reads null/false both while a
+PR is healthily queued and after the queue has ejected it, indistinguishably (the same trap `mq
+watch` avoids by tracking the armed SHA instead). `pr_watch.sh` uses GraphQL `isInMergeQueue` +
+`mergeQueueEntry{state position}` instead, which is what makes `EJECTED-FROM-QUEUE` a real signal.
+
+**`MISSING-REQUIRED` is the skipped-matrix-job scar** — `comm -23 <(required contexts) <(reported
+names)` against the FULL reported-name set (not just required-flagged ones), because a skipped
+matrix job's suffixed required context never shows up under any name at all (§2's "required check
+never reported" class; scar `discovery_skipped_matrix_job_never_emits_its_required_contexts`).
+
+**Re-running a check by hand never uses `gh run rerun` on a stale ref (W111)** — it replays the OLD
+merge commit; `gh pr update-branch` first, or use `mq requeue` / `queue_rearm.sh --apply`.
+
+Test: `scripts/tests/test_pr_watch.sh` (fake `gh`, no network). `mq watch` is the post-arm drift
+guard for one PR against its armed SHA; `pr_watch.sh` is the terminal-state watcher for one or many
+PRs, replacing the hand-poll loop — neither reimplements the other.
+
+---
+
 ## 5. Override procedure (owner admin)
 
 When merge queue blocks a legitimate hotfix and CI infrastructure itself is broken:

--- a/scripts/pr_watch.sh
+++ b/scripts/pr_watch.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# pr_watch.sh — deterministic PR terminal-state watcher.
+#
+# Owner order (2026-08-21): 54% of a PR-session's output tokens were being
+# spent AFTER `gh pr create` — babysitting CI by hand (14% of all Bash calls
+# were `gh pr checks/view/run`). This replaces that manual poll loop: arm
+# with `gh pr merge --auto`, run this in the background, and read its
+# terminal-event lines instead of re-deriving PR state from scratch every
+# few minutes.
+#
+# USAGE
+#   scripts/pr_watch.sh [--repo OWNER/REPO] <PR#> [<PR#>...]
+#
+# Emits ONE line per event to stdout:
+#   #N MERGED <mergedAt>
+#   #N CLOSED
+#   #N REQUIRED-FAILING: <name1,name2,...>   (once per NEW failing set)
+#   #N MISSING-REQUIRED: <ctx1,ctx2,...>     (once per NEW missing set)
+#   #N EJECTED-FROM-QUEUE                    (left the merge queue while
+#                                              still OPEN — the ejection
+#                                              class the runbook §6 Step 2b
+#                                              describes)
+# and exactly one final line: ALL_DONE (exit 0) or TIMEOUT (exit 1).
+#
+# DESIGN RULES (blood-bought, cicatrix-superscar.md — same discipline as
+# scripts/mq.sh, which this script deliberately mirrors so the two tools
+# read as one family):
+#   - Every `gh` call's rc is captured errexit-immune (`|| var=$?`), never a
+#     bare assignment under `set -e` (W101 — a bare assignment aborts the
+#     script BEFORE the caller can inspect the rc it was written to inspect).
+#   - `gh pr checks` is judged by CONTENT, not exit code alone (W104): its rc
+#     is data-dependent (non-zero can mean "a check is failing", not "the
+#     tool broke") — only rc!=0 WITH an empty body is a real transient
+#     failure. `gh pr view` / `gh api` rc IS a straightforward tool-error
+#     signal, so those are checked on rc alone.
+#   - `autoMergeRequest` is NEVER read to infer queue state (W118): it reads
+#     null both while a PR is healthily queued AND after it has been
+#     ejected — indistinguishable from that one field. The only way to tell
+#     "still queued" from "ejected while still open" apart is the GraphQL
+#     `isInMergeQueue` truth source, which is what EJECTED-FROM-QUEUE below
+#     is built on.
+#   - MISSING-REQUIRED is computed via `comm -23` against the FULL reported
+#     check-name set (not just the ones flagged isRequired) — this is what
+#     catches a skipped matrix job: its suffixed required context never
+#     shows up in the reported set at all, under any name (2026-08-21 scar,
+#     `discovery_skipped_matrix_job_never_emits_its_required_contexts`).
+#   - No arrays expanded when they might be empty (bash 3.2 on macOS raises
+#     "unbound variable" under `set -u` on `"${empty_arr[@]}"` — reproduced
+#     against this repo's shipped bash). Per-PR "done" state lives in a
+#     state-dir file, not a shrinking array, so the main loop never expands
+#     one.
+#   - Field delimiter in every `IFS='|' read -r` below is `|`, never a tab:
+#     under POSIX "IFS whitespace" rules `read` COLLAPSES consecutive
+#     whitespace delimiters instead of yielding an empty field, and a blank
+#     middle field would silently shift everything after it by one.
+#
+# No Telegram, no writes outside its own state dir. Poll interval
+# PR_WATCH_INTERVAL (default 180s), ceiling PR_WATCH_MAX_MIN (default 120).
+set -euo pipefail
+
+PR_WATCH_INTERVAL="${PR_WATCH_INTERVAL:-180}"
+PR_WATCH_MAX_MIN="${PR_WATCH_MAX_MIN:-120}"
+PR_WATCH_REPO="${PR_WATCH_REPO:-}"
+
+_usage() {
+  cat <<USAGE
+pr_watch.sh — deterministic PR terminal-state watcher
+
+  scripts/pr_watch.sh [--repo OWNER/REPO] <PR#> [<PR#>...]
+
+Env: PR_WATCH_INTERVAL (poll seconds, default 180)
+     PR_WATCH_MAX_MIN  (ceiling minutes, default 120)
+     PR_WATCH_REPO     (same as --repo)
+
+Exits 0 on ALL_DONE, 1 on TIMEOUT, 2 on a usage/setup error.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  _usage
+  exit 0
+fi
+
+if [[ "${1:-}" == "--repo" ]]; then
+  [[ -n "${2:-}" ]] || { echo "pr_watch: --repo requires a value" >&2; exit 2; }
+  PR_WATCH_REPO="$2"
+  shift 2
+fi
+
+if [[ $# -eq 0 ]]; then
+  _usage
+  exit 2
+fi
+
+for _pr in "$@"; do
+  [[ "$_pr" =~ ^[0-9]+$ ]] || { echo "pr_watch: not a PR number: '$_pr'" >&2; exit 2; }
+done
+
+PR_WATCH_TMP_ERR="$(mktemp "${TMPDIR:-/tmp}/pr_watch_err.XXXXXX")"
+STATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/pr_watch.XXXXXX")"
+trap 'rm -rf "$STATE_DIR" "$PR_WATCH_TMP_ERR"' EXIT
+
+# Run `gh "$@"`, capturing stdout in GH_OUT, stderr in GH_ERR, rc in GH_RC.
+# Never trips `set -e` on its own — every gh call in this script goes
+# through here so a failure is DATA the caller inspects, not an abort.
+_gh() {
+  GH_RC=0
+  GH_OUT="$(gh "$@" 2>"$PR_WATCH_TMP_ERR")" || GH_RC=$?
+  GH_ERR="$(cat "$PR_WATCH_TMP_ERR" 2>/dev/null || true)"
+  : > "$PR_WATCH_TMP_ERR"
+}
+
+if [[ -z "$PR_WATCH_REPO" ]]; then
+  _gh repo view --json nameWithOwner --jq .nameWithOwner
+  if (( GH_RC != 0 )) || [[ -z "$GH_OUT" ]]; then
+    echo "pr_watch: could not resolve repo (rc=$GH_RC): ${GH_ERR:0:200} — pass --repo OWNER/REPO" >&2
+    exit 2
+  fi
+  PR_WATCH_REPO="$GH_OUT"
+fi
+REPO="$PR_WATCH_REPO"
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+REPO_FLAGS=(--repo "$REPO")
+
+_last() { [[ -f "$1" ]] && cat "$1" || true; }  # _last <file> -> content or ""
+
+# _tick <pr> — one probe pass. Prints event lines as a side effect. Creates
+# $STATE_DIR/<pr>.done when a terminal state is reached; the main loop reads
+# that file's existence, never this function's return value, as the signal.
+_tick() {
+  local pr="$1"
+
+  _gh pr view "$pr" "${REPO_FLAGS[@]}" --json state,mergedAt,mergeStateStatus
+  if (( GH_RC != 0 )); then
+    echo "  (transient) gh pr view #$pr failed rc=$GH_RC: ${GH_ERR:0:160}" >&2
+    return 0
+  fi
+  local state="" merged_at=""
+  IFS='|' read -r state merged_at < <(
+    printf '%s' "$GH_OUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+print((d.get("state") or "") + "|" + (d.get("mergedAt") or ""))
+'
+  )
+
+  if [[ "$state" == "MERGED" || -n "$merged_at" ]]; then
+    echo "#$pr MERGED $merged_at"
+    : > "$STATE_DIR/$pr.done"
+    return 0
+  fi
+  if [[ "$state" == "CLOSED" ]]; then
+    echo "#$pr CLOSED"
+    : > "$STATE_DIR/$pr.done"
+    return 0
+  fi
+
+  # Still OPEN — everything below is advisory, never terminal.
+  _gh pr checks "$pr" "${REPO_FLAGS[@]}" --json name,state,isRequired
+  if (( GH_RC != 0 )) && [[ -z "$GH_OUT" ]]; then
+    echo "  (transient) gh pr checks #$pr failed rc=$GH_RC: ${GH_ERR:0:160}" >&2
+  else
+    local checks_json="${GH_OUT:-[]}"
+    _emit_required_failing "$pr" "$checks_json"
+    _emit_missing_required "$pr" "$checks_json"
+  fi
+
+  _emit_queue_ejection "$pr"
+  return 0
+}
+
+# _emit_required_failing <pr> <checks_json> — names every isRequired check
+# NOT in {SUCCESS,SKIPPED,NEUTRAL}, deduped against the last-emitted set.
+_emit_required_failing() {
+  local pr="$1" checks_json="$2"
+  local failing
+  failing="$(printf '%s' "$checks_json" | python3 -c '
+import json, sys
+try:
+    checks = json.load(sys.stdin) or []
+except Exception:
+    checks = []
+ok_states = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+names = sorted(
+    c.get("name", "") for c in checks
+    if c.get("isRequired") and c.get("state") not in ok_states
+)
+print(",".join(names))
+')"
+  local last_file="$STATE_DIR/$pr.failing"
+  local last; last="$(_last "$last_file")"
+  if [[ -n "$failing" && "$failing" != "$last" ]]; then
+    echo "#$pr REQUIRED-FAILING: $failing"
+    printf '%s' "$failing" > "$last_file"
+  elif [[ -z "$failing" && -n "$last" ]]; then
+    : > "$last_file"   # silent reset on recovery — a later re-failure with
+                        # the SAME names is a NEW set relative to "" and re-alerts
+  fi
+}
+
+# _emit_missing_required <pr> <checks_json> — branch-protection required
+# contexts absent from the reported name set entirely, via comm -23. This is
+# what catches a skipped matrix job: its suffixed context never appears
+# under ANY name in the reported set, required-flag or not — so the
+# comparison set is every reported name, not just the required-flagged ones.
+_emit_missing_required() {
+  local pr="$1" checks_json="$2"
+  _gh api "repos/$REPO/branches/main/protection" --jq '.required_status_checks.checks[].context'
+  if (( GH_RC != 0 )); then
+    echo "  (transient) branch-protection lookup failed for #$pr rc=$GH_RC: ${GH_ERR:0:160}" >&2
+    return 0
+  fi
+  local req_names="$GH_OUT"
+  [[ -n "$req_names" ]] || return 0
+
+  local reported_names
+  reported_names="$(printf '%s' "$checks_json" | python3 -c '
+import json, sys
+try:
+    checks = json.load(sys.stdin) or []
+except Exception:
+    checks = []
+print("\n".join(sorted(set(c.get("name", "") for c in checks))))
+')"
+
+  local req_sorted="$STATE_DIR/$pr.req_sorted.tmp" rep_sorted="$STATE_DIR/$pr.rep_sorted.tmp"
+  printf '%s\n' "$req_names" | sort > "$req_sorted"
+  printf '%s\n' "$reported_names" | sort > "$rep_sorted"
+  local missing
+  missing="$(comm -23 "$req_sorted" "$rep_sorted" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')"
+  rm -f "$req_sorted" "$rep_sorted"
+
+  local last_file="$STATE_DIR/$pr.missing"
+  local last; last="$(_last "$last_file")"
+  if [[ -n "$missing" && "$missing" != "$last" ]]; then
+    echo "#$pr MISSING-REQUIRED: $missing"
+    printf '%s' "$missing" > "$last_file"
+  elif [[ -z "$missing" && -n "$last" ]]; then
+    : > "$last_file"
+  fi
+}
+
+# _emit_queue_ejection <pr> — GraphQL isInMergeQueue is the ONLY reliable
+# signal here (W118): a transition true->false while the PR is still OPEN
+# (already excluded from reaching this point when MERGED/CLOSED) means the
+# queue dropped it, not that it landed.
+_emit_queue_ejection() {
+  local pr="$1"
+  # shellcheck disable=SC2016  # GraphQL $vars, must stay single-quoted (unrelated to $OWNER/$NAME/$pr below)
+  _gh api graphql -f query='
+    query($owner:String!,$name:String!,$number:Int!) {
+      repository(owner:$owner,name:$name) {
+        pullRequest(number:$number) {
+          isInMergeQueue
+          mergeQueueEntry { state position }
+        }
+      }
+    }' -F owner="$OWNER" -F name="$NAME" -F number="$pr"
+  if (( GH_RC != 0 )); then
+    echo "  (transient) merge-queue probe failed for #$pr rc=$GH_RC: ${GH_ERR:0:160}" >&2
+    return 0
+  fi
+  local in_queue="0"
+  in_queue="$(printf '%s' "$GH_OUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+pr = ((d.get("data") or {}).get("repository") or {}).get("pullRequest") or {}
+print("1" if pr.get("isInMergeQueue") else "0")
+')"
+  local last_file="$STATE_DIR/$pr.inqueue"
+  local last; last="$(_last "$last_file")"
+  [[ -n "$last" ]] || last="0"
+  if [[ "$last" == "1" && "$in_queue" == "0" ]]; then
+    echo "#$pr EJECTED-FROM-QUEUE"
+  fi
+  printf '%s' "$in_queue" > "$last_file"
+}
+
+start_ts=$(date +%s)
+ceiling=$(( PR_WATCH_MAX_MIN * 60 ))
+
+while :; do
+  now=$(date +%s)
+  if (( now - start_ts >= ceiling )); then
+    echo "TIMEOUT"
+    exit 1
+  fi
+
+  all_done=1
+  for pr in "$@"; do
+    [[ -f "$STATE_DIR/$pr.done" ]] && continue   # already terminal — skip, not re-probed
+    all_done=0
+    _tick "$pr"
+  done
+
+  if (( all_done )); then
+    echo "ALL_DONE"
+    exit 0
+  fi
+
+  sleep "$PR_WATCH_INTERVAL"
+done

--- a/scripts/tests/test_pr_watch.sh
+++ b/scripts/tests/test_pr_watch.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# test_pr_watch.sh — proof for scripts/pr_watch.sh (deterministic PR watcher).
+#
+# WHAT IT PINS
+#   merged           — a MERGED pr view reply prints "#N MERGED <ts>" and the
+#                       PR drops out of polling immediately (no further
+#                       gh pr checks/graphql calls for it after that tick).
+#   closed            — a CLOSED reply prints "#N CLOSED" and drops out too.
+#   multi-pr all-done — two PRs merging on different ticks still produce
+#                       exactly one ALL_DONE, only after BOTH are terminal.
+#   required-failing dedup — the SAME failing set across ticks emits its
+#                       line ONCE; a changed set re-emits; recovery-then-
+#                       refail with the same names alerts again.
+#   missing-required  — a branch-protection context absent from the FULL
+#                       reported name set (not just isRequired ones) is
+#                       flagged — the skipped-matrix-job shape.
+#   W118 trap         — isInMergeQueue flips true->false while the PR is
+#                       still OPEN: EJECTED-FROM-QUEUE fires. Never inferred
+#                       from autoMergeRequest (this script never even reads
+#                       that field — grepped for in the harness log below).
+#   transient gh error — a probe that fails with empty output does not abort
+#                       the script; polling continues to the next tick.
+#   timeout            — an eternally-OPEN, all-clean PR exits TIMEOUT/1
+#                       once PR_WATCH_MAX_MIN elapses.
+#
+# No network, no real gh: a fake `gh` on PATH answers from per-scenario
+# fixture files and logs every invocation for order/absence assertions.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+SCRIPT="$REPO_ROOT/pr_watch.sh"
+[ -f "$SCRIPT" ] || { echo "FAIL: pr_watch.sh not found at $SCRIPT"; exit 2; }
+[ -x "$SCRIPT" ] || { echo "FAIL: pr_watch.sh not executable at $SCRIPT"; exit 2; }
+
+failures=0
+check() {  # check <name> <0-or-1>
+  if [ "$2" = "1" ]; then printf '  ok   %s\n' "$1"
+  else printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); fi
+}
+has() { case "$2" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+yesno() { if "$@"; then echo 1; else echo 0; fi; }
+count_of() { grep -c -- "$1" "$2" 2>/dev/null || true; }  # never trips set -e in $(...)
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/prwatch_test.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# One scenario = one fresh world: its own fake-gh state dir, log, PATH.
+# Nothing here touches real gh or real GitHub.
+new_world() {
+  W="$(mktemp -d "$SANDBOX/w.XXXXXX")"
+  mkdir -p "$W/bin" "$W/fgh"
+  LOG="$W/log"
+  : > "$LOG"
+  # Per-PR view-response sequences: $W/fgh/view_<pr>  (one JSON line per call,
+  # last line repeats once exhausted). Per-PR checks/graphql are simpler —
+  # single fixed fixture unless a scenario overrides it (see helpers below).
+  cat > "$W/bin/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+# Fake gh — logs every invocation, answers from $FAKE_GH_STATE. An
+# invocation shape this fake does not recognise is a HARNESS bug (exit 99).
+set -uo pipefail
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+
+_next_line() {  # _next_line <fixture-file> <counter-file> -> stdout
+  local fx="$1" ctr="$2" n
+  n=$(( $(cat "$ctr" 2>/dev/null || echo 0) + 1 ))
+  echo "$n" > "$ctr"
+  local line
+  line="$(sed -n "${n}p" "$fx" 2>/dev/null)"
+  [ -z "$line" ] && line="$(tail -1 "$fx" 2>/dev/null)"
+  printf '%s\n' "$line"
+}
+
+case "${1:-}" in
+  repo)
+    # repo view --json nameWithOwner --jq .nameWithOwner
+    echo "test-owner/test-repo"
+    exit 0
+    ;;
+  api)
+    case " $* " in
+      *" graphql "*)
+        # extract PR number from -F number=<n>
+        num=""
+        prev=""
+        for a in "$@"; do
+          case "$prev" in
+            -F) case "$a" in number=*) num="${a#number=}";; esac;;
+          esac
+          prev="$a"
+        done
+        fx="$FAKE_GH_STATE/graphql_${num}"
+        ctr="$FAKE_GH_STATE/graphql_${num}_ctr"
+        [ -f "$fx" ] || { echo '{"data":{"repository":{"pullRequest":{"isInMergeQueue":false,"mergeQueueEntry":null}}}}'; exit 0; }
+        _next_line "$fx" "$ctr"
+        exit 0
+        ;;
+      *"/branches/main/protection "*)
+        rc=0
+        [ -f "$FAKE_GH_STATE/required_names_rc" ] && rc="$(cat "$FAKE_GH_STATE/required_names_rc")"
+        [ -f "$FAKE_GH_STATE/required_names" ] && cat "$FAKE_GH_STATE/required_names"
+        exit "$rc"
+        ;;
+    esac
+    echo "FAKE_GH: unhandled api invocation: $*" >&2
+    exit 99
+    ;;
+  pr)
+    case "${2:-}" in
+      view)
+        num="$3"
+        fx="$FAKE_GH_STATE/view_${num}"
+        ctr="$FAKE_GH_STATE/view_${num}_ctr"
+        rcfx="$FAKE_GH_STATE/view_${num}_rc_seq"
+        if [ -f "$fx" ]; then _next_line "$fx" "$ctr"; else echo '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}'; fi
+        rc=0
+        if [ -f "$rcfx" ]; then
+          n="$(cat "$ctr" 2>/dev/null || echo 1)"
+          line_rc="$(sed -n "${n}p" "$rcfx" 2>/dev/null)"
+          [ -n "$line_rc" ] && rc="$line_rc"
+        fi
+        exit "$rc"
+        ;;
+      checks)
+        num="$3"
+        rc=0
+        [ -f "$FAKE_GH_STATE/checks_${num}_rc" ] && rc="$(cat "$FAKE_GH_STATE/checks_${num}_rc")"
+        fx="$FAKE_GH_STATE/checks_${num}"
+        ctr="$FAKE_GH_STATE/checks_${num}_ctr"
+        if [ -f "$fx" ]; then _next_line "$fx" "$ctr"; else echo '[]'; fi
+        exit "$rc"
+        ;;
+    esac
+    ;;
+esac
+echo "FAKE_GH: unhandled invocation: $*" >&2
+exit 99
+FAKEGH
+  chmod +x "$W/bin/gh"
+}
+
+# run <args...> — invokes pr_watch.sh via env (real exec, no ambiguity about
+# shell-function propagation), capturing combined stdout+stderr in $OUT and
+# exit code in $RC.
+run() {
+  OUT="$(env FAKE_GH_LOG="$LOG" FAKE_GH_STATE="$W/fgh" \
+             PATH="$W/bin:$PATH" \
+             PR_WATCH_INTERVAL="${PR_WATCH_INTERVAL:-0}" \
+             PR_WATCH_MAX_MIN="${PR_WATCH_MAX_MIN:-1}" \
+             bash "$SCRIPT" --repo test-owner/test-repo "$@" 2>&1)"
+  RC=$?
+}
+
+# poverty check — the fake must actually be the one gh resolves to.
+new_world
+resolved="$(PATH="$W/bin:$PATH" command -v gh)"
+if [ "$resolved" != "$W/bin/gh" ]; then
+  echo "HARNESS TOO POOR TO JUDGE: PATH did not resolve gh to the fake ($resolved)" >&2
+  exit 2
+fi
+
+echo "merged — prints MERGED once and stops probing that PR:"
+new_world
+printf '{"state":"MERGED","mergedAt":"2026-08-21T01:00:00Z","mergeStateStatus":"CLEAN"}\n' > "$W/fgh/view_42"
+run 42
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "prints #42 MERGED with the timestamp" "$(yesno has '#42 MERGED 2026-08-21T01:00:00Z' "$OUT")"
+check "prints ALL_DONE" "$(yesno has 'ALL_DONE' "$OUT")"
+check "never called pr checks for a PR merged on tick 1" "$(yesno eval '[ "$(count_of "pr checks 42" "$LOG")" = "0" ]')"
+
+echo "closed — prints CLOSED once:"
+new_world
+printf '{"state":"CLOSED","mergedAt":null,"mergeStateStatus":"CLOSED"}\n' > "$W/fgh/view_43"
+run 43
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "prints #43 CLOSED" "$(yesno has '#43 CLOSED' "$OUT")"
+
+echo "multi-pr — ALL_DONE only after BOTH reach a terminal state:"
+new_world
+{
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"MERGED","mergedAt":"2026-08-21T02:00:00Z","mergeStateStatus":"CLEAN"}\n'
+} > "$W/fgh/view_50"
+printf '{"state":"MERGED","mergedAt":"2026-08-21T01:30:00Z","mergeStateStatus":"CLEAN"}\n' > "$W/fgh/view_51"
+run 50 51
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "#50 MERGED printed" "$(yesno has '#50 MERGED' "$OUT")"
+check "#51 MERGED printed" "$(yesno has '#51 MERGED' "$OUT")"
+check "exactly one ALL_DONE" "$(yesno eval '[ "$(count_of "ALL_DONE" <(printf "%s" "$OUT"))" = "1" ]')"
+
+echo "required-failing — same set once, changed set re-emits, recovery resets:"
+new_world
+cat > "$W/fgh/checks_60" <<'JSON'
+[{"name":"Backend Tests","state":"FAILURE","isRequired":true}]
+[{"name":"Backend Tests","state":"FAILURE","isRequired":true}]
+[{"name":"Backend Tests","state":"SUCCESS","isRequired":true}]
+[{"name":"Backend Tests","state":"FAILURE","isRequired":true}]
+JSON
+{
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"MERGED","mergedAt":"2026-08-21T03:00:00Z","mergeStateStatus":"CLEAN"}\n'
+} > "$W/fgh/view_60"
+PR_WATCH_MAX_MIN=5 run 60
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "REQUIRED-FAILING printed exactly twice (not once per tick)" \
+  "$(yesno eval '[ "$(count_of "REQUIRED-FAILING: Backend Tests" <(printf "%s" "$OUT"))" = "2" ]')"
+
+echo "missing-required — branch-protection context absent from the FULL reported set:"
+new_world
+printf 'Backend Tests (Python)\nDetect Secrets\nE2E (matrix, shard 3)\n' > "$W/fgh/required_names"
+printf '[{"name":"Backend Tests (Python)","state":"SUCCESS","isRequired":true},{"name":"Detect Secrets","state":"SUCCESS","isRequired":true}]\n[{"name":"Backend Tests (Python)","state":"SUCCESS","isRequired":true},{"name":"Detect Secrets","state":"SUCCESS","isRequired":true}]\n' > "$W/fgh/checks_70"
+{
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"MERGED","mergedAt":"2026-08-21T04:00:00Z","mergeStateStatus":"CLEAN"}\n'
+} > "$W/fgh/view_70"
+run 70
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "flags the skipped-matrix context by name" "$(yesno has 'MISSING-REQUIRED: E2E (matrix, shard 3)' "$OUT")"
+check "does not flag a context that WAS reported" "$(yesno eval '! has "MISSING-REQUIRED: Backend Tests" "$OUT" && ! has "MISSING-REQUIRED: Detect Secrets" "$OUT"')"
+
+echo "W118 trap — isInMergeQueue true then false while still OPEN fires EJECTED-FROM-QUEUE:"
+new_world
+printf '{"data":{"repository":{"pullRequest":{"isInMergeQueue":true,"mergeQueueEntry":{"state":"AWAITING_CHECKS","position":1}}}}}\n{"data":{"repository":{"pullRequest":{"isInMergeQueue":false,"mergeQueueEntry":null}}}}\n' > "$W/fgh/graphql_80"
+{
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"MERGED","mergedAt":"2026-08-21T05:00:00Z","mergeStateStatus":"CLEAN"}\n'
+} > "$W/fgh/view_80"
+PR_WATCH_MAX_MIN=5 run 80
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "EJECTED-FROM-QUEUE fires exactly once" \
+  "$(yesno eval '[ "$(count_of "EJECTED-FROM-QUEUE" <(printf "%s" "$OUT"))" = "1" ]')"
+check "the ejected PR is named" "$(yesno has '#80 EJECTED-FROM-QUEUE' "$OUT")"
+check "autoMergeRequest is NEVER read by this script (grep the harness log)" \
+  "$(yesno eval '! grep -qi "autoMergeRequest" "$LOG"')"
+
+echo "transient gh error — a nonzero-rc gh pr view does not abort; polling continues:"
+new_world
+{
+  printf '{}\n'
+  printf '{"state":"MERGED","mergedAt":"2026-08-21T06:00:00Z","mergeStateStatus":"CLEAN"}\n'
+} > "$W/fgh/view_90"
+printf '1\n0\n' > "$W/fgh/view_90_rc_seq"
+run 90
+check "exit 0 (recovered on the next tick)" "$(yesno test "$RC" = 0)"
+check "eventually MERGED" "$(yesno has '#90 MERGED' "$OUT")"
+check "the transient tick is logged, not swallowed silently" "$(yesno has 'transient' "$OUT")"
+
+echo "W104 — gh pr checks rc!=0 WITH a body is data, not a tool failure (still used):"
+new_world
+printf '1\n' > "$W/fgh/checks_91_rc"
+printf '[{"name":"Backend Tests","state":"FAILURE","isRequired":true}]\n' > "$W/fgh/checks_91"
+{
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"MERGED","mergedAt":"2026-08-21T07:00:00Z","mergeStateStatus":"CLEAN"}\n'
+} > "$W/fgh/view_91"
+run 91
+check "exit 0" "$(yesno test "$RC" = 0)"
+check "the body was used despite rc!=0 (W104)" "$(yesno has '#91 REQUIRED-FAILING: Backend Tests' "$OUT")"
+
+echo "W104 — gh pr checks rc!=0 WITH an empty body IS a real transient failure:"
+new_world
+printf '1\n' > "$W/fgh/checks_92_rc"
+: > "$W/fgh/checks_92"   # empty body, not even '[]'
+{
+  printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n'
+  printf '{"state":"MERGED","mergedAt":"2026-08-21T08:00:00Z","mergeStateStatus":"CLEAN"}\n'
+} > "$W/fgh/view_92"
+run 92
+check "exit 0 (recovers next tick)" "$(yesno test "$RC" = 0)"
+check "logs the transient checks failure" "$(yesno has 'transient' "$OUT")"
+check "does not fabricate a REQUIRED-FAILING line from an empty body" "$(yesno eval '! has "REQUIRED-FAILING" "$OUT"')"
+
+echo "timeout — an eternally-OPEN, all-clean PR exits TIMEOUT/1:"
+new_world
+printf '{"state":"OPEN","mergedAt":null,"mergeStateStatus":"CLEAN"}\n' > "$W/fgh/view_95"
+PR_WATCH_MAX_MIN=0 run 95
+check "exit 1" "$(yesno test "$RC" = 1)"
+check "prints TIMEOUT" "$(yesno has 'TIMEOUT' "$OUT")"
+check "never prints ALL_DONE on a timeout" "$(yesno eval '! has "ALL_DONE" "$OUT"')"
+
+echo
+if [ "$failures" -eq 0 ]; then echo "PASS (all checks)"; exit 0; fi
+echo "FAIL ($failures check(s))"; exit 1


### PR DESCRIPTION
## Why

Owner order (2026-08-21): stop spending LLM tokens babysitting CI. Measured: 54% of a
PR-session's output tokens are spent AFTER `gh pr create` (watching CI, merge, prove-live);
14% of all Bash calls in that phase are `gh pr checks/view/run`.

## What

- `scripts/pr_watch.sh <PR#> [<PR#>...]` — a deterministic watcher, no network beyond `gh`,
  no writes outside its own tmp state dir. Emits one line per event:
  `#N MERGED <ts>` / `#N CLOSED` / `#N REQUIRED-FAILING: <names>` (once per new failing set)
  / `#N MISSING-REQUIRED: <contexts>` (via `comm -23` against the FULL reported-check-name
  set, catching the skipped-matrix-job class) / `#N EJECTED-FROM-QUEUE` (GraphQL
  `isInMergeQueue` transition true→false while still OPEN — never inferred from
  `autoMergeRequest`, which reads null/false both while healthily queued and after ejection,
  W118). Polls every `PR_WATCH_INTERVAL` (default 180s) up to `PR_WATCH_MAX_MIN` (default
  120), exits `ALL_DONE`/0 or `TIMEOUT`/1. Mirrors `scripts/mq.sh`'s discipline (errexit-immune
  rc capture, W104 content-over-exit-code judgment for `gh pr checks`, bash-3.2-safe — no
  assoc arrays, no empty-array expansion).
- `scripts/tests/test_pr_watch.sh` — fake `gh` on PATH, fixture-driven, no network.
- `docs/runbooks/merge-queue-discipline.md` — new "After arming: watch, don't poll" section
  (36 lines) with the standing gesture, the W118/W111 notes, and how `pr_watch.sh` relates to
  `mq.sh`'s `watch` verb (drift-guard for one PR vs. terminal-state watcher for one or many).

## Test

- `bash scripts/tests/test_pr_watch.sh` — 27/27 checks pass (merged/closed/multi-PR/dedup/
  missing-required/W118-ejection/W104-transient/timeout).
- Two hand-run mutations (killed the REQUIRED-FAILING dedup; killed the EJECTED-FROM-QUEUE
  branch) both turned the suite red, confirming the corpus isn't vacuous.
- `shellcheck -s bash scripts/pr_watch.sh scripts/tests/test_pr_watch.sh` — clean (only the
  same info-level SC2016 already present in the sibling `test_mq_sh.sh`'s `yesno eval` idiom).
- `python3 scripts/docs_sync.py --check` — OK.
- `python3 scripts/lint_tcc_desktop_paths.py` — clean.

## Adversarial review

fixture-driven test covers every terminal state and the two proxy traps (W118, skipped
matrix); orchestrating session 3563604c re-verifies.