### PR TITLE
fix(fleet): use live qwen3.8-max API slug in role_chains

### DIFF
--- a/FLEET_TOPOLOGY.json
+++ b/FLEET_TOPOLOGY.json
@@ -323,7 +323,7 @@
           "accounts": ["G1"]
         },
         {
-          "model": "qwen-3.8-max",
+          "model": "qwen3.8-max",
           "accounts": ["TP1"],
           "note": "ARMED 2026-08-14 (PROBE-1-residual closed, 459 calls / 74.1M tokens measured 2026-08-08→14, see accounts.alibaba.slots.TP1 and research/operations/2026-08-14-probe1-tp1-burn-rate.md)"
         }
@@ -369,7 +369,7 @@
     "doc_mass_nonpii": {
       "chain": [
         {
-          "model": "qwen-3.8-max",
+          "model": "qwen3.8-max",
           "accounts": ["TP1"],
           "note": "ARMED 2026-08-14 (PROBE-1-residual closed, see accounts.alibaba.slots.TP1)"
         },
@@ -404,7 +404,7 @@
           "accounts": ["G1"]
         },
         {
-          "model": "qwen-3.8-max",
+          "model": "qwen3.8-max",
           "accounts": ["TP1"],
           "note": "ARMED 2026-08-14 (PROBE-1-residual closed, see accounts.alibaba.slots.TP1) — the compliance-exact hard_no below is unrelated to PROBATION status and still applies unconditionally"
         }


### PR DESCRIPTION
The three `role_chains` entries for the Qwen 3.8 Max seat (panel third-pole, `doc_mass_nonpii`, `normative_search`) spelled the model `qwen-3.8-max`, which is not a slug the Token Plan exposes.

**Evidence:**
- Live read-only probe of the TP1 `compatible-mode/v1/models` endpoint (2026-08-21) returns only `qwen3.8-max` — the `qwen3.8-max-preview` slug from the 2026-08-10 PROBE-1 census is gone too (preview promoted to GA).
- Console roster verified 2026-08-14 lists `qwen3.8-max`.
- All 459 production calls measured 2026-08-08→14 ran under `qwen3.8-max` (research/operations/2026-08-14-probe1-tp1-burn-rate.md).

**Change:** 3 lines, `qwen-3.8-max` → `qwen3.8-max`. JSON syntax validated. The historical `pass_all_three_machines` census array (which still lists `qwen3.8-max-preview`) is a probe snapshot and is intentionally left untouched.