### PR TITLE
docs(contract): scope the rerun prohibition by CAUSE, because the blanket form deadlocks PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,14 @@ still does not arm, merge, or deploy). The operational commands are documented i
    permits it.
 2. **Arm means freeze.** After `mq arm`, the branch is read-only. Put every follow-up in a new
    PR created from a fresh `origin/main`.
-3. **Never rerun a check without repointing the ref.** Use `mq requeue`; never use a bare
-   `gh run rerun`.
+3. **Never rerun a check without first knowing WHY it is red.** The gesture depends on the cause,
+   and a blanket prohibition here deadlocked two PRs on 2026-08-21. If the red is the CODE or the
+   base has moved, `gh run rerun` replays a stale merge ref (W111) — repoint it: `mq requeue`, or
+   `gh pr update-branch` first. If instead the red is an EXTERNAL COMMIT STATUS on an unchanged
+   head SHA — a Gear-3 gate verdict posted after the run finished — then `gh run rerun` on the
+   original `pull_request` run is the ONLY instrument that clears the PR's rollup, because a
+   `workflow_dispatch` run's check-run lands in a different check suite and never enters that
+   rollup at all. Details and the diagnostic traps: `docs/runbooks/merge-queue-discipline.md`.
 4. **Never commit while a push is in flight.** Judge the push by its captured return code, not
    by a background-task summary.
 5. **Serialize Dependabot PRs that share a lockfile.** Arm them one at a time.

--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -256,7 +256,11 @@ matrix job's suffixed required context never shows up under any name at all (§2
 never reported" class; scar `discovery_skipped_matrix_job_never_emits_its_required_contexts`).
 
 **Re-running a check by hand never uses `gh run rerun` on a stale ref (W111)** — it replays the OLD
-merge commit; `gh pr update-branch` first, or use `mq requeue` / `queue_rearm.sh --apply`.
+merge commit; `gh pr update-branch` first, or use `mq requeue` / `queue_rearm.sh --apply`. **One
+scoped exception, measured 2026-08-21:** when the red is an external commit status on an UNCHANGED
+head SHA (a Gear-3 gate verdict posted after the run finished) and the workflow checks out a pinned
+base SHA rather than a merge ref, `gh run rerun` on the original `pull_request` run is the only
+instrument that clears the rollup — see §6quater.
 
 Test: `scripts/tests/test_pr_watch.sh` (fake `gh`, no network). `mq watch` is the post-arm drift
 guard for one PR against its armed SHA; `pr_watch.sh` is the terminal-state watcher for one or many
@@ -321,10 +325,51 @@ retried.**
   SYSTEMATIC failure that retrying will reproduce forever. Separate the two before retrying —
   see §6ter, which is the shape that actually bit this repo on 2026-07-27/28.
 
-`gh run rerun <run_id> --failed` is the right gesture ONLY in the INFRA case, and note the trap
-before using it: **`rerun` replays the OLD merge commit**, so on a branch that has since fallen
-behind it re-tests a stale base — `gh pr update-branch` first
-(`lesson_gh_run_rerun_replays_the_stale_merge_commit_2026_07_27`).
+`gh run rerun <run_id> --failed` is the right gesture in the INFRA case and in the
+EXTERNAL-STATUS case (§6quater), and note the trap before using it: **`rerun` replays the OLD merge
+commit**, so on a branch that has since fallen behind it re-tests a stale base — `gh pr
+update-branch` first (`lesson_gh_run_rerun_replays_the_stale_merge_commit_2026_07_27`).
+
+---
+
+## 6quater. The red is an external commit status, not the code
+
+A job that reads a commit status on the head SHA — the Gear-3 `harness/fable-gate` verdict is the
+one in this repo — fails identically whether the verdict is REWORK or simply **not posted yet**.
+Once the gate session posts it, the job has to run again, and the obvious gesture is the wrong one.
+
+**Do not use `gh workflow run --ref`.** A `workflow_dispatch` run creates its check-run in a
+DIFFERENT CHECK SUITE from the `pull_request` event's, and it does not enter the PR's
+`statusCheckRollup` **at all** — it is an absent entry, not a superseded one. Measured on #4543:
+the rollup holds exactly ONE `Harness floor recompute` entry and it points at the `pull_request`
+run; the dispatch run appears nowhere in it. So the dispatch goes green while the PR stays BLOCKED.
+This cost two sessions the same detour (#4543, #4549).
+
+**Use `gh run rerun <the original pull_request run id>`.** Find it with:
+
+```bash
+gh run list --branch <branch> --workflow <file>.yml --json databaseId,event,headSha,conclusion
+```
+
+and take the row whose `event` is `pull_request` and whose `headSha` is the PR's current head. Same
+SHA, same suite, verdict now posted — the rollup clears.
+
+**Why this does not repeal W111.** W111's hazard is a run whose ref RESOLVES THROUGH A MOVING BASE;
+its own incident was #3463 replayed against `refs/pull/3463/merge` — a pull-request merge ref, so
+"reruns are only dangerous on merge_group" is false. The exception here is not "pull_request reruns
+are safe"; it is that _this_ workflow checks out a PINNED base SHA
+(`github.event.merge_group.base_sha || github.event.pull_request.base.sha`) and never
+`refs/pull/N/merge`, so there is no moving ref for the rerun to resolve differently. **Before
+copying this to another workflow, read that workflow's `ref:`.**
+
+**Diagnostic trap.** While diagnosing, `gh pr checks` and `gh api …/check-runs` will appear to
+contradict each other. The cause is **pagination**, not the filter: the endpoint returns 30 rows by
+default and a PR head here carries ~55-63 check-runs. Measured on `76edf60e2` — no `per_page`:
+`returned=30 failures=0`; `filter=all` with no `per_page`: **still** `returned=30 failures=0`;
+`filter=all&per_page=100`: `returned=55 failures=1`. So `per_page=100` (or `--paginate`) is
+mandatory; `filter=all` alone reports zero failures on a head that has one. `filter=all` does a
+different job — it re-adds attempts superseded _within_ their own suite. Then compare
+`check_suite.id`, which is the field that actually explains the disagreement.
 
 **Do not classify by job name, and do not classify from a snapshot.** An empty `conclusion` is
 _"not yet known"_, never _"no failure"_ — #3326 was read while `in_progress`/`conclusion=∅` and


### PR DESCRIPTION
## What

Agent PR Contract rule 3 (`CLAUDE.md`) read **"never use a bare `gh run rerun`"**, unqualified. Followed literally it has now deadlocked two PRs — #4543 and #4549 — and cost two sessions the same detour.

## Why the blanket form is wrong

When a job fails because a Gear-3 gate verdict is *not yet posted*, the documented alternative (`gh workflow run --ref`) creates its check-run in a **different check suite**, and that run **does not enter the PR's `statusCheckRollup` at all** — an absent entry, not a superseded one.

Measured on #4543: the rollup holds exactly ONE `Harness floor recompute` entry and it points at run `32489011695` (the `pull_request` run); the dispatch run `32489857553` appears nowhere in it. The dispatch goes green, the PR keeps the old failure and stays `BLOCKED`.

## What changed

Rule 3 now branches on the **cause** of the red:

| Cause | Instrument |
|---|---|
| Code red, or the base has moved | `gh run rerun` replays a stale merge ref (W111) — repoint it (`mq requeue`, `gh pr update-branch`) |
| External commit status on an **unchanged** head SHA | `gh run rerun` on the original `pull_request` run — the only thing that clears the rollup |

New runbook section **§6quater** carries the full procedure, the run-id discovery command, and the trap.

## This does not repeal W111

It also does not claim `pull_request` reruns are inherently safe. W111's own incident was #3463 replayed against `refs/pull/3463/merge` — a *pull-request* merge ref — so "only `merge_group` is dangerous" is false.

The exception holds because **this** workflow checks out a PINNED base SHA. Verified against `harness-floor.yml:181` on `origin/main`: it resolves `github.event.merge_group.base_sha || github.event.pull_request.base.sha` and never `refs/pull/N/merge`. The runbook says to read the target workflow's `ref:` before copying the exception anywhere else.

## Diagnostic trap — measured, and it corrects an earlier claim of mine

`gh api .../check-runs` hides the row you need by **PAGINATION**, not by `filter=latest`. On `76edf60e2`:

| invocation | returned | failures |
|---|---|---|
| no `per_page` | 30 of 54 | 0 |
| `filter=all`, no `per_page` | 30 of 55 | **0** |
| `filter=all&per_page=100` | 55 | **1** |

So `filter=all` alone reports zero failures on a head that has one. `per_page=100` (or `--paginate`) is mandatory.

## Verification

- `prettier --check` clean on both files
- The `ref:` claim re-read from `origin/main`, not from the local checkout (which is held behind)
- Every number above re-measured in-session against live GitHub state

🤖 Generated with [Claude Code](https://claude.com/claude-code)