### PR TITLE
feat(arsenal): cron payload wrapper for qwen_quota_watch (Pro daily)

### DIFF
--- a/scripts/qwen_quota_watch_cron.sh
+++ b/scripts/qwen_quota_watch_cron.sh
@@ -15,7 +15,7 @@
 # the states where the watcher could NOT speak for itself.
 set -uo pipefail
 
-REPO="/Users/nuzantara/Desktop/nuzantara"
+REPO="/Users/nuzantara/nuzantara"
 WATCHER="$REPO/scripts/qwen_quota_watch.py"
 
 if [ ! -f "$WATCHER" ]; then

--- a/scripts/qwen_quota_watch_cron.sh
+++ b/scripts/qwen_quota_watch_cron.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# qwen_quota_watch_cron.sh — cron payload for cron-runner.sh (Pro, daily).
+#
+# cron-runner executes payloads with /bin/bash, so the python watcher needs
+# this thin wrapper. It lives IN THE REPO and the crontab line points here
+# directly (never a ~/scripts copy — superscar #1 HOME-fork).
+#
+# Exit-code mapping (deliberate, W104-aware): the watcher's 1 (WARN) and
+# 2 (CRIT) mean "threshold crossed AND the Telegram alert was already
+# dispatched and verdict-verified by the watcher itself" — that is the job
+# WORKING, not failing, so the cron receipt stays ok (otherwise every
+# legitimate warning would also fire a redundant cron-fail P0). Only 4
+# (CANNOT-MEASURE: no log readable / CANNOT-DELIVER: alert reached nobody)
+# and unexpected codes propagate, so cron-runner's own alert covers exactly
+# the states where the watcher could NOT speak for itself.
+set -uo pipefail
+
+REPO="/Users/nuzantara/Desktop/nuzantara"
+WATCHER="$REPO/scripts/qwen_quota_watch.py"
+
+if [ ! -f "$WATCHER" ]; then
+    echo "qwen_quota_watch_cron: watcher not found at $WATCHER (checkout behind?)" >&2
+    exit 66  # armed-to-nothing must be a loud receipt, never a silent green (W81)
+fi
+
+/usr/bin/env python3 "$WATCHER" --hosts mini,air --alert
+rc=$?
+echo "qwen_quota_watch_cron: watcher rc=$rc" >&2
+case "$rc" in
+    0|1|2) exit 0 ;;
+    *) exit "$rc" ;;
+esac


### PR DESCRIPTION
Thin bash wrapper so `cron-runner.sh` (which executes payloads with /bin/bash) can run the python quota watcher merged in #4490. Repo-resident — the crontab line will point at the repo path directly, never a ~/scripts copy (superscar #1).

Exit mapping (W104-aware): WARN/CRIT (1/2) = the watcher already dispatched and verdict-verified its own Telegram alert → receipt ok (no redundant cron-fail P0 on every legitimate warning); CANNOT-MEASURE/CANNOT-DELIVER (4) and unexpected codes propagate — cron-runner alerts exactly when the watcher could not speak for itself. Missing watcher file → exit 66 loud (W81). Guilt-probed in-branch: watcher-absent exits 66.

Arming after merge (this session): crontab line on Pro via cron-runner + prove-live receipt read.

adversarial_review: exempt-thin-wrapper-guilt-probed

🤖 Generated with [Claude Code](https://claude.com/claude-code)