### PR TITLE
docs(portal): declare the helper-call detector's known limit — presence, not dataflow

### DIFF
--- a/apps/backend-rag/backend/tests/unit/services/portal/test_deleted_at_guard_registry.py
+++ b/apps/backend-rag/backend/tests/unit/services/portal/test_deleted_at_guard_registry.py
@@ -147,6 +147,20 @@ def _has_deleted_at_guard(method_node: ast.AST) -> bool:
     current call site uses it — all four mixin files import it directly
     (`from backend.services.portal._document_visibility import
     document_visibility_clause`), never via a module-qualified attribute.
+
+    DECLARED LIMIT (2026-08-21): this is still a SYNTACTIC criterion, not a
+    dataflow one — it checks that the call is PRESENT in the method's own
+    body, not that its return value actually reaches the executed SQL. A
+    method that calls `document_visibility_clause()` and then discards or
+    ignores the result (assigns it to an unused local, passes it to
+    something that never runs, etc.) would still be counted as guarded here.
+    No call site does that today (confirmed by hand for every reader of
+    this file at pin time), but this function cannot prove it and does not
+    try to — the SAME class of gap the helper-call fix above closed for the
+    inline-literal detector (a signal that CORRELATES with the guard,
+    mistaken for the guard itself). Closing this one would mean tracing the
+    call's return value through the f-string construction — worth doing if
+    a future refactor makes the call-but-ignore shape plausible, not before.
     """
     for sub in _iter_own_body(method_node):
         if isinstance(sub, ast.Constant) and isinstance(sub.value, str):


### PR DESCRIPTION
## Summary
Follow-up to #4414. The team-lead's review of that fix flagged a real gap: `_has_deleted_at_guard`'s new helper-call recognition (added to fix a false "guard lost" alarm and surface two real gains — `get_company_detail`/`get_timeline`) is itself a **syntactic** criterion — it checks that `document_visibility_clause()` is *called* in a method's own body, not that the call's return value actually reaches the executed SQL. A method that called the helper and then discarded the result would still be counted as guarded.

- No call site does that today (checked by hand for all 12 registry members).
- Not chasing the dataflow-tracing fix now (would be the "caccia all'infinito" the reviewer explicitly said not to start) — this PR just declares the limit in the docstring so the next reader knows where the protection actually ends.
- Docstring-only change to `_has_deleted_at_guard`. No behavior change, no registry change.

## Test plan
- [x] `PYTHONPATH=. pytest backend/tests/unit/services/portal/test_deleted_at_guard_registry.py -q` — 17/17 pass, unchanged from pre-edit baseline.
- [x] Diff scoped to one docstring addition — no other file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)