### PR TITLE
docs(harness): the gate's own header claimed a promotion that had already happened

### DIFF
--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -82,10 +82,45 @@ name: Harness floor recompute
 # `workflow_dispatch:` trigger below exists for exactly this) — never a bare `gh run rerun` on
 # this run's own stale object (CLAUDE.md Agent PR Contract rule 3 / cicatrix W111).
 #
-# ARMING NOTE (operator/session): with (a) and (b) resolved, the one action left is adding the
-# job's check name ("Harness floor recompute") to branch protection's required_status_checks —
-# a GUI/branch-protection change, tracked in modus PENDING-ARMS, deliberately left to the operator
-# (see the design doc's §Solo-operatore). This workflow's own behavior is otherwise ready for it.
+# ARMED — NOTHING IS PENDING (corrected 2026-08-21, measured, superseding the ARMING NOTE that
+# stood here). That note said "the one action left is adding the job's check name to branch
+# protection's required_status_checks — a GUI change, deliberately left to the operator." There is
+# no such action, and there never was: `Harness floor recompute` was ALREADY a required context
+# before the unblock work began. Measured live rather than reasoned:
+#
+#   gh api repos/Bali-Zero/Teman2/branches/main/protection --jq '.required_status_checks'
+#   -> 27 contexts; "Harness floor recompute" present (app_id 15368, GitHub Actions);
+#      "harness/fable-gate" absent; strict: false
+#
+# and the repo's tracked snapshot infra/required.d/contexts.json agrees (generated 2026-08-11,
+# i.e. before the unblock task existed). That is precisely WHY the redesign above works: it moved
+# enforcement onto a job branch protection already demanded, instead of onto a hand-posted status
+# that would have had to be promoted. So this file's enforcement went live the moment the redesign
+# merged — no flag was ever waiting to be flipped.
+#
+# DO NOT "finish" this by adding `harness/fable-gate` itself as a second required context. That
+# resurrects blocker (a) exactly as it stood: a commit status on the PR's real head SHA never
+# appears on the merge queue's synthetic test-merge SHA, so every Gear-3 PR would deadlock in the
+# queue. If a future session is told to "promote harness/fable-gate to required," the correct
+# action is to point at §Solo-operatore of the design doc and confirm the job already covers it.
+#
+# STILL OPEN, and it is NOT this note (do not read the above as "the gate is fully trustworthy"):
+# verdict provenance. scripts/harness_fable_gate.py never verifies WHO posted a verdict — any
+# credential with `statuses: write` can post PASS on any SHA. Before the redesign that was inert
+# because nothing read the status; now it is load-bearing, so the severity went UP. Tracked in
+# modus PENDING-ARMS as design gap (b), owner: a dedicated CI-integrity lane. Its sibling, the
+# repo-wide required-check NAME-spoofing gap, has its own 2026-08-21 ledger entry.
+#
+# NAME NOTE (2026-08-21): `harness/fable-gate` does NOT invoke Fable and never has — it relays a
+# verdict a Gear-3 session already reached (scripts/harness_fable_gate.py is a publisher with no
+# verdict logic). Zero ruled Fable out of the workflow on 2026-08-20; that changes WHO reaches the
+# verdict, not WHETHER a Gear-3 PR must carry one, so this check is unaffected by the routing
+# change. The context string stays as-is: it is the literal string branch protection would match,
+# and it appears in 15 tracked files at origin/main, including dated research captures that record
+# what was true when written. (Cross-family review before merge removed a FLEET_TOPOLOGY.json
+# citation from this note: that file does not contain the string, and the Fable-named key it DID
+# carry, `fable_gate_gear3`, was already renamed to `gear3_final_gate` by the same 2026-08-20
+# ruling — the file cited against renaming had itself been renamed.)
 
 on:
   pull_request:

--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -110,8 +110,9 @@ name: Harness floor recompute
 # because nothing read the status; now it is load-bearing, so the severity went UP. Tracked in
 # modus PENDING-ARMS as design gap (b) of the 2026-08-10 entry, owner there: "me (next session)
 # for the design work". Its SIBLING — the repo-wide required-check NAME-spoofing gap — is the one
-# with its own 2026-08-21 entry earmarked for a dedicated CI-integrity lane. Two rows, two owners;
-# an earlier draft of this line gave gap (b) the sibling's owner, which the Gear-3 gate caught.
+# with its own 2026-08-21 entry, whose owner field adds the CI-integrity lane qualifier. Both rows
+# name the same party; only the lane differs. An earlier draft of this line moved the qualifier
+# onto gap (b), where the ledger does not put it — the Gear-3 gate caught it.
 #
 # NAME NOTE (2026-08-21): `harness/fable-gate` does NOT invoke Fable and never has — it relays a
 # verdict a Gear-3 session already reached (scripts/harness_fable_gate.py is a publisher with no

--- a/.github/workflows/harness-floor.yml
+++ b/.github/workflows/harness-floor.yml
@@ -108,8 +108,10 @@ name: Harness floor recompute
 # verdict provenance. scripts/harness_fable_gate.py never verifies WHO posted a verdict — any
 # credential with `statuses: write` can post PASS on any SHA. Before the redesign that was inert
 # because nothing read the status; now it is load-bearing, so the severity went UP. Tracked in
-# modus PENDING-ARMS as design gap (b), owner: a dedicated CI-integrity lane. Its sibling, the
-# repo-wide required-check NAME-spoofing gap, has its own 2026-08-21 ledger entry.
+# modus PENDING-ARMS as design gap (b) of the 2026-08-10 entry, owner there: "me (next session)
+# for the design work". Its SIBLING — the repo-wide required-check NAME-spoofing gap — is the one
+# with its own 2026-08-21 entry earmarked for a dedicated CI-integrity lane. Two rows, two owners;
+# an earlier draft of this line gave gap (b) the sibling's owner, which the Gear-3 gate caught.
 #
 # NAME NOTE (2026-08-21): `harness/fable-gate` does NOT invoke Fable and never has — it relays a
 # verdict a Gear-3 session already reached (scripts/harness_fable_gate.py is a publisher with no

--- a/evidence/brief.yml
+++ b/evidence/brief.yml
@@ -1,41 +1,61 @@
-task_id: ops-gate-required-unblock
+task_id: ops-gate-header-truth
 gear: 3
 l_level: L3
-gate_class: fable
+gate_class: opus
 objective: |
-  Unblock promoting `harness/fable-gate` to a GitHub branch-protection required status
-  check — the two design problems its own ARMING NOTE (harness-floor.yml, 2026-08-10)
-  names: (a) a manually-posted commit status never carries over to the merge queue's
-  synthetic test-merge SHA; (b) a fork PR's read-only GITHUB_TOKEN breaks the workflow's
-  own `gh api` WRITE calls, hard-blocking external contributors once required. Chosen
-  fix: stop requiring the commit-status directly; require the WORKFLOW JOB itself
-  (`Harness floor recompute`, already required today), natively tied to whatever SHA it
-  runs against (real head / workflow_dispatch ref / merge_group's synthetic SHA), and
-  make it READ (never write) whether scripts/harness_fable_gate.py already posted a
-  verdict. Deliverable is the design + code that make the promotion safe, not the
-  branch-protection flip itself (operator action, §Solo-operatore).
+  Three artifacts in this repo tell a reader that promoting the harness gate to a required
+  branch-protection check is still PENDING and reserved for the operator. It is not, and it never
+  was: `Harness floor recompute` was already a required context before the unblock work of
+  2026-08-21 began — which is exactly why that redesign works. It moved enforcement onto a job
+  branch protection already demanded, instead of onto a hand-posted commit status that would have
+  needed promoting.
+
+  This PR corrects the two artifacts that live in code:
+    - the ARMING NOTE in `.github/workflows/harness-floor.yml` — the one a session touching the
+      gate has to walk past, whereas the research capture has to be sought out;
+    - and, folded in from superseded PR #4537, two comment-only notes explaining that
+      `harness/fable-gate` does NOT invoke Fable — it relays a verdict a session already reached.
+      #4537 went DIRTY when the 2026-08-21 redesign rewrote its anchor point out from under it;
+      its `scripts/harness_fable_gate.py` hunk is carried with ONE phrasing fix — "Fable out of
+      the interactive workflow" becomes "out of the workflow on 2026-08-20", matching CLAUDE.md's
+      ruling verbatim; the 2026-08-20 ruling is not scoped to interactive sessions. Its workflow
+      hunk is re-anchored, since the text it sat against no longer exists.
+
+  The third artifact (the research capture) is corrected in PR #4541. The fourth (the modus
+  PENDING-ARMS row) is deliberately NOT in this diff — see constraints.
 constraints:
-  - '.github/workflows/harness-floor.yml is a CODEOWNERS Tier-1 hot-zone; actionlint must pass and required context name ("Harness floor recompute") stays unchanged'
-  - "the required check must never write a commit status on a fork-triggered pull_request event — verified by static AST source-scan (test_no_write_shaped_string_literal_appears_anywhere_in_the_code), not just behavioral tests"
-  - "a Gear-3 PR with no verdict posted yet must fail the same way a REWORK/BLOCK verdict does (fail-closed), never silently pass as 'pending'"
-  - "the 'is this PR Gear-3' decision (evidence/brief.yml presence) must be scoped to THIS PR's own diff, never to whatever happens to sit in the HEAD tree — evidence/brief.yml is a tracked file at a fixed path and is inherited by every branch from the last Gear-3 PR to touch it (found live during independent review, F1 — see this pack's dissent)"
-  - "scripts/harness_fable_gate.py (the publisher) stays untouched — its contract is sound and orthogonal to both blockers"
+  - "No behaviour change: comment/docstring text only in both files. The YAML `on:`, `jobs:`,
+    `permissions:` blocks and every step remain byte-identical, and the Python module's code is
+    untouched below the docstring."
+  - "The context string `harness/fable-gate` is NOT renamed. It is the literal string branch
+    protection would match, and it appears in 15 tracked files at origin/main including dated
+    research captures. Renaming across those is a doctrine change, not a cleanup."
+  - "The modus PENDING-ARMS ledger is deliberately excluded from this diff: it carries a
+    `merge=union` driver, and GitHub's server-side mergeability does not honour custom merge
+    drivers (PR-1 landing scar), so folding it in would make a clean docs PR read CONFLICTING.
+    It gets its own PR."
+  - "Nothing in this diff may be read as closing design gap (b), verdict provenance. It stays open
+    and the corrected note says so explicitly."
 acceptance:
-  - "scripts/tests/test_harness_gate_read.py: 37/37 pass, including main() integration coverage and an AST write-verb proof"
-  - "scripts/tests/test_harness_floor_brief_diff_membership.sh: 4/4 pass (guilt+innocence for the diff-membership fix)"
-  - "actionlint .github/workflows/harness-floor.yml exits 0"
-  - 'python3 -c ''import yaml; yaml.safe_load(open(".github/workflows/harness-floor.yml"))'' exits 0'
-  - "an independent, non-fork review session (Agent tool, fresh context) reviews the diff cold and returns PASS or PASS-WITH-CONDITIONS before this PR is armed"
+  - "The ARMING NOTE no longer asserts a pending operator action, and states the measured live
+    branch-protection fact together with the command that produced it."
+  - "The note explicitly forbids the plausible-but-wrong finish — adding `harness/fable-gate`
+    itself as a second required context, which resurrects blocker (a)."
+  - "actionlint passes on the rewritten workflow."
+  - "The publisher script still parses (AST) and still exits 0 on --help."
+  - "An independent grader with fresh context, not this diff's author, finds no false claim in the
+    ADDED lines."
 consumer_map:
-  - "harness-floor.yml Step 7c (Gear-3 verdict read) is the only consumer of scripts/ci/harness_gate_read.py"
-  - "harness-floor.yml Steps 4/7b are the only consumers of the diff-membership fix"
-  - "the operator's future branch-protection edit (adding the ALREADY-required 'Harness floor recompute' job — no new name to add) is the sole remaining downstream action, per §Solo-operatore in the design doc"
+  - "`.github/workflows/harness-floor.yml` — read by every PR run of the required job; its header
+    is the artifact sessions actually read before touching the gate."
+  - "`scripts/harness_fable_gate.py` — invoked by a Gear-3 gate session to publish a verdict."
+  - "Neither file's behaviour changes, so there is no runtime surface to prove-live beyond CI."
 risks:
-  - "verdict provenance/attestation (any statuses:write credential can forge a PASS) is a THIRD, separate design gap tracked in .claude/skills/modus/PENDING-ARMS.md (2026-08-10 entry, gap b) — genuinely out of this task's scope, left open, severity now escalated (the signal becomes load-bearing once the operator flips the required-check flag) — see design doc §Solo-operatore"
-  - "gh workflow run harness-floor.yml --ref <branch> (the documented retrigger flow) cannot run on any branch cut before this PR merges, since that branch's harness-floor.yml predates the workflow_dispatch trigger — an inherent one-time bootstrap limitation, not a defect"
-  - "this diff is 5 files / ~1250 net lines, over the ~400-line Agent PR Contract guideline — declared and accepted: the workflow change, its new script, and that script's test corpus are one cohesive unit that cannot be safely split without leaving code unverified in isolation"
-grader: independent-review-session (Agent tool, subagent_type general-purpose, model opus, fresh context — not the diff's author)
-budget:
-  seats: [sonnet-5, opus]
-  fable_gate_est_tokens: 2200
+  - "The corrected note asserts a live measurement. If branch protection changed later, the note
+    would go stale exactly as the one it replaces did. Mitigated by naming the exact command, so a
+    reader can re-run it rather than trusting the assertion."
+  - "Folding #4537 in means closing it; if this PR were abandoned its content would be lost. The
+    close happens only after this PR merges."
+grader: independent-review-session (Agent tool, general-purpose, model sonnet, fresh context — not the diff's author) + cross-family seat (Kimi K3) on the added lines
+budget: ~2 subagents, no council (single-concern comment correction; the divergent-priors gate does not fire)
 pii: none

--- a/evidence/pack.yml
+++ b/evidence/pack.yml
@@ -2,7 +2,7 @@ brief_ref: evidence/brief.yml
 plan_ref: "harness-floor.yml ARMING NOTE says a promotion is pending that already happened (2026-08-21); folds in superseded PR #4537"
 diff:
   files: 4
-  net_lines: "+~95 / -8, comment/docstring text plus two evidence files; zero executable lines"
+  net_lines: "+61/-4 across the two code files (39/4 yml, 22/0 py), +171/-133 counting the two evidence files; zero executable lines"
   behaviour_change: none
 receipts:
   - claim: "`Harness floor recompute` is ALREADY a required context on main; 27 contexts; app_id 15368; `harness/fable-gate` absent; strict false"
@@ -31,8 +31,8 @@ receipts:
     ts: "2026-08-21T13:34:36Z"
     seat: session (m5)
   - claim: "FLEET_TOPOLOGY.json does NOT contain the context string, and its Fable-named key was already renamed"
-    cmd: "git show origin/main:FLEET_TOPOLOGY.json | grep -c 'fable-gate'  (-> 0); grep -B3 -A6 fable_gate_gear3 (-> _renamed_from gear3_final_gate)"
-    exit: 0
+    cmd: "git show origin/main:FLEET_TOPOLOGY.json | grep -c 'fable-gate'  (prints 0, and grep exits 1 on zero matches -- the ZERO is the finding); then grep -B3 -A6 fable_gate_gear3 -> _renamed_from gear3_final_gate"
+    exit: 1
     ts: "2026-08-21T13:34:36Z"
     seat: session (m5)
   - claim: "The context string really does appear in 15 tracked files at origin/main"
@@ -60,6 +60,15 @@ dissent:
     status: CONFIRMED
   - seat: kimi-k3 (cross-family, Moonshot)
     objection: "Three added locations cite FLEET_TOPOLOGY.json as naming `harness/fable-gate`. It contains the string zero times — a phantom citation (superscar #6), inherited from #4537 and re-asserted here"
+    status: CONFIRMED
+  - seat: gear3-final-gate (opus 5, fresh context, read-only, not the author)
+    objection: 'An ADDED line in harness-floor.yml attributed design gap (b) to "a dedicated CI-integrity lane". Measured: gap (b) is ledger line 933, owner "me (next session)"; the string CI-integrity occurs once in the whole ledger, at line 1108 — the SIBLING name-spoofing entry. The owner was attached to the wrong of the two rows the paragraph discusses, in the PR whose thesis is that headers must stop asserting unmeasured things'
+    status: CONFIRMED
+  - seat: gear3-final-gate (opus 5, fresh context, read-only, not the author)
+    objection: 'pack net_lines "+~95 / -8" reproduces under no reading — code files are +61/-4, whole diff +171/-133, single commit so not stale from an intermediate state'
+    status: CONFIRMED
+  - seat: gear3-final-gate (opus 5, fresh context, read-only, not the author)
+    objection: "receipt R6 recorded exit 0, but grep -c exits 1 on zero matches — the claim reproduces, the exit field did not"
     status: CONFIRMED
   - seat: session (m5), verifying kimi-k3's finding rather than accepting it
     objection: "Deleting the citation would have hidden the sharper fact: FLEET_TOPOLOGY.json DID carry `fable_gate_gear3`, already renamed to `gear3_final_gate` by the same 2026-08-20 ruling — the file cited against renaming had itself been renamed"

--- a/evidence/pack.yml
+++ b/evidence/pack.yml
@@ -2,7 +2,7 @@ brief_ref: evidence/brief.yml
 plan_ref: "harness-floor.yml ARMING NOTE says a promotion is pending that already happened (2026-08-21); folds in superseded PR #4537"
 diff:
   files: 4
-  net_lines: "+61/-4 across the two code files (39/4 yml, 22/0 py), +171/-133 counting the two evidence files; zero executable lines"
+  net_lines: "CODE +64/-4 (42/4 harness-floor.yml, 22/0 harness_fable_gate.py); WHOLE DIFF +193/-131 including the two evidence files. Measured at merge-base 3b1ca2fbb (git diff <merge-base> --numstat), never two-dot against a moving origin/main — that form attributes main's own commits to this PR (W102). Zero executable lines; the workflow non-comment body is byte-identical."
   behaviour_change: none
 receipts:
   - claim: "`Harness floor recompute` is ALREADY a required context on main; 27 contexts; app_id 15368; `harness/fable-gate` absent; strict false"
@@ -65,13 +65,25 @@ dissent:
     objection: 'An ADDED line in harness-floor.yml attributed design gap (b) to "a dedicated CI-integrity lane". Measured: gap (b) is ledger line 933, owner "me (next session)"; the string CI-integrity occurs once in the whole ledger, at line 1108 — the SIBLING name-spoofing entry. The owner was attached to the wrong of the two rows the paragraph discusses, in the PR whose thesis is that headers must stop asserting unmeasured things'
     status: CONFIRMED
   - seat: gear3-final-gate (opus 5, fresh context, read-only, not the author)
-    objection: 'pack net_lines "+~95 / -8" reproduces under no reading — code files are +61/-4, whole diff +171/-133, single commit so not stale from an intermediate state'
+    objection: 'pack net_lines "+~95 / -8" reproduced under no reading at the SHA it was raised against (6ee02427f): code files were +61/-4 there, whole diff +171/-133'
     status: CONFIRMED
   - seat: gear3-final-gate (opus 5, fresh context, read-only, not the author)
     objection: "receipt R6 recorded exit 0, but grep -c exits 1 on zero matches — the claim reproduces, the exit field did not"
     status: CONFIRMED
   - seat: session (m5), verifying kimi-k3's finding rather than accepting it
     objection: "Deleting the citation would have hidden the sharper fact: FLEET_TOPOLOGY.json DID carry `fable_gate_gear3`, already renamed to `gear3_final_gate` by the same 2026-08-20 ruling — the file cited against renaming had itself been renamed"
+    status: CONFIRMED
+  - seat: gear3-final-gate (opus 5, re-gate on 72ac75db0, read-only, not the author)
+    objection: 'REWORK-BUILD. The fix for the net_lines condition replaced an unreproducible approximation with a PRECISE value measured at the PREVIOUS SHA (6ee02427f) — false at the SHA it shipped on, because the same commit also edited harness-floor.yml. The gate named it "the same disease at higher confidence, in the one field the gate conditioned", and refused to soften on a repeat.'
+    status: CONFIRMED
+  - seat: gear3-final-gate (opus 5, re-gate on 72ac75db0, read-only, not the author)
+    objection: "CI cannot catch a wrong net_lines: evidence_pack_lint prefers a MEASURED --net-lines/--numstat-file over the pack field precisely because the field is untrustworthy, but the field here is a STRING, so the int path never engages and the rule never fires. Green lint was not evidence."
+    status: CONFIRMED
+  - seat: gear3-final-gate (opus 5, re-gate on 72ac75db0, read-only, not the author)
+    objection: '"single commit so not stale from an intermediate state" was false as shipped — git rev-list --count origin/main..HEAD was 2. Corrected to past tense against the SHA it was raised at.'
+    status: CONFIRMED
+  - seat: gear3-final-gate (opus 5, re-gate on 72ac75db0, read-only, not the author)
+    objection: '"Two rows, two owners" over-claimed: both ledger rows name the same party, me (next session); only the CI-integrity lane qualifier differs. A small over-claim in a PR about not over-claiming.'
     status: CONFIRMED
 residual_risks:
   - "Design gap (b), verdict provenance, stays OPEN and is now load-bearing. Nothing here closes it; the corrected note says so explicitly."

--- a/evidence/pack.yml
+++ b/evidence/pack.yml
@@ -1,117 +1,78 @@
 brief_ref: evidence/brief.yml
-plan_ref: "harness/fable-gate required-check promotion unblock (2026-08-21, team-lead mandate)"
+plan_ref: "harness-floor.yml ARMING NOTE says a promotion is pending that already happened (2026-08-21); folds in superseded PR #4537"
 diff:
-  files: 7
-  insertions: 1348
-  deletions: 92
-  hotzone_hits:
-    - ".github/workflows/harness-floor.yml"
+  files: 4
+  net_lines: "+~95 / -8, comment/docstring text plus two evidence files; zero executable lines"
+  behaviour_change: none
 receipts:
-  - claim: "the new + existing harness_gate_read test suite passes in full (37/37), including main() integration coverage and the AST write-verb proof"
-    cmd: "cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest ../../scripts/tests/test_harness_gate_read.py -q"
+  - claim: "`Harness floor recompute` is ALREADY a required context on main; 27 contexts; app_id 15368; `harness/fable-gate` absent; strict false"
+    cmd: "gh api repos/Bali-Zero/Teman2/branches/main/protection --jq '.required_status_checks | {n:(.checks|length), harness:[...], fable:[...], strict}'"
     exit: 0
-    ts: "2026-08-21T11:14:12Z"
-    seat: "sonnet-5"
-  - claim: "the diff-membership guilt+innocence corpus (F1 fix) passes 4/4"
-    cmd: "bash scripts/tests/test_harness_floor_brief_diff_membership.sh"
+    ts: "2026-08-21T13:23:00Z"
+    seat: session (m5)
+  - claim: "The tracked snapshot agrees and predates the unblock work — generated 2026-08-11"
+    cmd: "grep -m1 generated_at infra/required.d/contexts.json"
     exit: 0
-    ts: "2026-08-21T11:14:30Z"
-    seat: "sonnet-5"
-  - claim: "the modified harness-floor.yml (hot-zone, CODEOWNERS Tier-1) is schema/expression-valid"
+    ts: "2026-08-21T13:23:00Z"
+    seat: session (m5)
+  - claim: "NO BEHAVIOUR CHANGE: the workflow's non-comment body is byte-identical to origin/main"
+    cmd: "git show origin/main:.github/workflows/harness-floor.yml | grep -v '^\\s*#' > /tmp/a.yml; grep -v '^\\s*#' .github/workflows/harness-floor.yml > /tmp/b.yml; diff -q /tmp/a.yml /tmp/b.yml"
+    exit: 0
+    ts: "2026-08-21T13:34:36Z"
+    seat: session (m5)
+  - claim: "actionlint passes on the rewritten workflow"
     cmd: "actionlint .github/workflows/harness-floor.yml"
     exit: 0
-    ts: "2026-08-21T11:14:35Z"
-    seat: "sonnet-5"
-  - claim: "the workflow YAML parses cleanly after every edit"
-    cmd: 'python3 -c "import yaml; yaml.safe_load(open(''.github/workflows/harness-floor.yml''))"'
+    ts: "2026-08-21T13:34:36Z"
+    seat: session (m5)
+  - claim: "The publisher script still parses after the docstring insert"
+    cmd: 'python3 -c ''import ast,io;ast.parse(io.open("scripts/harness_fable_gate.py",encoding="utf-8").read())'''
     exit: 0
-    ts: "2026-08-21T11:14:37Z"
-    seat: "sonnet-5"
-  - claim: "the sibling harness_fable_gate.py test suite (the unchanged publisher) is unaffected"
-    cmd: "cd apps/backend-rag && PYTHONPATH=. .venv/bin/python -m pytest ../../scripts/tests/test_harness_fable_gate.py -q"
+    ts: "2026-08-21T13:34:36Z"
+    seat: session (m5)
+  - claim: "FLEET_TOPOLOGY.json does NOT contain the context string, and its Fable-named key was already renamed"
+    cmd: "git show origin/main:FLEET_TOPOLOGY.json | grep -c 'fable-gate'  (-> 0); grep -B3 -A6 fable_gate_gear3 (-> _renamed_from gear3_final_gate)"
     exit: 0
-    ts: "2026-08-21T11:14:40Z"
-    seat: "sonnet-5"
-  - claim: "the diff-membership guilt test fails under the OLD (pre-F1-fix) tree-presence-only logic — proves the corpus is not vacuously green"
-    cmd: "bash /tmp/scarpin_test.sh  # test_harness_floor_brief_diff_membership.sh with brief_present() reverted to tree-presence-only"
-    exit: 1
-    ts: "2026-08-21T10:52:00Z"
-    seat: "sonnet-5"
-  - claim: "the three F2 fail-open mutations in main() (sha-unresolvable->0, GhCallError->0, decide()-discarded->0) each turn at least one test red"
-    cmd: "python3 -m pytest scripts/tests/test_harness_gate_read.py -q  # run three times against a /tmp sandbox copy, one mutation applied at a time"
-    exit: 1
-    ts: "2026-08-21T11:00:00Z"
-    seat: "sonnet-5"
-  - claim: "the AST write-verb scan (F3 fix) catches the independent reviewer's exact counterexample function when appended to a real copy of the script, with zero false positives on the script's own docstrings"
-    cmd: "python3 -m pytest scripts/tests/test_harness_gate_read.py -q -k not_context_constant  # against a /tmp sandbox copy with publish_backdoor() appended"
-    exit: 1
-    ts: "2026-08-21T11:08:00Z"
-    seat: "sonnet-5"
+    ts: "2026-08-21T13:34:36Z"
+    seat: session (m5)
+  - claim: "The context string really does appear in 15 tracked files at origin/main"
+    cmd: "git grep -l 'harness/fable-gate' origin/main -- . | wc -l"
+    exit: 0
+    ts: "2026-08-21T13:34:36Z"
+    seat: session (m5)
 tests:
-  cmd: "pytest scripts/tests/test_harness_gate_read.py -q && bash scripts/tests/test_harness_floor_brief_diff_membership.sh"
-  passed: 41
-  failed: 0
+  - "No new tests: comment-only diff. The behavioural proof is the byte-identical non-comment body receipt above, which is stronger than a test would be here."
+  - "Existing guards exercised by CI on this PR: actionlint, guard-conformance, R1 gate, evidence_pack_lint (this pack, on itself)."
 static:
-  lint: ok
-  typecheck: n/a
-  build: n/a
+  - "actionlint 1.7.12 — exit 0"
+  - "AST parse of scripts/harness_fable_gate.py — ok; grader independently confirmed ast.dump() equality with the docstring stripped"
 runtime_proof:
-  - "harness_gate_read.py --event-name pull_request with no --pr-head-sha fails closed (exit 1, 'could not resolve') — smoke-tested directly, not just via pytest"
-  - "the diff-membership fix (F1) correctly reports 'absent' for a file that exists at HEAD but is not in the PR's own changed-files list, 'present' only when both hold, and 'absent' when the tree lacks the file entirely regardless of what an adversarial changed-files.txt claims"
-  - "the AST write-verb scan flags exactly the 4 offending string constants (state=, context=, -f, -f) in the reviewer's counterexample, at their real line numbers, and flags zero constants in the unmodified script"
+  - "None applicable and none claimed: nothing in this diff executes. Consumer-map in the brief records that both consumers' behaviour is unchanged, so 'live' equals 'merged' here — deliberately stated rather than skipped."
 dissent:
-  - seat: independent-gear3-reviewer
-    objection: "F1 CRITICAL — Step 4 tested evidence/brief.yml's presence in the HEAD tree, not whether THIS PR's own diff touched it. Since the file is tracked at a fixed repo-root path, every branch inherits whatever the last-merged Gear-3 PR (#4474) left there — verified live against origin/main and against a real merged single-file docs PR (#4535) that inherited gear:3 from it. Under the OLD Step 7c (never failed) this was harmless; under the NEW read-based Step 7c it would have put every PR in the repo on the Gear-3 path and broken the already-required 'Harness floor recompute' job repo-wide."
+  - seat: independent-review-session (sonnet, fresh context, not the author)
+    objection: "brief.yml claimed PR #4537's python hunk was 'carried verbatim' — it was edited ('interactive workflow' -> 'the workflow on 2026-08-20')"
     status: CONFIRMED
-    repro: "git show origin/main:evidence/brief.yml declares gear:3 for task_id ops-gear-ceiling-pr4474; PR #4535 (a single .md ledger edit) ran harness_gate_read.py against its real head sha and hit the Gear-3 'PENDING, no verdict' path despite touching nothing hot-zone-shaped."
-    resolution: "Steps 4 and 7b now require BOTH tree presence AND membership in /tmp/changed-files.txt (this PR's own merge-base-anchored diff) before treating brief.yml/pack.yml as authored by this PR. Pinned by scripts/tests/test_harness_floor_brief_diff_membership.sh, verified to fail 2/4 cases under the reverted (pre-fix) logic."
-  - seat: independent-gear3-reviewer
-    objection: "F2 HIGH — main(), the only code path CI actually executes, had zero test coverage. Three independent fail-open mutations (sha-unresolvable returns 0, GhCallError returns 0, decide()'s code discarded and always returns 0) all survived the full 30-test corpus."
+  - seat: independent-review-session (sonnet, fresh context, not the author)
+    objection: "'the highest-traffic of the three' is unverifiable — no command measures which artifact more sessions read"
     status: CONFIRMED
-    repro: "Each mutation applied individually to a /tmp sandbox copy of harness_gate_read.py; pytest run against the unmodified test file showed 0 failures for all three, confirming the gap."
-    resolution: "Added 6 tests calling hgr.main() directly (mocked resolve_real_head_sha/read_fable_gate_state) plus one real subprocess smoke test. Re-verified: each of the three mutations now fails 1-2 tests."
-  - seat: independent-gear3-reviewer
-    objection: 'F3 HIGH — the two static ''proves it can''t publish'' tests matched source TEXT via substring regex, not argv semantics. A 4-line addition building the write via split string constants (field_state = "state=" + verdict; passed as a separate ''-f'' list element) is a fully working status POST and passed all 30 tests.'
+  - seat: independent-review-session (sonnet, fresh context, not the author)
+    objection: "gate_class: opus5-max is outside the declared enum none|opus|fable (nothing machine-checks it, so drift rather than failure)"
     status: CONFIRMED
-    repro: "Reviewer's exact publish_backdoor() function appended verbatim to a real copy of the script; the (then-current) source-scan tests passed with the backdoor present."
-    resolution: "Replaced with an AST scan of every string CONSTANT node for exact write-verb flags (-f/-F/-X/--method/...) and write-shaped value PREFIXES (state=/context=/POST/...), which catches split-construction the same as inline. Re-verified against the exact counterexample: now caught, with a dedicated guilt pin proving the scan itself is not vacuously green, and zero false positives on the script's own docstrings (scans full-source constants, which is safe against prose — see the test's own docstring for why)."
-  - seat: independent-gear3-reviewer
-    objection: "F4 MEDIUM — this PR's design doc claimed it carries its own evidence/brief.yml + pack.yml. It did not; both were still PR #4474's leftover files, so Step 7b would have graded this PR against an unrelated task's evidence pack."
+  - seat: kimi-k3 (cross-family, Moonshot)
+    objection: "Three added locations cite FLEET_TOPOLOGY.json as naming `harness/fable-gate`. It contains the string zero times — a phantom citation (superscar #6), inherited from #4537 and re-asserted here"
     status: CONFIRMED
-    repro: "git diff origin/main --name-only at review time showed no evidence/*.yml changes; the tracked files were byte-identical to origin/main's."
-    resolution: "This PR now genuinely authors its own evidence/brief.yml and evidence/pack.yml (this file), and — as a structural consequence of the F1 fix — could not pass Steps 4/7b any other way, since an untouched brief/pack no longer satisfies the diff-membership requirement."
-  - seat: independent-gear3-reviewer
-    objection: "F5 MEDIUM — .claude/skills/modus/PENDING-ARMS.md's 2026-08-10 entry tracks THREE design gaps (synthetic-SHA relay, verdict provenance/attestation, fork-PR write permission), not the two this task's mandate named. The design doc's §Solo-operatore implied nothing was left open."
+  - seat: session (m5), verifying kimi-k3's finding rather than accepting it
+    objection: "Deleting the citation would have hidden the sharper fact: FLEET_TOPOLOGY.json DID carry `fable_gate_gear3`, already renamed to `gear3_final_gate` by the same 2026-08-20 ruling — the file cited against renaming had itself been renamed"
     status: CONFIRMED
-    repro: "PENDING-ARMS.md line ~933 names gap (b) 'verdict provenance/attestation ... any credential with statuses:write can post PASS on any SHA' verbatim, independent of and predating this task."
-    resolution: "Design doc corrected: gap (b) is explicitly named as out of this task's scope, left open, with an escalated-severity note (the forgeable signal becomes load-bearing for merge-blocking once required, versus inert today)."
-  - seat: independent-gear3-reviewer
-    objection: "F6 MEDIUM — Step 7c called scripts/ci/harness_gate_read.py with no bootstrap-window guard, unlike its three siblings (floor compute, net-lines, pack validation), which each guard against the base checkout predating a script this very PR introduces."
-    status: CONFIRMED
-    repro: "This PR's own base checkout (Step 1) lacks scripts/ci/harness_gate_read.py until the PR merges; without a guard, Step 7c would raise a raw file-not-found on its own first CI run."
-    resolution: "Added the same [[ ! -f ... ]] NOTICE+skip guard pattern used by the three sibling steps."
-  - seat: independent-gear3-reviewer
-    objection: "F7 MEDIUM (plausible, not executed — review-only mandate) — the documented 'gh workflow run harness-floor.yml --ref <branch>' recovery flow cannot run on any branch cut before this PR merges, since that branch's own harness-floor.yml predates the workflow_dispatch trigger this PR adds."
-    status: PLAUSIBLE
-    repro: "Not independently executed (review-only mandate); consistent with GitHub's documented behavior that workflow_dispatch runs the workflow AS DEFINED AT THE DISPATCHED REF."
-    resolution: "Documented explicitly in the design doc as an inherent, one-time bootstrap limitation rather than oversold as universally available immediately — not a code fix (there isn't one; every repo's first PR adding a new trigger has this property)."
-  - seat: independent-gear3-reviewer
-    objection: "F8 LOW — the script's docstring/comment claimed PR_NUMBER_RE is 'the same regex shape' as queue_ejection_attribution.py::PR_SHA_RE; the shipped regex is strictly looser (it drops the 40-hex trailing-sha anchor)."
-    status: CONFIRMED
-    repro: "PR_SHA_RE = re.compile(r'pr-(\\d+)-([0-9a-f]{40})') vs this script's PR_NUMBER_RE = re.compile(r'pr-(\\d+)-') — visibly different patterns."
-    resolution: "Reworded to 'a looser version of,' with the reason (only the number group is needed; the trailing sha is the base commit at queue time, not useful here) stated explicitly."
 residual_risks:
-  - "verdict provenance/attestation (PENDING-ARMS gap b) remains fully open — see brief.yml risks and design doc §Solo-operatore for the escalated-severity note; a future task must design it, this one deliberately does not"
-  - "the F7 workflow_dispatch bootstrap limitation means any currently-open PR cut before this merges cannot use the documented retrigger flow until rebased onto post-merge main — inherent, not fixable within this diff"
-  - "the hot-zone/floor pattern-list duplication between evidence_pack_lint.py and hot-zone-pr-gate.yml's bash case-block (pre-existing, declared in that script's own docstring) is untouched by this PR — a fair follow-up, not a blocker here"
-  - "this diff (7 files, ~1250 net lines across evidence/*, the workflow, the new script, its tests, and the design doc) exceeds the Agent PR Contract's ~400-net-line guideline — declared in brief.yml's constraints as a deliberate exception: the workflow change, its new script, and that script's test corpus are one unit that cannot safely ship split, and evidence/* + the design doc are this PR's own required evidence, not separable content"
+  - "Design gap (b), verdict provenance, stays OPEN and is now load-bearing. Nothing here closes it; the corrected note says so explicitly."
+  - "Required-check NAME spoofing (Kimi K1) is repo-wide across all 27 contexts and bounds what this gate guarantees. Own ledger entry, own lane."
+  - "The corrected note asserts a live measurement and could go stale exactly as its predecessor did. Mitigated by naming the command, not just the state."
+  - "The modus PENDING-ARMS row still carries the stale 'flip pending' framing. Excluded here on purpose (merge=union mergeability defect); it needs its own PR and is not closed by this one."
 sources:
-  - ".github/workflows/harness-floor.yml"
-  - "scripts/ci/harness_gate_read.py"
-  - "scripts/tests/test_harness_gate_read.py"
-  - "scripts/tests/test_harness_floor_brief_diff_membership.sh"
-  - "research/operations/2026-08-21-fable-gate-required-promotion.md"
-  - ".claude/skills/modus/PENDING-ARMS.md"
-  - "scripts/harness_fable_gate.py"
+  - research/operations/2026-08-21-fable-gate-required-promotion.md
+  - infra/required.d/contexts.json
+  - CLAUDE.md (2026-08-20 Fable-out ruling, line 114)
+  - PR #4537 (superseded, content carried), PR #4539 (redesign), PR #4541 (research capture correction)
 pii_scan: clean
-size_tokens: 4200
+size_tokens: 1500

--- a/scripts/harness_fable_gate.py
+++ b/scripts/harness_fable_gate.py
@@ -9,6 +9,28 @@ status, via `gh api`, so branch protection can require it and merging a
 Gear-3 PR without a real gate verdict becomes physically impossible ("il
 gate diventa CI-enforced, non prompt-enforced").
 
+THE NAME IS HISTORICAL — THIS SCRIPT NEVER INVOKES FABLE (note added
+2026-08-21). Zero ruled Fable out of the workflow on 2026-08-20, and a reader
+meeting "fable-gate" reasonably concludes this context depends on a model
+that is no longer routed to. It does not: the context is a relay for a
+verdict a SESSION already reached, and it is indifferent to which model
+reached it — the routing question and the "does a Gear-3 PR carry a real
+verdict" question are separate, and only the second one lives here. The
+context string is deliberately NOT renamed: `harness/fable-gate` appears in
+15 tracked files at origin/main — harness-v2-teman2.md, fleet-order-spec.md,
+and dated research captures that record what was true when written. Renaming
+across those is a doctrine change, not a cleanup, and a status context is
+also the exact string branch protection would match. Fix the misreading
+where a reader meets it, not by rewriting the record.
+
+CITATION CORRECTED 2026-08-21 (cross-family review, before merge): an earlier
+draft of this note also cited FLEET_TOPOLOGY.json. It does NOT contain the
+string — `grep -c "fable-gate"` returns 0. What it carried was a role-chain
+key `fable_gate_gear3`, and that key was ALREADY renamed to `gear3_final_gate`
+under the same 2026-08-20 ruling. So the one file cited as a reason not to
+rename had itself already been renamed. The argument stands on the other
+grounds; that citation did not, and is removed rather than quietly dropped.
+
 **PUBLISHER ONLY — NO VERDICT LOGIC.** This script never decides PASS vs
 REWORK vs BLOCK; it only validates that a caller-supplied verdict is one of
 the five legal values, maps it to a GitHub commit-status `state`


### PR DESCRIPTION
## The claim that was false

`.github/workflows/harness-floor.yml` lines 85-88 told every reader:

> ARMING NOTE (operator/session): with (a) and (b) resolved, **the one action left** is adding the
> job's check name ("Harness floor recompute") to branch protection's required_status_checks — a
> GUI/branch-protection change … **deliberately left to the operator**.

There is no such action, and there never was.

```
$ gh api repos/Bali-Zero/Teman2/branches/main/protection --jq '.required_status_checks'
27 contexts · "Harness floor recompute" PRESENT (app_id 15368, GitHub Actions)
            · "harness/fable-gate" absent · strict: false
$ grep -m1 generated_at infra/required.d/contexts.json
  "generated_at": "2026-08-11"        # before the unblock work existed
```

That is exactly **why** the 2026-08-21 redesign works: it moved enforcement onto a job branch
protection already demanded, instead of onto a hand-posted commit status that would have needed
promoting. The gate went live the moment #4539 merged — no flag was ever waiting to be flipped.

## Why a diff and not a shrug

The stale note sends the next reader hunting for an operator action that does not exist, and the
obvious way to "finish" the hunt is to add `harness/fable-gate` itself as a second required
context — which **resurrects blocker (a)**, the synthetic-SHA relay the whole redesign exists to
route around. The corrected note forbids that move by name, and states plainly what is *not*
closed: verdict provenance, inert before the redesign and load-bearing after it.

Same false framing was in two sibling artifacts. The research capture is fixed in #4541 (merged).
The modus PENDING-ARMS row is deliberately **not** here — it carries a `merge=union` driver and
GitHub's server-side mergeability does not honour custom merge drivers, so folding it in would make
a clean docs PR read CONFLICTING. It gets its own PR.

## Supersedes #4537

#4537 went DIRTY when #4539 rewrote its anchor out from under it. Its content survives:
- `scripts/harness_fable_gate.py` hunk carried, with one phrasing fix — "Fable out of the
  *interactive* workflow" → "out of the workflow on 2026-08-20", matching CLAUDE.md's ruling, which
  is **not** scoped to interactive sessions;
- workflow hunk re-anchored to the rewritten header.

#4537 will be closed once this lands, not before.

## Adversarial review — two seats, generator≠grader

**Same-family grader (fresh context, not the author)** — 3 findings, all CONFIRMED, all fixed:
the brief claimed the python hunk was "carried verbatim" when it had been edited; "highest-traffic
of the three" was an unverifiable assertion; `gate_class: opus5-max` sat outside the declared enum.

**Cross-family seat (Kimi K3)** — 1 finding the same-family grader missed, and it is the important
one: three added locations cited **FLEET_TOPOLOGY.json** as naming `harness/fable-gate`. It
contains the string **zero** times — a phantom citation (superscar #6) inherited from #4537 and
re-asserted here.

Verified before acting on it, and the verification found the sharper fact that simply deleting the
citation would have buried: FLEET_TOPOLOGY.json **did** carry a role-chain key `fable_gate_gear3`,
and that key was **already renamed** to `gear3_final_gate` by the same 2026-08-20 ruling. The one
file cited as a reason not to rename had itself already been renamed. The don't-rename argument
survives on its other grounds (the literal string branch protection would match; 15 tracked files);
the citation did not, and the notes now say so rather than quietly dropping it.

## No behaviour change — proved, not asserted

```
$ git show origin/main:.github/workflows/harness-floor.yml | grep -v '^\s*#' > /tmp/a.yml
$ grep -v '^\s*#' .github/workflows/harness-floor.yml > /tmp/b.yml
$ diff -q /tmp/a.yml /tmp/b.yml && echo IDENTICAL
IDENTICAL
```

`on:`, `permissions:`, `jobs:` and every step byte-identical; the grader independently confirmed
`ast.dump()` equality for the Python module with the docstring stripped. `actionlint` exit 0.
Evidence Pack lints clean at the recomputed floor (3).