### PR TITLE
fix(ci): add Next.js convention filenames to consumer-map's common-basename skip-list

### DIFF
--- a/scripts/consumer_map.py
+++ b/scripts/consumer_map.py
@@ -130,7 +130,23 @@ from pathlib import Path
 # search, so it must be a name this repo has actually measured as noisy, not
 # a defensive guess. `--include-common` forces the scan anyway.
 # ---------------------------------------------------------------------------
-COMMON_BASENAMES: frozenset[str] = frozenset({"conftest.py", "__init__.py"})
+COMMON_BASENAMES: frozenset[str] = frozenset(
+    {
+        "conftest.py",
+        "__init__.py",
+        # Next.js App Router convention filenames (2026-08-21, measured on
+        # PR #4344): deleting apps/mouth/src/app/visa/voa/page.tsx flagged
+        # 414 "LIVE" hits, every one of them an unrelated page.tsx in a
+        # different route directory of a different app (kbli-navigator,
+        # admin-dashboard, bali-zero-magazine, ...). Repo-wide counts at
+        # the time of this fix: page.tsx=188, route.ts=113, layout.tsx=39
+        # — same noise class as conftest.py/__init__.py, just framework
+        # convention instead of test/package convention.
+        "page.tsx",
+        "route.ts",
+        "layout.tsx",
+    }
+)
 
 # Kinds where "#" is the comment marker — a hit whose line, after lstrip(),
 # starts with "#" is a comment naming the file, not a consumer of it (module

--- a/scripts/tests/test_consumer_map.py
+++ b/scripts/tests/test_consumer_map.py
@@ -411,6 +411,28 @@ def test_common_basename_include_common_forces_the_scan(tmp_path: Path) -> None:
     assert "runner.sh" in result.stdout
 
 
+def test_nextjs_convention_basename_skipped_by_default(tmp_path: Path) -> None:
+    """page.tsx (2026-08-21, PR #4344): deleting one app's page.tsx must not
+    flag every OTHER app's unrelated page.tsx of the same convention name —
+    same noise class as conftest.py, just framework convention instead of
+    test convention."""
+    repo = _init_repo(tmp_path)
+    target = repo / "apps" / "mouth" / "src" / "app" / "visa" / "voa" / "page.tsx"
+    _write(target, "export default function Page() { return null }\n")
+    _write(
+        repo / "apps" / "kbli-navigator" / "src" / "app" / "page.tsx",
+        "export default function Page() { return null }\n",
+    )
+    base = _commit_all(repo, "base")
+
+    target.unlink()
+    _commit_all(repo, "delete voa page.tsx")
+
+    result = _run(repo, "--base", base)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SKIPPED-common-basename" in result.stdout
+
+
 # ---------------------------------------------------------------------------
 # CLI surface
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- \`scripts/consumer_map.py\` (#4459) searches by bare basename to catch consumers referenced relative to something other than the deleted file's full path.
- PR #4344 deletes two GARUDA VOA \`page.tsx\` route files (retiring the public routes) and the pre-push hook flagged 414 "LIVE" consumers — every one an unrelated \`page.tsx\` in a different app's route directory.
- \`page.tsx\`/\`route.ts\`/\`layout.tsx\` are Next.js App Router convention filenames repeated by framework design across every route directory in every app in this monorepo (measured: 188/113/39 occurrences repo-wide) — same noise class the tool already exempts \`conftest.py\`/\`__init__.py\` for.

## Test plan
- [x] \`python3 -m pytest scripts/tests/test_consumer_map.py -q\` — 18 passed (17 existing + 1 new regression test mirroring the existing conftest.py coverage)
- [x] Manually reproduced the 414-hit false positive on PR #4344's branch before the fix, confirmed clean after

Discovered as a side effect of triaging PR #4344 (stale red-check backlog); this is a standalone fix to a local pre-push tool, not part of that PR's own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)