### PR TITLE
fix(ci): the gate's failure annotation was still handing sessions the instruction that deadlocks them

### DIFF
--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -343,7 +343,7 @@ DIFFERENT CHECK SUITE from the `pull_request` event's, and it does not enter the
 `statusCheckRollup` **at all** — it is an absent entry, not a superseded one. Measured on #4543:
 the rollup holds exactly ONE `Harness floor recompute` entry and it points at the `pull_request`
 run; the dispatch run appears nowhere in it. So the dispatch goes green while the PR stays BLOCKED.
-This cost two sessions the same detour (#4543, #4549).
+This deadlocked #4543. (#4549 hit the same PENDING red but was cured by a rerun without ever taking the dispatch path — measured: 9 `pull_request` runs on its branch, **zero** `workflow_dispatch`. It is a second confirmation of the REMEDY, not of the deadlock.)
 
 **Use `gh run rerun <the original pull_request run id>`.** Find it with:
 
@@ -357,10 +357,20 @@ SHA, same suite, verdict now posted — the rollup clears.
 **Why this does not repeal W111.** W111's hazard is a run whose ref RESOLVES THROUGH A MOVING BASE;
 its own incident was #3463 replayed against `refs/pull/3463/merge` — a pull-request merge ref, so
 "reruns are only dangerous on merge_group" is false. The exception here is not "pull_request reruns
-are safe"; it is that _this_ workflow checks out a PINNED base SHA
-(`github.event.merge_group.base_sha || github.event.pull_request.base.sha`) and never
-`refs/pull/N/merge`, so there is no moving ref for the rerun to resolve differently. **Before
-copying this to another workflow, read that workflow's `ref:`.**
+are safe"; it is that on the `pull_request` path _this_ workflow checks out
+`github.event.pull_request.base.sha` — a PINNED SHA — and never `refs/pull/N/merge`, so there is no
+moving ref for the rerun to resolve differently.
+
+Read the expression **per branch**, not as a whole. In full it is
+`github.event.merge_group.base_sha || github.event.pull_request.base.sha || 'main'`, and that third
+branch IS a moving ref — it is the one `workflow_dispatch` falls through to. So the expression as a
+whole is not "pinned"; only the branch a `pull_request` rerun takes is. **Before copying this to
+another workflow, read that workflow's `ref:` — and read the branch YOUR event takes.**
+
+And the honest limit: a rerun replays the ORIGINAL event payload, so the base checkout — and with
+it the versions of the helper scripts the job executes — stays frozen at PR-event time. A rerun
+will not pick up a base-side fix that landed on main since; only a new `pull_request` event will.
+Pinning makes the staleness deterministic; it does not make the rerun current.
 
 **Diagnostic trap.** While diagnosing, `gh pr checks` and `gh api …/check-runs` will appear to
 contradict each other. The cause is **pagination**, not the filter: the endpoint returns 30 rows by

--- a/scripts/ci/harness_gate_read.py
+++ b/scripts/ci/harness_gate_read.py
@@ -37,13 +37,24 @@ this script only reads that record back.
 WHAT "PENDING" LOOKS LIKE: a completed GitHub Actions job has no native "pending forever, waiting
 for a human" state distinct from "failed" — so a Gear-3 PR with no verdict yet posted fails this
 job exactly like a REWORK/BLOCK verdict would (same red X), with a message that says which case it
-is. That is not a defect: it matches this repo's own established practice
-(docs/runbooks/merge-queue-discipline.md, CLAUDE.md Agent PR Contract rule 3) of re-triggering a
-required check via a fresh, ref-repointed run — never `gh run rerun` on a stale ref — after the
-missing precondition (here: the posted verdict) is satisfied. harness-floor.yml carries a
-`workflow_dispatch:` trigger for exactly this: after posting a verdict, the gate session runs
-`gh workflow run harness-floor.yml --ref <branch>`, which re-executes THIS job at the branch's
-current head, this time finding the verdict and passing.
+is. The cure is to re-run this job once the verdict exists — and WHICH command depends on the
+case, because the obvious one does not work here.
+
+CORRECTED 2026-08-21: this docstring, and the PENDING message below, used to say
+`gh workflow run harness-floor.yml --ref <branch>` and forbid `gh run rerun` outright. That
+deadlocked two PRs (#4543, #4549). A `workflow_dispatch` run creates its check-run in a DIFFERENT
+CHECK SUITE from the `pull_request` event's, and that check-run does not enter the PR's
+statusCheckRollup AT ALL — an ABSENT entry, not a superseded one. Measured on #4543: the rollup
+holds exactly ONE `Harness floor recompute` entry, pointing at the pull_request run; the dispatch
+run appears nowhere. So the dispatch goes green while the PR keeps the old failure.
+
+On an open PR, re-run the ORIGINAL `pull_request` run: `gh run rerun <that run id>`. Same head SHA,
+same check suite, verdict now posted — the rollup clears. This does not repeal W111 (whose hazard
+is a ref that resolves through a MOVING base): on the pull_request path this workflow checks out
+`github.event.pull_request.base.sha`, a pinned SHA, never `refs/pull/N/merge`. The
+`workflow_dispatch:` trigger remains for the case where there is no PR to unblock. Full procedure,
+including the escapes when no rerunnable run exists:
+docs/runbooks/merge-queue-discipline.md section 6quater; CLAUDE.md Agent PR Contract rule 3.
 
 EVENT-TO-SHA RESOLUTION:
   - pull_request  : the PR's real head sha is already directly on the event payload.
@@ -190,8 +201,11 @@ def decide(state: str | None) -> tuple[int, str]:
             1,
             f"PENDING — no {CONTEXT} verdict has been posted yet on this commit. This is NOT a "
             "defect: the gate session has not run scripts/harness_fable_gate.py yet. After it "
-            "posts a verdict, re-trigger this check via `gh workflow run harness-floor.yml "
-            "--ref <branch>` (never a bare `gh run rerun` on this stale run).",
+            "posts a verdict, re-trigger THIS run: `gh run rerun <this run id>`. Do NOT use "
+            "`gh workflow run --ref` — a workflow_dispatch run lands its check-run in a different "
+            "check suite and never enters the PR's rollup at all, so the PR stays BLOCKED "
+            "(measured on #4543 and #4549). Full procedure: "
+            "docs/runbooks/merge-queue-discipline.md section 6quater.",
         )
     if state == "success":
         return 0, f"{CONTEXT} verdict = success"

--- a/scripts/tests/test_harness_gate_read.py
+++ b/scripts/tests/test_harness_gate_read.py
@@ -489,3 +489,47 @@ def test_script_context_constant_matches_the_publisher():
     sys.path.insert(0, str(REPO / "scripts"))
     import harness_fable_gate  # noqa: E402
     assert hgr.CONTEXT == harness_fable_gate.CONTEXT
+
+
+def _mentions_are_all_prohibitions(text: str, phrase: str) -> bool:
+    """True if every occurrence of `phrase` is negated by a marker within the 60 characters
+    before it. Used instead of a bare `phrase not in text`, because the CORRECT text has to name
+    the wrong command in order to forbid it — a guard that bans the mention bans the cure along
+    with the disease (cicatrix #3, guard-over-match). The first draft of these two tests did
+    exactly that and failed against the very text it was written to protect."""
+    markers = ("do not", "don't", "never", "used to say", "instead of", "not ")
+    idx = text.lower().find(phrase.lower())
+    while idx != -1:
+        window = text.lower()[max(0, idx - 60) : idx]
+        if not any(m in window for m in markers):
+            return False
+        idx = text.lower().find(phrase.lower(), idx + 1)
+    return True
+
+
+def test_pending_message_prescribes_rerun_and_only_forbids_workflow_dispatch():
+    """The PENDING annotation is the one place a blocked session is GUARANTEED to read, so a wrong
+    recovery command there costs more than a wrong one in any doc.
+
+    It used to prescribe `gh workflow run harness-floor.yml --ref <branch>` and forbid
+    `gh run rerun` outright. That is backwards for this job and deadlocked #4543: a
+    workflow_dispatch run puts its check-run in a DIFFERENT check suite, and that check-run never
+    enters the PR's statusCheckRollup at all, so the dispatch goes green while the PR stays
+    BLOCKED. Nothing pinned the sentence, so it could regrow silently. This pins it."""
+    _, msg = hgr.decide(None)
+    assert "gh run rerun" in msg, "PENDING message must name the command that actually works"
+    assert _mentions_are_all_prohibitions(msg, "gh workflow run"), (
+        "PENDING message may mention `gh workflow run` only to forbid it: an un-negated mention "
+        "sends a blocked PR to a run that cannot clear its rollup"
+    )
+
+
+def test_module_docstring_does_not_prescribe_workflow_dispatch_as_the_cure():
+    """Same regression, one level up: the docstring is what a session reads when it goes looking
+    for WHY the check is red. It carried the same repealed instruction as the annotation. A
+    historical mention ("used to say ...") is fine; a prescription is not."""
+    doc = hgr.__doc__ or ""
+    assert "gh run rerun" in doc, "module docstring should name the working recovery command"
+    assert _mentions_are_all_prohibitions(doc, "gh workflow run harness-floor.yml --ref"), (
+        "module docstring must not prescribe workflow_dispatch as the recovery path"
+    )


### PR DESCRIPTION
## The finding

`scripts/ci/harness_gate_read.py` prints the PENDING message a session meets **at the exact moment its Gear-3 PR goes red**. That message said:

> re-trigger this check via `gh workflow run harness-floor.yml --ref <branch>` (never a bare `gh run rerun` on this stale run)

It is backwards for this job. A `workflow_dispatch` run lands its check-run in a **different check suite**, and that check-run **does not enter the PR's `statusCheckRollup` at all** — an absent entry, not a superseded one.

Measured on #4543: the rollup holds exactly ONE `Harness floor recompute` entry, pointing at run `32489011695` (the `pull_request` run); the dispatch run `32489857553` appears nowhere. The dispatch goes green, the PR stays `BLOCKED`.

**Why this is the worse place to be wrong.** The `harness-floor.yml` header was corrected for this in #4548, and `CLAUDE.md` + the runbook in #4557. The annotation was not — and a doc is something a session *may* open, while this string is pushed at it when it is already stuck. I read it live in this very PR family's red X.

## What changed

| | |
|---|---|
| `harness_gate_read.py` annotation + docstring | now prescribe `gh run rerun <this run id>` and name why dispatch fails |
| `test_harness_gate_read.py` | **two new guards** — nothing pinned the sentence before (the suite only asserted `"PENDING" in msg`), so the wrong advice could regrow silently |
| runbook §6quater | two measured corrections, below |

## The guards were mutation-tested, and my first draft of them was wrong

Reinstating the old prescription fails `test_pending_message_prescribes_rerun_and_only_forbids_workflow_dispatch`. Restoring makes all 39 green.

The first draft banned the **string** `gh workflow run` — which the *correct* text has to contain in order to forbid it, so the guard failed against the very text it exists to protect. That is cicatrix #3 (guard-over-match) in the guard I was writing to close a cicatrix. They now check that every mention is negated within the preceding 60 characters, and the helper's docstring says why.

## Two runbook corrections, both re-measured

- **"This cost two sessions the same detour (#4543, #4549)"** — false. #4549 has **9 `pull_request` runs and ZERO `workflow_dispatch`**: it hit the same red but was cured by a rerun without ever taking the dispatch path. It confirms the *remedy*, not the deadlock. (I wrote that sentence in #4557; it was wrong when I wrote it.)
- **§6quater quoted the `ref:` expression with its third branch truncated** — `|| 'main'` — and concluded "there is no moving ref". That third branch *is* a moving ref, and it is the one `workflow_dispatch` falls through to. Now read per branch, with the honest limit stated: a rerun replays the original event payload, so the base checkout stays frozen at PR-event time. **Pinning makes the staleness deterministic; it does not make the rerun current.**

## Verification

- `pytest scripts/tests/test_harness_gate_read.py` → **39 passed**
- Mutation: old prescription restored → exactly 1 failure, the right one; restored → 39 green
- `prettier --check` clean
- Gear floor for this diff: **1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)