### PR TITLE
fix(visa-engine-tests): teach shadow_schema about migration 264, in setup only

### DIFF
--- a/apps/backend-rag/backend/tests/services/visa_engine/conftest.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/conftest.py
@@ -424,6 +424,34 @@ ALTER TABLE IF EXISTS public.visa_decisions
 """
 
 
+async def tables_exist(conn: asyncpg.Connection, *table_names: str) -> bool:
+    """True iff every named table in the ``public`` schema currently exists.
+
+    Shared home for a guard three fixtures in this directory need, so the fourth
+    does not have to rediscover it. Migrations after 252 are NOT written to the
+    "safe regardless of current state" standard 250-257 are: several statements in
+    264 are bare ``ALTER TABLE`` / ``DROP TRIGGER ... ON <table>`` / ``CREATE
+    TRIGGER`` forms that require their target table to already exist (Postgres has
+    no ``ALTER TABLE IF EXISTS ... DROP COLUMN IF EXISTS``). On a shared xdist-worker
+    clone another file may have torn one of those tables down without restoring it,
+    so running such a rollback unconditionally raises ``UndefinedTableError`` instead
+    of being a no-op. Guard with this, and check only the tables that migration's own
+    SQL touches unconditionally.
+
+    ``test_shadow_evidence.py`` carries its own private copy of this predicate,
+    written first; it is deliberately left alone here (it is green and its xdist
+    interactions cannot be exercised outside a full ``visa_engine/`` run) rather than
+    refactored from under a working fixture.
+    """
+    return bool(
+        await conn.fetchval(
+            "SELECT bool_and(to_regclass('public.' || name) IS NOT NULL) "
+            "FROM unnest($1::text[]) AS name",
+            list(table_names),
+        )
+    )
+
+
 def _read_migration_250() -> tuple[str, str]:
     """Return (forward_sql, rollback_sql) for migration 250.
 

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_evidence.py
@@ -237,12 +237,18 @@ async def shadow_evidence_schema(db_pool: asyncpg.Pool, visa_schema: None) -> As
     migration 264 in `_schema_versions` (executed_at recorded) while the
     physical `visa_decision_legal_hold_events` table is absent — the same
     out-of-band, ledger-diverging teardown happened here too, at some
-    point, from ordinary local test runs. Files that touch
-    `visa_decision_legal_hold_events` via raw SQL without restoring it (not
-    fixed here — a separate question, left for whoever picks this up
-    next): ``test_write_substrate.py``, ``test_evaluate_endpoint.py``,
-    ``test_privacy_operations.py`` (all under
-    ``backend/tests/services/visa_engine/``).
+    point, from ordinary local test runs. Files that reference
+    `visa_decision_legal_hold_events` (all under
+    ``backend/tests/services/visa_engine/``): only ``test_evaluate_endpoint.py``,
+    whose own ``evaluate_schema`` fixture already rolls 264 back existence-guarded
+    and re-applies its forward, so it is not a source of the damage. Re-measured
+    2026-08-21 against the current tree while teaching ``test_shadow_match.py`` the
+    same lesson: ``test_write_substrate.py`` and ``test_privacy_operations.py``,
+    named here when this note was written, carry ZERO occurrences of
+    ``legal_hold_events`` or ``264`` — the first provisions its own private
+    per-test database and never reads migration 264, the second opens no database
+    connection at all. Left uncorrected, this sentence sends whoever picks this up
+    next hunting two innocent files.
     """
     forward_252, rollback_252 = _read_migration(_MIGRATION_252_PATH, 252)
     forward_255, rollback_255 = _read_migration(_MIGRATION_255_PATH, 255)

--- a/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_match.py
+++ b/apps/backend-rag/backend/tests/services/visa_engine/test_shadow_match.py
@@ -52,6 +52,7 @@ from backend.services.visa_engine.enums import UnknownReason, VisaPurpose
 from backend.services.visa_engine.models import RulePack
 from backend.services.visa_engine.repository import VisaEngineRepository
 from backend.tests.services.visa_engine import _builders as builders
+from backend.tests.services.visa_engine.conftest import tables_exist
 from backend.tests.services.visa_engine.gold_harness import loader as gold_loader
 from backend.tests.services.visa_engine.test_repository import (
     _ENV,
@@ -516,6 +517,9 @@ class TestMaybeSpawnShadowMatch:
 _BACKEND_DIR = Path(__file__).resolve().parents[3]
 _MIGRATION_252_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "252_visa_engine_write_substrate.sql"
 _MIGRATION_255_PATH = _BACKEND_DIR / "db" / "migrations_v2" / "255_visa_shadow_evidence.sql"
+_MIGRATION_264_PATH = (
+    _BACKEND_DIR / "db" / "migrations_v2" / "264_visa_decision_retention_policy.sql"
+)
 
 
 def _read_migration_252() -> tuple[str, str]:
@@ -532,19 +536,105 @@ def _read_migration_255() -> tuple[str, str]:
     return forward, rollback
 
 
+def _read_migration_264() -> tuple[str, str]:
+    sql = _MIGRATION_264_PATH.read_text(encoding="utf-8")
+    forward, rollback = split_migration_sql(sql)
+    assert rollback, "migration 264 must carry a '-- === ROLLBACK ===' section"
+    return forward, rollback
+
+
 @pytest_asyncio.fixture
 async def shadow_schema(db_pool: asyncpg.Pool, visa_schema: None) -> AsyncIterator[None]:
+    """Layers migrations 252+255 on conftest.py's visa_schema.
+
+    264's rollback runs FIRST **in setup only** — the real forward-migration order in
+    reverse, which this fixture already followed for 255-before-252 and simply never
+    extended. Migration 264 landed long after 252/255 and puts TWO blockers in front of
+    252's rollback:
+
+      * ``visa_decision_legal_hold_events.decision_row_id`` is a foreign key back to
+        ``visa_decisions``, so 252's bare ``DROP TABLE public.visa_decisions`` fails
+        with ``DependentObjectsStillExistError``; and
+      * four MORE tables 264 adds (``visa_decision_retention_policies``,
+        ``visa_decision_retention_batches``, ``visa_idempotency_retention_batches``,
+        ``visa_decision_dsr_erasure_batches``) hang ``no_wipe``/``immutable`` triggers
+        off ``reject_visa_write_substrate_mutation()`` — the function 252's rollback
+        drops unconditionally at its end. Solving only the FK moves the failure to the
+        function drop rather than removing it; both were measured, in that order, on a
+        disposable full-head database before this fixture was touched.
+
+    252's rollback below stays a bare DROP with no CASCADE, deliberately: a CASCADE
+    would silently swallow the NEXT migration that FKs onto ``visa_decisions``, which is
+    the same silent tolerance that hid this one.
+
+    **Setup only, and this is load-bearing.** 264's rollback carries unconditional
+    ``CREATE TRIGGER visa_decisions_immutable`` / ``visa_decision_payloads_guard``
+    statements: it restores the 252-era triggers that 264's forward had replaced, so it
+    is only valid against a schema that is CURRENTLY 264-shaped. Going into teardown the
+    schema is 252+255-shaped — setup deliberately does not re-apply ``forward_264``
+    before ``yield`` (it would re-arm ``visa_decisions_retention_binding``, a BEFORE
+    INSERT trigger demanding an active row in ``visa_decision_retention_policies`` this
+    fixture never seeds, breaking every raw INSERT in this file) — and ``forward_252``
+    has just recreated ``visa_decisions_immutable``. Calling ``rollback_264`` there
+    raises ``DuplicateObjectError`` on EVERY run, aborting teardown before any of
+    ``rollback_255``/``rollback_252``/the forwards can run and leaving the shared clone
+    missing all five of 264's tables — the exact clone-poisoning this fixture exists to
+    stop. Measured on a bone-fresh full-head database; do not "symmetrise" the two
+    branches.
+
+    264's forward IS re-applied at the end of teardown, after this fixture's own forward
+    SQL has put ``visa_decisions`` back, so the worker's clone returns to true head shape
+    (252→255→264) for whichever file shares it next rather than inheriting a silent gap.
+
+    The 264 calls are existence-guarded on two DIFFERENT questions, because one predicate
+    cannot answer both. ``retention_present`` asks whether 264 is the active shape at all
+    (skip cleanly when it was never applied). ``rollback_264_runnable`` asks whether the
+    tables 264's own rollback touches unconditionally are present — 264's SQL is not
+    written to the "safe regardless of current state" standard 250-257 are, and Postgres
+    has no ``ALTER TABLE IF EXISTS ... DROP COLUMN IF EXISTS``, so an unconditional call
+    against a clone another file has disturbed raises ``UndefinedTableError``. When 264
+    IS active but its rollback cannot run, this fixture FAILS LOUDLY naming that state:
+    the tempting alternative — skipping the rollback — leaves the legal-hold FK in place
+    and hands the very next statement the original ``DependentObjectsStillExistError``,
+    i.e. silently reintroduces the bug this fixture exists to fix, under a different
+    cause. Measured: dropping the unrelated 262 table ``visa_evaluate_idempotency`` is
+    enough to trigger it.
+    """
     forward_252, rollback_252 = _read_migration_252()
     forward_255, rollback_255 = _read_migration_255()
+    forward_264, rollback_264 = _read_migration_264()
     async with db_pool.acquire() as conn:
+        retention_present = await tables_exist(conn, "visa_decision_legal_hold_events")
+        rollback_264_runnable = await tables_exist(
+            conn, "visa_decisions", "visa_decision_payloads", "visa_evaluate_idempotency"
+        )
+        if retention_present:
+            if not rollback_264_runnable:
+                raise RuntimeError(
+                    "migration 264 is applied on this database (visa_decision_legal_hold_events "
+                    "exists) but the tables its rollback edits unconditionally are not all "
+                    "present, so 264 cannot be rolled back and migration 252's DROP TABLE "
+                    "visa_decisions would fail on 264's foreign key. Some other test file tore "
+                    "part of 264 down without restoring it. Recreate this worker's clone from a "
+                    "full-head template."
+                )
+            await conn.execute(rollback_264)
         await conn.execute(rollback_255)
         await conn.execute(rollback_252)
         await conn.execute(forward_252)
         await conn.execute(forward_255)
     yield
     async with db_pool.acquire() as conn:
+        # NO rollback_264 here — see the docstring. The schema is 252+255-shaped at this
+        # point and 264's rollback would collide with the triggers forward_252 recreated.
         await conn.execute(rollback_255)
         await conn.execute(rollback_252)
+        await conn.execute(forward_252)
+        await conn.execute(forward_255)
+        # Only visa_evaluate_idempotency's state is outside this fixture's control here —
+        # forward_252 just recreated the other two tables 264's forward needs.
+        if await tables_exist(conn, "visa_evaluate_idempotency"):
+            await conn.execute(forward_264)
 
 
 def _seed_gold_rule_pack_row(*, raw: dict, signature_seed: bytes) -> dict:


### PR DESCRIPTION
## The failure

`test_shadow_match.py::shadow_schema` runs migration 252's rollback, which contains a bare `DROP TABLE public.visa_decisions`. Migration 264 hangs a foreign key on that table from `visa_decision_legal_hold_events`, so on any worker clone carrying 264 the fixture dies **at setup**:

```
asyncpg.exceptions.DependentObjectsStillExistError: cannot drop table visa_decisions because other objects depend on it
DETAIL: constraint visa_decision_legal_hold_events_decision_row_id_fkey on table visa_decision_legal_hold_events depends on table visa_decisions
```

CI runs `-x`, so this **halts the whole xdist session**. It hit PR #4536 twice in a row — a PR whose diff touches six files, none of them backend.

It is intermittent because it depends on whether another file on the same worker happened to tear 264's tables down first. `test_shadow_evidence.py`'s docstring records the same discovery from the other side: before per-worker clones, that accidental damage is what kept these fixtures green. **The isolation change did not break them — it stopped them being rescued.**

## The FK is only the first blocker

252's rollback also drops `reject_visa_write_substrate_mutation()`, and 264 reuses that same function on 8 triggers across 5 tables it creates. Removing only the FK **moves** the failure to the function drop rather than removing it — measured in that order on a disposable full-head database before anything was written. Rolling 264 back first removes both.

## Setup only, and that asymmetry is the fix

264's rollback carries unconditional `CREATE TRIGGER visa_decisions_immutable` / `visa_decision_payloads_guard`: it restores what 264's forward replaced, so it is valid only against a *currently-264-shaped* schema. At teardown the schema is 252+255-shaped and `forward_252` has just recreated that trigger, so calling it there raises `DuplicateObjectError` **on every run**, aborting teardown before the forwards and leaving the clone missing all five of 264's tables.

The first version of this fix did exactly that — symmetric, plausible, wrong, and reproducing the very disease it was written to cure one migration deeper. The sibling it follows never called it in teardown; the deviation was invented here and caught only by **running** it.

## The guard asks two questions, because one predicate cannot answer both

- `retention_present` — is 264 the active shape at all (skip cleanly when it was never applied).
- `rollback_264_runnable` — are the tables 264's rollback edits unconditionally present (its SQL is not written to the "safe regardless of state" standard 250-257 are).

When 264 **is** active but its rollback cannot run, the fixture now fails loudly naming that state. The tempting alternative — skip the rollback — leaves the FK in place and hands the next statement the original error: it silently reintroduces the bug under a different cause. Dropping the *unrelated* migration-262 table `visa_evaluate_idempotency` is enough to reach it. That was the second defect in the first version.

264's forward is re-applied at the end of teardown, so the clone returns to true head for whichever file shares the worker next.

## Verification — disposable full-head databases, never a shared one

| | Result |
|---|---|
| Pristine files, full-head DB | reproduces the CI error verbatim, at setup |
| Fixed files | 31 passed, 0 errors |
| Run twice on one DB | passes both times |
| Clone after two runs | all five 264 tables present — true head, not 252+255 |
| DB that never had 264 | passes untouched; the new `RuntimeError` cannot fire there |
| Adversarial `DROP TABLE visa_evaluate_idempotency CASCADE` | named `RuntimeError`, not `DependentObjectsStillExistError` |
| Mutation: re-insert the teardown call | reproduces `DuplicateObjectError` on demand |

That last row is the one that matters: the "do not symmetrise the two branches" warning in the docstring is load-bearing, and undoing it reproduces the bug.

## Also in here

`tables_exist` moves to `conftest.py` so the fourth file does not rediscover it. `test_shadow_evidence.py`'s own copy is deliberately left alone — it is green and its xdist interactions cannot be exercised outside a full `visa_engine/` run.

And a stale pointer corrected in that sibling's docstring: it names `test_write_substrate.py` and `test_privacy_operations.py` as files that damage 264's tables. Re-measured against the current tree, **both carry zero occurrences** of `legal_hold_events` or `264` — the first provisions its own private per-test database, the second opens no connection at all. Only `test_evaluate_endpoint.py` remains, and it already handles 264 itself. That sentence invites whoever picks this up next to follow it, and it was sending them to two innocent files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)