### PR TITLE
docs(cicatrix): W121 — mutation testing running on poisoned bytecode

### DIFF
--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -30,7 +30,7 @@ Famiglia #2: green ≠ working, applicata allo strumento di verifica invece che 
 
 **GOTCHA — non è un difetto di questo ciclo, è di tutti.** Nessun ciclo di mutation in questo repo disattiva la scrittura del bytecode oggi; questa cicatrice è stata trovata perché il caso è caduto dal lato rumoroso. Quelli caduti dal lato silenzioso non hanno lasciato traccia da cercare — è un limite dichiarato di questa entry, non un invito a fidarsi degli esiti passati.
 
-**Reference:** memory `discovery_mutation_testing_can_run_on_poisoned_bytecode_2026_08_21` · parenti diretti [[lesson_a_corpus_can_pass_the_wrong_implementation_too_2026_08_21]] e [[lesson_mutation_guard_save_restore_reference_cannot_catch_shipped_weakness_2026_08_21]] · W107 (la sonda che misura una malattia può averla).
+**Reference:** memory `discovery_mutation_testing_can_run_on_poisoned_bytecode_2026_08_21` · scoperta durante PR #4521 (commit `988684c92`, "mutation-verified 10/10 across both") sul branch `agent/air-m5/ops/vercel-autopromote` — lo stesso worktree `ops-vercel-autopromote` citato sopra · parenti diretti [[lesson_a_corpus_can_pass_the_wrong_implementation_too_2026_08_21]] e [[lesson_mutation_guard_save_restore_reference_cannot_catch_shipped_weakness_2026_08_21]] · W107 (la sonda che misura una malattia può averla).
 
 ---
 

--- a/.claude/rules/cicatrix-scars.md
+++ b/.claude/rules/cicatrix-scars.md
@@ -5,6 +5,35 @@ Each entry has TRAUMA (what went wrong), ANTIBODY (how it's now protected), and 
 
 ---
 
+### 🐛 W121 (P1 STRUCTURAL): il mutation testing girava su BYTECODE AVVELENATO — lo strumento che misura se il corpus morde stava giudicando una versione del codice diversa da quella sul disco
+
+_Scoperto 2026-08-21, worktree `ops-vercel-autopromote`, armando `--promote-only` in `scripts/vercel_prod_deploy.py`. Non cercato: un test è andato ROSSO su codice CORRETTO, e la contraddizione non si scioglieva leggendo il sorgente._
+
+**TRAUMA.** Un ciclo di mutation testing scritto come `muta → pytest → ripristina dal backup` è la forma ovvia e la usiamo dappertutto. Python però valida un `.pyc` confrontando **mtime + size** del sorgente. Due condizioni ordinarie lo rompono insieme: (a) la mutazione non cambia la LUNGHEZZA in byte — `return 1` → `return 0` è il caso tipico, e sono proprio le mutazioni più utili; (b) mutazione e ripristino cadono nello **stesso secondo**, che per un ciclo automatizzato è la norma, non l'eccezione. Allora l'mtime registrato nel `.pyc` combacia ancora, la size pure, e Python **riusa il bytecode MUTATO** contro un sorgente che è tornato corretto.
+
+Misurato sul disco, non dedotto — stesso mtime al secondo, size diverse perché una è il `.py` e l'altra il `.pyc`:
+
+```
+1787297375 24404 scripts/vercel_prod_deploy.py
+1787297375 28345 scripts/__pycache__/vercel_prod_deploy.cpython-311.pyc
+```
+
+**Il sintomo che l'ha rivelato è quello benigno.** Un test asseriva `1`, il sorgente diceva `return 1`, e il `print` immediatamente sopra quel `return` VENIVA ESEGUITO (lo si leggeva nel captured stdout) — cioè il flusso arrivava lì e usciva con un altro valore. Riprodotto fuori da pytest prima di credere a qualunque ipotesi: `RC = 0` con `return 1` sotto gli occhi. Solo allora ho guardato il `__pycache__`.
+
+**Il verso opposto è quello che conta, ed è silenzioso.** Se il `.pyc` bloccato è quello PULITO, la mutazione successiva non viene mai eseguita e lo strumento riporta *«mutante sopravvissuto»* → si va a rinforzare un corpus che stava già benissimo. Se è quello MUTATO, si riporta *«mutante ucciso»* per un test che non ha mai visto la mutazione → **il numero che finisce nel PR body è prodotto dal filesystem, non dal corpus**, e in questo repo quel numero è una delle poche prove che offriamo che un test morda davvero. Nessuno dei due casi lascia un errore, un warning o una riga di log.
+
+Famiglia #2: green ≠ working, applicata allo strumento di verifica invece che a un organo. La cosa che dice «ho controllato» non ha controllato.
+
+**ANTIBODY.** `PYTHONDONTWRITEBYTECODE=1` (o `python3 -B`) su ogni ciclo di mutation, più `-p no:cacheprovider` su pytest. E la regola di condotta, che è la parte non automatizzabile: **un esito di mutation ottenuto senza aver disattivato il bytecode è inaffidabile e si RIFÀ** — non si discute, non si razionalizza, perché la sua invalidità non è osservabile a posteriori. Nel caso vissuto avevo già raccolto 4 esiti «uccisa» prima di accorgermene: li ho rifatti tutti e quattro, ed erano veri — ma non potevo saperlo prima di rieseguirli, ed è esattamente questo il punto.
+
+**GOTCHA — il ripristino con `git checkout --` cancella il lavoro non committato.** Chiudendo il ciclo ho usato `git checkout -- <file>` per «tornare al pulito» dopo l'ultima mutazione: ha riportato il file al COMMIT, che era anteriore a una correzione che avevo appena scritto e non ancora committato, cancellandola in silenzio. Il baseline post-restore è andato a 2 rossi e per un attimo li ho letti come un difetto della cura. Il ripristino di un ciclo di mutation deve venire da un backup del file COM'ERA (`cp`), mai da git: git conosce l'ultimo commit, non lo stato di partenza del ciclo.
+
+**GOTCHA — non è un difetto di questo ciclo, è di tutti.** Nessun ciclo di mutation in questo repo disattiva la scrittura del bytecode oggi; questa cicatrice è stata trovata perché il caso è caduto dal lato rumoroso. Quelli caduti dal lato silenzioso non hanno lasciato traccia da cercare — è un limite dichiarato di questa entry, non un invito a fidarsi degli esiti passati.
+
+**Reference:** memory `discovery_mutation_testing_can_run_on_poisoned_bytecode_2026_08_21` · parenti diretti [[lesson_a_corpus_can_pass_the_wrong_implementation_too_2026_08_21]] e [[lesson_mutation_guard_save_restore_reference_cannot_catch_shipped_weakness_2026_08_21]] · W107 (la sonda che misura una malattia può averla).
+
+---
+
 ### 🐛 W119 (P1 STRUCTURAL): il gruppo di cattura degli argomenti leggeva `\s` come separatore — un `rm -f` di riga 1 è stato accusato del `cd` di riga 6
 
 _Discovered: 2026-08-18, sessione parallela sul repair di `node_modules` (worktree `ops-kita-nav-dead-links`). Non cercato adversarialmente: un comando multi-riga innocuo (riparazione di un symlink rotto sotto `node_modules/`, gitignored) si è visto bloccare con "WORKTREE REMOVAL BLOCKED (dirty + unarmed — scar W80)" nominando l'INTERO worktree corrente come vittima._

--- a/.claude/rules/cicatrix-superscar.md
+++ b/.claude/rules/cicatrix-superscar.md
@@ -63,7 +63,7 @@ access-wall, dev identity su proxy PROD) · W97 (display-cap `[:40]` letto come 
 W101-recidiva-fly-backup (PARTIAL: Fase 2 mai parte) · W104 (`redis-cli` esce 0 con NOAUTH su stdout) ·
 W107 (curato 1 wrapper su 5) · W108 (19/20 cron muti, 2 cause) · W110 (heartbeat sull'organo sbagliato)
 · W116 (allarme su esito giusto, cura codice morto) · W118 (11h fermo, nessun check rosso) · W120
-(sentinella della famiglia stessa disarmata).
+(sentinella della famiglia stessa disarmata) · W121 (mutation su bytecode avvelenato).
 **→ dettaglio:** cicatrix-scars.md (resto) + archive (W34/W32/W64/W69/W71/W74/503) · `scar query "esiste non armato"`
 
 ---

--- a/agent-library/learn/proposals/lesson-proposals.json
+++ b/agent-library/learn/proposals/lesson-proposals.json
@@ -5,13 +5,14 @@
   "_enforcement": "none",
   "recurrence_threshold": 3,
   "totals": {
-    "scars_scanned": 14,
+    "scars_scanned": 15,
     "mechanical_candidates": 9,
     "consultive": 1,
-    "rejected_no_anchor": 4
+    "rejected_no_anchor": 5
   },
   "recurring_patterns": {
     "w_numbers": {
+      "W107": 3,
       "W108": 3,
       "W64": 3,
       "W68": 3,
@@ -113,6 +114,7 @@
       ],
       "recurring_via": {
         "w": [
+          "W107",
           "W108"
         ],
         "family": []
@@ -255,6 +257,10 @@
     },
     {
       "title": "🐛 W117 (P0 STRUCTURAL): la guardia non aveva un buco — non poteva VEDERE il gesto, e a fidarmi del ramo sbagliato avrei scritto codice morto",
+      "reason": "no objective anchor (G1)"
+    },
+    {
+      "title": "🐛 W121 (P1 STRUCTURAL): il mutation testing girava su BYTECODE AVVELENATO — lo strumento che misura se il corpus morde stava giudicando una versione del codice diversa da quella sul disco",
       "reason": "no objective anchor (G1)"
     },
     {

--- a/agent-library/learn/proposals/lesson-proposals.json
+++ b/agent-library/learn/proposals/lesson-proposals.json
@@ -6,9 +6,9 @@
   "recurrence_threshold": 3,
   "totals": {
     "scars_scanned": 15,
-    "mechanical_candidates": 9,
+    "mechanical_candidates": 10,
     "consultive": 1,
-    "rejected_no_anchor": 5
+    "rejected_no_anchor": 4
   },
   "recurring_patterns": {
     "w_numbers": {
@@ -145,6 +145,22 @@
       "note": "Recurring objective pattern (>=3). Candidate for an EXECUTABLE antibody via scar_replay -> test -> SHADOW -> (human-gate) -> enforcement. NOT auto-applied."
     },
     {
+      "title": "🐛 W121 (P1 STRUCTURAL): il mutation testing girava su BYTECODE AVVELENATO — lo strumento che misura se il corpus morde stava giudicando una versione del codice diversa da quella sul disco",
+      "severity": "UNKNOWN",
+      "w_numbers": [
+        "W107",
+        "W121"
+      ],
+      "recurring_via": {
+        "w": [
+          "W107"
+        ],
+        "family": []
+      },
+      "pipeline": "mechanical",
+      "note": "Recurring objective pattern (>=3). Candidate for an EXECUTABLE antibody via scar_replay -> test -> SHADOW -> (human-gate) -> enforcement. NOT auto-applied."
+    },
+    {
       "title": "🐛 W83 (P2 STRUCTURAL): il worktree-isolation hook decide su substring testuale → 3 falsi BLOCK in una sessione (git pull remoto ssh, `cd <worktree> && git`, git-verb dentro una stringa quotata) (2026-06-16)",
       "severity": "P2",
       "w_numbers": [
@@ -257,10 +273,6 @@
     },
     {
       "title": "🐛 W117 (P0 STRUCTURAL): la guardia non aveva un buco — non poteva VEDERE il gesto, e a fidarmi del ramo sbagliato avrei scritto codice morto",
-      "reason": "no objective anchor (G1)"
-    },
-    {
-      "title": "🐛 W121 (P1 STRUCTURAL): il mutation testing girava su BYTECODE AVVELENATO — lo strumento che misura se il corpus morde stava giudicando una versione del codice diversa da quella sul disco",
       "reason": "no objective anchor (G1)"
     },
     {

--- a/agent-library/learn/proposals/lesson-proposals.md
+++ b/agent-library/learn/proposals/lesson-proposals.md
@@ -7,9 +7,9 @@
 > (P7 §3.4). Kill-switch: `LESSON_HARVESTER_OFF=1`.
 
 - scars scanned: **15**
-- mechanical candidates (recurring ≥3): **9**
+- mechanical candidates (recurring ≥3): **10**
 - consultive (single-occurrence): **1**
-- rejected (no objective anchor, G1): **5**
+- rejected (no objective anchor, G1): **4**
 
 ## Recurring patterns (the objective recurrence signal, G4)
 
@@ -35,6 +35,7 @@
 - **✅ W81 (FIXED): i 3 loop di apprendimento WR3 erano "verdi ma vuoti" — malattia-madre "Omeostasi Tautologica" (telemetria-verde ≠ delta-di-stato); F20+F21 curati come codice+test, F18 escalato (2026-06-14)** [P2] — recurring via: W64
 - **🐛 W118 (P0 STRUCTURAL): il repo è stato fermo 11 ore per DUE cause indipendenti che si nascondevano a vicenda, e nessuna delle due lasciava un check rosso da indicare** [UNKNOWN] — recurring via: W107, W108
 - **🐛 W119 (P1 STRUCTURAL): il gruppo di cattura degli argomenti leggeva `\s` come separatore — un `rm -f` di riga 1 è stato accusato del `cd` di riga 6** [UNKNOWN] — recurring via: W84, W85
+- **🐛 W121 (P1 STRUCTURAL): il mutation testing girava su BYTECODE AVVELENATO — lo strumento che misura se il corpus morde stava giudicando una versione del codice diversa da quella sul disco** [UNKNOWN] — recurring via: W107
 - **🐛 W83 (P2 STRUCTURAL): il worktree-isolation hook decide su substring testuale → 3 falsi BLOCK in una sessione (git pull remoto ssh, `cd <worktree> && git`, git-verb dentro una stringa quotata) (2026-06-16)** [P2] — recurring via: W68, W72, W73, W77, W79, W82, W83
 - **🐛 W84 (P2 STRUCTURAL): `_strip_noise` del worktree-isolation hook usa `[^q]*` che MATCHA i newline → in un comando multi-riga una quota orfana (apostrofo IT / apertura `ssh '...'`) si accoppia cross-line, fonde i comandi e fa leakare i pattern grep nello scan redirect → phantom write-target (2026-06-16)** [P2] — recurring via: W68, W72, W73, W77, W79, W82, W83, W84
 - **🐛 W85 (P3 STRUCTURAL): il worktree-isolation hook ha `stash` in `BLOCKED_SUBCMD_RE` senza distinguere il sottocomando → `git stash list` / `git stash show` (read-only) bloccati come se fossero `stash push`/`pop` (2026-06-17)** [P3] — recurring via: W68, W72, W73, W77, W82, W83, W84, W85
@@ -48,5 +49,4 @@
 - 🐛 W111 (P2 STRUCTURAL): `gh run rerun` rigioca un merge-ref STANTIO — «ho rilanciato il check» non è «l'ho testato contro main di adesso» — no objective anchor (G1)
 - 🐛 W112 (P1 STRUCTURAL): il formattatore è uno scrittore che nessuno controlla, e giudica per FORMA — no objective anchor (G1)
 - 🐛 W117 (P0 STRUCTURAL): la guardia non aveva un buco — non poteva VEDERE il gesto, e a fidarmi del ramo sbagliato avrei scritto codice morto — no objective anchor (G1)
-- 🐛 W121 (P1 STRUCTURAL): il mutation testing girava su BYTECODE AVVELENATO — lo strumento che misura se il corpus morde stava giudicando una versione del codice diversa da quella sul disco — no objective anchor (G1)
 - 🚨 P0 SECURITY: `apps/cell/.env` holds prod superuser password in cleartext, readable by plain `cat` (2026-06-03) — no objective anchor (G1)

--- a/agent-library/learn/proposals/lesson-proposals.md
+++ b/agent-library/learn/proposals/lesson-proposals.md
@@ -6,14 +6,15 @@
 > active rule requires shadow-period + zero false-positives + human-gate
 > (P7 §3.4). Kill-switch: `LESSON_HARVESTER_OFF=1`.
 
-- scars scanned: **14**
+- scars scanned: **15**
 - mechanical candidates (recurring ≥3): **9**
 - consultive (single-occurrence): **1**
-- rejected (no objective anchor, G1): **4**
+- rejected (no objective anchor, G1): **5**
 
 ## Recurring patterns (the objective recurrence signal, G4)
 
 **W-numbers seen ≥3×:**
+- `W107` × 3
 - `W108` × 3
 - `W64` × 3
 - `W68` × 3
@@ -32,7 +33,7 @@
 - **⚠️ W80 (P2 STRUCTURAL): il WIP-guard del worktree-cleanup protegge SOLO i worktree sporchi → committare-tutto (per soddisfare stop_verify) rende il proprio worktree reap-eligibile mentre ci lavori ancora (2026-06-13)** [P2] — recurring via: W64, W79
 - **⚠️ W82 (P1 STRUCTURAL): il sentinel di freschezza-conoscenza sorveglia la STRINGA, non il FATTO → under-match: lo stesso fatto stale in tabella / altra formulazione / altra lingua sfugge, e il guardiano resta VERDE (2026-06-16)** [P1] — recurring via: W82
 - **✅ W81 (FIXED): i 3 loop di apprendimento WR3 erano "verdi ma vuoti" — malattia-madre "Omeostasi Tautologica" (telemetria-verde ≠ delta-di-stato); F20+F21 curati come codice+test, F18 escalato (2026-06-14)** [P2] — recurring via: W64
-- **🐛 W118 (P0 STRUCTURAL): il repo è stato fermo 11 ore per DUE cause indipendenti che si nascondevano a vicenda, e nessuna delle due lasciava un check rosso da indicare** [UNKNOWN] — recurring via: W108
+- **🐛 W118 (P0 STRUCTURAL): il repo è stato fermo 11 ore per DUE cause indipendenti che si nascondevano a vicenda, e nessuna delle due lasciava un check rosso da indicare** [UNKNOWN] — recurring via: W107, W108
 - **🐛 W119 (P1 STRUCTURAL): il gruppo di cattura degli argomenti leggeva `\s` come separatore — un `rm -f` di riga 1 è stato accusato del `cd` di riga 6** [UNKNOWN] — recurring via: W84, W85
 - **🐛 W83 (P2 STRUCTURAL): il worktree-isolation hook decide su substring testuale → 3 falsi BLOCK in una sessione (git pull remoto ssh, `cd <worktree> && git`, git-verb dentro una stringa quotata) (2026-06-16)** [P2] — recurring via: W68, W72, W73, W77, W79, W82, W83
 - **🐛 W84 (P2 STRUCTURAL): `_strip_noise` del worktree-isolation hook usa `[^q]*` che MATCHA i newline → in un comando multi-riga una quota orfana (apostrofo IT / apertura `ssh '...'`) si accoppia cross-line, fonde i comandi e fa leakare i pattern grep nello scan redirect → phantom write-target (2026-06-16)** [P2] — recurring via: W68, W72, W73, W77, W79, W82, W83, W84
@@ -47,4 +48,5 @@
 - 🐛 W111 (P2 STRUCTURAL): `gh run rerun` rigioca un merge-ref STANTIO — «ho rilanciato il check» non è «l'ho testato contro main di adesso» — no objective anchor (G1)
 - 🐛 W112 (P1 STRUCTURAL): il formattatore è uno scrittore che nessuno controlla, e giudica per FORMA — no objective anchor (G1)
 - 🐛 W117 (P0 STRUCTURAL): la guardia non aveva un buco — non poteva VEDERE il gesto, e a fidarmi del ramo sbagliato avrei scritto codice morto — no objective anchor (G1)
+- 🐛 W121 (P1 STRUCTURAL): il mutation testing girava su BYTECODE AVVELENATO — lo strumento che misura se il corpus morde stava giudicando una versione del codice diversa da quella sul disco — no objective anchor (G1)
 - 🚨 P0 SECURITY: `apps/cell/.env` holds prod superuser password in cleartext, readable by plain `cat` (2026-06-03) — no objective anchor (G1)


### PR DESCRIPTION
## What happened

While arming `--promote-only` in #4521, a test went **red against correct source**: it asserted `1`, the source read `return 1`, and the `print` immediately above that `return` was visibly executing in the captured stdout. Reproduced outside pytest before believing any hypothesis — `RC = 0` with `return 1` on screen — and only then looked at `__pycache__`.

Python validates a `.pyc` on **mtime + size**. Two ordinary conditions break it together:

- the mutation does not change byte length — `return 1` → `return 0`, which is the useful kind;
- mutation and restore land in the **same second**, which for an automated loop is the norm.

Both matched, measured on disk:

```
1787297375 24404 scripts/vercel_prod_deploy.py
1787297375 28345 scripts/__pycache__/vercel_prod_deploy.cpython-311.pyc
```

## Why it is worth a scar and not just a note

The loud direction is what surfaced it. The **silent** direction is the one that matters: if the pinned bytecode is the clean one, the mutation never runs and the tool reports *"mutant survived"*; if it is the mutated one, it reports *"mutant killed"* for a test that never saw the mutation. Either way the number that ends up in a PR body is produced by the filesystem rather than by the corpus — and in this repo that number is one of the few proofs we offer that a test bites at all. No error, no warning, no log line.

Family **#2** (green ≠ working), pointed at the verification tool instead of at an organ.

## Antibody

`PYTHONDONTWRITEBYTECODE=1` (or `python3 -B`) on every mutation cycle, plus `-p no:cacheprovider`. And the part that cannot be automated: **a mutation result obtained without disabling bytecode is unreliable and gets re-run** — not argued about, because its invalidity is not observable after the fact. In the lived case four "killed" results had already been collected; re-run, all four were true, but that could not be known beforehand.

Two gotchas recorded in the body:

- **Restoring with `git checkout --` destroys uncommitted work.** Closing the loop that way reverted the file to the *commit*, silently discarding a fix written minutes earlier and not yet committed. A mutation loop's restore must come from a `cp` backup of the file as it was, never from git.
- **This is not a defect of one loop.** No mutation cycle in this repo disables bytecode writing today. This scar exists because the case happened to fall on the noisy side; the ones that fell on the silent side left nothing to look for. Stated as a limit of the entry, not as a reason to trust past results.

## Budget note

Body in `cicatrix-scars.md`. One member line added to the family-#2 list in the bridge, which is now at **13,988 of its 14,000-byte budget** — the next scar will not fit without trimming something first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)