### PR TITLE
feat(ci): diff-scope Detect Secrets on PR/queue runs (audit lever L3)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -865,11 +865,19 @@ jobs:
           done < /tmp/changed_all.txt
           COUNT=$(wc -l < /tmp/changed_existing.txt | tr -d ' ')
           echo "diff-scope: ${COUNT} scannable file(s) out of $(wc -l < /tmp/changed_all.txt | tr -d ' ') changed"
-          # Blind-scan tripwire (W84): a gate that scanned NOTHING must not
-          # report green — fail loud instead.
           if [ "${COUNT}" -eq 0 ]; then
-            echo "::error::diff-scope produced zero scannable files — refusing to report green on a blind scan"
-            exit 1
+            # Enumeration SUCCEEDED — hotzone_changed_files.sh exits 3 when
+            # it cannot determine the changed set, so a blind/lying scan set
+            # never reaches this line (that is the W84 tripwire, upstream).
+            # Zero scannable files here is therefore a TRUTHFUL statement:
+            # the diff is empty, or everything it touched was deleted — and
+            # a deletion cannot introduce a secret (Codex red-team round 1:
+            # the previous fail-on-0 blocked legitimate deletion-only PRs).
+            # Report the no-op explicitly — never the word "clean": this
+            # step scanned nothing.
+            echo "diff-scope: nothing to scan (empty or deletion-only diff; enumeration succeeded)"
+            echo "mode=noop" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "mode=diff" >> "$GITHUB_OUTPUT"
 
@@ -878,7 +886,11 @@ jobs:
           SCAN_MODE: ${{ steps.scope.outputs.mode }}
         run: |
           set -euo pipefail
-          if [ "${SCAN_MODE}" = "diff" ]; then
+          if [ "${SCAN_MODE}" = "noop" ]; then
+            # Empty or deletion-only diff — the Decide step proved the
+            # enumeration succeeded; there is nothing a scan could find.
+            echo "scan skipped: nothing to scan (see Decide scan scope)"
+          elif [ "${SCAN_MODE}" = "diff" ]; then
             # Explicit paths keep repo-relative keys, so baseline audit
             # decisions for known false positives in those files still
             # match and stay filtered (verified against detect-secrets on

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -783,6 +783,18 @@ jobs:
     # one scanner in this file where "better ten unnecessary scans than one
     # skipped wrongly" has no exception, and it always runs on every
     # pull_request/merge_group/push/schedule trigger, exactly as before.
+    #
+    # Scan WIDTH is a different question from WHETHER the job runs
+    # (2026-08-21, token-ceremony CI-critical-path audit, lever L3 —
+    # research/operations/2026-08-21-token-ceremony-ci-system-audit.md):
+    # on pull_request/merge_group the scan is scoped to the files the diff
+    # touches, because a secret can only ENTER through a changed file. A
+    # secret sitting in an UNCHANGED file is already on main — the daily +
+    # weekly scheduled full-tree scans (and any push/workflow_dispatch run)
+    # are the net that catches those, per the audit's own risk note. The
+    # full scan measured 19m34s on run 31312661093; the diff-scoped scan is
+    # seconds. The gate semantics are unchanged: any NEW finding in a
+    # changed file still arrives unaudited and still fails the job below.
     runs-on: ubuntu-latest
     # Run 31312661093 measured 19m34s in the scan alone and was cancelled at
     # the 20m job limit after every gating step had succeeded. Keep this gate
@@ -813,14 +825,81 @@ jobs:
       - name: Install detect-secrets
         run: pip install detect-secrets
 
-      - name: Run detect-secrets scan
+      - name: Decide scan scope
+        # L3 (see the job header above): pull_request/merge_group scan only
+        # the diff's files; every other event keeps the full-tree scan.
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MQ_BASE: ${{ github.event.merge_group.base_sha }}
+          MQ_HEAD: ${{ github.event.merge_group.head_sha }}
         run: |
-          detect-secrets scan \
-            --baseline .secrets.baseline \
-            --exclude-files 'node_modules/.*' \
-            --exclude-files '\.venv/.*' \
-            --exclude-files 'venv/.*' \
-            --exclude-files '\.git/.*'
+          set -euo pipefail
+          if [ "${EVENT_NAME}" != "pull_request" ] && [ "${EVENT_NAME}" != "merge_group" ]; then
+            echo "full-tree scan (event: ${EVENT_NAME})"
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            BASE="${PR_BASE}"; HEAD="${PR_HEAD}"; PRN="${PR_NUMBER}"
+          else
+            BASE="${MQ_BASE}"; HEAD="${MQ_HEAD}"; PRN=""
+          fi
+          # hotzone_changed_files.sh anchors on the merge-base (three-dot,
+          # exactly what the PR "Files changed" tab shows) and exits 3 when
+          # it cannot determine the changed set — `set -e` turns that into a
+          # RED job here, never a blind green (the script's own contract).
+          if [ -n "${PRN}" ]; then
+            bash scripts/ci/hotzone_changed_files.sh "${BASE}" "${HEAD}" "${PRN}" > /tmp/changed_all.txt
+          else
+            bash scripts/ci/hotzone_changed_files.sh "${BASE}" "${HEAD}" > /tmp/changed_all.txt
+          fi
+          # A diff can DELETE files, and detect-secrets errors on a path that
+          # does not exist in the worktree — scan only what is still there.
+          : > /tmp/changed_existing.txt
+          while IFS= read -r f; do
+            [ -f "$f" ] && printf '%s\n' "$f" >> /tmp/changed_existing.txt
+          done < /tmp/changed_all.txt
+          COUNT=$(wc -l < /tmp/changed_existing.txt | tr -d ' ')
+          echo "diff-scope: ${COUNT} scannable file(s) out of $(wc -l < /tmp/changed_all.txt | tr -d ' ') changed"
+          # Blind-scan tripwire (W84): a gate that scanned NOTHING must not
+          # report green — fail loud instead.
+          if [ "${COUNT}" -eq 0 ]; then
+            echo "::error::diff-scope produced zero scannable files — refusing to report green on a blind scan"
+            exit 1
+          fi
+          echo "mode=diff" >> "$GITHUB_OUTPUT"
+
+      - name: Run detect-secrets scan
+        env:
+          SCAN_MODE: ${{ steps.scope.outputs.mode }}
+        run: |
+          set -euo pipefail
+          if [ "${SCAN_MODE}" = "diff" ]; then
+            # Explicit paths keep repo-relative keys, so baseline audit
+            # decisions for known false positives in those files still
+            # match and stay filtered (verified against detect-secrets on
+            # a fixture: decisions preserved, new findings arrive unaudited,
+            # unscanned entries pruned — ephemeral in this workspace).
+            # Portable array build, no mapfile: bash 3.2-safe (fleet macs).
+            FILES=()
+            while IFS= read -r f; do
+              FILES+=("$f")
+            done < /tmp/changed_existing.txt
+            detect-secrets scan \
+              --baseline .secrets.baseline \
+              "${FILES[@]}"
+          else
+            detect-secrets scan \
+              --baseline .secrets.baseline \
+              --exclude-files 'node_modules/.*' \
+              --exclude-files '\.venv/.*' \
+              --exclude-files 'venv/.*' \
+              --exclude-files '\.git/.*'
+          fi
 
       - name: Auto-triage new findings
         # The scan step above updates .secrets.baseline in place with any new


### PR DESCRIPTION
## What

Lever **L3** of the token-ceremony CI-critical-path audit (`research/operations/2026-08-21-token-ceremony-ci-system-audit.md`): Detect Secrets stops paying a full-tree scan on every PR/queue run.

- `pull_request` / `merge_group`: scan only the files the diff touches (`scripts/ci/hotzone_changed_files.sh`, merge-base anchored — the same helper the hot-zone gate uses).
- `schedule` (daily + weekly), `push`, `workflow_dispatch`: full-tree scan unchanged — the net for anything already on main.
- Gate semantics unchanged: a **new** finding in a changed file still arrives unaudited and fails the job (`detect_secrets_check_unaudited.py` path untouched).

## Why

The full scan measured **19m34s** (run 31312661093, cancelled at the 20m cap) and runs on every PR including docs-only ones — per the audit, ~15–17 runner-min and ~15 min wall-clock per docs-only PR. A secret can only *enter* through a changed file, so diff-scoping the PR/queue scan does not shrink the net for anything already on main.

**Correction to the original risk note (measured 2026-08-21, not assumed):** the phrase "the scheduled full scan is the designated catch" for pre-existing secrets is **false in the case that matters most**. `detect_secrets_check_unaudited.py` only checks that an `is_secret` decision *exists* on a finding — true or false — never what earned it or whether it's still correct. A finding entered as `is_secret: false` is exempt from every future scheduled run, forever, full-tree scan included. This is not theoretical: nine files under `apps/backend-rag/scripts/` carried a live Google OAuth triple (client_id + GOCSPX- client secret + 1// refresh token) in cleartext since before this baseline was generated (2026-07-17) — the daily *and* weekly full-tree scan ran green over it every single time, because a single broad path-only rule in `detect_secrets_auto_triage.py`'s `AUTO_APPROVE_RULES` (`apps/backend-rag/scripts/.*\.(py|sh)$`, no content check) had already marked it `is_secret: false`. Measured repo-wide: 6,939 `is_secret:false` findings across the 326 still-live baseline files rest on that same class of broad, content-blind approval — none of them will ever resurface via the scheduled scan this PR is relying on as the backstop.

**Why this PR is still fine to ship as-is**: the blindness above is orthogonal to what this PR changes — it lives entirely in the baseline/auto-triage layer, pre-dates this PR, and is identical before and after this diff on both the diff-scoped and full-tree paths (this PR does not touch `.secrets.baseline` or `detect_secrets_auto_triage.py`). The condition that makes shipping this acceptable: the gap is now tracked and visible — `scripts/baseline_debt_report.py` (new, `--strict` flags any broad-approved live file matching a high-confidence credential shape) and a PENDING-ARMS ledger row — rather than resting on the false assumption this note originally stated. The OAuth-9 fix itself is separate, in-flight PR #4489.

## Verification (all local, real)

- Fixture proof against detect-secrets semantics: baseline audit decisions on known false positives in scanned files are **preserved** (no false red); a new finding in a scanned file arrives **unaudited** (gate fails); explicit path args keep repo-relative baseline keys; unscanned baseline entries are pruned (ephemeral in the CI workspace).
- End-to-end on this repo: `hotzone_changed_files.sh` on this branch → 1 file; diff-scoped scan against the real `.secrets.baseline` → **0.185s**, rc 0; baseline restored afterwards (the scan mutates it in place — CI-only side effect).
- Tripwires fail-loud (W84): hotzone exit 3 → red job; **zero scannable files → red job** (a gate that scanned nothing never reports green); deleted files filtered so detect-secrets never errors on a missing path. Scanned-file count echoed every run.
- `actionlint` clean; YAML parses; `check_watcher_coverage.py` 94/94 (1 pre-existing stale-entry warning from #4435, not introduced here); `check_required_workflow_conformance.py` 27 contexts, 0 violations — job name/contexts untouched.
- This PR's own `Detect Secrets` run is the live innocence proof: diff-scoped to 1 file, expected seconds instead of ~19 min.

## Not verified (honest residuals)

- No live `merge_group` run yet — the merge_group diff base/head mapping follows GitHub's documented payload (`base_sha`→`head_sha` = the group's tree); first queue entry will demonstrate it. Failure mode if wrong: hotzone exit 3 → red and loud, never blind green.
- Full-tree path is byte-identical to before and is not re-measured here (runs nightly).
- The audit's "fake-secret canaries" idea is NOT implemented — the mechanical tripwires above cover the blind-scan class instead; canaries would need a fixture file that rides every diff, which doesn't exist as a mechanism.

Auto-merge deliberately NOT armed (external-agent contract): a Claude verify session merges after review.

🤖 Lane: Kimi K3 (continuation of the token-ceremony program, mandated by Zero 2026-08-21)


---

## Adversarial review — round 1 (Codex O2, red-team, verdict BLOCK → fixed)

1. **Deletion-only / empty diffs falsely rejected** (accepted, fixed in `b63a796e3`): the fail-on-zero tripwire blocked PRs whose changed files no longer exist. `hotzone_changed_files.sh`'s exit-3 contract already covers blind enumeration upstream, so zero scannable files is a truthful no-op → new `mode=noop` (explicit "nothing to scan", never the word "clean"). Simulated locally: enumeration-succeeded + empty set → `mode=noop`, rc 0.
2. Reviewer-verified, unchanged: exit-3 → red propagation under `set -e`; `merge_group.base_sha/head_sha` payload fields; baseline pruning ephemeral and gate-correct (`detect_secrets_check_unaudited.py` reads the diff-scoped results); no event leaves `mode` unset; renames handled conservatively (`--no-renames`: deleted source dropped, existing destination scanned).

Round 2 re-review of `b63a796e3` dispatched (Codex O2).

## Adversarial review — independent verification (Claude session, dispatched by Zero to audit `.secrets.baseline` blindness)

Measured the risk note in the "Why" section against the real `.secrets.baseline` (455 entries, 326 still on HEAD) and `scripts/detect_secrets_auto_triage.py`'s live ruleset: the claim "the scheduled full scan is the designated catch" for pre-existing secrets does not hold for anything already marked `is_secret: false` — `detect_secrets_check_unaudited.py` only checks that a decision exists, never its correctness, so a baselined finding is exempt from every future scheduled run regardless of content. Confirmed live: nine files under `apps/backend-rag/scripts/` carrying a real Google OAuth triple have been in this exact state since before the baseline was generated, invisible to every daily/weekly full-tree run. 6,939 other `is_secret:false` findings in still-live files rest on the same broad, content-blind class of approval. **This PR is not the cause and does not make it worse** — it neither touches `.secrets.baseline`/`detect_secrets_auto_triage.py` nor changes what the full-tree path scans; the "Why" section's risk note has been corrected in place above to state the measured truth instead of the (false) assumption, and the condition that makes shipping this PR acceptable despite the corrected note is spelled out there. Verdict: **no block** — the diff-scoping change itself is sound (verified the fixture proofs and tripwires independently); ship after the note correction. New visibility tool + ledger row tracking the structural gap: `scripts/baseline_debt_report.py` + `.claude/skills/modus/PENDING-ARMS.md`.

