### PR TITLE
feat(conductor): add model intelligence foundation

### DIFF
--- a/infra/conductor/calibration_overlay.schema.json
+++ b/infra/conductor/calibration_overlay.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "calibration_overlay.schema.json",
+  "title": "MIR endpoint task calibration overlay v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_at", "records"],
+  "properties": {
+    "schema_version": {
+      "const": "calibration-overlay.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "benchmark_id",
+          "benchmark_version",
+          "endpoint_id",
+          "endpoint_profile_hash",
+          "task_profile_id",
+          "score",
+          "conservative_score",
+          "sample_count",
+          "sample_hashes",
+          "scorer",
+          "measured_at",
+          "expires_at",
+          "dispersion"
+        ],
+        "properties": {
+          "benchmark_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "benchmark_version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "endpoint_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]*$"
+          },
+          "endpoint_profile_hash": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "task_profile_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]*$"
+          },
+          "score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "conservative_score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "sample_count": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "sample_hashes": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            }
+          },
+          "scorer": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "version"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "version": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "measured_at": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+          },
+          "expires_at": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+          },
+          "dispersion": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["metric", "value"],
+            "properties": {
+              "metric": {
+                "const": "sample_variance"
+              },
+              "value": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 0.25
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/infra/conductor/calibrations.v1.json
+++ b/infra/conductor/calibrations.v1.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "calibration-overlay.v1",
+  "generated_at": "2026-08-22T00:00:00Z",
+  "records": []
+}

--- a/infra/conductor/capability_ontology.v1.json
+++ b/infra/conductor/capability_ontology.v1.json
@@ -1,0 +1,382 @@
+{
+  "schema_version": "capability-ontology.v1",
+  "generated_at": "2026-08-21",
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#5",
+      "observed_at": "2026-08-21"
+    }
+  ],
+  "modalities": [
+    {
+      "id": "language",
+      "description": "Text input/output capability.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "description": "Code-oriented language work; does not imply mutation authorization.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "description": "Image understanding or OCR.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "ocr",
+      "description": "Optical character recognition as an explicitly declared modality.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "embedding",
+      "description": "Vector embedding generation.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "image_generation",
+      "description": "Image synthesis.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "video_generation",
+      "description": "Video synthesis.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "video",
+      "description": "Video understanding or generation as an explicitly declared modality.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "audio_tts",
+      "description": "Text-to-speech.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "audio_realtime",
+      "description": "Realtime audio.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Alibaba-Token-Plan-TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "audio_asr",
+      "description": "Speech recognition.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "knowledge_verification",
+      "description": "Ground-truth source verification service, not an inference-quality claim.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "techniques": [
+    {
+      "id": "reasoning_control",
+      "description": "Documented effort/thinking control; exact values remain per endpoint.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling",
+      "description": "Tool use exposed by the invocation surface.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling_declared",
+      "description": "Declared tool-use support that is not a runtime availability claim.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "approval_review",
+      "description": "Approval or policy review capability; does not authorize mutation.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI Running Codex safely | https://openai.com/index/running-codex-safely/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "multimodal_review",
+      "description": "Visual artifact or screenshot review.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "description": "Eligible only on local Pro or Mini placement.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    {
+      "id": "pii_safe_local",
+      "description": "Local lane approved for PII intake; no claim about every prompt or output.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.pii_intake",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence_levels": [
+    {
+      "id": "declared",
+      "meaning": "Repository policy, roster, or vendor/console declaration; not a quality score.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#10",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "probed",
+      "meaning": "Observed availability/feature probe with a documented method.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#10",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "benchmarked",
+      "meaning": "Scored against a versioned task benchmark with traceable sample evidence.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#10",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "production",
+      "meaning": "Measured production outcome or consumption record.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "unmeasured",
+      "meaning": "Explicitly unknown; must not be treated as a positive capability.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#3.2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "routing_statuses": [
+    {
+      "id": "eligible",
+      "meaning": "Policy permits automated candidate selection subject to fresh endpoint health and task rules.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#3.2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "manual_only",
+      "meaning": "Known model; never auto-routed.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    {
+      "id": "probation",
+      "meaning": "Known endpoint but never load-bearing or quorum-eligible.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    {
+      "id": "phantom",
+      "meaning": "Explicitly absent from the known plan; no live seat.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.grunt",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "denied",
+      "meaning": "Observed access denial; unavailable until a new observation changes it.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "investigation_required",
+      "meaning": "A probe succeeded but billing/plan eligibility is unresolved; router must not select it.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "MODEL_ROSTER.md#Coding-plan-models-measured-2026-08-21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "listed_unexploited",
+      "meaning": "Console-listed specialized capability with no role-chain or use decision.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "deprecated",
+      "meaning": "Known historical surface retained for inventory but not selectable.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#pending_arms",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    {
+      "id": "known_unmeasured",
+      "meaning": "Known identifier without a current eligibility or health claim.",
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profile.schema.json
+++ b/infra/conductor/endpoint_profile.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "endpoint_profile.schema.json",
+  "title": "MIR EndpointProfile v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "model_card_id",
+    "invocation",
+    "account_class",
+    "auth_surface",
+    "machine_constraints",
+    "routing",
+    "enforcement",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "endpoint-profile.v1"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "model_card_id": {
+      "type": "string"
+    },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "invocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["engine", "model_identifier", "evidence"],
+      "properties": {
+        "engine": {
+          "type": "string"
+        },
+        "model_identifier": {
+          "type": "string"
+        },
+        "harness": {
+          "type": ["string", "null"]
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "account_class": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "evidence"],
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "auth_surface": {
+      "enum": [
+        "unknown",
+        "local_runtime",
+        "anthropic_oauth_subscription",
+        "anthropic_paid_api",
+        "openai_chatgpt_subscription",
+        "google_oauth_subscription",
+        "manual_gui",
+        "other_provider_api"
+      ]
+    },
+    "machine_constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowlist", "evidence"],
+      "properties": {
+        "allowlist": {
+          "type": "array",
+          "items": {
+            "enum": ["air-m5", "pro", "mini-pro2"]
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "automated_routing", "evidence"],
+      "properties": {
+        "status": {
+          "enum": [
+            "eligible",
+            "manual_only",
+            "probation",
+            "phantom",
+            "denied",
+            "investigation_required",
+            "listed_unexploited",
+            "deprecated",
+            "known_unmeasured"
+          ]
+        },
+        "automated_routing": {
+          "type": "boolean"
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "enforcement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "evidence"],
+      "properties": {
+        "mode": {
+          "enum": [
+            "enforced",
+            "shadow",
+            "advisory_only",
+            "manual_only",
+            "unmeasured"
+          ]
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "exposed_capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "value", "evidence"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "value": {
+            "enum": [true, false, null]
+          },
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/evidence"
+            }
+          }
+        }
+      }
+    },
+    "restrictions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "value", "evidence"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "value": {
+            "type": ["string", "boolean", "null"]
+          },
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/evidence"
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/evidence"
+      }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "ref", "observed_at"],
+      "properties": {
+        "level": {
+          "enum": [
+            "declared",
+            "probed",
+            "benchmarked",
+            "production",
+            "unmeasured"
+          ]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "observed_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+        }
+      }
+    }
+  }
+}

--- a/infra/conductor/endpoint_profiles/agy-gemini-3-flash-preview.json
+++ b/infra/conductor/endpoint_profiles/agy-gemini-3-flash-preview.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "agy-gemini-3-flash-preview",
+  "model_card_id": "gemini-3-flash-preview",
+  "aliases": [],
+  "invocation": {
+    "engine": "agy",
+    "model_identifier": "google-gemini-cli/gemini-3-flash-preview",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "google-ai-ultra",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "google_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "deprecated",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/agy-gemini-3.1-pro.json
+++ b/infra/conductor/endpoint_profiles/agy-gemini-3.1-pro.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "agy-gemini-3.1-pro",
+  "model_card_id": "gemini-3.1-pro",
+  "aliases": [],
+  "invocation": {
+    "engine": "agy",
+    "model_identifier": "gemini-3.1-pro",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "google-ai-ultra",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "google_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/agy-gemini-3.5-flash.json
+++ b/infra/conductor/endpoint_profiles/agy-gemini-3.5-flash.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "agy-gemini-3.5-flash",
+  "model_card_id": "gemini-3.5-flash",
+  "aliases": [],
+  "invocation": {
+    "engine": "agy",
+    "model_identifier": "gemini-3.5-flash",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "google-ai-ultra",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "google_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/agy-gemini-deepthink.json
+++ b/infra/conductor/endpoint_profiles/agy-gemini-deepthink.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "agy-gemini-deepthink",
+  "model_card_id": "gemini-deepthink",
+  "aliases": [],
+  "invocation": {
+    "engine": "agy",
+    "model_identifier": "gemini-deepthink",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+        "observed_at": "2026-08-20"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "google-ai-ultra",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+        "observed_at": "2026-08-20"
+      }
+    ]
+  },
+  "auth_surface": "google_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+        "observed_at": "2026-08-20"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+        "observed_at": "2026-08-20"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+        "observed_at": "2026-08-20"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+      "observed_at": "2026-08-20"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-claude-fable-5.json
+++ b/infra/conductor/endpoint_profiles/claude-claude-fable-5.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-claude-fable-5",
+  "model_card_id": "claude-fable-5",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude",
+    "model_identifier": "claude-fable-5",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "anthropic-oauth-subscription",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "anthropic_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "manual_only",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "manual_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-claude-haiku-4-5.json
+++ b/infra/conductor/endpoint_profiles/claude-claude-haiku-4-5.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-claude-haiku-4-5",
+  "model_card_id": "claude-haiku-4-5",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude",
+    "model_identifier": "claude-haiku-4-5-20251001",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "anthropic-oauth-subscription",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "anthropic_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-claude-opus-4-8.json
+++ b/infra/conductor/endpoint_profiles/claude-claude-opus-4-8.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-claude-opus-4-8",
+  "model_card_id": "claude-opus-4-8",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude",
+    "model_identifier": "claude-opus-4-8",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "anthropic-oauth-subscription",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "anthropic_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-claude-opus-5.json
+++ b/infra/conductor/endpoint_profiles/claude-claude-opus-5.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-claude-opus-5",
+  "model_card_id": "claude-opus-5",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude",
+    "model_identifier": "claude-opus-5",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "anthropic-oauth-subscription",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "anthropic_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-claude-sonnet-4-6.json
+++ b/infra/conductor/endpoint_profiles/claude-claude-sonnet-4-6.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-claude-sonnet-4-6",
+  "model_card_id": "claude-sonnet-4-6",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude",
+    "model_identifier": "claude-sonnet-4-6",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "anthropic-oauth-subscription",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "anthropic_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-claude-sonnet-5.json
+++ b/infra/conductor/endpoint_profiles/claude-claude-sonnet-5.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-claude-sonnet-5",
+  "model_card_id": "claude-sonnet-5",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude",
+    "model_identifier": "claude-sonnet-5",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "anthropic-oauth-subscription",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "anthropic_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-glm-glm-4.5.json
+++ b/infra/conductor/endpoint_profiles/claude-glm-glm-4.5.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-glm-glm-4.5",
+  "model_card_id": "glm-4.5",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude-glm",
+    "model_identifier": "glm-4.5",
+    "harness": "Anthropic-compatible shim",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "z-ai-coding-plan",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-glm-glm-4.7.json
+++ b/infra/conductor/endpoint_profiles/claude-glm-glm-4.7.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-glm-glm-4.7",
+  "model_card_id": "glm-4.7",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude-glm",
+    "model_identifier": "glm-4.7",
+    "harness": "Anthropic-compatible shim",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "z-ai-coding-plan",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-glm-glm-4.json
+++ b/infra/conductor/endpoint_profiles/claude-glm-glm-4.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-glm-glm-4",
+  "model_card_id": "glm-4",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude-glm",
+    "model_identifier": "glm-4",
+    "harness": "Anthropic-compatible shim",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "z-ai-coding-plan",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-glm-glm-5.1.json
+++ b/infra/conductor/endpoint_profiles/claude-glm-glm-5.1.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-glm-glm-5.1",
+  "model_card_id": "glm-5.1",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude-glm",
+    "model_identifier": "glm-5.1",
+    "harness": "Anthropic-compatible shim",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "z-ai-coding-plan",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-glm-glm-5.2.json
+++ b/infra/conductor/endpoint_profiles/claude-glm-glm-5.2.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-glm-glm-5.2",
+  "model_card_id": "glm-5.2",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude-glm",
+    "model_identifier": "glm-5.2",
+    "harness": "Anthropic-compatible shim",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#z.ai",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "z-ai-coding-plan",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#z.ai",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#z.ai",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": true,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#z.ai",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#z.ai",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#z.ai",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/claude-glm-glm-5.json
+++ b/infra/conductor/endpoint_profiles/claude-glm-glm-5.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "claude-glm-glm-5",
+  "model_card_id": "glm-5",
+  "aliases": [],
+  "invocation": {
+    "engine": "claude-glm",
+    "model_identifier": "glm-5",
+    "harness": "Anthropic-compatible shim",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "z-ai-coding-plan",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-codex-auto-review.json
+++ b/infra/conductor/endpoint_profiles/codex-codex-auto-review.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-codex-auto-review",
+  "model_card_id": "codex-auto-review",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "codex-auto-review",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-5.3-codex-spark.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-5.3-codex-spark.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-5.3-codex-spark",
+  "model_card_id": "gpt-5.3-codex-spark",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-5.3-codex-spark",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-5.4-mini.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-5.4-mini.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-5.4-mini",
+  "model_card_id": "gpt-5.4-mini",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-5.4-mini",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-5.4.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-5.4.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-5.4",
+  "model_card_id": "gpt-5.4",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-5.4",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-5.5.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-5.5.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-5.5",
+  "model_card_id": "gpt-5.5",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-5.5",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-5.6-luna.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-5.6-luna.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-5.6-luna",
+  "model_card_id": "gpt-5.6-luna",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-5.6-luna",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-5.6-sol.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-5.6-sol.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-5.6-sol",
+  "model_card_id": "gpt-5.6-sol",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-5.6-sol",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-5.6-terra.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-5.6-terra.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-5.6-terra",
+  "model_card_id": "gpt-5.6-terra",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-5.6-terra",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-gpt-reserve.json
+++ b/infra/conductor/endpoint_profiles/codex-gpt-reserve.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-gpt-reserve",
+  "model_card_id": "gpt-reserve",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex",
+    "model_identifier": "gpt-reserve",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/codex-imagegen-gpt-image-2.json
+++ b/infra/conductor/endpoint_profiles/codex-imagegen-gpt-image-2.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "codex-imagegen-gpt-image-2",
+  "model_card_id": "gpt-image-2",
+  "aliases": [],
+  "invocation": {
+    "engine": "codex-imagegen",
+    "model_identifier": "$imagegen",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "chatgpt-subscription",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "openai_chatgpt_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "image_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/gemini-spark-gui-gemini-spark.json
+++ b/infra/conductor/endpoint_profiles/gemini-spark-gui-gemini-spark.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "gemini-spark-gui-gemini-spark",
+  "model_card_id": "gemini-spark",
+  "aliases": [],
+  "invocation": {
+    "engine": "gemini-spark-gui",
+    "model_identifier": "gemini-spark",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "google-consumer",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "manual_gui",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "manual_only",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "manual_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "knowledge_verification",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/kimi-kimi-for-coding-highspeed.json
+++ b/infra/conductor/endpoint_profiles/kimi-kimi-for-coding-highspeed.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "kimi-kimi-for-coding-highspeed",
+  "model_card_id": "kimi-for-coding-highspeed",
+  "aliases": [],
+  "invocation": {
+    "engine": "kimi",
+    "model_identifier": "kimi-for-coding-highspeed",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "moonshot-allegro",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["pro"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Moonshot",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/kimi-kimi-for-coding.json
+++ b/infra/conductor/endpoint_profiles/kimi-kimi-for-coding.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "kimi-kimi-for-coding",
+  "model_card_id": "kimi-for-coding",
+  "aliases": [],
+  "invocation": {
+    "engine": "kimi",
+    "model_identifier": "kimi-for-coding",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "moonshot-allegro",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["pro"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Moonshot",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/kimi-kimi-k2.5.json
+++ b/infra/conductor/endpoint_profiles/kimi-kimi-k2.5.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "kimi-kimi-k2.5",
+  "model_card_id": "kimi-k2.5",
+  "aliases": [],
+  "invocation": {
+    "engine": "kimi",
+    "model_identifier": "kimi-k2.5",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "moonshot-allegro",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/kimi-kimi-k2.6.json
+++ b/infra/conductor/endpoint_profiles/kimi-kimi-k2.6.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "kimi-kimi-k2.6",
+  "model_card_id": "kimi-k2.6",
+  "aliases": [],
+  "invocation": {
+    "engine": "kimi",
+    "model_identifier": "kimi-k2.6",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "moonshot-allegro",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/kimi-kimi-k2.7.json
+++ b/infra/conductor/endpoint_profiles/kimi-kimi-k2.7.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "kimi-kimi-k2.7",
+  "model_card_id": "kimi-k2.7",
+  "aliases": [],
+  "invocation": {
+    "engine": "kimi",
+    "model_identifier": "kimi-k2.7",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "moonshot-allegro",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/kimi-kimi-k2.json
+++ b/infra/conductor/endpoint_profiles/kimi-kimi-k2.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "kimi-kimi-k2",
+  "model_card_id": "kimi-k2",
+  "aliases": [],
+  "invocation": {
+    "engine": "kimi",
+    "model_identifier": "kimi-k2",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "moonshot-allegro",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/kimi-kimi-k3.json
+++ b/infra/conductor/endpoint_profiles/kimi-kimi-k3.json
@@ -1,0 +1,156 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "kimi-kimi-k3",
+  "model_card_id": "kimi-k3",
+  "aliases": [],
+  "invocation": {
+    "engine": "kimi",
+    "model_identifier": "k3",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "moonshot-allegro",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["pro"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "multimodal_review",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Moonshot",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/notebooklm-mcp-notebooklm-default.json
+++ b/infra/conductor/endpoint_profiles/notebooklm-mcp-notebooklm-default.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "notebooklm-mcp-notebooklm-default",
+  "model_card_id": "notebooklm-default",
+  "aliases": [],
+  "invocation": {
+    "engine": "notebooklm-mcp",
+    "model_identifier": "notebooklm-default",
+    "harness": null,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "google-ai-ultra",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "google_oauth_subscription",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "knowledge_verification",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m.json
+++ b/infra/conductor/endpoint_profiles/ollama-aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m",
+  "model_card_id": "aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "pii_safe_local",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-bge-m3.json
+++ b/infra/conductor/endpoint_profiles/ollama-bge-m3.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-bge-m3",
+  "model_card_id": "bge-m3",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "bge-m3",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "embedding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-deepseek-r1-32b.json
+++ b/infra/conductor/endpoint_profiles/ollama-deepseek-r1-32b.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-deepseek-r1-32b",
+  "model_card_id": "deepseek-r1-32b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "deepseek-r1:32b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-gemma3-27b.json
+++ b/infra/conductor/endpoint_profiles/ollama-gemma3-27b.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-gemma3-27b",
+  "model_card_id": "gemma3-27b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "gemma3:27b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-gemma4-26b.json
+++ b/infra/conductor/endpoint_profiles/ollama-gemma4-26b.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-gemma4-26b",
+  "model_card_id": "gemma4-26b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "gemma4:26b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-glm-ocr.json
+++ b/infra/conductor/endpoint_profiles/ollama-glm-ocr.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-glm-ocr",
+  "model_card_id": "glm-ocr",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "glm-ocr",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-nomic-embed-text.json
+++ b/infra/conductor/endpoint_profiles/ollama-nomic-embed-text.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-nomic-embed-text",
+  "model_card_id": "nomic-embed-text",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "nomic-embed-text",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "embedding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-qwen2.5-7b.json
+++ b/infra/conductor/endpoint_profiles/ollama-qwen2.5-7b.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-qwen2.5-7b",
+  "model_card_id": "qwen2.5-7b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "qwen2.5:7b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-qwen2.5vl-7b.json
+++ b/infra/conductor/endpoint_profiles/ollama-qwen2.5vl-7b.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-qwen2.5vl-7b",
+  "model_card_id": "qwen2.5vl-7b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "qwen2.5vl:7b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-qwen3-4b.json
+++ b/infra/conductor/endpoint_profiles/ollama-qwen3-4b.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-qwen3-4b",
+  "model_card_id": "qwen3-4b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "qwen3:4b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-qwen3-8b.json
+++ b/infra/conductor/endpoint_profiles/ollama-qwen3-8b.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-qwen3-8b",
+  "model_card_id": "qwen3-8b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "qwen3:8b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-qwen3-vl-8b.json
+++ b/infra/conductor/endpoint_profiles/ollama-qwen3-vl-8b.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-qwen3-vl-8b",
+  "model_card_id": "qwen3-vl-8b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "qwen3-vl:8b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-qwen3.5-9b.json
+++ b/infra/conductor/endpoint_profiles/ollama-qwen3.5-9b.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-qwen3.5-9b",
+  "model_card_id": "qwen3.5-9b",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "qwen3.5:9b",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/ollama-qwen3.8-27b-mlx.json
+++ b/infra/conductor/endpoint_profiles/ollama-qwen3.8-27b-mlx.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "ollama-qwen3.8-27b-mlx",
+  "model_card_id": "qwen3.8-27b-mlx",
+  "aliases": [],
+  "invocation": {
+    "engine": "ollama",
+    "model_identifier": "qwen3.8:27b-mlx",
+    "harness": "Ollama CLI/service",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "local-ollama",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "local_runtime",
+  "machine_constraints": {
+    "allowlist": ["mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "local policy still applies",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-deepseek-chat-v3-0324.json
+++ b/infra/conductor/endpoint_profiles/qwen-deepseek-chat-v3-0324.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-deepseek-chat-v3-0324",
+  "model_card_id": "deepseek-chat-v3-0324",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "openrouter/deepseek/deepseek-chat-v3-0324",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "deprecated",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-deepseek-v3.json
+++ b/infra/conductor/endpoint_profiles/qwen-deepseek-v3.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-deepseek-v3",
+  "model_card_id": "deepseek-v3",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "deepseek-v3",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-deepseek-v4-flash-0731.json
+++ b/infra/conductor/endpoint_profiles/qwen-deepseek-v4-flash-0731.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-deepseek-v4-flash-0731",
+  "model_card_id": "deepseek-v4-flash-0731",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "deepseek-v4-flash-0731",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": true,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-deepseek-v4-flash.json
+++ b/infra/conductor/endpoint_profiles/qwen-deepseek-v4-flash.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-deepseek-v4-flash",
+  "model_card_id": "deepseek-v4-flash",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "deepseek-v4-flash",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-deepseek-v4-pro.json
+++ b/infra/conductor/endpoint_profiles/qwen-deepseek-v4-pro.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-deepseek-v4-pro",
+  "model_card_id": "deepseek-v4-pro",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "deepseek-v4-pro",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "probation",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-deepseek-v4.json
+++ b/infra/conductor/endpoint_profiles/qwen-deepseek-v4.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-deepseek-v4",
+  "model_card_id": "deepseek-v4",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "deepseek-v4",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-glm-5.2-tp1.json
+++ b/infra/conductor/endpoint_profiles/qwen-glm-5.2-tp1.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-glm-5.2-tp1",
+  "model_card_id": "glm-5.2",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "glm-5.2",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "probation",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "load_bearing",
+      "value": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-happyhorse-1.1-i2v.json
+++ b/infra/conductor/endpoint_profiles/qwen-happyhorse-1.1-i2v.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-happyhorse-1.1-i2v",
+  "model_card_id": "happyhorse-1.1-i2v",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "happyhorse-1.1-i2v",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "video_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-happyhorse-1.1-r2v.json
+++ b/infra/conductor/endpoint_profiles/qwen-happyhorse-1.1-r2v.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-happyhorse-1.1-r2v",
+  "model_card_id": "happyhorse-1.1-r2v",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "happyhorse-1.1-r2v",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "video_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-happyhorse-1.1-t2v.json
+++ b/infra/conductor/endpoint_profiles/qwen-happyhorse-1.1-t2v.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-happyhorse-1.1-t2v",
+  "model_card_id": "happyhorse-1.1-t2v",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "happyhorse-1.1-t2v",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "video_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-minimax-m2.5.json
+++ b/infra/conductor/endpoint_profiles/qwen-minimax-m2.5.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-minimax-m2.5",
+  "model_card_id": "minimax-m2.5",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "MiniMax-M2.5",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "phantom",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-minimax-m2.7.json
+++ b/infra/conductor/endpoint_profiles/qwen-minimax-m2.7.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-minimax-m2.7",
+  "model_card_id": "minimax-m2.7",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "minimax-m2.7",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-minimax-m3.json
+++ b/infra/conductor/endpoint_profiles/qwen-minimax-m3.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-minimax-m3",
+  "model_card_id": "minimax-m3",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "minimax-m3",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen-audio-3.0-realtime-plus.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen-audio-3.0-realtime-plus.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen-audio-3.0-realtime-plus",
+  "model_card_id": "qwen-audio-3.0-realtime-plus",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen-audio-3.0-realtime-plus",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "audio_tts",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "audio_realtime",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen-audio-3.0-tts-plus.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen-audio-3.0-tts-plus.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen-audio-3.0-tts-plus",
+  "model_card_id": "qwen-audio-3.0-tts-plus",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen-audio-3.0-tts-plus",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "audio_tts",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-asr-flash.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-asr-flash.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-asr-flash",
+  "model_card_id": "qwen3-asr-flash",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-asr-flash",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "audio_tts",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "audio_asr",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-coder-flash.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-coder-flash.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-coder-flash",
+  "model_card_id": "qwen3-coder-flash",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-coder-flash",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-coder-next.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-coder-next.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-coder-next",
+  "model_card_id": "qwen3-coder-next",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-coder-next",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-coder-plus.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-coder-plus.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-coder-plus",
+  "model_card_id": "qwen3-coder-plus",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-coder-plus",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-coder.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-coder.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-coder",
+  "model_card_id": "qwen3-coder",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-coder",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-max-2026-01-23.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-max-2026-01-23.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-max-2026-01-23",
+  "model_card_id": "qwen3-max-2026-01-23",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-max-2026-01-23",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-max.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-max.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-max",
+  "model_card_id": "qwen3-max",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-max",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3-vl-plus.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3-vl-plus.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3-vl-plus",
+  "model_card_id": "qwen3-vl-plus",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3-vl-plus",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3.5-plus.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3.5-plus.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3.5-plus",
+  "model_card_id": "qwen3.5-plus",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3.5-plus",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3.6-flash.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3.6-flash.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3.6-flash",
+  "model_card_id": "qwen3.6-flash",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen-3.6-flash",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "probation",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3.6-plus.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3.6-plus.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3.6-plus",
+  "model_card_id": "qwen3.6-plus",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3.6-plus",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3.7-max.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3.7-max.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3.7-max",
+  "model_card_id": "qwen3.7-max",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen-3.7-max",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "probation",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3.7-plus.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3.7-plus.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3.7-plus",
+  "model_card_id": "qwen3.7-plus",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen-3.7-plus",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": true,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3.8-max-preview.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3.8-max-preview.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3.8-max-preview",
+  "model_card_id": "qwen3.8-max-preview",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen3.8-max-preview",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-qwen3.8-max.json
+++ b/infra/conductor/endpoint_profiles/qwen-qwen3.8-max.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-qwen3.8-max",
+  "model_card_id": "qwen3.8-max",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "qwen-3.8-max",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": true,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "advisory_only",
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-wan2.7-image-pro.json
+++ b/infra/conductor/endpoint_profiles/qwen-wan2.7-image-pro.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-wan2.7-image-pro",
+  "model_card_id": "wan2.7-image-pro",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "wan2.7-image-pro",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "image_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/endpoint_profiles/qwen-wan2.7-image.json
+++ b/infra/conductor/endpoint_profiles/qwen-wan2.7-image.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "endpoint-profile.v1",
+  "id": "qwen-wan2.7-image",
+  "model_card_id": "wan2.7-image",
+  "aliases": [],
+  "invocation": {
+    "engine": "qwen",
+    "model_identifier": "wan2.7-image",
+    "harness": "Qwen CLI",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "account_class": {
+    "value": "alibaba-tp1",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "auth_surface": "unknown",
+  "machine_constraints": {
+    "allowlist": ["air-m5", "pro", "mini-pro2"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "enforcement": {
+    "mode": "unmeasured",
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "exposed_capabilities": [
+    {
+      "id": "image_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "restrictions": [
+    {
+      "id": "client_pii",
+      "value": "not eligible for PII/local-only routing",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#_invariants",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/host_observation_overlay.schema.json
+++ b/infra/conductor/host_observation_overlay.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "host_observation_overlay.schema.json",
+  "title": "MIR exact endpoint host observation overlay v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_at", "observations"],
+  "properties": {
+    "schema_version": {
+      "const": "host-observation-overlay.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+    },
+    "observations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "endpoint_id",
+          "endpoint_profile_hash",
+          "host",
+          "model_identifier",
+          "available",
+          "healthy",
+          "latency_ms",
+          "context_tokens",
+          "output_tokens",
+          "enforcement_mode",
+          "identity_verified",
+          "probe",
+          "observed_at",
+          "expires_at"
+        ],
+        "properties": {
+          "endpoint_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]*$"
+          },
+          "endpoint_profile_hash": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          },
+          "host": {
+            "enum": ["air-m5", "pro", "mini-pro2"]
+          },
+          "model_identifier": {
+            "type": "string",
+            "minLength": 1
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "healthy": {
+            "type": "boolean"
+          },
+          "latency_ms": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "context_tokens": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "output_tokens": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "enforcement_mode": {
+            "enum": [
+              "enforced",
+              "shadow",
+              "advisory",
+              "advisory_only",
+              "manual_only",
+              "unmeasured"
+            ]
+          },
+          "identity_verified": {
+            "type": "boolean"
+          },
+          "probe": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "version"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "version": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "observed_at": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+          },
+          "expires_at": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+          }
+        }
+      }
+    }
+  }
+}

--- a/infra/conductor/host_observations.v1.json
+++ b/infra/conductor/host_observations.v1.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "host-observation-overlay.v1",
+  "generated_at": "2026-08-22T00:00:00Z",
+  "observations": []
+}

--- a/infra/conductor/inventory_observations.v1.json
+++ b/infra/conductor/inventory_observations.v1.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "mir-inventory-observation.v1",
+  "observed_at": "2026-08-21",
+  "method": "Zero-token CLI/version, model-list, and cached-model discovery supplied to the registry implementation; cache discovery is not authentication, quota, or inference proof.",
+  "observations": [
+    {
+      "machine": "pro",
+      "cli_versions": {
+        "codex": "0.148.0",
+        "claude": "2.1.237",
+        "agy": "1.1.17",
+        "kimi": "0.36.1",
+        "qwen": "0.21.12",
+        "ollama": "0.20.2"
+      },
+      "ollama_models": ["qwen3.5:9b", "qwen2.5vl:7b", "bge-m3:latest"]
+    },
+    {
+      "machine": "mini-pro2",
+      "cli_versions": {
+        "codex": "0.148.0",
+        "claude": "2.1.237",
+        "agy": "1.1.17",
+        "qwen": "0.21.12",
+        "ollama": "0.32.14",
+        "kimi": null
+      },
+      "ollama_models": [
+        "qwen3.8:27b-mlx",
+        "glm-ocr",
+        "qwen3-vl:8b",
+        "qwen3.5:9b",
+        "qwen3:8b",
+        "qwen2.5vl:7b",
+        "qwen2.5:7b",
+        "bge-m3",
+        "nomic-embed-text"
+      ]
+    },
+    {
+      "machine": "air-m5",
+      "cli_versions": {
+        "codex": "0.147.0",
+        "claude": "2.1.238",
+        "agy": "1.1.17",
+        "qwen": "0.21.15",
+        "kimi": null,
+        "ollama": null
+      },
+      "ollama_models": []
+    },
+    {
+      "scope": "codex_cache_union",
+      "model_identifiers": [
+        "codex-auto-review",
+        "gpt-5.3-codex-spark",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.5",
+        "gpt-5.6-luna",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-reserve"
+      ],
+      "interpretation": "Discovery only; effective served model, authentication, quota, and inference access remain unverified."
+    }
+  ]
+}

--- a/infra/conductor/model_capability_index.v1.json
+++ b/infra/conductor/model_capability_index.v1.json
@@ -1,0 +1,2879 @@
+{
+  "schema_version": "model-capability-index.v1",
+  "generated_at": "2026-08-21",
+  "generation": {
+    "style": "deterministic checked-in projection",
+    "inputs": [
+      "capability_ontology.v1.json",
+      "task_profiles.v1.json",
+      "model_cards/*.json",
+      "endpoint_profiles/*.json",
+      "inventory_observations.v1.json"
+    ],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#4",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "model_count": 80,
+  "endpoint_count": 81,
+  "models": [
+    {
+      "model_card_id": "aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m",
+      "family": "aisingapore",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "bge-m3",
+      "family": "bge",
+      "kind": "embedding",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "claude-fable-5",
+      "family": "claude-5",
+      "kind": "language",
+      "routing_status": "manual_only",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "claude-haiku-4-5",
+      "family": "claude-4",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "claude-opus-4-8",
+      "family": "claude-4",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Anthropic Introducing Claude Opus 4.8 | https://www.anthropic.com/news/claude-opus-4-8",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "claude-opus-5",
+      "family": "claude-5",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "claude-sonnet-4-6",
+      "family": "claude-4",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Anthropic Introducing Claude Sonnet 4.6 | https://www.anthropic.com/news/claude-sonnet-4-6",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "claude-sonnet-5",
+      "family": "claude-5",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Anthropic What's new in Claude Sonnet 5 | https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "codex-auto-review",
+      "family": "codex",
+      "kind": "service",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI Running Codex safely | https://openai.com/index/running-codex-safely/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "deepseek-chat-v3-0324",
+      "family": "deepseek-v3",
+      "kind": "language",
+      "routing_status": "deprecated",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "model_card_id": "deepseek-r1-32b",
+      "family": "deepseek",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "deepseek-v3",
+      "family": "deepseek",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://github.com/deepseek-ai/DeepSeek-V3 | DeepSeek-V3 | accessed 2026-08-21 | Exact claim: DeepSeek-V3 is a 671B-total/37B-activated MoE language model with a 128K context length and documented MLA, DeepSeekMoE, auxiliary-loss-free balancing, and multi-token prediction.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "deepseek-v4-flash-0731",
+      "family": "deepseek-v4",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "model_card_id": "deepseek-v4-flash",
+      "family": "deepseek",
+      "kind": "language",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "deepseek-v4-pro",
+      "family": "deepseek-v4",
+      "kind": "language",
+      "routing_status": "probation",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://api-docs.deepseek.com/guides/json_mode/ | JSON Output | accessed 2026-08-21 | Exact claim: the official JSON Output guide includes deepseek-v4-pro with json_object and documents these prompt constraints.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "deepseek-v4",
+      "family": "deepseek",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gemini-3-flash-preview",
+      "family": "gemini-3",
+      "kind": "language",
+      "routing_status": "deprecated",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3 Flash Preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gemini-3.1-pro",
+      "family": "gemini-3",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.1 Pro preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gemini-3.5-flash",
+      "family": "gemini-3",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.5 Flash model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gemini-deepthink",
+      "family": "gemini",
+      "kind": "service",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        },
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3 Deep Think announcement | https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-deep-think/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gemini-spark",
+      "family": "gemini-spark",
+      "kind": "service",
+      "routing_status": "manual_only",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Google Introducing Gemini Spark | https://blog.google/innovation-and-ai/products/gemini-app/next-evolution-gemini-app/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gemma3-27b",
+      "family": "gemma3",
+      "kind": "vision",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gemma4-26b",
+      "family": "gemma4",
+      "kind": "vision",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "glm-4.5",
+      "family": "glm",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "glm-4.7",
+      "family": "glm",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: glm-4.7 has a 202,752-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "glm-4",
+      "family": "glm",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "glm-5.1",
+      "family": "glm",
+      "kind": "language",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "glm-5.2",
+      "family": "glm",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/newly-released-models | Newly released models | accessed 2026-08-21 | Exact claim: glm-5.2 documents a 1M-token context and long-horizon reasoning, text generation, and coding capabilities.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "glm-5",
+      "family": "glm",
+      "kind": "language",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: glm-5 has a 202,752-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "glm-ocr",
+      "family": "glm",
+      "kind": "vision",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://github.com/zai-org/GLM-OCR | GLM-OCR: Accurate x Fast x Comprehensive | accessed 2026-08-21 | Exact claim: GLM-OCR documents a two-stage document OCR pipeline with image/PDF input and JSON/Markdown output formats.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-5.3-codex-spark",
+      "family": "gpt-5.3",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI Introducing GPT-5.3-Codex-Spark | https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-5.4-mini",
+      "family": "gpt-5.4",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 mini Model | https://developers.openai.com/api/docs/models/gpt-5.4-mini",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-5.4",
+      "family": "gpt-5.4",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 Model | https://developers.openai.com/api/docs/models/gpt-5.4",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-5.5",
+      "family": "gpt-5.5",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.5 Model | https://developers.openai.com/api/docs/models/gpt-5.5",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-5.6-luna",
+      "family": "gpt-5.6",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Luna Model | https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-5.6-sol",
+      "family": "gpt-5.6",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Sol Model | https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-5.6-terra",
+      "family": "gpt-5.6",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Terra Model | https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-image-2",
+      "family": "gpt-image",
+      "kind": "image",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT Image 2 Model | https://developers.openai.com/api/docs/models/gpt-image-2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "gpt-reserve",
+      "family": "gpt",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "happyhorse-1.1-i2v",
+      "family": "happyhorse",
+      "kind": "video",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-i2v is first-frame image-to-video with audio and 480P/720P/1080P, 3-15 second, 24 fps MP4 output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "happyhorse-1.1-r2v",
+      "family": "happyhorse",
+      "kind": "video",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-r2v is reference-image-to-video with audio and 480P/720P/1080P, 3-15 second, 24 fps MP4 output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "happyhorse-1.1-t2v",
+      "family": "happyhorse",
+      "kind": "video",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-t2v is text-to-video with audio and 480P/720P/1080P, 3-15 second, 24 fps MP4 output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "kimi-for-coding-highspeed",
+      "family": "kimi",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "kimi-for-coding",
+      "family": "kimi",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "kimi-k2.5",
+      "family": "kimi",
+      "kind": "language",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://github.com/MoonshotAI/Kimi-K2.5 | Kimi-K2.5 | accessed 2026-08-21 | Exact claim: Kimi K2.5 is a native multimodal agentic model using MoonViT with a 256K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "kimi-k2.6",
+      "family": "kimi",
+      "kind": "language",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/visual-reasoning | Usage of visual reasoning models | accessed 2026-08-21 | Exact claim: kimi-k2.6 is listed as a hybrid-thinking model with enable_thinking control.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "kimi-k2.7",
+      "family": "kimi",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "kimi-k2",
+      "family": "kimi",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://github.com/MoonshotAI/Kimi-K2 | Kimi-K2 | accessed 2026-08-21 | Exact claim: Kimi K2 is a 1T-total/32B-activated MoE language model with 128K context and documented tool-use/reasoning capabilities.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "kimi-k3",
+      "family": "kimi",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "minimax-m2.5",
+      "family": "minimax",
+      "kind": "language",
+      "routing_status": "phantom",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.5 documents text generation, tool-call triggering, and a 204,800-token total input/output maximum.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "minimax-m2.7",
+      "family": "MiniMax",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.7 documents text generation, tool-call triggering, and a 204,800-token total input/output maximum.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "minimax-m3",
+      "family": "MiniMax",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "nomic-embed-text",
+      "family": "nomic",
+      "kind": "embedding",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "notebooklm-default",
+      "family": "notebooklm",
+      "kind": "service",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "Google NotebookLM Help: Learn about NotebookLM | https://support.google.com/notebooklm/answer/16164461?hl=en",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen-audio-3.0-realtime-plus",
+      "family": "qwen",
+      "kind": "audio",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://www.alibabacloud.com/help/en/model-studio/qwen-audio-realtime-user-guides | Qwen-Audio real-time voice model | accessed 2026-08-21 | Exact claim: qwen-audio-3.0-realtime-plus documents real-time voice interaction with audio and text output plus cloned-voice support.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen-audio-3.0-tts-plus",
+      "family": "qwen",
+      "kind": "audio",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://docs.qwencloud.com/developer-guides/speech/tts-models | TTS models | accessed 2026-08-21 | Exact claim: qwen-audio-3.0-tts-plus documents streaming synthesis, custom voices, and instruction control.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen2.5-7b",
+      "family": "qwen2.5",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen2.5-llm/ | Qwen2.5-LLM: Extending the boundary of LLMs | accessed 2026-08-21 | Exact claim: Qwen2.5-7B has a 128K context and 8K generation length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen2.5vl-7b",
+      "family": "qwen2.5vl",
+      "kind": "vision",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-4b",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | Qwen3: Think Deeper, Act Faster | accessed 2026-08-21 | Exact claim: Qwen3-4B is a listed Qwen3 model with a 32K context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-8b",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | Qwen3: Think Deeper, Act Faster | accessed 2026-08-21 | Exact claim: Qwen3-8B is a listed Qwen3 model with a 128K context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-asr-flash",
+      "family": "qwen3",
+      "kind": "audio",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/asr-model | Speech recognition models | accessed 2026-08-21 | Exact claim: qwen3-asr-flash is documented for automatic speech recognition and emotion recognition.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen-asr-api-reference | Qwen-ASR API reference | accessed 2026-08-21 | Exact claim: qwen3-asr-flash offline HTTP requests are limited to 5 minutes of audio or 10 MB.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-coder-flash",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-coder-next",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen-coder | Code capabilities (Qwen-Coder) | accessed 2026-08-21 | Exact claim: qwen3-coder-next documents code generation, code completion, and tool calls.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-coder-next has a 262,144-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-coder-plus",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-coder-plus has a 1,000,000-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-coder",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-max-2026-01-23",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-max-2026-01-23 has a 262,144-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-max",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/model-pricing | Model pricing | accessed 2026-08-21 | Exact claim: qwen3-max is documented as the current equivalent of qwen3-max-2026-01-23, whose documented context ceiling is 262,144 tokens.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-vl-8b",
+      "family": "qwen-3",
+      "kind": "vision",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3-vl-plus",
+      "family": "qwen3",
+      "kind": "vision",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.5-9b",
+      "family": "qwen3.5",
+      "kind": "vision",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.5-plus",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-5-plus | qwen3.5-plus Model Info | accessed 2026-08-21 | Exact claim: qwen3.5-plus accepts text, image, and video input; supports Function Calling, Structured Outputs, Web Search, Prefix Completion, Context Caching, and Batch.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3.5-plus has a 1,000,000-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.6-flash",
+      "family": "qwen-3",
+      "kind": "language",
+      "routing_status": "probation",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-6-flash | qwen3.6-flash Model Info | accessed 2026-08-21 | Exact claim: text, image, and video input; text output; 1,000,000-token context; 65,536-token output limit; Function Calling and related documented features; Batch Inference is region-dependent.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.6-plus",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.7-max",
+      "family": "qwen-3",
+      "kind": "language",
+      "routing_status": "probation",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-7-max | qwen3.7-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.7-max has text input/output, a 1,000,000-token context, a 131,072-token output limit, documents Structured Outputs, and has region-dependent documented feature support.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.7-plus",
+      "family": "qwen-3",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3.7-plus has a 1,000,000-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.8-27b-mlx",
+      "family": "qwen-3",
+      "kind": "language",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.8-max-preview",
+      "family": "qwen3",
+      "kind": "language",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "qwen3.8-max",
+      "family": "qwen-3",
+      "kind": "language",
+      "routing_status": "eligible",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-8-max | qwen3.8-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.8-max documents text, image, and video input; text output; Function Calling, Structured Outputs, Web Search, Prefix Completion, and Context Caching; Batch Inference is region-dependent.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "wan2.7-image-pro",
+      "family": "wan2.7",
+      "kind": "image",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/wan-image-generation-and-editing-api-reference | Wan2.7 - image generation and editing | accessed 2026-08-21 | Exact claim: wan2.7-image-pro documents text-to-image generation at up to 4K output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "model_card_id": "wan2.7-image",
+      "family": "wan2.7",
+      "kind": "image",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/wan-image-generation-and-editing-api-reference | Wan2.7 - image generation and editing | accessed 2026-08-21 | Exact claim: wan2.7-image documents text/image generation and editing modes with 1K/2K output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "endpoints": [
+    {
+      "endpoint_id": "agy-gemini-3-flash-preview",
+      "model_card_id": "gemini-3-flash-preview",
+      "engine": "agy",
+      "model_identifier": "google-gemini-cli/gemini-3-flash-preview",
+      "auth_surface": "google_oauth_subscription",
+      "routing_status": "deprecated",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "agy-gemini-3.1-pro",
+      "model_card_id": "gemini-3.1-pro",
+      "engine": "agy",
+      "model_identifier": "gemini-3.1-pro",
+      "auth_surface": "google_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "agy-gemini-3.5-flash",
+      "model_card_id": "gemini-3.5-flash",
+      "engine": "agy",
+      "model_identifier": "gemini-3.5-flash",
+      "auth_surface": "google_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "agy-gemini-deepthink",
+      "model_card_id": "gemini-deepthink",
+      "engine": "agy",
+      "model_identifier": "gemini-deepthink",
+      "auth_surface": "google_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-claude-fable-5",
+      "model_card_id": "claude-fable-5",
+      "engine": "claude",
+      "model_identifier": "claude-fable-5",
+      "auth_surface": "anthropic_oauth_subscription",
+      "routing_status": "manual_only",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-claude-haiku-4-5",
+      "model_card_id": "claude-haiku-4-5",
+      "engine": "claude",
+      "model_identifier": "claude-haiku-4-5-20251001",
+      "auth_surface": "anthropic_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-claude-opus-4-8",
+      "model_card_id": "claude-opus-4-8",
+      "engine": "claude",
+      "model_identifier": "claude-opus-4-8",
+      "auth_surface": "anthropic_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-claude-opus-5",
+      "model_card_id": "claude-opus-5",
+      "engine": "claude",
+      "model_identifier": "claude-opus-5",
+      "auth_surface": "anthropic_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-claude-sonnet-4-6",
+      "model_card_id": "claude-sonnet-4-6",
+      "engine": "claude",
+      "model_identifier": "claude-sonnet-4-6",
+      "auth_surface": "anthropic_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-claude-sonnet-5",
+      "model_card_id": "claude-sonnet-5",
+      "engine": "claude",
+      "model_identifier": "claude-sonnet-5",
+      "auth_surface": "anthropic_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-glm-glm-4.5",
+      "model_card_id": "glm-4.5",
+      "engine": "claude-glm",
+      "model_identifier": "glm-4.5",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-glm-glm-4.7",
+      "model_card_id": "glm-4.7",
+      "engine": "claude-glm",
+      "model_identifier": "glm-4.7",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-glm-glm-4",
+      "model_card_id": "glm-4",
+      "engine": "claude-glm",
+      "model_identifier": "glm-4",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-glm-glm-5.1",
+      "model_card_id": "glm-5.1",
+      "engine": "claude-glm",
+      "model_identifier": "glm-5.1",
+      "auth_surface": "unknown",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-glm-glm-5.2",
+      "model_card_id": "glm-5.2",
+      "engine": "claude-glm",
+      "model_identifier": "glm-5.2",
+      "auth_surface": "unknown",
+      "routing_status": "eligible",
+      "automated_routing": true,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "claude-glm-glm-5",
+      "model_card_id": "glm-5",
+      "engine": "claude-glm",
+      "model_identifier": "glm-5",
+      "auth_surface": "unknown",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-codex-auto-review",
+      "model_card_id": "codex-auto-review",
+      "engine": "codex",
+      "model_identifier": "codex-auto-review",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.3-codex-spark",
+      "model_card_id": "gpt-5.3-codex-spark",
+      "engine": "codex",
+      "model_identifier": "gpt-5.3-codex-spark",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.4-mini",
+      "model_card_id": "gpt-5.4-mini",
+      "engine": "codex",
+      "model_identifier": "gpt-5.4-mini",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.4",
+      "model_card_id": "gpt-5.4",
+      "engine": "codex",
+      "model_identifier": "gpt-5.4",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.5",
+      "model_card_id": "gpt-5.5",
+      "engine": "codex",
+      "model_identifier": "gpt-5.5",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.6-luna",
+      "model_card_id": "gpt-5.6-luna",
+      "engine": "codex",
+      "model_identifier": "gpt-5.6-luna",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.6-sol",
+      "model_card_id": "gpt-5.6-sol",
+      "engine": "codex",
+      "model_identifier": "gpt-5.6-sol",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.6-terra",
+      "model_card_id": "gpt-5.6-terra",
+      "engine": "codex",
+      "model_identifier": "gpt-5.6-terra",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-gpt-reserve",
+      "model_card_id": "gpt-reserve",
+      "engine": "codex",
+      "model_identifier": "gpt-reserve",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "codex-imagegen-gpt-image-2",
+      "model_card_id": "gpt-image-2",
+      "engine": "codex-imagegen",
+      "model_identifier": "$imagegen",
+      "auth_surface": "openai_chatgpt_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "gemini-spark-gui-gemini-spark",
+      "model_card_id": "gemini-spark",
+      "engine": "gemini-spark-gui",
+      "model_identifier": "gemini-spark",
+      "auth_surface": "manual_gui",
+      "routing_status": "manual_only",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "kimi-kimi-for-coding-highspeed",
+      "model_card_id": "kimi-for-coding-highspeed",
+      "engine": "kimi",
+      "model_identifier": "kimi-for-coding-highspeed",
+      "auth_surface": "unknown",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "kimi-kimi-for-coding",
+      "model_card_id": "kimi-for-coding",
+      "engine": "kimi",
+      "model_identifier": "kimi-for-coding",
+      "auth_surface": "unknown",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "kimi-kimi-k2.5",
+      "model_card_id": "kimi-k2.5",
+      "engine": "kimi",
+      "model_identifier": "kimi-k2.5",
+      "auth_surface": "unknown",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "kimi-kimi-k2.6",
+      "model_card_id": "kimi-k2.6",
+      "engine": "kimi",
+      "model_identifier": "kimi-k2.6",
+      "auth_surface": "unknown",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "kimi-kimi-k2.7",
+      "model_card_id": "kimi-k2.7",
+      "engine": "kimi",
+      "model_identifier": "kimi-k2.7",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "kimi-kimi-k2",
+      "model_card_id": "kimi-k2",
+      "engine": "kimi",
+      "model_identifier": "kimi-k2",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "kimi-kimi-k3",
+      "model_card_id": "kimi-k3",
+      "engine": "kimi",
+      "model_identifier": "k3",
+      "auth_surface": "unknown",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "notebooklm-mcp-notebooklm-default",
+      "model_card_id": "notebooklm-default",
+      "engine": "notebooklm-mcp",
+      "model_identifier": "notebooklm-default",
+      "auth_surface": "google_oauth_subscription",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m",
+      "model_card_id": "aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m",
+      "engine": "ollama",
+      "model_identifier": "aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-bge-m3",
+      "model_card_id": "bge-m3",
+      "engine": "ollama",
+      "model_identifier": "bge-m3",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-deepseek-r1-32b",
+      "model_card_id": "deepseek-r1-32b",
+      "engine": "ollama",
+      "model_identifier": "deepseek-r1:32b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-gemma3-27b",
+      "model_card_id": "gemma3-27b",
+      "engine": "ollama",
+      "model_identifier": "gemma3:27b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-gemma4-26b",
+      "model_card_id": "gemma4-26b",
+      "engine": "ollama",
+      "model_identifier": "gemma4:26b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-glm-ocr",
+      "model_card_id": "glm-ocr",
+      "engine": "ollama",
+      "model_identifier": "glm-ocr",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-nomic-embed-text",
+      "model_card_id": "nomic-embed-text",
+      "engine": "ollama",
+      "model_identifier": "nomic-embed-text",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-qwen2.5-7b",
+      "model_card_id": "qwen2.5-7b",
+      "engine": "ollama",
+      "model_identifier": "qwen2.5:7b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-qwen2.5vl-7b",
+      "model_card_id": "qwen2.5vl-7b",
+      "engine": "ollama",
+      "model_identifier": "qwen2.5vl:7b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-qwen3-4b",
+      "model_card_id": "qwen3-4b",
+      "engine": "ollama",
+      "model_identifier": "qwen3:4b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-qwen3-8b",
+      "model_card_id": "qwen3-8b",
+      "engine": "ollama",
+      "model_identifier": "qwen3:8b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-qwen3-vl-8b",
+      "model_card_id": "qwen3-vl-8b",
+      "engine": "ollama",
+      "model_identifier": "qwen3-vl:8b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-qwen3.5-9b",
+      "model_card_id": "qwen3.5-9b",
+      "engine": "ollama",
+      "model_identifier": "qwen3.5:9b",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "ollama-qwen3.8-27b-mlx",
+      "model_card_id": "qwen3.8-27b-mlx",
+      "engine": "ollama",
+      "model_identifier": "qwen3.8:27b-mlx",
+      "auth_surface": "local_runtime",
+      "routing_status": "known_unmeasured",
+      "automated_routing": false,
+      "machine_allowlist": ["mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-deepseek-chat-v3-0324",
+      "model_card_id": "deepseek-chat-v3-0324",
+      "engine": "qwen",
+      "model_identifier": "openrouter/deepseek/deepseek-chat-v3-0324",
+      "auth_surface": "unknown",
+      "routing_status": "deprecated",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-deepseek-v3",
+      "model_card_id": "deepseek-v3",
+      "engine": "qwen",
+      "model_identifier": "deepseek-v3",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-deepseek-v4-flash-0731",
+      "model_card_id": "deepseek-v4-flash-0731",
+      "engine": "qwen",
+      "model_identifier": "deepseek-v4-flash-0731",
+      "auth_surface": "unknown",
+      "routing_status": "eligible",
+      "automated_routing": true,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-deepseek-v4-flash",
+      "model_card_id": "deepseek-v4-flash",
+      "engine": "qwen",
+      "model_identifier": "deepseek-v4-flash",
+      "auth_surface": "unknown",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-deepseek-v4-pro",
+      "model_card_id": "deepseek-v4-pro",
+      "engine": "qwen",
+      "model_identifier": "deepseek-v4-pro",
+      "auth_surface": "unknown",
+      "routing_status": "probation",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-deepseek-v4",
+      "model_card_id": "deepseek-v4",
+      "engine": "qwen",
+      "model_identifier": "deepseek-v4",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-glm-5.2-tp1",
+      "model_card_id": "glm-5.2",
+      "engine": "qwen",
+      "model_identifier": "glm-5.2",
+      "auth_surface": "unknown",
+      "routing_status": "probation",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-happyhorse-1.1-i2v",
+      "model_card_id": "happyhorse-1.1-i2v",
+      "engine": "qwen",
+      "model_identifier": "happyhorse-1.1-i2v",
+      "auth_surface": "unknown",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-happyhorse-1.1-r2v",
+      "model_card_id": "happyhorse-1.1-r2v",
+      "engine": "qwen",
+      "model_identifier": "happyhorse-1.1-r2v",
+      "auth_surface": "unknown",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-happyhorse-1.1-t2v",
+      "model_card_id": "happyhorse-1.1-t2v",
+      "engine": "qwen",
+      "model_identifier": "happyhorse-1.1-t2v",
+      "auth_surface": "unknown",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-minimax-m2.5",
+      "model_card_id": "minimax-m2.5",
+      "engine": "qwen",
+      "model_identifier": "MiniMax-M2.5",
+      "auth_surface": "unknown",
+      "routing_status": "phantom",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-minimax-m2.7",
+      "model_card_id": "minimax-m2.7",
+      "engine": "qwen",
+      "model_identifier": "minimax-m2.7",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-minimax-m3",
+      "model_card_id": "minimax-m3",
+      "engine": "qwen",
+      "model_identifier": "minimax-m3",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen-audio-3.0-realtime-plus",
+      "model_card_id": "qwen-audio-3.0-realtime-plus",
+      "engine": "qwen",
+      "model_identifier": "qwen-audio-3.0-realtime-plus",
+      "auth_surface": "unknown",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen-audio-3.0-tts-plus",
+      "model_card_id": "qwen-audio-3.0-tts-plus",
+      "engine": "qwen",
+      "model_identifier": "qwen-audio-3.0-tts-plus",
+      "auth_surface": "unknown",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-asr-flash",
+      "model_card_id": "qwen3-asr-flash",
+      "engine": "qwen",
+      "model_identifier": "qwen3-asr-flash",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-coder-flash",
+      "model_card_id": "qwen3-coder-flash",
+      "engine": "qwen",
+      "model_identifier": "qwen3-coder-flash",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-coder-next",
+      "model_card_id": "qwen3-coder-next",
+      "engine": "qwen",
+      "model_identifier": "qwen3-coder-next",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-coder-plus",
+      "model_card_id": "qwen3-coder-plus",
+      "engine": "qwen",
+      "model_identifier": "qwen3-coder-plus",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-coder",
+      "model_card_id": "qwen3-coder",
+      "engine": "qwen",
+      "model_identifier": "qwen3-coder",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-max-2026-01-23",
+      "model_card_id": "qwen3-max-2026-01-23",
+      "engine": "qwen",
+      "model_identifier": "qwen3-max-2026-01-23",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-max",
+      "model_card_id": "qwen3-max",
+      "engine": "qwen",
+      "model_identifier": "qwen3-max",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-vl-plus",
+      "model_card_id": "qwen3-vl-plus",
+      "engine": "qwen",
+      "model_identifier": "qwen3-vl-plus",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3.5-plus",
+      "model_card_id": "qwen3.5-plus",
+      "engine": "qwen",
+      "model_identifier": "qwen3.5-plus",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3.6-flash",
+      "model_card_id": "qwen3.6-flash",
+      "engine": "qwen",
+      "model_identifier": "qwen-3.6-flash",
+      "auth_surface": "unknown",
+      "routing_status": "probation",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3.6-plus",
+      "model_card_id": "qwen3.6-plus",
+      "engine": "qwen",
+      "model_identifier": "qwen3.6-plus",
+      "auth_surface": "unknown",
+      "routing_status": "denied",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3.7-max",
+      "model_card_id": "qwen3.7-max",
+      "engine": "qwen",
+      "model_identifier": "qwen-3.7-max",
+      "auth_surface": "unknown",
+      "routing_status": "probation",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3.7-plus",
+      "model_card_id": "qwen3.7-plus",
+      "engine": "qwen",
+      "model_identifier": "qwen-3.7-plus",
+      "auth_surface": "unknown",
+      "routing_status": "eligible",
+      "automated_routing": true,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3.8-max-preview",
+      "model_card_id": "qwen3.8-max-preview",
+      "engine": "qwen",
+      "model_identifier": "qwen3.8-max-preview",
+      "auth_surface": "unknown",
+      "routing_status": "investigation_required",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-qwen3.8-max",
+      "model_card_id": "qwen3.8-max",
+      "engine": "qwen",
+      "model_identifier": "qwen-3.8-max",
+      "auth_surface": "unknown",
+      "routing_status": "eligible",
+      "automated_routing": true,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-wan2.7-image-pro",
+      "model_card_id": "wan2.7-image-pro",
+      "engine": "qwen",
+      "model_identifier": "wan2.7-image-pro",
+      "auth_surface": "unknown",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "endpoint_id": "qwen-wan2.7-image",
+      "model_card_id": "wan2.7-image",
+      "engine": "qwen",
+      "model_identifier": "wan2.7-image",
+      "auth_surface": "unknown",
+      "routing_status": "listed_unexploited",
+      "automated_routing": false,
+      "machine_allowlist": ["air-m5", "pro", "mini-pro2"],
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/conductor/model_card.schema.json
+++ b/infra/conductor/model_card.schema.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "model-card.schema.json",
+  "title": "MIR ModelCard v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "display_name",
+    "identity",
+    "routing",
+    "modalities",
+    "limits",
+    "task_scores",
+    "evidence"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "model-card.v1"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "family", "kind", "aliases", "evidence"],
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "language",
+            "vision",
+            "embedding",
+            "image",
+            "audio",
+            "video",
+            "service"
+          ]
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "automated_routing", "evidence"],
+      "properties": {
+        "status": {
+          "enum": [
+            "eligible",
+            "manual_only",
+            "probation",
+            "phantom",
+            "denied",
+            "investigation_required",
+            "listed_unexploited",
+            "deprecated",
+            "known_unmeasured"
+          ]
+        },
+        "automated_routing": {
+          "type": "boolean"
+        },
+        "evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/evidence"
+          }
+        }
+      }
+    },
+    "modalities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "value", "evidence"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "value": {
+            "enum": [true, false, null]
+          },
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/evidence"
+            }
+          }
+        }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["context_tokens", "output_tokens"],
+      "properties": {
+        "context_tokens": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value", "evidence"],
+          "properties": {
+            "value": {
+              "type": ["integer", "null"],
+              "minimum": 1
+            },
+            "evidence": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/evidence"
+              }
+            }
+          }
+        },
+        "output_tokens": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value", "evidence"],
+          "properties": {
+            "value": {
+              "type": ["integer", "null"],
+              "minimum": 1
+            },
+            "evidence": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/evidence"
+              }
+            }
+          }
+        }
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "value", "evidence"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "value": {
+            "type": ["string", "boolean", "null"]
+          },
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/evidence"
+            }
+          }
+        }
+      }
+    },
+    "task_scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["task_profile_id", "score", "sample_count", "evidence"],
+        "properties": {
+          "task_profile_id": {
+            "type": "string"
+          },
+          "score": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "maximum": 1
+          },
+          "benchmark_id": {
+            "type": ["string", "null"]
+          },
+          "benchmark_version": {
+            "type": ["string", "null"]
+          },
+          "sample_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/evidence"
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/evidence"
+      }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "ref", "observed_at"],
+      "properties": {
+        "level": {
+          "enum": [
+            "declared",
+            "probed",
+            "benchmarked",
+            "production",
+            "unmeasured"
+          ]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "observed_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+        }
+      }
+    }
+  }
+}

--- a/infra/conductor/model_cards/aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m.json
+++ b/infra/conductor/model_cards/aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "aisingapore-qwen-sea-lion-v4-32b-it-q4-k-m",
+  "display_name": "Qwen SEA-LION v4 32B IT Q4_K_M",
+  "identity": {
+    "provider": "ollama",
+    "family": "aisingapore",
+    "kind": "language",
+    "aliases": ["aisingapore/Qwen-SEA-LION-v4-32B-IT:q4_k_m"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      },
+      {
+        "level": "declared",
+        "ref": "https://huggingface.co/aisingapore/Qwen-SEA-LION-v4-32B-IT | title=Qwen-SEA-LION-v4-32B-IT model card | note=The exact upstream checkpoint is an instruction-tuned text-generation model with a 32K context; the local q4_k_m Ollama alias is not separately documented.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/aisingapore/Qwen-SEA-LION-v4-32B-IT | title=Qwen-SEA-LION-v4-32B-IT model card | note=The official card identifies this checkpoint as an instruction-tuned text-generation model.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 32768,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/aisingapore/Qwen-SEA-LION-v4-32B-IT | title=Qwen-SEA-LION-v4-32B-IT model card | note=The official card declares a 32K context for the upstream text checkpoint; the local quantized runtime is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "pii_intake",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "multilingual_sea_languages",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/aisingapore/Qwen-SEA-LION-v4-32B-IT | title=Qwen-SEA-LION-v4-32B-IT model card | note=The official card lists Burmese, English, Indonesian, Khmer, Lao, Malay, Mandarin, Tagalog, Tamil, Thai, and Vietnamese among supported languages.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    },
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/bge-m3.json
+++ b/infra/conductor/model_cards/bge-m3.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "bge-m3",
+  "display_name": "BGE M3",
+  "identity": {
+    "provider": "ollama",
+    "family": "bge",
+    "kind": "embedding",
+    "aliases": ["bge-m3"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/bge-m3 | title=BGE-M3 Ollama library page | note=The exact bge-m3 package is an embedding model supporting dense, multi-vector, and sparse retrieval across more than 100 languages.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "embedding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 8192,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/bge-m3/blobs/6eaafd7b20ee | title=BGE-M3 Ollama model metadata | note=The exact package metadata declares an 8,192-token context and 1,024-dimensional embedding output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "multilingual_embedding",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "embedding_dimensions",
+      "value": "1024",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/BAAI/bge-m3 | title=BGE-M3 model card | note=The BAAI card declares 1,024-dimensional embeddings and a unified dense, sparse, and ColBERT-style retrieval model.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "multilingual_100_plus",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/BAAI/bge-m3 | title=BGE-M3 model card | note=The BAAI card documents multilingual support across more than 100 languages.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/claude-fable-5.json
+++ b/infra/conductor/model_cards/claude-fable-5.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "claude-fable-5",
+  "display_name": "Claude Fable 5",
+  "identity": {
+    "provider": "anthropic",
+    "family": "claude-5",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "manual_only",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "manual_session_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text and image input; text output; adaptive thinking is always on; intended for long-running agents, software engineering, knowledge work, vision, and science.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview and Introducing Claude Fable 5 and Mythos 5 | https://platform.claude.com/docs/en/about-claude/models/overview | https://www.anthropic.com/news/claude-fable-5-mythos-5",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/claude-haiku-4-5.json
+++ b/infra/conductor/model_cards/claude-haiku-4-5.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "claude-haiku-4-5",
+  "display_name": "Claude Haiku 4.5",
+  "identity": {
+    "provider": "anthropic",
+    "family": "claude-4",
+    "kind": "language",
+    "aliases": ["claude-haiku-4-5-20251001"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 200000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 64000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "dated_identifier_available",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text and image input; text output; manual extended thinking supported; adaptive and interleaved thinking unsupported; intended for fast, cost-efficient coding and agent work.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview, Migration guide, and Context windows | https://platform.claude.com/docs/en/about-claude/models/overview | https://platform.claude.com/docs/en/about-claude/models/migration-guide | https://platform.claude.com/docs/en/build-with-claude/context-windows",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/claude-opus-4-8.json
+++ b/infra/conductor/model_cards/claude-opus-4-8.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "claude-opus-4-8",
+  "display_name": "Claude Opus 4.8",
+  "identity": {
+    "provider": "anthropic",
+    "family": "claude-4",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "valid_pin",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text and image input; text output; adaptive thinking; high effort is the default and xhigh is recommended by Anthropic for difficult coding and long-running asynchronous workflows; intended for coding, deep agentic reasoning, multimodal knowledge work, legal, and tax workflows.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview and Introducing Claude Opus 4.8 | https://platform.claude.com/docs/en/about-claude/models/overview | https://www.anthropic.com/news/claude-opus-4-8",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Anthropic Introducing Claude Opus 4.8 | https://www.anthropic.com/news/claude-opus-4-8",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/claude-opus-5.json
+++ b/infra/conductor/model_cards/claude-opus-5.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "claude-opus-5",
+  "display_name": "Claude Opus 5",
+  "identity": {
+    "provider": "anthropic",
+    "family": "claude-5",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "final_gate_effort",
+      "value": "max",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "thinking_default",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text and image input; text output; adaptive thinking on by default; intended for complex agentic coding, deep reasoning, enterprise work, and long-horizon tasks. Supports prompt caching, batches, Files, PDF, vision, and server/client tools; web fetch and Priority Tier are unavailable.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview and Migration guide | https://platform.claude.com/docs/en/about-claude/models/overview | https://platform.claude.com/docs/en/about-claude/models/migration-guide",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/claude-sonnet-4-6.json
+++ b/infra/conductor/model_cards/claude-sonnet-4-6.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "claude-sonnet-4-6",
+  "display_name": "Claude Sonnet 4.6",
+  "identity": {
+    "provider": "anthropic",
+    "family": "claude-4",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 64000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "valid_pin",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text and image input; text output; adaptive thinking; intended for coding, computer use, long-context reasoning, planning, knowledge work, and design.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview and Introducing Claude Sonnet 4.6 | https://platform.claude.com/docs/en/about-claude/models/overview | https://www.anthropic.com/news/claude-sonnet-4-6",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Anthropic Introducing Claude Sonnet 4.6 | https://www.anthropic.com/news/claude-sonnet-4-6",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/claude-sonnet-5.json
+++ b/infra/conductor/model_cards/claude-sonnet-5.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "claude-sonnet-5",
+  "display_name": "Claude Sonnet 5",
+  "identity": {
+    "provider": "anthropic",
+    "family": "claude-5",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Anthropic",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Anthropic",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic Claude models overview | https://platform.claude.com/docs/en/about-claude/models/overview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "tokenizer_change",
+      "value": "New tokenizer may produce approximately 30 percent more tokens than Sonnet 4.6 for the same text; this is a model-scoped migration note, not a measured local multiplier.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic What's new in Claude Sonnet 5 | https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text and image input; text output; adaptive thinking on by default; intended for agentic planning, coding, browser and terminal tool use, knowledge work, and autonomous workflows.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Anthropic What's new in Claude Sonnet 5 and Introducing Claude Sonnet 5 | https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5 | https://www.anthropic.com/news/claude-sonnet-5",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Anthropic",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Anthropic What's new in Claude Sonnet 5 | https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/codex-auto-review.json
+++ b/infra/conductor/model_cards/codex-auto-review.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "codex-auto-review",
+  "display_name": "Codex Auto Review",
+  "identity": {
+    "provider": "openai",
+    "family": "codex",
+    "kind": "service",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "approval_review",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI Running Codex safely | https://openai.com/index/running-codex-safely/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Codex permission feature, not a standalone language model: automatically reviews and may approve certain requests that cross the configured sandbox boundary.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI Running Codex safely | https://openai.com/index/running-codex-safely/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI Running Codex safely | https://openai.com/index/running-codex-safely/",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/deepseek-chat-v3-0324.json
+++ b/infra/conductor/model_cards/deepseek-chat-v3-0324.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "deepseek-chat-v3-0324",
+  "display_name": "DeepSeek Chat V3 0324",
+  "identity": {
+    "provider": "deepseek",
+    "family": "deepseek-v3",
+    "kind": "language",
+    "aliases": ["openrouter/deepseek/deepseek-chat-v3-0324"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "deprecated",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "legacy_aider_fix",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "retired_route",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/deepseek-r1-32b.json
+++ b/infra/conductor/model_cards/deepseek-r1-32b.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "deepseek-r1-32b",
+  "display_name": "DeepSeek R1 32B",
+  "identity": {
+    "provider": "ollama",
+    "family": "deepseek",
+    "kind": "language",
+    "aliases": ["deepseek-r1:32b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/deepseek-r1/tags | title=DeepSeek-R1 Ollama library tags | note=The exact deepseek-r1:32b package is listed as a 128K-context text model; the library describes DeepSeek-R1 as a reasoning model and lists distilled variants.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/deepseek-r1 | title=DeepSeek-R1 Ollama library page | note=The official library describes DeepSeek-R1 as a reasoning model; local reasoning quality is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 131072,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/deepseek-r1/tags | title=DeepSeek-R1 Ollama library tags | note=Exact deepseek-r1:32b package is listed with 128K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "offline_reasoning",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/deepseek-v3.json
+++ b/infra/conductor/model_cards/deepseek-v3.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "deepseek-v3",
+  "display_name": "deepseek-v3",
+  "identity": {
+    "provider": "deepseek",
+    "family": "deepseek",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 131072,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://github.com/deepseek-ai/DeepSeek-V3 | DeepSeek-V3 | accessed 2026-08-21 | Exact claim: DeepSeek-V3 has a 128K context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_architecture",
+      "value": "MoE language model with 671B total parameters and 37B activated parameters; documents Multi-head Latent Attention, DeepSeekMoE, auxiliary-loss-free load balancing, and multi-token prediction training.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://github.com/deepseek-ai/DeepSeek-V3 | DeepSeek-V3 | accessed 2026-08-21 | Exact claim: DeepSeek-V3 documents this architecture and training approach.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://github.com/deepseek-ai/DeepSeek-V3 | DeepSeek-V3 | accessed 2026-08-21 | Exact claim: DeepSeek-V3 is a 671B-total/37B-activated MoE language model with a 128K context length and documented MLA, DeepSeekMoE, auxiliary-loss-free balancing, and multi-token prediction.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/deepseek-v4-flash-0731.json
+++ b/infra/conductor/model_cards/deepseek-v4-flash-0731.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "deepseek-v4-flash-0731",
+  "display_name": "DeepSeek V4 Flash 0731",
+  "identity": {
+    "provider": "deepseek",
+    "family": "deepseek-v4",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "distinct_from_bare_alias",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/deepseek-v4-flash.json
+++ b/infra/conductor/model_cards/deepseek-v4-flash.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "deepseek-v4-flash",
+  "display_name": "deepseek-v4-flash",
+  "identity": {
+    "provider": "deepseek",
+    "family": "deepseek",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "access_result",
+      "value": "403 Access to model denied",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/deepseek-v4-pro.json
+++ b/infra/conductor/model_cards/deepseek-v4-pro.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "deepseek-v4-pro",
+  "display_name": "DeepSeek V4 Pro",
+  "identity": {
+    "provider": "deepseek",
+    "family": "deepseek-v4",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "probation",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_json_output",
+      "value": "Official JSON Output guidance includes an exact deepseek-v4-pro example using json_object; the prompt must request JSON and an empty response is documented as possible without it.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://api-docs.deepseek.com/guides/json_mode/ | JSON Output | accessed 2026-08-21 | Exact claim: the official JSON Output guide includes deepseek-v4-pro with json_object and documents these prompt constraints.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "eligible_for_quorum",
+      "value": false,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "zero_measured_calls",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://api-docs.deepseek.com/guides/json_mode/ | JSON Output | accessed 2026-08-21 | Exact claim: the official JSON Output guide includes deepseek-v4-pro with json_object and documents these prompt constraints.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/deepseek-v4.json
+++ b/infra/conductor/model_cards/deepseek-v4.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "deepseek-v4",
+  "display_name": "deepseek-v4",
+  "identity": {
+    "provider": "deepseek",
+    "family": "deepseek",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gemini-3-flash-preview.json
+++ b/infra/conductor/model_cards/gemini-3-flash-preview.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gemini-3-flash-preview",
+  "display_name": "Gemini 3 Flash Preview",
+  "identity": {
+    "provider": "google",
+    "family": "gemini-3",
+    "kind": "language",
+    "aliases": ["google-gemini-cli/gemini-3-flash-preview"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "routing": {
+    "status": "deprecated",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1048576,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3 Flash Preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 65536,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3 Flash Preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "deprecated_cli_surface",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text, image, video, audio, and PDF input with text output; supports caching, code execution, computer use, file search, function calling, Maps/Search grounding, structured output, thinking, and URL context. Official model page identifies this preview as a legacy/deprecated version of Gemini 3.5 Flash.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3 Flash Preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    },
+    {
+      "level": "declared",
+      "ref": "Google Gemini 3 Flash Preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gemini-3.1-pro.json
+++ b/infra/conductor/model_cards/gemini-3.1-pro.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gemini-3.1-pro",
+  "display_name": "Gemini 3.1 Pro",
+  "identity": {
+    "provider": "google",
+    "family": "gemini-3",
+    "kind": "language",
+    "aliases": ["gemini-3.1-pro-preview"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1048576,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.1 Pro preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 65536,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.1 Pro preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "candidate_only_harness",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "official_api_variant_scope",
+      "value": "Limits and tool capabilities in this card are declared specifically for the official gemini-3.1-pro-preview API identifier; they are not inherited to other Gemini 3.1 family aliases.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.1 Pro preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "For gemini-3.1-pro-preview: text, image, video, audio, and PDF input with text output; supports caching, code execution, function calling, Maps/Search grounding, structured output, thinking, and URL context; intended for advanced reasoning, synthesis, complex tasks, and coding agents.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.1 Pro preview model page and announcement | https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview | https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-pro/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Google Gemini 3.1 Pro preview model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gemini-3.5-flash.json
+++ b/infra/conductor/model_cards/gemini-3.5-flash.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gemini-3.5-flash",
+  "display_name": "Gemini 3.5 Flash",
+  "identity": {
+    "provider": "google",
+    "family": "gemini-3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1048576,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.5 Flash model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 65536,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.5 Flash model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "candidate_only_harness",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text, image, video, audio, and PDF input with text output; supports caching, code execution, computer use preview, file search, function calling, Maps/Search grounding, structured output, thinking, and URL context; intended for subagent deployment, multistep work, long-horizon tasks, and rapid coding loops.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3.5 Flash model page and Gemini 3.5 announcement | https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash | https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Google Gemini 3.5 Flash model page | https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gemini-deepthink.json
+++ b/infra/conductor/model_cards/gemini-deepthink.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gemini-deepthink",
+  "display_name": "Gemini DeepThink",
+  "identity": {
+    "provider": "google",
+    "family": "gemini",
+    "kind": "service",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+        "observed_at": "2026-08-20"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+        "observed_at": "2026-08-20"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capability_profile",
+      "value": "Specialized Gemini reasoning mode that uses parallel reasoning to explore multiple hypotheses; intended for complex science, mathematics, engineering, and research. Official public sources do not declare an independent model identifier, context window, output limit, or complete tool-support matrix for this mode.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Gemini 3 Deep Think announcement | https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-deep-think/ | https://blog.google/products-and-platforms/products/gemini/gemini-3-deep-think/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#role_chains.strategy_panel",
+      "observed_at": "2026-08-20"
+    },
+    {
+      "level": "declared",
+      "ref": "Google Gemini 3 Deep Think announcement | https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-deep-think/",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gemini-spark.json
+++ b/infra/conductor/model_cards/gemini-spark.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gemini-spark",
+  "display_name": "Gemini Spark",
+  "identity": {
+    "provider": "google",
+    "family": "gemini-spark",
+    "kind": "service",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "manual_only",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "knowledge_verification",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "consumer_account_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "gui_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "schedulable",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "24/7 personal-agent service that works proactively in the cloud and integrates with Google Workspace. The cited current India rollout is powered by Gemini 3.6 Flash; this engine claim is rollout-scoped and is not inherited as a generic Gemini Spark model identifier or token limit.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google Introducing Gemini Spark and India expansion | https://blog.google/innovation-and-ai/products/gemini-app/next-evolution-gemini-app/ | https://blog.google/intl/en-in/company-news/technology/introducing-gemini-spark-your-247-personal-ai-agent-in-country/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Google Introducing Gemini Spark | https://blog.google/innovation-and-ai/products/gemini-app/next-evolution-gemini-app/",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gemma3-27b.json
+++ b/infra/conductor/model_cards/gemma3-27b.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gemma3-27b",
+  "display_name": "Gemma 3 27B",
+  "identity": {
+    "provider": "ollama",
+    "family": "gemma3",
+    "kind": "vision",
+    "aliases": ["gemma3:27b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/gemma3/tags | title=Gemma3 Ollama library tags | note=The exact gemma3:27b package is listed as a 128K-context text-and-image model.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/google/gemma-3-27b-pt | title=Gemma 3 27B model card | note=The Google card documents text-and-image input for Gemma 3 27B and support for 140+ languages.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 131072,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/gemma3/tags | title=Gemma3 Ollama library tags | note=Exact gemma3:27b package is listed with 128K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "translation",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "multilingual_140_plus",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/google/gemma-3-27b-pt | title=Gemma 3 27B model card | note=The Google card documents support for 140+ languages.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    },
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gemma4-26b.json
+++ b/infra/conductor/model_cards/gemma4-26b.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gemma4-26b",
+  "display_name": "Gemma 4 26B",
+  "identity": {
+    "provider": "ollama",
+    "family": "gemma4",
+    "kind": "vision",
+    "aliases": ["gemma4:26b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/gemma4/tags | title=Gemma4 Ollama library tags | note=The exact gemma4:26b package is listed as a 256K-context text-and-image model with reasoning, coding, agentic, and function-calling features.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ai.google.dev/gemma/docs/core/model_card_4 | title=Gemma 4 model card | note=The Google card documents multimodal text-and-image input for Gemma 4 26B A4B.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/gemma4/tags | title=Gemma4 Ollama library tags | note=Exact gemma4:26b package is listed with 256K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "kg_json_or_translation",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "thinking",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/google/gemma-4-26B-A4B | title=Gemma 4 26B A4B model card | note=The Google card documents thinking/reasoning support; local runtime behavior is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "function_calling",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/google/gemma-4-26B-A4B | title=Gemma 4 26B A4B model card | note=The Google card documents function calling and coding capabilities; local serving behavior remains unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    },
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/glm-4.5.json
+++ b/infra/conductor/model_cards/glm-4.5.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "glm-4.5",
+  "display_name": "glm-4.5",
+  "identity": {
+    "provider": "z.ai",
+    "family": "glm",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/glm-4.7.json
+++ b/infra/conductor/model_cards/glm-4.7.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "glm-4.7",
+  "display_name": "glm-4.7",
+  "identity": {
+    "provider": "z.ai",
+    "family": "glm",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 202752,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: glm-4.7 has a 202,752-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: glm-4.7 has a 202,752-token context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/glm-4.json
+++ b/infra/conductor/model_cards/glm-4.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "glm-4",
+  "display_name": "glm-4",
+  "identity": {
+    "provider": "z.ai",
+    "family": "glm",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/glm-5.1.json
+++ b/infra/conductor/model_cards/glm-5.1.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "glm-5.1",
+  "display_name": "glm-5.1",
+  "identity": {
+    "provider": "z.ai",
+    "family": "glm",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "access_result",
+      "value": "403 Access to model denied",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/glm-5.2.json
+++ b/infra/conductor/model_cards/glm-5.2.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "glm-5.2",
+  "display_name": "GLM 5.2",
+  "identity": {
+    "provider": "z.ai",
+    "family": "glm",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#z.ai",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#z.ai",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/newly-released-models | Newly released models | accessed 2026-08-21 | Exact claim: glm-5.2 documents a 1M-token context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Documents long-horizon reasoning, text generation, and coding capabilities.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/newly-released-models | Newly released models | accessed 2026-08-21 | Exact claim: glm-5.2 documents a 1M-token context and long-horizon reasoning, text generation, and coding capabilities.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "clear_thinking",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "never_architecture",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "never_merge",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#z.ai",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#z.ai",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/newly-released-models | Newly released models | accessed 2026-08-21 | Exact claim: glm-5.2 documents a 1M-token context and long-horizon reasoning, text generation, and coding capabilities.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/glm-5.json
+++ b/infra/conductor/model_cards/glm-5.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "glm-5",
+  "display_name": "glm-5",
+  "identity": {
+    "provider": "z.ai",
+    "family": "glm",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 202752,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: glm-5 has a 202,752-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "access_result",
+      "value": "403 Access to model denied",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: glm-5 has a 202,752-token context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/glm-ocr.json
+++ b/infra/conductor/model_cards/glm-ocr.json
@@ -1,0 +1,155 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "glm-ocr",
+  "display_name": "GLM OCR",
+  "identity": {
+    "provider": "ollama",
+    "family": "glm",
+    "kind": "vision",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "https://huggingface.co/zai-org/GLM-OCR | title=GLM-OCR model card | note=The exact upstream GLM-OCR checkpoint is a multimodal OCR and complex-document-understanding model; no exact official Ollama package alias was found.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/zai-org/GLM-OCR | title=GLM-OCR model card | note=The upstream checkpoint accepts image and text for OCR/document understanding; exact local packaging is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/zai-org/GLM-OCR | title=GLM-OCR model card | note=The upstream checkpoint uses an image-text input pipeline.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_document_pipeline",
+      "value": "Supports complex-document OCR with layout analysis followed by recognition; README documents image and PDF input and JSON or Markdown output formats.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://github.com/zai-org/GLM-OCR | GLM-OCR: Accurate x Fast x Comprehensive | accessed 2026-08-21 | Exact claim: GLM-OCR documents this two-stage document OCR pipeline, image/PDF input, and JSON/Markdown output formats.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "ocr",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/zai-org/GLM-OCR | title=GLM-OCR model card | note=The upstream checkpoint is explicitly designed for OCR, including layout-aware and parallel recognition workflows.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "document_understanding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/zai-org/GLM-OCR | title=GLM-OCR model card | note=The upstream checkpoint documents complex document understanding, tables, formulas, and structured extraction.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "supported_languages",
+      "value": "8",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/zai-org/GLM-OCR | title=GLM-OCR model card | note=The official card documents OCR support for eight languages; exact local alias remains unresolved.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://github.com/zai-org/GLM-OCR | GLM-OCR: Accurate x Fast x Comprehensive | accessed 2026-08-21 | Exact claim: GLM-OCR documents a two-stage document OCR pipeline with image/PDF input and JSON/Markdown output formats.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-5.3-codex-spark.json
+++ b/infra/conductor/model_cards/gpt-5.3-codex-spark.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-5.3-codex-spark",
+  "display_name": "GPT-5.3 Codex Spark",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-5.3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI Introducing GPT-5.3-Codex-Spark | https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Research-preview, text-only coding model optimized for real-time interaction, targeted edits, logic, and UI work; lightweight by default and does not automatically run tests unless requested. Availability is Codex surfaces for Pro users with separate limits, not general API availability.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI Introducing GPT-5.3-Codex-Spark | https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI Introducing GPT-5.3-Codex-Spark | https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-5.4-mini.json
+++ b/infra/conductor/model_cards/gpt-5.4-mini.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-5.4-mini",
+  "display_name": "GPT-5.4 Mini",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-5.4",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 400000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 mini Model | https://developers.openai.com/api/docs/models/gpt-5.4-mini",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 mini Model | https://developers.openai.com/api/docs/models/gpt-5.4-mini",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text input/output and image input; function calling, structured outputs, web/file search, image generation, code interpreter, hosted shell, apply patch, skills, and computer use are supported; intended for high-volume coding, computer use, and subagent workloads.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 mini Model and Introducing GPT-5.4 mini and nano | https://developers.openai.com/api/docs/models/gpt-5.4-mini | https://openai.com/index/introducing-gpt-5-4-mini-and-nano/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI GPT-5.4 mini Model | https://developers.openai.com/api/docs/models/gpt-5.4-mini",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-5.4.json
+++ b/infra/conductor/model_cards/gpt-5.4.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-5.4",
+  "display_name": "GPT-5.4",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-5.4",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1050000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 Model | https://developers.openai.com/api/docs/models/gpt-5.4",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 Model | https://developers.openai.com/api/docs/models/gpt-5.4",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text input/output and image input; reasoning effort none, low, medium, high, or xhigh; intended for complex professional work and coding, with native computer use and tool search.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.4 Model and Introducing GPT-5.4 | https://developers.openai.com/api/docs/models/gpt-5.4 | https://openai.com/index/introducing-gpt-5-4/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI GPT-5.4 Model | https://developers.openai.com/api/docs/models/gpt-5.4",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-5.5.json
+++ b/infra/conductor/model_cards/gpt-5.5.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-5.5",
+  "display_name": "GPT-5.5",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-5.5",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1050000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.5 Model | https://developers.openai.com/api/docs/models/gpt-5.5",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.5 Model | https://developers.openai.com/api/docs/models/gpt-5.5",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text input/output and image input; reasoning effort none, low, medium, high, or xhigh; intended for complex professional work, agentic coding, tool use, computer use, and document, spreadsheet, and slide production.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.5 Model and Introducing GPT-5.5 | https://developers.openai.com/api/docs/models/gpt-5.5 | https://openai.com/index/introducing-gpt-5-5/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI GPT-5.5 Model | https://developers.openai.com/api/docs/models/gpt-5.5",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-5.6-luna.json
+++ b/infra/conductor/model_cards/gpt-5.6-luna.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-5.6-luna",
+  "display_name": "GPT-5.6 Luna",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-5.6",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1050000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Luna Model | https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Luna Model | https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "observed_explicit_slug",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text input/output and image input; reasoning effort none, low, medium, high, xhigh, or max; cost-sensitive high-volume tier optimized for fast and affordable workloads.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Luna Model and GPT-5.6 announcement | https://developers.openai.com/api/docs/models/gpt-5.6-luna | https://openai.com/index/gpt-5-6/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI GPT-5.6 Luna Model | https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-5.6-sol.json
+++ b/infra/conductor/model_cards/gpt-5.6-sol.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-5.6-sol",
+  "display_name": "GPT-5.6 Sol",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-5.6",
+    "kind": "language",
+    "aliases": ["gpt-5.6"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1050000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Sol Model | https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Sol Model | https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "observed_explicit_slug",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text input/output and image input; reasoning effort none, low, medium, high, xhigh, or max; frontier tier for complex professional work, agentic coding, computer use, science, cybersecurity, and design.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Sol Model and GPT-5.6 announcement | https://developers.openai.com/api/docs/models/gpt-5.6-sol | https://openai.com/index/gpt-5-6/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI GPT-5.6 Sol Model | https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-5.6-terra.json
+++ b/infra/conductor/model_cards/gpt-5.6-terra.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-5.6-terra",
+  "display_name": "GPT-5.6 Terra",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-5.6",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "reasoning_control",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1050000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Terra Model | https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 128000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Terra Model | https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "observed_explicit_slug",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Text input/output and image input; reasoning effort none, low, medium, high, xhigh, or max; balanced intelligence-and-cost tier for everyday professional and coding workloads.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT-5.6 Terra Model and GPT-5.6 announcement | https://developers.openai.com/api/docs/models/gpt-5.6-terra | https://openai.com/index/gpt-5-6/",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI GPT-5.6 Terra Model | https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-image-2.json
+++ b/infra/conductor/model_cards/gpt-image-2.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-image-2",
+  "display_name": "GPT Image 2",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt-image",
+    "kind": "image",
+    "aliases": ["$imagegen"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "image_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "surface",
+      "value": "Codex image generation tool",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Image generation and editing model with text and image input and image output; supports flexible image sizes and high-fidelity input handling. Function calling, structured outputs, fine-tuning, audio, and video are unsupported.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "OpenAI GPT Image 2 Model | https://developers.openai.com/api/docs/models/gpt-image-2",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#2",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "OpenAI GPT Image 2 Model | https://developers.openai.com/api/docs/models/gpt-image-2",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/gpt-reserve.json
+++ b/infra/conductor/model_cards/gpt-reserve.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "gpt-reserve",
+  "display_name": "GPT Reserve",
+  "identity": {
+    "provider": "openai",
+    "family": "gpt",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/happyhorse-1.1-i2v.json
+++ b/infra/conductor/model_cards/happyhorse-1.1-i2v.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "happyhorse-1.1-i2v",
+  "display_name": "HappyHorse 1.1 I2V",
+  "identity": {
+    "provider": "alibaba",
+    "family": "happyhorse",
+    "kind": "video",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "video_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_video_output",
+      "value": "First-frame image-to-video with audio; 480P, 720P, or 1080P; 3 to 15 seconds; 24 fps MP4 output.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-i2v documents first-frame image-to-video and these output properties.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "wired_to_role_chain",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-i2v is first-frame image-to-video with audio and 480P/720P/1080P, 3-15 second, 24 fps MP4 output.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/happyhorse-1.1-r2v.json
+++ b/infra/conductor/model_cards/happyhorse-1.1-r2v.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "happyhorse-1.1-r2v",
+  "display_name": "HappyHorse 1.1 R2V",
+  "identity": {
+    "provider": "alibaba",
+    "family": "happyhorse",
+    "kind": "video",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "video_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_video_output",
+      "value": "Reference-image-to-video with audio; 480P, 720P, or 1080P; 3 to 15 seconds; 24 fps MP4 output.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-r2v documents reference-image-to-video and these output properties.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "wired_to_role_chain",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-r2v is reference-image-to-video with audio and 480P/720P/1080P, 3-15 second, 24 fps MP4 output.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/happyhorse-1.1-t2v.json
+++ b/infra/conductor/model_cards/happyhorse-1.1-t2v.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "happyhorse-1.1-t2v",
+  "display_name": "HappyHorse 1.1 T2V",
+  "identity": {
+    "provider": "alibaba",
+    "family": "happyhorse",
+    "kind": "video",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "video_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_video_output",
+      "value": "Text-to-video with audio; 480P, 720P, or 1080P; 3 to 15 seconds; 24 fps MP4 output.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-t2v documents these output properties.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "wired_to_role_chain",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/video-generate-edit-model | Video generation and editing | accessed 2026-08-21 | Exact claim: happyhorse-1.1-t2v is text-to-video with audio and 480P/720P/1080P, 3-15 second, 24 fps MP4 output.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/kimi-for-coding-highspeed.json
+++ b/infra/conductor/model_cards/kimi-for-coding-highspeed.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "kimi-for-coding-highspeed",
+  "display_name": "Kimi for Coding Highspeed",
+  "identity": {
+    "provider": "moonshot",
+    "family": "kimi",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Moonshot",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/kimi-for-coding.json
+++ b/infra/conductor/model_cards/kimi-for-coding.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "kimi-for-coding",
+  "display_name": "Kimi for Coding",
+  "identity": {
+    "provider": "moonshot",
+    "family": "kimi",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "hot_zone_alone",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Moonshot",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/kimi-k2.5.json
+++ b/infra/conductor/model_cards/kimi-k2.5.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "kimi-k2.5",
+  "display_name": "kimi-k2.5",
+  "identity": {
+    "provider": "moonshot",
+    "family": "kimi",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://github.com/MoonshotAI/Kimi-K2.5 | Kimi-K2.5 | accessed 2026-08-21 | Exact claim: Kimi K2.5 has a 256K context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Native multimodal agentic model using MoonViT; model card documents 1T total and 32B activated parameters.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://github.com/MoonshotAI/Kimi-K2.5 | Kimi-K2.5 | accessed 2026-08-21 | Exact claim: Kimi K2.5 is a native multimodal agentic model using MoonViT with this parameterization and a 256K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "access_result",
+      "value": "403 Access to model denied",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://github.com/MoonshotAI/Kimi-K2.5 | Kimi-K2.5 | accessed 2026-08-21 | Exact claim: Kimi K2.5 is a native multimodal agentic model using MoonViT with a 256K context.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/kimi-k2.6.json
+++ b/infra/conductor/model_cards/kimi-k2.6.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "kimi-k2.6",
+  "display_name": "kimi-k2.6",
+  "identity": {
+    "provider": "moonshot",
+    "family": "kimi",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_reasoning_control",
+      "value": "Documents hybrid thinking with an enable_thinking control in the provider visual-reasoning guide.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/visual-reasoning | Usage of visual reasoning models | accessed 2026-08-21 | Exact claim: kimi-k2.6 is listed as a hybrid-thinking model with enable_thinking control.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "access_result",
+      "value": "403 Access to model denied",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/visual-reasoning | Usage of visual reasoning models | accessed 2026-08-21 | Exact claim: kimi-k2.6 is listed as a hybrid-thinking model with enable_thinking control.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/kimi-k2.7.json
+++ b/infra/conductor/model_cards/kimi-k2.7.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "kimi-k2.7",
+  "display_name": "kimi-k2.7",
+  "identity": {
+    "provider": "moonshot",
+    "family": "kimi",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/kimi-k2.json
+++ b/infra/conductor/model_cards/kimi-k2.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "kimi-k2",
+  "display_name": "kimi-k2",
+  "identity": {
+    "provider": "moonshot",
+    "family": "kimi",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 131072,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://github.com/MoonshotAI/Kimi-K2 | Kimi-K2 | accessed 2026-08-21 | Exact claim: Kimi K2 has a 128K context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "MoE language model with 1T total and 32B activated parameters; the official model card describes tool use, reasoning, and autonomous problem solving.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://github.com/MoonshotAI/Kimi-K2 | Kimi-K2 | accessed 2026-08-21 | Exact claim: Kimi K2 documents this architecture, 128K context, and these capabilities.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://github.com/MoonshotAI/Kimi-K2 | Kimi-K2 | accessed 2026-08-21 | Exact claim: Kimi K2 is a 1T-total/32B-activated MoE language model with 128K context and documented tool-use/reasoning capabilities.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/kimi-k3.json
+++ b/infra/conductor/model_cards/kimi-k3.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "kimi-k3",
+  "display_name": "Kimi K3",
+  "identity": {
+    "provider": "moonshot",
+    "family": "kimi",
+    "kind": "language",
+    "aliases": ["k3", "kimi-code/k3"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Moonshot",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "multimodal_review",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "never_final_gate",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Moonshot",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Moonshot",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/minimax-m2.5.json
+++ b/infra/conductor/model_cards/minimax-m2.5.json
@@ -1,0 +1,111 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "minimax-m2.5",
+  "display_name": "MiniMax M2.5",
+  "identity": {
+    "provider": "minimax",
+    "family": "minimax",
+    "kind": "language",
+    "aliases": ["MiniMax-M2.5", "minimax-2.5"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "phantom",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 204800,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.5 has a 204,800-token maximum for total input plus output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Text-generation model that documents tool-call triggering; its text-generation guide classifies M2.5 as a reasoning model.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.5 documents text generation, tool-call triggering, and a 204,800-token total input/output maximum.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/text-post | Text Generation | accessed 2026-08-21 | Exact claim: MiniMax-M2.5 is documented as a reasoning model.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "in_tp1_plan",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.roster.NOT_in_plan",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.5 documents text generation, tool-call triggering, and a 204,800-token total input/output maximum.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/minimax-m2.7.json
+++ b/infra/conductor/model_cards/minimax-m2.7.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "minimax-m2.7",
+  "display_name": "MiniMax-M2.7",
+  "identity": {
+    "provider": "minimax",
+    "family": "MiniMax",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 204800,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.7 has a 204,800-token maximum for total input plus output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Text-generation model that documents tool-call triggering; its text-generation guide classifies M2.7 as a reasoning model.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.7 documents text generation, tool-call triggering, and a 204,800-token total input/output maximum.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://platform.minimax.io/docs/api-reference/text-post | Text Generation | accessed 2026-08-21 | Exact claim: MiniMax-M2.7 is documented as a reasoning model.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://platform.minimax.io/docs/api-reference/api-overview | API Overview | accessed 2026-08-21 | Exact claim: MiniMax-M2.7 documents text generation, tool-call triggering, and a 204,800-token total input/output maximum.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/minimax-m3.json
+++ b/infra/conductor/model_cards/minimax-m3.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "minimax-m3",
+  "display_name": "MiniMax-M3",
+  "identity": {
+    "provider": "minimax",
+    "family": "MiniMax",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/nomic-embed-text.json
+++ b/infra/conductor/model_cards/nomic-embed-text.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "nomic-embed-text",
+  "display_name": "Nomic Embed Text",
+  "identity": {
+    "provider": "ollama",
+    "family": "nomic",
+    "kind": "embedding",
+    "aliases": ["nomic-embed-text"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/nomic-embed-text | title=Nomic Embed Text Ollama library page | note=The exact nomic-embed-text package is embedding-only and is listed with a 2K runtime context; the upstream model card documents a longer 8,192-token sequence limit.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "embedding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "local_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 2048,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/nomic-embed-text | title=Nomic Embed Text Ollama library page | note=The exact Ollama package is listed with a 2K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "general_embedding",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "embedding_dimensions",
+      "value": "768",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5 | title=Nomic Embed Text v1.5 model card | note=The upstream card declares a default 768-dimensional embedding and Matryoshka dimensions down to 64; exact Ollama output behavior is not separately probed.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "embedding_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/nomic-embed-text | title=Nomic Embed Text Ollama library page | note=The official Ollama page identifies the package as embedding-only.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/notebooklm-default.json
+++ b/infra/conductor/model_cards/notebooklm-default.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "notebooklm-default",
+  "display_name": "NotebookLM default profile",
+  "identity": {
+    "provider": "google",
+    "family": "notebooklm",
+    "kind": "service",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Google",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "knowledge_verification",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "ground_truth_verifier",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "synthesis",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Google",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_capability_profile",
+      "value": "Research-assistant service whose chat answers are grounded in notebook sources with inline citations; accepts PDFs, websites, YouTube, audio, Google Docs, and Slides and can create guides, briefs, audio, video, mind maps, infographics, and slide decks.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google NotebookLM Help: Learn about NotebookLM and Use NotebookLM with a work or school Google account | https://support.google.com/notebooklm/answer/16164461?hl=en | https://support.google.com/notebooklm/answer/17003757",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "declared_source_limits",
+      "value": "Per-source ingestion limit is 500,000 words or 200 MB; the standard free tier supports up to 50 sources per notebook. These are service ingestion limits, not model context or output token limits.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "Google NotebookLM Help: Add or discover new sources | https://support.google.com/notebooklm/answer/16215270",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Google",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "Google NotebookLM Help: Learn about NotebookLM | https://support.google.com/notebooklm/answer/16164461?hl=en",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen-audio-3.0-realtime-plus.json
+++ b/infra/conductor/model_cards/qwen-audio-3.0-realtime-plus.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen-audio-3.0-realtime-plus",
+  "display_name": "Qwen Audio 3.0 Realtime Plus",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen",
+    "kind": "audio",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "audio_tts",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "audio_realtime",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Documents real-time voice interaction with audio and text output and cloned-voice support.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://www.alibabacloud.com/help/en/model-studio/qwen-audio-realtime-user-guides | Qwen-Audio real-time voice model | accessed 2026-08-21 | Exact claim: qwen-audio-3.0-realtime-plus documents audio and text output plus cloned-voice support.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "wired_to_role_chain",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://www.alibabacloud.com/help/en/model-studio/qwen-audio-realtime-user-guides | Qwen-Audio real-time voice model | accessed 2026-08-21 | Exact claim: qwen-audio-3.0-realtime-plus documents real-time voice interaction with audio and text output plus cloned-voice support.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen-audio-3.0-tts-plus.json
+++ b/infra/conductor/model_cards/qwen-audio-3.0-tts-plus.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen-audio-3.0-tts-plus",
+  "display_name": "Qwen Audio 3.0 TTS Plus",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen",
+    "kind": "audio",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "audio_tts",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Documents streaming synthesis, custom voices, voice cloning, and instruction control.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://docs.qwencloud.com/developer-guides/speech/tts-models | TTS models | accessed 2026-08-21 | Exact claim: qwen-audio-3.0-tts-plus documents streaming synthesis, custom voices, and instruction control.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "wired_to_role_chain",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://docs.qwencloud.com/developer-guides/speech/tts-models | TTS models | accessed 2026-08-21 | Exact claim: qwen-audio-3.0-tts-plus documents streaming synthesis, custom voices, and instruction control.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen2.5-7b.json
+++ b/infra/conductor/model_cards/qwen2.5-7b.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen2.5-7b",
+  "display_name": "Qwen 2.5 7B",
+  "identity": {
+    "provider": "ollama",
+    "family": "qwen2.5",
+    "kind": "language",
+    "aliases": ["qwen2.5:7b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      },
+      {
+        "level": "declared",
+        "ref": "https://qwenlm.github.io/blog/qwen2.5-llm/ | Qwen2.5-LLM: Extending the boundary of LLMs | accessed 2026-08-21 | Exact claim: Qwen2.5-7B has a 128K context and 8K generation length.",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/qwen2.5/tags | title=Qwen2.5 Ollama library tags | note=The exact qwen2.5:7b local package is listed with a 32K context; this package-level limit is kept distinct from the upstream 128K claim.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 32768,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen2.5-llm/ | Qwen2.5-LLM: Extending the boundary of LLMs | accessed 2026-08-21 | Exact claim: Qwen2.5-7B has a 128K context length.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/qwen2.5/tags | title=Qwen2.5 Ollama library tags | note=Exact qwen2.5:7b package is listed with 32K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 8192,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen2.5-llm/ | Qwen2.5-LLM: Extending the boundary of LLMs | accessed 2026-08-21 | Exact claim: Qwen2.5-7B has an 8K generation length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "coding_math_json",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen2.5-llm/ | title=Qwen2.5-LLM: Extending the boundary of LLMs | note=The official Qwen source documents coding, mathematics, structured JSON generation, and multilingual support.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "generation_tokens",
+      "value": "8192",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen2.5-llm/ | title=Qwen2.5-LLM: Extending the boundary of LLMs | note=The upstream Qwen2.5-7B source documents an 8K generation length; local serving behavior is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    },
+    {
+      "level": "declared",
+      "ref": "https://qwenlm.github.io/blog/qwen2.5-llm/ | Qwen2.5-LLM: Extending the boundary of LLMs | accessed 2026-08-21 | Exact claim: Qwen2.5-7B has a 128K context and 8K generation length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen2.5vl-7b.json
+++ b/infra/conductor/model_cards/qwen2.5vl-7b.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen2.5vl-7b",
+  "display_name": "Qwen 2.5 VL 7B",
+  "identity": {
+    "provider": "ollama",
+    "family": "qwen2.5vl",
+    "kind": "vision",
+    "aliases": ["qwen2.5vl:7b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/qwen2.5vl/tags | title=Qwen2.5-VL Ollama library tags | note=The exact qwen2.5vl:7b package is listed as a 125K-context text-and-image model; exact host installation and runtime behavior remain unmeasured.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_ROSTER.md#Local-Ollama",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct | title=Qwen2.5-VL-7B-Instruct model card | note=The upstream card documents image, chart, layout, document, visual-localization, long-video, and visual-agent capabilities; this does not establish quantized local quality.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 131072,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/qwen2.5vl/tags | title=Qwen2.5-VL Ollama library tags | note=Exact qwen2.5vl:7b package is listed with 125K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "sole_vision_ocr_seat",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_ROSTER.md#Local-Ollama",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "document_understanding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct | title=Qwen2.5-VL-7B-Instruct model card | note=The upstream card documents document, chart, table, layout, and visual-localization understanding.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "visual_localization",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct | title=Qwen2.5-VL-7B-Instruct model card | note=The upstream card documents visual localization and visual-agent interactions.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "tool_use_declared",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct | title=Qwen2.5-VL-7B-Instruct model card | note=The upstream card documents visual-agent use with computer and phone interaction examples; local tool execution is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_ROSTER.md#Local-Ollama",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-4b.json
+++ b/infra/conductor/model_cards/qwen3-4b.json
@@ -1,0 +1,132 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-4b",
+  "display_name": "Qwen 3 4B",
+  "identity": {
+    "provider": "ollama",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": ["qwen3:4b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/qwen3/tags | title=Qwen3 Ollama library tags | note=The exact qwen3:4b local package is listed with a 256K context; this package-level limit is kept distinct from the upstream 32K claim.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | Qwen3: Think Deeper, Act Faster | accessed 2026-08-21 | Exact claim: Qwen3-4B has a 32K context length.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/qwen3/tags | title=Qwen3 Ollama library tags | note=Exact qwen3:4b package is listed with 256K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "role",
+      "value": "sentry",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "thinking_and_tool_use_declared",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | title=Qwen3: Think Deeper, Act Faster | note=The official Qwen source documents switchable thinking/non-thinking modes and agent tool integration; local runtime behavior is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "multilingual_100_plus",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | title=Qwen3: Think Deeper, Act Faster | note=The official Qwen source documents support for more than 100 languages and dialects.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    },
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://qwenlm.github.io/blog/qwen3/ | Qwen3: Think Deeper, Act Faster | accessed 2026-08-21 | Exact claim: Qwen3-4B is a listed Qwen3 model with a 32K context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-8b.json
+++ b/infra/conductor/model_cards/qwen3-8b.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-8b",
+  "display_name": "Qwen 3 8B",
+  "identity": {
+    "provider": "ollama",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": ["qwen3:8b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/qwen3/tags | title=Qwen3 Ollama library tags | note=The exact qwen3:8b local package is listed with a 40K context; this package-level limit is kept distinct from the upstream 128K claim.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 40960,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        },
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | Qwen3: Think Deeper, Act Faster | accessed 2026-08-21 | Exact claim: Qwen3-8B has a 128K context length.",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/qwen3/tags | title=Qwen3 Ollama library tags | note=Exact qwen3:8b package is listed with 40K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "think",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "thinking_and_tool_use_declared",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | title=Qwen3: Think Deeper, Act Faster | note=The official Qwen source documents switchable thinking/non-thinking modes and agent tool integration; the existing think=false field remains the local roster observation.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "multilingual_100_plus",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://qwenlm.github.io/blog/qwen3/ | title=Qwen3: Think Deeper, Act Faster | note=The official Qwen source documents support for more than 100 languages and dialects.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    },
+    {
+      "level": "declared",
+      "ref": "https://qwenlm.github.io/blog/qwen3/ | Qwen3: Think Deeper, Act Faster | accessed 2026-08-21 | Exact claim: Qwen3-8B is a listed Qwen3 model with a 128K context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-asr-flash.json
+++ b/infra/conductor/model_cards/qwen3-asr-flash.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-asr-flash",
+  "display_name": "qwen3-asr-flash",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "audio",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "audio_asr",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/asr-model | Speech recognition models | accessed 2026-08-21 | Exact claim: qwen3-asr-flash is an automatic speech recognition model supporting emotion recognition and a documented language set.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "offline_request_limit",
+      "value": "Maximum audio duration is 5 minutes or 10 MB per HTTP request.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen-asr-api-reference | Qwen-ASR API reference | accessed 2026-08-21 | Exact claim: qwen3-asr-flash offline HTTP requests are limited to 5 minutes of audio or 10 MB.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/asr-model | Speech recognition models | accessed 2026-08-21 | Exact claim: qwen3-asr-flash is documented for automatic speech recognition and emotion recognition.",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/qwen-asr-api-reference | Qwen-ASR API reference | accessed 2026-08-21 | Exact claim: qwen3-asr-flash offline HTTP requests are limited to 5 minutes of audio or 10 MB.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-coder-flash.json
+++ b/infra/conductor/model_cards/qwen3-coder-flash.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-coder-flash",
+  "display_name": "qwen3-coder-flash",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-coder-next.json
+++ b/infra/conductor/model_cards/qwen3-coder-next.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-coder-next",
+  "display_name": "qwen3-coder-next",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-coder-next has a 262,144-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Documents code generation, code completion, and tool calls.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen-coder | Code capabilities (Qwen-Coder) | accessed 2026-08-21 | Exact claim: qwen3-coder-next documents code generation, code completion, and tool calls.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/qwen-coder | Code capabilities (Qwen-Coder) | accessed 2026-08-21 | Exact claim: qwen3-coder-next documents code generation, code completion, and tool calls.",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-coder-next has a 262,144-token context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-coder-plus.json
+++ b/infra/conductor/model_cards/qwen3-coder-plus.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-coder-plus",
+  "display_name": "qwen3-coder-plus",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-coder-plus has a 1,000,000-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-coder-plus has a 1,000,000-token context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-coder.json
+++ b/infra/conductor/model_cards/qwen3-coder.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-coder",
+  "display_name": "qwen3-coder",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-max-2026-01-23.json
+++ b/infra/conductor/model_cards/qwen3-max-2026-01-23.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-max-2026-01-23",
+  "display_name": "qwen3-max-2026-01-23",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-max-2026-01-23 has a 262,144-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3-max-2026-01-23 has a 262,144-token context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-max.json
+++ b/infra/conductor/model_cards/qwen3-max.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-max",
+  "display_name": "qwen3-max",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/model-pricing | Model pricing | accessed 2026-08-21 | Exact claim: qwen3-max is documented as the current equivalent of qwen3-max-2026-01-23, whose documented context ceiling is 262,144 tokens.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/model-pricing | Model pricing | accessed 2026-08-21 | Exact claim: qwen3-max is documented as the current equivalent of qwen3-max-2026-01-23, whose documented context ceiling is 262,144 tokens.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-vl-8b.json
+++ b/infra/conductor/model_cards/qwen3-vl-8b.json
@@ -1,0 +1,139 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-vl-8b",
+  "display_name": "Qwen 3 VL 8B",
+  "identity": {
+    "provider": "ollama",
+    "family": "qwen-3",
+    "kind": "vision",
+    "aliases": ["qwen3-vl:8b"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      },
+      {
+        "level": "declared",
+        "ref": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct | title=Qwen3-VL-8B-Instruct model card | note=The exact upstream checkpoint documents 256K native context, visual agents, video, OCR, spatial understanding, and tool-oriented interaction; the local Ollama packaging is not independently documented here.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct | title=Qwen3-VL-8B-Instruct model card | note=The upstream checkpoint is multimodal; exact local serving identity and quality remain unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct | title=Qwen3-VL-8B-Instruct model card | note=The upstream checkpoint accepts text and image/video inputs.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "video",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct | title=Qwen3-VL-8B-Instruct model card | note=The upstream checkpoint documents video understanding and long-video processing.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "ocr",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct | title=Qwen3-VL-8B-Instruct model card | note=The upstream checkpoint documents OCR in 32 languages and structured extraction from long documents.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling_declared",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct | title=Qwen3-VL-8B-Instruct model card | note=The upstream checkpoint documents visual-agent and tool-oriented interaction capabilities; local execution is unmeasured.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct | title=Qwen3-VL-8B-Instruct model card | note=The upstream checkpoint documents 256K native context; this does not establish local Ollama runtime limits.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3-vl-plus.json
+++ b/infra/conductor/model_cards/qwen3-vl-plus.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3-vl-plus",
+  "display_name": "qwen3-vl-plus",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "vision",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.5-9b.json
+++ b/infra/conductor/model_cards/qwen3.5-9b.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.5-9b",
+  "display_name": "Qwen 3.5 9B",
+  "identity": {
+    "provider": "ollama",
+    "family": "qwen3.5",
+    "kind": "vision",
+    "aliases": ["qwen3.5:9b"],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      },
+      {
+        "level": "declared",
+        "ref": "https://ollama.com/library/qwen3.5/tags | title=Qwen3.5 Ollama library tags | note=The exact qwen3.5:9b package is listed as a 256K-context text-and-image model with vision, thinking, coding, and agent-oriented features; local runtime behavior remains unmeasured.",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "MODEL_TOPOLOGY.json#roles",
+        "observed_at": "2026-06-16"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://huggingface.co/Qwen/Qwen3.5-9B | title=Qwen3.5-9B model card | note=The exact upstream checkpoint documents an image-text pipeline; this does not establish local quantized quality.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 262144,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/qwen3.5/tags | title=Qwen3.5 Ollama library tags | note=Exact qwen3.5:9b package is listed with 256K context.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "think",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling_broken",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "MODEL_TOPOLOGY.json#roles",
+          "observed_at": "2026-06-16"
+        }
+      ]
+    },
+    {
+      "id": "thinking_declared",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/qwen3.5/tags | title=Qwen3.5 Ollama library tags | note=The official package page documents thinking support; the existing think=false field remains a local roster observation.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling_declared",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://ollama.com/library/qwen3.5/tags | title=Qwen3.5 Ollama library tags | note=The official package page documents tool and agent-oriented features; the existing tool_calling_broken field remains a local observation.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "MODEL_TOPOLOGY.json#roles",
+      "observed_at": "2026-06-16"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.5-plus.json
+++ b/infra/conductor/model_cards/qwen3.5-plus.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.5-plus",
+  "display_name": "qwen3.5-plus",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3.5-plus has a 1,000,000-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "vision",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-5-plus | qwen3.5-plus Model Info | accessed 2026-08-21 | Exact claim: qwen3.5-plus accepts image and video input and returns text.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "tool_calling",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-5-plus | qwen3.5-plus Model Info | accessed 2026-08-21 | Exact claim: qwen3.5-plus documents Function Calling support.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/qwen3-5-plus | qwen3.5-plus Model Info | accessed 2026-08-21 | Exact claim: qwen3.5-plus accepts text, image, and video input; supports Function Calling, Structured Outputs, Web Search, Prefix Completion, Context Caching, and Batch.",
+      "observed_at": "2026-08-21"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3.5-plus has a 1,000,000-token context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.6-flash.json
+++ b/infra/conductor/model_cards/qwen3.6-flash.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.6-flash",
+  "display_name": "Qwen 3.6 Flash",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen-3",
+    "kind": "language",
+    "aliases": ["qwen-3.6-flash"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "probation",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-6-flash | qwen3.6-flash Model Info | accessed 2026-08-21 | Exact claim: qwen3.6-flash documents a 1,000,000-token context limit.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 65536,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-6-flash | qwen3.6-flash Model Info | accessed 2026-08-21 | Exact claim: qwen3.6-flash documents a 65,536-token output limit.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Accepts text, image, and video input; returns text; documents Function Calling, Structured Outputs, Web Search, Prefix Completion, and Context Caching. Batch Inference is documented as supported in China (Beijing) and unsupported in Singapore, Germany, the US, and Japan.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-6-flash | qwen3.6-flash Model Info | accessed 2026-08-21 | Exact claim: qwen3.6-flash documents these input/output modalities and features; Batch Inference is supported in China (Beijing) and unsupported in Singapore, Germany, the US, and Japan; it documents a 1,000,000-token context and 65,536-token output limit.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "zero_measured_calls",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/qwen3-6-flash | qwen3.6-flash Model Info | accessed 2026-08-21 | Exact claim: text, image, and video input; text output; 1,000,000-token context; 65,536-token output limit; Function Calling and related documented features; Batch Inference is region-dependent.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.6-plus.json
+++ b/infra/conductor/model_cards/qwen3.6-plus.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.6-plus",
+  "display_name": "qwen3.6-plus",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "denied",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "access_result",
+      "value": "403 Access to model denied",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21.fail_403_access_denied_m5_measured",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.7-max.json
+++ b/infra/conductor/model_cards/qwen3.7-max.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.7-max",
+  "display_name": "Qwen 3.7 Max",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen-3",
+    "kind": "language",
+    "aliases": ["qwen-3.7-max"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "probation",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-7-max | qwen3.7-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.7-max documents a 1,000,000-token context limit.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": 131072,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-7-max | qwen3.7-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.7-max documents a 131,072-token output limit.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Accepts and returns text; documents Function Calling, Structured Outputs, Web Search, Prefix Completion, and Context Caching. Batch Inference is documented as supported in China (Beijing) and unsupported in Singapore, Germany, the US, and Japan.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-7-max | qwen3.7-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.7-max has text input/output, a 1,000,000-token context, a 131,072-token output limit, documents Structured Outputs, and documents Batch Inference as supported in China (Beijing) and unsupported in Singapore, Germany, the US, and Japan.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "zero_measured_calls",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/qwen3-7-max | qwen3.7-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.7-max has text input/output, a 1,000,000-token context, a 131,072-token output limit, documents Structured Outputs, and has region-dependent documented feature support.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.7-plus.json
+++ b/infra/conductor/model_cards/qwen3.7-plus.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.7-plus",
+  "display_name": "Qwen 3.7 Plus",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen-3",
+    "kind": "language",
+    "aliases": ["qwen-3.7-plus"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": 1000000,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        },
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3.7-plus has a 1,000,000-token context length.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "never_load_bearing_alone",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/coding-plan-faq | FAQ | accessed 2026-08-21 | Exact claim: qwen3.7-plus has a 1,000,000-token context length.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.8-27b-mlx.json
+++ b/infra/conductor/model_cards/qwen3.8-27b-mlx.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.8-27b-mlx",
+  "display_name": "Qwen 3.8 27B MLX",
+  "identity": {
+    "provider": "ollama",
+    "family": "qwen-3",
+    "kind": "language",
+    "aliases": ["qwen3.8:27b-mlx"],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "known_unmeasured",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "infra/conductor/inventory_observations.v1.json#observations",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "probed_fact_boundary",
+      "value": "Discovery only; auth, quota, effective served model, and inference access unverified.",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "infra/conductor/inventory_observations.v1.json#observations",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "infra/conductor/inventory_observations.v1.json#observations",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.8-max-preview.json
+++ b/infra/conductor/model_cards/qwen3.8-max-preview.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.8-max-preview",
+  "display_name": "qwen3.8-max-preview",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen3",
+    "kind": "language",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "routing": {
+    "status": "investigation_required",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "probed",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+        "observed_at": "2026-08-21"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "live_probe_result",
+      "value": "PONG on Air-M5, Pro, and Mini-Pro2",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "billing_plan_eligibility",
+      "value": "unresolved",
+      "evidence": [
+        {
+          "level": "probed",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "probed",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.models_measured_2026_08_21",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/qwen3.8-max.json
+++ b/infra/conductor/model_cards/qwen3.8-max.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "qwen3.8-max",
+  "display_name": "Qwen 3.8 Max",
+  "identity": {
+    "provider": "alibaba",
+    "family": "qwen-3",
+    "kind": "language",
+    "aliases": ["qwen-3.8-max", "qwen3.8-max (Limited-time Night 50% Off)"],
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "eligible",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "production",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "language",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "coding",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_capabilities",
+      "value": "Accepts text, image, and video input; returns text; documents Function Calling, Structured Outputs, Web Search, Prefix Completion, and Context Caching. Batch Inference is documented as supported in China (Beijing) and unsupported in Singapore, Germany, the US, and Japan.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/qwen3-8-max | qwen3.8-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.8-max documents these modalities and features; Batch Inference is supported in China (Beijing) and unsupported in Singapore, Germany, the US, and Japan.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "non_pii_only",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    {
+      "id": "compliance_exact_requires_independent_verification",
+      "value": true,
+      "evidence": [
+        {
+          "level": "production",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "production",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/qwen3-8-max | qwen3.8-max Model Info | accessed 2026-08-21 | Exact claim: qwen3.8-max documents text, image, and video input; text output; Function Calling, Structured Outputs, Web Search, Prefix Completion, and Context Caching; Batch Inference is region-dependent.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/wan2.7-image-pro.json
+++ b/infra/conductor/model_cards/wan2.7-image-pro.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "wan2.7-image-pro",
+  "display_name": "Wan 2.7 Image Pro",
+  "identity": {
+    "provider": "alibaba",
+    "family": "wan2.7",
+    "kind": "image",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "image_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_image_modes",
+      "value": "Documents text-to-image generation at up to 4K output; its Model Info page distinguishes the Pro model from editing-capable standard variants.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/wan-image-generation-and-editing-api-reference | Wan2.7 - image generation and editing | accessed 2026-08-21 | Exact claim: wan2.7-image-pro documents text-to-image generation at up to 4K output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "wired_to_role_chain",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/wan-image-generation-and-editing-api-reference | Wan2.7 - image generation and editing | accessed 2026-08-21 | Exact claim: wan2.7-image-pro documents text-to-image generation at up to 4K output.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/model_cards/wan2.7-image.json
+++ b/infra/conductor/model_cards/wan2.7-image.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "model-card.v1",
+  "id": "wan2.7-image",
+  "display_name": "Wan 2.7 Image",
+  "identity": {
+    "provider": "alibaba",
+    "family": "wan2.7",
+    "kind": "image",
+    "aliases": [],
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "routing": {
+    "status": "listed_unexploited",
+    "automated_routing": false,
+    "evidence": [
+      {
+        "level": "declared",
+        "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+        "observed_at": "2026-08-14"
+      }
+    ]
+  },
+  "modalities": [
+    {
+      "id": "image_generation",
+      "value": true,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "limits": {
+    "context_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    },
+    "output_tokens": {
+      "value": null,
+      "evidence": [
+        {
+          "level": "unmeasured",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  },
+  "constraints": [
+    {
+      "id": "declared_image_modes",
+      "value": "Documents text-to-image, image-to-image, multi-image reference, and image editing; standard model supports 1K and 2K output.",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "https://help.aliyun.com/en/model-studio/wan-image-generation-and-editing-api-reference | Wan2.7 - image generation and editing | accessed 2026-08-21 | Exact claim: wan2.7-image documents these generation/editing modes and 1K/2K output.",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "wired_to_role_chain",
+      "value": false,
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+          "observed_at": "2026-08-14"
+        }
+      ]
+    }
+  ],
+  "task_scores": [],
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "FLEET_TOPOLOGY.json#accounts.alibaba.slots.TP1.console_verified_2026_08_14.unexploited_capabilities",
+      "observed_at": "2026-08-14"
+    },
+    {
+      "level": "declared",
+      "ref": "https://help.aliyun.com/en/model-studio/wan-image-generation-and-editing-api-reference | Wan2.7 - image generation and editing | accessed 2026-08-21 | Exact claim: wan2.7-image documents text/image generation and editing modes with 1K/2K output.",
+      "observed_at": "2026-08-21"
+    }
+  ]
+}

--- a/infra/conductor/priority_calibration_pilot.v1.json
+++ b/infra/conductor/priority_calibration_pilot.v1.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "priority-calibration-pilot.v1",
+  "benchmark_id": "conductor-priority-pilot",
+  "benchmark_version": "1.0.0",
+  "roster": [
+    {
+      "endpoint_id": "claude-claude-haiku-4-5",
+      "task_profile_ids": ["mechanical"]
+    },
+    {
+      "endpoint_id": "claude-claude-opus-5",
+      "task_profile_ids": ["architecture", "hard_build", "review"]
+    },
+    {
+      "endpoint_id": "claude-claude-sonnet-5",
+      "task_profile_ids": ["standard_build", "hard_build"]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.6-luna",
+      "task_profile_ids": ["mechanical"]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.6-sol",
+      "task_profile_ids": ["architecture", "hard_build", "review"]
+    },
+    {
+      "endpoint_id": "codex-gpt-5.6-terra",
+      "task_profile_ids": ["standard_build", "hard_build"]
+    },
+    {
+      "endpoint_id": "kimi-kimi-for-coding",
+      "task_profile_ids": ["standard_build"]
+    },
+    {
+      "endpoint_id": "ollama-deepseek-r1-32b",
+      "task_profile_ids": ["architecture"]
+    },
+    {
+      "endpoint_id": "qwen-qwen3-coder-plus",
+      "task_profile_ids": ["standard_build"]
+    }
+  ]
+}

--- a/infra/conductor/task_profile.schema.json
+++ b/infra/conductor/task_profile.schema.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "task_profile.schema.json",
+  "title": "MIR task profiles v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "generated_at", "evidence", "profiles"],
+  "properties": {
+    "schema_version": {
+      "const": "task-profiles.v1"
+    },
+    "generated_at": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+    },
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/evidence"
+      }
+    },
+    "profiles": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "mutation",
+          "minimum_quality_tier",
+          "minimum_task_score",
+          "benchmark_id",
+          "benchmark_version",
+          "minimum_sample_count",
+          "maximum_dispersion",
+          "minimum_context_tokens",
+          "minimum_output_tokens",
+          "required_capabilities",
+          "allowed_modalities",
+          "pii_policy",
+          "evidence"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9._-]*$"
+          },
+          "mutation": {
+            "type": "boolean"
+          },
+          "minimum_quality_tier": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "minimum_task_score": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "maximum": 1
+          },
+          "benchmark_id": {
+            "type": ["string", "null"]
+          },
+          "benchmark_version": {
+            "type": ["string", "null"]
+          },
+          "minimum_sample_count": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maximum_dispersion": {
+            "type": ["number", "null"],
+            "minimum": 0,
+            "maximum": 0.25
+          },
+          "minimum_context_tokens": {
+            "type": ["integer", "null"],
+            "minimum": 1
+          },
+          "minimum_output_tokens": {
+            "type": ["integer", "null"],
+            "minimum": 1
+          },
+          "required_capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "allowed_modalities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "pii_policy": {
+            "enum": ["context_dependent", "forbidden_cloud", "local_only"]
+          },
+          "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/evidence"
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "ref", "observed_at"],
+      "properties": {
+        "level": {
+          "enum": [
+            "declared",
+            "probed",
+            "benchmarked",
+            "production",
+            "unmeasured"
+          ]
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "observed_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+        }
+      }
+    }
+  }
+}

--- a/infra/conductor/task_profiles.v1.json
+++ b/infra/conductor/task_profiles.v1.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": "task-profiles.v1",
+  "generated_at": "2026-08-21",
+  "evidence": [
+    {
+      "level": "declared",
+      "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#6.1",
+      "observed_at": "2026-08-21"
+    }
+  ],
+  "profiles": [
+    {
+      "id": "read_only",
+      "mutation": false,
+      "minimum_quality_tier": 0,
+      "minimum_task_score": null,
+      "benchmark_id": null,
+      "benchmark_version": null,
+      "minimum_sample_count": 1,
+      "maximum_dispersion": null,
+      "minimum_context_tokens": null,
+      "minimum_output_tokens": null,
+      "required_capabilities": [],
+      "allowed_modalities": ["language"],
+      "pii_policy": "context_dependent",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#6.1",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "mechanical",
+      "mutation": true,
+      "minimum_quality_tier": 1,
+      "minimum_task_score": 0.7,
+      "benchmark_id": "conductor-priority-pilot",
+      "benchmark_version": "1.0.0",
+      "minimum_sample_count": 5,
+      "maximum_dispersion": 0.05,
+      "minimum_context_tokens": 8192,
+      "minimum_output_tokens": 2048,
+      "required_capabilities": ["coding"],
+      "allowed_modalities": ["language"],
+      "pii_policy": "forbidden_cloud",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#6.1",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "standard_build",
+      "mutation": true,
+      "minimum_quality_tier": 2,
+      "minimum_task_score": 0.75,
+      "benchmark_id": "conductor-priority-pilot",
+      "benchmark_version": "1.0.0",
+      "minimum_sample_count": 5,
+      "maximum_dispersion": 0.05,
+      "minimum_context_tokens": 16384,
+      "minimum_output_tokens": 4096,
+      "required_capabilities": ["coding"],
+      "allowed_modalities": ["language"],
+      "pii_policy": "forbidden_cloud",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#6.1",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "hard_build",
+      "mutation": true,
+      "minimum_quality_tier": 3,
+      "minimum_task_score": 0.8,
+      "benchmark_id": "conductor-priority-pilot",
+      "benchmark_version": "1.0.0",
+      "minimum_sample_count": 5,
+      "maximum_dispersion": 0.04,
+      "minimum_context_tokens": 32768,
+      "minimum_output_tokens": 8192,
+      "required_capabilities": ["coding", "reasoning_control"],
+      "allowed_modalities": ["language"],
+      "pii_policy": "forbidden_cloud",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#6.1",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "architecture",
+      "mutation": false,
+      "minimum_quality_tier": 3,
+      "minimum_task_score": 0.8,
+      "benchmark_id": "conductor-priority-pilot",
+      "benchmark_version": "1.0.0",
+      "minimum_sample_count": 5,
+      "maximum_dispersion": 0.04,
+      "minimum_context_tokens": 32768,
+      "minimum_output_tokens": 8192,
+      "required_capabilities": ["reasoning_control"],
+      "allowed_modalities": ["language"],
+      "pii_policy": "forbidden_cloud",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#6.1",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "review",
+      "mutation": false,
+      "minimum_quality_tier": 3,
+      "minimum_task_score": 0.8,
+      "benchmark_id": "conductor-priority-pilot",
+      "benchmark_version": "1.0.0",
+      "minimum_sample_count": 5,
+      "maximum_dispersion": 0.04,
+      "minimum_context_tokens": 32768,
+      "minimum_output_tokens": 8192,
+      "required_capabilities": ["reasoning_control"],
+      "allowed_modalities": ["language", "vision"],
+      "pii_policy": "forbidden_cloud",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#6.1",
+          "observed_at": "2026-08-21"
+        }
+      ]
+    },
+    {
+      "id": "pii_local",
+      "mutation": false,
+      "minimum_quality_tier": 1,
+      "minimum_task_score": 0.7,
+      "benchmark_id": "conductor-priority-pilot",
+      "benchmark_version": "1.0.0",
+      "minimum_sample_count": 5,
+      "maximum_dispersion": 0.05,
+      "minimum_context_tokens": 8192,
+      "minimum_output_tokens": 2048,
+      "required_capabilities": ["local_only", "pii_safe_local"],
+      "allowed_modalities": ["language", "vision"],
+      "pii_policy": "local_only",
+      "evidence": [
+        {
+          "level": "declared",
+          "ref": "FLEET_TOPOLOGY.json#role_chains.pii_intake",
+          "observed_at": "2026-08-20"
+        }
+      ]
+    }
+  ]
+}

--- a/research/operations/2026-08-21-universal-conductor-control-plane-design.md
+++ b/research/operations/2026-08-21-universal-conductor-control-plane-design.md
@@ -1,0 +1,1019 @@
+# Universal Conductor Control Plane
+
+**Status:** implementation-ready design + compiled MIR baseline; router/hooks not yet armed
+
+**Date:** 2026-08-21
+
+**Scope:** Air-M5, Pro, Mini-Pro2; Claude, Codex, Antigravity (`agy`), Kimi, and future CLI-backed LLMs
+
+**Decision owner:** Zero
+
+## 1. Decision
+
+The LLM that opens an interactive session is the **conductor** for that session. The
+conductor owns the mandate, plan, routing decisions, evidence synthesis, and final
+conversation with Zero. It is not automatically the architect, builder, or grader.
+
+The conductor routes through a **Model Intelligence Registry (MIR)**. The MIR is the
+router's evidence-backed knowledge of every sanctioned model and every concrete way of
+invoking it: techniques, modalities, tool support, context/output limits, reasoning
+controls, known failure modes, task-specific quality, latency, quota pressure, privacy
+eligibility, and current availability. Routing from model names or provider reputation
+alone is forbidden.
+
+For every non-trivial code mutation, the conductor must route the implementation to a
+separate builder session when a healthy, policy-eligible builder is available. The
+builder is selected by task shape and minimum sufficient capability, not by the model
+that happened to open the session.
+
+Examples:
+
+- Codex Sol may route mechanical work to Luna or Haiku and standard implementation to
+  Terra, Sonnet, Kimi 2.7, Qwen 3.7, DeepSeek V4 Flash, or any future eligible builder.
+  Cross-provider builders are first-class candidates, not merely emergency fallbacks.
+  Sol remains available for architecture, integration judgment, and red-team.
+- Codex Terra or Luna may also be the conductor. They keep control of the session but
+  must request a stronger architect when the task exceeds their capability, and use a
+  separate builder session for non-trivial mutations.
+- Claude, `agy`, and Kimi follow the same role protocol. Provider-specific names are
+  adapters around one model-independent contract.
+- The grader is selected independently and must be from a different model family than
+  the principal builder when the repository's generator-not-grader rule applies.
+
+This is a **session-local control plane**, not a new central daemon. Each session owns
+its own state and emits durable receipts. This preserves SYMBIOSIS Law 3: no central
+polling orchestrator and no new always-on service.
+
+## 2. What the live system proves today
+
+The current system has the right doctrine but does not enforce it consistently:
+
+1. `AGENTS.md` already defines conductor as a role and allows any frontier LLM to open
+   the session.
+2. `FLEET_TOPOLOGY.json` contains useful role chains, but it mixes current decisions,
+   historical prose, accounts, and stale availability claims. It is not a small runtime
+   policy that a hook can validate deterministically.
+3. `scripts/fleet_dispatch.py` answers **where** a lane may run and protects file scope.
+   It explicitly does not choose or run an LLM. It should remain the placement engine.
+4. The current `orchestrate_gate.py` gates on transcript length (`>800` lines) and lack
+   of recent dispatches. It does not know the task class, conductor model, builder
+   capability, mutation scope, or whether a valid implementation receipt exists.
+5. The current home-level `model_routing_gate.py` only requires an explicit model on an
+   `Agent` call. Its message still names the former Fable-only doctrine. It governs how
+   a dispatch is expressed, not whether a conductor must delegate.
+6. Codex hook state is split across the fleet:
+   - Pro has orchestration, model-routing, dispatch-nudge, and subagent-stop hooks.
+   - Air-M5 launches `orchestrate_gate.py` with `ORCHESTRATE_GATE_OFF=1` and lacks the
+     Codex model-routing and subagent-stop hooks.
+   - Mini-Pro2 has no `~/.codex/hooks.json`.
+7. A zero-token inventory on 2026-08-21 found Codex CLI 0.148.0 on Pro/Mini and 0.147.0
+   on Air-M5. All three caches list `gpt-5.6-sol`, `gpt-5.6-terra`, and
+   `gpt-5.6-luna`, but cache presence proves discovery only, not authenticated inference.
+   The stale topology sentence that the slugs are dead and the opposite claim that they
+   are live are therefore both too strong until an explicit endpoint probe succeeds.
+8. `MODEL_TOPOLOGY.json` is stale against the same live inventory. Pro currently lists
+   only `qwen3.5:9b`, `qwen2.5vl:7b`, and `bge-m3`; Mini lists nine models, including
+   newer Qwen/VL/OCR entries absent from the topology. Static role assignments cannot be
+   used as live model availability.
+
+Conclusion: current behavior is advisory and host-dependent. It cannot prove that Sol
+did not implement a delegable task, nor that a session begun in another LLM obeyed the
+same role split.
+
+## 3. Architectural boundaries
+
+### 3.1 Responsibilities
+
+| Component | Owns | Must not own |
+| --- | --- | --- |
+| Conductor | mandate, decomposition, routing, synthesis, evidence, user interaction | default implementation of delegable mutations |
+| Architect | design and hard technical judgment | grading its own implementation |
+| Builder | scoped code mutation and builder-local tests | session mandate or final verdict |
+| Grader | independent review and verdict | mutation of the diff it judges |
+| Placement engine | machine capacity, repo alignment, file-scope collision | model quality decisions |
+| Model Intelligence Registry | versioned model/endpoint facts, evidence, benchmark results | live process execution or task policy |
+| Capability probe | observed CLI/model/seat availability and feature checks | task quality claims or routing policy |
+| Hook adapter | translate harness event into canonical event | provider-specific policy |
+
+### 3.2 Hard invariants
+
+The runtime must enforce these invariants:
+
+1. `session_starter == conductor` for the lifetime of the interactive session.
+2. `conductor_session_id != builder_session_id` for every delegable mutation.
+3. A conductor write requires either a valid builder/integration receipt or a typed
+   direct-write exemption.
+4. An exemption is explicit, bounded by files and expiry, and stored in the evidence
+   ledger. There is no boolean kill switch that silently disables the policy.
+5. Builder selection uses the least expensive healthy **endpoint** whose evidence-backed
+   capabilities and task score meet the task profile. The abstract model name is not a
+   routable target.
+6. Architecture may route upward; implementation normally routes downward or laterally.
+7. Grading is independently routed and observes the repository's family-separation
+   rule.
+8. One writer owns a file scope at a time. Existing `fleet_dispatch.py` remains the
+   authority for machine placement and collision refusal.
+9. PII/OSINT tasks obey the local-only policy and never write cleartext into session
+   manifests, prompts persisted for reuse, receipts, or telemetry.
+10. Unknown model identity, unreadable policy, invalid receipt, or unprovable file scope
+    is visible degradation. It is never reported as compliant.
+11. Read-only exploration is never blocked by the delegation gate.
+12. No hook performs a token-consuming health probe on every tool call.
+13. Every routing decision binds the hashes of the task profile, model card, endpoint
+    profile, capability snapshot, benchmark version, and executable policy it used.
+14. A vendor declaration, CLI model listing, or model self-report never becomes an
+    empirical quality score without an external benchmark or observed task outcome.
+
+## 4. Proposed repository layout
+
+```text
+infra/conductor/
+├── policy.v1.json                 # small executable routing policy
+├── policy.schema.json             # JSON Schema, rejects drift at load time
+├── capability_ontology.v1.json    # canonical feature and technique vocabulary
+├── task_profiles.v1.json          # typed requirements and quality floors per task shape
+├── model_cards/                   # model-level facts, limitations, and evidence
+│   └── *.json
+├── endpoint_profiles/             # CLI/harness/account-class/node invocation surfaces
+│   └── *.json
+├── benchmark_manifest.v1.json     # benchmark suites, versions, and promotion rules
+├── model_capability_index.v1.json # generated normalized router projection
+├── hook_manifest.v1.json          # desired adapters per harness
+└── fixtures/
+    ├── claude_events.jsonl
+    ├── codex_events.jsonl
+    └── session_examples.json
+
+scripts/conductor/
+├── __init__.py
+├── contracts.py                   # enums + frozen dataclasses
+├── policy.py                      # load, schema validate, policy hash
+├── identity.py                    # engine/model/family/session/host resolution
+├── model_registry.py              # load, join, validate, and hash MIR records
+├── capability.py                  # cached observed endpoint availability/features
+├── benchmarks.py                  # ingest external benchmark evidence
+├── outcomes.py                    # privacy-safe task outcome calibration
+├── classifier.py                  # deterministic task and mutation classifier
+├── router.py                      # pure role assignment function
+├── receipts.py                    # signed/hash-bound append-only receipts
+├── state.py                       # atomic session manifest state machine
+├── hooks.py                       # canonical hook decisions
+├── adapters/
+│   ├── claude.py
+│   ├── codex.py
+│   └── subprocess.py              # agy/Kimi and future CLI engines
+└── doctor.py                      # local and three-node conformance checks
+
+scripts/conductor/conductor_ctl.py # SHADOW doctor/status/smoke/fleet-doctor entry point
+scripts/nuz_session.py             # universal session launcher
+scripts/install_conductor_hooks.py # idempotent, path-aware home installer
+
+scripts/tests/
+├── test_conductor_router.py
+├── test_conductor_policy.py
+├── test_conductor_model_registry.py
+├── test_conductor_benchmarks.py
+├── test_conductor_receipts.py
+├── test_conductor_hook_contract.py
+├── test_conductor_installer.py
+└── test_conductor_fleet_doctor.py
+```
+
+`FLEET_TOPOLOGY.json` remains the strategic fleet/account SSOT and
+`MODEL_TOPOLOGY.json` remains the local-model inventory SSOT. Model cards and endpoint
+profiles add technical intelligence; they do not duplicate account or node topology.
+The small `policy.v1.json` and `model_capability_index.v1.json` are executable
+projections consumed by hooks and the router. A generator builds them from the topology,
+MIR records, and explicit corrections; CI fails if either checked-in projection is
+stale. Runtime hooks never parse historical prose.
+
+## 5. Canonical contracts
+
+The core is standard-library Python, fully typed, deterministic, and importable without
+the backend virtualenv. The following shapes are the implementation contract.
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+
+class Role(StrEnum):
+    CONDUCTOR = "conductor"
+    ARCHITECT = "architect"
+    BUILDER = "builder"
+    GRADER = "grader"
+
+
+class TaskClass(StrEnum):
+    READ_ONLY = "read_only"
+    MECHANICAL = "mechanical"
+    STANDARD_BUILD = "standard_build"
+    HARD_BUILD = "hard_build"
+    ARCHITECTURE = "architecture"
+    REVIEW = "review"
+    PII_LOCAL = "pii_local"
+
+
+class Decision(StrEnum):
+    ALLOW = "allow"
+    DELEGATE_REQUIRED = "delegate_required"
+    BLOCK = "block"
+    DEGRADED = "degraded"
+
+
+class EvidenceKind(StrEnum):
+    DECLARED = "declared"
+    PROBED = "probed"
+    BENCHMARKED = "benchmarked"
+    PRODUCTION = "production"
+
+
+@dataclass(frozen=True)
+class SessionIdentity:
+    session_id: str
+    root_session_id: str
+    parent_session_id: str | None
+    role: Role
+    engine: Literal["claude", "codex", "agy", "kimi", "unknown"]
+    model: str
+    family: str
+    host: str
+    repo_root: Path
+    repo_head: str
+    started_at: str
+
+
+@dataclass(frozen=True)
+class TaskIntent:
+    task_id: str
+    task_class: TaskClass
+    gear: Literal[1, 2, 3]
+    mutation: bool
+    files: tuple[str, ...]
+    requires: frozenset[str]
+    task_profile_id: str
+    estimated_context_tokens: int | None
+    required_modalities: frozenset[str]
+    required_tools: frozenset[str]
+    contains_pii: bool
+
+
+@dataclass(frozen=True)
+class CapabilityEvidence:
+    capability: str
+    value: bool | int | float | str | None
+    kind: EvidenceKind
+    evidence_ref: str
+    observed_at: str
+    expires_at: str | None
+    confidence: float
+
+
+@dataclass(frozen=True)
+class TaskScore:
+    task_profile_id: str
+    score: float | None
+    benchmark_id: str | None
+    benchmark_version: str | None
+    sample_count: int
+    observed_at: str | None
+
+
+@dataclass(frozen=True)
+class EndpointCandidate:
+    endpoint_id: str
+    engine: str
+    model_card_id: str
+    model: str
+    family: str
+    role: Role
+    features: tuple[CapabilityEvidence, ...]
+    task_scores: tuple[TaskScore, ...]
+    healthy: bool
+    health_observed_at: str
+    machine_allowlist: tuple[str, ...]
+    cost_rank: int
+    latency_rank: int
+    quota_pressure_rank: int
+    quality_tier: int
+    enforcement_mode: Literal["enforced", "shadow", "advisory"]
+    identity_confidence: float
+    model_card_hash: str
+    endpoint_profile_hash: str
+    capability_snapshot_hash: str
+
+
+@dataclass(frozen=True)
+class RoleAssignment:
+    role: Role
+    engine: str
+    endpoint_id: str
+    model: str
+    family: str
+    machine: str
+    reason_code: str
+    model_card_hash: str
+    capability_snapshot_hash: str
+    benchmark_version: str | None
+
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    decision: Decision
+    conductor: SessionIdentity
+    task: TaskIntent
+    assignments: tuple[RoleAssignment, ...]
+    policy_hash: str
+    task_profile_hash: str
+    capability_index_hash: str
+    degraded_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DispatchReceipt:
+    receipt_id: str
+    parent_session_id: str
+    child_session_id: str
+    role: Role
+    task_id: str
+    model: str
+    family: str
+    machine: str
+    allowed_files: tuple[str, ...]
+    worktree: str
+    base_commit: str
+    policy_hash: str
+    created_at: str
+    expires_at: str
+```
+
+The receipt hash binds task, child session, model, machine, worktree, file scope, base
+commit, and policy version. A textual mention of delegation in a transcript is not a
+receipt.
+
+Only a root interactive session (`parent_session_id is None`) acquires the conductor
+role automatically. A CLI launched by `conductor_ctl dispatch` is a child actor even if
+it uses the same engine/model as the parent. This prevents the sentence "every starting
+LLM is a conductor" from accidentally promoting every spawned worker into a second
+conductor.
+
+## 6. Routing policy
+
+### 6.1 Task-to-builder matrix
+
+The first implementation must treat the complete sanctioned arsenal as one builder pool.
+The examples below are candidates, not fixed chains; the exact model identifiers and
+seats come from the executable policy and fresh capability snapshot.
+
+| Task class | Minimum capability | Example eligible builders | Conductor behavior |
+| --- | --- | --- | --- |
+| Read-only exploration | current conductor | current conductor | execute directly |
+| Mechanical mutation | fast/grunt | Luna, Haiku, Kimi fast lane, Qwen/DeepSeek flash lane, eligible local model | delegate unless micro exemption applies |
+| Standard implementation | balanced coding | Terra, Sonnet, Kimi 2.7 coding, Qwen 3.7, DeepSeek V4 Flash | delegate |
+| Hard implementation | strong coding/reasoning | Terra high, Sonnet high, Qwen high-capability lane, separate Sol/Opus worker when genuinely required | delegate and integrate |
+| Architecture | frontier reasoner | Sol, Opus, Gemini/other policy-approved architect | conduct directly if capable; otherwise delegate architect |
+| Red-team/review | frontier reviewer, different family where required | Sol, Opus, Gemini, Kimi, Qwen or another independent eligible reviewer | never grade own builder output |
+| PII/local-only | eligible local model | policy-approved Ollama/local models only | route local or queue |
+
+Sol therefore does **not** own a private `Sol -> Terra -> Luna` cascade. That is only the
+Codex subset of a fleet-wide candidate graph. Claude, Gemini, Kimi, Qwen, DeepSeek, Codex,
+and local models are normalized into the same `EndpointCandidate` contract and compete on task
+fit. Model names belong in policy data, never router branches.
+
+Selection is lexicographic rather than based on a fabricated all-purpose score:
+
+1. Reject endpoints that violate sovereignty, hard feature requirements, context/output
+   bounds, machine, role, worktree, enforcement-adapter, verified identity, or
+   fresh-health requirements.
+2. Require a benchmarked task score at or above the task profile's quality floor. An
+   unmeasured endpoint may enter shadow/probation, never a load-bearing lane.
+3. Prefer the endpoint specialized for the task shape, using first-pass success and
+   re-entry evidence rather than provider reputation.
+4. Prefer already-paid subscription/token-plan/local capacity over incremental spend.
+5. Prefer lower quota pressure, then lower expected total work, among equally capable
+   candidates. Expected total work includes latency, likely retries, and review burden;
+   low token price alone is not efficiency.
+6. Apply campaign diversity and generator-not-grader constraints.
+7. If still tied, use a stable policy order so identical inputs produce identical plans.
+
+Provider is not a quality rank. Sonnet or Qwen may beat Terra for a specific task; Luna
+or Haiku may beat every frontier model for a mechanical edit. The router records the
+reason code for the chosen candidate and the rejected reason for every higher-ranked
+alternative.
+
+Classification is two-stage. The conductor submits a typed `TaskIntent`; a deterministic
+policy floor then raises (but can never lower) the declared gear/capabilities based on
+observable scope: sensitive paths, migrations, auth, dependency manifests, public APIs,
+number of files, and requested operation. Natural-language intent alone never grants a
+cheaper lane or a direct-write exemption.
+
+### 6.2 Model Intelligence Registry
+
+The router's unit of selection is a **model endpoint**, not a model name:
+
+```text
+TaskProfile
+    x ModelCard
+    x EndpointProfile (engine + harness + account class + node constraints)
+    x fresh CapabilitySnapshot
+    x BenchmarkSeries
+    x privacy-safe OutcomeSeries
+    x RoutingPolicy
+        -> ranked EndpointCandidates + rejection reasons
+```
+
+This distinction is load-bearing. The same underlying model may expose native tool use,
+subagents, resumable sessions, vision, a different context limit, or no enforceable
+mutation hook depending on the CLI/harness and account surface. A model can therefore
+have several endpoint profiles with different eligibility.
+
+The MIR contains four evidence layers. Later layers do not erase earlier ones; conflicts
+remain explicit:
+
+| Layer | What it proves | What it does not prove |
+| --- | --- | --- |
+| `declared` | documented modality, limit, parameter, or intended role | that the current seat can invoke it or that it performs well |
+| `probed` | exact endpoint identity, auth/access, CLI version, feature handshake, node availability | task quality from a ping or model listing |
+| `benchmarked` | performance on a versioned, PII-free Nuzantara task suite with external deterministic grading | production reliability outside the measured distribution |
+| `production` | first-pass success, retry, re-entry, latency, and failure outcomes from real routed work | capabilities that were never exercised |
+
+Every capability assertion carries `kind`, `evidence_ref`, `observed_at`, optional
+`expires_at`, and `confidence`. Hard capabilities with missing, stale, contradictory, or
+self-reported-only evidence are ineligible. Soft preferences may remain `unmeasured` and
+receive no positive score. The registry never converts `GET /models`, a CLI cache, a
+marketing claim, or the model saying its own name into proof of access or quality.
+
+#### Capability ontology
+
+The ontology must cover at least these independently addressable dimensions:
+
+- reasoning controls and supported effort levels;
+- code implementation by stack: Python/FastAPI, TypeScript/React, tests/debugging,
+  refactors, shell/infra, and large-repository navigation;
+- architecture, synthesis, adversarial review, and instruction adherence;
+- native tool calls, structured output, streaming, parallel calls, subagents, MCP,
+  resumability, sandbox modes, and hook-enforcement compatibility;
+- text, vision, PDF/document, image generation, audio, video, embedding, and OCR
+  modalities;
+- declared and empirically usable context/output limits, prompt caching/compaction, and
+  tokenizer behavior;
+- known invocation constraints and failure modes: allowed parameters, reasoning defaults,
+  refusal semantics, tool-call reliability, aliases, and model-identity ambiguity;
+- privacy/sovereignty eligibility, machine restrictions, account class, incremental cost
+  class, quota window, p50/p95 latency, and health freshness;
+- task-specific benchmark score, first-pass acceptance, retry/re-entry rate, grader
+  findings, and sample size.
+
+There is no single global intelligence or Elo score. A fast model may lead mechanical
+edits and lose on migrations; a vision model may be eligible for OCR and forbidden from
+code; a strong reasoner may remain ineligible when its harness cannot enforce file scope.
+
+#### Task profiles and evidence-backed calibration
+
+Each deterministic `TaskProfile` declares required and preferred features, minimum task
+score, expected context, modality/tool needs, privacy class, maximum acceptable latency,
+and whether probation endpoints are allowed. Initial scores come only from a versioned
+benchmark suite built from redacted or synthetic Nuzantara-shaped tasks. Deterministic
+tests, not the candidate model, grade functional correctness wherever possible; an
+independent model family grades judgment tasks.
+
+Production outcomes update a time-series calibration record, not the immutable model
+card. Promotion follows `identity probe -> feature census -> benchmark -> probation ->
+armed`; failures may demote an endpoint without rewriting its historical evidence. New
+versions and aliases receive new card or endpoint identities rather than inheriting an
+old score silently.
+
+#### Initial compiled baseline (2026-08-21)
+
+The initial MIR dataset in this worktree contains 80 abstract ModelCards and 81 concrete
+EndpointProfiles. Abstract cards are deliberately non-invocable. After reconciling the
+static roster with zero-token live inventory, only four endpoints retain automated
+eligibility:
+
+- `claude-glm-glm-5.2`;
+- `qwen-deepseek-v4-flash-0731`;
+- `qwen-qwen3.7-plus`;
+- `qwen-qwen3.8-max`.
+
+Every other endpoint remains catalogued but non-routable under an explicit state such as
+`known_unmeasured`, `investigation_required`, `probation`, `manual_only`, `denied`,
+`phantom`, or `listed_unexploited`. This is intentionally conservative: compiling a card
+does not promote an endpoint. The baseline passes eight standard-library registry tests,
+schema/JSON parsing, uniqueness checks, evidence-reference checks, and deterministic
+index regeneration. It does **not** make the conductor operational; the router, runtime
+snapshots, benchmark corpus, adapters, hooks, and three-node enforcement remain to be
+built and armed.
+
+Every plan returns the full ranked candidate list internally, including typed rejection
+reasons such as `missing_native_tools`, `benchmark_unmeasured`, `identity_ambiguous`,
+`context_insufficient`, `health_stale`, `privacy_ineligible`, or
+`generator_family_conflict`. The persisted audit record contains hashes and reason codes,
+not prompts, code, PII, or secret-bearing command lines.
+
+### 6.3 Pure routing function
+
+```python
+def plan_dispatch(
+    *,
+    session: SessionIdentity,
+    task: TaskIntent,
+    candidates: tuple[EndpointCandidate, ...],
+    policy: RoutingPolicy,
+) -> DispatchPlan:
+    if task.task_class is TaskClass.READ_ONLY:
+        return allow_conductor(session, task, policy)
+
+    eligible = filter_by_sovereignty_capability_and_health(
+        task=task,
+        candidates=candidates,
+        policy=policy,
+    )
+
+    if task.mutation:
+        builder = choose_best_eligible_builder(eligible, task, policy)
+        if builder is None:
+            return degraded_or_queue(session, task, policy)
+        return require_delegation(session, task, builder, policy)
+
+    if task.task_class is TaskClass.ARCHITECTURE:
+        return route_architect_if_needed(session, task, eligible, policy)
+
+    return route_review(session, task, eligible, policy)
+```
+
+The router is pure: no subprocesses, filesystem writes, SSH, or network calls. Live
+observations are inputs. This makes every policy decision table-testable.
+
+### 6.4 Direct-write exemptions
+
+An exemption is not a global environment variable. It is a scoped record with one of
+these reason codes:
+
+- `micro_change`: one file, at most 20 changed lines, no dependency/config/schema/auth/
+  migration/security surface, and Gear 1.
+- `integration_only`: conductor applies a bounded integration patch after a builder
+  receipt; it may not replace the builder's assigned scope.
+- `worker_unavailable`: every eligible builder has a fresh negative health observation;
+  the session is visibly degraded and the exemption expires in 15 minutes.
+- `emergency_recovery`: active incident, explicit incident ID, bounded files, automatic
+  expiry.
+
+`micro_change` reconciles role discipline with the anti-waste rule: a one-line typo does
+not need a second 100k-token context. Sol still delegates normal feature/debug work.
+Hooks reject unknown reason codes, wildcard file scopes, expired records, and exemptions
+whose base commit no longer matches.
+
+## 7. Session lifecycle
+
+```text
+Zero starts any supported CLI
+          │
+          ▼
+  nuz_session bootstrap
+  - resolve engine/model/host/repo
+  - create session manifest
+  - starter becomes conductor
+          │
+          ▼
+  conductor_ctl plan
+  - classify task/gear/mutation
+  - join task profile + MIR + fresh endpoint snapshot
+  - rank architect/builder/grader endpoints with evidence
+          │
+          ├── read-only ───────────────► conductor executes
+          │
+          └── mutation
+                 │
+                 ▼
+          fleet_dispatch place
+          - capacity
+          - worktree
+          - file-scope collision
+                 │
+                 ▼
+          conductor_ctl dispatch
+          - spawn selected CLI/model
+          - persist receipt
+                 │
+                 ▼
+          builder mutates/tests in lane
+                 │
+                 ▼
+          result receipt + diff evidence
+                 │
+                 ▼
+          conductor synthesizes/integrates
+                 │
+                 ▼
+          independent grader + final gate
+```
+
+The state machine is:
+
+```text
+BOOTSTRAPPED -> PLANNED -> DISPATCHED -> BUILT -> VERIFIED -> CLOSED
+                    \-> DEGRADED -> QUEUED
+```
+
+State transitions are atomic and monotonic. Repeated commands are idempotent. A child
+process cannot promote the parent session's state beyond `BUILT`.
+
+Dispatch uses a parent-child handshake:
+
+1. The parent writes an `ISSUED` receipt after placement succeeds.
+2. The dispatcher launches the child with `NUZ_AGENT_ROLE`, `NUZ_AGENT_SESSION_ID`,
+   `NUZ_PARENT_SESSION_ID`, and `NUZ_DISPATCH_RECEIPT_ID` set explicitly.
+3. The child's startup adapter validates the on-disk receipt, policy hash, base commit,
+   worktree, model assignment, and file scope, then transitions it to `ACTIVE`.
+4. Pre-mutation hooks validate state from disk; environment variables are locators, not
+   authority.
+5. On completion, the child records evidence hashes and transitions to `COMPLETED`.
+6. The parent may request a separate, bounded `integration_only` grant. A builder receipt
+   never authorizes conductor writes by itself.
+
+## 8. Universal launcher and engine adapters
+
+### 8.1 Launcher
+
+Supported entry points:
+
+```bash
+python3 scripts/nuz_session.py codex --model gpt-5.6-sol
+python3 scripts/nuz_session.py claude --model opus
+python3 scripts/nuz_session.py agy
+python3 scripts/nuz_session.py kimi
+```
+
+The launcher exports only non-secret context:
+
+```text
+NUZ_CONDUCTOR_SESSION_ID
+NUZ_CONDUCTOR_ENGINE
+NUZ_CONDUCTOR_MODEL
+NUZ_CONDUCTOR_FAMILY
+NUZ_CONDUCTOR_POLICY_HASH
+NUZANTARA_ROOT
+```
+
+It then `exec`s the requested CLI. Direct starts remain supported: a native SessionStart
+hook reconstructs identity when possible and marks the session `identity_degraded` when
+the effective model cannot be proven. It never guesses from the CLI flag alone.
+
+### 8.2 Hook adapters
+
+Claude and Codex adapters translate native hook payloads into:
+
+```json
+{
+  "event": "pre_mutation",
+  "session_id": "...",
+  "tool": "Edit",
+  "cwd": "...",
+  "files": ["relative/path.py"],
+  "command_class": null
+}
+```
+
+The core returns one canonical decision:
+
+```json
+{
+  "decision": "block",
+  "reason_code": "delegation_receipt_missing",
+  "message": "Standard mutation must be executed by the assigned builder",
+  "required_action": "conductor_ctl dispatch --task <id>"
+}
+```
+
+For `agy` and Kimi, which do not expose the same complete hook surface, the universal
+launcher is the enforcement boundary. Their mutation-capable subprocess/tool command
+must pass through `conductor_ctl authorize`. An engine without a provable enforcement
+adapter is declared `advisory_only` and cannot receive a mutation role.
+
+## 9. Semantic mutation gate
+
+The current line-count gate should be replaced, not extended. Transcript length may
+remain an observability metric but must not authorize code mutation.
+
+`conductor_ctl hook pre-mutation` performs only local, bounded work:
+
+1. Resolve session and policy hash.
+2. Normalize affected repo-relative files.
+3. Allow read-only tools immediately.
+4. If this is a builder child session, require a valid unexpired receipt whose file
+   scope contains every target.
+5. If this is the conductor session, require either:
+   - a valid integration receipt covering the target; or
+   - a valid typed direct-write exemption.
+6. Refuse writes in the main checkout using the existing worktree discipline.
+7. Emit a structured decision without prompt content or PII.
+
+Shell commands require a conservative command classifier. Known read-only commands are
+allowed. Known mutation commands (`sed -i`, redirect, package install, `git commit`,
+formatters, generators, migrations) require authorization. Unknown shell syntax is
+`cannot_verify`, not silently read-only.
+
+## 10. Model intelligence refresh without token waste
+
+The MIR separates slow-changing knowledge from live state:
+
+- **Model cards** are reviewed, version-controlled descriptions of the abstract model.
+- **Endpoint profiles** describe the concrete invocation surface and its enforcement,
+  account-class, engine, and node constraints.
+- **Capability snapshots** are TTL-bound observations of endpoint identity, access,
+  feature handshakes, CLI version, health, and quota pressure.
+- **Benchmark series** are append-only results keyed by model-card hash, endpoint-profile
+  hash, task-profile hash, repository fixture version, and grader version.
+- **Outcome series** hold only privacy-safe operational counters and reason codes.
+
+`conductor_ctl probe` refreshes zero-token/static facts first: executable/version,
+configuration shape, installed-model inventory, endpoint metadata, and auth-state checks
+that do not invoke inference. Session bootstrap reads the cached snapshot; it does not
+spend an LLM turn. A minimal live inference probe is reserved for stale or ambiguous
+state, explicit health runs, new endpoint onboarding, and recovery from a real failure.
+
+`conductor_ctl benchmark` is an explicit, bounded job, never a hook side effect. It uses
+the same frozen PII-free task packet for competing endpoints, records token/wall-time
+usage when the harness exposes it, runs deterministic tests, and writes an immutable
+result. Benchmarks expire or are invalidated when model identity, CLI/harness major
+version, invocation profile, task suite, or relevant policy changes.
+
+The router never treats a model cache entry as proof that authentication/quota is live.
+It also never treats a model CLI flag as proof of the effective served model unless the
+provider returns independently verifiable identity metadata. A model-list endpoint proves
+discovery only, not access; a successful `PONG` proves reachability only, not coding
+quality; a model's prose about its own features proves nothing.
+
+Mini's missing Kimi executable, a revoked Codex token, a locked Keychain, an alias silently
+serving another tier, or a tool-use feature absent from one harness therefore becomes a
+typed endpoint observation instead of a silent fallback or inherited family claim.
+
+## 11. State, receipts, and privacy
+
+Session state lives outside the repository:
+
+```text
+~/.local/state/nuzantara/conductor/<session-id>/
+├── manifest.json
+├── decisions.jsonl
+├── receipts.jsonl
+├── hook-observations.jsonl
+└── evidence.json
+
+~/.local/state/nuzantara/conductor/
+├── install-state.json             # current generation/policy binding, mode 0600
+├── .install.lock                  # persistent inode; kernel lock owns liveness
+└── install-backups/               # rollback journal and prior bytes
+```
+
+Files are user-only (`0700` directory, `0600` files), atomically replaced where mutable,
+and append-only where audit history matters. Payloads contain task IDs, hashes, relative
+file paths, model/family names, reason codes, timings, and verdicts. They do not contain
+raw user prompts, code bodies, client data, credentials, or OSINT.
+
+Receipts use keyed HMAC only if an existing local secret authority can provision it
+without creating a new secret distribution problem. The minimum viable implementation
+uses SHA-256 content binding plus ownership/permission checks and never claims
+cryptographic signer identity it cannot prove.
+
+### 11.1 Producer-consumer map
+
+| Artifact | Producer | Consumer | Durability |
+| --- | --- | --- | --- |
+| Session manifest | launcher/start adapter | router, hooks, doctor | atomic local JSON |
+| Dispatch receipt | dispatcher | child startup, mutation gate, verifier | append-only local JSONL + indexed manifest state |
+| Completion evidence | builder adapter | conductor, grader, final gate | content hashes and bounded metadata |
+| Model card | reviewed registry source | capability-index generator, benchmark runner | versioned repository JSON |
+| Endpoint profile | reviewed registry source + fleet topology | probe, router, doctor | versioned repository JSON |
+| Task profile | policy maintainer + benchmark owner | classifier, router, benchmark runner | versioned repository JSON |
+| Benchmark result | explicit benchmark runner + external grader | capability-index generator, router | append-only local evidence + reviewed aggregate |
+| Outcome series | completion/verifier adapters | calibration job, doctor | privacy-safe append-only counters |
+| Capability snapshot | explicit probe/health wrapper | router, doctor | TTL-bound local JSON |
+| Executable policy | topology projection generator | router, hooks, CI | versioned repository JSON |
+| Fleet conformance report | doctor | conductor and verification gate | ephemeral output or explicitly captured evidence |
+
+No artifact has an undefined consumer. No session prompt or code body is copied into the
+control-plane state.
+
+## 12. Three-machine installation
+
+The repository is the SSOT; home files are generated projections.
+
+```bash
+# Run with the repository's Python >=3.11; the installer attests this exact
+# interpreter in the generated shim rather than relying on PATH's python3.
+.venv/bin/python scripts/install_conductor_hooks.py --check
+.venv/bin/python scripts/install_conductor_hooks.py --apply
+.venv/bin/python scripts/conductor/conductor_ctl.py status --require wired
+.venv/bin/python scripts/conductor/conductor_ctl.py status --require observed
+.venv/bin/python scripts/conductor/conductor_ctl.py fleet-doctor --require static
+```
+
+In SHADOW, `doctor`, `status`, `smoke`, and `fleet-doctor` report
+`static_registry_valid`, `shadow_wired`, `shadow_observed`, and `enforced` as
+separate facts. `operational` remains false until an enforcing policy is
+actually active; a manual-origin wrapper or a static registry is never evidence
+of a native hook. The default requirement remains `static` for compatibility;
+automation must select `--require wired|observed|shadow|enforced` explicitly.
+Exit status is `0` only when the selected threshold is met, `1` when it is
+verifiably unmet, and `2` when the local host or contract cannot be verified.
+
+Codex native evidence is captured after a completed collaboration dispatch via
+`PostToolUse`, where the function call can be correlated with its result. A
+`PreToolUse` callback or an arbitrary non-empty `0600` file is never counted as
+`shadow_observed`. Every accepted observation is bound to the current installer
+generation and policy hash and is rejected when malformed, replayed, stale, or
+from a previous generation.
+
+Installer requirements:
+
+1. Resolve the repository from `git rev-parse` or `$HOME/nuzantara`; never commit an
+   absolute `/Users/...` path.
+2. Detect `hostname` and home directory; M5's `balizero` user is not a special-case string
+   copied into templates.
+3. Merge managed hook entries idempotently while preserving unrelated home hooks.
+4. Store a managed-block version and policy hash.
+5. Install a small stable shim in `~/.local/bin`, not duplicate policy code into home.
+6. Support `--check`, `--diff`, `--apply`, and `--rollback <backup>`.
+7. Re-run `--check` after apply and require byte-equivalent managed sections.
+8. Reject an installer runtime below Python 3.11; the generated shim executes the
+   compatible interpreter that performed the installation.
+9. Derive local host identity from hostname plus effective UID. Reject a claimed
+   `--machine` mismatch; only `--diff --offline-target --machine <node>` may render
+   an explicitly offline target and it never attests or applies that node.
+10. Hold an owner-only interprocess lock across the complete read/backup/write/verify
+    or rollback transaction. Compare digests before atomic replacement so a
+    concurrent hook or generation mutation fails without losing the other writer.
+11. Keep paths redacted from public JSON. Absolute local paths appear only with the
+    explicit `--verbose-paths` diagnostic flag.
+
+Target behavior:
+
+| Node | Interactive conductor | Builder placement | Heavy/local lanes |
+| --- | --- | --- | --- |
+| Air-M5 | primary | light code/edit lanes | route to Pro/Mini |
+| Pro | supported | standard and hard lanes | supported |
+| Mini-Pro2 | supported/headless | batch and isolated lanes | preferred where eligible |
+
+Deployment is two-phase:
+
+1. **Shadow:** adapters calculate and log decisions but never block. Compare planned
+   routing with actual mutations for at least 30 representative sessions.
+2. **Enforce:** arm per engine and node only after guilt/innocence canaries pass. A failed
+   node remains visibly `SHADOW` or `UNARMED`; no fleet-wide green claim is allowed.
+
+## 13. CLI surface
+
+```text
+conductor_ctl bootstrap      create/recover session identity
+conductor_ctl classify       print deterministic TaskIntent
+conductor_ctl plan           print DispatchPlan; no mutation
+conductor_ctl place          call fleet_dispatch with declared scope
+conductor_ctl dispatch       run selected CLI and create receipt
+conductor_ctl authorize      authorize one bounded mutation
+conductor_ctl exempt         create typed, scoped, expiring exemption
+conductor_ctl complete       close a child receipt with evidence hashes
+conductor_ctl verify         verify state/receipt/policy invariants
+conductor_ctl probe          refresh local capability snapshot
+conductor_ctl models         list cards/endpoints/evidence/rejection reasons
+conductor_ctl benchmark      run a bounded versioned capability suite explicitly
+conductor_ctl doctor         local or --fleet conformance report
+```
+
+Every command supports `--json`. Human output is concise; machine output has versioned
+schemas and stable reason codes.
+
+## 14. Test strategy
+
+### 14.1 Unit and table tests
+
+- Sol conductor + mechanical mutation -> Luna builder, direct write denied.
+- Sol conductor + standard mutation -> Terra builder, direct write denied.
+- Sol conductor + task where Sonnet/Kimi/Qwen has the best measured fit -> that
+  cross-provider endpoint wins; no Codex-family preference is applied.
+- Terra/Luna/Claude/agy/Kimi starter -> remains conductor; builder is a separate child.
+- Underpowered conductor + architecture -> architect routed upward; conductor retained.
+- Read-only exploration -> no dispatch required.
+- PII task + cloud-only candidates -> queue, no cloud fallback.
+- Builder family equals grader family -> plan rejected.
+- Missing/expired/wrong-policy/wrong-commit/wrong-file receipt -> write rejected.
+- Valid receipt within scope -> builder write allowed.
+- Micro exemption crossing 20 lines or a sensitive path -> rejected.
+- Unknown shell command -> cannot-verify, never mislabeled read-only.
+- Same model through two harnesses with different tool support -> only the qualifying
+  endpoint is eligible.
+- Model-list presence without an access probe -> endpoint remains unavailable.
+- Successful reachability probe without a task benchmark -> probation only.
+- Stale, contradictory, self-reported, wrong-hash, or inherited-alias capability -> hard
+  requirement rejected.
+- Cheaper endpoint with high measured retry/re-entry burden -> loses to lower expected
+  total-work endpoint.
+- Model/version change -> historical benchmark is retained but not inherited.
+
+### 14.2 Installer and adapter tests
+
+- Temporary homes for `nuzantara`-style and `balizero`-style paths.
+- Existing unrelated hooks preserved.
+- Second apply produces zero diff.
+- Codex and Claude fixture payloads produce the same canonical decision.
+- Missing hook file is `UNARMED`, not green.
+- Disarmed environment variable cannot silently convert an enforcement gate to allow.
+
+### 14.3 Fleet canaries
+
+On each node and each supported engine:
+
+1. Start a session and prove the starter is recorded as conductor.
+2. Attempt a standard direct mutation; prove it is blocked.
+3. Dispatch the selected builder into an isolated worktree; prove its scoped mutation is
+   allowed.
+4. Attempt an out-of-scope builder write; prove it is blocked.
+5. Complete the builder and invoke an independent grader.
+6. Compare policy hash and managed hook version across all three nodes.
+
+## 15. Metrics and acceptance criteria
+
+The design is operational only when all of these are measured:
+
+| Metric | Acceptance |
+| --- | --- |
+| Delegable conductor mutation rate | `0%` in enforcement mode |
+| Builder receipt coverage | `100%` of non-exempt code mutations |
+| Invalid out-of-scope write blocks | `100%` guilt canaries |
+| Innocent read-only false blocks | `0%` |
+| Policy hash drift across fleet | `0` armed nodes |
+| Managed hook drift | `0` armed nodes |
+| Router latency | p95 `<100 ms` local, excluding capability refresh |
+| Bootstrap overhead | p95 `<1 s`, excluding an explicitly requested live LLM probe |
+| PII/prompt bodies in state | `0` occurrences in audit corpus |
+| Fan-out waste | fan-out only for at least three independent units |
+| Armed endpoint registry coverage | `100%` have model card, endpoint profile, and fresh identity snapshot |
+| Load-bearing task-score coverage | `100%` have a current benchmark for the selected task profile |
+| Unproven hard-capability assumptions | `0` |
+| Decision evidence binding | `100%` contain policy/task/card/endpoint/snapshot/benchmark hashes |
+| Capability alias inheritance | `0` unreviewed transfers across model/version identities |
+
+The before/after benchmark must record, for a representative session corpus: conductor
+tokens, builder tokens, wall time to first mutation, total wall time, direct conductor
+write count, dispatch count, retry count, first-pass acceptance, re-entry, and final-gate
+outcome. Token reduction is not accepted if defect/re-entry rate increases. Routing regret
+is estimated through a bounded sampled bake-off, not by duplicating every production task
+across every model.
+
+## 16. Build sequence
+
+Implement in the following narrow slices:
+
+1. **Capability ontology, model cards, endpoint profiles, and task profiles** — compile the
+   complete sanctioned roster; unknowns remain explicitly unmeasured.
+2. **Registry schemas, integrity tests, and generated capability index** — no routing yet.
+3. **PII-free benchmark fixtures and baseline run** — establish task-specific quality and
+   expected-work evidence before choosing defaults.
+4. **Core contracts and pure router** — no hooks or home mutation.
+5. **Policy schema and generated executable projection** — remove stale runtime prose.
+6. **Session state and receipts** — atomic, private, idempotent.
+7. **Codex adapter in shadow mode** — prove Sol can select any qualifying fleet endpoint,
+   not only Terra/Luna.
+8. **Claude adapter in shadow mode** — same core decisions, different payload parser.
+9. **Universal launcher and subprocess adapter** — `agy`/Kimi supported without pretending
+   they expose native hook parity.
+10. **Installer and fleet doctor** — path-aware, managed-block merge, rollback.
+11. **Three-node shadow benchmark** — 30 representative sessions.
+12. **Per-node enforcement canaries** — arm only proven combinations.
+13. **Delete/supersede legacy gates** — only after every consumer is mapped and the new
+    enforcement path is live.
+
+Each slice is one concern, one worktree, one PR, with generator-not-grader verification.
+Do not combine policy, installer, and enforcement into a single large change.
+
+## 17. Explicit non-goals
+
+- No new central scheduler, daemon, Redis polling loop, or LaunchAgent.
+- No automatic fan-out for every task.
+- No model quality judgment derived solely from brand names.
+- No manually maintained universal score or router branch per model name.
+- No inheritance of capability or benchmark evidence across an unverified alias/version.
+- No live LLM probe before every tool call.
+- No duplicate implementation of worktree placement or file collision logic.
+- No silent global bypass comparable to `ORCHESTRATE_GATE_OFF=1`.
+- No Codex-only routing funnel. Sol may delegate to the full sanctioned builder fleet.
+- No forced use of Sol for ordinary coding when any lower-cost eligible builder is sufficient.
+- No replacement of the existing final-gate doctrine in this design.
+
+## 18. Final assessment
+
+The organization has already made the correct conceptual decision: conductor is a role,
+generator and grader are separate, and task-shaped routing is preferable to reflexively
+spending the strongest model. The implementation has not caught up with the doctrine.
+
+The proposed control plane closes that gap with one evidence-backed Model Intelligence
+Registry, typed task profiles, one policy, one pure router, one session receipt protocol,
+thin engine adapters, and an idempotent three-node installer. It makes
+the intended behavior measurable: a Sol session can own the work without spending Sol
+tokens on code that Terra, Luna, Sonnet, Haiku, Kimi, Qwen, DeepSeek Flash, or another
+eligible builder can implement, and the same law holds when the session starts from any
+other supported LLM.

--- a/research/operations/2026-08-21-universal-conductor-control-plane-design.md
+++ b/research/operations/2026-08-21-universal-conductor-control-plane-design.md
@@ -1,3 +1,7 @@
+---
+adversarial_review: codex
+---
+
 # Universal Conductor Control Plane
 
 **Status:** implementation-ready design + compiled MIR baseline; router/hooks not yet armed
@@ -1017,3 +1021,11 @@ the intended behavior measurable: a Sol session can own the work without spendin
 tokens on code that Terra, Luna, Sonnet, Haiku, Kimi, Qwen, DeepSeek Flash, or another
 eligible builder can implement, and the same law holds when the session starts from any
 other supported LLM.
+
+## Adversarial review
+
+The A4 aggregate review passed at exact head
+`0260d47eb000d8139b555adccd2726e2e09eb831` after the focused resolution. It recorded zero
+unresolved P0, P1, or P2 findings. The only remaining P3 item is documentation for
+`unknown_rank`; it does not alter the control-plane design verdict. The successful Claude
+review cost was `$0.2529752`.

--- a/scripts/conductor/SECURITY.md
+++ b/scripts/conductor/SECURITY.md
@@ -1,0 +1,54 @@
+# Conductor receipt authority boundary
+
+## Routed child handshake
+
+A routed receipt is not authority while it is `ISSUED`. The parent starts one
+Python wrapper with `spawn_registered_child`, observes that direct child through
+the OS, and records `LAUNCHING`. Only then does the parent release two inherited,
+one-shot pipes:
+
+- the receipt claim token;
+- optional bounded, opaque launch context for transient provider spec/task data.
+
+The wrapper calls `await_launch_registration()` and `read_launch_context()`, then
+calls `ReceiptLedger.claim_routed_from_current_process()`. The ledger derives the
+claimant identity locally from PID, process start, and executable observations; it
+does not accept caller-supplied task or runtime labels. The task/session binding is
+copied from the receipt.
+
+The registered wrapper remains the supervisor while it starts and waits for the
+provider CLI as a subprocess. It must not replace itself with `exec`, because an
+executable change deliberately invalidates the authority binding. The same wrapper
+completes with `complete_routed_from_current_process()`. A dead, replaced, or
+PID-reused wrapper is terminally rejected before policy use.
+
+The claim token and launch context are never placed in argv, environment values,
+the receipt log, or the index. Descriptor numbers are environment metadata, not
+authority. Provider bridges must not log or persist decoded launch context.
+
+Caller-labelled `claim`, `validate_active`, `complete`, and their runtime CLI argv
+builders are restricted to explicit `manual + legacy_non_launch` receipts. They
+cannot authorize routed launches.
+
+## Ledger integrity threat model
+
+The JSONL log and JSON index are a matched pair. Any mismatch, chain gap, duplicate
+or replay, reorder, truncation, invalid lifecycle transition, rollback visible
+between the pair, or implausible future timestamp fails closed. Private modes,
+no-follow opens, atomic replacement, locks, and hash chains improve corruption
+detection.
+
+They do **not** prevent a malicious process running as the same UID from rewriting
+and re-hashing every local artifact. No local secret stored under that UID changes
+this boundary. `ledger_integrity_report()` therefore declares:
+
+```text
+same_uid_tamper_resistant = false
+shadow_eligible = true
+enforcement_ready = false
+```
+
+`require_enforcement_ready()` blocks autonomous `ENFORCED` mode. `SHADOW` may run
+with this limitation declared. Enforced authority requires a privileged or
+separate-UID broker (and a migration of the ledger trust anchor); until then, this
+storage must never be described as tamper-proof.

--- a/scripts/conductor/__init__.py
+++ b/scripts/conductor/__init__.py
@@ -1,0 +1,8 @@
+"""Deterministic, session-local Universal Conductor runtime primitives.
+
+This package intentionally contains no process launcher, network client, probe, or
+daemon loop.  Those boundaries are handled by later adapters; this layer turns
+already-observed MIR data into an explainable routing plan.
+"""
+
+from __future__ import annotations

--- a/scripts/conductor/build_model_capability_index.py
+++ b/scripts/conductor/build_model_capability_index.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Build or verify the deterministic checked-in MIR capability projection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIR = ROOT / "infra" / "conductor"
+CARD_DIR = MIR / "model_cards"
+ENDPOINT_DIR = MIR / "endpoint_profiles"
+INDEX_PATH = MIR / "model_capability_index.v1.json"
+GENERATED_AT = "2026-08-21"
+GENERATION_EVIDENCE = [
+    {
+        "level": "declared",
+        "ref": "research/operations/2026-08-21-universal-conductor-control-plane-design.md#4",
+        "observed_at": "2026-08-21",
+    }
+]
+
+
+def load_records(directory: Path) -> list[dict[str, Any]]:
+    """Load records in filename order so equivalent inputs produce equivalent bytes."""
+    return [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(directory.glob("*.json"))
+    ]
+
+
+def build_index(
+    cards: list[dict[str, Any]], endpoints: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Return the router projection without interpreting availability or quality."""
+    return {
+        "schema_version": "model-capability-index.v1",
+        "generated_at": GENERATED_AT,
+        "generation": {
+            "style": "deterministic checked-in projection",
+            "inputs": [
+                "capability_ontology.v1.json",
+                "task_profiles.v1.json",
+                "model_cards/*.json",
+                "endpoint_profiles/*.json",
+                "inventory_observations.v1.json",
+            ],
+            "evidence": GENERATION_EVIDENCE,
+        },
+        "model_count": len(cards),
+        "endpoint_count": len(endpoints),
+        "models": [
+            {
+                "model_card_id": card["id"],
+                "family": card["identity"]["family"],
+                "kind": card["identity"]["kind"],
+                "routing_status": card["routing"]["status"],
+                "automated_routing": card["routing"]["automated_routing"],
+                "evidence": card["evidence"],
+            }
+            for card in cards
+        ],
+        "endpoints": [
+            {
+                "endpoint_id": endpoint["id"],
+                "model_card_id": endpoint["model_card_id"],
+                "engine": endpoint["invocation"]["engine"],
+                "model_identifier": endpoint["invocation"]["model_identifier"],
+                "auth_surface": endpoint["auth_surface"],
+                "routing_status": endpoint["routing"]["status"],
+                "automated_routing": endpoint["routing"]["automated_routing"],
+                "machine_allowlist": endpoint["machine_constraints"]["allowlist"],
+                "evidence": endpoint["evidence"],
+            }
+            for endpoint in endpoints
+        ],
+    }
+
+
+def render(index: dict[str, Any]) -> str:
+    """Return deterministic JSON in the repository's enforced Prettier shape."""
+    canonical_json = json.dumps(index, ensure_ascii=False, indent=2, sort_keys=False)
+    result = subprocess.run(
+        ["npx", "--no-install", "prettier", "--parser", "json"],
+        cwd=ROOT,
+        input=canonical_json,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Prettier could not format the deterministic MIR projection: "
+            + result.stderr.strip()
+        )
+    return result.stdout
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if the checked-in projection is stale",
+    )
+    parser.add_argument(
+        "--write", action="store_true", help="replace the checked-in projection"
+    )
+    args = parser.parse_args()
+    if args.check and args.write:
+        parser.error("--check and --write are mutually exclusive")
+
+    output = render(build_index(load_records(CARD_DIR), load_records(ENDPOINT_DIR)))
+    if args.check:
+        return 0 if INDEX_PATH.read_text(encoding="utf-8") == output else 1
+    if args.write:
+        INDEX_PATH.write_text(output, encoding="utf-8")
+        return 0
+    print(output, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/conductor/calibration.py
+++ b/scripts/conductor/calibration.py
@@ -1,0 +1,306 @@
+"""Pure records and aggregation helpers for MIR calibration artifacts.
+
+This module never invokes a model.  It accepts blinded sample hashes and scores,
+then emits the versioned overlay consumed by :mod:`model_registry`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from math import sqrt
+from statistics import fmean, pvariance
+from typing import Any, Mapping, Sequence
+
+from scripts.conductor.contracts import TaskProfile
+
+
+class CalibrationError(ValueError):
+    """Raised when a calibration artifact is internally inconsistent."""
+
+
+@dataclass(frozen=True)
+class CalibrationRecord:
+    """One blinded, endpoint-specific task-profile calibration result."""
+
+    benchmark_id: str
+    benchmark_version: str
+    endpoint_id: str
+    endpoint_profile_hash: str
+    task_profile_id: str
+    score: float
+    conservative_score: float
+    sample_count: int
+    sample_hashes: tuple[str, ...]
+    scorer_id: str
+    scorer_version: str
+    measured_at: str
+    expires_at: str
+    dispersion: float
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> CalibrationRecord:
+        """Build a record after JSON Schema validation and check cross-fields."""
+        scorer = raw["scorer"]
+        dispersion = raw["dispersion"]
+        record = cls(
+            benchmark_id=str(raw["benchmark_id"]),
+            benchmark_version=str(raw["benchmark_version"]),
+            endpoint_id=str(raw["endpoint_id"]),
+            endpoint_profile_hash=str(raw["endpoint_profile_hash"]),
+            task_profile_id=str(raw["task_profile_id"]),
+            score=float(raw["score"]),
+            conservative_score=float(raw["conservative_score"]),
+            sample_count=int(raw["sample_count"]),
+            sample_hashes=tuple(str(item) for item in raw["sample_hashes"]),
+            scorer_id=str(scorer["id"]),
+            scorer_version=str(scorer["version"]),
+            measured_at=str(raw["measured_at"]),
+            expires_at=str(raw["expires_at"]),
+            dispersion=float(dispersion["value"]),
+        )
+        record.validate()
+        return record
+
+    def validate(self) -> None:
+        """Reject artifacts whose aggregate cannot be traced to unique samples."""
+        if self.sample_count != len(self.sample_hashes):
+            raise CalibrationError("sample_count does not match sample_hashes")
+        if len(set(self.sample_hashes)) != len(self.sample_hashes):
+            raise CalibrationError("sample_hashes must be unique")
+        if self.conservative_score > self.score:
+            raise CalibrationError("conservative_score cannot exceed score")
+        measured = parse_timestamp(self.measured_at)
+        expires = parse_timestamp(self.expires_at)
+        if measured is None or expires is None:
+            raise CalibrationError(
+                "calibration timestamps must be timezone-aware ISO-8601"
+            )
+        if expires <= measured:
+            raise CalibrationError("calibration expires_at must follow measured_at")
+
+    def rejection(
+        self,
+        *,
+        endpoint_profile_hash: str,
+        profile: TaskProfile,
+        as_of: datetime | None,
+    ) -> str | None:
+        """Return the single stable reason this record cannot open a route."""
+        if self.endpoint_profile_hash != endpoint_profile_hash:
+            return "endpoint_profile_mismatch"
+        if self.benchmark_id != profile.benchmark_id:
+            return "benchmark_id_mismatch"
+        if self.benchmark_version != profile.benchmark_version:
+            return "benchmark_version_mismatch"
+        if self.sample_count < profile.minimum_sample_count:
+            return "low_sample"
+        if profile.maximum_dispersion is not None and (
+            self.dispersion > profile.maximum_dispersion
+        ):
+            return "high_variance"
+        if profile.minimum_task_score is not None and (
+            self.conservative_score < profile.minimum_task_score
+        ):
+            return "below_floor"
+        if as_of is None:
+            return "clock_missing"
+        measured = parse_timestamp(self.measured_at)
+        expires = parse_timestamp(self.expires_at)
+        if measured is None or expires is None:
+            return "timestamp_invalid"
+        if measured > as_of:
+            return "timestamp_future"
+        if expires < as_of:
+            return "stale"
+        return None
+
+    def as_mapping(self) -> dict[str, Any]:
+        """Return the canonical JSON shape for the checked-in overlay schema."""
+        return {
+            "benchmark_id": self.benchmark_id,
+            "benchmark_version": self.benchmark_version,
+            "endpoint_id": self.endpoint_id,
+            "endpoint_profile_hash": self.endpoint_profile_hash,
+            "task_profile_id": self.task_profile_id,
+            "score": self.score,
+            "conservative_score": self.conservative_score,
+            "sample_count": self.sample_count,
+            "sample_hashes": list(self.sample_hashes),
+            "scorer": {"id": self.scorer_id, "version": self.scorer_version},
+            "measured_at": self.measured_at,
+            "expires_at": self.expires_at,
+            "dispersion": {"metric": "sample_variance", "value": self.dispersion},
+        }
+
+
+@dataclass(frozen=True)
+class EndpointHostObservation:
+    """Fresh evidence for an exact endpoint model on one allowed fleet host."""
+
+    endpoint_id: str
+    endpoint_profile_hash: str
+    host: str
+    model_identifier: str
+    available: bool
+    healthy: bool
+    latency_ms: int
+    context_tokens: int
+    output_tokens: int
+    enforcement_mode: str
+    identity_verified: bool
+    probe_id: str
+    probe_version: str
+    observed_at: str
+    expires_at: str
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> EndpointHostObservation:
+        """Build an observation after JSON Schema validation and check its clock."""
+        probe = raw["probe"]
+        observation = cls(
+            endpoint_id=str(raw["endpoint_id"]),
+            endpoint_profile_hash=str(raw["endpoint_profile_hash"]),
+            host=str(raw["host"]),
+            model_identifier=str(raw["model_identifier"]),
+            available=bool(raw["available"]),
+            healthy=bool(raw["healthy"]),
+            latency_ms=int(raw["latency_ms"]),
+            context_tokens=int(raw["context_tokens"]),
+            output_tokens=int(raw["output_tokens"]),
+            enforcement_mode=str(raw["enforcement_mode"]),
+            identity_verified=bool(raw["identity_verified"]),
+            probe_id=str(probe["id"]),
+            probe_version=str(probe["version"]),
+            observed_at=str(raw["observed_at"]),
+            expires_at=str(raw["expires_at"]),
+        )
+        observation.validate()
+        return observation
+
+    def validate(self) -> None:
+        observed = parse_timestamp(self.observed_at)
+        expires = parse_timestamp(self.expires_at)
+        if observed is None or expires is None:
+            raise CalibrationError(
+                "observation timestamps must be timezone-aware ISO-8601"
+            )
+        if expires <= observed:
+            raise CalibrationError("observation expires_at must follow observed_at")
+
+    def rejection(
+        self,
+        *,
+        endpoint_profile_hash: str,
+        model_identifier: str,
+        machine_allowlist: Sequence[str],
+        as_of: datetime | None,
+    ) -> str | None:
+        """Return why an observation cannot be merged into the exact endpoint."""
+        if self.endpoint_profile_hash != endpoint_profile_hash:
+            return "endpoint_profile_mismatch"
+        if self.model_identifier != model_identifier:
+            return "model_identifier_mismatch"
+        if self.host not in machine_allowlist:
+            return "host_not_allowed"
+        if as_of is None:
+            return "clock_missing"
+        observed = parse_timestamp(self.observed_at)
+        expires = parse_timestamp(self.expires_at)
+        if observed is None or expires is None:
+            return "timestamp_invalid"
+        if observed > as_of:
+            return "timestamp_future"
+        if expires < as_of:
+            return "stale"
+        if not self.identity_verified:
+            return "identity_unverified"
+        return None
+
+
+def parse_timestamp(value: str | None) -> datetime | None:
+    """Parse only timezone-aware ISO timestamps and normalize them to UTC."""
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def aggregate_blinded_samples(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    endpoint_hashes: Mapping[str, str],
+    benchmark_id: str,
+    benchmark_version: str,
+    scorer_id: str,
+    scorer_version: str,
+    measured_at: str,
+    expires_at: str,
+) -> tuple[CalibrationRecord, ...]:
+    """Aggregate score-only samples without retaining prompts or model outputs."""
+    grouped: dict[tuple[str, str], list[tuple[str, float]]] = defaultdict(list)
+    for sample in samples:
+        if set(sample) != {"endpoint_id", "task_profile_id", "sample_hash", "score"}:
+            raise CalibrationError(
+                "sample fields must be endpoint_id, task_profile_id, sample_hash, score"
+            )
+        endpoint_id = sample["endpoint_id"]
+        task_profile_id = sample["task_profile_id"]
+        sample_hash = sample["sample_hash"]
+        score = sample["score"]
+        if not all(
+            isinstance(item, str) and item
+            for item in (endpoint_id, task_profile_id, sample_hash)
+        ):
+            raise CalibrationError("sample identifiers must be non-empty strings")
+        if len(sample_hash) != 64 or any(
+            character not in "0123456789abcdef" for character in sample_hash
+        ):
+            raise CalibrationError("sample_hash must be a lowercase SHA-256 digest")
+        if (
+            not isinstance(score, (int, float))
+            or isinstance(score, bool)
+            or not 0 <= score <= 1
+        ):
+            raise CalibrationError("sample score must be between 0 and 1")
+        grouped[(endpoint_id, task_profile_id)].append((sample_hash, float(score)))
+
+    records: list[CalibrationRecord] = []
+    for (endpoint_id, task_profile_id), values in sorted(grouped.items()):
+        if endpoint_id not in endpoint_hashes:
+            raise CalibrationError(f"unknown endpoint_id: {endpoint_id}")
+        hashes = tuple(sorted(item[0] for item in values))
+        if len(set(hashes)) != len(hashes):
+            raise CalibrationError(
+                f"duplicate sample_hash for {endpoint_id}/{task_profile_id}"
+            )
+        scores = [item[1] for item in values]
+        mean = fmean(scores)
+        variance = pvariance(scores)
+        conservative = max(0.0, mean - sqrt(variance / len(scores)))
+        record = CalibrationRecord(
+            benchmark_id=benchmark_id,
+            benchmark_version=benchmark_version,
+            endpoint_id=endpoint_id,
+            endpoint_profile_hash=endpoint_hashes[endpoint_id],
+            task_profile_id=task_profile_id,
+            score=mean,
+            conservative_score=conservative,
+            sample_count=len(scores),
+            sample_hashes=hashes,
+            scorer_id=scorer_id,
+            scorer_version=scorer_version,
+            measured_at=measured_at,
+            expires_at=expires_at,
+            dispersion=variance,
+        )
+        record.validate()
+        records.append(record)
+    return tuple(records)

--- a/scripts/conductor/calibration_cli.py
+++ b/scripts/conductor/calibration_cli.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Offline CLI for planning and aggregating the MIR priority calibration pilot.
+
+No command in this module invokes a provider.  An operator or separate benchmark
+runner supplies blinded JSONL scores and exact host observations as artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from scripts.conductor.calibration import (  # noqa: E402
+    CalibrationError,
+    aggregate_blinded_samples,
+)
+from scripts.conductor.model_registry import (  # noqa: E402
+    ModelIntelligenceRegistry,
+    RegistryError,
+    load_registry,
+)
+
+
+def _json_text(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, indent=2, sort_keys=True) + "\n"
+
+
+def _load_pilot(root: Path, registry: ModelIntelligenceRegistry) -> dict[str, Any]:
+    path = root / "infra" / "conductor" / "priority_calibration_pilot.v1.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or set(raw) != {
+        "schema_version",
+        "benchmark_id",
+        "benchmark_version",
+        "roster",
+    }:
+        raise CalibrationError("priority pilot has an unexpected top-level shape")
+    if raw["schema_version"] != "priority-calibration-pilot.v1":
+        raise CalibrationError("priority pilot schema_version is unsupported")
+    if not all(
+        isinstance(raw.get(field), str) and raw[field]
+        for field in ("benchmark_id", "benchmark_version")
+    ):
+        raise CalibrationError("priority pilot benchmark identity is incomplete")
+    roster = raw["roster"]
+    if not isinstance(roster, list) or not roster:
+        raise CalibrationError("priority pilot roster must be a non-empty array")
+    seen: set[str] = set()
+    for item in roster:
+        if not isinstance(item, dict) or set(item) != {
+            "endpoint_id",
+            "task_profile_ids",
+        }:
+            raise CalibrationError("priority pilot roster item shape is invalid")
+        endpoint_id = item["endpoint_id"]
+        task_profile_ids = item["task_profile_ids"]
+        if endpoint_id in seen:
+            raise CalibrationError(f"duplicate priority endpoint: {endpoint_id}")
+        seen.add(endpoint_id)
+        if endpoint_id not in registry.endpoint_profiles:
+            raise CalibrationError(f"unknown priority endpoint: {endpoint_id}")
+        if (
+            not isinstance(task_profile_ids, list)
+            or not task_profile_ids
+            or len(task_profile_ids) != len(set(task_profile_ids))
+        ):
+            raise CalibrationError(
+                f"priority endpoint {endpoint_id} needs unique task profiles"
+            )
+        for profile_id in task_profile_ids:
+            profile = registry.profile(profile_id)
+            if (
+                profile.benchmark_id != raw["benchmark_id"]
+                or profile.benchmark_version != raw["benchmark_version"]
+            ):
+                raise CalibrationError(
+                    f"priority profile {profile_id} does not bind the pilot benchmark"
+                )
+    return raw
+
+
+def _plan(root: Path) -> dict[str, Any]:
+    registry = load_registry(root)
+    pilot = _load_pilot(root, registry)
+    entries: list[dict[str, Any]] = []
+    for item in sorted(pilot["roster"], key=lambda value: value["endpoint_id"]):
+        endpoint_id = item["endpoint_id"]
+        candidate = registry.endpoint(endpoint_id)
+        for profile_id in sorted(item["task_profile_ids"]):
+            profile = registry.profile(profile_id)
+            entries.append(
+                {
+                    "endpoint_id": endpoint_id,
+                    "endpoint_profile_hash": candidate.endpoint_profile_hash,
+                    "task_profile_id": profile_id,
+                    "minimum_task_score": profile.minimum_task_score,
+                    "minimum_sample_count": profile.minimum_sample_count,
+                    "maximum_dispersion": profile.maximum_dispersion,
+                    "minimum_context_tokens": profile.minimum_context_tokens,
+                    "minimum_output_tokens": profile.minimum_output_tokens,
+                    "source_routing_status": registry.endpoint_profiles[endpoint_id][
+                        "routing"
+                    ]["status"],
+                    "auth_surface": candidate.auth_surface.value,
+                }
+            )
+    return {
+        "schema_version": "priority-calibration-plan.v1",
+        "benchmark_id": pilot["benchmark_id"],
+        "benchmark_version": pilot["benchmark_version"],
+        "execution": "not_implemented_no_provider_calls",
+        "entries": entries,
+    }
+
+
+def _read_samples(path: Path) -> tuple[Mapping[str, Any], ...]:
+    samples: list[Mapping[str, Any]] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise CalibrationError(
+                f"invalid sample JSON on line {line_number}: {error.msg}"
+            ) from error
+        if not isinstance(value, dict):
+            raise CalibrationError(f"sample line {line_number} must be an object")
+        samples.append(value)
+    if not samples:
+        raise CalibrationError("sample file is empty")
+    return tuple(samples)
+
+
+def _aggregate(args: argparse.Namespace) -> dict[str, Any]:
+    root = args.root.resolve()
+    registry = load_registry(root)
+    records = aggregate_blinded_samples(
+        _read_samples(args.samples),
+        endpoint_hashes={
+            endpoint_id: registry.endpoint(endpoint_id).endpoint_profile_hash
+            for endpoint_id in registry.endpoint_profiles
+        },
+        benchmark_id=args.benchmark_id,
+        benchmark_version=args.benchmark_version,
+        scorer_id=args.scorer_id,
+        scorer_version=args.scorer_version,
+        measured_at=args.measured_at,
+        expires_at=args.expires_at,
+    )
+    return {
+        "schema_version": "calibration-overlay.v1",
+        "generated_at": args.measured_at,
+        "records": [record.as_mapping() for record in records],
+    }
+
+
+def _validate(args: argparse.Namespace) -> dict[str, Any]:
+    registry = load_registry(
+        args.root,
+        as_of=args.as_of,
+        calibration_path=args.calibration,
+        host_observation_paths=tuple(args.observations),
+    )
+    return {
+        "schema_version": "calibration-validation.v1",
+        "as_of": args.as_of,
+        "operational": registry.operational,
+        "eligible_endpoint_ids": [
+            candidate.endpoint_id for candidate in registry.endpoints()
+        ],
+        "diagnostics": list(registry.overlay_diagnostics),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan = subparsers.add_parser("plan", help="render the offline priority roster")
+    plan.add_argument("--root", type=Path, default=ROOT)
+
+    aggregate = subparsers.add_parser(
+        "aggregate", help="aggregate blinded JSONL samples into an overlay"
+    )
+    aggregate.add_argument("--root", type=Path, default=ROOT)
+    aggregate.add_argument("--samples", type=Path, required=True)
+    aggregate.add_argument("--output", type=Path, required=True)
+    aggregate.add_argument("--benchmark-id", required=True)
+    aggregate.add_argument("--benchmark-version", required=True)
+    aggregate.add_argument("--scorer-id", required=True)
+    aggregate.add_argument("--scorer-version", required=True)
+    aggregate.add_argument("--measured-at", required=True)
+    aggregate.add_argument("--expires-at", required=True)
+
+    validate = subparsers.add_parser(
+        "validate", help="validate overlay joins without invoking endpoints"
+    )
+    validate.add_argument("--root", type=Path, default=ROOT)
+    validate.add_argument("--as-of", required=True)
+    validate.add_argument("--calibration", type=Path, required=True)
+    validate.add_argument("--observations", type=Path, action="append", required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "plan":
+            output = _plan(args.root.resolve())
+            sys.stdout.write(_json_text(output))
+            return 0
+        if args.command == "aggregate":
+            output = _aggregate(args)
+            args.output.write_text(_json_text(output), encoding="utf-8")
+            return 0
+        if args.command == "validate":
+            sys.stdout.write(_json_text(_validate(args)))
+            return 0
+    except (CalibrationError, RegistryError, OSError) as error:
+        sys.stderr.write(f"calibration error: {error}\n")
+        return 2
+    parser.error("unsupported command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/conductor/contracts.py
+++ b/scripts/conductor/contracts.py
@@ -1,0 +1,274 @@
+"""Typed, immutable contracts for deterministic Conductor routing.
+
+The module is deliberately standard-library only so hooks and tests can import it
+without the backend virtual environment.  It is a session-local decision library:
+it never performs I/O, probes an endpoint, or launches a worker.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal, Mapping
+
+
+class Role(StrEnum):
+    """A role in a session-local control-plane plan."""
+
+    CONDUCTOR = "conductor"
+    ARCHITECT = "architect"
+    BUILDER = "builder"
+    GRADER = "grader"
+
+
+class TaskClass(StrEnum):
+    """The deterministic task classes defined by the conductor design."""
+
+    READ_ONLY = "read_only"
+    MECHANICAL = "mechanical"
+    STANDARD_BUILD = "standard_build"
+    HARD_BUILD = "hard_build"
+    ARCHITECTURE = "architecture"
+    REVIEW = "review"
+    PII_LOCAL = "pii_local"
+
+
+class Decision(StrEnum):
+    """An outcome of pure planning, including a visible abstention."""
+
+    ALLOW = "allow"
+    DELEGATE_REQUIRED = "delegate_required"
+    BLOCK = "block"
+    DEGRADED = "degraded"
+    ABSTAIN = "abstain"
+
+
+class EvidenceKind(StrEnum):
+    """Provenance of a capability or score; unknown data is never positive proof."""
+
+    DECLARED = "declared"
+    PROBED = "probed"
+    BENCHMARKED = "benchmarked"
+    PRODUCTION = "production"
+    UNMEASURED = "unmeasured"
+
+
+class AuthSurface(StrEnum):
+    """Concrete authentication/billing surface asserted by an EndpointProfile.
+
+    ``UNKNOWN`` is intentionally a real registry value rather than an omitted
+    field: callers can see that authority was not established, and the router
+    must reject it rather than inferring safety from a provider or harness name.
+    """
+
+    UNKNOWN = "unknown"
+    LOCAL_RUNTIME = "local_runtime"
+    ANTHROPIC_OAUTH_SUBSCRIPTION = "anthropic_oauth_subscription"
+    ANTHROPIC_PAID_API = "anthropic_paid_api"
+    OPENAI_CHATGPT_SUBSCRIPTION = "openai_chatgpt_subscription"
+    GOOGLE_OAUTH_SUBSCRIPTION = "google_oauth_subscription"
+    MANUAL_GUI = "manual_gui"
+    OTHER_PROVIDER_API = "other_provider_api"
+
+
+@dataclass(frozen=True)
+class SessionIdentity:
+    """Origin of an interactive session; the starter remains its conductor."""
+
+    session_id: str
+    root_session_id: str
+    parent_session_id: str | None
+    role: Role
+    engine: Literal["claude", "codex", "agy", "kimi", "unknown"] | str
+    model: str
+    family: str
+    host: str
+    repo_root: Path
+    repo_head: str
+    started_at: str
+
+
+@dataclass(frozen=True)
+class TaskIntent:
+    """A typed task request supplied by the conductor or deterministic classifier."""
+
+    task_id: str
+    task_class: TaskClass
+    gear: Literal[1, 2, 3]
+    mutation: bool
+    files: tuple[str, ...]
+    requires: frozenset[str]
+    task_profile_id: str
+    estimated_context_tokens: int | None
+    required_modalities: frozenset[str]
+    required_tools: frozenset[str]
+    contains_pii: bool
+
+
+# TaskRequest is the public, plain-language name used by callers.  TaskIntent is kept
+# as the canonical name from the approved control-plane contract.
+TaskRequest = TaskIntent
+
+
+@dataclass(frozen=True)
+class CapabilityEvidence:
+    """A single capability assertion with its evidence class and freshness metadata."""
+
+    capability: str
+    value: bool | int | float | str | None
+    kind: EvidenceKind
+    evidence_ref: str
+    observed_at: str
+    expires_at: str | None
+    confidence: float
+
+
+@dataclass(frozen=True)
+class TaskScore:
+    """A task-profile-specific score; only a benchmarked score opens a load-bearing lane."""
+
+    task_profile_id: str
+    score: float | None
+    benchmark_id: str | None
+    benchmark_version: str | None
+    sample_count: int
+    observed_at: str | None
+    evidence_kind: EvidenceKind = EvidenceKind.UNMEASURED
+    conservative_score: float | None = None
+    sample_hashes: tuple[str, ...] = ()
+    scorer_id: str | None = None
+    scorer_version: str | None = None
+    expires_at: str | None = None
+    dispersion: float | None = None
+
+
+@dataclass(frozen=True)
+class EndpointCandidate:
+    """A concrete invocation surface assembled from a model card and endpoint profile."""
+
+    endpoint_id: str
+    engine: str
+    model_card_id: str
+    model: str
+    family: str
+    role: Role
+    features: tuple[CapabilityEvidence, ...]
+    task_scores: tuple[TaskScore, ...]
+    healthy: bool
+    health_observed_at: str
+    machine_allowlist: tuple[str, ...]
+    cost_rank: int
+    latency_rank: int
+    quota_pressure_rank: int
+    quality_tier: int
+    enforcement_mode: Literal[
+        "enforced", "shadow", "advisory", "advisory_only", "manual_only", "unmeasured"
+    ]
+    identity_confidence: float
+    model_card_hash: str
+    endpoint_profile_hash: str
+    capability_snapshot_hash: str
+    automated_routing: bool = True
+    routing_status: str = "eligible"
+    uses_paid_anthropic_api: bool = False
+    auth_surface: AuthSurface = AuthSurface.UNKNOWN
+
+
+@dataclass(frozen=True)
+class TaskProfile:
+    """The task-shape floor loaded from MIR task profiles plus reviewed calibration."""
+
+    id: str
+    mutation: bool
+    minimum_quality_tier: int
+    minimum_task_score: float | None
+    required_capabilities: frozenset[str]
+    allowed_modalities: frozenset[str]
+    pii_policy: Literal["context_dependent", "forbidden_cloud", "local_only"] | str
+    benchmark_id: str | None = None
+    benchmark_version: str | None = None
+    minimum_sample_count: int = 1
+    maximum_dispersion: float | None = None
+    minimum_context_tokens: int | None = None
+    minimum_output_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class HostObservation:
+    """A caller-provided, timestamped availability observation for one fleet host.
+
+    The router consumes this as evidence only; it never attempts a host probe or
+    assumes that the conductor's local host is available for a selected endpoint.
+    """
+
+    host: str
+    available: bool
+    observed_at: str
+
+
+@dataclass(frozen=True)
+class RoutingPolicy:
+    """All policy inputs needed by the pure router, including its explicit clock."""
+
+    policy_hash: str
+    task_profile_hashes: Mapping[str, str]
+    capability_index_hash: str
+    task_profiles: tuple[TaskProfile, ...]
+    as_of: str
+    max_health_age_days: int
+    host_observations: tuple[HostObservation, ...] = ()
+    require_enforced_mutation: bool = True
+    minimum_identity_confidence: float = 1.0
+    forbid_paid_anthropic_api: bool = True
+
+
+@dataclass(frozen=True)
+class RoleAssignment:
+    """A selected concrete endpoint for a role; never an abstract model card."""
+
+    role: Role
+    engine: str
+    endpoint_id: str
+    model: str
+    family: str
+    machine: str
+    reason_code: str
+    model_card_hash: str
+    endpoint_profile_hash: str
+    capability_snapshot_hash: str
+    benchmark_version: str | None
+    auth_surface: AuthSurface = AuthSurface.UNKNOWN
+
+
+@dataclass(frozen=True)
+class CandidateRejection:
+    """Why one endpoint could not be selected, in stable endpoint order."""
+
+    endpoint_id: str
+    reason_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    """A pure, explainable selection plan with a primary endpoint and fallbacks."""
+
+    decision: Decision
+    conductor: SessionIdentity
+    task: TaskIntent
+    assignments: tuple[RoleAssignment, ...]
+    primary: RoleAssignment | None
+    fallbacks: tuple[RoleAssignment, ...]
+    policy_hash: str
+    task_profile_hash: str
+    capability_index_hash: str
+    selection_reason_codes: tuple[str, ...]
+    rejections: tuple[CandidateRejection, ...]
+    degraded_reasons: tuple[str, ...]
+    abstention_reason: str | None
+    separate_builder_session_required: bool
+
+
+# SelectionPlan is a clearer public synonym for integrations that do not need the
+# broader dispatch lifecycle yet.
+SelectionPlan = DispatchPlan

--- a/scripts/conductor/model_registry.py
+++ b/scripts/conductor/model_registry.py
@@ -1,0 +1,1518 @@
+"""Validated, read-only loader for the Model Intelligence Registry (MIR).
+
+The registry deliberately separates abstract ModelCards from concrete endpoint profiles.
+Only the latter can become an ``EndpointCandidate``.  Loading a card never grants an
+invocation path, and static registry evidence is never upgraded into live health or a
+benchmarked task score.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from hashlib import sha256
+import json
+import logging
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+from scripts.conductor.contracts import (
+    AuthSurface,
+    CapabilityEvidence,
+    EndpointCandidate,
+    EvidenceKind,
+    HostObservation,
+    Role,
+    TaskProfile,
+    TaskScore,
+)
+from scripts.conductor.calibration import (
+    CalibrationError,
+    CalibrationRecord,
+    EndpointHostObservation,
+    parse_timestamp,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+_SUPPORTED_SCHEMA_KEYS = frozenset(
+    {
+        "$schema",
+        "$id",
+        "$defs",
+        "$ref",
+        "title",
+        "type",
+        "additionalProperties",
+        "required",
+        "properties",
+        "const",
+        "enum",
+        "pattern",
+        "minLength",
+        "minimum",
+        "maximum",
+        "minItems",
+        "items",
+    }
+)
+
+_CANONICAL_EVIDENCE_LEVELS = frozenset(kind.value for kind in EvidenceKind)
+_CANONICAL_ROUTING_STATUSES = frozenset(
+    {
+        "eligible",
+        "manual_only",
+        "probation",
+        "phantom",
+        "denied",
+        "investigation_required",
+        "listed_unexploited",
+        "deprecated",
+        "known_unmeasured",
+    }
+)
+_LOCAL_PII_CAPABILITIES = frozenset({"local_only", "pii_safe_local"})
+
+
+class RegistryError(ValueError):
+    """Base error for invalid or unavailable MIR data."""
+
+
+class RegistryValidationError(RegistryError):
+    """Raised when a checked-in MIR projection cannot be safely joined."""
+
+
+class UnknownEndpointError(RegistryError):
+    """Raised when an endpoint ID is not a known concrete endpoint."""
+
+
+class AbstractModelCardError(RegistryError):
+    """Raised when code attempts to invoke a model card instead of an endpoint."""
+
+
+@dataclass(frozen=True)
+class ModelIntelligenceRegistry:
+    """Validated MIR records and safe concrete endpoint accessors."""
+
+    root: Path
+    model_cards: Mapping[str, Mapping[str, Any]]
+    endpoint_profiles: Mapping[str, Mapping[str, Any]]
+    task_profiles: Mapping[str, TaskProfile]
+    capability_ids: frozenset[str]
+    capability_index_hash: str
+    calibrations: Mapping[str, tuple[CalibrationRecord, ...]]
+    host_endpoint_observations: Mapping[str, tuple[EndpointHostObservation, ...]]
+    overlay_diagnostics: tuple[str, ...]
+    as_of: str | None
+
+    def endpoint(self, endpoint_id: str) -> EndpointCandidate:
+        """Return one concrete endpoint or reject direct ModelCard invocation."""
+        if endpoint_id in self.model_cards:
+            raise AbstractModelCardError(
+                f"{endpoint_id!r} is an abstract ModelCard and cannot be invoked; select an EndpointProfile"
+            )
+        try:
+            endpoint = self.endpoint_profiles[endpoint_id]
+        except KeyError as error:
+            raise UnknownEndpointError(
+                f"unknown endpoint profile: {endpoint_id}"
+            ) from error
+        return _candidate_from_records(
+            endpoint,
+            self.model_cards[endpoint["model_card_id"]],
+            self.calibrations.get(endpoint_id, ()),
+            self.host_endpoint_observations.get(endpoint_id, ()),
+            self.task_profiles,
+        )
+
+    def endpoints(
+        self, *, automated_only: bool = True
+    ) -> tuple[EndpointCandidate, ...]:
+        """Return concrete endpoint candidates in stable endpoint-ID order.
+
+        ``automated_only`` is true by default because manual, probation, and abstract
+        records are inventory data rather than router inputs.  Runtime health remains a
+        separate injected fact, so static records load as unhealthy by default.
+        """
+        candidates: list[EndpointCandidate] = []
+        for endpoint_id in sorted(self.endpoint_profiles):
+            candidate = self.endpoint(endpoint_id)
+            if automated_only and not (
+                candidate.automated_routing and candidate.routing_status == "eligible"
+            ):
+                continue
+            candidates.append(candidate)
+        return tuple(candidates)
+
+    @property
+    def operational(self) -> bool:
+        """Whether any measured, healthy concrete endpoint is currently eligible."""
+        return bool(self.endpoints())
+
+    def host_availability_observations(self) -> tuple[HostObservation, ...]:
+        """Project exact endpoint observations into the router's host placement view."""
+        by_host: dict[str, list[EndpointHostObservation]] = {}
+        for observations in self.host_endpoint_observations.values():
+            for observation in observations:
+                by_host.setdefault(observation.host, []).append(observation)
+        projected: list[HostObservation] = []
+        for host in sorted(by_host):
+            observations = by_host[host]
+            projected.append(
+                HostObservation(
+                    host=host,
+                    available=any(
+                        item.available and item.healthy for item in observations
+                    ),
+                    observed_at=min(item.observed_at for item in observations),
+                )
+            )
+        return tuple(projected)
+
+    def profile(self, profile_id: str) -> TaskProfile:
+        """Return a validated task profile by canonical identifier."""
+        try:
+            return self.task_profiles[profile_id]
+        except KeyError as error:
+            raise RegistryValidationError(
+                f"unknown task profile: {profile_id}"
+            ) from error
+
+
+def load_registry(
+    root: Path,
+    *,
+    as_of: str | None = None,
+    calibration_path: Path | None = None,
+    host_observation_paths: tuple[Path, ...] | None = None,
+) -> ModelIntelligenceRegistry:
+    """Load, validate, and join MIR files rooted at a repository directory.
+
+    This function performs filesystem reads only.  It does not run a capability probe,
+    execute a CLI, inspect credentials, or perform an LLM/API call.
+    """
+    repository_root = root.resolve()
+    mir = repository_root / "infra" / "conductor"
+    if not mir.is_dir():
+        raise RegistryValidationError(f"MIR directory does not exist: {mir}")
+
+    cards = _load_record_directory(mir / "model_cards", "ModelCard")
+    endpoints = _load_record_directory(mir / "endpoint_profiles", "EndpointProfile")
+    model_card_schema = _load_json(mir / "model_card.schema.json")
+    endpoint_profile_schema = _load_json(mir / "endpoint_profile.schema.json")
+    ontology = _load_json(mir / "capability_ontology.v1.json")
+    profiles_document = _load_json(mir / "task_profiles.v1.json")
+    index = _load_json(mir / "model_capability_index.v1.json")
+    task_profile_schema = _load_json(mir / "task_profile.schema.json")
+    calibration_schema = _load_json(mir / "calibration_overlay.schema.json")
+    host_observation_schema = _load_json(mir / "host_observation_overlay.schema.json")
+    calibration_document = _load_json(calibration_path or mir / "calibrations.v1.json")
+    observation_paths = host_observation_paths or (mir / "host_observations.v1.json",)
+    observation_documents = tuple(_load_json(path) for path in observation_paths)
+
+    capability_ids = _validate_ontology(ontology)
+    _validate_document_against_schema(
+        profiles_document, task_profile_schema, "task profiles"
+    )
+    profiles = _validate_task_profiles(profiles_document, capability_ids)
+    _validate_records_against_schema(cards, model_card_schema, "ModelCard")
+    _validate_records_against_schema(
+        endpoints, endpoint_profile_schema, "EndpointProfile"
+    )
+    _validate_cards(cards, capability_ids, set(profiles))
+    _validate_endpoints(endpoints, cards, capability_ids)
+    _validate_index(index, cards, endpoints)
+    _validate_document_against_schema(
+        calibration_document, calibration_schema, "calibration overlay"
+    )
+    for index_number, observation_document in enumerate(observation_documents):
+        _validate_document_against_schema(
+            observation_document,
+            host_observation_schema,
+            f"host observation overlay {index_number}",
+        )
+    calibrations, observations, diagnostics = _validated_overlays(
+        calibration_document=calibration_document,
+        observation_documents=observation_documents,
+        endpoints=endpoints,
+        profiles=profiles,
+        as_of=as_of,
+    )
+
+    index_hash = _content_hash(index)
+    logger.debug(
+        "loaded validated MIR: cards=%d endpoints=%d", len(cards), len(endpoints)
+    )
+    return ModelIntelligenceRegistry(
+        root=repository_root,
+        model_cards=cards,
+        endpoint_profiles=endpoints,
+        task_profiles=profiles,
+        capability_ids=frozenset(capability_ids),
+        capability_index_hash=index_hash,
+        calibrations=calibrations,
+        host_endpoint_observations=observations,
+        overlay_diagnostics=diagnostics,
+        as_of=as_of,
+    )
+
+
+def _load_record_directory(
+    directory: Path, record_name: str
+) -> dict[str, Mapping[str, Any]]:
+    if not directory.is_dir():
+        raise RegistryValidationError(
+            f"{record_name} directory does not exist: {directory}"
+        )
+    records: dict[str, Mapping[str, Any]] = {}
+    paths = sorted(directory.glob("*.json"))
+    if not paths:
+        raise RegistryValidationError(f"{record_name} directory is empty: {directory}")
+    for path in paths:
+        record = _load_json(path)
+        identifier = record.get("id")
+        if not isinstance(identifier, str) or not identifier:
+            raise RegistryValidationError(
+                f"{path}: record id must be a non-empty string"
+            )
+        if identifier in records:
+            raise RegistryValidationError(f"duplicate {record_name} id: {identifier}")
+        records[identifier] = record
+    return records
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise RegistryValidationError(f"cannot read {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise RegistryValidationError(f"invalid JSON in {path}: {error.msg}") from error
+    if not isinstance(value, dict):
+        raise RegistryValidationError(f"{path}: top-level JSON must be an object")
+    return value
+
+
+def _validate_records_against_schema(
+    records: Mapping[str, Mapping[str, Any]],
+    schema: Mapping[str, Any],
+    record_type: str,
+) -> None:
+    """Validate every MIR record against its checked-in JSON Schema subset.
+
+    The registry has a deliberately small fixed schema vocabulary, so a
+    standard-library validator keeps bootstrap/CI dependency-free.  Unsupported
+    schema constructs are errors rather than silently weakening validation.
+    """
+    _validate_schema_contract(schema, f"{record_type} schema")
+    for identifier, record in records.items():
+        _validate_schema_value(record, schema, schema, f"{record_type} {identifier}")
+
+
+def _validate_document_against_schema(
+    document: Mapping[str, Any], schema: Mapping[str, Any], document_type: str
+) -> None:
+    """Validate one strict top-level MIR document with the local schema subset."""
+    _validate_schema_contract(schema, f"{document_type} schema")
+    _validate_schema_value(document, schema, schema, document_type)
+
+
+def _validate_schema_contract(schema: Mapping[str, Any], location: str) -> None:
+    """Reject malformed or unsupported local schema vocabulary before record checks."""
+    if not isinstance(schema, Mapping):
+        raise RegistryValidationError(f"{location}: schema node must be an object")
+    unexpected = sorted(set(schema) - _SUPPORTED_SCHEMA_KEYS)
+    if unexpected:
+        raise RegistryValidationError(
+            f"{location}: unsupported JSON Schema keyword {unexpected[0]}"
+        )
+    for label in ("$schema", "$id", "title"):
+        if label in schema and not isinstance(schema[label], str):
+            raise RegistryValidationError(
+                f"{location}: schema {label} must be a string"
+            )
+    if "$ref" in schema:
+        reference = schema["$ref"]
+        if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
+            raise RegistryValidationError(f"{location}: unsupported schema reference")
+    if "type" in schema:
+        raw_types = schema["type"]
+        types = (
+            (raw_types,)
+            if isinstance(raw_types, str)
+            else tuple(raw_types)
+            if isinstance(raw_types, list)
+            else ()
+        )
+        if not types or not all(isinstance(item, str) for item in types):
+            raise RegistryValidationError(
+                f"{location}: schema type must be a string or string array"
+            )
+        for expected_type in types:
+            _json_type_matches(None, expected_type)
+    if "additionalProperties" in schema and schema["additionalProperties"] is not False:
+        raise RegistryValidationError(
+            f"{location}: MIR schemas must forbid additional properties"
+        )
+    if "required" in schema and (
+        not isinstance(schema["required"], list)
+        or not all(isinstance(item, str) for item in schema["required"])
+    ):
+        raise RegistryValidationError(
+            f"{location}: schema required must be a string array"
+        )
+    if "properties" in schema:
+        properties = schema["properties"]
+        if not isinstance(properties, Mapping) or not all(
+            isinstance(key, str) and isinstance(value, Mapping)
+            for key, value in properties.items()
+        ):
+            raise RegistryValidationError(
+                f"{location}: schema properties must map strings to objects"
+            )
+        for key, child in properties.items():
+            _validate_schema_contract(child, f"{location}.properties.{key}")
+    if "items" in schema:
+        items = schema["items"]
+        if not isinstance(items, Mapping):
+            raise RegistryValidationError(f"{location}: schema items must be an object")
+        _validate_schema_contract(items, f"{location}.items")
+    if "$defs" in schema:
+        definitions = schema["$defs"]
+        if not isinstance(definitions, Mapping) or not all(
+            isinstance(key, str) and isinstance(value, Mapping)
+            for key, value in definitions.items()
+        ):
+            raise RegistryValidationError(
+                f"{location}: schema definitions must map strings to objects"
+            )
+        for key, child in definitions.items():
+            _validate_schema_contract(child, f"{location}.$defs.{key}")
+    if "enum" in schema and not isinstance(schema["enum"], list):
+        raise RegistryValidationError(f"{location}: schema enum must be an array")
+    for key in ("minLength", "minItems"):
+        if key in schema and (
+            not isinstance(schema[key], int)
+            or isinstance(schema[key], bool)
+            or schema[key] < 0
+        ):
+            raise RegistryValidationError(
+                f"{location}: schema {key} must be a non-negative integer"
+            )
+    if "minimum" in schema and (
+        not isinstance(schema["minimum"], (int, float))
+        or isinstance(schema["minimum"], bool)
+    ):
+        raise RegistryValidationError(f"{location}: schema minimum must be a number")
+    if "maximum" in schema and (
+        not isinstance(schema["maximum"], (int, float))
+        or isinstance(schema["maximum"], bool)
+    ):
+        raise RegistryValidationError(f"{location}: schema maximum must be a number")
+    if "pattern" in schema:
+        if not isinstance(schema["pattern"], str):
+            raise RegistryValidationError(
+                f"{location}: schema pattern must be a string"
+            )
+        try:
+            re.compile(schema["pattern"])
+        except re.error as error:
+            raise RegistryValidationError(
+                f"{location}: invalid schema pattern"
+            ) from error
+
+
+def _validate_schema_value(
+    value: Any, schema: Mapping[str, Any], root_schema: Mapping[str, Any], location: str
+) -> None:
+    if not isinstance(schema, Mapping):
+        raise RegistryValidationError(f"{location}: schema node must be an object")
+    reference = schema.get("$ref")
+    if reference is not None:
+        if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
+            raise RegistryValidationError(f"{location}: unsupported schema reference")
+        definitions = root_schema.get("$defs")
+        key = reference.removeprefix("#/$defs/")
+        if not isinstance(definitions, Mapping) or not isinstance(
+            definitions.get(key), Mapping
+        ):
+            raise RegistryValidationError(
+                f"{location}: unresolved schema reference {reference}"
+            )
+        _validate_schema_value(value, definitions[key], root_schema, location)
+        return
+
+    raw_types = schema.get("type")
+    if raw_types is not None:
+        expected_types = (
+            (raw_types,)
+            if isinstance(raw_types, str)
+            else tuple(raw_types)
+            if isinstance(raw_types, list)
+            else ()
+        )
+        if not expected_types or not all(
+            isinstance(item, str) for item in expected_types
+        ):
+            raise RegistryValidationError(
+                f"{location}: schema type must be a string or string array"
+            )
+        if not any(_json_type_matches(value, item) for item in expected_types):
+            raise RegistryValidationError(
+                f"{location}: expected JSON type {list(expected_types)}"
+            )
+
+    if "const" in schema and value != schema["const"]:
+        raise RegistryValidationError(f"{location}: value must equal schema const")
+    if "enum" in schema:
+        allowed = schema["enum"]
+        if not isinstance(allowed, list) or not any(
+            value == option for option in allowed
+        ):
+            raise RegistryValidationError(
+                f"{location}: value is not permitted by schema enum"
+            )
+    if "pattern" in schema:
+        pattern = schema["pattern"]
+        if (
+            not isinstance(pattern, str)
+            or not isinstance(value, str)
+            or re.search(pattern, value) is None
+        ):
+            raise RegistryValidationError(
+                f"{location}: value does not match schema pattern"
+            )
+    if "minLength" in schema:
+        minimum_length = schema["minLength"]
+        if not isinstance(minimum_length, int) or isinstance(minimum_length, bool):
+            raise RegistryValidationError(
+                f"{location}: schema minimum string length must be an integer"
+            )
+        if isinstance(value, str) and len(value) < minimum_length:
+            raise RegistryValidationError(
+                f"{location}: string is shorter than schema minimum"
+            )
+    if "minimum" in schema:
+        minimum = schema["minimum"]
+        if not isinstance(minimum, (int, float)) or isinstance(minimum, bool):
+            raise RegistryValidationError(
+                f"{location}: schema numeric minimum must be a number"
+            )
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value < minimum
+        ):
+            raise RegistryValidationError(f"{location}: number is below schema minimum")
+    if "maximum" in schema:
+        maximum = schema["maximum"]
+        if not isinstance(maximum, (int, float)) or isinstance(maximum, bool):
+            raise RegistryValidationError(
+                f"{location}: schema numeric maximum must be a number"
+            )
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value > maximum
+        ):
+            raise RegistryValidationError(f"{location}: number is above schema maximum")
+
+    if isinstance(value, dict):
+        properties = schema.get("properties", {})
+        required = schema.get("required", [])
+        if (
+            not isinstance(properties, Mapping)
+            or not isinstance(required, list)
+            or not all(isinstance(item, str) for item in required)
+        ):
+            raise RegistryValidationError(f"{location}: malformed object schema")
+        for field in required:
+            if field not in value:
+                raise RegistryValidationError(
+                    f"{location}: missing required property {field}"
+                )
+        if schema.get("additionalProperties") is False:
+            unexpected = sorted(set(value) - set(properties))
+            if unexpected:
+                raise RegistryValidationError(
+                    f"{location}: unexpected property {unexpected[0]}"
+                )
+        for field, field_value in value.items():
+            field_schema = properties.get(field)
+            if field_schema is not None:
+                if not isinstance(field_schema, Mapping):
+                    raise RegistryValidationError(
+                        f"{location}.{field}: malformed property schema"
+                    )
+                _validate_schema_value(
+                    field_value, field_schema, root_schema, f"{location}.{field}"
+                )
+
+    if isinstance(value, list):
+        minimum_items = schema.get("minItems")
+        if minimum_items is not None:
+            if (
+                not isinstance(minimum_items, int)
+                or isinstance(minimum_items, bool)
+                or len(value) < minimum_items
+            ):
+                raise RegistryValidationError(
+                    f"{location}: array is shorter than schema minimum"
+                )
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            if not isinstance(item_schema, Mapping):
+                raise RegistryValidationError(f"{location}: malformed item schema")
+            for index, item in enumerate(value):
+                _validate_schema_value(
+                    item, item_schema, root_schema, f"{location}[{index}]"
+                )
+
+
+def _json_type_matches(value: Any, expected_type: str) -> bool:
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "null":
+        return value is None
+    raise RegistryValidationError(
+        f"unsupported JSON Schema type in MIR schema: {expected_type}"
+    )
+
+
+def _validate_cards(
+    cards: Mapping[str, Mapping[str, Any]],
+    capability_ids: set[str],
+    task_profile_ids: set[str],
+) -> None:
+    aliases: set[str] = set()
+    for identifier, card in cards.items():
+        _require_equal(
+            card, "schema_version", "model-card.v1", f"ModelCard {identifier}"
+        )
+        identity = _require_mapping(card, "identity", f"ModelCard {identifier}")
+        routing = _require_mapping(card, "routing", f"ModelCard {identifier}")
+        if routing.get("automated_routing") is not False:
+            raise RegistryValidationError(
+                f"ModelCard {identifier} must remain abstract and non-invocable"
+            )
+        for field in ("family", "kind"):
+            _require_string(identity, field, f"ModelCard {identifier}.identity")
+        for alias in _require_list(
+            identity, "aliases", f"ModelCard {identifier}.identity"
+        ):
+            if not isinstance(alias, str) or not alias:
+                raise RegistryValidationError(
+                    f"ModelCard {identifier}: alias must be a non-empty string"
+                )
+            if alias in aliases:
+                raise RegistryValidationError(
+                    f"model alias belongs to more than one ModelCard: {alias}"
+                )
+            aliases.add(alias)
+        _validate_capability_records(
+            card,
+            "modalities",
+            capability_ids,
+            f"ModelCard {identifier}",
+        )
+        _validate_task_scores(card, identifier, task_profile_ids)
+
+
+def _validate_capability_records(
+    record: Mapping[str, Any],
+    key: str,
+    capability_ids: set[str],
+    location: str,
+) -> dict[str, bool | None]:
+    """Validate capability IDs and return their asserted values by identifier."""
+    asserted: dict[str, bool | None] = {}
+    for capability in _require_list(record, key, location):
+        if not isinstance(capability, dict):
+            raise RegistryValidationError(f"{location}: capability must be an object")
+        capability_id = capability.get("id")
+        if capability_id not in capability_ids:
+            raise RegistryValidationError(
+                f"{location}: capability not declared by ontology: {capability_id}"
+            )
+        if capability_id in asserted:
+            raise RegistryValidationError(
+                f"{location}: capability is declared more than once: {capability_id}"
+            )
+        value = capability.get("value")
+        if value not in {True, False, None}:
+            raise RegistryValidationError(
+                f"{location}: capability value must be true, false, or null"
+            )
+        asserted[capability_id] = value
+    return asserted
+
+
+def _validate_task_scores(
+    card: Mapping[str, Any], card_id: str, task_profile_ids: set[str]
+) -> None:
+    """Reject unjoinable or sampleless static scores before routing can read them."""
+    for score in _require_list(card, "task_scores", f"ModelCard {card_id}"):
+        if not isinstance(score, dict):
+            raise RegistryValidationError(
+                f"ModelCard {card_id}: task score must be an object"
+            )
+        profile_id = score.get("task_profile_id")
+        if profile_id not in task_profile_ids:
+            raise RegistryValidationError(
+                f"ModelCard {card_id}: task score references unknown task profile: {profile_id}"
+            )
+        sample_count = score.get("sample_count")
+        if (
+            not isinstance(sample_count, int)
+            or isinstance(sample_count, bool)
+            or sample_count < 0
+        ):
+            raise RegistryValidationError(
+                f"ModelCard {card_id}: task score sample_count must be a non-negative integer"
+            )
+        numeric_score = score.get("score")
+        if sample_count == 0:
+            if numeric_score is not None:
+                raise RegistryValidationError(
+                    f"ModelCard {card_id}: task score with zero samples must be unavailable"
+                )
+            if (
+                score.get("benchmark_id") is not None
+                or score.get("benchmark_version") is not None
+            ):
+                raise RegistryValidationError(
+                    f"ModelCard {card_id}: unavailable task score cannot declare a benchmark"
+                )
+            continue
+        if (
+            not isinstance(numeric_score, (int, float))
+            or isinstance(numeric_score, bool)
+            or not 0 <= numeric_score <= 1
+        ):
+            raise RegistryValidationError(
+                f"ModelCard {card_id}: sampled task score must be between 0 and 1"
+            )
+        benchmark_id = score.get("benchmark_id")
+        benchmark_version = score.get("benchmark_version")
+        if not isinstance(benchmark_id, str) or not benchmark_id:
+            raise RegistryValidationError(
+                f"ModelCard {card_id}: sampled task score requires benchmark_id"
+            )
+        if not isinstance(benchmark_version, str) or not benchmark_version:
+            raise RegistryValidationError(
+                f"ModelCard {card_id}: sampled task score requires benchmark_version"
+            )
+
+
+def _validate_endpoints(
+    endpoints: Mapping[str, Mapping[str, Any]],
+    cards: Mapping[str, Mapping[str, Any]],
+    capability_ids: set[str],
+) -> None:
+    invocation_keys: set[tuple[str, str]] = set()
+    for identifier, endpoint in endpoints.items():
+        _require_equal(
+            endpoint,
+            "schema_version",
+            "endpoint-profile.v1",
+            f"EndpointProfile {identifier}",
+        )
+        card_id = endpoint.get("model_card_id")
+        if card_id not in cards:
+            raise RegistryValidationError(
+                f"EndpointProfile {identifier} references unknown ModelCard: {card_id}"
+            )
+        invocation = _require_mapping(
+            endpoint, "invocation", f"EndpointProfile {identifier}"
+        )
+        engine = _require_string(
+            invocation, "engine", f"EndpointProfile {identifier}.invocation"
+        )
+        model_identifier = _require_string(
+            invocation, "model_identifier", f"EndpointProfile {identifier}.invocation"
+        )
+        invocation_key = (engine, model_identifier)
+        if invocation_key in invocation_keys:
+            raise RegistryValidationError(
+                f"duplicate endpoint invocation: {engine}/{model_identifier}"
+            )
+        invocation_keys.add(invocation_key)
+        auth_surface = _require_auth_surface(endpoint, f"EndpointProfile {identifier}")
+
+        routing = _require_mapping(endpoint, "routing", f"EndpointProfile {identifier}")
+        automated = routing.get("automated_routing")
+        status = routing.get("status")
+        if not isinstance(automated, bool):
+            raise RegistryValidationError(
+                f"EndpointProfile {identifier}: automated_routing must be boolean"
+            )
+        if automated and status != "eligible":
+            raise RegistryValidationError(
+                f"EndpointProfile {identifier}: automated routing requires eligible status"
+            )
+        if auth_surface is AuthSurface.ANTHROPIC_PAID_API and (
+            status == "eligible" or automated
+        ):
+            raise RegistryValidationError(
+                f"EndpointProfile {identifier}: paid Anthropic API endpoints cannot be eligible or auto-routed"
+            )
+
+        machine_constraints = _require_mapping(
+            endpoint, "machine_constraints", f"EndpointProfile {identifier}"
+        )
+        allowlist = _require_list(
+            machine_constraints,
+            "allowlist",
+            f"EndpointProfile {identifier}.machine_constraints",
+        )
+        if not allowlist or not all(
+            isinstance(host, str) and host for host in allowlist
+        ):
+            raise RegistryValidationError(
+                f"EndpointProfile {identifier}: machine allowlist must be non-empty strings"
+            )
+
+        enforcement = _require_mapping(
+            endpoint, "enforcement", f"EndpointProfile {identifier}"
+        )
+        _require_string(
+            enforcement, "mode", f"EndpointProfile {identifier}.enforcement"
+        )
+        exposed_capabilities = _validate_capability_records(
+            endpoint,
+            "exposed_capabilities",
+            capability_ids,
+            f"EndpointProfile {identifier}",
+        )
+        claimed_local_pii_capabilities = {
+            capability_id
+            for capability_id, value in exposed_capabilities.items()
+            if capability_id in _LOCAL_PII_CAPABILITIES and value is True
+        }
+        if (
+            claimed_local_pii_capabilities
+            and auth_surface is not AuthSurface.LOCAL_RUNTIME
+        ):
+            raise RegistryValidationError(
+                f"EndpointProfile {identifier}: local PII capabilities require local_runtime auth_surface"
+            )
+
+
+def _validate_ontology(ontology: Mapping[str, Any]) -> set[str]:
+    _require_equal(
+        ontology, "schema_version", "capability-ontology.v1", "capability ontology"
+    )
+    capability_ids: set[str] = set()
+    for key in ("modalities", "techniques"):
+        for entry in _require_list(ontology, key, "capability ontology"):
+            if not isinstance(entry, dict):
+                raise RegistryValidationError(
+                    f"capability ontology {key}: entry must be an object"
+                )
+            identifier = entry.get("id")
+            if not isinstance(identifier, str) or not identifier:
+                raise RegistryValidationError(
+                    f"capability ontology {key}: id must be a non-empty string"
+                )
+            if identifier in capability_ids:
+                raise RegistryValidationError(
+                    f"duplicate capability ontology id: {identifier}"
+                )
+            capability_ids.add(identifier)
+    _require_exact_ontology_ids(
+        ontology,
+        "evidence_levels",
+        _CANONICAL_EVIDENCE_LEVELS,
+    )
+    _require_exact_ontology_ids(
+        ontology,
+        "routing_statuses",
+        _CANONICAL_ROUTING_STATUSES,
+    )
+    return capability_ids
+
+
+def _require_exact_ontology_ids(
+    ontology: Mapping[str, Any], key: str, expected_ids: frozenset[str]
+) -> None:
+    """Keep schema-visible vocabulary aligned with the typed routing contracts."""
+    identifiers: set[str] = set()
+    for entry in _require_list(ontology, key, "capability ontology"):
+        if not isinstance(entry, dict):
+            raise RegistryValidationError(
+                f"capability ontology {key}: entry must be an object"
+            )
+        identifier = entry.get("id")
+        if not isinstance(identifier, str) or not identifier:
+            raise RegistryValidationError(
+                f"capability ontology {key}: id must be a non-empty string"
+            )
+        if identifier in identifiers:
+            raise RegistryValidationError(
+                f"duplicate capability ontology {key} id: {identifier}"
+            )
+        identifiers.add(identifier)
+    if identifiers != expected_ids:
+        raise RegistryValidationError(
+            f"capability ontology {key} must exactly match canonical contract"
+        )
+
+
+def _validate_task_profiles(
+    document: Mapping[str, Any], capability_ids: set[str]
+) -> dict[str, TaskProfile]:
+    _require_equal(document, "schema_version", "task-profiles.v1", "task profiles")
+    profiles: dict[str, TaskProfile] = {}
+    for raw in _require_list(document, "profiles", "task profiles"):
+        if not isinstance(raw, dict):
+            raise RegistryValidationError("task profile must be an object")
+        identifier = raw.get("id")
+        if not isinstance(identifier, str) or not identifier:
+            raise RegistryValidationError("task profile id must be a non-empty string")
+        if identifier in profiles:
+            raise RegistryValidationError(f"duplicate task profile id: {identifier}")
+        required = _string_set(
+            raw.get("required_capabilities"),
+            f"task profile {identifier}.required_capabilities",
+        )
+        modalities = _string_set(
+            raw.get("allowed_modalities"),
+            f"task profile {identifier}.allowed_modalities",
+        )
+        unknown = (required | modalities) - capability_ids
+        if unknown:
+            raise RegistryValidationError(
+                f"task profile {identifier} has unknown capabilities: {sorted(unknown)}"
+            )
+        pii_policy = str(raw.get("pii_policy", "context_dependent"))
+        if pii_policy == "local_only" and not _LOCAL_PII_CAPABILITIES <= required:
+            raise RegistryValidationError(
+                f"task profile {identifier}: local_only policy requires local_only and pii_safe_local capabilities"
+            )
+        minimum_tier = raw.get("minimum_quality_tier")
+        if (
+            not isinstance(minimum_tier, int)
+            or isinstance(minimum_tier, bool)
+            or minimum_tier < 0
+        ):
+            raise RegistryValidationError(
+                f"task profile {identifier}: minimum_quality_tier must be a non-negative integer"
+            )
+        minimum_score = raw.get("minimum_task_score")
+        if minimum_score is not None and (
+            not isinstance(minimum_score, (int, float))
+            or isinstance(minimum_score, bool)
+            or not 0 <= minimum_score <= 1
+        ):
+            raise RegistryValidationError(
+                f"task profile {identifier}: minimum_task_score must be null or between 0 and 1"
+            )
+        profiles[identifier] = TaskProfile(
+            id=identifier,
+            mutation=bool(raw.get("mutation")),
+            minimum_quality_tier=minimum_tier,
+            minimum_task_score=float(minimum_score)
+            if minimum_score is not None
+            else None,
+            required_capabilities=frozenset(required),
+            allowed_modalities=frozenset(modalities),
+            pii_policy=pii_policy,
+            benchmark_id=_optional_string(
+                raw.get("benchmark_id"),
+                f"task profile {identifier}.benchmark_id",
+            ),
+            benchmark_version=_optional_string(
+                raw.get("benchmark_version"),
+                f"task profile {identifier}.benchmark_version",
+            ),
+            minimum_sample_count=_positive_integer(
+                raw.get("minimum_sample_count", 1),
+                f"task profile {identifier}.minimum_sample_count",
+            ),
+            maximum_dispersion=_bounded_optional_number(
+                raw.get("maximum_dispersion"),
+                f"task profile {identifier}.maximum_dispersion",
+                upper=0.25,
+            ),
+            minimum_context_tokens=_optional_positive_integer(
+                raw.get("minimum_context_tokens"),
+                f"task profile {identifier}.minimum_context_tokens",
+            ),
+            minimum_output_tokens=_optional_positive_integer(
+                raw.get("minimum_output_tokens"),
+                f"task profile {identifier}.minimum_output_tokens",
+            ),
+        )
+        profile = profiles[identifier]
+        benchmark_fields = (profile.benchmark_id, profile.benchmark_version)
+        if (benchmark_fields[0] is None) != (benchmark_fields[1] is None):
+            raise RegistryValidationError(
+                f"task profile {identifier}: benchmark id and version must both be set or null"
+            )
+        if profile.minimum_task_score is not None and profile.benchmark_id is None:
+            raise RegistryValidationError(
+                f"task profile {identifier}: a score floor requires a benchmark contract"
+            )
+    if not profiles:
+        raise RegistryValidationError("task profiles cannot be empty")
+    return profiles
+
+
+def _validate_index(
+    index: Mapping[str, Any],
+    cards: Mapping[str, Mapping[str, Any]],
+    endpoints: Mapping[str, Mapping[str, Any]],
+) -> None:
+    _require_equal(
+        index, "schema_version", "model-capability-index.v1", "capability index"
+    )
+    from scripts.conductor.build_model_capability_index import build_index
+
+    expected = build_index(list(cards.values()), list(endpoints.values()))
+    if index != expected:
+        raise RegistryValidationError(
+            "capability index is not the exact deterministic projection of MIR records"
+        )
+
+
+def _validated_overlays(
+    *,
+    calibration_document: Mapping[str, Any],
+    observation_documents: tuple[Mapping[str, Any], ...],
+    endpoints: Mapping[str, Mapping[str, Any]],
+    profiles: Mapping[str, TaskProfile],
+    as_of: str | None,
+) -> tuple[
+    Mapping[str, tuple[CalibrationRecord, ...]],
+    Mapping[str, tuple[EndpointHostObservation, ...]],
+    tuple[str, ...],
+]:
+    """Validate and retain only fresh exact-join overlay facts."""
+    clock = parse_timestamp(as_of)
+    if as_of is not None and clock is None:
+        raise RegistryValidationError(
+            "overlay as_of must be a timezone-aware ISO-8601 timestamp"
+        )
+    calibrations: dict[str, list[CalibrationRecord]] = {}
+    observations: dict[str, list[EndpointHostObservation]] = {}
+    diagnostics: list[str] = []
+    calibration_keys: set[tuple[str, str, str, str]] = set()
+    for raw in calibration_document["records"]:
+        try:
+            record = CalibrationRecord.from_mapping(raw)
+        except CalibrationError as error:
+            raise RegistryValidationError(f"calibration overlay: {error}") from error
+        if record.endpoint_id not in endpoints:
+            raise RegistryValidationError(
+                f"calibration overlay references unknown endpoint: {record.endpoint_id}"
+            )
+        if record.task_profile_id not in profiles:
+            raise RegistryValidationError(
+                f"calibration overlay references unknown task profile: {record.task_profile_id}"
+            )
+        key = (
+            record.endpoint_id,
+            record.task_profile_id,
+            record.benchmark_id,
+            record.benchmark_version,
+        )
+        if key in calibration_keys:
+            raise RegistryValidationError(
+                "calibration overlay contains a duplicate endpoint/task/benchmark record"
+            )
+        calibration_keys.add(key)
+        endpoint = endpoints[record.endpoint_id]
+        reason = record.rejection(
+            endpoint_profile_hash=_content_hash(endpoint),
+            profile=profiles[record.task_profile_id],
+            as_of=clock,
+        )
+        if reason is not None:
+            diagnostics.append(
+                f"calibration:{record.endpoint_id}:{record.task_profile_id}:{reason}"
+            )
+            continue
+        calibrations.setdefault(record.endpoint_id, []).append(record)
+
+    observation_keys: set[tuple[str, str]] = set()
+    for document in observation_documents:
+        for raw in document["observations"]:
+            try:
+                observation = EndpointHostObservation.from_mapping(raw)
+            except CalibrationError as error:
+                raise RegistryValidationError(
+                    f"host observation overlay: {error}"
+                ) from error
+            if observation.endpoint_id not in endpoints:
+                raise RegistryValidationError(
+                    "host observation overlay references unknown endpoint: "
+                    f"{observation.endpoint_id}"
+                )
+            key = (observation.endpoint_id, observation.host)
+            if key in observation_keys:
+                raise RegistryValidationError(
+                    "host observation overlay contains duplicate endpoint/host evidence"
+                )
+            observation_keys.add(key)
+            endpoint = endpoints[observation.endpoint_id]
+            reason = observation.rejection(
+                endpoint_profile_hash=_content_hash(endpoint),
+                model_identifier=str(endpoint["invocation"]["model_identifier"]),
+                machine_allowlist=tuple(
+                    str(host) for host in endpoint["machine_constraints"]["allowlist"]
+                ),
+                as_of=clock,
+            )
+            if reason is not None:
+                diagnostics.append(
+                    f"observation:{observation.endpoint_id}:{observation.host}:{reason}"
+                )
+                continue
+            observations.setdefault(observation.endpoint_id, []).append(observation)
+
+    return (
+        {
+            endpoint_id: tuple(
+                sorted(
+                    records,
+                    key=lambda item: (
+                        item.task_profile_id,
+                        item.benchmark_id,
+                        item.benchmark_version,
+                    ),
+                )
+            )
+            for endpoint_id, records in sorted(calibrations.items())
+        },
+        {
+            endpoint_id: tuple(sorted(items, key=lambda item: item.host))
+            for endpoint_id, items in sorted(observations.items())
+        },
+        tuple(sorted(diagnostics)),
+    )
+
+
+def _candidate_from_records(
+    endpoint: Mapping[str, Any],
+    card: Mapping[str, Any],
+    calibrations: tuple[CalibrationRecord, ...],
+    observations: tuple[EndpointHostObservation, ...],
+    profiles: Mapping[str, TaskProfile],
+) -> EndpointCandidate:
+    endpoint_features = _evidence_by_capability(
+        endpoint.get("exposed_capabilities", [])
+    )
+    card_features = _evidence_by_capability(card.get("modalities", []))
+    combined: dict[str, CapabilityEvidence] = dict(card_features)
+    combined.update(endpoint_features)
+    auth_surface = _require_auth_surface(
+        endpoint, f"EndpointProfile {endpoint.get('id', 'unknown')}"
+    )
+    if auth_surface is not AuthSurface.LOCAL_RUNTIME:
+        for capability_id in _LOCAL_PII_CAPABILITIES:
+            combined.pop(capability_id, None)
+    usable_observations = tuple(
+        observation
+        for observation in observations
+        if observation.available
+        and observation.healthy
+        and observation.identity_verified
+    )
+    if usable_observations:
+        observed_at = min(item.observed_at for item in usable_observations)
+        expires_at = min(item.expires_at for item in usable_observations)
+        combined["context_tokens"] = CapabilityEvidence(
+            capability="context_tokens",
+            value=min(item.context_tokens for item in usable_observations),
+            kind=EvidenceKind.PROBED,
+            evidence_ref="host-observation-overlay:context_tokens",
+            observed_at=observed_at,
+            expires_at=expires_at,
+            confidence=1.0,
+        )
+        combined["output_tokens"] = CapabilityEvidence(
+            capability="output_tokens",
+            value=min(item.output_tokens for item in usable_observations),
+            kind=EvidenceKind.PROBED,
+            evidence_ref="host-observation-overlay:output_tokens",
+            observed_at=observed_at,
+            expires_at=expires_at,
+            confidence=1.0,
+        )
+    health_date = (
+        min(item.observed_at for item in usable_observations)
+        if usable_observations
+        else _first_observed_at(endpoint.get("evidence", []))
+    )
+    overlay_scores = tuple(_task_score_from_calibration(item) for item in calibrations)
+    quality_tier = max(
+        (profiles[item.task_profile_id].minimum_quality_tier for item in calibrations),
+        default=0,
+    )
+    evidence_ready = any(
+        _observation_supports_profile(
+            observation,
+            profiles[calibration.task_profile_id],
+        )
+        for calibration in calibrations
+        for observation in usable_observations
+    )
+    static_routing = endpoint["routing"]
+    status = str(static_routing["status"])
+    statically_authorized = (
+        status == "eligible" and static_routing["automated_routing"] is True
+    )
+    automated_routing = bool(
+        evidence_ready
+        and statically_authorized
+        and auth_surface is not AuthSurface.UNKNOWN
+        and auth_surface is not AuthSurface.ANTHROPIC_PAID_API
+    )
+    enforcement_mode = _conservative_enforcement_mode(usable_observations)
+    return EndpointCandidate(
+        endpoint_id=str(endpoint["id"]),
+        engine=str(endpoint["invocation"]["engine"]),
+        model_card_id=str(card["id"]),
+        model=str(endpoint["invocation"]["model_identifier"]),
+        family=str(card["identity"]["family"]),
+        role=Role.BUILDER,
+        features=tuple(combined[key] for key in sorted(combined)),
+        task_scores=tuple(
+            sorted(
+                (*_task_scores(card.get("task_scores", [])), *overlay_scores),
+                key=lambda item: (
+                    item.task_profile_id,
+                    item.benchmark_id or "",
+                    item.benchmark_version or "",
+                ),
+            )
+        ),
+        healthy=bool(usable_observations),
+        health_observed_at=health_date,
+        machine_allowlist=(
+            tuple(sorted(item.host for item in usable_observations))
+            if usable_observations
+            else tuple(
+                sorted(
+                    str(host) for host in endpoint["machine_constraints"]["allowlist"]
+                )
+            )
+        ),
+        cost_rank=_unknown_rank(),
+        latency_rank=max(
+            (item.latency_ms for item in usable_observations),
+            default=_unknown_rank(),
+        ),
+        quota_pressure_rank=_unknown_rank(),
+        quality_tier=quality_tier,
+        enforcement_mode=enforcement_mode,
+        identity_confidence=1.0 if usable_observations else 0.0,
+        model_card_hash=_content_hash(card),
+        endpoint_profile_hash=_content_hash(endpoint),
+        capability_snapshot_hash=_content_hash(
+            {
+                "endpoint": endpoint["id"],
+                "calibrations": [item.as_mapping() for item in calibrations],
+                "observations": [
+                    {
+                        "host": item.host,
+                        "model_identifier": item.model_identifier,
+                        "observed_at": item.observed_at,
+                        "expires_at": item.expires_at,
+                        "probe_id": item.probe_id,
+                        "probe_version": item.probe_version,
+                    }
+                    for item in observations
+                ],
+            }
+        ),
+        automated_routing=automated_routing,
+        routing_status=status,
+        uses_paid_anthropic_api=auth_surface is AuthSurface.ANTHROPIC_PAID_API,
+        auth_surface=auth_surface,
+    )
+
+
+def _task_score_from_calibration(record: CalibrationRecord) -> TaskScore:
+    return TaskScore(
+        task_profile_id=record.task_profile_id,
+        score=record.score,
+        benchmark_id=record.benchmark_id,
+        benchmark_version=record.benchmark_version,
+        sample_count=record.sample_count,
+        observed_at=record.measured_at,
+        evidence_kind=EvidenceKind.BENCHMARKED,
+        conservative_score=record.conservative_score,
+        sample_hashes=record.sample_hashes,
+        scorer_id=record.scorer_id,
+        scorer_version=record.scorer_version,
+        expires_at=record.expires_at,
+        dispersion=record.dispersion,
+    )
+
+
+def _observation_supports_profile(
+    observation: EndpointHostObservation, profile: TaskProfile
+) -> bool:
+    if (
+        profile.minimum_context_tokens is not None
+        and observation.context_tokens < profile.minimum_context_tokens
+    ):
+        return False
+    if (
+        profile.minimum_output_tokens is not None
+        and observation.output_tokens < profile.minimum_output_tokens
+    ):
+        return False
+    return not profile.mutation or observation.enforcement_mode == "enforced"
+
+
+def _conservative_enforcement_mode(
+    observations: tuple[EndpointHostObservation, ...],
+) -> str:
+    if not observations:
+        return "unmeasured"
+    strength = {
+        "unmeasured": 0,
+        "manual_only": 1,
+        "advisory_only": 2,
+        "advisory": 2,
+        "shadow": 3,
+        "enforced": 4,
+    }
+    return min(
+        (item.enforcement_mode for item in observations),
+        key=lambda mode: (strength.get(mode, 0), mode),
+    )
+
+
+def _evidence_by_capability(raw_capabilities: Any) -> dict[str, CapabilityEvidence]:
+    if not isinstance(raw_capabilities, list):
+        return {}
+    result: dict[str, CapabilityEvidence] = {}
+    for raw in raw_capabilities:
+        if not isinstance(raw, dict) or not isinstance(raw.get("id"), str):
+            continue
+        evidence = raw.get("evidence", [])
+        result[raw["id"]] = CapabilityEvidence(
+            capability=raw["id"],
+            value=raw.get("value"),
+            kind=_evidence_kind(evidence),
+            evidence_ref=_first_evidence_ref(evidence),
+            observed_at=_first_observed_at(evidence),
+            expires_at=None,
+            confidence=1.0
+            if _evidence_kind(evidence) is not EvidenceKind.UNMEASURED
+            else 0.0,
+        )
+    return result
+
+
+def _task_scores(raw_scores: Any) -> tuple[TaskScore, ...]:
+    if not isinstance(raw_scores, list):
+        return ()
+    scores: list[TaskScore] = []
+    for raw in raw_scores:
+        if not isinstance(raw, dict) or not isinstance(raw.get("task_profile_id"), str):
+            continue
+        evidence = raw.get("evidence", [])
+        benchmark_id = raw.get("benchmark_id")
+        benchmark_version = raw.get("benchmark_version")
+        scores.append(
+            TaskScore(
+                task_profile_id=raw["task_profile_id"],
+                score=raw.get("score")
+                if isinstance(raw.get("score"), (int, float))
+                else None,
+                benchmark_id=benchmark_id if isinstance(benchmark_id, str) else None,
+                benchmark_version=benchmark_version
+                if isinstance(benchmark_version, str)
+                else None,
+                sample_count=raw.get("sample_count")
+                if isinstance(raw.get("sample_count"), int)
+                else 0,
+                observed_at=_first_observed_at(evidence),
+                evidence_kind=_evidence_kind(evidence),
+            )
+        )
+    return tuple(
+        sorted(scores, key=lambda item: (item.task_profile_id, item.benchmark_id or ""))
+    )
+
+
+def _is_automated_eligible(endpoint: Mapping[str, Any]) -> bool:
+    routing = endpoint.get("routing")
+    return (
+        isinstance(routing, dict)
+        and routing.get("status") == "eligible"
+        and routing.get("automated_routing") is True
+    )
+
+
+def _require_auth_surface(endpoint: Mapping[str, Any], location: str) -> AuthSurface:
+    """Return explicit endpoint authority; never infer it from names or harnesses."""
+    raw = endpoint.get("auth_surface")
+    try:
+        return AuthSurface(raw)
+    except (TypeError, ValueError) as error:
+        raise RegistryValidationError(
+            f"{location}.auth_surface is unknown or missing"
+        ) from error
+
+
+def _evidence_kind(raw_evidence: Any) -> EvidenceKind:
+    if not isinstance(raw_evidence, list):
+        return EvidenceKind.UNMEASURED
+    levels = {item.get("level") for item in raw_evidence if isinstance(item, dict)}
+    if "benchmarked" in levels:
+        return EvidenceKind.BENCHMARKED
+    if "production" in levels:
+        return EvidenceKind.PRODUCTION
+    if "probed" in levels:
+        return EvidenceKind.PROBED
+    if "declared" in levels:
+        return EvidenceKind.DECLARED
+    return EvidenceKind.UNMEASURED
+
+
+def _first_evidence_ref(raw_evidence: Any) -> str:
+    if isinstance(raw_evidence, list):
+        for item in raw_evidence:
+            if isinstance(item, dict) and isinstance(item.get("ref"), str):
+                return item["ref"]
+    return "unmeasured"
+
+
+def _first_observed_at(raw_evidence: Any) -> str:
+    if isinstance(raw_evidence, list):
+        dates = sorted(
+            item["observed_at"]
+            for item in raw_evidence
+            if isinstance(item, dict)
+            and isinstance(item.get("observed_at"), str)
+            and _is_iso_date(item["observed_at"])
+        )
+        if dates:
+            return dates[-1]
+    return "1970-01-01"
+
+
+def _is_iso_date(value: str) -> bool:
+    try:
+        date.fromisoformat(value[:10])
+    except ValueError:
+        return False
+    return True
+
+
+def _content_hash(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+def _unknown_rank() -> int:
+    return 2_147_483_647
+
+
+def _require_mapping(
+    value: Mapping[str, Any], key: str, location: str
+) -> Mapping[str, Any]:
+    item = value.get(key)
+    if not isinstance(item, dict):
+        raise RegistryValidationError(f"{location}.{key} must be an object")
+    return item
+
+
+def _require_list(value: Mapping[str, Any], key: str, location: str) -> list[Any]:
+    item = value.get(key)
+    if not isinstance(item, list):
+        raise RegistryValidationError(f"{location}.{key} must be an array")
+    return item
+
+
+def _require_string(value: Mapping[str, Any], key: str, location: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item:
+        raise RegistryValidationError(f"{location}.{key} must be a non-empty string")
+    return item
+
+
+def _require_equal(
+    value: Mapping[str, Any], key: str, expected: str, location: str
+) -> None:
+    if value.get(key) != expected:
+        raise RegistryValidationError(f"{location}.{key} must equal {expected!r}")
+
+
+def _string_set(value: Any, location: str) -> set[str]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise RegistryValidationError(
+            f"{location} must be an array of non-empty strings"
+        )
+    return set(value)
+
+
+def _optional_string(value: Any, location: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise RegistryValidationError(f"{location} must be null or a non-empty string")
+    return value
+
+
+def _positive_integer(value: Any, location: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise RegistryValidationError(f"{location} must be a positive integer")
+    return value
+
+
+def _optional_positive_integer(value: Any, location: str) -> int | None:
+    if value is None:
+        return None
+    return _positive_integer(value, location)
+
+
+def _bounded_optional_number(
+    value: Any, location: str, *, upper: float
+) -> float | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not 0 <= value <= upper
+    ):
+        raise RegistryValidationError(
+            f"{location} must be null or between 0 and {upper}"
+        )
+    return float(value)
+
+
+def _index_ids(value: Any, key: str, location: str) -> set[str]:
+    if not isinstance(value, list):
+        raise RegistryValidationError(f"{location} must be an array")
+    identifiers: set[str] = set()
+    for item in value:
+        if not isinstance(item, dict) or not isinstance(item.get(key), str):
+            raise RegistryValidationError(f"{location} entries must contain {key}")
+        identifiers.add(item[key])
+    if len(identifiers) != len(value):
+        raise RegistryValidationError(f"{location} contains duplicate identifiers")
+    return identifiers

--- a/scripts/tests/test_conductor_calibration.py
+++ b/scripts/tests/test_conductor_calibration.py
@@ -1,0 +1,334 @@
+"""Fail-closed tests for MIR calibration and exact host observation overlays."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from scripts.conductor.model_registry import RegistryValidationError, load_registry
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIR = ROOT / "infra" / "conductor"
+AS_OF = "2026-08-23T00:00:00Z"
+MEASURED_AT = "2026-08-22T00:00:00Z"
+EXPIRES_AT = "2026-08-29T00:00:00Z"
+ENDPOINT_ID = "codex-gpt-5.6-luna"
+PROFILE_ID = "mechanical"
+
+
+def _hashes(count: int, prefix: str = "sample") -> list[str]:
+    return [sha256(f"{prefix}-{index}".encode()).hexdigest() for index in range(count)]
+
+
+class CalibrationOverlayTest(unittest.TestCase):
+    def _clone(self, directory: str) -> Path:
+        root = Path(directory)
+        target = root / "infra" / "conductor"
+        target.parent.mkdir(parents=True)
+        shutil.copytree(MIR, target)
+        return root
+
+    def _endpoint_hash(self, root: Path, endpoint_id: str = ENDPOINT_ID) -> str:
+        return load_registry(root).endpoint(endpoint_id).endpoint_profile_hash
+
+    def _calibration(
+        self,
+        root: Path,
+        *,
+        endpoint_id: str = ENDPOINT_ID,
+        profile_id: str = PROFILE_ID,
+        count: int = 5,
+    ) -> dict[str, object]:
+        return {
+            "benchmark_id": "conductor-priority-pilot",
+            "benchmark_version": "1.0.0",
+            "endpoint_id": endpoint_id,
+            "endpoint_profile_hash": self._endpoint_hash(root, endpoint_id),
+            "task_profile_id": profile_id,
+            "score": 0.95,
+            "conservative_score": 0.9,
+            "sample_count": count,
+            "sample_hashes": _hashes(count, endpoint_id),
+            "scorer": {"id": "blinded-code-scorer", "version": "1.0.0"},
+            "measured_at": MEASURED_AT,
+            "expires_at": EXPIRES_AT,
+            "dispersion": {"metric": "sample_variance", "value": 0.01},
+        }
+
+    def _observation(
+        self, root: Path, *, endpoint_id: str = ENDPOINT_ID
+    ) -> dict[str, object]:
+        endpoint = load_registry(root).endpoint_profiles[endpoint_id]
+        return {
+            "endpoint_id": endpoint_id,
+            "endpoint_profile_hash": self._endpoint_hash(root, endpoint_id),
+            "host": "pro",
+            "model_identifier": endpoint["invocation"]["model_identifier"],
+            "available": True,
+            "healthy": True,
+            "latency_ms": 500,
+            "context_tokens": 32768,
+            "output_tokens": 8192,
+            "enforcement_mode": "enforced",
+            "identity_verified": True,
+            "probe": {"id": "exact-cli-model-probe", "version": "1.0.0"},
+            "observed_at": MEASURED_AT,
+            "expires_at": EXPIRES_AT,
+        }
+
+    def _write_overlays(
+        self,
+        root: Path,
+        calibrations: list[dict[str, object]],
+        observations: list[dict[str, object]],
+    ) -> None:
+        mir = root / "infra" / "conductor"
+        (mir / "calibrations.v1.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "calibration-overlay.v1",
+                    "generated_at": MEASURED_AT,
+                    "records": calibrations,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (mir / "host_observations.v1.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "host-observation-overlay.v1",
+                    "generated_at": MEASURED_AT,
+                    "observations": observations,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_fresh_calibrated_healthy_noneligible_endpoint_stays_unroutable(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone(directory)
+            self._write_overlays(
+                root, [self._calibration(root)], [self._observation(root)]
+            )
+
+            registry = load_registry(root, as_of=AS_OF)
+            candidates = registry.endpoints()
+
+            self.assertFalse(registry.operational)
+            self.assertEqual(candidates, ())
+
+    def test_missing_and_rejected_artifacts_never_open_a_route(self) -> None:
+        cases = {
+            "missing_observation": (None, None, ""),
+            "stale_calibration": ("expires_at", "2026-08-22T12:00:00Z", "stale"),
+            "low_sample": ("sample", 4, "low_sample"),
+            "high_variance": ("variance", 0.06, "high_variance"),
+            "endpoint_mismatch": (
+                "endpoint_profile_hash",
+                "0" * 64,
+                "endpoint_profile_mismatch",
+            ),
+            "benchmark_mismatch": (
+                "benchmark_version",
+                "2.0.0",
+                "benchmark_version_mismatch",
+            ),
+        }
+        for name, (field, value, reason) in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = self._clone(directory)
+                calibration = self._calibration(root)
+                observations = (
+                    [] if name == "missing_observation" else [self._observation(root)]
+                )
+                if field == "sample":
+                    calibration["sample_count"] = value
+                    calibration["sample_hashes"] = _hashes(int(value), ENDPOINT_ID)
+                elif field == "variance":
+                    calibration["dispersion"] = {
+                        "metric": "sample_variance",
+                        "value": value,
+                    }
+                elif field is not None:
+                    calibration[field] = value
+                self._write_overlays(root, [calibration], observations)
+
+                registry = load_registry(root, as_of=AS_OF)
+
+                self.assertFalse(registry.operational)
+                self.assertEqual(registry.endpoints(), ())
+                if reason:
+                    self.assertTrue(
+                        any(reason in item for item in registry.overlay_diagnostics),
+                        registry.overlay_diagnostics,
+                    )
+
+    def test_stale_or_wrong_exact_model_observation_is_rejected(self) -> None:
+        for name, mutation, reason in (
+            ("stale", {"expires_at": "2026-08-22T12:00:00Z"}, "stale"),
+            (
+                "wrong_model",
+                {"model_identifier": "gpt-5.6-not-luna"},
+                "model_identifier_mismatch",
+            ),
+        ):
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = self._clone(directory)
+                observation = self._observation(root)
+                observation.update(mutation)
+                self._write_overlays(root, [self._calibration(root)], [observation])
+
+                registry = load_registry(root, as_of=AS_OF)
+
+                self.assertFalse(registry.operational)
+                self.assertTrue(
+                    any(reason in item for item in registry.overlay_diagnostics)
+                )
+
+    def test_overlay_schema_forbids_auth_secret_prompt_and_pii_fields(self) -> None:
+        for forbidden in ("api_key", "prompt", "client_name"):
+            with (
+                self.subTest(field=forbidden),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                root = self._clone(directory)
+                calibration = self._calibration(root)
+                calibration[forbidden] = "must-not-survive"
+                self._write_overlays(root, [calibration], [self._observation(root)])
+
+                with self.assertRaisesRegex(
+                    RegistryValidationError, f"unexpected property {forbidden}"
+                ):
+                    load_registry(root, as_of=AS_OF)
+
+    def test_diagnostics_and_routing_are_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone(directory)
+            low_sample = self._calibration(root, count=4)
+            high_variance = self._calibration(
+                root,
+                endpoint_id="codex-gpt-5.6-terra",
+                profile_id="standard_build",
+            )
+            high_variance["dispersion"] = {
+                "metric": "sample_variance",
+                "value": 0.06,
+            }
+            records = [high_variance, low_sample]
+            self._write_overlays(root, records, [])
+            first = load_registry(root, as_of=AS_OF)
+            self._write_overlays(root, list(reversed(records)), [])
+            second = load_registry(root, as_of=AS_OF)
+
+            self.assertEqual(first.overlay_diagnostics, second.overlay_diagnostics)
+            self.assertEqual(first.endpoints(), second.endpoints())
+
+    def test_real_registry_is_non_operational_without_pilot_artifacts(self) -> None:
+        registry = load_registry(ROOT)
+        source_eligible = [
+            endpoint_id
+            for endpoint_id, endpoint in registry.endpoint_profiles.items()
+            if endpoint["routing"]["status"] == "eligible"
+            and endpoint["routing"]["automated_routing"] is True
+        ]
+        effective_eligible = registry.endpoints()
+
+        self.assertEqual(len(source_eligible), 4)
+        self.assertEqual(effective_eligible, ())
+        self.assertFalse(registry.operational)
+        self.assertTrue(
+            all(
+                registry.endpoint_profiles[endpoint_id]["routing"]["automated_routing"]
+                is True
+                for endpoint_id in source_eligible
+            ),
+            "the effective overlay must not mutate source routing truth",
+        )
+
+        candidate = registry.endpoint(ENDPOINT_ID)
+        self.assertFalse(candidate.healthy)
+        self.assertEqual(candidate.task_scores, ())
+
+    def test_priority_cli_is_offline_and_aggregate_retains_only_hashes(self) -> None:
+        plan = subprocess.run(
+            [
+                str(ROOT / "apps" / "backend-rag" / ".venv" / "bin" / "python"),
+                str(ROOT / "scripts" / "conductor" / "calibration_cli.py"),
+                "plan",
+                "--root",
+                str(ROOT),
+            ],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(plan.returncode, 0, plan.stderr)
+        manifest = json.loads(plan.stdout)
+        self.assertEqual(manifest["execution"], "not_implemented_no_provider_calls")
+        self.assertEqual(len({item["endpoint_id"] for item in manifest["entries"]}), 9)
+
+        with tempfile.TemporaryDirectory() as directory:
+            sample_path = Path(directory) / "samples.jsonl"
+            output_path = Path(directory) / "overlay.json"
+            samples = [
+                {
+                    "endpoint_id": ENDPOINT_ID,
+                    "task_profile_id": PROFILE_ID,
+                    "sample_hash": digest,
+                    "score": 0.9,
+                }
+                for digest in _hashes(5)
+            ]
+            sample_path.write_text(
+                "\n".join(json.dumps(item) for item in samples) + "\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    str(ROOT / "apps" / "backend-rag" / ".venv" / "bin" / "python"),
+                    "-m",
+                    "scripts.conductor.calibration_cli",
+                    "aggregate",
+                    "--root",
+                    str(ROOT),
+                    "--samples",
+                    str(sample_path),
+                    "--output",
+                    str(output_path),
+                    "--benchmark-id",
+                    "conductor-priority-pilot",
+                    "--benchmark-version",
+                    "1.0.0",
+                    "--scorer-id",
+                    "blinded-code-scorer",
+                    "--scorer-version",
+                    "1.0.0",
+                    "--measured-at",
+                    MEASURED_AT,
+                    "--expires-at",
+                    EXPIRES_AT,
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            artifact = json.loads(output_path.read_text(encoding="utf-8"))
+            serialized = json.dumps(artifact)
+            self.assertNotIn("prompt", serialized)
+            self.assertNotIn("response", serialized)
+            self.assertEqual(artifact["records"][0]["sample_count"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_conductor_model_registry.py
+++ b/scripts/tests/test_conductor_model_registry.py
@@ -1,0 +1,786 @@
+"""Integrity checks for the static Model Intelligence Registry (MIR).
+
+These tests intentionally use only the standard library: runtime schema validation may
+choose a JSON Schema library later, but the checked-in data must remain inspectable in
+minimal CI environments.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from scripts.conductor.calibration import CalibrationRecord, EndpointHostObservation
+from scripts.conductor.model_registry import (
+    RegistryValidationError,
+    _candidate_from_records,
+    _content_hash,
+    load_registry,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIR = ROOT / "infra" / "conductor"
+CARD_DIR = MIR / "model_cards"
+ENDPOINT_DIR = MIR / "endpoint_profiles"
+STATUSES = {
+    "eligible",
+    "manual_only",
+    "probation",
+    "phantom",
+    "denied",
+    "investigation_required",
+    "listed_unexploited",
+    "deprecated",
+    "known_unmeasured",
+}
+EVIDENCE_LEVELS = {"declared", "probed", "benchmarked", "production", "unmeasured"}
+PUBLIC_URL_PATTERN = re.compile(r"https?://[^\s|]+")
+AUTH_SURFACE_COUNTS = {
+    "anthropic_oauth_subscription": 6,
+    "google_oauth_subscription": 5,
+    "local_runtime": 14,
+    "manual_gui": 1,
+    "openai_chatgpt_subscription": 10,
+    "unknown": 45,
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def assert_evidence(test: unittest.TestCase, evidence: Any, location: str) -> None:
+    test.assertIsInstance(evidence, list, location)
+    test.assertGreater(len(evidence), 0, location)
+    for item in evidence:
+        test.assertIsInstance(item, dict, location)
+        test.assertIn(item.get("level"), EVIDENCE_LEVELS, location)
+        test.assertTrue(item.get("ref"), location)
+        test.assertRegex(str(item.get("observed_at")), r"^\d{4}-\d{2}-\d{2}", location)
+
+
+def iter_evidence(value: Any) -> list[dict[str, Any]]:
+    """Return evidence records nested anywhere in a static registry record."""
+    if isinstance(value, dict):
+        if set(value) == {"level", "ref", "observed_at"}:
+            return [value]
+        return [item for child in value.values() for item in iter_evidence(child)]
+    if isinstance(value, list):
+        return [item for child in value for item in iter_evidence(child)]
+    return []
+
+
+def has_declared_limit_evidence(limit: dict[str, Any]) -> bool:
+    """Require an explicit declaration before a token limit may be non-null."""
+    return any(item["level"] == "declared" for item in limit["evidence"])
+
+
+def limit_value_is_evidenced(limit: dict[str, Any]) -> bool:
+    """Keep unknown limits null and admit numeric limits only with a declaration."""
+    if limit["value"] is None:
+        return any(item["level"] == "unmeasured" for item in limit["evidence"])
+    return has_declared_limit_evidence(limit)
+
+
+def json_type_matches(value: Any, expected_type: str) -> bool:
+    """Implement the JSON types used by the checked-in MIR schemas."""
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "null":
+        return value is None
+    raise AssertionError(f"unsupported JSON Schema type in MIR schema: {expected_type}")
+
+
+def assert_matches_mir_schema(
+    test: unittest.TestCase,
+    value: Any,
+    schema: dict[str, Any],
+    root_schema: dict[str, Any],
+    location: str,
+) -> None:
+    """Validate all JSON Schema keywords used by the two MIR schemas.
+
+    This deliberately implements only the fixed, local schema subset in this repository,
+    avoiding a new dependency merely to validate static registry data in minimal CI.
+    """
+    if "$ref" in schema:
+        reference = schema["$ref"]
+        test.assertTrue(
+            reference.startswith("#/$defs/"),
+            f"{location}: local $defs reference expected",
+        )
+        definition_name = reference.removeprefix("#/$defs/")
+        assert_matches_mir_schema(
+            test, value, root_schema["$defs"][definition_name], root_schema, location
+        )
+        return
+
+    if "type" in schema:
+        expected_types = schema["type"]
+        if isinstance(expected_types, str):
+            expected_types = [expected_types]
+        test.assertTrue(
+            any(
+                json_type_matches(value, expected_type)
+                for expected_type in expected_types
+            ),
+            f"{location}: expected JSON type {expected_types}, got {type(value).__name__}",
+        )
+
+    if "const" in schema:
+        test.assertEqual(value, schema["const"], f"{location}: const mismatch")
+    if "enum" in schema:
+        test.assertTrue(
+            any(value == allowed for allowed in schema["enum"]),
+            f"{location}: enum mismatch",
+        )
+    if "pattern" in schema and isinstance(value, str):
+        test.assertRegex(value, schema["pattern"], f"{location}: pattern mismatch")
+    if "minLength" in schema and isinstance(value, str):
+        test.assertGreaterEqual(
+            len(value), schema["minLength"], f"{location}: string is too short"
+        )
+    if (
+        "minimum" in schema
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+    ):
+        test.assertGreaterEqual(
+            value, schema["minimum"], f"{location}: number is too small"
+        )
+    if (
+        "maximum" in schema
+        and isinstance(value, (int, float))
+        and not isinstance(value, bool)
+    ):
+        test.assertLessEqual(
+            value, schema["maximum"], f"{location}: number is too large"
+        )
+
+    if isinstance(value, dict):
+        properties = schema.get("properties", {})
+        for required_name in schema.get("required", []):
+            test.assertIn(
+                required_name, value, f"{location}: missing required property"
+            )
+        if schema.get("additionalProperties") is False:
+            unexpected = set(value) - set(properties)
+            test.assertFalse(
+                unexpected, f"{location}: unexpected properties {sorted(unexpected)}"
+            )
+        for property_name, property_schema in properties.items():
+            if property_name in value:
+                assert_matches_mir_schema(
+                    test,
+                    value[property_name],
+                    property_schema,
+                    root_schema,
+                    f"{location}.{property_name}",
+                )
+
+    if isinstance(value, list):
+        if "minItems" in schema:
+            test.assertGreaterEqual(
+                len(value), schema["minItems"], f"{location}: array is too short"
+            )
+        if "items" in schema:
+            for index, item in enumerate(value):
+                assert_matches_mir_schema(
+                    test, item, schema["items"], root_schema, f"{location}[{index}]"
+                )
+
+
+class ModelIntelligenceRegistryTest(unittest.TestCase):
+    def _clone_registry(self, directory: str) -> Path:
+        """Return a disposable repository root containing only MIR inputs."""
+        root = Path(directory)
+        target = root / "infra" / "conductor"
+        target.parent.mkdir(parents=True)
+        shutil.copytree(MIR, target)
+        return root
+
+    def _endpoint_document(self, root: Path) -> tuple[Path, dict[str, Any]]:
+        path = sorted(
+            (root / "infra" / "conductor" / "endpoint_profiles").glob("*.json")
+        )[0]
+        return path, load_json(path)
+
+    def test_loader_rejects_endpoint_without_explicit_auth_surface(self) -> None:
+        """A missing concrete auth authority must never be treated as routable."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            path, endpoint = self._endpoint_document(root)
+            endpoint.pop("auth_surface", None)
+            path.write_text(json.dumps(endpoint), encoding="utf-8")
+
+            with self.assertRaisesRegex(RegistryValidationError, "auth_surface"):
+                load_registry(root)
+
+    def test_loader_rejects_paid_anthropic_endpoint_as_eligible(self) -> None:
+        """The paid Anthropic surface is inventory-only even if schema-valid."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            path, endpoint = self._endpoint_document(root)
+            endpoint["auth_surface"] = "anthropic_paid_api"
+            endpoint["routing"]["status"] = "eligible"
+            endpoint["routing"]["automated_routing"] = False
+            path.write_text(json.dumps(endpoint), encoding="utf-8")
+
+            with self.assertRaisesRegex(RegistryValidationError, "paid Anthropic"):
+                load_registry(root)
+
+    def test_loader_rejects_unknown_task_profile_in_static_score(self) -> None:
+        """Static score evidence must join to a real task profile before routing."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            path = sorted(
+                (root / "infra" / "conductor" / "model_cards").glob("*.json")
+            )[0]
+            card = load_json(path)
+            card["task_scores"] = [
+                {
+                    "task_profile_id": "unknown-profile",
+                    "score": 0.9,
+                    "benchmark_id": "test-benchmark",
+                    "benchmark_version": "1.0.0",
+                    "sample_count": 1,
+                    "evidence": [
+                        {
+                            "level": "benchmarked",
+                            "ref": "test:score",
+                            "observed_at": "2026-08-21",
+                        }
+                    ],
+                }
+            ]
+            path.write_text(json.dumps(card), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RegistryValidationError, "unknown task profile"
+            ):
+                load_registry(root)
+
+    def test_loader_rejects_numeric_static_score_without_samples(self) -> None:
+        """A zero-sample score is unavailable rather than a routable quality claim."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            path = sorted(
+                (root / "infra" / "conductor" / "model_cards").glob("*.json")
+            )[0]
+            card = load_json(path)
+            card["task_scores"] = [
+                {
+                    "task_profile_id": "mechanical",
+                    "score": 0.9,
+                    "benchmark_id": None,
+                    "benchmark_version": None,
+                    "sample_count": 0,
+                    "evidence": [
+                        {
+                            "level": "unmeasured",
+                            "ref": "test:unavailable-score",
+                            "observed_at": "2026-08-21",
+                        }
+                    ],
+                }
+            ]
+            path.write_text(json.dumps(card), encoding="utf-8")
+
+            with self.assertRaisesRegex(RegistryValidationError, "zero samples"):
+                load_registry(root)
+
+    def test_loader_rejects_nonlocal_endpoint_claiming_local_pii_capability(
+        self,
+    ) -> None:
+        """A cloud auth surface cannot self-attest the local PII execution boundary."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            path, endpoint = self._endpoint_document(root)
+            endpoint["auth_surface"] = "openai_chatgpt_subscription"
+            endpoint["exposed_capabilities"].append(
+                {
+                    "id": "local_only",
+                    "value": True,
+                    "evidence": [
+                        {
+                            "level": "declared",
+                            "ref": "test:nonlocal-local-only",
+                            "observed_at": "2026-08-21",
+                        }
+                    ],
+                }
+            )
+            path.write_text(json.dumps(endpoint), encoding="utf-8")
+
+            with self.assertRaisesRegex(RegistryValidationError, "local_runtime"):
+                load_registry(root)
+
+    def test_cloud_endpoint_cannot_inherit_local_pii_capability_from_model_card(
+        self,
+    ) -> None:
+        """The concrete auth surface, not a shared card, binds PII-local claims."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            path, endpoint = self._endpoint_document(root)
+            endpoint["auth_surface"] = "openai_chatgpt_subscription"
+            endpoint["model_card_id"] = "deepseek-r1-32b"
+            path.write_text(json.dumps(endpoint), encoding="utf-8")
+
+            card = load_json(
+                root / "infra" / "conductor" / "model_cards" / "deepseek-r1-32b.json"
+            )
+            candidate = _candidate_from_records(
+                endpoint,
+                card,
+                (),
+                (),
+                load_registry(ROOT).task_profiles,
+            )
+
+            capabilities = {item.capability for item in candidate.features}
+            self.assertNotIn("local_only", capabilities)
+            self.assertNotIn("pii_safe_local", capabilities)
+
+    def test_loader_rejects_local_pii_profile_without_local_capabilities(self) -> None:
+        """A local-only task must request both capability guards at the schema join."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            path = root / "infra" / "conductor" / "task_profiles.v1.json"
+            profiles = load_json(path)
+            profile = profiles["profiles"][0]
+            profile["pii_policy"] = "local_only"
+            profile["required_capabilities"] = ["coding"]
+            path.write_text(json.dumps(profiles), encoding="utf-8")
+
+            with self.assertRaisesRegex(RegistryValidationError, "local_only policy"):
+                load_registry(root)
+
+    def test_noneligible_endpoint_is_not_promoted_after_valid_overlay_evidence(
+        self,
+    ) -> None:
+        """Calibration health cannot override a static non-eligibility status."""
+        registry = load_registry(ROOT)
+        endpoint = registry.endpoint_profiles["claude-claude-opus-5"]
+        profile = registry.task_profiles["mechanical"]
+        endpoint_hash = _content_hash(endpoint)
+        calibration = CalibrationRecord(
+            benchmark_id="conductor-priority-pilot",
+            benchmark_version="1.0.0",
+            endpoint_id="claude-claude-opus-5",
+            endpoint_profile_hash=endpoint_hash,
+            task_profile_id=profile.id,
+            score=0.95,
+            conservative_score=0.9,
+            sample_count=5,
+            sample_hashes=("a", "b", "c", "d", "e"),
+            scorer_id="test-scorer",
+            scorer_version="1.0.0",
+            measured_at="2026-08-21T00:00:00Z",
+            expires_at="2026-08-22T00:00:00Z",
+            dispersion=0.01,
+        )
+        observation = EndpointHostObservation(
+            endpoint_id="claude-claude-opus-5",
+            endpoint_profile_hash=endpoint_hash,
+            host="pro",
+            model_identifier="claude-opus-5",
+            available=True,
+            healthy=True,
+            latency_ms=10,
+            context_tokens=100_000,
+            output_tokens=10_000,
+            enforcement_mode="enforced",
+            identity_verified=True,
+            probe_id="test-probe",
+            probe_version="1.0.0",
+            observed_at="2026-08-21T00:00:00Z",
+            expires_at="2026-08-22T00:00:00Z",
+        )
+
+        candidate = _candidate_from_records(
+            endpoint,
+            registry.model_cards[endpoint["model_card_id"]],
+            (calibration,),
+            (observation,),
+            registry.task_profiles,
+        )
+
+        self.assertTrue(candidate.healthy)
+        self.assertFalse(candidate.automated_routing)
+        self.assertEqual(candidate.routing_status, "known_unmeasured")
+
+    def test_all_noneligible_statuses_stay_nonautomated(self) -> None:
+        """Every non-eligible static status is a hard routing boundary."""
+        registry = load_registry(ROOT)
+        source = registry.endpoint_profiles["claude-claude-opus-5"]
+        card = registry.model_cards[source["model_card_id"]]
+        for status in (
+            "known_unmeasured",
+            "denied",
+            "phantom",
+            "investigation_required",
+        ):
+            with self.subTest(status=status):
+                endpoint = {
+                    **source,
+                    "routing": {
+                        **source["routing"],
+                        "status": status,
+                        "automated_routing": False,
+                    },
+                }
+                candidate = _candidate_from_records(
+                    endpoint,
+                    card,
+                    (),
+                    (),
+                    registry.task_profiles,
+                )
+                self.assertFalse(candidate.automated_routing)
+                self.assertEqual(candidate.routing_status, status)
+
+    def test_loader_rejects_unknown_model_card_and_endpoint_profile_fields(
+        self,
+    ) -> None:
+        """Schema drift cannot silently create an unreviewed authority field."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            endpoint_path, endpoint = self._endpoint_document(root)
+            endpoint["unreviewed_authority"] = "allow"
+            endpoint_path.write_text(json.dumps(endpoint), encoding="utf-8")
+            card_path = sorted(
+                (root / "infra" / "conductor" / "model_cards").glob("*.json")
+            )[0]
+            card = load_json(card_path)
+            card["unreviewed_authority"] = "allow"
+            card_path.write_text(json.dumps(card), encoding="utf-8")
+
+            with self.assertRaisesRegex(RegistryValidationError, "unexpected property"):
+                load_registry(root)
+
+    def test_loader_rejects_malformed_checked_in_schema(self) -> None:
+        """A malformed schema must not downgrade validation into an allow path."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            schema_path = root / "infra" / "conductor" / "endpoint_profile.schema.json"
+            schema = load_json(schema_path)
+            schema["properties"]["auth_surface"] = {"type": "not-a-json-type"}
+            schema_path.write_text(json.dumps(schema), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RegistryValidationError, "unsupported JSON Schema type"
+            ):
+                load_registry(root)
+
+    def test_loader_rejects_index_that_is_not_the_exact_generated_projection(
+        self,
+    ) -> None:
+        """Counts and identifiers alone cannot prove the generated index is current."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._clone_registry(directory)
+            index_path = root / "infra" / "conductor" / "model_capability_index.v1.json"
+            index = load_json(index_path)
+            index["endpoints"][0]["machine_allowlist"] = ["mini-pro2"]
+            index_path.write_text(json.dumps(index), encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                RegistryValidationError, "deterministic projection"
+            ):
+                load_registry(root)
+
+    def test_static_json_is_parseable(self) -> None:
+        json_paths = (
+            sorted(MIR.glob("*.json"))
+            + sorted(CARD_DIR.glob("*.json"))
+            + sorted(ENDPOINT_DIR.glob("*.json"))
+        )
+        self.assertGreater(len(json_paths), 0)
+        for path in json_paths:
+            with self.subTest(path=path.relative_to(ROOT)):
+                load_json(path)
+
+    def test_cards_have_evidenced_claims_and_unique_ids(self) -> None:
+        cards = [load_json(path) for path in sorted(CARD_DIR.glob("*.json"))]
+        self.assertEqual(len(cards), 80)
+        ids = [card["id"] for card in cards]
+        self.assertEqual(len(ids), len(set(ids)))
+        aliases = [alias for card in cards for alias in card["identity"]["aliases"]]
+        self.assertEqual(
+            len(aliases),
+            len(set(aliases)),
+            "a concrete model alias must identify exactly one ModelCard",
+        )
+        for card in cards:
+            with self.subTest(card=card["id"]):
+                self.assertEqual(card["schema_version"], "model-card.v1")
+                self.assertIn(card["routing"]["status"], STATUSES)
+                self.assertFalse(
+                    card["routing"]["automated_routing"],
+                    "ModelCard is abstract; only EndpointProfile can authorize invocation",
+                )
+                assert_evidence(self, card["evidence"], card["id"])
+                assert_evidence(
+                    self, card["identity"]["evidence"], card["id"] + ".identity"
+                )
+                assert_evidence(
+                    self, card["routing"]["evidence"], card["id"] + ".routing"
+                )
+                for modality in card["modalities"]:
+                    assert_evidence(
+                        self, modality["evidence"], card["id"] + ".modalities"
+                    )
+                modality_ids = [modality["id"] for modality in card["modalities"]]
+                self.assertEqual(
+                    len(modality_ids),
+                    len(set(modality_ids)),
+                    card["id"] + ".modalities",
+                )
+                for limit_name, limit in card["limits"].items():
+                    assert_evidence(
+                        self, limit["evidence"], f"{card['id']}.limits.{limit_name}"
+                    )
+                    self.assertTrue(
+                        limit_value_is_evidenced(limit),
+                        f"{card['id']}.limits.{limit_name}: numeric limits require declared evidence; "
+                        "unmeasured limits must remain null",
+                    )
+                for constraint in card.get("constraints", []):
+                    assert_evidence(
+                        self, constraint["evidence"], card["id"] + ".constraints"
+                    )
+                self.assertEqual(card["task_scores"], [])
+
+    def test_cards_and_endpoints_conform_to_checked_in_schemas(self) -> None:
+        model_schema = load_json(MIR / "model_card.schema.json")
+        endpoint_schema = load_json(MIR / "endpoint_profile.schema.json")
+        for path in sorted(CARD_DIR.glob("*.json")):
+            with self.subTest(path=path.relative_to(ROOT)):
+                assert_matches_mir_schema(
+                    self, load_json(path), model_schema, model_schema, path.stem
+                )
+        for path in sorted(ENDPOINT_DIR.glob("*.json")):
+            with self.subTest(path=path.relative_to(ROOT)):
+                assert_matches_mir_schema(
+                    self, load_json(path), endpoint_schema, endpoint_schema, path.stem
+                )
+
+    def test_evidence_and_routing_vocabularies_are_contract_consistent(self) -> None:
+        """Schemas, ontology, and typed registry vocabulary cannot silently drift."""
+        ontology = load_json(MIR / "capability_ontology.v1.json")
+        ontology_evidence = {item["id"] for item in ontology["evidence_levels"]}
+        ontology_routing = {item["id"] for item in ontology["routing_statuses"]}
+        self.assertEqual(ontology_evidence, EVIDENCE_LEVELS)
+        self.assertEqual(ontology_routing, STATUSES)
+        for schema_name in (
+            "model_card.schema.json",
+            "endpoint_profile.schema.json",
+            "task_profile.schema.json",
+        ):
+            schema = load_json(MIR / schema_name)
+            with self.subTest(schema=schema_name):
+                self.assertEqual(
+                    set(schema["$defs"]["evidence"]["properties"]["level"]["enum"]),
+                    EVIDENCE_LEVELS,
+                )
+        for schema_name in ("model_card.schema.json", "endpoint_profile.schema.json"):
+            schema = load_json(MIR / schema_name)
+            with self.subTest(schema=schema_name):
+                self.assertEqual(
+                    set(
+                        schema["properties"]["routing"]["properties"]["status"]["enum"]
+                    ),
+                    STATUSES,
+                )
+
+    def test_limit_rule_rejects_unsupported_numbers(self) -> None:
+        unsupported_numeric_limit = {
+            "value": 1,
+            "evidence": [
+                {
+                    "level": "unmeasured",
+                    "ref": "inventory",
+                    "observed_at": "2026-08-21",
+                }
+            ],
+        }
+        supported_numeric_limit = {
+            "value": 1,
+            "evidence": [
+                {
+                    "level": "declared",
+                    "ref": "https://example.com/model",
+                    "observed_at": "2026-08-21",
+                }
+            ],
+        }
+        unknown_limit = {
+            "value": None,
+            "evidence": [
+                {
+                    "level": "unmeasured",
+                    "ref": "inventory",
+                    "observed_at": "2026-08-21",
+                }
+            ],
+        }
+
+        self.assertFalse(limit_value_is_evidenced(unsupported_numeric_limit))
+        self.assertTrue(limit_value_is_evidenced(supported_numeric_limit))
+        self.assertTrue(limit_value_is_evidenced(unknown_limit))
+
+    def test_public_evidence_is_declared_and_urls_are_valid(self) -> None:
+        registry_paths = sorted(CARD_DIR.glob("*.json")) + sorted(
+            ENDPOINT_DIR.glob("*.json")
+        )
+        for path in registry_paths:
+            for item in iter_evidence(load_json(path)):
+                for raw_url in PUBLIC_URL_PATTERN.findall(item["ref"]):
+                    with self.subTest(path=path.relative_to(ROOT), url=raw_url):
+                        parsed = urlparse(raw_url)
+                        self.assertIn(parsed.scheme, {"http", "https"})
+                        self.assertTrue(parsed.netloc)
+                        self.assertEqual(
+                            item["level"],
+                            "declared",
+                            "public documentation is a declaration, not an availability, auth, or quality probe",
+                        )
+
+    def test_endpoint_profiles_are_unique_and_conservatively_routable(self) -> None:
+        cards = {
+            card["id"]: card
+            for card in (load_json(path) for path in sorted(CARD_DIR.glob("*.json")))
+        }
+        endpoints = [load_json(path) for path in sorted(ENDPOINT_DIR.glob("*.json"))]
+        endpoint_ids = [endpoint["id"] for endpoint in endpoints]
+        self.assertEqual(len(endpoint_ids), len(set(endpoint_ids)))
+        invocation_keys = [
+            (
+                endpoint["invocation"]["engine"],
+                endpoint["invocation"]["model_identifier"],
+            )
+            for endpoint in endpoints
+        ]
+        self.assertEqual(
+            len(invocation_keys),
+            len(set(invocation_keys)),
+            "a concrete provider invocation must identify exactly one EndpointProfile",
+        )
+        self.assertGreaterEqual(len(endpoints), len(cards))
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint["id"]):
+                self.assertEqual(endpoint["schema_version"], "endpoint-profile.v1")
+                self.assertIn(endpoint["model_card_id"], cards)
+                self.assertIn(endpoint["auth_surface"], AUTH_SURFACE_COUNTS)
+                self.assertIn(endpoint["routing"]["status"], STATUSES)
+                if endpoint["routing"]["automated_routing"]:
+                    self.assertEqual(endpoint["routing"]["status"], "eligible")
+                assert_evidence(self, endpoint["evidence"], endpoint["id"])
+                assert_evidence(
+                    self,
+                    endpoint["invocation"]["evidence"],
+                    endpoint["id"] + ".invocation",
+                )
+                assert_evidence(
+                    self,
+                    endpoint["account_class"]["evidence"],
+                    endpoint["id"] + ".account_class",
+                )
+                assert_evidence(
+                    self,
+                    endpoint["machine_constraints"]["evidence"],
+                    endpoint["id"] + ".machines",
+                )
+                self.assertTrue(endpoint["machine_constraints"]["allowlist"])
+                capability_ids = [
+                    capability["id"] for capability in endpoint["exposed_capabilities"]
+                ]
+                self.assertEqual(
+                    len(capability_ids),
+                    len(set(capability_ids)),
+                    endpoint["id"] + ".exposed_capabilities",
+                )
+
+    def test_auth_surface_migration_has_conservative_complete_counts(self) -> None:
+        """Every concrete endpoint states an authority; unverified providers stay denied."""
+        endpoints = [load_json(path) for path in sorted(ENDPOINT_DIR.glob("*.json"))]
+        counts = Counter(endpoint["auth_surface"] for endpoint in endpoints)
+
+        self.assertEqual(dict(sorted(counts.items())), AUTH_SURFACE_COUNTS)
+        self.assertEqual(sum(counts.values()), 81)
+        self.assertNotIn("anthropic_paid_api", counts)
+
+    def test_index_is_a_complete_normalized_projection(self) -> None:
+        cards = [load_json(path) for path in sorted(CARD_DIR.glob("*.json"))]
+        endpoints = [load_json(path) for path in sorted(ENDPOINT_DIR.glob("*.json"))]
+        index = load_json(MIR / "model_capability_index.v1.json")
+        self.assertEqual(index["schema_version"], "model-capability-index.v1")
+        self.assertEqual(index["model_count"], len(cards))
+        self.assertEqual(index["endpoint_count"], len(endpoints))
+        self.assertEqual(
+            {item["model_card_id"] for item in index["models"]},
+            {card["id"] for card in cards},
+        )
+        self.assertEqual(
+            {item["endpoint_id"] for item in index["endpoints"]},
+            {endpoint["id"] for endpoint in endpoints},
+        )
+        self.assertEqual(
+            len(index["endpoints"]),
+            len({item["endpoint_id"] for item in index["endpoints"]}),
+        )
+        assert_evidence(self, index["generation"]["evidence"], "index.generation")
+        for item in index["models"] + index["endpoints"]:
+            assert_evidence(self, item["evidence"], "index item")
+
+    def test_projection_is_current_for_the_deterministic_generator(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "scripts/conductor/build_model_capability_index.py",
+                "--check",
+            ],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        prettier = subprocess.run(
+            [
+                "npx",
+                "--no-install",
+                "prettier",
+                "--check",
+                str(MIR / "model_capability_index.v1.json"),
+            ],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(prettier.returncode, 0, prettier.stdout + prettier.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Adds the read-only Model Intelligence Registry foundation: typed contracts, strict registry validation, deterministic capability-index projection, calibration aggregation, reviewed model/endpoint data, and focused tests. The foundation is intentionally non-operational: it introduces no live routing, provider calls, hook arming, deployment, or other production mutation.

## Verification

- Targeted local tests: **29/29 passed** (753 subtests).
- Deterministic capability index: `build_model_capability_index.py --check` passed.
- Ruff passed.
- Format check passed.
- `git diff --check` passed.
- A4 aggregate: **PASS** at implementation head `0260d47eb000d8139b555adccd2726e2e09eb831` after the focused resolution.
- Exact docs-only delta: **PASS** at current head `287edde738615781d10520022d18187278e40b64`.
- External review: zero unresolved P0/P1/P2 findings; the sole nonblocking P3 is the precision note `unknown_rank` versus `_unknown_rank()`.
- Successful Claude review cost total: **$0.2529752**.
- Current `adversarial-review-gate`: **PASS**.

No deploy.