### PR TITLE
fix(docs): #4558 contradicted itself about #4549, and #4557 gave the runbook two sections numbered 6quater

### DIFF
--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -260,7 +260,7 @@ merge commit; `gh pr update-branch` first, or use `mq requeue` / `queue_rearm.sh
 scoped exception, measured 2026-08-21:** when the red is an external commit status on an UNCHANGED
 head SHA (a Gear-3 gate verdict posted after the run finished) and the workflow checks out a pinned
 base SHA rather than a merge ref, `gh run rerun` on the original `pull_request` run is the only
-instrument that clears the rollup — see §6quater.
+instrument that clears the rollup — see §6quinquies.
 
 Test: `scripts/tests/test_pr_watch.sh` (fake `gh`, no network). `mq watch` is the post-arm drift
 guard for one PR against its armed SHA; `pr_watch.sh` is the terminal-state watcher for one or many
@@ -326,13 +326,13 @@ retried.**
   see §6ter, which is the shape that actually bit this repo on 2026-07-27/28.
 
 `gh run rerun <run_id> --failed` is the right gesture in the INFRA case and in the
-EXTERNAL-STATUS case (§6quater), and note the trap before using it: **`rerun` replays the OLD merge
+EXTERNAL-STATUS case (§6quinquies), and note the trap before using it: **`rerun` replays the OLD merge
 commit**, so on a branch that has since fallen behind it re-tests a stale base — `gh pr
 update-branch` first (`lesson_gh_run_rerun_replays_the_stale_merge_commit_2026_07_27`).
 
 ---
 
-## 6quater. The red is an external commit status, not the code
+## 6quinquies. The red is an external commit status, not the code
 
 A job that reads a commit status on the head SHA — the Gear-3 `harness/fable-gate` verdict is the
 one in this repo — fails identically whether the verdict is REWORK or simply **not posted yet**.

--- a/scripts/ci/harness_gate_read.py
+++ b/scripts/ci/harness_gate_read.py
@@ -42,7 +42,9 @@ case, because the obvious one does not work here.
 
 CORRECTED 2026-08-21: this docstring, and the PENDING message below, used to say
 `gh workflow run harness-floor.yml --ref <branch>` and forbid `gh run rerun` outright. That
-deadlocked two PRs (#4543, #4549). A `workflow_dispatch` run creates its check-run in a DIFFERENT
+deadlocked #4543. (#4549 hit the same PENDING red but was cured by a rerun without ever taking
+the dispatch path -- 9 `pull_request` runs on its branch, zero `workflow_dispatch`. It confirms the
+REMEDY a second time, not the deadlock.) A `workflow_dispatch` run creates its check-run in a DIFFERENT
 CHECK SUITE from the `pull_request` event's, and that check-run does not enter the PR's
 statusCheckRollup AT ALL — an ABSENT entry, not a superseded one. Measured on #4543: the rollup
 holds exactly ONE `Harness floor recompute` entry, pointing at the pull_request run; the dispatch
@@ -54,7 +56,7 @@ is a ref that resolves through a MOVING base): on the pull_request path this wor
 `github.event.pull_request.base.sha`, a pinned SHA, never `refs/pull/N/merge`. The
 `workflow_dispatch:` trigger remains for the case where there is no PR to unblock. Full procedure,
 including the escapes when no rerunnable run exists:
-docs/runbooks/merge-queue-discipline.md section 6quater; CLAUDE.md Agent PR Contract rule 3.
+docs/runbooks/merge-queue-discipline.md section 6quinquies; CLAUDE.md Agent PR Contract rule 3.
 
 EVENT-TO-SHA RESOLUTION:
   - pull_request  : the PR's real head sha is already directly on the event payload.
@@ -204,8 +206,8 @@ def decide(state: str | None) -> tuple[int, str]:
             "posts a verdict, re-trigger THIS run: `gh run rerun <this run id>`. Do NOT use "
             "`gh workflow run --ref` — a workflow_dispatch run lands its check-run in a different "
             "check suite and never enters the PR's rollup at all, so the PR stays BLOCKED "
-            "(measured on #4543 and #4549). Full procedure: "
-            "docs/runbooks/merge-queue-discipline.md section 6quater.",
+            "(measured on #4543). Full procedure: "
+            "docs/runbooks/merge-queue-discipline.md section 6quinquies.",
         )
     if state == "success":
         return 0, f"{CONTEXT} verdict = success"


### PR DESCRIPTION
Two defects landed in the last two PRs of this lane. Both were found by an independent gate reviewing a *sibling* PR — neither PR's own review caught them.

## 1. #4558 cited #4549 as a second deadlock, in the same diff that corrected the claim

| where | said |
|---|---|
| `harness_gate_read.py` docstring | "deadlocked two PRs (#4543, #4549)" |
| the PENDING annotation | "(measured on #4543 and #4549)" |
| **its own runbook hunk, same diff** | "#4549 … is a second confirmation of the REMEDY, not of the deadlock" |

Measured: #4549 has **9 `pull_request` runs** on its branch and **ZERO `workflow_dispatch`**. It hit the same PENDING red but was cured by a rerun without ever taking the dispatch path.

Writing the correction into one hunk and leaving the error in two others — in a commit whose whole subject was that a claim has to be gone from *every* artifact — is the defect this lane keeps producing.

## 2. #4557 numbered its new runbook section `6quater`, which was already taken

`## 6quater. Dependabot: PRs that share a lock file must be armed ONE AT A TIME` has existed since #3381. My new section took the same number, so the runbook shipped with **two `## 6quater` headings** and every `§6quater` citation became ambiguous — including the two in the CI failure annotation, which is the one text a blocked session is *guaranteed* to read.

The newer section is renumbered to **`6quinquies`**; all four pointers follow it. The pre-existing section keeps its number.

## Verification

- `pytest scripts/tests/test_harness_gate_read.py` → **39 passed**
- Mutation: reinstating the old prescription still fails exactly `test_pending_message_prescribes_rerun_and_only_forbids_workflow_dispatch`; restored → 39 green
- `prettier --check` clean
- Exactly one `## 6quater` heading remains

## Known stale cross-reference, deliberately not fixed here

#4548's `evidence/brief.yml` cites `§6quater` for the external-status procedure, and was already frozen in the merge queue when this renumber was made. It is an evidence artifact recording what was true when written, not doctrine a session follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)