### PR TITLE
docs(mouth): the 29-minute promote-wait was 12m22s — 12:37:57Z was queue-entry, not merge

### DIFF
--- a/apps/mouth/README.md
+++ b/apps/mouth/README.md
@@ -39,9 +39,12 @@ git push origin main   # builds — see the note below, this is NOT the whole st
 > production already carries it, and promotes the existing READY build — it never rebuilds.
 > Budget about half an hour, not fifteen minutes and not instantly: Vercel has to finish the
 > build first, and only then can the next cron tick promote it. Measured end-to-end once, on
-> 2026-08-21: merge at 12:37:57Z, live at 13:07:00Z — **29 minutes**. That is a single
-> observation, not a distribution; the 15 minutes is only the cron's cadence, which an earlier
-> draft of this note mistook for the whole wait.
+> 2026-08-21: merge (GitHub `merged_at`) at 12:54:38Z, live at 13:07:00Z — **about 12
+> minutes**. That is a single observation, not a distribution; the 15 minutes is only the
+> cron's cadence, which an earlier draft of this note mistook for the whole wait. (An even
+> earlier draft anchored on 12:37:57Z and reported 29 minutes: that was the merge-queue entry
+> timestamp, not the merge — the 29 included ~17 minutes of queue dwell, which is not part of
+> the deploy path.)
 >
 > To do it by hand from a machine where `vercel whoami` answers:
 > `python3 scripts/vercel_prod_deploy.py --dry-run` reports the gap and changes nothing;


### PR DESCRIPTION
## What

Corrects the measured-anchor in `apps/mouth/README.md`'s promote note: the merge anchor is GitHub's authoritative `merged_at` (**12:54:38Z** for #4540), not 12:37:57Z — which was the merge-queue entry / merge-commit timestamp. Against the correct anchor, merge→production was **~12m22s** (live at 13:07:00Z), not 29 minutes; the 29 included ~17 minutes of merge-queue dwell, which is not part of the deploy path.

## Why this exists

The 2026-08-22 live audit of yesterday's campaign (dispatched by Zero, Qwen lane) verified #4544's "measured" anchor against GitHub's own `merged_at` and the Mini organ log. The live-side timestamp IS corroborated: the `PROMOTED — production moved` line in Mini's `~/logs/mini-vercel_autopromote/run.log` at 2026-08-21 21:07 WITA (13:07 UTC) and the 13:07:18Z "Is production serving this commit?" check-run. The merge-side anchor was not.

The conservative guidance ("budget about half an hour") is deliberately KEPT — only the confident number is corrected, and the correction is written into the text so the next reader sees where the 29 came from.

## Verification

- `gh pr view 4540 --json mergedAt` → `2026-08-21T12:54:38Z`
- Mini organ log: `[2026-08-21 21:07:00] PROMOTED — production moved` (= 13:07:00Z)
- Arithmetic: 12:54:38Z → 13:07:00Z = 12m22s

Found by: 2026-08-22 campaign live-audit, docs-verification pass.
