### PR TITLE
feat(prepush): consumer_map.py — catch deleted/renamed-file consumers before push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -304,6 +304,64 @@ else
     fi
 fi
 
+# ============================================================================
+# CONSUMER-MAP — deleted/renamed-file live-consumer check (2026-08-21, #4459)
+#
+# #4459 deleted apps/backend-rag/tests/ (an orphan tree) and went CI-red
+# TWICE: two consumers were invisible to a path-prefix search because each
+# named the deleted files relative to something OTHER than the deleted path
+# — a `cd apps/backend-rag` step in .github/workflows/sonarqube.yml, and a
+# bare string inside a Python list literal in
+# apps/backend-rag/scripts/backend_stability_gate.py:41. scripts/consumer_map.py
+# (invoked here through prepush_classify.py --check-consumers — see that
+# file's module docstring "SEPARATE MODE") searches by BASENAME instead
+# (cicatrix-superscar.md #3: search the entity a reader actually names, not
+# the form of a path), so both shapes are caught before the push leaves this
+# machine.
+#
+# Runs UNCONDITIONALLY — NOT gated by PREPUSH_RUN_BACKEND/DEFAULT-OFF above.
+# That flag only controls whether the local pytest suite runs; this check
+# answers a different question CI's Backend Tests job never asks (CI only
+# ever sees the tree AFTER the deletion, so an elsewhere-living consumer
+# just fails late and unrelated-looking — the exact #4459 pattern). Resolves
+# python3 independently of PYTHON_BIN (which the path-aware gate above may
+# never have set, e.g. under PREPUSH_FULL=1/PREPUSH_PATHAWARE=0) — W108: the
+# reporting interpreter must not share the resolution path of whatever it is
+# diagnosing. Errexit-immune capture (`|| CM_RC=$?`) — W101, same reason as
+# every other captured RC in this file under `sh -e`.
+#
+# rc 0 = clean (silent, matches the tip-drift happy-path silence rationale
+# below). rc 1 = live consumer(s) found — BLOCKS the push, loudly, with the
+# table. rc 2+ = could not verify (not this script's kind of git state, no
+# python3, missing helper) — WARNS, does NOT block: an environment problem
+# here must not wedge a push the way a genuine finding should, the same
+# permissive-but-honest posture the PG/venv skips below take.
+# Kill switch: PREPUSH_SKIP_CONSUMER_MAP=1.
+# ============================================================================
+if [ "${PREPUSH_SKIP_CONSUMER_MAP:-0}" != "1" ]; then
+    CM_PYTHON="$(command -v python3 || command -v python || true)"
+    CM_CLASSIFIER="$PREPUSH_TRUST_ROOT/scripts/prepush_classify.py"
+    if [ -n "$CM_PYTHON" ] && [ -f "$CM_CLASSIFIER" ]; then
+        CM_RC=0
+        CM_OUT="$("$CM_PYTHON" "$CM_CLASSIFIER" --check-consumers --base origin/main 2>&1)" || CM_RC=$?
+        case "$CM_RC" in
+            0) : ;;
+            1)
+                CM_COUNT="$(printf '%s\n' "$CM_OUT" | sed -n 's/^CONSUMER_MAP_LIVE_COUNT=//p')"
+                echo "❌ consumer-map: ${CM_COUNT:-N} live consumers of deleted/renamed files — push blocked."
+                printf '%s\n' "$CM_OUT"
+                exit 1
+                ;;
+            *)
+                echo "⚠️  consumer-map check could not verify this push (rc=$CM_RC) — not blocking, but read below:"
+                printf '%s\n' "$CM_OUT" | sed 's/^/    /'
+                ;;
+        esac
+    else
+        echo "⚠️  consumer-map check skipped — no python3/python on PATH or classifier missing at $CM_CLASSIFIER."
+    fi
+fi
+
 # Run Python tests — gated on a PROVISIONED local PostgreSQL (CI-parity).
 #
 # Most backend tests build their schema against DATABASE_URL. With no local PG the

--- a/scripts/consumer_map.py
+++ b/scripts/consumer_map.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""consumer_map.py — enumerate live consumers of DELETED or RENAMED files.
+
+MOTIVATION (2026-08-21, PR #4459): deleting `apps/backend-rag/tests/` (an
+orphan tree) went CI-red TWICE because two consumers were invisible to a
+search anchored on the deleted PATH:
+
+  - `.github/workflows/sonarqube.yml` names the files as `tests/...` AFTER a
+    `cd apps/backend-rag` step in the job — the string in the YAML never
+    contains the deleted directory's path at all, only its suffix.
+  - `apps/backend-rag/scripts/backend_stability_gate.py:41` lists
+    `tests/test_migrations.py` inside a plain Python argument list — same
+    shape: a string relative to a `cd`, not to repo root, that a required
+    check later reads (`backend_stability_gate.py`'s own required-CI step).
+
+A consumer search keyed on the deleted PATH is under-match by construction
+(cicatrix-superscar.md #3 — the guard sees the FORM of a path, not the
+ENTITY a reader actually types). This tool searches by BASENAME instead
+(and, for `.py` modules, ALSO by the bare import-stem — `test_migrations`
+for `test_migrations.py`, since a Python `import` never carries the
+extension) — the string every one of the shapes above actually contains.
+
+CONTRACT
+--------
+Input: either
+  - `--base <ref>` (default `origin/main`) — every DELETED or RENAMED file
+    between `git merge-base <ref> HEAD` and `HEAD` is a target. Rename
+    detection is deliberately ON here (`git diff -M`) — the OPPOSITE of
+    `.husky/pre-push`'s own path-aware gate, which forces `--no-renames` so
+    BOTH the old and new path are visible to its allowlist classifier. This
+    tool wants the old->new PAIR specifically (see RENAME SAFETY below), so
+    it needs rename detection to get one.
+  - explicit `paths...` (positional) — each treated as a DELETED target
+    directly, bypassing git diff entirely (manual invocation / composition
+    with another tool that already knows the deleted set). No rename pairing
+    is available in this mode.
+
+For each target, this tool:
+  1. Skips it (with a SKIPPED-common-basename row) if its basename is a
+     COMMON_BASENAME (conftest.py, __init__.py) and `--include-common` was
+     not passed — nearly every hit on a name that common would be an
+     unrelated file of the same name, not a real consumer.
+  2. `git grep -n -F` (fixed-string, one call per basename/stem, never a
+     Python tree-walk — this is what keeps the whole tool well under the
+     10s budget) for the basename, and — for `.py` targets — again for the
+     bare stem, against `HEAD` (the commit about to be pushed, not whatever
+     the working tree happens to hold, so a dirty tree cannot hide or
+     fabricate a finding).
+  3. Drops a hit if: its path IS one of the deleted/renamed targets
+     themselves (self-reference, not a consumer — "the deleted tree
+     itself"); its path is excluded (see EXCLUSIONS below); OR — for a
+     RENAME — the SAME LINE already contains the full NEW path (a consumer
+     that has already been repointed is not a finding: RENAME SAFETY).
+  4. Classifies every surviving hit by CONSUMER KIND (the file that mentions
+     it, not the target) and by verdict: `.md` hits are `docs-mention`
+     (reported, never a blocking finding — CLAUDE.md §15 research docs and
+     README prose legitimately NAME files without executing them); every
+     other kind is `LIVE`.
+
+EXCLUSIONS (never scanned as consumers, regardless of kind)
+  - `docs/archive/**`, `research/**` — historical/ad-hoc capture, not code.
+  - `.secrets.baseline`, `infra/tcc-desktop-paths/allowlist.txt` — content
+    hash/allowlist files that mention paths as DATA, never as references.
+  - `*.jsonl` — append-only event/escalation logs; a basename appearing
+    inside a historical JSON line is a record, not a live reference.
+
+PROXY WARNING (declared, not hidden — cicatrix-superscar.md #3): basename
+matching OVER-matches. Two different files sharing a common name will
+collide; `git grep -F` also matches the basename as a plain substring, so a
+longer name containing it as a fragment will show up too. This is
+DELIBERATE and safe-by-construction for this tool's purpose: an over-match
+costs a human 10 seconds reading one extra row in the printed table; an
+UNDER-match (the actual #4459 defect) ships a red required check. Only the
+COMMON_BASENAMES skip-list narrows the search, and only for names common
+enough that scanning them would be pure noise.
+
+Exit codes: 0 = clean (no LIVE consumer found for any target). 1 = at least
+one LIVE consumer found — this diff is not safe to push as-is. 2 = usage
+error (not a git repo, bad `--base` ref, git itself unavailable).
+
+Run:
+    python3 scripts/consumer_map.py --base origin/main
+    python3 scripts/consumer_map.py --base origin/main --include-common
+    python3 scripts/consumer_map.py apps/backend-rag/tests/test_foo.py
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Basenames common enough that a bare-basename search is pure noise (every
+# hit is an unrelated file of the same name, not a real consumer). Kept
+# deliberately short and explicit — an entry here silently narrows the
+# search, so it must be a name this repo has actually measured as noisy, not
+# a defensive guess. `--include-common` forces the scan anyway.
+# ---------------------------------------------------------------------------
+COMMON_BASENAMES: frozenset[str] = frozenset({"conftest.py", "__init__.py"})
+
+EXCLUDE_DIR_PREFIXES: tuple[str, ...] = ("docs/archive/", "research/")
+EXCLUDE_EXACT_PATHS: frozenset[str] = frozenset(
+    {".secrets.baseline", "infra/tcc-desktop-paths/allowlist.txt"}
+)
+EXCLUDE_SUFFIXES: tuple[str, ...] = (".jsonl",)
+
+
+def _is_excluded(path: str) -> bool:
+    if path in EXCLUDE_EXACT_PATHS:
+        return True
+    if path.endswith(EXCLUDE_SUFFIXES):
+        return True
+    return any(path.startswith(prefix) for prefix in EXCLUDE_DIR_PREFIXES)
+
+
+def _classify_kind(path: str) -> str:
+    """Classify the CONSUMING file (not the target) by kind, for the table.
+
+    `.md` returns "docs-mention" deliberately — the caller uses this single
+    return value both to label the row AND to decide LIVE vs docs-mention,
+    so there is exactly one place that decision is made.
+    """
+    if path.startswith(".github/workflows/") and path.endswith(".yml"):
+        return "workflow"
+    basename = path.rsplit("/", 1)[-1]
+    if basename == "Makefile":
+        return "makefile"
+    if basename == "package.json":
+        return "package.json"
+    if basename in ("pyproject.toml", "setup.cfg"):
+        return "pyproject"
+    if basename == "pytest.ini":
+        return "pytest.ini"
+    if path.startswith(".husky/"):
+        return "husky"
+    if basename in ("docker-compose.yml", "docker-compose.yaml") or (
+        basename.startswith("docker-compose.") and basename.endswith((".yml", ".yaml"))
+    ):
+        return "docker-compose"
+    if path.startswith("infra/") and path.endswith(".plist"):
+        return "plist"
+    if path.endswith(".sh"):
+        return "shell"
+    if path.endswith(".py"):
+        return "python"
+    if path.endswith(".md"):
+        return "docs-mention"
+    return "other"
+
+
+def _git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True
+    )
+
+
+def _deleted_or_renamed_from_diff(base: str, cwd: Path | None) -> list[tuple[str, str | None]]:
+    """[(old_path, new_path_or_None), ...] for every D/R entry between
+    merge-base(base, HEAD) and HEAD. Raises RuntimeError (caller turns this
+    into exit 2) on any git failure — a silent empty result here would read
+    as "nothing to check" instead of "could not check", exactly the
+    fail-OPEN shape cicatrix-superscar.md #2 warns about for a guard that
+    exists to block something.
+    """
+    mb = _git(["merge-base", base, "HEAD"], cwd=cwd)
+    if mb.returncode != 0:
+        raise RuntimeError(
+            f"git merge-base {base} HEAD failed: {mb.stderr.strip() or mb.stdout.strip()}"
+        )
+    merge_base = mb.stdout.strip()
+    if not merge_base:
+        raise RuntimeError(f"git merge-base {base} HEAD returned no sha")
+
+    diff = _git(["diff", "--name-status", "-M", merge_base, "HEAD"], cwd=cwd)
+    if diff.returncode != 0:
+        raise RuntimeError(
+            f"git diff --name-status {merge_base} HEAD failed: "
+            f"{diff.stderr.strip() or diff.stdout.strip()}"
+        )
+
+    out: list[tuple[str, str | None]] = []
+    for line in diff.stdout.splitlines():
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        status = fields[0]
+        if status == "D" and len(fields) >= 2:
+            out.append((fields[1], None))
+        elif status.startswith("R") and len(fields) >= 3:
+            out.append((fields[1], fields[2]))
+    return out
+
+
+def _git_grep_basename(needle: str, cwd: Path | None) -> list[tuple[str, int, str]]:
+    """[(path, line_no, line_text), ...] for every tracked-file hit of
+    `needle` at HEAD — the commit about to be pushed, robust to a dirty
+    working tree in either direction (a stray local edit can neither hide
+    nor fabricate a finding). `-F` = fixed string (never a regex — a
+    basename can contain `.`/`+`/etc that would otherwise be metacharacters
+    git-grep exit 1 = zero hits, NOT an error: for an already-migrated
+    rename this is exactly the innocence signal (RENAME SAFETY above).
+    """
+    result = _git(["grep", "-n", "-F", "-e", needle, "HEAD", "--"], cwd=cwd)
+    if result.returncode == 1:
+        return []
+    if result.returncode != 0:
+        raise RuntimeError(f"git grep -F {needle!r} HEAD failed: {result.stderr.strip()}")
+    hits: list[tuple[str, int, str]] = []
+    for line in result.stdout.splitlines():
+        # Format: "HEAD:path:lineno:content" — split on ':' with maxsplit=3
+        # so a ':' inside the matched CONTENT never truncates it.
+        parts = line.split(":", 3)
+        if len(parts) < 4:
+            continue
+        _rev, path, lineno, content = parts
+        try:
+            lineno_int = int(lineno)
+        except ValueError:
+            continue
+        hits.append((path, lineno_int, content))
+    return hits
+
+
+def find_consumers(
+    targets: list[tuple[str, str | None]],
+    include_common: bool,
+    cwd: Path | None = None,
+) -> list[tuple[str, str, str, str]]:
+    """Pure(ish) core: given the target list, return rows
+    (location, kind, basename, verdict). The only I/O is `git grep`, which
+    is why this takes `targets` already resolved rather than a `--base` —
+    the git-diff resolution step and the grep step are separable, and
+    keeping them separate is what lets scripts/tests/test_consumer_map.py
+    assert on `find_consumers` a set of already-known targets without also
+    having to fabricate a realistic diff for every case.
+    """
+    all_target_paths = {p for old, new in targets for p in (old, new) if p}
+    rows: list[tuple[str, str, str, str]] = []
+
+    for old_path, new_path in targets:
+        basename = old_path.rsplit("/", 1)[-1]
+        if basename in COMMON_BASENAMES and not include_common:
+            rows.append(
+                (f"{old_path} (skipped)", "-", basename, "SKIPPED-common-basename")
+            )
+            continue
+
+        stems = [basename]
+        if basename.endswith(".py"):
+            stems.append(basename[:-3])
+
+        seen_locations: set[str] = set()
+        for stem in stems:
+            for path, lineno, content in _git_grep_basename(stem, cwd):
+                if path in all_target_paths:
+                    continue  # the deleted/renamed tree itself, not a consumer
+                if _is_excluded(path):
+                    continue
+                if new_path and new_path in content:
+                    continue  # RENAME SAFETY — already points at the new path
+                loc = f"{path}:{lineno}"
+                if loc in seen_locations:
+                    continue
+                seen_locations.add(loc)
+                kind = _classify_kind(path)
+                verdict = "docs-mention" if kind == "docs-mention" else "LIVE"
+                rows.append((loc, kind, basename, verdict))
+
+    return rows
+
+
+def _print_table(rows: list[tuple[str, str, str, str]]) -> None:
+    if not rows:
+        # Reached only when targets existed but every git-grep hit was
+        # filtered out (self-reference, exclusion, or an already-repointed
+        # rename) — NOT the same as "no targets" (that's main()'s own,
+        # differently-worded, earlier-return message). Do not conflate the
+        # two: one says "nothing to check", this says "checked, all clean".
+        print("consumer_map: targets checked, zero surviving hits (all clean).")
+        return
+    print("location | kind | basename | verdict")
+    for loc, kind, basename, verdict in rows:
+        print(f"{loc} | {kind} | {basename} | {verdict}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="consumer_map.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Enumerate live consumers of DELETED or RENAMED files, matched by "
+            "BASENAME (and by bare import-stem for .py targets) across "
+            ".github/workflows/*.yml, shell scripts, Python files (string "
+            "literals and imports), Makefiles, package.json, pyproject.toml/"
+            "pytest.ini, .husky/ hooks, docker-compose files, and infra/*.plist.\n\n"
+            "PROXY WARNING: basename matching OVER-matches by design — two "
+            "unrelated files sharing a name will collide, and -F does a plain "
+            "substring match (a longer name containing this one as a fragment "
+            "shows up too). A common basename (conftest.py, __init__.py) is "
+            "skipped by default for exactly this reason (--include-common to "
+            "force it). This is a deliberate safety asymmetry: an over-match "
+            "costs a human one extra row to read; an under-match is the actual "
+            "PR #4459 defect this tool exists to close. Read the printed table "
+            "before trusting the verdict — same discipline cicatrix-superscar.md "
+            "#3 asks of every substring-matching guard in this repo."
+        ),
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Diff base ref (default: origin/main). Ignored if PATHS are given.",
+    )
+    parser.add_argument(
+        "--include-common",
+        action="store_true",
+        help="Do not skip common basenames (conftest.py, __init__.py).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Explicit deleted-file paths to check, bypassing git diff (no rename pairing available in this mode).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.paths:
+            targets: list[tuple[str, str | None]] = [(p, None) for p in args.paths]
+        else:
+            targets = _deleted_or_renamed_from_diff(args.base, cwd=None)
+    except RuntimeError as exc:
+        print(f"consumer_map: {exc}", file=sys.stderr)
+        return 2
+
+    if not targets:
+        print("consumer_map: no deleted/renamed files in scope — nothing to check.")
+        print("CONSUMER_MAP_LIVE_COUNT=0")
+        return 0
+
+    try:
+        rows = find_consumers(targets, args.include_common, cwd=None)
+    except RuntimeError as exc:
+        print(f"consumer_map: {exc}", file=sys.stderr)
+        return 2
+
+    _print_table(rows)
+    live_count = sum(1 for row in rows if row[3] == "LIVE")
+    # Machine-parseable summary line, always printed (even 0), always LAST —
+    # a caller (the pre-push wiring) greps this one line instead of counting
+    # table rows, so a future change to the table's human-readable format
+    # cannot silently break the count it reports.
+    print(f"CONSUMER_MAP_LIVE_COUNT={live_count}")
+    return 1 if live_count else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/consumer_map.py
+++ b/scripts/consumer_map.py
@@ -74,6 +74,38 @@ UNDER-match (the actual #4459 defect) ships a red required check. Only the
 COMMON_BASENAMES skip-list narrows the search, and only for names common
 enough that scanning them would be pure noise.
 
+PROSE-MENTION FILTER (2026-08-21, real-corpus replay finding — a SECOND
+over-match, distinct from the common-basename one above): a REAL replay
+against this repo's own `apps/backend-rag/tests/test_sentry_lazy_import.py`
+found 3 of 20 "LIVE" hits that name the file only in PROSE, never consume
+it — a `#` comment line, and two Python module docstrings, all three
+narrating the exact incident this tool's own #4459 motivation section
+describes. A guard that blocks a legitimate push on prose is the guard
+getting disabled (cicatrix-superscar.md #3 / W105 — an over-match annoying
+enough turns into a #2 "esiste ≠ armato" via the escape hatch). Two
+independent filters, applied in this order, downgrade such a hit to
+`docs-mention`:
+  1. Any hit whose line, after `.lstrip()`, starts with `#` — a whole-line
+     comment — in a kind where `#` is the comment marker (python, shell,
+     workflow, docker-compose, makefile, husky, pyproject, pytest.ini,
+     other). A TRAILING end-of-line comment does NOT qualify (the line
+     does not start with `#`) — that shape still carries a real code
+     statement earlier on the same line.
+  2. For `.py` targets specifically: a hit whose line falls inside a
+     DOCSTRING's line range (module/class/function/async-function, the
+     first statement, an `Expr` wrapping a string `Constant`) — found via
+     `ast.parse` + `ast.walk`, never a heuristic guess at where a
+     docstring "probably" ends. An `import`/`from` of the stem, or a
+     string literal OUTSIDE any docstring range (list/tuple/call
+     args — the actual #4459 `backend_stability_gate.py` shape) is
+     UNCHANGED by this filter and stays LIVE; that is the guilt tripwire
+     this filter must never swallow (scripts/tests/test_consumer_map.py).
+     If `ast.parse` fails (the file does not parse as Python — a template,
+     a deliberately-broken fixture, a Python-2-only script), this tool
+     fails CLOSED: the hit stays LIVE and a one-line note goes to stderr
+     naming the file — silently skipping the filter would be silently
+     TRUSTING an unreadable file's structure, which is backwards.
+
 Exit codes: 0 = clean (no LIVE consumer found for any target). 1 = at least
 one LIVE consumer found — this diff is not safe to push as-is. 2 = usage
 error (not a git repo, bad `--base` ref, git itself unavailable).
@@ -86,6 +118,7 @@ Run:
 from __future__ import annotations
 
 import argparse
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -98,6 +131,26 @@ from pathlib import Path
 # a defensive guess. `--include-common` forces the scan anyway.
 # ---------------------------------------------------------------------------
 COMMON_BASENAMES: frozenset[str] = frozenset({"conftest.py", "__init__.py"})
+
+# Kinds where "#" is the comment marker — a hit whose line, after lstrip(),
+# starts with "#" is a comment naming the file, not a consumer of it (module
+# docstring "PROSE-MENTION FILTER" item 1). Excludes "package.json" (JSON has
+# no comments — a leading "#" there is not valid JSON and would never be a
+# real hit) and "plist" (XML, comments are `<!-- -->`). "docs-mention" is
+# already handled upstream and never reaches this check.
+HASH_COMMENT_KINDS: frozenset[str] = frozenset(
+    {
+        "python",
+        "shell",
+        "workflow",
+        "docker-compose",
+        "makefile",
+        "husky",
+        "pyproject",
+        "pytest.ini",
+        "other",
+    }
+)
 
 EXCLUDE_DIR_PREFIXES: tuple[str, ...] = ("docs/archive/", "research/")
 EXCLUDE_EXACT_PATHS: frozenset[str] = frozenset(
@@ -222,6 +275,53 @@ def _git_grep_basename(needle: str, cwd: Path | None) -> list[tuple[str, int, st
     return hits
 
 
+def _read_file_at_head(path: str, cwd: Path | None) -> str | None:
+    """The consuming FILE's own full content at HEAD (not the target's) —
+    needed to compute docstring line ranges, since a single grep hit line has
+    no idea whether it sits inside one. Returns None on any git failure
+    (unreadable, binary, path vanished between grep and here) — callers treat
+    that the same as an unparseable file: fail closed, stay LIVE, note it.
+    """
+    result = _git(["show", f"HEAD:{path}"], cwd=cwd)
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _python_docstring_line_ranges(source: str) -> list[tuple[int, int]]:
+    """[(start_line, end_line), ...] (1-indexed, inclusive) for every
+    docstring in `source` — module, class, function, and async-function, at
+    every nesting depth (`ast.walk` visits the whole tree, not just the top
+    level). A docstring is a node's first body statement, an `Expr` wrapping
+    a string `Constant` — the same shape Python itself uses to recognize one.
+    Raises SyntaxError (propagated, not swallowed) if `source` does not parse
+    as Python — the caller decides the fail-closed behavior for that, this
+    function's only job is the AST walk.
+    """
+    tree = ast.parse(source)
+    ranges: list[tuple[int, int]] = []
+    docstring_owners = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    for node in ast.walk(tree):
+        if not isinstance(node, docstring_owners):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            end = getattr(first, "end_lineno", first.lineno)
+            ranges.append((first.lineno, end))
+    return ranges
+
+
+def _in_any_range(lineno: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= lineno <= end for start, end in ranges)
+
+
 def find_consumers(
     targets: list[tuple[str, str | None]],
     include_common: bool,
@@ -237,6 +337,13 @@ def find_consumers(
     """
     all_target_paths = {p for old, new in targets for p in (old, new) if p}
     rows: list[tuple[str, str, str, str]] = []
+    # Per-CALL caches (not per-target — the same consuming file can be hit by
+    # multiple targets, e.g. two deleted files both mentioned in one README):
+    # docstring ranges keyed by the CONSUMING file's path, and a set of paths
+    # already warned about (unparseable-Python note printed once per file,
+    # never once per hit).
+    docstring_cache: dict[str, list[tuple[int, int]] | None] = {}
+    warned_unparseable: set[str] = set()
 
     for old_path, new_path in targets:
         basename = old_path.rsplit("/", 1)[-1]
@@ -265,6 +372,33 @@ def find_consumers(
                 seen_locations.add(loc)
                 kind = _classify_kind(path)
                 verdict = "docs-mention" if kind == "docs-mention" else "LIVE"
+
+                # PROSE-MENTION FILTER (module docstring, same name) — a hit
+                # that only NAMES the file in prose is not a consumer.
+                if verdict == "LIVE" and kind in HASH_COMMENT_KINDS and content.lstrip().startswith("#"):
+                    verdict = "docs-mention"
+                elif verdict == "LIVE" and kind == "python":
+                    if path not in docstring_cache:
+                        source = _read_file_at_head(path, cwd)
+                        if source is None:
+                            docstring_cache[path] = None
+                        else:
+                            try:
+                                docstring_cache[path] = _python_docstring_line_ranges(source)
+                            except SyntaxError:
+                                docstring_cache[path] = None
+                        if docstring_cache[path] is None and path not in warned_unparseable:
+                            print(
+                                f"consumer_map: could not read/parse {path} as Python "
+                                "at HEAD — docstring filter skipped for it, hit(s) stay "
+                                "LIVE (fail-closed).",
+                                file=sys.stderr,
+                            )
+                            warned_unparseable.add(path)
+                    ranges = docstring_cache[path]
+                    if ranges is not None and _in_any_range(lineno, ranges):
+                        verdict = "docs-mention"
+
                 rows.append((loc, kind, basename, verdict))
 
     return rows

--- a/scripts/prepush_classify.py
+++ b/scripts/prepush_classify.py
@@ -264,6 +264,17 @@ uses `--no-renames`, so a rename is always delete+add (both paths visible).
 Run:
     python3 scripts/prepush_classify.py <<< "$FILES"
     python3 scripts/prepush_classify.py apps/backend-rag/backend/foo.py
+
+SEPARATE MODE (2026-08-21, PR #4459 aftermath): `--check-consumers [--base
+REF]` is a DIFFERENT, git-based check bolted onto this same CLI purely so
+the hook has one script to invoke — it does NOT share the classify()/
+_innocent_reason() SSOT above, does NOT touch stdout's "full"/"skip-backend"
+contract, and is never reached unless `--check-consumers` is literally the
+first argument. See `_run_consumer_check()` and scripts/consumer_map.py
+(the actual detection logic — exclusions, kind classification, the
+basename-over-match tradeoff — is documented there, not duplicated here).
+Exit codes in this mode: 0 clean, 1 live consumer(s) found (see
+CONSUMER_MAP_LIVE_COUNT=N on the last stdout line), 2 usage/git error.
 """
 from __future__ import annotations
 
@@ -968,8 +979,42 @@ def _log_full(unknown: list[str], total: int) -> None:
     )
 
 
+def _run_consumer_check(args: list[str]) -> int:
+    """`--check-consumers [--base REF]` — a thin CLI adapter over
+    scripts/consumer_map.py, deliberately NOT part of the classify()/
+    _innocent_reason() SSOT above (module docstring "SEPARATE MODE").
+
+    That SSOT stays a pure, git-free function of a file list — this mode is
+    git-based BY NECESSITY (it needs to know which files were DELETED or
+    RENAMED, information `git diff --name-only` alone erases: see
+    consumer_map.py's own RENAME SAFETY note). It lives in THIS CLI only so
+    `.husky/pre-push` has one script to invoke for both concerns; it shares
+    the file, not the contract, and every actual exclusion/classification
+    rule lives in consumer_map.py, not duplicated here.
+    """
+    base = "origin/main"
+    if "--base" in args:
+        i = args.index("--base")
+        if i + 1 < len(args):
+            base = args[i + 1]
+    try:
+        import consumer_map  # sibling module — scripts/ is sys.path[0] when
+        # this file is run as `python3 scripts/prepush_classify.py ...`
+        # (the interpreter puts the launched script's own directory first).
+    except ImportError as exc:
+        print(
+            f"⚠️  --check-consumers: could not import consumer_map.py ({exc}) "
+            "— treating as unverifiable, not a finding.",
+            file=sys.stderr,
+        )
+        return 2
+    return consumer_map.main(["--base", base])
+
+
 def main(argv: list[str] | None = None) -> int:
     args = sys.argv[1:] if argv is None else argv
+    if args and args[0] == "--check-consumers":
+        return _run_consumer_check(args)
     try:
         files = _read_input(args)
     except Exception as exc:  # noqa: BLE001 - fail-closed on ANY read error

--- a/scripts/tests/test_consumer_map.py
+++ b/scripts/tests/test_consumer_map.py
@@ -1,0 +1,318 @@
+"""Tests for scripts/consumer_map.py — enumerate live consumers of DELETED
+or RENAMED files by BASENAME.
+
+WHY (2026-08-21, PR #4459): deleting `apps/backend-rag/tests/` (an orphan
+tree) went CI-red TWICE because two consumers were invisible to a search
+anchored on the deleted PATH: `.github/workflows/sonarqube.yml` named the
+files as `tests/...` AFTER a `cd apps/backend-rag` step, and
+`apps/backend-rag/scripts/backend_stability_gate.py:41` listed
+`tests/test_migrations.py` inside a Python list literal. Both guilt cases
+below reproduce those exact two shapes.
+
+Every case operates on a REAL, throwaway git repo (`tmp_path` fixture) with
+REAL commits and a REAL `git diff -M` — never a synthetic/mocked target
+list — per cicatrix-superscar.md #6 ("anti-hallucination blindness": build
+on what you actually executed, not on a re-typed mirror of what you assume
+the code does).
+
+Run:
+    cd <worktree> && python3 -m pytest scripts/tests/test_consumer_map.py -q
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "consumer_map.py"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        f"git {' '.join(args)} failed in {repo}: {result.stderr}"
+    )
+    return result
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    return repo
+
+
+def _commit_all(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+# ---------------------------------------------------------------------------
+# GUILT — the two real #4459 shapes.
+# ---------------------------------------------------------------------------
+
+
+def test_guilt_workflow_cd_relative_reference_is_live(tmp_path: Path) -> None:
+    """A deleted file referenced by a workflow via a cd-relative path (the
+    #4459 sonarqube.yml shape) must be found — LIVE, exit 1."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_migrations.py"
+    _write(target, "def test_x(): pass\n")
+    _write(
+        repo / ".github" / "workflows" / "sonarqube.yml",
+        "jobs:\n  test:\n    steps:\n"
+        "      - run: cd apps/backend-rag && pytest tests/test_migrations.py\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete orphan tests tree")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "sonarqube.yml" in result.stdout
+    assert "| workflow |" in result.stdout
+    assert "| LIVE" in result.stdout
+    assert "CONSUMER_MAP_LIVE_COUNT=1" in result.stdout
+
+
+def test_guilt_python_list_literal_reference_is_live(tmp_path: Path) -> None:
+    """A deleted file listed as a bare string inside a Python list literal
+    (the #4459 backend_stability_gate.py:41 shape) must be found — LIVE,
+    exit 1."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_migrations.py"
+    _write(target, "def test_x(): pass\n")
+    _write(
+        repo / "apps" / "backend-rag" / "scripts" / "backend_stability_gate.py",
+        'REQUIRED = [\n    "tests/test_migrations.py",\n]\n',
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete orphan tests tree")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "backend_stability_gate.py" in result.stdout
+    assert "| python |" in result.stdout
+    assert "| LIVE" in result.stdout
+
+
+def test_guilt_two_targets_one_live_one_clean_reports_only_the_live_one(
+    tmp_path: Path,
+) -> None:
+    """Sanity check on multi-target aggregation: deleting two files where
+    only one has a real consumer must still exit 1, and the count must
+    reflect exactly the live one."""
+    repo = _init_repo(tmp_path)
+    referenced = repo / "apps" / "backend-rag" / "tests" / "test_ref.py"
+    orphan = repo / "apps" / "backend-rag" / "tests" / "test_orphan_clean.py"
+    _write(referenced, "def test_x(): pass\n")
+    _write(orphan, "def test_y(): pass\n")
+    _write(
+        repo / "Makefile",
+        "test:\n\tpytest apps/backend-rag/tests/test_ref.py\n",
+    )
+    base = _commit_all(repo, "base")
+
+    referenced.unlink()
+    orphan.unlink()
+    _commit_all(repo, "delete both")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "test_ref.py" in result.stdout
+    assert "CONSUMER_MAP_LIVE_COUNT=1" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# INNOCENCE
+# ---------------------------------------------------------------------------
+
+
+def test_innocence_rename_consumer_already_repointed(tmp_path: Path) -> None:
+    """A RENAME whose only consumer already references the NEW path must
+    exit 0 — the consumer is not stale, it never pointed at the old path in
+    the surviving diff."""
+    repo = _init_repo(tmp_path)
+    old_dir = repo / "apps" / "backend-rag" / "tests"
+    new_dir = repo / "apps" / "backend-rag" / "backend" / "tests"
+    old_file = old_dir / "test_migrations.py"
+    _write(old_file, "def test_x(): pass\n")
+    _write(
+        repo / ".github" / "workflows" / "tests.yml",
+        "jobs:\n  test:\n    steps:\n"
+        "      - run: pytest apps/backend-rag/backend/tests/test_migrations.py\n",
+    )
+    base = _commit_all(repo, "base")
+
+    new_dir.mkdir(parents=True, exist_ok=True)
+    _git(repo, "mv", str(old_file.relative_to(repo)), str((new_dir / "test_migrations.py").relative_to(repo)))
+    _git(repo, "commit", "-q", "-m", "move test into backend/tests")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "CONSUMER_MAP_LIVE_COUNT=0" in result.stdout
+
+
+def test_innocence_docs_only_mention_is_not_a_finding(tmp_path: Path) -> None:
+    """A hit that lives only in a `.md` file is reported as docs-mention,
+    never counted as LIVE, and must not fail the push."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_orphan.py"
+    _write(target, "def test_x(): pass\n")
+    _write(repo / "docs" / "notes.md", "See test_orphan.py for context.\n")
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "docs-mention" in result.stdout
+    assert "| LIVE" not in result.stdout
+    assert "CONSUMER_MAP_LIVE_COUNT=0" in result.stdout
+
+
+def test_innocence_no_deleted_or_renamed_files_is_clean(tmp_path: Path) -> None:
+    """A push that only ADDS/MODIFIES files (nothing deleted or renamed)
+    must be a trivial clean pass — this is the common case, most pushes."""
+    repo = _init_repo(tmp_path)
+    _write(repo / "README.md", "hello\n")
+    base = _commit_all(repo, "base")
+    _write(repo / "README.md", "hello world\n")
+    _commit_all(repo, "modify only")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "CONSUMER_MAP_LIVE_COUNT=0" in result.stdout
+
+
+def test_innocence_excluded_tree_research_is_not_reported_even_as_docs_mention(
+    tmp_path: Path,
+) -> None:
+    """research/** is excluded outright — not even surfaced as a
+    docs-mention row — per the ad-hoc/non-authoritative status CLAUDE.md
+    §15 gives that tree."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_gone.py"
+    _write(target, "def test_x(): pass\n")
+    _write(repo / "research" / "ops" / "note.md", "test_gone.py was mentioned here\n")
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "research" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Common-basename skip
+# ---------------------------------------------------------------------------
+
+
+def test_common_basename_skipped_by_default_with_a_note(tmp_path: Path) -> None:
+    """conftest.py is common enough that a bare-basename search is noise —
+    skipped by default, reported with a note, never blocks the push."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "conftest.py"
+    _write(target, "import pytest\n")
+    _write(
+        repo / "apps" / "other" / "tests" / "runner.sh",
+        "#!/bin/sh\ncat conftest.py\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete conftest")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SKIPPED-common-basename" in result.stdout
+
+
+def test_common_basename_include_common_forces_the_scan(tmp_path: Path) -> None:
+    """--include-common must force the same scenario above to find the real
+    (over-matching, by design) hit."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "conftest.py"
+    _write(target, "import pytest\n")
+    _write(
+        repo / "apps" / "other" / "tests" / "runner.sh",
+        "#!/bin/sh\ncat conftest.py\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete conftest")
+
+    result = _run(repo, "--base", base, "--include-common")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "runner.sh" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_paths_mode_bypasses_git_diff(tmp_path: Path) -> None:
+    """Positional paths are treated as the deleted-file set directly,
+    without computing a git diff at all."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_x.py"
+    _write(target, "def test_x(): pass\n")
+    _write(repo / "Makefile", "test:\n\tpytest apps/backend-rag/tests/test_x.py\n")
+    _commit_all(repo, "base")
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "apps/backend-rag/tests/test_x.py")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Makefile" in result.stdout
+
+
+def test_usage_error_bad_base_ref_exits_2(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _write(repo / "README.md", "hello\n")
+    _commit_all(repo, "base")
+
+    result = _run(repo, "--base", "definitely-not-a-real-ref-xyz")
+    assert result.returncode == 2, result.stdout + result.stderr
+
+
+def test_help_exits_0_and_mentions_the_overmatch_proxy_warning() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "over-match" in result.stdout.lower() or "overmatch" in result.stdout.lower()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/scripts/tests/test_consumer_map.py
+++ b/scripts/tests/test_consumer_map.py
@@ -197,6 +197,141 @@ def test_innocence_docs_only_mention_is_not_a_finding(tmp_path: Path) -> None:
     assert "CONSUMER_MAP_LIVE_COUNT=0" in result.stdout
 
 
+# ---------------------------------------------------------------------------
+# PROSE-MENTION FILTER (2026-08-21, real-corpus replay finding): a comment
+# line or a Python docstring naming the file is not a consumer of it. Real
+# shapes found live in apps/backend-rag/backend/tests/integration/zantara/
+# test_tier1_fallback.py:32 (comment) and apps/backend-rag/backend/tests/
+# test_no_global_cwd_mutation.py:12 + scripts/tests/test_no_import_time_
+# chdir_in_tests.py:11 (module docstrings), all narrating the SAME incident
+# this tool's own module-docstring #4459 motivation describes.
+# ---------------------------------------------------------------------------
+
+
+def test_innocence_comment_line_mention_is_not_a_finding(tmp_path: Path) -> None:
+    """A hit whose line, after lstrip(), starts with '#' is a comment naming
+    the file, not a consumer — must be docs-mention, exit 0."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_gone_orphan.py"
+    _write(target, "def test_x(): pass\n")
+    _write(
+        repo / "apps" / "backend-rag" / "backend" / "tests" / "test_other.py",
+        "# see also tests/test_gone_orphan.py for the historical incident\n"
+        "def test_y(): pass\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "docs-mention" in result.stdout
+    assert "| LIVE" not in result.stdout
+    assert "CONSUMER_MAP_LIVE_COUNT=0" in result.stdout
+
+
+def test_innocence_trailing_comment_on_a_code_line_still_counts_as_live(
+    tmp_path: Path,
+) -> None:
+    """The comment filter is WHOLE-LINE only (line must START with '#' after
+    lstrip): a real code statement with a trailing end-of-line comment must
+    NOT be swallowed — it still carries a real reference."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_gone_trailing.py"
+    _write(target, "def test_x(): pass\n")
+    _write(
+        repo / "Makefile",
+        'test:\n\tpytest apps/backend-rag/tests/test_gone_trailing.py  # noqa\n',
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "| LIVE" in result.stdout
+
+
+def test_innocence_python_docstring_mention_is_not_a_finding(tmp_path: Path) -> None:
+    """A hit that lives only inside a Python module docstring is prose, not
+    a consumer — must be docs-mention, exit 0."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_gone_doc.py"
+    _write(target, "def test_x(): pass\n")
+    _write(
+        repo / "apps" / "backend-rag" / "backend" / "tests" / "test_narrator.py",
+        '"""This module explains why test_gone_doc.py was retired.\n\n'
+        "Historical context in prose only, no import, no string reference\n"
+        'outside this docstring.\n"""\n\n'
+        "def test_y(): pass\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "docs-mention" in result.stdout
+    assert "| LIVE" not in result.stdout
+    assert "CONSUMER_MAP_LIVE_COUNT=0" in result.stdout
+
+
+def test_guilt_docstring_mention_does_not_swallow_a_real_reference_in_the_same_file(
+    tmp_path: Path,
+) -> None:
+    """Guilt tripwire (team-lead's explicit ask): the SAME file has BOTH a
+    docstring mention of the basename AND a real list-literal string
+    reference (the #4459 backend_stability_gate.py shape) to it — the
+    docstring hit must downgrade to docs-mention, but the list-literal hit
+    must stay LIVE. The docstring filter must never swallow a real
+    consumer just because it lives near a prose mention in the same file."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_gone_both.py"
+    _write(target, "def test_x(): pass\n")
+    _write(
+        repo / "apps" / "backend-rag" / "scripts" / "gate_and_doc.py",
+        '"""Runs REQUIRED, including test_gone_both.py, per the gate below."""\n\n'
+        "REQUIRED = [\n"
+        '    "tests/test_gone_both.py",\n'
+        "]\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "docs-mention" in result.stdout
+    assert "| LIVE" in result.stdout
+    assert "CONSUMER_MAP_LIVE_COUNT=1" in result.stdout
+
+
+def test_innocence_unparseable_python_fails_closed_to_live(tmp_path: Path) -> None:
+    """A .py consuming file that does not parse (syntax error) must fail
+    CLOSED: the docstring filter is skipped for it, the hit stays LIVE, and
+    a note is printed — never silently trusted as prose."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "backend-rag" / "tests" / "test_gone_syntax.py"
+    _write(target, "def test_x(): pass\n")
+    _write(
+        repo / "apps" / "backend-rag" / "backend" / "broken.py",
+        "def not valid python syntax here test_gone_syntax.py (\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "| LIVE" in result.stdout
+    assert "could not read/parse" in result.stderr or "could not read/parse" in result.stdout
+
+
 def test_innocence_no_deleted_or_renamed_files_is_clean(tmp_path: Path) -> None:
     """A push that only ADDS/MODIFIES files (nothing deleted or renamed)
     must be a trivial clean pass — this is the common case, most pushes."""

--- a/scripts/tests/test_prepush_failclosed.sh
+++ b/scripts/tests/test_prepush_failclosed.sh
@@ -428,6 +428,126 @@ else
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# Case 18 (guilt, PR #4459, 2026-08-21): the CONSUMER-MAP block added to
+# .husky/pre-push must actually BLOCK a push that deletes a file some other
+# tracked file still names by basename — the exact #4459 shape
+# (.github/workflows/*.yml naming the deleted path relative to a `cd`).
+#
+# This runs the REAL extracted block (not a re-typed mirror — same
+# discipline as extract_pathaware_block() in test_prepush_default_off.sh)
+# against a REAL, throwaway git fixture, with PREPUSH_TRUST_ROOT pointed at
+# THIS repo's real scripts/prepush_classify.py + scripts/consumer_map.py —
+# so this proves the actual shipped code blocks, not a stand-in for it.
+# `origin/main` is faked via `update-ref` (no network needed) since the
+# block hardcodes `--base origin/main`.
+# ---------------------------------------------------------------------------
+extract_consumer_map_block() {
+    sed -n '/^if \[ "\${PREPUSH_SKIP_CONSUMER_MAP:-0}" != "1" \]; then$/,/^fi$/p' "$HOOK_FILE"
+}
+
+cm_block="$(extract_consumer_map_block)"
+cm_block_lines="$(printf '%s\n' "$cm_block" | wc -l | tr -d ' ')"
+if [ -z "$cm_block" ] || [ "${cm_block_lines:-0}" -lt 5 ]; then
+    note_fail "guilt (consumer-map, #4459) — could not extract the consumer-map block from $HOOK_FILE (got $cm_block_lines lines)"
+    note_fail "innocence (consumer-map, #4459) — SKIPPED, block extraction failed above"
+else
+    CM18_TMP="$(mktemp -d)"
+    git init -q "$CM18_TMP"
+    git -C "$CM18_TMP" config user.email t@example.invalid
+    git -C "$CM18_TMP" config user.name "Test"
+    mkdir -p "$CM18_TMP/apps/backend-rag/tests" "$CM18_TMP/.github/workflows"
+    printf 'def test_x(): pass\n' > "$CM18_TMP/apps/backend-rag/tests/test_migrations.py"
+    printf 'jobs:\n  test:\n    steps:\n      - run: cd apps/backend-rag && pytest tests/test_migrations.py\n' \
+        > "$CM18_TMP/.github/workflows/sonarqube.yml"
+    git -C "$CM18_TMP" add -A
+    git -C "$CM18_TMP" commit -q -m base
+    CM18_BASE_SHA="$(git -C "$CM18_TMP" rev-parse HEAD)"
+    git -C "$CM18_TMP" update-ref refs/remotes/origin/main "$CM18_BASE_SHA"
+    rm -f "$CM18_TMP/apps/backend-rag/tests/test_migrations.py"
+    git -C "$CM18_TMP" add -A
+    git -C "$CM18_TMP" commit -q -m "delete orphan tests tree"
+
+    out18="$(cd "$CM18_TMP" && PREPUSH_TRUST_ROOT="$REPO_ROOT" sh -e -c "
+$cm_block
+echo REACHED_END
+" 2>&1)"
+    rc18=$?
+    if [ "$rc18" != "0" ] && printf '%s' "$out18" | grep -q 'consumer-map:.*live consumers' \
+        && ! printf '%s' "$out18" | grep -q 'REACHED_END'; then
+        note_pass "guilt (consumer-map, #4459) — a deleted file with a live consumer BLOCKS the push (rc=$rc18)"
+    else
+        note_fail "guilt (consumer-map, #4459) — expected a non-zero blocking exit naming live consumers, got rc=$rc18 out='$out18'"
+    fi
+
+    # -----------------------------------------------------------------------
+    # Case 19 (innocence, PR #4459): the SAME block, against a CLEAN deletion
+    # (a file with zero references anywhere) on the SAME fixture repo, must
+    # NOT block — execution must reach past the block to REACHED_END. This
+    # is not merely "no error" — Case 2/3's own shape (this file's early
+    # cases) already showed a bare non-zero classifier exit is easy to
+    # confuse with "working"; REACHED_END proves the block did not exit 1.
+    # -----------------------------------------------------------------------
+    printf 'def test_never_referenced_anywhere(): pass\n' \
+        > "$CM18_TMP/apps/backend-rag/tests/test_never_referenced_anywhere.py"
+    git -C "$CM18_TMP" add -A
+    git -C "$CM18_TMP" commit -q -m "add an unreferenced file"
+    CM19_BASE_SHA="$(git -C "$CM18_TMP" rev-parse HEAD)"
+    git -C "$CM18_TMP" update-ref refs/remotes/origin/main "$CM19_BASE_SHA"
+    rm -f "$CM18_TMP/apps/backend-rag/tests/test_never_referenced_anywhere.py"
+    git -C "$CM18_TMP" add -A
+    git -C "$CM18_TMP" commit -q -m "delete the unreferenced file — clean"
+
+    out19="$(cd "$CM18_TMP" && PREPUSH_TRUST_ROOT="$REPO_ROOT" sh -e -c "
+$cm_block
+echo REACHED_END
+" 2>&1)"
+    rc19=$?
+    if [ "$rc19" = "0" ] && printf '%s' "$out19" | grep -q 'REACHED_END' \
+        && ! printf '%s' "$out19" | grep -q 'push blocked'; then
+        note_pass "innocence (consumer-map, #4459) — a clean deletion (no consumers anywhere) does NOT block the push"
+    else
+        note_fail "innocence (consumer-map, #4459) — expected rc=0 and REACHED_END, got rc=$rc19 out='$out19'"
+    fi
+
+    rm -rf "$CM18_TMP"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 20 (tripwire, PR #4459): the consumer-map block in the LIVE hook must
+# (a) run UNCONDITIONALLY — outside the `if [ "$PREPUSH_RUN_BACKEND" = "1" ]`
+#     guard, never made to depend on DEFAULT-OFF (2026-08-13) the way the
+#     pytest suite is;
+# (b) capture the classifier's exit code errexit-immune (`|| CM_RC=$?`) —
+#     the W101 shape this whole file exists to catch, now on its 4th call
+#     site in this hook;
+# (c) actually `exit 1` on rc=1 — a block that only echoes would be
+#     decorative (W104: "il primo anticorpo scritto era un check
+#     sull'rc — decorativo per costruzione").
+# ---------------------------------------------------------------------------
+if [ ! -f "$HOOK_FILE" ]; then
+    note_fail "tripwire (consumer-map) — $HOOK_FILE not found (cannot verify)"
+else
+    if printf '%s' "$cm_block" | grep -q '|| CM_RC=\$?' \
+        && printf '%s' "$cm_block" | grep -q 'exit 1' \
+        && printf '%s' "$cm_block" | grep -q -- '--check-consumers'; then
+        note_pass "tripwire (consumer-map) — block is errexit-immune-captured and actually exits 1 on a live finding"
+    else
+        note_fail "tripwire (consumer-map) — block missing the errexit-immune capture, the --check-consumers call, or the blocking exit 1"
+    fi
+
+    # (a) above, checked structurally: the consumer-map block's own `if`
+    # line must appear BEFORE line 366's `if [ "$PREPUSH_RUN_BACKEND" = "1" ]`
+    # guard, i.e. outside and ahead of it, not nested inside.
+    cm_if_line="$(grep -n '^if \[ "\${PREPUSH_SKIP_CONSUMER_MAP:-0}" != "1" \]; then$' "$HOOK_FILE" | head -1 | cut -d: -f1)"
+    run_backend_if_line="$(grep -n '^if \[ "\$PREPUSH_RUN_BACKEND" = "1" \]; then$' "$HOOK_FILE" | head -1 | cut -d: -f1)"
+    if [ -n "$cm_if_line" ] && [ -n "$run_backend_if_line" ] && [ "$cm_if_line" -lt "$run_backend_if_line" ]; then
+        note_pass "tripwire (consumer-map) — block (line $cm_if_line) runs before/outside the PREPUSH_RUN_BACKEND guard (line $run_backend_if_line), not gated by DEFAULT-OFF"
+    else
+        note_fail "tripwire (consumer-map) — could not confirm the block sits outside the PREPUSH_RUN_BACKEND guard (cm=$cm_if_line, guard=$run_backend_if_line)"
+    fi
+fi
+
 echo "---"
 echo "$pass passed, $fail failed"
 


### PR DESCRIPTION
## Why

PR #4459 (deleting the orphan `apps/backend-rag/tests/` tree) went CI-red **twice** because two consumers were invisible to a search anchored on the deleted PATH:

- `.github/workflows/sonarqube.yml` named the files as `tests/...` **after a `cd apps/backend-rag`** step — the YAML string never contains the deleted directory's path.
- `apps/backend-rag/scripts/backend_stability_gate.py:41` listed `tests/test_migrations.py` inside a bare Python list literal.

A path-form search under-matches by construction (cicatrix-superscar.md #3 — guard the entity a reader actually types, not the form of a path). This PR adds a **basename**-anchored consumer search that catches both shapes, wired fail-closed into `.husky/pre-push` so a red PR like #4459 never leaves the machine.

## What

- **`scripts/consumer_map.py`** (new, standalone CLI): for every DELETED/RENAMED file between `git merge-base <base> HEAD` and `HEAD` (rename detection ON, unlike the hook's own `--no-renames` gate — this tool wants the old→new pair), `git grep -F` the basename (+ bare import-stem for `.py`) across the tracked tree at `HEAD`, classify every surviving hit by consumer kind, print a table + `CONSUMER_MAP_LIVE_COUNT=N`. Excludes `docs/archive/**`, `research/**`, `.secrets.baseline`, `infra/tcc-desktop-paths/allowlist.txt`, `*.jsonl`; skips common basenames (`conftest.py`, `__init__.py`) by default (`--include-common` to force). Exit 0 clean / 1 live consumer(s) / 2 usage error. Measured well under the 10s budget (0.28s typical, 4.5s worst-case on 3 heavily-referenced real basenames).
- **`scripts/prepush_classify.py`**: new `--check-consumers [--base REF]` mode — a thin adapter over `consumer_map.py`, deliberately kept OUT of the pure `classify()`/`_innocent_reason()` SSOT (it's git-based by necessity; lives in this CLI only so the hook has one script to invoke).
- **`.husky/pre-push`**: new CONSUMER-MAP block, **unconditional** — not gated by `PREPUSH_RUN_BACKEND`/DEFAULT-OFF (2026-08-13), which only controls the local pytest suite and no longer blocks a push on its own. This is the one check CI structurally can't do (CI only ever sees the tree *after* the deletion). Errexit-immune capture, resolves `python3` independently of `PYTHON_BIN`. `rc=1` → `exit 1`, push blocked, table printed. `rc>=2` → warn, don't block. Kill switch `PREPUSH_SKIP_CONSUMER_MAP=1`.

### Fix (2nd commit): comment/docstring over-match found by real-corpus replay

Team-lead ran a real replay against `apps/backend-rag/backend/tests/test_sentry_lazy_import.py` and found 3 of 20 "LIVE" hits that only **name** the file in prose, never consume it:
- `apps/backend-rag/backend/tests/integration/zantara/test_tier1_fallback.py:32` — a `#` comment line.
- `apps/backend-rag/backend/tests/test_no_global_cwd_mutation.py:12` and `scripts/tests/test_no_import_time_chdir_in_tests.py:11` — both inside a Python module docstring.

Added two filters that downgrade such hits to `docs-mention` (never blocking):
1. A hit whose line, after `lstrip()`, starts with `#` (whole-line comment only — a trailing end-of-line comment still counts as LIVE).
2. For `.py` targets, a hit inside a docstring's line range, found via `ast.parse` + `ast.walk` (module/class/function/async-function docstrings, at any nesting depth) — never a heuristic. Unparseable Python fails **closed**: the hit stays LIVE with a one-line stderr note.

**Re-ran the exact replay after the fix** (real, not synthetic — `python3 scripts/consumer_map.py apps/backend-rag/backend/tests/test_sentry_lazy_import.py`):

```
location                                                                        | kind     | basename                    | verdict
.github/workflows/tests.yml:617                                                | workflow | test_sentry_lazy_import.py | LIVE
.husky/pre-push:125                                                            | husky    | test_sentry_lazy_import.py | docs-mention
apps/backend-rag/backend/tests/integration/zantara/test_tier1_fallback.py:32   | python   | test_sentry_lazy_import.py | docs-mention
apps/backend-rag/backend/tests/test_no_global_cwd_mutation.py:12               | python   | test_sentry_lazy_import.py | docs-mention
scripts/tests/test_no_import_time_chdir_in_tests.py:11                         | python   | test_sentry_lazy_import.py | docs-mention
CONSUMER_MAP_LIVE_COUNT=1
```

5 hits total (was 5 LIVE before the fix) → now **1 LIVE**, the genuine consumer (`.github/workflows/tests.yml:617`, the CI step that actually `pytest`-invokes this file), and 4 `docs-mention`. Note: `.husky/pre-push:125` was a **4th** real comment I found re-running the replay (not one of the 3 team-lead listed) — same shape (`# ... tests/test_sentry_lazy_import.py, ...` explaining what this hook does NOT run), correctly caught by the same whole-line-comment filter.

Added 5 new test cases (`scripts/tests/test_consumer_map.py`, now 17 total): comment-line innocence, trailing-comment guilt (proves the filter is whole-line only, not substring), docstring innocence, guilt tripwire (same file has BOTH a docstring mention AND a real list-literal reference — docstring hit downgrades, list-literal hit stays LIVE), unparseable-Python fail-closed guilt.

## Tests

- `scripts/tests/test_consumer_map.py` (17 cases, real throwaway git repos, real commits — never mocked): both real #4459 shapes + multi-target aggregation (guilt); rename already repointed, docs-only mention, no D/R files, `research/**` excluded outright, common-basename skip + override, explicit-paths mode, usage error, `--help` proxy warning (innocence); + the 5 prose-mention cases above.
- `scripts/tests/test_prepush_failclosed.sh` (+3 cases, 18-20): guilt/innocence run the block **extracted verbatim from the live hook** (not a re-typed mirror) against a real git fixture with a faked `origin/main` ref — proves it actually blocks (rc=1) vs actually passes through (rc=0, `REACHED_END` reached); tripwire pins the errexit-immune capture, the blocking `exit 1`, and that the block sits outside/ahead of the `PREPUSH_RUN_BACKEND` guard so DEFAULT-OFF can never neuter it. Table-printing-on-failure re-verified via Case 18 after the fix (unchanged).

Verified: 23/23 `test_prepush_failclosed.sh`, 17/17 `test_consumer_map.py`, 158/158 `test_prepush_classify.py`, 30/30 honest-verdict/freshness, 14/14 default-off, `docs_sync.py --check` clean, reward-hacking lint clean, `sh -n` clean.

## Adversarial review

Guilt corpus = the two real #4459 misses, reproduced verbatim. Innocence corpus covers the "already migrated" rename (a naive basename search would still flag this), docs-only mentions, an excluded tree, the common-basename skip, and — after team-lead's real-corpus replay caught a genuine over-match — comment lines and Python docstrings (with a guilt tripwire proving the docstring filter cannot swallow a real list-literal reference living in the same file). The pre-push wiring test runs the block extracted from the real hook file (cicatrix-superscar.md #6 discipline: never build on a re-typed mirror) and asserts `REACHED_END` as *positive* proof of non-blocking, not merely "no error". Declared, un-fixed proxy: basename matching still over-matches on real CODE references sharing a name (e.g. two files with the same basename in different directories) — an over-match there costs a human one extra table row; the alternative (under-match) is the literal #4459 defect this tool exists to close. Not wired into any required CI gate's path-filter list — out of scope per this task's boundary (workflows owned elsewhere); orchestrating session 3563604c re-verifies and owns that follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)