### PR TITLE
docs(mouth): replace the promote-wait estimate with the measured one

### DIFF
--- a/apps/mouth/README.md
+++ b/apps/mouth/README.md
@@ -37,7 +37,11 @@ git push origin main   # builds — see the note below, this is NOT the whole st
 > The promote now happens by itself, on a cron on Mini (`mini.vercel_autopromote`, every 15
 > minutes): it finds the newest commit on main that can change the bundle, checks whether
 > production already carries it, and promotes the existing READY build — it never rebuilds.
-> Expect your merge to be live within ~15 minutes, not instantly.
+> Budget about half an hour, not fifteen minutes and not instantly: Vercel has to finish the
+> build first, and only then can the next cron tick promote it. Measured end-to-end once, on
+> 2026-08-21: merge at 12:37:57Z, live at 13:07:00Z — **29 minutes**. That is a single
+> observation, not a distribution; the 15 minutes is only the cron's cadence, which an earlier
+> draft of this note mistook for the whole wait.
 >
 > To do it by hand from a machine where `vercel whoami` answers:
 > `python3 scripts/vercel_prod_deploy.py --dry-run` reports the gap and changes nothing;


### PR DESCRIPTION
The note added two hours ago said **"live within ~15 minutes"**. The first real end-to-end measurement contradicts it.

PR #4540 merged at `12:37:57Z`; `balizero.com/api/health` served that commit at `13:07:00Z` — **29 minutes**. The 15 is only the cron's cadence. The wait is Vercel's build **plus** up to one tick, and the draft mistook the second half for the whole.

It matters more than a docs nit: this figure is what a developer uses to decide whether something is broken. Told fifteen minutes, they start hunting a fault at minute twenty — on a promote that is working exactly as designed. That is the same wasted hunt this note exists to prevent, just relocated.

Now stated as what it is: one observation, not a distribution.

Second-order: this PR touches `apps/mouth/`, so it is itself another induced promote — a second data point on the same clock, and a second unattended run of the branch that had never fired before today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)