### PR TITLE
fix(arsenal): classify jules missing-key as CRED_UNAVAILABLE not UNKNOWN_ERR

### DIFF
--- a/scripts/arsenal_probe.py
+++ b/scripts/arsenal_probe.py
@@ -643,9 +643,24 @@ def probe_jules(timeout: float) -> tuple[str, str, int]:
     if res.timed_out and not live:
         return TIMEOUT, ev or "probe timed out", latency_ms
 
-    status = LIVE if live else AUTH_DEAD # Assuming auth dead for now if it fails, or maybe classify_generic?
-    # Wait, the prompt says: "Healthy means rc=0 AND at least one source line. Never print or embed the API key; the existing scrub() must cover the evidence tail."
-    status = classify_generic(res.stdout + res.stderr, live, "jules", is_ssh_context())
+    combined = res.stdout + res.stderr
+    # 2026-08-21 (healer tick, Mini): jules_dispatch.py's own credential-missing
+    # shape — "jules_dispatch: no API key — add it with: security
+    # add-generic-password ..." (get_api_key(), exit 2) — carries no 401/oauth
+    # marker and previously fell through classify_generic() to a bare
+    # UNKNOWN_ERR, same class as the nlm fix above: a Keychain lookup that
+    # genuinely found nothing (`security find-generic-password -s
+    # jules-api-key` -> item not found, verified on this host) is a
+    # provisioning gap, not an ambiguous failure — CRED_UNAVAILABLE names it
+    # precisely and puts it in CONTEXT_LIMITED, matching how glm's identical
+    # "credential missing" shape is already classified. Matched before
+    # classify_generic (mirrors probe_nlm's AUTH_DEAD special-case) so the
+    # existing UNKNOWN_ERR guilt case (empty stdout, rc=0, no error text —
+    # test_probe_jules_no_sources_is_unknown_err) stays untouched: that shape
+    # never contains this marker.
+    if not live and re.search(r"no API key", combined, re.IGNORECASE):
+        return CRED_UNAVAILABLE, ev or "jules credential missing", latency_ms
+    status = classify_generic(combined, live, "jules", is_ssh_context())
     return status, ev, latency_ms
 
 

--- a/scripts/tests/test_arsenal_probe.py
+++ b/scripts/tests/test_arsenal_probe.py
@@ -828,6 +828,43 @@ def test_probe_jules_no_sources_is_unknown_err(monkeypatch):
     assert status == ap.UNKNOWN_ERR
 
 
+def test_probe_jules_no_api_key_is_cred_unavailable(monkeypatch):
+    # guilt: real exemplar (2026-08-21, ~/.organism/arsenal/last.json on Mini) —
+    # jules_dispatch.py's get_api_key() prints "no API key" + a
+    # security add-generic-password recipe to stderr and exits 2 when the
+    # jules-api-key Keychain item was never provisioned (verified on Mini:
+    # `security find-generic-password -s jules-api-key` -> item not found).
+    # This shape carries no 401/oauth marker and previously fell through
+    # classify_generic() to a bare UNKNOWN_ERR — indistinguishable from the
+    # genuinely ambiguous empty-output case above.
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/bin/python3", True))
+    monkeypatch.setattr(
+        ap.subprocess,
+        "run",
+        lambda cmd, **kwargs: _FakeProc(
+            2,
+            "",
+            "jules_dispatch: no API key — add it with:\n"
+            "  security add-generic-password -a balizero -s jules-api-key -w '<KEY>'",
+        ),
+    )
+    status, ev, latency = ap.probe_jules(timeout=5)
+    assert status == ap.CRED_UNAVAILABLE
+
+
+def test_probe_jules_live_output_mentioning_api_key_stays_live(monkeypatch):
+    # innocence: a LIVE answer (real source lines) that happens to mention
+    # "API key" in a source name must never be reclassified as credential-dead.
+    monkeypatch.setattr(ap, "resolve_bin", lambda name, extra_paths=None: ("/usr/bin/python3", True))
+    monkeypatch.setattr(
+        ap.subprocess,
+        "run",
+        lambda cmd, **kwargs: _FakeProc(0, "sources/github/org/api-key-rotator\n", ""),
+    )
+    status, ev, latency = ap.probe_jules(timeout=5)
+    assert status == ap.LIVE
+
+
 def test_deepseek_retired_not_in_all_seats_or_probe_funcs():
     # DeepSeek V4 Pro API retired 2026-07-19 (owner order, pre-auth revoked —
     # never top up). Guilt-style: it must not resurface as a probeable seat.


### PR DESCRIPTION
## Summary
- `probe_jules()` fell through to a bare `UNKNOWN_ERR` when `jules_dispatch.py`'s `get_api_key()` reports "no API key" (Keychain item `jules-api-key` never provisioned) — indistinguishable from a genuinely ambiguous failure.
- Matches the existing `glm` credential-missing classification (`CRED_UNAVAILABLE`), matched before `classify_generic()` mirroring the `probe_nlm` AUTH_DEAD special-case.
- Root-caused this healer tick against `proprioception.py`'s `arsenal_seats` DIVERGED finding (seat `jules`: `UNKNOWN_ERR`).

## Test plan
- [x] `pytest scripts/tests/test_arsenal_probe.py -k jules -q` — 4 passed (guilt: no-API-key → CRED_UNAVAILABLE; innocence: live output mentioning "API key" stays LIVE; existing empty-output UNKNOWN_ERR case untouched)
- [x] pre-commit + pre-push hooks green

🤖 Generated by the Mini-Pro2 healer (autonomous cure loop)