### PR TITLE
fix(ci): npm-audit advisory job — three-way exit semantics (advisory green, CANNOT-VERIFY red)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1085,9 +1085,16 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Job-level, not step-level: an advisory finding must never flip this
-    # job's conclusion to something a future required-check addition (or a
-    # human reading the Checks tab) could mistake for a code regression.
+    # Two-layer advisory design (hardened after Codex red-team round 1 on
+    # this PR): (1) the audit step below NEVER exits non-zero on an advisory
+    # finding — it captures the gate's verdict, surfaces it as a ::warning +
+    # job summary, and exits 0 — so this job's check-run conclusion stays
+    # green even if the context is ever added to required checks by mistake
+    # (job-level continue-on-error alone does NOT guarantee that: it keeps
+    # the workflow green while the check run can still conclude failure).
+    # (2) continue-on-error then keeps a MACHINERY break (the gate's own
+    # test suite failing — our code, actionable) visible as a red job
+    # without taking the whole workflow run hostage.
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -1124,9 +1131,27 @@ jobs:
         # they failed the gate on EVERY PR repo-wide. Production-dependency
         # threshold stays at high.
         run: |
+          set -euo pipefail
+          # The gate's own test suite fails this job RED (our machinery,
+          # actionable, fail-loud) — everything below it never does.
           python3 scripts/ci/test_npm_audit_gate.py
           npm audit --audit-level=high --omit=dev --json > "$RUNNER_TEMP/audit.json" || true
+          set +e
           python3 scripts/ci/npm_audit_gate.py "$RUNNER_TEMP/audit.json"
+          GATE_RC=$?
+          set -e
+          if [ "${GATE_RC}" -ne 0 ]; then
+            echo "::warning::npm audit advisory (non-blocking, L13): gate exit ${GATE_RC} — see the job summary"
+            {
+              echo "### npm audit — advisory finding (non-blocking)"
+              echo ""
+              echo "The gate exited ${GATE_RC}. Advisory-only since 2026-08-21 (token-ceremony"
+              echo "audit, lever L13): the finding is real and worth triaging, but it is never"
+              echo "grounds to eject a queue entry or block a PR whose diff never touched a"
+              echo "dependency."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit 0
 
   packages-core-tests:
     name: Shared Core Package Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1085,16 +1085,17 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Two-layer advisory design (hardened after Codex red-team round 1 on
+    # Two-layer advisory design (hardened after Codex red-team rounds 1-2 on
     # this PR): (1) the audit step below NEVER exits non-zero on an advisory
-    # finding — it captures the gate's verdict, surfaces it as a ::warning +
-    # job summary, and exits 0 — so this job's check-run conclusion stays
-    # green even if the context is ever added to required checks by mistake
-    # (job-level continue-on-error alone does NOT guarantee that: it keeps
-    # the workflow green while the check run can still conclude failure).
-    # (2) continue-on-error then keeps a MACHINERY break (the gate's own
-    # test suite failing — our code, actionable) visible as a red job
-    # without taking the whole workflow run hostage.
+    # finding (gate exit 1) — it warns, writes a job summary, and exits 0 —
+    # so this job's check-run conclusion stays green even if the context is
+    # ever added to required checks by mistake (job-level continue-on-error
+    # alone does NOT guarantee that: it keeps the workflow green while the
+    # check run can still conclude failure). (2) MACHINERY failures still go
+    # red: the gate's own test suite, and a gate exit 2 (CANNOT VERIFY —
+    # unreadable/malformed audit report = no verdict was produced); continue-
+    # on-error keeps the workflow run green while the job shows red for a
+    # human.
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -1140,18 +1141,27 @@ jobs:
           python3 scripts/ci/npm_audit_gate.py "$RUNNER_TEMP/audit.json"
           GATE_RC=$?
           set -e
-          if [ "${GATE_RC}" -ne 0 ]; then
-            echo "::warning::npm audit advisory (non-blocking, L13): gate exit ${GATE_RC} — see the job summary"
+          # Three-way, keyed on the gate's own exit-code contract
+          # (scripts/ci/npm_audit_gate.py): 1 = advisory finding (external
+          # data, never blocks); 2 = CANNOT VERIFY — unreadable/malformed
+          # report, i.e. the audit itself failed and there is NO verdict.
+          # Codex red-team round 2: mapping every nonzero code to green
+          # would let a broken audit report clean — the blind-gate disease
+          # this job's split was written to kill.
+          if [ "${GATE_RC}" -eq 1 ]; then
+            echo "::warning::npm audit advisory (non-blocking, L13) — see the job summary"
             {
               echo "### npm audit — advisory finding (non-blocking)"
               echo ""
-              echo "The gate exited ${GATE_RC}. Advisory-only since 2026-08-21 (token-ceremony"
-              echo "audit, lever L13): the finding is real and worth triaging, but it is never"
-              echo "grounds to eject a queue entry or block a PR whose diff never touched a"
-              echo "dependency."
+              echo "Advisory-only since 2026-08-21 (token-ceremony audit, lever L13):"
+              echo "the finding is real and worth triaging, but it is never grounds to"
+              echo "eject a queue entry or block a PR whose diff never touched a dependency."
             } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          elif [ "${GATE_RC}" -ne 0 ]; then
+            echo "::error::npm audit gate could not produce a verdict (exit ${GATE_RC}) — machinery/infrastructure failure, not an advisory"
+            exit "${GATE_RC}"
           fi
-          exit 0
 
   packages-core-tests:
     name: Shared Core Package Tests


### PR DESCRIPTION
## What

Follow-up to #4477 (merged): two Codex-O2 red-team fixes for the npm-audit advisory job that landed on the lane branch AFTER the queue had already merged its head (agent-PR contract rule 2/7: post-merge work restarts from fresh origin/main — this is that PR; both commits cherry-picked verbatim, author history preserved).

- Round 1 (`5e46b634f`): the audit step itself never exits non-zero on an advisory finding — job-level `continue-on-error` alone keeps the WORKFLOW green while the check run could still conclude failure (and a future required-check addition would then block on external advisory data).
- Round 2 (`253912552`): three-way mapping on the gate's exit-code contract — advisory (1) = green + `::warning::` + job summary; **CANNOT VERIFY (2) = red** (unreadable/malformed audit report produced NO verdict — mapping every nonzero to green would let a broken audit read clean, the blind-gate disease the split was written to kill, W104 family).

## Verified on this branch (fresh origin/main)

- cherry-pick clean (RC=0, no conflicts)
- `actionlint` clean on tests.yml
- `scripts/ci/test_npm_audit_gate.py` 19/19 (gate contract exit codes pinned)

adversarial_review: codex-o2-two-rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)