### PR TITLE
feat(lanes): lane_ship.sh deterministic ship tail + lane report contract

### DIFF
--- a/docs/runbooks/agent-worktree-broker.md
+++ b/docs/runbooks/agent-worktree-broker.md
@@ -199,6 +199,28 @@ OGNI sessione agent dispatch (subagent dispatch, cron-spawned `claude`, parallel
 3. Lavorare lì. Mai `git stash` / `git checkout` nel main checkout.
 4. Quando finito: commit + push + `--release <task-id>` (oppure lascia che `--cleanup` lo prenda al prossimo cron tick).
 
+## Lane report contract (2026-08-21)
+
+Two implementer lanes finished in the same day with only an idle notification
+and no report — no PR number, no worktree path, no test result. A third was
+hard-blocked pushing/PR-ing by `orchestrate_gate.py` while running as a
+subagent (fixed the same day, see `infra/claude-hooks/orchestrate_gate.py`'s
+SUBAGENT EXEMPTION note). The contract that closes both gaps:
+
+1. **Every lane ends with a report message**, never an idle notification
+   alone: PR number/URL, worktree path, checks run with their result lines
+   (pass/fail, not just "ran"), and what was left undone and why.
+2. **A lane ships through `scripts/lane_ship.sh`** — refuses a dirty or
+   main-checkout worktree, pushes with a captured exit code, reuses or
+   creates the PR, arms `gh pr merge --auto` bare, and GraphQL-verifies the
+   arm before printing one grep-able verdict line, `LANE_SHIP_OK` or
+   `LANE_SHIP_FAIL reason=<why>`. Corpus: `scripts/tests/test_lane_ship.sh`.
+3. **The orchestrator reads the worktree/PR state as truth, the report as
+   a lead.** A report claiming "shipped" with no `LANE_SHIP_OK` line (or a
+   PR that doesn't actually exist/isn't armed) is treated as unverified,
+   never as done — same discipline as `final-gate-discipline`: re-run the
+   check yourself before trusting the claim.
+
 ## Broker-aware spawn convention (W62 ANTIBODY #4)
 
 Il TTL da solo non basta: nessun consumer lo applicava. La hygiene è ora a 3 livelli, in ordine di affidabilità decrescente:

--- a/infra/claude-hooks/orchestrate_gate.py
+++ b/infra/claude-hooks/orchestrate_gate.py
@@ -33,6 +33,29 @@ together; neither blocks (`permissionDecision` is always "allow" here).
 Cannot-verify (unreadable file / unrecognized transcript shape) stays fully
 silent rather than claim a count it does not have — same discipline as the
 blocking path's W106b guard just below.
+
+SUBAGENT EXEMPTION (2026-08-21, lane-ship mandate): a session was hard-blocked
+on this gate while running as a SUBAGENT — a context with no `Agent` tool of
+its own (the current harness does not let a dispatched subagent dispatch a
+further subagent), so "zero subagent dispatch in the last 300 lines" is a
+structural impossibility for it, not a signal that direct work should stop.
+Two independent markers identify that context, checked BEFORE any transcript
+read (`is_subagent_context`, right below `GATED_TOOLS`):
+  1. `payload["agent_id"]` — DOCUMENTED (code.claude.com/docs/en/hooks,
+     checked 2026-08-21): "Present only when the hook fires inside a
+     subagent call." Primary signal.
+  2. `transcript_path` containing a `subagents` path component — UNDOCUMENTED
+     but empirically verified live on 2026-08-21: a subagent's own dedicated
+     transcript file lives at
+     `<project>/<session>/subagents/agent-a<lane>-<hash>.jsonl`, confirmed
+     against real on-disk files including the hook-author's own live
+     transcript during this very investigation (every line of that file
+     carried `"agentId"` and `"isSidechain":true`; the parent session's own
+     transcript file carried neither — 0 occurrences of both). Fallback
+     signal, kept in case a harness version omits `agent_id` on some events.
+A main-session transcript with zero dispatches past the threshold keeps
+blocking exactly as before — this exemption is scoped to the two markers
+above, never to "transcript looks quiet."
 """
 import json
 import os
@@ -76,6 +99,19 @@ TRANSCRIPT_SHAPE_MARKERS = ('"tool_use"', '"tool_result"', '"role":"assistant"',
                             '"role": "assistant"')
 
 GATED_TOOLS = {"Bash", "Edit", "Write"}
+
+
+def is_subagent_context(payload):
+    """True when this PreToolUse call fires inside a dispatched subagent's own
+    turn. See the module docstring's SUBAGENT EXEMPTION note for the evidence
+    behind each signal. Checked BEFORE any transcript read — cheap, and works
+    even if the transcript file has not been flushed yet."""
+    if payload.get("agent_id"):
+        return True
+    transcript_path = payload.get("transcript_path") or ""
+    if transcript_path and "subagents" in pathlib.PurePath(transcript_path).parts:
+        return True
+    return False
 
 # Disarm-notice: at most once per session (keyed on transcript basename), so a
 # 6400-line session gets ONE reminder, not one per Bash call.
@@ -208,6 +244,15 @@ def main():
 
     tool_name = payload.get("tool_name") or payload.get("name") or ""
     if tool_name not in GATED_TOOLS:
+        sys.exit(0)
+
+    if is_subagent_context(payload):
+        sys.stderr.write(
+            "[ORCHESTRATE-GATE] subagent context detected (agent_id or "
+            "subagents/ transcript path) — exempt: a dispatched subagent has "
+            "no Agent tool of its own, so it cannot satisfy 'zero dispatch in "
+            f"last {RECENT_LINES} lines' by legitimate means. Not blocking.\n"
+        )
         sys.exit(0)
 
     transcript_path = payload.get("transcript_path", "")

--- a/infra/claude-hooks/test_orchestrate_gate_vocab.py
+++ b/infra/claude-hooks/test_orchestrate_gate_vocab.py
@@ -37,22 +37,35 @@ def _transcript(body_lines, shape=True, total=BIG):
     return "\n".join(pad + list(body_lines)) + "\n"
 
 
-def run_gate(text, tool="Bash", env_extra=None):
-    """Invoke the real hook; return its exit code."""
-    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
-        fh.write(text)
-        path = fh.name
+def run_gate(text, tool="Bash", env_extra=None, agent_id=None, transcript_path=None):
+    """Invoke the real hook; return its exit code.
+
+    `transcript_path`, when given, is used verbatim as the payload's
+    transcript_path INSTEAD of writing `text` to a real temp file — needed to
+    test the subagents/-path exemption, which must fire before the hook ever
+    opens the file (a subagent's transcript may not be flushed yet)."""
+    path = transcript_path
+    owns_file = False
+    if path is None:
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
+            fh.write(text)
+            path = fh.name
+        owns_file = True
     try:
         env = dict(os.environ)
         env.pop("ORCHESTRATE_GATE_OFF", None)  # the live machine sets it; tests must not inherit
         env.update(env_extra or {})
-        payload = json.dumps({"tool_name": tool, "transcript_path": path,
-                              "tool_input": {"command": "ls"}})
+        payload_dict = {"tool_name": tool, "transcript_path": path,
+                         "tool_input": {"command": "ls"}}
+        if agent_id is not None:
+            payload_dict["agent_id"] = agent_id
+        payload = json.dumps(payload_dict)
         p = subprocess.run([sys.executable, str(HOOK)], input=payload,
                            capture_output=True, text=True, env=env)
         return p.returncode
     finally:
-        os.unlink(path)
+        if owns_file:
+            os.unlink(path)
 
 
 # ── guilt ────────────────────────────────────────────────────────────────────
@@ -109,6 +122,42 @@ def test_innocence_non_gated_tool_passes():
 
 def test_innocence_kill_switch_passes():
     assert run_gate(_transcript([SHAPE]), env_extra={"ORCHESTRATE_GATE_OFF": "1"}) == 0
+
+
+# ── subagent exemption (2026-08-21) ───────────────────────────────────────────
+# A subagent has no Agent tool of its own — "zero dispatch in the last N
+# lines" is a structural impossibility for it, not a signal to heed. Two
+# independent markers exempt it (see the hook's module docstring for the
+# evidence): `agent_id` (documented) and a `subagents/` path component in
+# `transcript_path` (empirically verified, undocumented fallback).
+
+def test_innocence_agent_id_exempts_a_quiet_subagent():
+    """The documented marker: `agent_id` present ⇒ inside a subagent call.
+    A huge, dispatch-free transcript must NOT block when this is set."""
+    assert run_gate(_transcript([SHAPE]), agent_id="alane-ship-65c1db88930053a2") == 0
+
+
+def test_innocence_subagents_path_exempts_even_an_unwritten_transcript():
+    """The path-shaped marker must short-circuit BEFORE the file is ever
+    opened — a subagent's dedicated transcript may not be flushed yet. A
+    transcript_path that does not exist on disk must still exempt."""
+    fake = "/tmp/does-not-exist-on-purpose/subagents/agent-afoo-deadbeef.jsonl"
+    assert run_gate(None, transcript_path=fake) == 0
+
+
+def test_guilt_main_session_with_zero_dispatch_still_blocks():
+    """The guard must keep biting where it should: neither `agent_id` nor a
+    `subagents/` path is present ⇒ ordinary main-session behaviour, unchanged."""
+    assert run_gate(_transcript([SHAPE])) == 2
+
+
+def test_guilt_agent_id_alone_does_not_forge_a_subagents_path_bypass():
+    """Sanity: the exemption is not a blanket 'any extra field allows' —
+    it fires ONLY on the two named markers, checked directly against the
+    payload dict, never against transcript content."""
+    text = _transcript([SHAPE])
+    assert run_gate(text, agent_id="") == 2  # falsy agent_id must NOT exempt
+    assert run_gate(text, agent_id=None) == 2  # absent agent_id (default) must NOT exempt
 
 
 def test_unreadable_transcript_shape_does_not_convict():

--- a/scripts/lane_ship.sh
+++ b/scripts/lane_ship.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# lane_ship.sh — deterministic ship tail for an implementer-lane worktree.
+#
+# WHY THIS EXISTS (Zero, 2026-08-21): two Sonnet lanes finished with only an
+# idle notification and no report — the orchestrator had no reliable signal
+# that a lane's work had actually reached a PR, let alone an armed one. This
+# script is the missing tail: refuse-if-not-ready -> push -> reuse-or-create
+# PR -> arm -> GraphQL-verify, ending in exactly ONE machine-readable line
+# (LANE_SHIP_OK / LANE_SHIP_FAIL) an orchestrator can grep for. See
+# docs/runbooks/agent-worktree-broker.md "Lane report contract" for how a
+# lane's final message is supposed to use this.
+#
+# Usage:
+#   scripts/lane_ship.sh <worktree> "<PR title>" [--body-file <f>] [--no-arm]
+#
+# Steps:
+#   1. refuse if <worktree> IS the main checkout, or has uncommitted changes
+#      (prints them — never silently discards or decides for you)
+#   2. git -C <worktree> push -u origin HEAD, judged by CAPTURED exit code
+#   3. reuse the PR for this branch if one exists, else `gh pr create`
+#      (body MUST carry a "## Adversarial review" section; a missing one
+#      gets a placeholder appended, never silently dropped)
+#   4. arm `gh pr merge --auto <N>` BARE — no strategy flag, the queue
+#      refuses them (CLAUDE.md "Workflow rules" / feedback_arm_automerge_
+#      default_not_leave_to_operator.md); "already queued"/clean is a
+#      SUCCESS shape, not a failure (mq.sh precedent)
+#   5. verify via GraphQL that autoMergeRequest.enabledAt is set OR
+#      isInMergeQueue is true (W118: `autoMergeRequest` alone reads false
+#      while a PR sits INSIDE the queue) and print the one verdict line
+#
+# DESIGN RULES (blood-bought, cicatrix-superscar.md — same discipline as
+# scripts/mq.sh, which this script reuses conventions from but does not
+# invoke, since mq.sh operates on PR numbers already known, and this script's
+# job is to GET one):
+#   - every external call's rc is captured errexit-immune (`|| var=$?`,
+#     never a bare assignment under `set -e` — W101: the bare form aborts
+#     the script BEFORE the caller can inspect the rc it exists to inspect)
+#   - gh's answer is judged by CONTENT, never exit code alone (W104)
+#   - a command whose exit code matters is never piped into `tail`/`grep`
+#     directly (W97) — rc is captured on the command itself first
+#   - the merge-queue verify step reads `isInMergeQueue` too, not only
+#     `autoMergeRequest.enabledAt` (W118 — a PR can be armed and IN the
+#     queue while the latter alone still reads false)
+#   - the main-checkout / worktree-root check uses the SAME derivation as
+#     infra/claude-hooks/worktree_isolation.py::_derive_repo_root()
+#     (git rev-parse --path-format=absolute --git-common-dir) so this tool
+#     and that hook never invent two different answers for "where is main"
+#     (cicatrix family #3 lesson: two tools that must agree on a boundary
+#     and don't are how an over/under-match pair is born)
+#
+# bash 3.2 compatible (macOS ships 3.2.57) — no arrays (an empty array under
+# `set -u` on 3.2 raises "unbound variable"), no associative arrays, no
+# process-substitution `<( )` with a `#` comment as its immediately-preceding
+# line (mq.sh's own scar: bash 3.2 mis-parses that as an unterminated paren).
+set -euo pipefail
+
+REPO="${LANE_SHIP_REPO:-Bali-Zero/Teman2}"
+
+_die() {  # _die <reason> [exit_code]
+  echo "LANE_SHIP_FAIL reason=\"$1\"" >&2
+  exit "${2:-1}"
+}
+
+_usage() {
+  echo 'usage: lane_ship.sh <worktree> "<PR title>" [--body-file <f>] [--no-arm]' >&2
+}
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+if [ "$#" -lt 2 ]; then
+  _usage
+  exit 1
+fi
+WORKTREE="$1"
+PR_TITLE="$2"
+shift 2
+
+BODY_FILE=""
+NO_ARM=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --body-file)
+      [ "$#" -ge 2 ] || _die "--body-file requires a path"
+      BODY_FILE="$2"
+      shift 2
+      ;;
+    --no-arm)
+      NO_ARM=1
+      shift
+      ;;
+    *)
+      _die "unknown argument '$1'"
+      ;;
+  esac
+done
+
+[ -d "$WORKTREE" ] || _die "worktree not found: $WORKTREE"
+
+# ---------------------------------------------------------------------------
+# Step 1 — refuse main checkout / dirty worktree
+# ---------------------------------------------------------------------------
+# Both sides below are resolved BY GIT (--path-format=absolute), never by
+# shell `pwd`: on macOS $TMPDIR (and other spots) sit behind a symlink
+# (/var/folders/... -> /private/var/folders/...) that `pwd` does not
+# resolve but git's own realpath-based resolution does — mixing the two
+# made an identical directory compare as two different ones (caught live
+# by this script's own test corpus, not reasoned out in advance).
+WT_ABS=""
+WT_ABS="$(git -C "$WORKTREE" rev-parse --path-format=absolute --show-toplevel 2>/dev/null)" \
+  || _die "not a git worktree (git rev-parse --show-toplevel failed): $WORKTREE"
+
+COMMON_DIR=""
+COMMON_DIR="$(git -C "$WT_ABS" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+  || _die "not a git worktree (git rev-parse --git-common-dir failed): $WT_ABS"
+MAIN_ROOT="${COMMON_DIR%/.git}"
+
+if [ "$WT_ABS" = "$MAIN_ROOT" ]; then
+  _die "refusing: $WT_ABS IS the main checkout, not an isolated worktree (CLAUDE.md Agent Worktree Discipline — see scripts/agent_start.py)"
+fi
+
+DIRTY=""
+DIRTY="$(git -C "$WT_ABS" status --porcelain 2>/dev/null)" \
+  || _die "git status failed in $WT_ABS"
+if [ -n "$DIRTY" ]; then
+  {
+    echo "LANE_SHIP_FAIL reason=\"uncommitted changes in $WT_ABS\""
+    echo "$DIRTY"
+  } >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — push, judged by CAPTURED exit code (never by output alone, W97/W101)
+# ---------------------------------------------------------------------------
+PUSH_RC=0
+PUSH_LOG="$(git -C "$WT_ABS" push -u origin HEAD 2>&1)" || PUSH_RC=$?
+if [ "$PUSH_RC" -ne 0 ]; then
+  {
+    echo "LANE_SHIP_FAIL reason=\"git push failed (rc=$PUSH_RC)\""
+    printf '%s\n' "$PUSH_LOG" | tail -40
+  } >&2
+  exit 2
+fi
+
+BRANCH=""
+BRANCH="$(git -C "$WT_ABS" rev-parse --abbrev-ref HEAD 2>/dev/null)" \
+  || _die "could not determine current branch in $WT_ABS" 2
+
+# gh wrapper: every call runs FROM $WT_ABS (so gh resolves the right repo/
+# remote unambiguously) and captures rc/stdout+stderr together — the caller
+# always inspects $GH_RC before trusting $GH_OUT's shape (W104).
+_gh() {
+  GH_RC=0
+  GH_OUT="$(cd "$WT_ABS" && gh "$@" 2>&1)" || GH_RC=$?
+}
+
+# ---------------------------------------------------------------------------
+# Step 3 — reuse the PR for this branch, or create one
+# ---------------------------------------------------------------------------
+PR_NUMBER=""
+PR_URL=""
+
+_gh pr view "$BRANCH" --repo "$REPO" --json number,url
+if [ "$GH_RC" -eq 0 ]; then
+  PR_NUMBER="$(printf '%s' "$GH_OUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get("number") or "")
+except Exception:
+    print("")
+' 2>/dev/null || true)"
+  PR_URL="$(printf '%s' "$GH_OUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get("url") or "")
+except Exception:
+    print("")
+' 2>/dev/null || true)"
+fi
+
+if [ -z "$PR_NUMBER" ]; then
+  BODY_CONTENT=""
+  if [ -n "$BODY_FILE" ]; then
+    [ -f "$BODY_FILE" ] || _die "--body-file not found: $BODY_FILE"
+    BODY_CONTENT="$(cat "$BODY_FILE")"
+  fi
+  if ! printf '%s' "$BODY_CONTENT" | grep -q '## Adversarial review'; then
+    BODY_CONTENT="$BODY_CONTENT
+## Adversarial review
+_pending: orchestrating session re-verifies_"
+  fi
+
+  TMP_BODY="$(mktemp "${TMPDIR:-/tmp}/lane_ship_body.XXXXXX")"
+  printf '%s\n' "$BODY_CONTENT" > "$TMP_BODY"
+
+  _gh pr create --repo "$REPO" --title "$PR_TITLE" --body-file "$TMP_BODY"
+  CREATE_RC="$GH_RC"
+  CREATE_OUT="$GH_OUT"
+  rm -f "$TMP_BODY"
+
+  if [ "$CREATE_RC" -ne 0 ]; then
+    _die "gh pr create failed (rc=$CREATE_RC): $(printf '%s' "$CREATE_OUT" | tail -5 | tr '\n' ' ')" 2
+  fi
+
+  # `gh pr create` prints the new PR's URL as its last stdout line.
+  PR_URL="$(printf '%s' "$CREATE_OUT" | tail -1)"
+  PR_NUMBER="${PR_URL##*/}"
+fi
+
+case "$PR_NUMBER" in
+  ''|*[!0-9]*) _die "could not determine a numeric PR number (got '$PR_NUMBER')" 2 ;;
+esac
+
+# ---------------------------------------------------------------------------
+# --no-arm: report success now, skip step 4 (arm) and step 5 (verify) —
+# verifying "is it armed" after deliberately not arming would always read
+# as a false failure.
+# ---------------------------------------------------------------------------
+if [ "$NO_ARM" -eq 1 ]; then
+  LOCAL_HEAD="$(git -C "$WT_ABS" rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "LANE_SHIP_OK pr=$PR_NUMBER url=$PR_URL head=$LOCAL_HEAD armed=skipped"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — arm: bare `gh pr merge --auto <N>`, NEVER a strategy flag (the
+# queue refuses them — docs/runbooks/merge-queue-discipline.md). "already
+# queued"/"already enabled"/"clean" is a SUCCESS shape even at non-zero rc
+# (mq.sh cmd_arm precedent, same grep).
+# ---------------------------------------------------------------------------
+_gh pr merge "$PR_NUMBER" --repo "$REPO" --auto
+if [ "$GH_RC" -ne 0 ] && ! printf '%s' "$GH_OUT" | grep -qi "already queued\|auto-merge enabled\|already enabled\|clean"; then
+  _die "gh pr merge --auto failed on #$PR_NUMBER (rc=$GH_RC): $(printf '%s' "$GH_OUT" | tail -5 | tr '\n' ' ')" 2
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5 — verify via GraphQL (W118: `autoMergeRequest.enabledAt` alone can
+# read unset while the PR sits INSIDE the merge queue — `isInMergeQueue` is
+# the second, independent signal, and either one is sufficient).
+# ---------------------------------------------------------------------------
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+
+# shellcheck disable=SC2016 # deliberate: $owner/$name/$number are GraphQL
+# variable references sent literally via `gh api graphql -f/-F ...`, not
+# bash variables — single-quoting is correct here, not a typo (same as
+# .github/workflows/merge-queue-watch.yml's own query).
+GQL_QUERY='
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      autoMergeRequest { enabledAt }
+      isInMergeQueue
+      headRefOid
+      url
+    }
+  }
+}'
+
+_gh api graphql -f query="$GQL_QUERY" -f owner="$OWNER" -f name="$NAME" -F number="$PR_NUMBER"
+if [ "$GH_RC" -ne 0 ]; then
+  _die "GraphQL verify failed on #$PR_NUMBER (rc=$GH_RC): $(printf '%s' "$GH_OUT" | tail -5 | tr '\n' ' ')" 3
+fi
+
+# Comment intentionally NOT placed directly above the `< <( ... )` line below
+# (bash 3.2 mis-parses a `#` there as an unterminated paren — mq.sh scar).
+VERIFY_STATUS=""
+ARMED_YN=""
+HEAD_SHA=""
+VERIFY_URL=""
+IFS='|' read -r VERIFY_STATUS ARMED_YN HEAD_SHA VERIFY_URL < <(
+  printf '%s' "$GH_OUT" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    pr = ((d.get("data") or {}).get("repository") or {}).get("pullRequest") or {}
+except Exception:
+    print("parse_error|no||")
+    raise SystemExit(0)
+amr = pr.get("autoMergeRequest") or {}
+enabled_at = amr.get("enabledAt")
+in_queue = bool(pr.get("isInMergeQueue"))
+head = pr.get("headRefOid") or ""
+url = pr.get("url") or ""
+if enabled_at:
+    print("armed|yes|" + head + "|" + url)
+elif in_queue:
+    print("armed|queued|" + head + "|" + url)
+else:
+    print("not_armed|no|" + head + "|" + url)
+'
+)
+
+FINAL_URL="${VERIFY_URL:-$PR_URL}"
+
+if [ "$VERIFY_STATUS" = "armed" ]; then
+  echo "LANE_SHIP_OK pr=$PR_NUMBER url=$FINAL_URL head=$HEAD_SHA armed=$ARMED_YN"
+  exit 0
+fi
+
+_die "PR #$PR_NUMBER not armed after gh pr merge --auto (autoMergeRequest.enabledAt unset AND isInMergeQueue false)" 3

--- a/scripts/tests/test_lane_ship.sh
+++ b/scripts/tests/test_lane_ship.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# test_lane_ship.sh — proof for scripts/lane_ship.sh (deterministic lane
+# ship tail: push -> reuse-or-create PR -> arm -> GraphQL verify).
+#
+# GIT IS REAL, GH IS FAKED. lane_ship.sh's git calls (status/push/rev-parse)
+# are exercised against a REAL local git repo with a REAL local bare "origin"
+# (no network — a bare repo on the same filesystem is a legitimate git
+# remote) rather than mocked, because reimplementing git's own semantics in
+# a shell fake risks testing the fake's idea of git instead of git's actual
+# behaviour (the exact failure mode this repo's "poverty check" convention
+# — see test_mq_sh.sh — exists to catch). `gh` talks to GitHub's real API
+# and MUST be faked for an offline, deterministic test; its fake answers
+# from per-scenario fixture files and logs every invocation for assertions,
+# same pattern as test_mq_sh.sh.
+#
+# WHAT IT PINS
+#   guilt     — dirty worktree refused (files listed, exit 1, gh never
+#               invoked); push failure surfaces the captured rc + last 40
+#               lines of log, exit 2; GraphQL saying neither armed nor
+#               queued -> LANE_SHIP_FAIL, exit 3.
+#   innocence — an existing PR for the branch is REUSED (no `gh pr create`
+#               call); a new PR is created, armed, and verified ->
+#               LANE_SHIP_OK on stdout; `--no-arm` never calls `gh pr merge`.
+#
+# No network, no real gh, no real GitHub — fully offline.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+LANE_SHIP="$REPO_ROOT/lane_ship.sh"
+[ -f "$LANE_SHIP" ] || { echo "FAIL: lane_ship.sh not found at $LANE_SHIP"; exit 2; }
+[ -x "$LANE_SHIP" ] || { echo "FAIL: lane_ship.sh not executable at $LANE_SHIP"; exit 2; }
+
+failures=0
+check() {  # check <name> <0-or-1>
+  if [ "$2" = "1" ]; then printf '  ok   %s\n' "$1"
+  else printf '  FAIL %s\n' "$1"; failures=$((failures + 1)); fi
+}
+has() { case "$2" in *"$1"*) return 0 ;; *) return 1 ;; esac; }
+yesno() { if "$@"; then echo 1; else echo 0; fi; }
+
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/lane_ship_test.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# One scenario = one fresh world: real bare "origin", a real clone/worktree
+# checked out from it, its own fake-gh state dir + log. Nothing here touches
+# the real $HOME, the real nuzantara repo, or the real GitHub.
+new_world() {
+  W="$(mktemp -d "$SANDBOX/w.XXXXXX")"
+  mkdir -p "$W/bin" "$W/fgh"
+  LOG="$W/log"
+  : > "$LOG"
+
+  cat > "$W/bin/gh" <<'FAKEGH'
+#!/usr/bin/env bash
+# Fake gh — logs every invocation to $FAKE_GH_LOG, answers from
+# $FAKE_GH_STATE. An invocation shape this fake does not recognise is a
+# HARNESS bug (exit 99), never a silent empty answer (W108).
+set -uo pipefail
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+
+case "${1:-}" in
+  pr)
+    case "${2:-}" in
+      view)
+        rc=0
+        [ -f "$FAKE_GH_STATE/view_rc" ] && rc="$(cat "$FAKE_GH_STATE/view_rc")"
+        if [ -f "$FAKE_GH_STATE/view_json" ]; then cat "$FAKE_GH_STATE/view_json"; else echo 'no pull requests found' >&2; fi
+        exit "$rc"
+        ;;
+      create)
+        rc=0
+        [ -f "$FAKE_GH_STATE/create_rc" ] && rc="$(cat "$FAKE_GH_STATE/create_rc")"
+        if [ -f "$FAKE_GH_STATE/create_out" ]; then cat "$FAKE_GH_STATE/create_out"; else echo 'https://github.com/test-owner/test-repo/pull/99'; fi
+        # capture the body-file content for assertions
+        prev=""
+        for a in "$@"; do
+          if [ "$prev" = "--body-file" ]; then cp "$a" "$FAKE_GH_STATE/create_body_seen" 2>/dev/null || true; fi
+          prev="$a"
+        done
+        exit "$rc"
+        ;;
+      merge)
+        rc=0
+        [ -f "$FAKE_GH_STATE/arm_rc" ] && rc="$(cat "$FAKE_GH_STATE/arm_rc")"
+        if [ -f "$FAKE_GH_STATE/arm_out" ]; then cat "$FAKE_GH_STATE/arm_out"; else echo 'Auto-merge enabled for pull request'; fi
+        exit "$rc"
+        ;;
+    esac
+    ;;
+  api)
+    case "${2:-}" in
+      graphql)
+        rc=0
+        [ -f "$FAKE_GH_STATE/graphql_rc" ] && rc="$(cat "$FAKE_GH_STATE/graphql_rc")"
+        if [ -f "$FAKE_GH_STATE/graphql_json" ]; then cat "$FAKE_GH_STATE/graphql_json"; else echo '{}'; fi
+        exit "$rc"
+        ;;
+    esac
+    ;;
+esac
+echo "FAKE_GH: unhandled invocation: $*" >&2
+exit 99
+FAKEGH
+  chmod +x "$W/bin/gh"
+
+  # Real bare "origin" — a local filesystem remote, no network involved.
+  git init --quiet --bare "$W/origin.git"
+
+  # Real seed clone: one commit on main, so `origin/main` exists for the
+  # worktree's branch to diverge from.
+  git init --quiet "$W/seed"
+  git -C "$W/seed" config user.email "test@example.test"
+  git -C "$W/seed" config user.name "Test"
+  git -C "$W/seed" checkout --quiet -b main
+  echo "seed" > "$W/seed/README.md"
+  git -C "$W/seed" add README.md
+  git -C "$W/seed" commit --quiet -m "seed"
+  git -C "$W/seed" remote add origin "$W/origin.git"
+  git -C "$W/seed" push --quiet origin main
+
+  # Real worktree, real feature branch, one real commit — this is what
+  # lane_ship.sh is handed as $1.
+  WT="$W/wt"
+  git -C "$W/seed" worktree add --quiet -b "feat/lane-ship-test" "$WT" main
+  git -C "$WT" config user.email "test@example.test"
+  git -C "$WT" config user.name "Test"
+}
+
+# run <worktree> <title> [extra args...] — invokes lane_ship.sh via `env`
+# with the fake gh prepended to PATH. Captures stdout in $OUT, stderr in
+# $ERR, exit code in $RC.
+run() {
+  local wt="$1" title="$2"
+  shift 2
+  OUT="$(env LANE_SHIP_REPO="test-owner/test-repo" \
+             FAKE_GH_LOG="$LOG" FAKE_GH_STATE="$W/fgh" \
+             PATH="$W/bin:$PATH" \
+             bash "$LANE_SHIP" "$wt" "$title" "$@" 2>"$W/stderr")"
+  RC=$?
+  ERR="$(cat "$W/stderr" 2>/dev/null || true)"
+}
+
+# poverty check — the fake must actually be the one gh resolves to.
+new_world
+resolved="$(PATH="$W/bin:$PATH" command -v gh)"
+if [ "$resolved" != "$W/bin/gh" ]; then
+  echo "HARNESS TOO POOR TO JUDGE: PATH did not resolve gh to the fake ($resolved)" >&2
+  exit 2
+fi
+
+echo "guilt — refuses the main checkout (the seed repo itself, not a worktree):"
+new_world
+run "$W/seed" "should not ship"
+check "exit non-zero" "$(yesno test "$RC" -ne 0)"
+check "reason names it the main checkout" "$(yesno has "main checkout" "$ERR")"
+check "gh was never invoked" "$(yesno eval '[ ! -s "$LOG" ]')"
+
+echo "guilt — refuses a dirty worktree and lists the dirty files:"
+new_world
+echo "uncommitted" > "$WT/dirty.txt"
+run "$WT" "should not ship"
+check "exit non-zero" "$(yesno test "$RC" -ne 0)"
+check "LANE_SHIP_FAIL printed" "$(yesno has "LANE_SHIP_FAIL" "$ERR")"
+check "dirty file is named" "$(yesno has "dirty.txt" "$ERR")"
+check "gh was never invoked" "$(yesno eval '[ ! -s "$LOG" ]')"
+
+echo "guilt — push failure surfaces the captured rc + log tail, exit 2:"
+new_world
+git -C "$WT" remote set-url origin "$W/does-not-exist.git"
+run "$WT" "should not ship"
+check "exit 2" "$(yesno test "$RC" -eq 2)"
+check "LANE_SHIP_FAIL printed" "$(yesno has "LANE_SHIP_FAIL" "$ERR")"
+check "reason names git push" "$(yesno has "git push failed" "$ERR")"
+check "gh was never invoked (push failed before step 3)" "$(yesno eval '[ ! -s "$LOG" ]')"
+
+echo "innocence — existing PR for the branch is REUSED, never re-created:"
+new_world
+printf '{"number":42,"url":"https://github.com/test-owner/test-repo/pull/42"}\n' > "$W/fgh/view_json"
+printf '{"data":{"repository":{"pullRequest":{"autoMergeRequest":{"enabledAt":"2026-08-21T00:00:00Z"},"isInMergeQueue":false,"headRefOid":"deadbeef","url":"https://github.com/test-owner/test-repo/pull/42"}}}}\n' > "$W/fgh/graphql_json"
+run "$WT" "reuse me"
+check "exit 0" "$(yesno test "$RC" -eq 0)"
+check "LANE_SHIP_OK printed with pr=42" "$(yesno has "LANE_SHIP_OK pr=42" "$OUT")"
+check "armed=yes" "$(yesno has "armed=yes" "$OUT")"
+check "gh pr create was NEVER called" "$(yesno eval '! grep -q "pr create" "$LOG"')"
+check "gh pr view WAS called" "$(yesno eval 'grep -q "pr view" "$LOG"')"
+check "gh pr merge --auto WAS called (arm still runs on a reused PR)" "$(yesno eval 'grep -q -- "--auto" "$LOG"')"
+
+echo "innocence — new PR created + armed -> LANE_SHIP_OK, body carries the Adversarial review section:"
+new_world
+printf '{"data":{"repository":{"pullRequest":{"autoMergeRequest":{},"isInMergeQueue":true,"headRefOid":"cafef00d","url":"https://github.com/test-owner/test-repo/pull/99"}}}}\n' > "$W/fgh/graphql_json"
+run "$WT" "brand new PR"
+check "exit 0" "$(yesno test "$RC" -eq 0)"
+check "LANE_SHIP_OK printed with pr=99" "$(yesno has "LANE_SHIP_OK pr=99" "$OUT")"
+check "armed=queued (isInMergeQueue path, W118)" "$(yesno has "armed=queued" "$OUT")"
+check "gh pr create WAS called" "$(yesno eval 'grep -q "pr create" "$LOG"')"
+check "created PR's body carries the Adversarial review section (auto-appended)" \
+  "$(yesno eval 'grep -q "## Adversarial review" "$W/fgh/create_body_seen"')"
+
+echo "innocence — a body-file that already carries the section is NOT rewritten twice:"
+new_world
+printf '{"data":{"repository":{"pullRequest":{"autoMergeRequest":{"enabledAt":"x"},"isInMergeQueue":false,"headRefOid":"abc123","url":"u"}}}}\n' > "$W/fgh/graphql_json"
+BODY_F="$W/body.md"
+printf 'Why/What here.\n\n## Adversarial review\nseat X reviewed it.\n' > "$BODY_F"
+run "$WT" "with body file" --body-file "$BODY_F"
+check "exit 0" "$(yesno test "$RC" -eq 0)"
+check "seat's own review text preserved verbatim" "$(yesno eval 'grep -q "seat X reviewed it" "$W/fgh/create_body_seen"')"
+check "no duplicated Adversarial review heading" \
+  "$(yesno test "$(grep -c '## Adversarial review' "$W/fgh/create_body_seen")" -eq 1)"
+
+echo "--no-arm skips step 4 (gh pr merge is never invoked) and step 5 (no GraphQL call):"
+new_world
+run "$WT" "no arm please" --no-arm
+check "exit 0" "$(yesno test "$RC" -eq 0)"
+check "LANE_SHIP_OK armed=skipped" "$(yesno has "armed=skipped" "$OUT")"
+check "gh pr merge was NEVER called" "$(yesno eval '! grep -q "pr merge" "$LOG"')"
+check "gh api graphql was NEVER called" "$(yesno eval '! grep -q "graphql" "$LOG"')"
+
+echo "guilt — GraphQL says neither armed nor queued -> LANE_SHIP_FAIL, exit 3:"
+new_world
+printf '{"data":{"repository":{"pullRequest":{"autoMergeRequest":{},"isInMergeQueue":false,"headRefOid":"abc","url":"u"}}}}\n' > "$W/fgh/graphql_json"
+run "$WT" "will not verify armed"
+check "exit 3" "$(yesno test "$RC" -eq 3)"
+check "LANE_SHIP_FAIL printed" "$(yesno has "LANE_SHIP_FAIL" "$ERR")"
+check "reason names both checked fields" "$(yesno has "enabledAt" "$ERR")"
+
+echo
+if [ "$failures" -eq 0 ]; then echo "PASS (all checks)"; exit 0; fi
+echo "FAIL ($failures check(s))"; exit 1


### PR DESCRIPTION
## Why

Owner order (Zero, 2026-08-21): make implementer lanes ship deterministically.
Two Sonnet lanes finished today with only an idle notification and no report.
A third was hard-blocked pushing/PR-ing by `orchestrate_gate.py` while running
as a subagent (no `Agent` tool of its own — "zero subagent dispatch in last
300 lines" is a structural impossibility for a subagent, not a signal to
heed).

## What

- `scripts/lane_ship.sh <worktree> "<PR title>" [--body-file <f>] [--no-arm]`
  — deterministic ship tail: refuse dirty/main-checkout worktree → push
  (captured rc) → reuse-or-create PR (enforces `## Adversarial review`
  section) → arm bare `gh pr merge --auto` → GraphQL-verify
  `autoMergeRequest.enabledAt` OR `isInMergeQueue` (W118) → one
  machine-readable `LANE_SHIP_OK`/`LANE_SHIP_FAIL` line.
- `scripts/tests/test_lane_ship.sh` — real local git (bare `origin`, fully
  offline) + faked `gh` on PATH. 34/34 green, shellcheck clean. Caught a
  real bug live (not reasoned in advance): comparing shell `pwd` against
  git's `--path-format=absolute` output mismatches under macOS's `$TMPDIR`
  symlink (`/var/folders` → `/private/var/folders`) — fixed by resolving
  both sides through git itself (`rev-parse --show-toplevel`), never `pwd`.
- `infra/claude-hooks/orchestrate_gate.py` — the hook's source lives in this
  repo, declared+byte-identical to the live `~/.claude/hooks` copy
  (`infra/home-fork/declared-pairs.json:414-415`), so it was edited
  directly; no home copy touched (out of scope per the task — the home
  copy needs a manual `cp` by the operator to go live, same as any other
  declared HOME-fork pair). Added `is_subagent_context()`, checked BEFORE
  any transcript read. Two markers, both verified live during this
  investigation: (1) `payload["agent_id"]` — DOCUMENTED at
  `code.claude.com/docs/en/hooks`, "present only when the hook fires inside
  a subagent call" (confirmed via WebFetch this session); (2)
  `transcript_path` containing a `subagents/` path component — empirically
  confirmed against this very session's own subagent transcript (every
  line carries `"agentId"` + `"isSidechain":true`; the parent session's
  transcript carries neither, 0 occurrences of both, checked with `grep`).
  A main-session transcript with zero dispatches past the threshold still
  blocks exactly as before — the exemption is scoped to the two markers,
  never to "transcript looks quiet."
- `infra/claude-hooks/test_orchestrate_gate_vocab.py` — 4 new
  guilt+innocence tests for the exemption.
- `docs/runbooks/agent-worktree-broker.md` — new "Lane report contract"
  section (22 lines): every lane ends with a report naming PR/worktree/
  checks, ships via `lane_ship.sh`, and the orchestrator trusts
  worktree/PR state over the report's claim.

## Tests

- `bash scripts/tests/test_lane_ship.sh` — 34/34 green (dirty-worktree
  refusal, main-checkout refusal, push-failure exit 2, PR reuse, PR create
  with body enforcement, `--no-arm` skip, GraphQL not-armed → exit 3).
- `python3 infra/claude-hooks/test_orchestrate_gate_vocab.py` — 15/15
  green (11 pre-existing + 4 new).
- `python3 infra/claude-hooks/test_orchestrate_gate_disarm_notice.py` —
  13/13 green, no regression.
- `pytest infra/claude-hooks -q -k orchestrate` — 28 passed.
- `python3 scripts/docs_sync.py --check` — OK.
- `shellcheck` clean on both new shell files; `bash -n` clean on both;
  `prettier --check` clean on the runbook.

## Adversarial review

Fixture tests cover refusal (dirty worktree, main checkout, push failure),
reuse-vs-create, arm-and-verify (both the `enabledAt` and `isInMergeQueue`
paths of the W118 OR-condition), `--no-arm`, and a not-armed GraphQL
verdict. The orchestrate_gate.py exemption is pinned by BEHAVIOUR (real
subprocess invocation of the hook, not by reading its source) and includes
a guilt case proving the main-session block path is unchanged. Orchestrating
session 3563604c re-verifies before treating this as done.
