### PR TITLE
fix(ci): npm-audit advisory hardening — never red on advisory, always red on CANNOT-VERIFY

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1085,9 +1085,16 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Job-level, not step-level: an advisory finding must never flip this
-    # job's conclusion to something a future required-check addition (or a
-    # human reading the Checks tab) could mistake for a code regression.
+    # Two-layer advisory design (hardened after Codex red-team round 1 on
+    # this PR): (1) the audit step below NEVER exits non-zero on an advisory
+    # finding — it captures the gate's verdict, surfaces it as a ::warning +
+    # job summary, and exits 0 — so this job's check-run conclusion stays
+    # green even if the context is ever added to required checks by mistake
+    # (job-level continue-on-error alone does NOT guarantee that: it keeps
+    # the workflow green while the check run can still conclude failure).
+    # (2) continue-on-error then keeps a MACHINERY break (the gate's own
+    # test suite failing — our code, actionable) visible as a red job
+    # without taking the whole workflow run hostage.
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -1124,9 +1131,27 @@ jobs:
         # they failed the gate on EVERY PR repo-wide. Production-dependency
         # threshold stays at high.
         run: |
+          set -euo pipefail
+          # The gate's own test suite fails this job RED (our machinery,
+          # actionable, fail-loud) — everything below it never does.
           python3 scripts/ci/test_npm_audit_gate.py
           npm audit --audit-level=high --omit=dev --json > "$RUNNER_TEMP/audit.json" || true
+          set +e
           python3 scripts/ci/npm_audit_gate.py "$RUNNER_TEMP/audit.json"
+          GATE_RC=$?
+          set -e
+          if [ "${GATE_RC}" -ne 0 ]; then
+            echo "::warning::npm audit advisory (non-blocking, L13): gate exit ${GATE_RC} — see the job summary"
+            {
+              echo "### npm audit — advisory finding (non-blocking)"
+              echo ""
+              echo "The gate exited ${GATE_RC}. Advisory-only since 2026-08-21 (token-ceremony"
+              echo "audit, lever L13): the finding is real and worth triaging, but it is never"
+              echo "grounds to eject a queue entry or block a PR whose diff never touched a"
+              echo "dependency."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit 0
 
   packages-core-tests:
     name: Shared Core Package Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1085,16 +1085,17 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Two-layer advisory design (hardened after Codex red-team round 1 on
+    # Two-layer advisory design (hardened after Codex red-team rounds 1-2 on
     # this PR): (1) the audit step below NEVER exits non-zero on an advisory
-    # finding — it captures the gate's verdict, surfaces it as a ::warning +
-    # job summary, and exits 0 — so this job's check-run conclusion stays
-    # green even if the context is ever added to required checks by mistake
-    # (job-level continue-on-error alone does NOT guarantee that: it keeps
-    # the workflow green while the check run can still conclude failure).
-    # (2) continue-on-error then keeps a MACHINERY break (the gate's own
-    # test suite failing — our code, actionable) visible as a red job
-    # without taking the whole workflow run hostage.
+    # finding (gate exit 1) — it warns, writes a job summary, and exits 0 —
+    # so this job's check-run conclusion stays green even if the context is
+    # ever added to required checks by mistake (job-level continue-on-error
+    # alone does NOT guarantee that: it keeps the workflow green while the
+    # check run can still conclude failure). (2) MACHINERY failures still go
+    # red: the gate's own test suite, and a gate exit 2 (CANNOT VERIFY —
+    # unreadable/malformed audit report = no verdict was produced); continue-
+    # on-error keeps the workflow run green while the job shows red for a
+    # human.
     continue-on-error: true
     steps:
       - name: Checkout code
@@ -1140,18 +1141,27 @@ jobs:
           python3 scripts/ci/npm_audit_gate.py "$RUNNER_TEMP/audit.json"
           GATE_RC=$?
           set -e
-          if [ "${GATE_RC}" -ne 0 ]; then
-            echo "::warning::npm audit advisory (non-blocking, L13): gate exit ${GATE_RC} — see the job summary"
+          # Three-way, keyed on the gate's own exit-code contract
+          # (scripts/ci/npm_audit_gate.py): 1 = advisory finding (external
+          # data, never blocks); 2 = CANNOT VERIFY — unreadable/malformed
+          # report, i.e. the audit itself failed and there is NO verdict.
+          # Codex red-team round 2: mapping every nonzero code to green
+          # would let a broken audit report clean — the blind-gate disease
+          # this job's split was written to kill.
+          if [ "${GATE_RC}" -eq 1 ]; then
+            echo "::warning::npm audit advisory (non-blocking, L13) — see the job summary"
             {
               echo "### npm audit — advisory finding (non-blocking)"
               echo ""
-              echo "The gate exited ${GATE_RC}. Advisory-only since 2026-08-21 (token-ceremony"
-              echo "audit, lever L13): the finding is real and worth triaging, but it is never"
-              echo "grounds to eject a queue entry or block a PR whose diff never touched a"
-              echo "dependency."
+              echo "Advisory-only since 2026-08-21 (token-ceremony audit, lever L13):"
+              echo "the finding is real and worth triaging, but it is never grounds to"
+              echo "eject a queue entry or block a PR whose diff never touched a dependency."
             } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          elif [ "${GATE_RC}" -ne 0 ]; then
+            echo "::error::npm audit gate could not produce a verdict (exit ${GATE_RC}) — machinery/infrastructure failure, not an advisory"
+            exit "${GATE_RC}"
           fi
-          exit 0
 
   packages-core-tests:
     name: Shared Core Package Tests


### PR DESCRIPTION
## What

Follow-up to #4477 (merged): hardens the new `npm audit (advisory)` job per two Codex O2 adversarial rounds on the original branch. The branch entered the merge queue before these could land, so they arrive as this follow-up (both commits cherry-picked clean onto current main).

**Round 1 finding (accepted):** job-level `continue-on-error: true` keeps the workflow green but lets the check RUN conclude failure on an advisory finding — a future required-check addition would silently re-arm the 2026-08-17 main-red class the job was split out to kill (L13). Now the audit step captures the gate verdict and always exits 0 on an advisory, surfacing it as `::warning` + job summary.

**Round 2 finding (accepted):** mapping every nonzero exit to green would also green exit **2 = CANNOT VERIFY** (unreadable/malformed report — no verdict at all; the blind-gate disease). Now three-way per the gate's own contract (`scripts/ci/npm_audit_gate.py:117-132`): `0` pass · `1` advisory → warning+summary+exit 0 · anything else → `::error` + red. The gate's own test suite failing stays red (machinery, actionable).

## Verification

- YAML + actionlint clean on the cherry-picked result; `tests.yml` diff vs main is exactly the 41-line advisory-job change.
- Bash semantics simulated locally for all three paths: advisory rc=1 → warning + summary + exit 0; rc=2 → error + exit 2; machinery test failure → red under `bash -e` before the advisory capture exists.
- Gate contract re-read at source (`npm_audit_gate.py`), not taken from the reviewer's word.

Not verified: a live run with a real advisory (none in flight at authoring time; the step's warning/summary path was exercised by simulation only).

Auto-merge deliberately NOT armed (external-agent contract).

🤖 Lane: Kimi K3 (token-ceremony program)
