### PR TITLE
fix(arsenal): glm live-check inspects full body, not 160-char tail

### DIFF
--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -397,27 +397,50 @@ def load_env_master_key(var_name: str, path: str = "~/.openclaw/workspace/.env.m
 
 def http_post_json(
     url: str, headers: dict, body: dict, timeout: float, secret_values: list[str]
-) -> tuple[Optional[int], str]:
-    """POST JSON, return (status_code_or_None, evidence_text). Never raises past this
-    boundary, and the Authorization/x-api-key header value never appears in the
-    returned evidence even on error (scar #4 — errors are the #1 leak vector)."""
+) -> tuple[Optional[int], str, str]:
+    """POST JSON, return (status_code_or_None, full_body, evidence_tail). Never raises
+    past this boundary, and the Authorization/x-api-key header value never appears in
+    either returned string even on error (scar #4 — errors are the #1 leak vector).
+
+    full_body: the ENTIRE response/error text, scrubbed but NOT truncated. A
+    positive-proof marker (e.g. glm's `"model"` field) can sit near the START of a
+    long JSON body and fall outside a tail window — a live-check that inspects only
+    evidence_tail can misclassify a genuinely LIVE seat as dead (worst direction for
+    a dispatch panel: it silently diverts work away from an available seat instead of
+    failing loud). Callers whose positive-proof check needs to find a marker
+    ANYWHERE in the body must inspect full_body, never the tail alone (see
+    probe_glm — found live on M5 2026-08-21, a real HTTP 200 with `"model"` early in
+    the body was misread UNKNOWN_ERR by a tail-only check).
+
+    evidence_tail: the same text truncated to the tail (errors live at the tail — see
+    evidence_tail()'s own docstring) — kept for compact logging/display; existing
+    callers that only need a short diagnostic string are unaffected."""
+
+    def _scrub_and_split(raw: str) -> tuple[str, str]:
+        full = scrub((raw or "").strip().replace("\n", " "), secret_values)
+        return full, full[-160:]
+
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             raw = resp.read().decode("utf-8", errors="replace")
-            return resp.status, evidence_tail(raw, secret_values)
+            full, tail = _scrub_and_split(raw)
+            return resp.status, full, tail
     except urllib.error.HTTPError as e:
         raw = e.read().decode("utf-8", errors="replace") if e.fp else ""
-        return e.code, evidence_tail(raw, secret_values)
+        full, tail = _scrub_and_split(raw)
+        return e.code, full, tail
     except urllib.error.URLError as e:
         # str(e.reason) could theoretically echo a header on some transports; scrub
         # unconditionally rather than trust the transport not to leak (defense-in-depth).
-        return None, evidence_tail(f"{type(e).__name__}: {e.reason}", secret_values)
+        full, tail = _scrub_and_split(f"{type(e).__name__}: {e.reason}")
+        return None, full, tail
     except TimeoutError:
-        return None, "timed out"
+        return None, "timed out", "timed out"
     except Exception as e:  # a probe must never crash the whole run
-        return None, evidence_tail(f"{type(e).__name__}: {e}", secret_values)
+        full, tail = _scrub_and_split(f"{type(e).__name__}: {e}")
+        return None, full, tail
 
 
 # ---------------------------------------------------------------- per-seat probes
@@ -500,13 +523,17 @@ def probe_glm(timeout: float) -> tuple[str, str, int]:
         "Content-Type": "application/json",
     }
     body = {"model": "glm-5.2", "max_tokens": 8, "messages": [{"role": "user", "content": PONG_PROMPT}]}
-    status_code, ev = http_post_json(
+    status_code, full_body, ev = http_post_json(
         "https://api.z.ai/api/anthropic/v1/messages", headers, body, timeout, [token]
     )
     latency_ms = int((time.monotonic() - t0) * 1000)
     if status_code is None:
         return TIMEOUT if "timed out" in ev else UNKNOWN_ERR, ev, latency_ms
-    live = status_code == 200 and '"model"' in ev
+    # live-check runs on full_body (untruncated), never on the tail alone — see
+    # http_post_json's docstring: the "model" field can sit before the last 160
+    # chars of a long body, and a tail-only check misreads a genuinely LIVE seat
+    # as dead (worst direction for a dispatch panel).
+    live = status_code == 200 and '"model"' in full_body
     status = classify_generic(f"HTTP {status_code} {ev}", live, "glm", is_ssh_context())
     return status, f"HTTP {status_code} {ev}", latency_ms
 

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -411,12 +411,35 @@ def test_http_post_json_200_returns_scrubbed_evidence(monkeypatch):
         return _FakeHTTPResponse(200, b'{"model": "glm-5.2", "id": "abc"}')
 
     monkeypatch.setattr(ap.urllib.request, "urlopen", fake_urlopen)
-    status, ev = ap.http_post_json(
+    status, full, tail = ap.http_post_json(
         "https://api.z.ai/x", {"Authorization": "Bearer secrettoken12345678901234"}, {}, 10, ["secrettoken12345678901234"]
     )
     assert status == 200
-    assert "glm-5.2" in ev
-    assert "secrettoken12345678901234" not in ev
+    assert "glm-5.2" in full
+    assert "glm-5.2" in tail
+    assert "secrettoken12345678901234" not in full
+    assert "secrettoken12345678901234" not in tail
+
+
+def test_http_post_json_full_body_is_untruncated_past_160_chars(monkeypatch):
+    # scar (2026-08-21): the live-check marker must survive even when it sits
+    # BEFORE the last 160 chars of a long body — `full` is not tail-truncated.
+    # Padding uses short SPACED words, not one long run: any 24+-char contiguous
+    # alnum/._- run is itself redacted as token-shaped by scrub() (scar #4), which
+    # would shrink the body back under the tail window and hide the exact defect
+    # this test exists to pin.
+    padding = " ".join(["lorem"] * 40)
+    long_body = ('{"model": "glm-5.2", "padding": "' + padding + '"}').encode()
+
+    def fake_urlopen(req, timeout):
+        return _FakeHTTPResponse(200, long_body)
+
+    monkeypatch.setattr(ap.urllib.request, "urlopen", fake_urlopen)
+    status, full, tail = ap.http_post_json("https://api.z.ai/x", {}, {}, 10, [])
+    assert status == 200
+    assert '"model": "glm-5.2"' in full  # present in the untruncated body
+    assert '"model": "glm-5.2"' not in tail  # and absent from the 160-char tail
+    assert len(tail) <= 160
 
 
 def test_http_post_json_error_never_leaks_authorization_value(monkeypatch):
@@ -429,11 +452,12 @@ def test_http_post_json_error_never_leaks_authorization_value(monkeypatch):
         raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, None)
 
     monkeypatch.setattr(ap.urllib.request, "urlopen", fake_urlopen)
-    status, ev = ap.http_post_json(
+    status, full, tail = ap.http_post_json(
         "https://api.z.ai/x", {"Authorization": "Bearer secrettoken12345678901234"}, {}, 10, ["secrettoken12345678901234"]
     )
     assert status == 401
-    assert "secrettoken12345678901234" not in ev
+    assert "secrettoken12345678901234" not in full
+    assert "secrettoken12345678901234" not in tail
 
 
 def test_http_post_json_url_error_is_scrubbed(monkeypatch):
@@ -443,11 +467,12 @@ def test_http_post_json_url_error_is_scrubbed(monkeypatch):
         raise urllib.error.URLError("connection refused, token was secrettoken12345678901234")
 
     monkeypatch.setattr(ap.urllib.request, "urlopen", fake_urlopen)
-    status, ev = ap.http_post_json(
+    status, full, tail = ap.http_post_json(
         "https://api.z.ai/x", {}, {}, 10, ["secrettoken12345678901234"]
     )
     assert status is None
-    assert "secrettoken12345678901234" not in ev
+    assert "secrettoken12345678901234" not in full
+    assert "secrettoken12345678901234" not in tail
 
 
 # ---------------------------------------------------------------------------
@@ -601,16 +626,41 @@ def test_probe_glm_cred_unavailable_when_keychain_locked(monkeypatch):
 
 def test_probe_glm_live_on_200_with_model(monkeypatch):
     monkeypatch.setattr(ap, "load_keychain_token", lambda service, timeout=10: ("tok123456789012345678901", None))
-    monkeypatch.setattr(ap, "http_post_json", lambda *a, **kw: (200, '{"model": "glm-5.2"}'))
+    monkeypatch.setattr(ap, "http_post_json", lambda *a, **kw: (200, '{"model": "glm-5.2"}', '{"model": "glm-5.2"}'))
     status, ev, latency = ap.probe_glm(timeout=5)
     assert status == ap.LIVE
 
 
+def test_probe_glm_live_when_model_marker_only_survives_in_full_body(monkeypatch):
+    # GUILT case (2026-08-21 scar): a genuinely LIVE 200 response whose "model" field
+    # sits before the 160-char tail must still classify LIVE — this is exactly the
+    # shape z.ai's Anthropic-compatible envelope produces (model near the start,
+    # content/usage padding pushes it out of any tail window). Before the fix this
+    # read UNKNOWN_ERR — a live seat silently misread as dead.
+    monkeypatch.setattr(ap, "load_keychain_token", lambda service, timeout=10: ("tok123456789012345678901", None))
+    full_body = '{"model": "glm-5.2", "id": "abc", "content": "' + ("y" * 300) + '"}'
+    tail_only = full_body[-160:]
+    assert '"model"' not in tail_only  # premise: the marker really is outside the tail
+    monkeypatch.setattr(ap, "http_post_json", lambda *a, **kw: (200, full_body, tail_only))
+    status, ev, latency = ap.probe_glm(timeout=5)
+    assert status == ap.LIVE
+
+
+def test_probe_glm_not_live_when_model_absent_from_full_body(monkeypatch):
+    # INNOCENCE case: a genuinely dead/malformed 200 with no "model" field anywhere
+    # (not even truncated away) must NOT read LIVE — the fix widens WHERE the check
+    # looks, it must not widen WHAT counts as a positive marker.
+    monkeypatch.setattr(ap, "load_keychain_token", lambda service, timeout=10: ("tok123456789012345678901", None))
+    full_body = '{"id": "abc", "content": "' + ("y" * 300) + '"}'
+    monkeypatch.setattr(ap, "http_post_json", lambda *a, **kw: (200, full_body, full_body[-160:]))
+    status, ev, latency = ap.probe_glm(timeout=5)
+    assert status != ap.LIVE
+
+
 def test_probe_glm_model_err_on_1211(monkeypatch):
     monkeypatch.setattr(ap, "load_keychain_token", lambda service, timeout=10: ("tok123456789012345678901", None))
-    monkeypatch.setattr(
-        ap, "http_post_json", lambda *a, **kw: (400, '{"error": {"code": 1211, "message": "Unknown Model"}}')
-    )
+    body = '{"error": {"code": 1211, "message": "Unknown Model"}}'
+    monkeypatch.setattr(ap, "http_post_json", lambda *a, **kw: (400, body, body))
     status, ev, latency = ap.probe_glm(timeout=5)
     assert status == ap.MODEL_ERR
 
@@ -621,7 +671,8 @@ def test_probe_glm_never_leaks_token_in_evidence(monkeypatch):
 
     def fake_http(url, headers, body, timeout, secret_values):
         assert token in secret_values  # the probe must pass its own secret for scrubbing
-        return 401, ap.evidence_tail(f"unauthorized, saw {token}", secret_values)
+        scrubbed = ap.evidence_tail(f"unauthorized, saw {token}", secret_values)
+        return 401, scrubbed, scrubbed
 
     monkeypatch.setattr(ap, "http_post_json", fake_http)
     status, ev, latency = ap.probe_glm(timeout=5)


### PR DESCRIPTION
## Summary
- `probe_glm`'s positive-proof check ran against `evidence_tail`'s 160-char truncation instead of the full response body. A genuinely LIVE glm seat whose `"model"` field sits before the tail window (z.ai's Anthropic-shaped envelope) read `UNKNOWN_ERR` — the worst-direction dispatch error.
- Widened `http_post_json`'s return to `(status, full_body, evidence_tail)`; `probe_glm` now checks `full_body`.

## Test plan
- [x] 153/153 tests green (`scripts/tests/test_arsenal_probe.py`)
- [x] New guilt test (`test_probe_glm_live_when_model_marker_only_survives_in_full_body`) mutation-verified: reverting `probe_glm`'s check to `ev` turns it red
- [x] New innocence test asserts a genuinely dead body still fails
- [x] Existing `http_post_json`/`probe_glm` tests updated to the widened 3-tuple contract

Flagged in PENDING-ARMS.md 2026-08-21; deliberately left uncured in #4467/#4470 to keep those scoped.

🤖 [Mini-HEALER] autonomous tick