### PR TITLE
docs(mouth): merging to main does not put your code on balizero.com

### DIFF
--- a/apps/mouth/README.md
+++ b/apps/mouth/README.md
@@ -23,9 +23,30 @@ npm run dev
 # Build for production
 npm run build
 
-# Deploy to Vercel
-git push origin main  # Auto-deploys via GitHub integration
+# Reach production
+git push origin main   # builds — see the note below, this is NOT the whole story
 ```
+
+> **Merging to main does not put your code on balizero.com.** Vercel builds the commit and
+> leaves the deployment `STAGED`: built, reachable at its own preview URL, and **not** aliased
+> to any custom domain. Nothing repoints the domains on its own. Measured 2026-08-21: roughly
+> ninety consecutive deployments over two days had built and none had gone live, while
+> production served a commit ~22 hours old — and the same project serves every subdomain
+> (`kita`/`my`/`prime`/`visa`/`tax`/`zantara`), so all of them were stale together.
+>
+> The promote now happens by itself, on a cron on Mini (`mini.vercel_autopromote`, every 15
+> minutes): it finds the newest commit on main that can change the bundle, checks whether
+> production already carries it, and promotes the existing READY build — it never rebuilds.
+> Expect your merge to be live within ~15 minutes, not instantly.
+>
+> To do it by hand from a machine where `vercel whoami` answers:
+> `python3 scripts/vercel_prod_deploy.py --dry-run` reports the gap and changes nothing;
+> without `--dry-run` it promotes, and builds only if no READY build exists.
+> `--promote-only` promotes what is there and refuses to build — the mode the cron runs.
+>
+> Commits that touch no frontend path are deliberately **not** built at all
+> (`scripts/ci/vercel_should_build.sh`), so most merges to main produce no deployment and need
+> no promote.
 
 **Default URLs:**
 


### PR DESCRIPTION
## Why

The README's deploy block said:

```
git push origin main  # Auto-deploys via GitHub integration
```

That is the belief that cost a colleague two days this week. He watched ~90 consecutive deployments build and never reach Ready, and reasonably concluded a GitHub required status check was hanging and never reporting back.

Nothing was hanging. Vercel builds the commit and leaves the deployment `readySubstate: STAGED` — built, reachable at its own preview URL, **never aliased to a custom domain** — and nothing repointed the domains. Production was serving a commit ~22 hours old, on every subdomain at once, because `kita`/`my`/`prime`/`visa`/`tax`/`zantara` are all the same Vercel project.

The README is now correct, and says what actually happens today:

- a merge is live within **~15 minutes**, not instantly — the promote runs unattended on Mini (`mini.vercel_autopromote`), finds the newest bundle-relevant commit, and promotes the existing READY build without ever rebuilding;
- the manual path (`scripts/vercel_prod_deploy.py`, `--dry-run` / `--promote-only`);
- why most merges produce no deployment at all — the ignored-build step skips commits touching no frontend path.

## Scope

Documentation only. Nothing in this diff can change what a browser receives.

It does touch `apps/mouth/`, so it is bundle-relevant by `FRONTEND_RE` and will produce a real production build — deliberately: this PR is also the induced end-to-end proof that the auto-promote organ can *act*, not only observe. Its promote branch has never run unattended, because production has been current every time it looked. Expect a `PROMOTED` line in Mini's `~/logs/mini-vercel_autopromote/run.log` and `balizero.com/api/health` moving to this commit within ~15 minutes of merge, with nobody running anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)