### PR TITLE
docs(ci): declare check_watcher_coverage.py's known limit

### DIFF
--- a/scripts/check_watcher_coverage.py
+++ b/scripts/check_watcher_coverage.py
@@ -29,6 +29,21 @@ WHAT IT CHECKS:
      otherwise, which just accumulate forever without being wrong).
   3. The watcher does not list its OWN name (self-trigger risk).
 
+KNOWN LIMIT (not a gap this file closes): the contract above is pure
+name-set membership against the watcher's declared list — it proves a
+workflow is LISTED, not that a failure of that workflow actually reaches
+anyone. A `pull_request`-only workflow (actionlint, hot-zone-enforcement,
+Prettier, Harness floor, and now zantara-core-edit-gate) can never fire
+the `push`/`schedule`-on-main `workflow_run` event the watcher's own
+`alert` job's `if:` requires (see main-push-failure-watch.yml's SCOPE
+comment) — it is listed, this script reports green, and the alert path is
+still structurally unreachable for it. That is by design (the list is
+deliberately over-inclusive so adding a workflow never requires a
+push-vs-pull_request judgment call) but it means green here is narrower
+than it looks: verify alert-path reachability separately for any workflow
+whose failure actually needs a human paged, do not read this script's
+exit 0 as "someone gets told."
+
 Design note carried from the watcher's own build: two live workflow `name:`
 fields are unquoted YAML plain scalars containing " #" (`Golden Rule #10 —
 httpx pattern lint`, `Guard conformance (superscar #3 enforcement)`) — YAML


### PR DESCRIPTION
## Summary
- Follow-up to PR #4519 (actionlint fix): registering a `pull_request`-only workflow in `main-push-failure-watch.yml`'s list satisfies `check_watcher_coverage.py`'s name-set-membership contract, but the workflow's alert path stays structurally unreachable (the watcher only acts on `push`/`schedule`-on-main completions). That's intentional per the watcher's own header, but wasn't stated in the checker's own docstring — a reader could credit its exit 0 with more coverage than it actually proves.
- Adds one docstring paragraph naming the limit explicitly. No behavior change.

Prompted by team-lead feedback on PR #4519: "Un limite da dichiarare, non da chiudere ora... il prossimo lettore saprà dove finisce la protezione invece di crederla totale."

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('scripts/check_watcher_coverage.py').read())"` — syntax OK
- [x] `python3 scripts/check_watcher_coverage.py` — still exits 0, same output as before the docstring change (only comment added)
- [x] Off-limits file check passed in pre-commit hook (no touch to zantara_core.py / fly.toml / .env* / alembic/env.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)