### PR TITLE
fix(arsenal): qwen_quota_watch_cron.sh stops silently dropping Pro on Mini

### DIFF
--- a/scripts/qwen_quota_watch_cron.sh
+++ b/scripts/qwen_quota_watch_cron.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
-# qwen_quota_watch_cron.sh — cron payload for cron-runner.sh (Pro, daily).
+# qwen_quota_watch_cron.sh — cron payload for cron-runner.sh (daily; deployed
+# on Mini as of 2026-08-21 — Pro's ssh shell lacks Full Disk Access, so a
+# crontab write there fails EPERM; TCC, not Unix permissions).
 #
 # cron-runner executes payloads with /bin/bash, so the python watcher needs
 # this thin wrapper. It lives IN THE REPO and the crontab line points here
 # directly (never a ~/scripts copy — superscar #1 HOME-fork).
+#
+# Deliberately does NOT pass --hosts: the watcher's own default
+# ("pro,mini,air") already self-skips whichever host it is running ON
+# (qwen_quota_watch.py main(), "skip the alias that is THIS machine"), so the
+# union always covers exactly the 3 hosts regardless of which machine
+# cron-runner executes this on. An earlier revision hardcoded --hosts
+# mini,air (correct only when executed FROM Pro, where local=pro completes
+# the union) — moving the cron to Mini made local=mini, and Pro was then
+# silently omitted: not even flagged MISSED, since it was never queried at
+# all. Caught 2026-08-21 by comparing a live run's total against a
+# known-good cross-host figure before arming this cron on the new host.
 #
 # Exit-code mapping (deliberate, W104-aware): the watcher's 1 (WARN) and
 # 2 (CRIT) mean "threshold crossed AND the Telegram alert was already
@@ -23,7 +36,7 @@ if [ ! -f "$WATCHER" ]; then
     exit 66  # armed-to-nothing must be a loud receipt, never a silent green (W81)
 fi
 
-/usr/bin/env python3 "$WATCHER" --hosts mini,air --alert
+/usr/bin/env python3 "$WATCHER" --alert
 rc=$?
 echo "qwen_quota_watch_cron: watcher rc=$rc" >&2
 case "$rc" in


### PR DESCRIPTION
## Summary
- The cron wrapper hardcoded `--hosts mini,air`, correct only when executed FROM Pro (where local=pro completes the union of all 3 hosts). Discovered while arming the qwen quota-watch cron on **Mini** instead of Pro (Pro's ssh shell lacks Full Disk Access — `crontab <file>` fails EPERM/TCC, not Unix permissions).
- On Mini, local=mini + remote=air only, so Pro was **never queried at all** — not even flagged `MISSED`, since it wasn't in the host list to begin with.
- Live proof: a manual run on Mini reported `hosts covered: local,air`, total `71,411,936` tok. Querying Pro directly in the same window returned `8,144,402`. `71,411,936 + 8,144,402 = 79,556,338` — the same fleet-wide figure already independently measured from other machines, confirming Pro was the missing piece.

## Fix
Drop the `--hosts` override entirely and rely on `qwen_quota_watch.py`'s own default (`pro,mini,air`), which already self-skips whichever host it is running on (`main()`, "skip the alias that is THIS machine"). This makes the wrapper portable to whichever machine `cron-runner.sh` executes it on, instead of encoding an assumption about the deployment host.

## Test plan
- [x] `bash -n scripts/qwen_quota_watch_cron.sh` — syntax OK
- [x] Manual run on Mini before the fix reproduced the undercount (documented above)
- [x] Manual `read_remote("pro", now)` call on Mini confirmed Pro is reachable and returns real data once queried
- [ ] Post-merge: re-run the wrapper on Mini and confirm `hosts covered: local,pro,air` (3 hosts) before arming the daily cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)