### PR TITLE
docs(workflow): pin the model on every agent() — inheriting the session model broke the Fable-out ruling

### DIFF
--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -40,8 +40,15 @@ not N workflows), single-file fixes, anything already owned by a live sibling la
 ## 1. The contract (non-negotiable)
 
 1. **Opus 5 orchestrates, Sonnet builds, externals grade.** (Fable is out of the workflow, RULED
-   2026-08-20.) `agent()` lanes default to the session model; pass `model:"sonnet"` for
-   implementer lanes, `model:"haiku"` for grunt.
+   2026-08-20.) **PIN `model:` ON EVERY `agent()` CALL — never let a lane inherit the session
+   model.** An `agent()` without `model:` runs on whatever the session happens to be, which is
+   how a fan-out silently violates the ruling above: measured 2026-08-21, eight research lanes
+   with no `model:` all inherited Fable from an interactive session and died together on its
+   limit 25 s in, having produced nothing. The doctrine existed; the DEFAULT did the opposite,
+   and a default that contradicts the rule is the rule that wins. `model:"sonnet"` for
+   implementer AND research lanes, `model:"haiku"` for grunt, `model:"opus"` only where the lane
+   genuinely needs the orchestrator tier. The Gear-3 final on-disk gate is untouched by this
+   rule — it is never an `agent()` lane.
 2. **generator≠grader, always.** No lane grades its own output; a grader gets FRESH
    context and never sees the generator's answer before deriving its own (D5 pattern).
 3. **Cross-family beats same-family** (W100: same-lane agreement certified 7 false-clean


### PR DESCRIPTION
Contract rule 1 in the workflow skill said `agent()` lanes **default to the session model** while the 2026-08-20 ruling says Fable is out of the workflow. Those two sentences cannot both hold.

**Measured today**: a 6-angle research fan-out + 2 refuters, none passing `model:`, all inherited Fable from the interactive session and died together on its limit 25 s in — zero output, one burned window. The rule existed; the DEFAULT did the opposite. A default that contradicts a rule is the rule that wins (W104 shape: armed on paper, blind in practice).

Rule 1 now: explicit `model:` on **every** `agent()` call · `sonnet` is the default for research lanes as well as implementer lanes · `opus` only where the lane needs the orchestrator tier · the Gear-3 final on-disk gate is explicitly out of scope (it is never an `agent()` lane, so this cannot be read as putting logic in front of it).

Verified: prettier clean. Docs-only.

adversarial_review: exempt-docs-single-rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)