### PR TITLE
docs(cicatrix): restore W121 to the superscar bridge — #4534's 'zero W-token lost' claim was false

### DIFF
--- a/.claude/rules/cicatrix-superscar.md
+++ b/.claude/rules/cicatrix-superscar.md
@@ -64,7 +64,7 @@ access-wall, dev identity su proxy PROD) · W97 (display-cap `[:40]` letto come 
 W101-recidiva-fly-backup (PARTIAL: Fase 2 mai parte) · W104 (`redis-cli` esce 0 con NOAUTH su stdout) ·
 W107 (curato 1 wrapper su 5) · W108 (19/20 cron muti, 2 cause) · W110 (heartbeat sull'organo sbagliato)
 · W116 (allarme su esito giusto, cura codice morto) · W118 (11h fermo, nessun check rosso) · W120
-(sentinella della famiglia stessa disarmata).
+(sentinella della famiglia stessa disarmata) · W121 (mutation testing su bytecode avvelenato).
 **→ dettaglio:** cicatrix-scars.md (resto) + archive (W34/W32/W64/W69/W71/W74/503)
 
 ---


### PR DESCRIPTION
## What

Restores the family-#2 member line `· W121 (mutation testing su bytecode avvelenato)` to `.claude/rules/cicatrix-superscar.md` — the line PR #4534's own prune deleted.

## Why this exists

The 2026-08-22 live audit of yesterday's 46-PR campaign (dispatched by Zero, Qwen lane) verified every merged PR's claims against disk. #4534's central self-check claim — "the set of `W\d+` tokens is identical before and after — zero lost, zero gained" — is **falsified by its own diff**: the prune deleted the W121 member line, dropping the token set 78→77. W121 had been added to the bridge by #4525 only ~50 minutes earlier; its body in `cicatrix-scars.md:8` survives, but the bridge no longer referenced it — exactly the token loss the PR claimed impossible.

This PR does not touch the byte-count claim (13,988→13,470, verified exact) — only the membership loss is cured, by restoring the member.

## Verification

- `scripts/tests/test_superscar_budget.py`: **10/10 passed** post-edit (budget ≤14,000 bytes + W-number completeness)
- File size 13,520 bytes — 480 bytes of margin
- W121 body confirmed present at `cicatrix-scars.md:8` (P1 STRUCTURAL, mutation testing on poisoned bytecode)

Found by: 2026-08-22 campaign live-audit, docs-verification pass (claim-by-claim, worktree at origin/main).