### PR TITLE
feat(ci): static test-impact map for backend-tests, PR lane only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,14 @@
 /scripts/ci/test_change_map.py                       @Balizero1987
 /scripts/ci/hotzone_changed_files.sh                 @Balizero1987
 
+# Static test-impact map (tests.yml `changes` job, PR lane only —
+# world-patterns-import-map.md §1.2, 2026-08-21) — same trust boundary as
+# change_map.py above and extracted from BASE_SHA alongside it: it decides
+# which pytest modules backend-tests actually runs on a PR, so weakening it
+# is a merge-gate bypass on the same class as change_map.py itself.
+/scripts/ci/impact_map.py                             @Balizero1987
+/scripts/ci/test_impact_map.py                        @Balizero1987
+
 # Ring-gating manual kill-switch (Merge-OS v2 round-2 Cure #1, adapted
 # 2026-08-18) — sits in the same trust boundary as the classifier files
 # above: a PR that neuters this script's ability to force the full suite

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,15 @@ jobs:
       run_frontend_tests: ${{ steps.classify.outputs.run_frontend_tests || 'true' }}
       run_packages_core_tests: ${{ steps.classify.outputs.run_packages_core_tests || 'true' }}
       run_e2e_tests: ${{ steps.classify.outputs.run_e2e_tests || 'true' }}
+      # Static test-impact map (world-patterns-import-map.md §1.2, PR lane
+      # only — never merge_group, see impact_map.py's module docstring
+      # "SCOPE, DECLARED"). Same fail-open convention as the flags above:
+      # any failure anywhere in `impact` below leaves these two outputs
+      # unset, and backend-tests' own `|| 'true'` / empty-string check falls
+      # back to the unscoped `backend/tests/` target it already ran before
+      # this lever existed.
+      impact_run_all: ${{ steps.impact.outputs.run_all || 'true' }}
+      impact_selected_tests: ${{ steps.impact.outputs.selected_tests }}
 
     steps:
       - name: Checkout code
@@ -157,8 +166,16 @@ jobs:
       # origin/main:scripts/ci/change_map.py, unchanged by this PR), so a PR
       # that edits the classifier is itself classified as
       # suggested_jobs=all-six by the OLD copy doing the judging — no new
-      # rule needed for that. Defense in depth: these three files are also
+      # rule needed for that. Defense in depth: these files are also
       # added to CODEOWNERS TIER 1 in this same commit.
+      #
+      # impact_map.py / test_impact_map.py (added with the static
+      # test-impact lever, world-patterns-import-map.md §1.2): SAME trust
+      # boundary as change_map.py above — a PR that broke backend/ code
+      # could otherwise edit its own copy of the module-selection logic to
+      # under-select its own regression's test. Extracted unconditionally
+      # (cheap; unused on merge_group, where the `impact` step below never
+      # runs) rather than adding a second extraction step for one event type.
       - name: Extract trusted classifier (base ref)
         id: extract
         if: steps.override.outputs.active != 'true'
@@ -169,7 +186,7 @@ jobs:
           CLASSIFIER_DIR="$RUNNER_TEMP/trusted-classifier"
           mkdir -p "$CLASSIFIER_DIR"
           OK=true
-          for f in scripts/ci/change_map.py scripts/ci/test_change_map.py scripts/ci/hotzone_changed_files.sh; do
+          for f in scripts/ci/change_map.py scripts/ci/test_change_map.py scripts/ci/hotzone_changed_files.sh scripts/ci/impact_map.py scripts/ci/test_impact_map.py; do
             if ! git show "${BASE_SHA}:${f}" > "$CLASSIFIER_DIR/$(basename "$f")" 2>/dev/null; then
               echo "::warning::could not extract $f from base ref $BASE_SHA — treating classifier as untrusted for this run"
               OK=false
@@ -200,8 +217,18 @@ jobs:
           set -uo pipefail
           if [ "$EXTRACT_OK" != "true" ]; then
             echo "::error::base-ref classifier extraction failed — refusing to trust a corpus that didn't run"
+            echo "impact_ok=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+          # impact_map.py's own corpus is recorded as a SEPARATE `impact_ok`
+          # output rather than folded into this step's own exit code — a
+          # break in the newer, narrower test-impact-map corpus must fail
+          # open on the PR-lane module scoping below (the `impact` step),
+          # not force run_all=true on all six domain-routed jobs, which is
+          # change_map.py's unrelated concern.
+          IMPACT_RC=0
+          python3 "$CLASSIFIER_DIR/test_impact_map.py" || IMPACT_RC=$?
+          echo "impact_ok=$([ "$IMPACT_RC" -eq 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           python3 "$CLASSIFIER_DIR/test_change_map.py"
 
       # merge_group base/head SHAs (established pattern — see hot-zone-pr-gate.yml,
@@ -279,6 +306,67 @@ jobs:
           ')"
           echo "$JOB_FLAGS" >> "$GITHUB_OUTPUT"
           echo "::notice::change-map: $MAP_JSON"
+
+      # Lever L2, world-patterns-import-map.md §1.2: within backend-tests
+      # (once change_map above has already decided that job runs), select
+      # only the pytest modules impact_map.py's static import graph says
+      # this PR's changed files can reach — instead of the full
+      # `backend/tests/` (1400+ modules) that job ran unconditionally
+      # before this step existed. PR lane ONLY (`if:` below) — merge_group
+      # NEVER consults this output; it keeps running the unconditional full
+      # suite, so a wrong or incomplete impact map here costs a slow PR-lane
+      # run, never a missed regression (see the module's own "SCOPE,
+      # DECLARED" docstring for exactly what it cannot see: anything outside
+      # apps/backend-rag/backend/, dynamic imports, importlib, env-driven
+      # wiring). Reuses $CHANGED_FILE from "Enumerate and classify" above —
+      # same merge-base-anchored list, no second enumeration.
+      - name: Compute static test-impact map (PR lane only)
+        id: impact
+        if: steps.override.outputs.active != 'true' && github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          CLASSIFIER_DIR: ${{ steps.extract.outputs.dir }}
+          EXTRACT_OK: ${{ steps.extract.outputs.ok }}
+          IMPACT_OK: ${{ steps.classifier-tests.outputs.impact_ok }}
+        run: |
+          set -uo pipefail
+          CHANGED_FILE="$RUNNER_TEMP/change-map-changed-files.txt"
+
+          if [ "$EXTRACT_OK" != "true" ] || [ "$IMPACT_OK" != "true" ]; then
+            echo "::warning::impact-map classifier untrusted or its own corpus failed; backend-tests keeps the unscoped full suite"
+            echo "run_all=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! IMPACT_JSON="$(python3 "$CLASSIFIER_DIR/impact_map.py" < "$CHANGED_FILE")"; then
+            echo "::warning::impact_map.py exited non-zero; backend-tests keeps the unscoped full suite"
+            echo "run_all=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RUN_ALL="$(IMPACT_JSON="$IMPACT_JSON" python3 -c 'import json, os; print(str(json.loads(os.environ["IMPACT_JSON"])["run_all"]).lower())')"
+          echo "run_all=$RUN_ALL" >> "$GITHUB_OUTPUT"
+          if [ "$RUN_ALL" = "false" ]; then
+            {
+              echo "selected_tests<<IMPACT_TESTS_EOF"
+              IMPACT_JSON="$IMPACT_JSON" python3 -c 'import json, os; print("\n".join(json.loads(os.environ["IMPACT_JSON"])["selected_tests"]))'
+              echo "IMPACT_TESTS_EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+          # Counts only in the loud notice — the selected-file list itself
+          # can run into the hundreds of paths (see the module docstring's
+          # app-factory hub example) and belongs in $GITHUB_OUTPUT, not a
+          # GitHub Actions annotation.
+          SUMMARY="$(IMPACT_JSON="$IMPACT_JSON" python3 -c '
+          import json, os
+          d = json.loads(os.environ["IMPACT_JSON"])
+          print(
+              f"run_all={d[\"run_all\"]} reason={d[\"reason\"]} "
+              f"selected={d.get(\"selected_test_count\", \"-\")}/{d.get(\"total_test_count\", \"-\")}"
+          )
+          ')"
+          echo "::notice::test-impact-map: $SUMMARY"
 
       - name: Publish change-map decision
         if: always()
@@ -627,6 +715,16 @@ jobs:
           INTAKE_TEST_DSN: postgresql://test:test@localhost:5432/nuzantara_test
           REDIS_URL: redis://localhost:6379
           COLLECT_COVERAGE: ${{ steps.test-scope.outputs.collect_coverage }}
+          # Static test-impact map (world-patterns-import-map.md §1.2). Both
+          # unset (empty string) on merge_group/push/schedule — the `impact`
+          # step in the `changes` job only runs on `pull_request` — so the
+          # `[ "$IMPACT_RUN_ALL" = "false" ]` check below is false there by
+          # construction and this job keeps running the full `backend/tests/`
+          # it always has. `|| 'true'` mirrors change_map's own fail-open
+          # convention for the same reason (any upstream failure/skip must
+          # never silently narrow this job).
+          IMPACT_RUN_ALL: ${{ needs.changes.outputs.impact_run_all || 'true' }}
+          IMPACT_SELECTED_TESTS: ${{ needs.changes.outputs.impact_selected_tests }}
         run: |
           cd apps/backend-rag
           set -o pipefail
@@ -646,10 +744,36 @@ jobs:
           if [ "$COLLECT_COVERAGE" = "true" ]; then
             COV_ARGS=(--cov=backend --cov-branch --cov-report=xml:coverage.xml)
           fi
+
+          # Static test-impact map: scope this invocation to only the pytest
+          # modules impact_map.py's import graph says this PR's changed
+          # files can reach, IF the PR-lane classifier trusted itself, ran,
+          # and reached a non-empty selection. $IMPACT_SELECTED_TESTS holds
+          # repo-root-relative paths (e.g. apps/backend-rag/backend/tests/…)
+          # — strip the apps/backend-rag/ prefix this step's own `cd` above
+          # already put us inside. Any other outcome (merge_group, override
+          # active, classifier/corpus untrusted, out-of-scope diff, empty
+          # impact set) leaves TEST_TARGETS as the unscoped default this job
+          # has always run.
+          TEST_TARGETS=(
+            backend/tests/
+            ../../scripts/bot/test_build_deid_corpus.py
+            ../../scripts/bot/test_wa_blind_bench.py
+          )
+          if [ "$IMPACT_RUN_ALL" = "false" ] && [ -n "$IMPACT_SELECTED_TESTS" ]; then
+            TEST_TARGETS=()
+            while IFS= read -r selected_test; do
+              [ -n "$selected_test" ] && TEST_TARGETS+=("$selected_test")
+            done < <(printf '%s\n' "$IMPACT_SELECTED_TESTS" | sed 's#^apps/backend-rag/##')
+            {
+              echo "## Test-impact map — PR lane scoped"
+              echo ""
+              echo "Selected ${#TEST_TARGETS[@]} of $(find backend/tests -name 'test_*.py' -o -name '*_test.py' | wc -l | tr -d ' ') backend test modules (static import graph — see scripts/ci/impact_map.py)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           PYTHONPATH=.:../crm-cell pytest \
-            backend/tests/ \
-            ../../scripts/bot/test_build_deid_corpus.py \
-            ../../scripts/bot/test_wa_blind_bench.py \
+            "${TEST_TARGETS[@]}" \
             -q -ra --no-header --durations=50 \
             --ignore=backend/tests/e2e \
             "${COV_ARGS[@]}" \

--- a/scripts/ci/impact_map.py
+++ b/scripts/ci/impact_map.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""impact_map.py — static import-graph test selection for the PR lane.
+
+Lever L2 from research/operations/2026-08-21-world-patterns-import-map.md
+§1.2 ("Test Impact Analysis — start static, not ML"): `change_map.py`
+(sibling in this directory) already decides, at DOMAIN granularity, whether
+`backend-tests` runs at all. Once that job is selected to run, it has always
+run every file under `backend/tests/` (1400+ modules) regardless of how
+small the diff is — this module is the missing layer underneath: map the
+PR's changed files to the pytest MODULES that can actually reach them via a
+static Python import graph, and select only those.
+
+SCOPE, DECLARED (do not widen without re-deriving safety): this module has a
+static import graph for exactly one tree, `apps/backend-rag/backend/`. Any
+changed path outside that tree — `apps/crm-cell/`, `packages/cell-core/`,
+`scripts/bot/`, `data/*.json`, `requirements*.txt`, migrations, etc. — is
+UNMAPPABLE by construction and forces `run_all=True`. So does anything a
+static graph structurally cannot see: dynamic `importlib.import_module(...)`,
+string-built dotted paths, plugin/env-var-driven wiring, and dependency/data
+files a test reads via `open()` rather than `import`. This is why the
+`merge_group` lane (this module's caller, `tests.yml`, invokes it ONLY on
+`pull_request` — see that workflow) MUST stay the unconditional full suite:
+a wrong or incomplete impact map here costs a slow PR-lane run, never a
+missed regression, only because merge_group never scopes on this output.
+
+CONFTEST: pytest applies a directory's `conftest.py` to every test in that
+directory's subtree regardless of whether any test file literally imports
+it. A changed `conftest.py` therefore selects every test file under its own
+directory (recursively) — this is a directory rule, not a graph edge, and is
+handled before the import-graph walk below.
+
+ROOT OF TRUST: this file is extracted from BASE_SHA by tests.yml's `changes`
+job, exactly like change_map.py (CRITICAL-1, 2026-08-14) — a PR that broke
+backend/ code could otherwise edit its own copy of this file to under-select
+its own regression's test. See that job's "Extract trusted classifier" step.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+ENUMERATION_ERROR = "__CHANGE_MAP_ENUMERATION_ERROR__"  # shared sentinel with change_map.py
+
+# The only tree this module has a static import graph for (see module
+# docstring "SCOPE, DECLARED"). Repo-relative, POSIX.
+BACKEND_ROOT = "apps/backend-rag/backend"
+TEST_DIR = f"{BACKEND_ROOT}/tests"
+PACKAGE_ROOT_PREFIX = "apps/backend-rag/"  # PYTHONPATH=.:../crm-cell at that cwd
+
+
+def _module_name(rel_path: str) -> str:
+    """``apps/backend-rag/backend/services/x.py`` -> ``backend.services.x``."""
+
+    within = rel_path[len(PACKAGE_ROOT_PREFIX) :]
+    parts = within[: -len(".py")].split("/")
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _own_package(module_name: str, is_init: bool) -> str:
+    """The dotted package a module's relative imports resolve against."""
+
+    if is_init:
+        return module_name
+    if "." in module_name:
+        return module_name.rsplit(".", 1)[0]
+    return ""
+
+
+def _resolve_relative(package: str, level: int, module: str | None) -> str | None:
+    """Mirrors ``importlib._bootstrap._resolve_name`` for ``from . import x``."""
+
+    if not package:
+        return None
+    bits = package.rsplit(".", level - 1)
+    if len(bits) < level:
+        return None
+    base = bits[0]
+    return f"{base}.{module}" if module else base
+
+
+def _candidates_for_import(node: ast.AST, own_package: str) -> list[str]:
+    """Every dotted-name an import statement could touch.
+
+    Deliberately over-inclusive: every ancestor-package prefix of a resolved
+    target is added too, because Python imports (and executes) every
+    ancestor package's ``__init__.py`` before the leaf. An extra edge only
+    ever WIDENS selection (a test gets included that didn't strictly need
+    to be); it can never narrow it — the direction this module's caller
+    requires uncertainty to fail toward.
+    """
+
+    targets: list[str] = []
+    if isinstance(node, ast.Import):
+        for alias in node.names:
+            bits = alias.name.split(".")
+            targets.extend(".".join(bits[:i]) for i in range(1, len(bits) + 1))
+    elif isinstance(node, ast.ImportFrom):
+        base = (
+            _resolve_relative(own_package, node.level, node.module)
+            if node.level
+            else node.module
+        )
+        if base:
+            bits = base.split(".")
+            targets.extend(".".join(bits[:i]) for i in range(1, len(bits) + 1))
+            targets.extend(
+                f"{base}.{alias.name}" for alias in node.names if alias.name != "*"
+            )
+    return targets
+
+
+def _is_test_file(rel_path: str) -> bool:
+    if not rel_path.startswith(TEST_DIR + "/"):
+        return False
+    # backend-tests' own pytest invocation passes `--ignore=backend/tests/e2e`
+    # (a dedicated e2e-tests job owns that subtree) — mirror the same
+    # exclusion here so a scoped selection can never hand pytest a path its
+    # own `--ignore` flag would then filter back out, which for a selection
+    # confined entirely to e2e/ would leave zero collected items under `-x`
+    # (pytest exit 5), a spurious failure the always-ran-the-whole-directory
+    # baseline could never hit.
+    if rel_path.startswith(TEST_DIR + "/e2e/"):
+        return False
+    name = rel_path.rsplit("/", 1)[-1]
+    return name.startswith("test_") or name.endswith("_test.py")
+
+
+def _discover_modules(repo_root: Path) -> dict[str, str]:
+    """module name -> repo-relative POSIX path, for every ``.py`` under BACKEND_ROOT."""
+
+    base = repo_root / BACKEND_ROOT
+    if not base.is_dir():
+        return {}
+    modules: dict[str, str] = {}
+    for path in base.rglob("*.py"):
+        rel = path.relative_to(repo_root).as_posix()
+        modules[_module_name(rel)] = rel
+    return modules
+
+
+def _build_reverse_graph(
+    modules: dict[str, str], repo_root: Path
+) -> tuple[dict[str, set[str]], list[str]]:
+    """``dependents[module]`` = set of modules that (transitively-eligible) import it."""
+
+    dependents: dict[str, set[str]] = {name: set() for name in modules}
+    parse_errors: list[str] = []
+    for module_name, rel in modules.items():
+        is_init = rel.endswith("/__init__.py") or rel == f"{BACKEND_ROOT}/__init__.py"
+        own_package = _own_package(module_name, is_init)
+        try:
+            source = (repo_root / rel).read_text(encoding="utf-8", errors="surrogateescape")
+            tree = ast.parse(source, filename=rel)
+        except (SyntaxError, ValueError, OSError):
+            parse_errors.append(rel)
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for target in _candidates_for_import(node, own_package):
+                    bucket = dependents.get(target)
+                    if bucket is not None:
+                        bucket.add(module_name)
+    return dependents, parse_errors
+
+
+def _transitive_dependents(start: set[str], graph: dict[str, set[str]]) -> set[str]:
+    seen: set[str] = set()
+    queue = list(start)
+    while queue:
+        current = queue.pop()
+        for dep in graph.get(current, ()):
+            if dep not in seen:
+                seen.add(dep)
+                queue.append(dep)
+    return seen
+
+
+def _fail_open(changed_count: int, reason: str, **extra: object) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "changed_file_count": changed_count,
+        "run_all": True,
+        "reason": reason,
+        "selected_tests": [],
+        **extra,
+    }
+
+
+def compute(paths: Iterable[str], repo_root: Path) -> dict[str, object]:
+    """Build the static test-impact recommendation for ``paths`` under ``repo_root``."""
+
+    raw_paths = list(paths)
+    if ENUMERATION_ERROR in raw_paths:
+        return _fail_open(0, "enumeration_failed")
+
+    changed = sorted({p.strip() for p in raw_paths if p.strip()})
+    if not changed:
+        return _fail_open(0, "empty_changed_set")
+
+    out_of_scope = [
+        p for p in changed if not (p.startswith(BACKEND_ROOT + "/") and p.endswith(".py"))
+    ]
+    if out_of_scope:
+        return _fail_open(
+            len(changed), "out_of_scope_path", out_of_scope_paths=sorted(out_of_scope)
+        )
+
+    modules = _discover_modules(repo_root)
+    dependents, parse_errors = _build_reverse_graph(modules, repo_root)
+    if parse_errors:
+        return _fail_open(len(changed), "unparseable_module", parse_errors=sorted(parse_errors))
+
+    rel_by_module = modules
+    module_by_rel = {rel: name for name, rel in rel_by_module.items()}
+    test_modules = {
+        name: rel for name, rel in rel_by_module.items() if _is_test_file(rel)
+    }
+
+    changed_modules: set[str] = set()
+    conftest_dirs: list[str] = []
+    missing: list[str] = []
+    for rel in changed:
+        basename = rel.rsplit("/", 1)[-1]
+        if basename == "conftest.py":
+            conftest_dirs.append(rel.rsplit("/", 1)[0])
+            continue
+        module_name = module_by_rel.get(rel)
+        if module_name is None:
+            # In-scope path (backend/**/*.py) that isn't in the CURRENT tree —
+            # most commonly a deletion. Static analysis of what depended on a
+            # module that no longer exists is exactly the "uncertain" case
+            # the caller's contract requires to fail toward the full suite.
+            missing.append(rel)
+            continue
+        changed_modules.add(module_name)
+
+    if missing:
+        return _fail_open(len(changed), "unresolvable_changed_path", missing_paths=sorted(missing))
+
+    selected: set[str] = set()
+    for conftest_dir in conftest_dirs:
+        prefix = conftest_dir + "/"
+        selected.update(rel for rel in test_modules.values() if rel.startswith(prefix))
+
+    if changed_modules:
+        impacted = _transitive_dependents(changed_modules, dependents) | changed_modules
+        selected.update(rel_by_module[m] for m in impacted if m in test_modules)
+
+    if not selected:
+        # A real, in-scope, resolvable change with zero test-module
+        # dependents (transitive or otherwise) — declared uncertain per the
+        # caller's contract ("empty list" is explicitly a fail-open trigger),
+        # not treated as "nothing to verify".
+        return _fail_open(len(changed), "empty_impact_set")
+
+    return {
+        "schema_version": 1,
+        "changed_file_count": len(changed),
+        "run_all": False,
+        "reason": "scoped",
+        "selected_tests": sorted(selected),
+        "selected_test_count": len(selected),
+        "total_test_count": len(test_modules),
+    }
+
+
+def _read_paths(argv: list[str]) -> list[str]:
+    if argv:
+        return [line for arg in argv for line in arg.splitlines()]
+    return sys.stdin.read().splitlines()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    repo_root = Path.cwd()
+    if args[:1] == ["--repo-root"]:
+        repo_root = Path(args[1])
+        args = args[2:]
+    result = compute(_read_paths(args), repo_root)
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/test_impact_map.py
+++ b/scripts/ci/test_impact_map.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Guilt + innocence corpus for the static test-impact map (impact_map.py).
+
+Hermetic by design: builds a small synthetic ``apps/backend-rag/backend``
+tree under a temp directory per test, instead of asserting exact counts
+against the live 3000+-module repo tree (which would drift every time
+someone adds a file). A separate manual measurement against real recent PRs
+(selection ratio) lives in the PR body / research capture, not here.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import impact_map as im
+
+
+def _write(root: Path, rel: str, content: str = "") -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_fixture(root: Path) -> None:
+    b = "apps/backend-rag/backend"
+    _write(root, f"{b}/__init__.py")
+    _write(root, f"{b}/core/__init__.py")
+    _write(root, f"{b}/core/config.py", "SETTING = 1\n")
+    _write(root, f"{b}/services/__init__.py")
+    _write(root, f"{b}/services/leaf.py", "from backend.core import config\n\nX = config.SETTING\n")
+    _write(root, f"{b}/services/other.py", "from backend.core import config\n\nY = config.SETTING\n")
+    _write(root, f"{b}/services/third.py", "from backend.core import config\n\nZ = config.SETTING\n")
+    _write(root, f"{b}/services/unrelated.py", "W = 1\n")
+    _write(root, f"{b}/tests/__init__.py")
+    _write(root, f"{b}/tests/conftest.py", "import pytest\n")
+    _write(root, f"{b}/tests/services/__init__.py")
+    _write(root, f"{b}/tests/services/test_leaf.py", "from backend.services import leaf\n")
+    _write(root, f"{b}/tests/services/test_other.py", "from backend.services import other\n")
+    _write(root, f"{b}/tests/services/test_third.py", "from backend.services import third\n")
+    _write(
+        root,
+        f"{b}/tests/services/test_unrelated.py",
+        "from backend.services import unrelated\n",
+    )
+    _write(root, f"{b}/tests/services/sub/__init__.py")
+    _write(root, f"{b}/tests/services/sub/conftest.py", "import pytest\n")
+    _write(
+        root,
+        f"{b}/tests/services/sub/test_nested.py",
+        "from backend.services import unrelated  # deliberately unrelated to leaf/other/third\n",
+    )
+
+
+class ImpactMapTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        _build_fixture(self.root)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_guilt_leaf_module_selects_only_its_direct_test(self) -> None:
+        result = im.compute(["apps/backend-rag/backend/services/leaf.py"], self.root)
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["reason"], "scoped")
+        self.assertEqual(
+            result["selected_tests"],
+            ["apps/backend-rag/backend/tests/services/test_leaf.py"],
+        )
+
+    def test_e2e_dependent_is_excluded_mirroring_backend_tests_own_ignore_flag(
+        self,
+    ) -> None:
+        # backend-tests' pytest invocation passes --ignore=backend/tests/e2e;
+        # a direct importer living under that subtree must never appear in a
+        # scoped selection, or a diff whose ONLY dependent is an e2e test
+        # would hand pytest a target its own --ignore then filters back out.
+        _write(
+            self.root,
+            "apps/backend-rag/backend/tests/e2e/test_leaf_e2e.py",
+            "from backend.services import leaf\n",
+        )
+        result = im.compute(["apps/backend-rag/backend/services/leaf.py"], self.root)
+        self.assertFalse(result["run_all"])
+        self.assertEqual(
+            result["selected_tests"],
+            ["apps/backend-rag/backend/tests/services/test_leaf.py"],
+        )
+
+    def test_innocence_widely_imported_core_module_selects_broadly(self) -> None:
+        leaf_result = im.compute(["apps/backend-rag/backend/services/leaf.py"], self.root)
+        core_result = im.compute(["apps/backend-rag/backend/core/config.py"], self.root)
+        self.assertFalse(core_result["run_all"])
+        selected = set(core_result["selected_tests"])
+        # config.py is imported (transitively, via leaf/other/third) by three
+        # test modules; the fourth (test_unrelated / test_nested) never
+        # touches it and must stay excluded — broad is not "everything".
+        self.assertIn("apps/backend-rag/backend/tests/services/test_leaf.py", selected)
+        self.assertIn("apps/backend-rag/backend/tests/services/test_other.py", selected)
+        self.assertIn("apps/backend-rag/backend/tests/services/test_third.py", selected)
+        self.assertNotIn(
+            "apps/backend-rag/backend/tests/services/test_unrelated.py", selected
+        )
+        self.assertGreater(
+            core_result["selected_test_count"], leaf_result["selected_test_count"]
+        )
+
+    def test_nested_conftest_selects_only_its_own_subtree(self) -> None:
+        result = im.compute(
+            ["apps/backend-rag/backend/tests/services/sub/conftest.py"], self.root
+        )
+        self.assertFalse(result["run_all"])
+        self.assertEqual(
+            result["selected_tests"],
+            ["apps/backend-rag/backend/tests/services/sub/test_nested.py"],
+        )
+
+    def test_root_conftest_selects_every_test_file(self) -> None:
+        result = im.compute(["apps/backend-rag/backend/tests/conftest.py"], self.root)
+        self.assertFalse(result["run_all"])
+        self.assertEqual(result["selected_test_count"], result["total_test_count"])
+        self.assertEqual(result["total_test_count"], 5)
+
+    def test_editing_a_test_file_directly_selects_itself(self) -> None:
+        result = im.compute(
+            ["apps/backend-rag/backend/tests/services/test_unrelated.py"], self.root
+        )
+        self.assertFalse(result["run_all"])
+        self.assertEqual(
+            result["selected_tests"],
+            ["apps/backend-rag/backend/tests/services/test_unrelated.py"],
+        )
+
+    def test_innocence_out_of_scope_path_falls_open(self) -> None:
+        for path in (
+            "apps/crm-cell/crm_cell/x.py",
+            "scripts/bot/build_deid_corpus.py",
+            "apps/backend-rag/backend/data/prices.json",
+        ):
+            with self.subTest(path=path):
+                result = im.compute([path], self.root)
+                self.assertTrue(result["run_all"])
+                self.assertEqual(result["reason"], "out_of_scope_path")
+
+    def test_empty_changed_set_falls_open(self) -> None:
+        result = im.compute([], self.root)
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["reason"], "empty_changed_set")
+
+    def test_enumeration_error_falls_open(self) -> None:
+        result = im.compute([im.ENUMERATION_ERROR], self.root)
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["reason"], "enumeration_failed")
+
+    def test_deleted_file_falls_open(self) -> None:
+        result = im.compute(
+            ["apps/backend-rag/backend/services/does_not_exist.py"], self.root
+        )
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["reason"], "unresolvable_changed_path")
+
+    def test_module_with_zero_test_dependents_falls_open(self) -> None:
+        _write(self.root, "apps/backend-rag/backend/services/orphan.py", "V = 1\n")
+        result = im.compute(["apps/backend-rag/backend/services/orphan.py"], self.root)
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["reason"], "empty_impact_set")
+
+    def test_unparseable_module_anywhere_in_tree_falls_open(self) -> None:
+        # A syntax error in a file the diff never touched still forces
+        # run_all=True — the whole-tree graph is the unit of trust, per the
+        # module docstring's "ROOT OF TRUST" / uncertainty-fails-open
+        # contract, not just the changed file's own parse.
+        _write(self.root, "apps/backend-rag/backend/services/broken.py", "def (:\n")
+        result = im.compute(["apps/backend-rag/backend/services/leaf.py"], self.root)
+        self.assertTrue(result["run_all"])
+        self.assertEqual(result["reason"], "unparseable_module")
+
+    def test_relative_import_resolves_to_the_right_module(self) -> None:
+        b = "apps/backend-rag/backend"
+        _write(self.root, f"{b}/services/pkg/__init__.py")
+        _write(self.root, f"{b}/services/pkg/leaf_rel.py", "X = 1\n")
+        _write(
+            self.root,
+            f"{b}/services/pkg/user.py",
+            "from . import leaf_rel\n\nY = leaf_rel.X\n",
+        )
+        _write(self.root, f"{b}/tests/services/test_pkg_user.py", "from backend.services.pkg import user\n")
+        result = im.compute(
+            ["apps/backend-rag/backend/services/pkg/leaf_rel.py"], self.root
+        )
+        self.assertFalse(result["run_all"])
+        self.assertIn(
+            "apps/backend-rag/backend/tests/services/test_pkg_user.py",
+            result["selected_tests"],
+        )
+
+    def test_cli_stdout_is_one_compact_json_line(self) -> None:
+        script = Path(__file__).with_name("impact_map.py")
+        completed = subprocess.run(
+            [sys.executable, str(script), "--repo-root", str(self.root)],
+            input="apps/backend-rag/backend/services/leaf.py\n",
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        self.assertEqual(len(completed.stdout.splitlines()), 1)
+        parsed = json.loads(completed.stdout)
+        self.assertFalse(parsed["run_all"])
+        self.assertEqual(parsed["reason"], "scoped")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Lever L2 from `research/operations/2026-08-21-world-patterns-import-map.md`
§1.2 ("Test Impact Analysis — start static, not ML"). `change_map.py`
already decides, at DOMAIN granularity, whether `backend-tests` runs at all
(#4181); once selected, that job has always run every file under
`backend/tests/` (1400+ modules) regardless of diff size. This adds the
missing layer underneath: map a PR's changed files to the pytest modules
that can reach them via a static Python import graph
(`scripts/ci/impact_map.py`), and scope `backend-tests`' own pytest
invocation to that set — **PR lane only**. `merge_group` never consults this
output and keeps running the unconditional full suite: a wrong or
incomplete impact map here costs a slow PR-lane run, never a missed
regression.

## Scope, declared (blind spots by construction, not oversight)

The static graph covers exactly one tree: `apps/backend-rag/backend/`. All
of these fall open to the full suite:
- any changed path outside that tree (crm-cell, cell-core, scripts/bot,
  `data/*.json`, `requirements*.txt`, migrations, …)
- a parse failure **anywhere** in the whole discovered tree, not just the
  changed file (whole-tree graph is the unit of trust)
- an unresolvable changed path (most commonly a deletion)
- an empty impact set (per the mandate's own explicit "empty list" trigger)
- dynamic imports / `importlib` / plugin registries / env-var wiring —
  structurally invisible to any static graph

A changed `conftest.py` selects its whole directory subtree, matching
pytest's own auto-apply semantics rather than the import graph (pytest
applies a conftest to every test under it regardless of literal imports).

## Root of trust

`impact_map.py` + its guilt/innocence corpus (`test_impact_map.py`) are
extracted from `BASE_SHA` in the same step that already extracts
`change_map.py` (CRITICAL-1 boundary, 2026-08-14) — a PR that broke
`backend/` code could otherwise edit its own copy of the selection logic to
under-select its own regression's test — and added to CODEOWNERS TIER 1
alongside it. The corpus's own pass/fail is tracked as a separate
`impact_ok` output so a break in it forces `run_all=true` on the PR-lane
scoping only, never on change_map's unrelated six-job domain routing.

## Measured selection ratio — 7 real merged PRs

| PR | files | result |
|---|---|---|
| #4260 (E28D migration) | 2 | **1/1401** (0.1%) |
| #4411 (portal billing mixin) | 2 | 856/1401 (61.1%) |
| #4415 (portal visibility) | 5 | 856/1401 (61.1%) |
| #3138 (E33 claim guard) | 3 | 857/1401 (61.2%) |
| #3032 (public endpoints) | 3 | 856/1401 (61.1%) |
| #2611 (Gemini promote) | 12 | 856/1401 (61.1%) |
| #3062 (WA persona P0) | 7 | 1050/1401 (74.9%) |

Honest finding: the lever is **bimodal**, not uniformly narrow. Anything
that touches a router or service reachable from
`backend/app/setup/app_factory.py`'s router-registration import chain pulls
in the majority of the suite, because that factory imports every router
(and is itself imported by nearly every integration test that builds a
FastAPI test client) — a real, correct reflection of the import graph, not
a bug. Isolated leaves (the migration PR) get the full benefit. Verified
separately: dependabot/manifest-only PRs (#4270) and non-backend PRs
(#4459, #4481) correctly fall open on `out_of_scope_path`.

## Test plan

- [x] `scripts/ci/test_impact_map.py` — 14 hermetic guilt+innocence tests
      (leaf-selects-narrow, core-module-selects-broadly, nested conftest
      scoping, root conftest selects everything, relative-import
      resolution, e2e subtree exclusion mirroring backend-tests' own
      `--ignore`, and every fail-open trigger) — all green
- [x] `scripts/ci/test_change_map.py` — unmodified logic, still green
      (31 tests)
- [x] `actionlint .github/workflows/tests.yml` — clean (embedded
      shellcheck too)
- [x] `ruff check` — clean
- [x] Local end-to-end simulation of the new bash block (both fail-open and
      scoped paths), including a real `pytest --collect-only` against the
      scoped single-file target
- [x] Measured against 10 real merged PRs total (7 above + 3 fail-open
      cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)