### PR TITLE
ci(tests): skip merge_group's Backend Tests when the tree already passed on the PR (L4)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,24 @@ jobs:
       run_frontend_tests: ${{ steps.classify.outputs.run_frontend_tests || 'true' }}
       run_packages_core_tests: ${{ steps.classify.outputs.run_packages_core_tests || 'true' }}
       run_e2e_tests: ${{ steps.classify.outputs.run_e2e_tests || 'true' }}
+      # L4 (2026-08-21, token-ceremony CI-critical-path audit,
+      # research/operations/2026-08-21-token-ceremony-ci-system-audit.md §7):
+      # `Backend Tests (Python)` runs the SAME ~21,430-test suite on
+      # `pull_request` AND `merge_group` — median ~29min EITHER event,
+      # measured on 121 paired runs 2026-08-20/21. Verdict divergence between
+      # the two events was 0/63 real flips in that sample (only 2 ambiguous
+      # `None`-conclusion cases) — once a PR's own run is green, the queue's
+      # re-run of the IDENTICAL tree essentially never disagrees. When the
+      # tree really is byte-identical (main did not move between the PR run
+      # and the queue run — measured 3/63, ~4.8%), re-running is provably
+      # redundant, not merely likely-redundant: same tree, same tests, same
+      # environment shape. `backend_tests_tree_sha` and the restore step
+      # below let `backend-tests` skip ONLY that exact, provable case (see
+      # its `if:`) — never a probabilistic "looks similar" skip (family #3
+      # over-match). Defaults to 'false' (never skip) on ANY missing/
+      # ambiguous cache state — fail-open per this job's existing contract.
+      backend_tests_tree_sha: ${{ steps.tree-key.outputs.tree_sha }}
+      backend_tests_tree_verified: ${{ steps.tree-cache.outputs.cache-hit == 'true' && 'true' || 'false' }}
 
     steps:
       - name: Checkout code
@@ -280,6 +298,36 @@ jobs:
           echo "$JOB_FLAGS" >> "$GITHUB_OUTPUT"
           echo "::notice::change-map: $MAP_JSON"
 
+      # L4 companion steps (see the job's `backend_tests_tree_*` outputs
+      # above for the measurement and rationale). Deliberately two SEPARATE
+      # actions/cache calls (restore here, save at the tail of
+      # `backend-tests`) rather than one combined actions/cache: the combined
+      # action auto-saves via a post-hook at the END OF THIS JOB, which would
+      # cache a PASS before `backend-tests` has even started — this job knows
+      # nothing about that job's outcome.
+      - name: Compute backend-tests content-identity key
+        id: tree-key
+        run: |
+          TREE_SHA=$(git rev-parse 'HEAD^{tree}')
+          echo "tree_sha=$TREE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Check prior verdict for this exact backend-tests tree
+        id: tree-cache
+        continue-on-error: true
+        uses: actions/cache/restore@v6
+        with:
+          path: /tmp/backend-tests-verdict.txt
+          key: backend-tests-verdict-v1-${{ steps.tree-key.outputs.tree_sha }}
+
+      # Self-test, unconditional (mirrors "Self-test ring-gating override"
+      # and "Verify change-map guilt and innocence corpus" above): proves the
+      # L4 skip clause's guilt+innocence corpus holds AND that the mirror in
+      # that corpus still matches the literal `if:`/output text in this
+      # file — never gated behind the clause's own output, which would be a
+      # guard that can disable its own guilt test.
+      - name: Self-test backend-tests tree-skip clause (guilt + innocence)
+        run: python3 scripts/ci/test_backend_tests_tree_skip.py
+
       - name: Publish change-map decision
         if: always()
         env:
@@ -396,13 +444,26 @@ jobs:
     # does not get a false pass, it gets no verdict at all, same as before
     # change-map existed. That is intentional, not a gap this rule needs to
     # cover.
+    #
+    # L4 tail clause (2026-08-21, see `changes.outputs.backend_tests_tree_*`
+    # above for the measurement): skips ONLY on `merge_group`, and ONLY when
+    # this exact tree already produced a PASS (byte-identical content, not a
+    # heuristic similarity). `pull_request` is NEVER skipped by this clause —
+    # it is where ground truth gets established in the first place, and it
+    # is the run that actually catches real regressions early (measured: 3 of
+    # 5 real `pull_request` failures in the same sample were in the big "Run
+    # unit tests" step itself, so a PR-side skip would defer most of today's
+    # fast catches to the far more disruptive queue). Any missing/ambiguous
+    # value on the right resolves to `!= 'true'`, i.e. run — fail-open,
+    # consistent with every other clause in this `if:`.
     if: >-
       !cancelled() &&
       (
         (github.event_name != 'pull_request' && github.event_name != 'merge_group') ||
         needs.changes.result != 'success' ||
         needs.changes.outputs.run_backend_tests != 'false'
-      )
+      ) &&
+      !(github.event_name == 'merge_group' && needs.changes.outputs.backend_tests_tree_verified == 'true')
     runs-on: ubuntu-latest
     env:
       HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
@@ -694,6 +755,35 @@ jobs:
         run: |
           cd apps/backend-rag
           PYTHONPATH=.:../crm-cell coverage report --fail-under=55
+
+      # L4 (2026-08-21) — companion to the `changes` job's restore step: if
+      # this exact job (all its real checks, whatever this event ran) just
+      # passed, record it so a LATER `merge_group` run of a byte-identical
+      # tree can skip re-testing (see backend-tests' `if:` above). `success()`
+      # treats a step skipped by its OWN `if:` (e.g. "Check coverage
+      # threshold" above, off by design on `pull_request`) as non-failing, so
+      # this fires whenever every check that WAS supposed to run for this
+      # event did run and pass — never on a step that failed or was aborted.
+      # Declared cost, accepted (documented, not silently absorbed): a
+      # `merge_group` run skipped this way also skips coverage collection for
+      # that landing commit specifically (coverage is never collected on the
+      # `pull_request` run that produced the cached PASS either — L9(i), same
+      # job). The `--fail-under=55` floor is a standing-state check, not a
+      # per-PR delta, so a real regression introduced by that one commit is
+      # still caught by the NEXT `merge_group` run that actually executes
+      # (main's tree always changes again once another PR lands) — bounded,
+      # self-correcting lag, not a silent hole in the floor.
+      - name: Record backend-tests verdict for this tree (content-identity cache)
+        if: success()
+        run: echo "pass" > /tmp/backend-tests-verdict.txt
+
+      - name: Save verdict cache for this tree
+        if: success()
+        continue-on-error: true
+        uses: actions/cache/save@v6
+        with:
+          path: /tmp/backend-tests-verdict.txt
+          key: backend-tests-verdict-v1-${{ needs.changes.outputs.backend_tests_tree_sha }}
 
       - name: Upload coverage to Codecov
         if: ${{ env.HAS_CODECOV_TOKEN == 'true' && steps.test-scope.outputs.collect_coverage == 'true' }}

--- a/scripts/ci/test_backend_tests_tree_skip.py
+++ b/scripts/ci/test_backend_tests_tree_skip.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Guilt + innocence corpus for the L4 content-identity skip clause.
+
+L4 (2026-08-21, token-ceremony CI-critical-path audit,
+research/operations/2026-08-21-token-ceremony-ci-system-audit.md §7): `Backend
+Tests (Python)` in .github/workflows/tests.yml runs the full ~21,430-test
+suite on BOTH `pull_request` and `merge_group` — median ~29min either event,
+measured on 121 paired runs 2026-08-20/21. Verdict divergence between the two
+events was 0/63 real flips in that sample (only 2 ambiguous `None`-conclusion
+cases): once a PR's own run is green, the queue's re-run of the IDENTICAL
+tree essentially never disagrees. When the tree really is byte-identical
+(main did not move between the PR run and the queue run — measured 3/63,
+~4.8%), re-running it is provably redundant, not merely likely-redundant.
+
+The `changes` job now computes `backend_tests_tree_sha` (the git tree hash of
+the checked-out commit — for `pull_request` this is GitHub's own
+`refs/pull/<N>/merge` test-merge commit, empirically confirmed via a live
+job's checkout log, so it is directly comparable to what `merge_group` later
+tests) and restores a cache keyed on that hash to produce
+`backend_tests_tree_verified`. `backend-tests`' own `if:` gets ONE tail
+clause: skip only when `event_name == 'merge_group' AND
+backend_tests_tree_verified == 'true'`.
+
+This is NOT a textual substring guard (cicatrix-superscar.md family #3's
+usual target — `infra/guard-conformance/registry.json`) — it is an exact
+cryptographic tree-hash equality check, so it cannot over-match on a
+"looks similar" text pattern. The risk class here is closer to family #2
+(esiste != armato — a skip that fires when it should not) and family #9
+(a proxy that lies) than family #3, hence a standalone guilt+innocence
+corpus in this file rather than a `infra/guard-conformance/` registration
+(that registry is scoped to `_guard_*`-prefixed textual reply guards).
+
+`pull_request` is DELIBERATELY never eligible to skip via this clause — see
+`test_innocence_pull_request_never_skips_even_if_verified` below. It is the
+run that establishes ground truth in the first place, and it is not merely
+redundant work: 3 of the 5 real `pull_request` `Backend Tests (Python)`
+failures in the same 2026-08-20/21 sample were in the big "Run unit tests"
+step itself (the other 2 were in earlier, faster steps) — a PR-side skip
+would defer most of today's fast catches to the far more disruptive queue
+(ejection = +60min for that PR per the audit's own estimate). Only
+`merge_group` — the run this repo's doctrine already treats as THE gate,
+never the PR run — is eligible, and only on a provable exact match.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "tests.yml"
+)
+
+
+def backend_tests_tree_verified_expr(cache_hit: str | None) -> str:
+    """Mirrors `changes.outputs.backend_tests_tree_verified` verbatim:
+
+        ${{ steps.tree-cache.outputs.cache-hit == 'true' && 'true' || 'false' }}
+
+    GitHub Actions expressions here are string-typed: only the EXACT string
+    'true' ever yields 'true'. Every other value — missing, empty, 'True',
+    'TRUE', '1' — yields 'false'. Fail-open by construction: nothing this
+    function can be called with produces a skip except an exact 'true'.
+    """
+    return "true" if cache_hit == "true" else "false"
+
+
+def should_skip_backend_tests(event_name: str, tree_verified: str | None) -> bool:
+    """Mirrors ONLY the L4 tail clause added to `backend-tests`' `if:`:
+
+        !(github.event_name == 'merge_group' &&
+          needs.changes.outputs.backend_tests_tree_verified == 'true')
+
+    Returns True when that clause evaluates to False — i.e. when it is the
+    clause, not the pre-existing run-condition, that causes the job to skip.
+    The clause is AND-ed onto the existing `if:`, so it can only ever REMOVE
+    a reason to run, never add one — every other clause in the `if:` is
+    untouched by this function.
+    """
+    return event_name == "merge_group" and tree_verified == "true"
+
+
+class BackendTestsTreeSkipTests(unittest.TestCase):
+    # ---- guilt: the ONE case this clause exists for ----
+
+    def test_guilt_merge_group_with_verified_tree_skips(self) -> None:
+        self.assertTrue(should_skip_backend_tests("merge_group", "true"))
+
+    # ---- innocence: every adjacent case must still run ----
+
+    def test_innocence_pull_request_never_skips_even_if_verified(self) -> None:
+        # See module docstring: pull_request establishes ground truth and
+        # measurably catches real regressions the queue run does not need
+        # to re-discover — this clause must never touch it, regardless of
+        # what the tree-verified output says.
+        self.assertFalse(should_skip_backend_tests("pull_request", "true"))
+
+    def test_innocence_merge_group_without_verified_tree_runs(self) -> None:
+        self.assertFalse(should_skip_backend_tests("merge_group", "false"))
+
+    def test_innocence_merge_group_missing_output_runs(self) -> None:
+        self.assertFalse(should_skip_backend_tests("merge_group", None))
+
+    def test_innocence_merge_group_malformed_output_runs(self) -> None:
+        # Fail-open on anything that is not the exact string 'true' — a
+        # value that merely LOOKS truthy ('True', 'TRUE', '1', 'yes') must
+        # never satisfy this, or the guard would over-match on shape instead
+        # of the one literal value the cache-restore step can actually emit.
+        for bogus in ("True", "TRUE", "1", "yes", "", "null"):
+            with self.subTest(bogus=bogus):
+                self.assertFalse(should_skip_backend_tests("merge_group", bogus))
+
+    def test_innocence_other_events_never_reach_the_clause(self) -> None:
+        # push/schedule/workflow_dispatch already run unconditionally via
+        # the pre-existing first OR-branch of backend-tests' if: — this
+        # clause only narrows pull_request/merge_group, it cannot turn an
+        # always-run event off.
+        for event in ("push", "schedule", "workflow_dispatch"):
+            with self.subTest(event=event):
+                self.assertFalse(should_skip_backend_tests(event, "true"))
+
+    def test_tree_verified_output_defaults_false_on_missing_cache_hit(self) -> None:
+        self.assertEqual(backend_tests_tree_verified_expr(None), "false")
+        self.assertEqual(backend_tests_tree_verified_expr(""), "false")
+        self.assertEqual(backend_tests_tree_verified_expr("false"), "false")
+
+    def test_tree_verified_output_true_only_on_exact_cache_hit(self) -> None:
+        self.assertEqual(backend_tests_tree_verified_expr("true"), "true")
+
+    # ---- self-conformance: the mirror above must match the LIVE workflow,
+    # so an edit to the real YAML that silently changes this logic breaks
+    # this test, not just the mirror's own internal consistency (W65-class:
+    # a corpus that only tests itself proves nothing about the artifact).
+
+    def test_workflow_contains_the_exact_skip_clause(self) -> None:
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "!(github.event_name == 'merge_group' && "
+            "needs.changes.outputs.backend_tests_tree_verified == 'true')",
+            text,
+            "backend-tests' if: no longer contains the L4 tail clause "
+            "verbatim — either it was edited (re-verify guilt+innocence "
+            "still hold above) or removed (this file now tests a clause "
+            "that does not exist).",
+        )
+
+    def test_workflow_tail_clause_is_and_not_or(self) -> None:
+        # The clause must be impossible to OR in: an OR here could widen
+        # the skip far beyond the one intended case (family #3's over-match
+        # shape, even though this guard itself is not textual).
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        match = re.search(
+            r"\)\s*(&&|\|\|)\s*\n\s*!\(github\.event_name == 'merge_group'",
+            text,
+        )
+        self.assertIsNotNone(
+            match, "could not locate the tail clause's join operator"
+        )
+        assert match is not None  # mypy/type-narrowing for the line below
+        self.assertEqual(
+            match.group(1),
+            "&&",
+            f"tail clause is joined with {match.group(1)!r}, not '&&' — an "
+            "OR here could make the job skip in cases far beyond the one "
+            "intended",
+        )
+
+    def test_workflow_tree_verified_output_expression_unchanged(self) -> None:
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn(
+            "backend_tests_tree_verified: ${{ steps.tree-cache.outputs."
+            "cache-hit == 'true' && 'true' || 'false' }}",
+            text,
+        )
+
+    def test_workflow_restore_step_is_continue_on_error(self) -> None:
+        # A cache-service hiccup on the restore must fail OPEN (job still
+        # runs), never silently propagate as an unset/errored output that
+        # some future refactor might misread as a hit.
+        text = WORKFLOW_PATH.read_text(encoding="utf-8")
+        section_start = text.index("Check prior verdict for this exact backend-tests tree")
+        section = text[section_start : section_start + 300]
+        self.assertIn("continue-on-error: true", section)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

`Backend Tests (Python)` runs the same ~21,430-test suite twice per PR: once on `pull_request`, once on `merge_group`. Measured on 121 paired runs (2026-08-20/21): median **28.8min** on pull_request, **29.3min** on merge_group — essentially identical cost, paid twice.

## Measurement (decision criterion per mandate: divergence rate)

- **Verdict divergence between the two events: 0/63 real flips** (paired PRs, last run per event). Only 2 ambiguous cases (`None` conclusion, workflow-level cancellation, not a real success↔failure disagreement). Once a PR's own `pull_request` run is green, the `merge_group` re-run of the SAME tree essentially never disagrees — this is "puro raddoppio" by the mandate's own criterion.
- **Option B's exact trigger condition** (tree byte-identical, i.e. main didn't move between the PR run and the queue run) fires on **3/63 (4.8%)** — confirms the audit's own "rarely fires at 37 merges/day" estimate, measured rather than trusted.
- **Option A as literally worded** (make the `pull_request` run "impacted domains" by narrowing test selection) was investigated and rejected: `apps/backend-rag/backend/tests/` does **not** mirror `apps/backend-rag/backend/`'s directory structure 1:1 (`tests/routers`, `tests/integration`, `tests/unit` are cross-cutting, not per-module) — a safe automatic narrower isn't buildable at this scope without real under-match risk. Also: 3 of the 5 real `pull_request` failures in the sample were in the big "Run unit tests" step itself — dropping that step from PR would defer 60% of today's fast catches to the far more expensive/disruptive queue (+60min ejection per the audit's own estimate).

**Decision: implement a scoped, safe form of the redundancy the divergence measurement actually proves** — skip the queue run's `Backend Tests (Python)` job **only** when the exact tree it would test already produced a PASS (byte-identical git tree hash, not a heuristic). This is narrower than "Option A" (never touches `pull_request`'s coverage) and higher-yield in principle than the audit's literal "Option B" framing (any prior PASS on this tree counts, not only the immediately preceding PR run — though in practice re-entry chains mostly test genuinely different trees too: measured 60/63 pairs had main move between events).

## What

- `changes` job: new step computes the checked-out commit's git tree hash (`git rev-parse 'HEAD^{tree}'` — for `pull_request` this is GitHub's own `refs/pull/N/merge` test-merge commit, confirmed via a live job's checkout log: `git fetch ... +<sha>:refs/remotes/pull/N/merge`) and restores (read-only, `continue-on-error: true`) a cache keyed on that hash. New outputs `backend_tests_tree_sha` / `backend_tests_tree_verified`.
- `backend-tests` job: one tail clause AND-ed onto the existing `if:` — `!(github.event_name == 'merge_group' && needs.changes.outputs.backend_tests_tree_verified == 'true')`. Fail-open: any missing/ambiguous value resolves to "run". `pull_request` is never eligible.
- `backend-tests` job tail: two new steps (`if: success()`) write and save the verdict marker under the same tree-keyed cache, so a later `merge_group` run of byte-identical content can skip.
- `scripts/ci/test_backend_tests_tree_skip.py`: guilt+innocence corpus (12 cases) mirroring the clause's logic and cross-checking it against the literal YAML text, so an edit that silently changes the clause breaks this test. Self-tested unconditionally in the `changes` job (same pattern as this file's existing "Self-test ring-gating override" / "Verify change-map guilt and innocence corpus" steps).

## Hard constraints honored

- **The queue gate is never weakened.** `merge_group` still runs the full job on every tree it hasn't already proven — the skip only fires on a cryptographic exact match to a tree that already passed the SAME job.
- **`pull_request` is untouched** — full suite, same as today, in every case.
- No branch-protection / required-context changes.
- One declared, bounded, documented tradeoff: a `merge_group` run skipped this way also skips coverage collection for that landing commit (coverage is never collected on the `pull_request` run that produced the cached PASS either — already true today, unrelated to this PR). The `--fail-under=55` floor is a standing-state check, not a per-PR delta, so the next real `merge_group` run re-validates it — a bounded, self-correcting lag, not a silent hole.

## Test plan

- [x] `actionlint .github/workflows/tests.yml` clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tests.yml'))"` — parses
- [x] `python3 scripts/ci/test_backend_tests_tree_skip.py` — 12/12 pass
- [x] No duplicate step ids introduced (checked across all jobs)
- [ ] CI required checks green
- [ ] Live proof-of-armed (post-merge): a real `merge_group` run shows the `backend-tests` job SKIPPED with `backend_tests_tree_verified=true` in the job summary, on a PR whose queue entry lands with main unmoved since its own `pull_request` run

research/operations/2026-08-21-token-ceremony-ci-system-audit.md §7 L4

🤖 Generated with [Claude Code](https://claude.com/claude-code)