### PR TITLE
feat(ci): dedicated nightly alert + guilt/innocence corpus for Detect Secrets (L3 close-out)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -825,6 +825,20 @@ jobs:
       - name: Install detect-secrets
         run: pip install detect-secrets
 
+      - name: Guilt+innocence corpus (L3 diff-scope + nightly-alert composer)
+        # Self-contained regression tripwire for this job's own behavior — see
+        # each test file's header for what it proves (diff-scope: a changed-
+        # file secret goes red on the PR path and is invisible there while the
+        # nightly full-tree path still catches it; nightly-alert: the composer
+        # quotes a real summary verbatim, never fabricates one when none was
+        # captured, and does not swallow the gateway's exit code). Runs BEFORE
+        # the real scan below so a broken corpus fails loud here rather than
+        # silently degrading the scan it exists to guard. No network, no repo
+        # baseline touched — both scripts work against throwaway tmp fixtures.
+        run: |
+          bash scripts/tests/test_detect_secrets_diff_scope.sh
+          bash scripts/tests/test_detect_secrets_nightly_alert.sh
+
       - name: Decide scan scope
         # L3 (see the job header above): pull_request/merge_group scan only
         # the diff's files; every other event keeps the full-tree scan.
@@ -937,7 +951,48 @@ jobs:
         # scripts/detect_secrets_auto_triage.py pre-marks known false positives
         # by path pattern; any residue is a genuine new finding that needs
         # human eyes.
-        run: python scripts/detect_secrets_check_unaudited.py
+        #
+        # L3 nightly alert (2026-08-21, see the step below): capture this
+        # script's own stdout+stderr to a file so a failing full-tree run can
+        # quote it in the Telegram alert without a second execution. No
+        # pipe/tee here on purpose (W101/W97 — a pipe can mask the upstream
+        # exit code): the exit status is captured explicitly via `$?` and
+        # re-raised, so a finding still fails this step exactly as before.
+        run: |
+          set -uo pipefail
+          OUT="$(python scripts/detect_secrets_check_unaudited.py 2>&1)"
+          RC=$?
+          printf '%s\n' "$OUT"
+          printf '%s\n' "$OUT" > /tmp/unaudited-findings.txt
+          exit "$RC"
+
+      - name: Telegram alert — nightly full-tree scan failed
+        # L3 (audit lever, see this job's header comment above): the
+        # diff-scoped PR/queue path only sees changed files — a failure of
+        # THIS event's full-tree run is the net for anything else, so it gets
+        # a dedicated, content-bearing page (scripts/ci/detect_secrets_nightly_alert.sh)
+        # rather than relying only on main-push-failure-watch.yml's generic
+        # "Security Scanning failed" ping, which names the workflow, never
+        # the job or the finding.
+        #
+        # Gated on event name alone, not steps.scope.outputs.mode: "Decide
+        # scan scope" sets mode=full unconditionally for any non-pull_request/
+        # merge_group event (see that step), so schedule/workflow_dispatch
+        # always implies full-tree — and an earlier-step failure (pip
+        # install, the scan crashing) skips "Decide scan scope" entirely,
+        # which would leave its output unset and silently disarm an
+        # output-keyed condition. Push:develop full-tree runs are
+        # DELIBERATELY not covered here (out of this lever's scope, and
+        # main-push-failure-watch.yml doesn't see them either — its trigger
+        # filters branches:[main]).
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_OWNER_CHAT_ID: ${{ secrets.TELEGRAM_OWNER_CHAT_ID }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SUMMARY_FILE: /tmp/unaudited-findings.txt
+        run: bash scripts/ci/detect_secrets_nightly_alert.sh
 
   security-summary:
     name: Security Summary

--- a/scripts/ci/detect_secrets_nightly_alert.sh
+++ b/scripts/ci/detect_secrets_nightly_alert.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# detect_secrets_nightly_alert.sh — page when the FULL-TREE Detect Secrets
+# scan fails (schedule / workflow_dispatch runs of security.yml only).
+#
+# WHY THIS EXISTS (audit lever L3, 2026-08-21,
+# research/operations/2026-08-21-token-ceremony-ci-system-audit.md §7): PR and
+# merge-queue runs of the `detect-secrets` job now scan only the diff's
+# changed files (#4488, merge-base anchored via hotzone_changed_files.sh) — a
+# secret sitting in a file no PR touched is caught only by the scheduled
+# full-tree run. `main-push-failure-watch.yml` already pages the owner on ANY
+# "Security Scanning" workflow failure on push/schedule to main, but it names
+# only the WORKFLOW, never which of its 6 jobs failed or what a secrets scan
+# actually found — a dependency CVE from Snyk and a leaked credential read
+# identically in that generic message. This is the job-specific,
+# content-bearing alert layered on top of it (the same pattern security.yml
+# already uses for its Docker-build-failure alert): it fires only for THIS
+# job on the full-tree path, and it quotes what was found.
+#
+# NOT scripts/tg_notify.py. That gateway is fleet-native — it spools under
+# $HOME, dedups on a repeat ladder, and batches into a digest — none of which
+# survive an ephemeral GitHub Actions runner with no persistent $HOME between
+# runs; routing through it here would silently defeat its own contract. This
+# workflow's own file already established the CI-native, NON-BLIND
+# convention for this exact problem (see the "Telegram alert — production
+# image failed to BUILD" step further down in security.yml):
+# scripts/ci/telegram_notify.sh, which judges the Telegram API's REPLY via
+# telegram_verdict.sh (W104: curl's exit code lies — a rotated token still
+# answers 200 or a well-formed 401) instead of trusting a POST's exit code.
+# That is the identical "judge the verdict, never the exit code" contract the
+# antidotes lint (scripts/tests/test_gateway_callers_read_the_verdict.py)
+# enforces for tg_notify.py's own Python callers — applied here through the
+# gateway this workflow already uses, rather than introducing a second one
+# mid-file for one step.
+#
+# Honesty invariant (W114/W106 — "a message that inventories mutable state
+# lies"): this script does not assume the job failed BECAUSE a secret was
+# found. The same job can also fail earlier — `pip install detect-secrets`,
+# the scan itself crashing, or the auto-triage script erroring — and none of
+# those leave a findings summary behind. The message says only what it can
+# prove: if a summary file was captured it is quoted verbatim; if not, the
+# message says so explicitly, never fabricating a "secret found" claim the
+# run cannot back.
+#
+# Usage:
+#   EVENT_NAME=schedule RUN_URL=https://... SUMMARY_FILE=/tmp/x.txt \
+#     TELEGRAM_BOT_TOKEN=... TELEGRAM_OWNER_CHAT_ID=... \
+#     bash detect_secrets_nightly_alert.sh
+#
+# TELEGRAM_NOTIFY_BIN overrides the gateway binary — tests point this at a
+# stub so the guilt/innocence corpus never touches the network.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTIFY_BIN="${TELEGRAM_NOTIFY_BIN:-${SCRIPT_DIR}/telegram_notify.sh}"
+
+EVENT_NAME="${EVENT_NAME:-unknown}"
+RUN_URL="${RUN_URL:-}"
+SUMMARY_FILE="${SUMMARY_FILE:-}"
+
+SUMMARY="(no findings summary captured for this run — the failure may be earlier in the job: pip install, the scan itself, or auto-triage; check the run log)"
+if [ -n "${SUMMARY_FILE}" ] && [ -s "${SUMMARY_FILE}" ]; then
+  SUMMARY="$(head -c 2500 "${SUMMARY_FILE}")"
+fi
+
+TEXT="$(printf '%s\n' \
+  "Detect Secrets - nightly full-tree scan FAILED (event: ${EVENT_NAME})" \
+  "" \
+  "Diff-scoped PR/queue runs (lever L3) only see changed files - this scheduled full-tree run is the net for anything else." \
+  "" \
+  "${SUMMARY}" \
+  "" \
+  "Audit: python scripts/detect_secrets_auto_triage.py --report" \
+  "" \
+  "${RUN_URL}")"
+
+bash "${NOTIFY_BIN}" --text "${TEXT}"

--- a/scripts/tests/test_detect_secrets_diff_scope.sh
+++ b/scripts/tests/test_detect_secrets_diff_scope.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# test_detect_secrets_diff_scope.sh — guilt+innocence corpus for audit lever
+# L3 (research/operations/2026-08-21-token-ceremony-ci-system-audit.md §7):
+# the `detect-secrets` job in security.yml scans only a PR's changed files
+# on pull_request/merge_group, and the full tree on every other event
+# (schedule, workflow_dispatch, push).
+#
+# This does NOT execute the workflow YAML — it re-derives the exact same two
+# commands the job runs (hotzone_changed_files.sh for the file list,
+# `detect-secrets scan` with explicit paths vs no paths) against a synthetic
+# git repo, on a fresh throwaway baseline so detect-secrets' default plugin
+# set decides, independent of this repo's real .secrets.baseline / auto-
+# triage rules.
+#
+# Fixture: two commits.
+#   commit A: unchanged.py, carrying a fake AWS-key-shaped secret. Stands in
+#             for "a secret already on main, in a file this PR never touches".
+#   commit B (head): changed.py, carrying a DIFFERENT fake secret. Stands in
+#             for "what this PR's diff actually adds".
+#
+# Both fixtures use the obviously-fake pattern AKIAFAKEFAKEFAKE000N — matches
+# detect-secrets' AWSKeyDetector shape (AKIA + 16 alnum) without resembling a
+# real credential (never plant a real-looking one, per this file's own
+# mandate).
+#
+# Assertions:
+#   1. GUILT   (PR path):      changed.py's secret is scanned and unaudited.
+#   2. INNOCENCE (PR path):    unchanged.py's secret is NOT in that scan's
+#                               results at all — the PR-path baseline never
+#                               even looked at the file.
+#   3. GUILT   (nightly path): a full-tree scan (no path args, the "else"
+#                               branch of "Run detect-secrets scan") finds
+#                               BOTH secrets — the file the PR never touched
+#                               IS caught by the nightly net.
+#   4. hotzone_changed_files.sh itself reports exactly [changed.py] for this
+#      fixture (merge-base = commit A, head = commit B) — the same
+#      enumerator "Decide scan scope" calls.
+#
+# Run: bash scripts/tests/test_detect_secrets_diff_scope.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOTZONE="${REPO_ROOT}/scripts/ci/hotzone_changed_files.sh"
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \xe2\x9c\x97 %s\n' "$1"; }
+
+if ! command -v detect-secrets >/dev/null 2>&1; then
+  echo "SKIP: detect-secrets CLI not installed in this environment"
+  exit 0
+fi
+
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "${WORKDIR}"; }
+trap cleanup EXIT
+
+cd "${WORKDIR}" || exit 1
+git init -q
+git config user.email "test@example.com"
+git config user.name "test"
+
+echo "print('base')" > base.py
+git add base.py
+git commit -q -m base
+
+printf 'AWS_KEY = "AKIAFAKEFAKEFAKE0001"\n' > unchanged.py
+git add unchanged.py
+git commit -q -m "add unchanged.py (pre-existing secret)"
+A_SHA="$(git rev-parse HEAD)"
+
+printf 'AWS_KEY = "AKIAFAKEFAKEFAKE0002"\n' > changed.py
+git add changed.py
+git commit -q -m "add changed.py (this PR's diff)"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+echo "── enumerator: hotzone_changed_files.sh must report exactly [changed.py]"
+ENUM_OUT="$(bash "${HOTZONE}" "${A_SHA}" "${HEAD_SHA}" 2>/dev/null || true)"
+if [ "${ENUM_OUT}" = "changed.py" ]; then
+  ok "hotzone reports exactly changed.py"
+else
+  bad "hotzone reported [${ENUM_OUT}], expected [changed.py]"
+fi
+
+echo "── PR path: scan only changed.py (mirrors 'Run detect-secrets scan' diff branch)"
+detect-secrets scan changed.py > pr_baseline.json 2>pr_scan.err || true
+PR_FILES="$(python3 -c "import json;print(sorted(json.load(open('pr_baseline.json'))['results'].keys()))" 2>/dev/null || echo ERROR)"
+
+if printf '%s' "${PR_FILES}" | grep -q "'changed.py'"; then
+  ok "GUILT (PR path): changed.py's planted secret is scanned"
+else
+  bad "GUILT (PR path) missed: changed.py absent from PR-scoped results (${PR_FILES})"
+fi
+
+if printf '%s' "${PR_FILES}" | grep -q "'unchanged.py'"; then
+  bad "INNOCENCE (PR path) violated: unchanged.py appeared in a PR-scoped scan that never named it (${PR_FILES})"
+else
+  ok "INNOCENCE (PR path): unchanged.py never entered the PR-scoped baseline"
+fi
+
+echo "── nightly path: full-tree scan (mirrors the 'else' branch, no path args)"
+detect-secrets scan --exclude-files '\.git/.*' > full_baseline.json 2>full_scan.err || true
+FULL_FILES="$(python3 -c "import json;print(sorted(json.load(open('full_baseline.json'))['results'].keys()))" 2>/dev/null || echo ERROR)"
+
+if printf '%s' "${FULL_FILES}" | grep -q "'changed.py'" && printf '%s' "${FULL_FILES}" | grep -q "'unchanged.py'"; then
+  ok "GUILT (nightly path): full-tree scan catches BOTH changed.py and unchanged.py"
+else
+  bad "GUILT (nightly path) missed a file: got ${FULL_FILES}, expected both changed.py and unchanged.py"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/tests/test_detect_secrets_nightly_alert.sh
+++ b/scripts/tests/test_detect_secrets_nightly_alert.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# test_detect_secrets_nightly_alert.sh — guilt+innocence for
+# scripts/ci/detect_secrets_nightly_alert.sh (audit lever L3, 2026-08-21).
+#
+# No network, no real Telegram gateway: TELEGRAM_NOTIFY_BIN points at a fake
+# gateway (same pattern as scripts/tests/test_tg_sender_migration.sh) that
+# only records the text it was asked to send and exits with a scripted code,
+# so this corpus proves the MESSAGE-BUILDING and EXIT-CODE-PROPAGATION
+# contract without ever touching curl.
+#
+# Assertions:
+#   1. GUILT: a captured findings summary is quoted verbatim in the message.
+#   2. INNOCENCE: no summary file (or an empty one) never fabricates a
+#      "secret found" claim — it states plainly that nothing was captured
+#      (W114/W106 — a message may not inventory a state it cannot prove).
+#   3. The event name and run URL both land in the message.
+#   4. The gateway's exit code is propagated, not swallowed, in both
+#      directions (delivered vs refused) — this script is a message
+#      composer, not a second verdict judge; telegram_notify.sh/
+#      telegram_verdict.sh already own that judgment (W104), and this test
+#      only proves the composer does not eat their answer.
+#
+# Run: bash scripts/tests/test_detect_secrets_nightly_alert.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ALERT_SCRIPT="${REPO_ROOT}/scripts/ci/detect_secrets_nightly_alert.sh"
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \xe2\x9c\x97 %s\n' "$1"; }
+
+if [ ! -f "${ALERT_SCRIPT}" ]; then
+  bad "missing ${ALERT_SCRIPT}"
+  echo "Results: ${PASS} passed, ${FAIL} failed"
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+cleanup() { rm -rf "${WORKDIR}"; }
+trap cleanup EXIT
+
+# Fake gateway: writes its --text argument verbatim to CAPTURED_TEXT_FILE and
+# exits with whatever FAKE_GATEWAY_EXIT says (default 0 = "delivered").
+cat > "${WORKDIR}/fake_telegram_notify.sh" <<'FAKE'
+#!/usr/bin/env bash
+set -uo pipefail
+TEXT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --text) TEXT="${2-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s' "${TEXT}" > "${CAPTURED_TEXT_FILE}"
+exit "${FAKE_GATEWAY_EXIT:-0}"
+FAKE
+chmod +x "${WORKDIR}/fake_telegram_notify.sh"
+
+echo "── GUILT: a captured findings summary is quoted verbatim"
+printf '%s\n' "unaudited findings (of 3 total): apps/x.py:12 AWSKeyDetector" > "${WORKDIR}/summary.txt"
+CAPTURED_TEXT_FILE="${WORKDIR}/captured1.txt" \
+FAKE_GATEWAY_EXIT=0 \
+TELEGRAM_NOTIFY_BIN="${WORKDIR}/fake_telegram_notify.sh" \
+EVENT_NAME=schedule \
+RUN_URL="https://github.com/Bali-Zero/Teman2/actions/runs/12345" \
+SUMMARY_FILE="${WORKDIR}/summary.txt" \
+  bash "${ALERT_SCRIPT}"
+RC1=$?
+
+if [ "${RC1}" -eq 0 ] && grep -q "AWSKeyDetector" "${WORKDIR}/captured1.txt" 2>/dev/null; then
+  ok "summary content reaches the composed message"
+else
+  bad "summary content missing from composed message (rc=${RC1})"
+fi
+if grep -q "schedule" "${WORKDIR}/captured1.txt" 2>/dev/null; then
+  ok "event name lands in the message"
+else
+  bad "event name missing from message"
+fi
+if grep -q "actions/runs/12345" "${WORKDIR}/captured1.txt" 2>/dev/null; then
+  ok "run URL lands in the message"
+else
+  bad "run URL missing from message"
+fi
+
+echo "── INNOCENCE: no summary file never fabricates a finding"
+CAPTURED_TEXT_FILE="${WORKDIR}/captured2.txt" \
+FAKE_GATEWAY_EXIT=0 \
+TELEGRAM_NOTIFY_BIN="${WORKDIR}/fake_telegram_notify.sh" \
+EVENT_NAME=workflow_dispatch \
+RUN_URL="https://example/run/2" \
+SUMMARY_FILE="${WORKDIR}/does-not-exist.txt" \
+  bash "${ALERT_SCRIPT}" >/dev/null
+if grep -qi "no findings summary captured" "${WORKDIR}/captured2.txt" 2>/dev/null; then
+  ok "missing summary is stated honestly, not fabricated"
+else
+  bad "missing-summary case did not produce the honest fallback text"
+fi
+if grep -qi "AKIA\|AWSKeyDetector" "${WORKDIR}/captured2.txt" 2>/dev/null; then
+  bad "innocence violated: a finding-shaped string appeared with no summary file"
+else
+  ok "no finding-shaped content fabricated when nothing was captured"
+fi
+
+echo "── INNOCENCE: an EMPTY summary file is treated the same as absent"
+: > "${WORKDIR}/empty-summary.txt"
+CAPTURED_TEXT_FILE="${WORKDIR}/captured3.txt" \
+FAKE_GATEWAY_EXIT=0 \
+TELEGRAM_NOTIFY_BIN="${WORKDIR}/fake_telegram_notify.sh" \
+EVENT_NAME=schedule \
+RUN_URL="https://example/run/3" \
+SUMMARY_FILE="${WORKDIR}/empty-summary.txt" \
+  bash "${ALERT_SCRIPT}" >/dev/null
+if grep -qi "no findings summary captured" "${WORKDIR}/captured3.txt" 2>/dev/null; then
+  ok "empty summary file falls back to the honest message, same as absent"
+else
+  bad "empty summary file was not treated as 'no summary captured'"
+fi
+
+echo "── exit-code propagation: gateway REFUSAL is not swallowed"
+CAPTURED_TEXT_FILE="${WORKDIR}/captured4.txt" \
+FAKE_GATEWAY_EXIT=1 \
+TELEGRAM_NOTIFY_BIN="${WORKDIR}/fake_telegram_notify.sh" \
+EVENT_NAME=schedule \
+RUN_URL="https://example/run/4" \
+SUMMARY_FILE="${WORKDIR}/summary.txt" \
+  bash "${ALERT_SCRIPT}" >/dev/null
+RC4=$?
+if [ "${RC4}" -eq 1 ]; then
+  ok "gateway refusal (exit 1) propagates through the composer"
+else
+  bad "gateway refusal was swallowed: composer exited ${RC4}, expected 1"
+fi
+
+CAPTURED_TEXT_FILE="${WORKDIR}/captured5.txt" \
+FAKE_GATEWAY_EXIT=2 \
+TELEGRAM_NOTIFY_BIN="${WORKDIR}/fake_telegram_notify.sh" \
+EVENT_NAME=schedule \
+RUN_URL="https://example/run/5" \
+SUMMARY_FILE="${WORKDIR}/summary.txt" \
+  bash "${ALERT_SCRIPT}" >/dev/null
+RC5=$?
+if [ "${RC5}" -eq 2 ]; then
+  ok "gateway CANNOT-VERIFY (exit 2) propagates through the composer"
+else
+  bad "gateway CANNOT-VERIFY was not propagated: composer exited ${RC5}, expected 2"
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [ "${FAIL}" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Audit lever L3 (`research/operations/2026-08-21-token-ceremony-ci-system-audit.md` §7). **Grounding first found that the diff-scoping half was already merged**: PR #4488 (2026-08-20T23:55:18Z, Kimi K3 lane) already scopes `detect-secrets` to the diff's changed files on `pull_request`/`merge_group` (merge-base anchored via `scripts/ci/hotzone_changed_files.sh`), keeping the full-tree scan unchanged on `schedule`/`push`/`workflow_dispatch`. This PR does not touch that logic — it closes what was still missing against the mandate:

1. **A dedicated, content-bearing alert for a failing scheduled/`workflow_dispatch` full-tree run.** `main-push-failure-watch.yml` already pages on ANY `Security Scanning` workflow failure on push/schedule to main, but it only names the *workflow* — a Snyk CVE and a leaked credential read identically in that message. New `scripts/ci/detect_secrets_nightly_alert.sh` composes a message that quotes the actual unaudited-findings summary verbatim, or states honestly that none was captured (W114/W106 — never fabricate a "secret found" claim the run can't back, since the same job can also fail earlier: install, the scan itself, auto-triage). Sent through this workflow's own established, non-blind gateway — `scripts/ci/telegram_notify.sh` + `telegram_verdict.sh`, which judges the Telegram API's *reply*, never curl's exit code (W104) — the same pattern `security.yml` already uses for its Docker-build-failure alert.

   **Deliberately NOT `scripts/tg_notify.py`** (as literally named in the mandate): that gateway is fleet-native — it spools under `$HOME`, dedups on a repeat ladder, batches into a digest — none of which survive an ephemeral GitHub Actions runner with no persistent `$HOME` between runs. Routing through it here would silently defeat its own contract. `scripts/tests/test_gateway_callers_read_the_verdict.py` (the "antidotes" lint the mandate flagged) is a **Python-only** AST walker over `scripts/apps/infra` — it does not scan `.github/workflows/*.yml` or shell callers, so this substitution is out of its scope by construction; ran it anyway (clean, 25 readers / 0 blind) plus a manual end-to-end proof against a fake gateway (see Verification).

2. **A permanent guilt+innocence regression corpus.** #4488 verified diff-scoping by hand in its own PR body; nothing captured it as a test.
   - `scripts/tests/test_detect_secrets_diff_scope.sh` builds a synthetic two-commit git repo (a pre-existing secret in a file the "PR" never touches + a different secret in the file it does touch, both obviously-fake `AKIAFAKEFAKEFAKE...` patterns) and proves: the PR-scoped scan finds the changed-file secret (**guilt**) and never even looks at the unchanged file (**innocence** for the PR path); an unscoped full-tree scan catches **both** (**guilt** for the nightly path). Also asserts `hotzone_changed_files.sh` itself reports exactly the one changed file for the fixture.
   - `scripts/tests/test_detect_secrets_nightly_alert.sh` proves the alert composer against a fake gateway (no network, same pattern as `test_tg_sender_migration.sh`): summary quoted verbatim, honest fallback when nothing was captured (missing file AND empty file), gateway exit code (delivered / refused / cannot-verify) never swallowed in either direction.
   - Both are wired into the `detect-secrets` job itself (right after `Install detect-secrets`, before the real scan) so they run on every PR/queue entry — never "written but unarmed" (superscar #2).

`Check for unaudited findings` now captures its own stdout+stderr to a file via explicit `$?` capture — **no pipe/tee** (W101/W97: a pipe can mask the upstream exit code under some shells) — so the alert step can quote it without a second execution. The gate's pass/fail behavior is byte-identical to before.

## Why

Team-lead mandate (GO from Zero 2026-08-21): PR-path diff-scoping + a nightly full-tree net that alerts within a day, judged verdict, guilt+innocence tests. The diff-scoping arrived from a sibling session before this one started (confirmed via `gh pr list` grounding, not assumed) — duplicating it would be the sibling-race disease (superscar #5); this PR is scoped to exactly what was still open.

## Verification (all local, real — no live scheduled run yet, see Not verified)

- `actionlint` on `security.yml`: **0 findings** (repo-wide `actionlint` shows only pre-existing shellcheck info/style notices in *other*, untouched workflow files — confirmed by `grep -c security.yml` on its output = 0).
- `shellcheck` on the 3 new `.sh` files: clean except one info-level `SC2329` false-positive (`cleanup()` invoked via `trap ... EXIT`, a known shellcheck limitation with trap indirection).
- Both new tests: **12/12 green** (4 + 8). Mutation check: made the PR-path scan the whole tree (simulating the exact regression this lever guards against) — the innocence assertion correctly goes red.
- End-to-end simulation of `Check for unaudited findings`'s new capture logic against a fake `.secrets.baseline` (unaudited finding → RC=1, captured verbatim; all-audited → RC=0) — exit code and output both verified correct outside the real gate.
- Full realistic message preview (fake gateway) — readable, honest, links the run and the audit command.
- `scripts/lint_tg_direct_senders.py`: clean, 144 grandfathered (unchanged — this PR adds zero raw senders).
- `scripts/tests/test_gateway_callers_read_the_verdict.py`: clean, 25 readers / 0 blind.
- `scripts/check_watcher_coverage.py`: clean, 96/96 live workflows covered (1 pre-existing stale-entry warning, `AI PR review (advisory)`, unrelated — that workflow is disabled per CLAUDE.md §13).
- `scripts/ci/check_required_workflow_conformance.py`: clean, **27 required contexts, 0 violations** — `Detect Secrets` context name untouched, still emitted by the same job.

## Not verified (honest residuals)

- No live `schedule`/`workflow_dispatch` run yet — first one is the wiring proof (same declared gap #4488 left for `merge_group`).
- The dedicated alert's coverage is intentionally narrower than `main-push-failure-watch.yml`'s generic ping: it does not fire on `push:develop` full-tree failures. Declared, not hidden — out of this lever's stated scope, and the generic watcher doesn't see `push:develop` either (its trigger filters `branches:[main]`), so this is a pre-existing gap, not one this PR introduces.
- The `.secrets.baseline` eternal-forgiveness gap flagged in #4488's own adversarial review (a `is_secret:false` decision is never re-checked by any scan, scheduled or not) is orthogonal to this PR and already tracked separately (PR #4491, `baseline_debt_report.py`).

Auto-merge armed on open (`gh pr merge --auto`, nude — no strategy flag, per `feedback_arm_automerge_default_not_leave_to_operator`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)