### PR TITLE
fix(arsenal): qwen quota cron wrapper silently dropped a host from its own coverage

### DIFF
--- a/scripts/qwen_quota_watch_cron.sh
+++ b/scripts/qwen_quota_watch_cron.sh
@@ -17,10 +17,11 @@
 # whole coverage contract, so it is derived, not chosen.
 #
 # REPO PATH — derived from this script's own location, because the checkout
-# path differs per machine (Mini: ~/nuzantara · Pro: ~/Desktop/nuzantara) and
-# a hardcoded path is a machine-specific landmine: the previous literal
-# `/Users/nuzantara/nuzantara` was correct on Mini and exit-66 on the very
-# host the header claimed it was for.
+# path differs per machine and Pro is mid-migration (its crontab still points
+# mostly at the old Desktop-rooted checkout, a minority at the migrated one —
+# superscar #1 HOME-fork drift) — a hardcoded path is a machine-specific
+# landmine: the previous literal `/Users/nuzantara/nuzantara` was correct on
+# Mini and exit-66 on the very host the header claimed it was for.
 #
 # Exit-code mapping (deliberate, W104-aware): the watcher's 1 (WARN) and
 # 2 (CRIT) mean "threshold crossed AND the Telegram alert was already

--- a/scripts/qwen_quota_watch_cron.sh
+++ b/scripts/qwen_quota_watch_cron.sh
@@ -1,9 +1,26 @@
 #!/usr/bin/env bash
-# qwen_quota_watch_cron.sh — cron payload for cron-runner.sh (Pro, daily).
+# qwen_quota_watch_cron.sh — cron payload for cron-runner.sh (Mini, daily).
 #
 # cron-runner executes payloads with /bin/bash, so the python watcher needs
 # this thin wrapper. It lives IN THE REPO and the crontab line points here
 # directly (never a ~/scripts copy — superscar #1 HOME-fork).
+#
+# HOST LIST — pass ALL THREE aliases, never a hand-picked subset. The watcher
+# already skips whichever alias names the machine it is running on (see
+# qwen_quota_watch.py's local_host checks), so `pro,mini,air` yields full
+# fleet coverage from ANY host. The first version of this file hardcoded
+# `mini,air` because it was written for Pro, where that happens to be the
+# complement; run on Mini the same list silently omitted Pro and reported
+# 71,411,936 tokens against the true 79,556,338 — and reported it as a
+# COMPLETE reading, because a host that is never in the list never appears
+# in the "MISSED:" line either. A narrowed host list defeats the watcher's
+# whole coverage contract, so it is derived, not chosen.
+#
+# REPO PATH — derived from this script's own location, because the checkout
+# path differs per machine (Mini: ~/nuzantara · Pro: ~/Desktop/nuzantara) and
+# a hardcoded path is a machine-specific landmine: the previous literal
+# `/Users/nuzantara/nuzantara` was correct on Mini and exit-66 on the very
+# host the header claimed it was for.
 #
 # Exit-code mapping (deliberate, W104-aware): the watcher's 1 (WARN) and
 # 2 (CRIT) mean "threshold crossed AND the Telegram alert was already
@@ -15,7 +32,8 @@
 # the states where the watcher could NOT speak for itself.
 set -uo pipefail
 
-REPO="/Users/nuzantara/nuzantara"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
 WATCHER="$REPO/scripts/qwen_quota_watch.py"
 
 if [ ! -f "$WATCHER" ]; then
@@ -23,7 +41,7 @@ if [ ! -f "$WATCHER" ]; then
     exit 66  # armed-to-nothing must be a loud receipt, never a silent green (W81)
 fi
 
-/usr/bin/env python3 "$WATCHER" --hosts mini,air --alert
+/usr/bin/env python3 "$WATCHER" --hosts pro,mini,air --alert
 rc=$?
 echo "qwen_quota_watch_cron: watcher rc=$rc" >&2
 case "$rc" in

--- a/scripts/tests/test_qwen_quota_cron_wrapper.sh
+++ b/scripts/tests/test_qwen_quota_cron_wrapper.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Guilt + innocence for scripts/qwen_quota_watch_cron.sh.
+#
+# The defect this pins (found by prove-live on Mini, 2026-08-21, before the
+# cron was armed): the wrapper hardcoded `--hosts mini,air`, which is Pro's
+# complement. Run on Mini it therefore never even ATTEMPTED Pro and reported
+# 71,411,936 tokens as a complete reading against the true 79,556,338 — with
+# no "MISSED:" line, because a host absent from the list is never missed, it
+# is simply never asked about. That is a silent coverage hole in the one tool
+# whose entire contract is to declare its coverage.
+#
+# Guilt   : narrowing the host list, or hardcoding a machine-specific repo
+#           path, must fail.
+# Innocence: the shipped wrapper passes.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/qwen_quota_watch_cron.sh"
+fails=0
+
+check() {  # check <label> <expect-pass|expect-fail> <file>
+    local label="$1" expect="$2" file="$3" rc=0
+    # The wrapper must ask for all three fleet aliases; the watcher self-skips
+    # whichever one names the running host, so this is the only list that is
+    # correct from every machine.
+    grep -Eq -- '--hosts[[:space:]]+pro,mini,air' "$file" || rc=1
+    # And it must not carry a literal checkout path: Mini is ~/nuzantara,
+    # Pro is ~/Desktop/nuzantara, so any literal is wrong on some host.
+    grep -Eq 'REPO="?/Users/' "$file" && rc=1
+    if [ "$expect" = "expect-pass" ] && [ "$rc" -ne 0 ]; then
+        echo "FAIL[$label]: shipped wrapper rejected (rc=$rc)"; fails=$((fails+1))
+    elif [ "$expect" = "expect-fail" ] && [ "$rc" -eq 0 ]; then
+        echo "FAIL[$label]: mutant accepted — the check does not bite"; fails=$((fails+1))
+    else
+        echo "ok[$label]"
+    fi
+}
+
+[ -f "$WRAPPER" ] || { echo "FAIL: wrapper missing at $WRAPPER"; exit 1; }
+
+# innocence — the real file
+check innocence expect-pass "$WRAPPER"
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+# guilt 1 — the exact historical defect: Pro's complement, run anywhere else
+sed 's/--hosts pro,mini,air/--hosts mini,air/' "$WRAPPER" > "$tmp/narrowed.sh"
+check guilt-narrowed-host-list expect-fail "$tmp/narrowed.sh"
+
+# guilt 2 — a machine-specific checkout path
+sed 's#^REPO=.*#REPO="/Users/nuzantara/nuzantara"#' "$WRAPPER" > "$tmp/hardcoded.sh"
+check guilt-hardcoded-repo-path expect-fail "$tmp/hardcoded.sh"
+
+# the wrapper must also still be valid bash
+bash -n "$WRAPPER" || { echo "FAIL: wrapper is not valid bash"; fails=$((fails+1)); }
+
+[ "$fails" -eq 0 ] && { echo "PASS (1 innocence, 2 guilt)"; exit 0; }
+echo "FAILED: $fails"; exit 1

--- a/scripts/tests/test_qwen_quota_cron_wrapper.sh
+++ b/scripts/tests/test_qwen_quota_cron_wrapper.sh
@@ -25,7 +25,8 @@ check() {  # check <label> <expect-pass|expect-fail> <file>
     # correct from every machine.
     grep -Eq -- '--hosts[[:space:]]+pro,mini,air' "$file" || rc=1
     # And it must not carry a literal checkout path: Mini is ~/nuzantara,
-    # Pro is ~/Desktop/nuzantara, so any literal is wrong on some host.
+    # Pro is mid-migration between a Desktop-rooted checkout and that same
+    # path, so any literal is wrong on some host.
     grep -Eq 'REPO="?/Users/' "$file" && rc=1
     if [ "$expect" = "expect-pass" ] && [ "$rc" -ne 0 ]; then
         echo "FAIL[$label]: shipped wrapper rejected (rc=$rc)"; fails=$((fails+1))


### PR DESCRIPTION
## Caught by prove-live, before arming

The wrapper hardcoded `--hosts mini,air`. That is **Pro's complement** — right on the machine the header claimed the file was for, wrong everywhere else. Run on Mini it never even *attempted* Pro:

| invocation on Mini | hosts covered | tokens |
|---|---|---|
| `bash scripts/qwen_quota_watch_cron.sh` (2/2 runs) | `local,air` | **71,411,936** |
| `python3 scripts/qwen_quota_watch.py` (direct) | `local,pro,air` | **79,556,338** |

Reproducible, not transient — two wrapper runs and one direct run back to back on the same box, with `ssh pro` and the remote `cat` both verified working from Mini at the time.

## Why the missing 8M tokens is the smaller half

The watcher's entire contract is to **declare its coverage**, and to exit 4 rather than claim "0% used" when it cannot measure. A narrowed host list defeats exactly that: **a host absent from the list is never `MISSED:`, it is simply never asked about**, so the run looks complete and the `hosts covered` line reads like a full reading. An alert armed on this would have been quietly blind to Pro — the workhorse — while looking healthy.

## Fix

- **Pass all three aliases** (`pro,mini,air`) and let the watcher's existing self-skip drop whichever names the running host. Correct from *every* machine, so the list stops being a per-host choice somebody has to get right.
- **Derive `REPO` from `BASH_SOURCE`** instead of the literal `/Users/nuzantara/nuzantara`. Checkout paths differ per machine (Mini `~/nuzantara`, Pro `~/Desktop/nuzantara`), so that literal was simultaneously correct on Mini and `exit 66` on Pro — the host it was written for. Deriving it also keeps the HOME-fork property: the wrapper uses the repo it actually lives in.

## Tests

`scripts/tests/test_qwen_quota_cron_wrapper.sh` — 1 innocence + 2 guilt mutants:

- innocence: the shipped wrapper passes.
- guilt: the exact historical narrowed list (`--hosts mini,air`) is rejected.
- guilt: a re-hardcoded `REPO="/Users/..."` is rejected.

Both mutants pass when the checks are removed, so the checks bite.

## Context

Follow-up to #4502. The cron line is not armed yet — this had to land first, since arming the previous wrapper would have installed a daily alert running on a structural undercount that announced itself as complete.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)