### PR TITLE
feat(conductor): add static host seat truth

### DIFF
--- a/infra/conductor/host_seat_map.schema.json
+++ b/infra/conductor/host_seat_map.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nuzantara.local/schemas/conductor-host-seat-map.v1.json",
+  "title": "Universal Conductor non-secret host seat map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "manifest_id",
+    "machine",
+    "as_of",
+    "classification",
+    "scope",
+    "providers",
+    "operator_actions"
+  ],
+  "properties": {
+    "schema_version": { "const": "conductor-host-seat-map.v1" },
+    "manifest_id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+    "machine": { "enum": ["Pro", "Mini", "Air-M5"] },
+    "as_of": { "type": "string", "format": "date" },
+    "classification": { "const": "non-secret-static-discovery-only" },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model_endpoints", "account_seats", "runtime_auth"],
+      "properties": {
+        "model_endpoints": { "const": "owned-by-model-intelligence-registry" },
+        "account_seats": { "const": "owned-by-this-host-manifest" },
+        "runtime_auth": { "const": "owned-by-fresh-runtime-proof" }
+      }
+    },
+    "providers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anthropic", "openai"],
+      "properties": {
+        "anthropic": { "$ref": "#/$defs/anthropic" },
+        "openai": { "$ref": "#/$defs/openai" }
+      }
+    },
+    "operator_actions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "seatStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "seat_id",
+        "local_binding",
+        "selector_state",
+        "runtime_auth",
+        "evidence"
+      ],
+      "properties": {
+        "seat_id": { "type": "string" },
+        "local_binding": { "enum": ["bound", "unbound", "unverified"] },
+        "selector_state": {
+          "enum": ["available", "unavailable", "unverified"]
+        },
+        "runtime_auth": { "const": "unverified" },
+        "evidence": { "enum": ["tracked-pro-seat-map", "no-host-evidence"] }
+      }
+    },
+    "anthropic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "binding_surface",
+        "canonical_roster",
+        "headless_oauth_surface",
+        "seats"
+      ],
+      "properties": {
+        "binding_surface": { "const": "claude-config-profile" },
+        "canonical_roster": {
+          "const": ["A1", "A2", "A3", "A4", "A5", "AZ"]
+        },
+        "headless_oauth_surface": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["relationship_to_profiles", "logical_seat_mapping"],
+          "properties": {
+            "relationship_to_profiles": { "const": "separate-surface" },
+            "logical_seat_mapping": { "const": "unverified" }
+          }
+        },
+        "seats": {
+          "type": "array",
+          "minItems": 6,
+          "maxItems": 6,
+          "prefixItems": [
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "A1" } } }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "A2" } } }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "A3" } } }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "A4" } } }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "A5" } } }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "AZ" } } }
+              ]
+            }
+          ],
+          "items": false
+        }
+      }
+    },
+    "openai": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "binding_surface",
+        "canonical_roster",
+        "o2_alias_policy",
+        "seats"
+      ],
+      "properties": {
+        "binding_surface": { "const": "codex-home" },
+        "canonical_roster": { "const": ["O1", "O2"] },
+        "o2_alias_policy": {
+          "const": "canonical-plus-compatibility-name-is-one-seat"
+        },
+        "seats": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "prefixItems": [
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "O1" } } }
+              ]
+            },
+            {
+              "allOf": [
+                { "$ref": "#/$defs/seatStatus" },
+                { "properties": { "seat_id": { "const": "O2" } } }
+              ]
+            }
+          ],
+          "items": false
+        }
+      }
+    }
+  }
+}

--- a/infra/conductor/seat_maps/README.md
+++ b/infra/conductor/seat_maps/README.md
@@ -1,0 +1,19 @@
+# Universal Conductor host seat maps
+
+These manifests are static, non-secret discovery inputs. They answer only:
+which opaque account seats are locally bound and visible to a selector on one
+specific machine?
+
+They do not select models. Model endpoint selection belongs to the Model
+Intelligence Registry. They also do not prove authentication: every committed
+`runtime_auth` value is deliberately `unverified`; authority comes from a
+fresh runtime receipt for the same host and seat.
+
+The Claude roster is exactly A1-A5+AZ. `CLAUDE_CONFIG_DIR` profiles and
+headless OAuth token slots are separate surfaces and have no inferred identity
+mapping. The Codex roster is exactly O1/O2; O2's canonical and compatibility
+names refer to one seat.
+
+No manifest may contain a local path, email/account identity, credential,
+provider output, or token value. Pro evidence never establishes Mini or Air-M5
+state.

--- a/infra/conductor/seat_maps/air-m5.v1.json
+++ b/infra/conductor/seat_maps/air-m5.v1.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "conductor-host-seat-map.v1",
+  "manifest_id": "air-m5-v1",
+  "machine": "Air-M5",
+  "as_of": "2026-08-22",
+  "classification": "non-secret-static-discovery-only",
+  "scope": {
+    "model_endpoints": "owned-by-model-intelligence-registry",
+    "account_seats": "owned-by-this-host-manifest",
+    "runtime_auth": "owned-by-fresh-runtime-proof"
+  },
+  "providers": {
+    "anthropic": {
+      "binding_surface": "claude-config-profile",
+      "canonical_roster": ["A1", "A2", "A3", "A4", "A5", "AZ"],
+      "headless_oauth_surface": {
+        "relationship_to_profiles": "separate-surface",
+        "logical_seat_mapping": "unverified"
+      },
+      "seats": [
+        {
+          "seat_id": "A1",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A2",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A3",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A4",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A5",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "AZ",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        }
+      ]
+    },
+    "openai": {
+      "binding_surface": "codex-home",
+      "canonical_roster": ["O1", "O2"],
+      "o2_alias_policy": "canonical-plus-compatibility-name-is-one-seat",
+      "seats": [
+        {
+          "seat_id": "O1",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "O2",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        }
+      ]
+    }
+  },
+  "operator_actions": [
+    "operator[profile_binding]: bind each intended Claude seat to an Air-M5-local profile",
+    "operator[interactive_login]: authenticate each intended Claude seat on Air-M5 and capture a fresh seat-specific proof",
+    "operator[profile_binding]: normalize Air-M5 O1 and O2 without treating the O2 compatibility name as another seat",
+    "operator[interactive_login]: authenticate Air-M5 O1 and O2 separately and capture fresh seat-specific proofs"
+  ]
+}

--- a/infra/conductor/seat_maps/mini.v1.json
+++ b/infra/conductor/seat_maps/mini.v1.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "conductor-host-seat-map.v1",
+  "manifest_id": "mini-v1",
+  "machine": "Mini",
+  "as_of": "2026-08-22",
+  "classification": "non-secret-static-discovery-only",
+  "scope": {
+    "model_endpoints": "owned-by-model-intelligence-registry",
+    "account_seats": "owned-by-this-host-manifest",
+    "runtime_auth": "owned-by-fresh-runtime-proof"
+  },
+  "providers": {
+    "anthropic": {
+      "binding_surface": "claude-config-profile",
+      "canonical_roster": ["A1", "A2", "A3", "A4", "A5", "AZ"],
+      "headless_oauth_surface": {
+        "relationship_to_profiles": "separate-surface",
+        "logical_seat_mapping": "unverified"
+      },
+      "seats": [
+        {
+          "seat_id": "A1",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A2",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A3",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A4",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "A5",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "AZ",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        }
+      ]
+    },
+    "openai": {
+      "binding_surface": "codex-home",
+      "canonical_roster": ["O1", "O2"],
+      "o2_alias_policy": "canonical-plus-compatibility-name-is-one-seat",
+      "seats": [
+        {
+          "seat_id": "O1",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "O2",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        }
+      ]
+    }
+  },
+  "operator_actions": [
+    "operator[profile_binding]: bind each intended Claude seat to a Mini-local profile",
+    "operator[interactive_login]: authenticate each intended Claude seat on Mini and capture a fresh seat-specific proof",
+    "operator[profile_binding]: normalize Mini O1 and O2 without treating the O2 compatibility name as another seat",
+    "operator[interactive_login]: authenticate Mini O1 and O2 separately and capture fresh seat-specific proofs"
+  ]
+}

--- a/infra/conductor/seat_maps/pro.v1.json
+++ b/infra/conductor/seat_maps/pro.v1.json
@@ -1,0 +1,92 @@
+{
+  "schema_version": "conductor-host-seat-map.v1",
+  "manifest_id": "pro-v1",
+  "machine": "Pro",
+  "as_of": "2026-08-22",
+  "classification": "non-secret-static-discovery-only",
+  "scope": {
+    "model_endpoints": "owned-by-model-intelligence-registry",
+    "account_seats": "owned-by-this-host-manifest",
+    "runtime_auth": "owned-by-fresh-runtime-proof"
+  },
+  "providers": {
+    "anthropic": {
+      "binding_surface": "claude-config-profile",
+      "canonical_roster": ["A1", "A2", "A3", "A4", "A5", "AZ"],
+      "headless_oauth_surface": {
+        "relationship_to_profiles": "separate-surface",
+        "logical_seat_mapping": "unverified"
+      },
+      "seats": [
+        {
+          "seat_id": "A1",
+          "local_binding": "bound",
+          "selector_state": "available",
+          "runtime_auth": "unverified",
+          "evidence": "tracked-pro-seat-map"
+        },
+        {
+          "seat_id": "A2",
+          "local_binding": "bound",
+          "selector_state": "available",
+          "runtime_auth": "unverified",
+          "evidence": "tracked-pro-seat-map"
+        },
+        {
+          "seat_id": "A3",
+          "local_binding": "bound",
+          "selector_state": "available",
+          "runtime_auth": "unverified",
+          "evidence": "tracked-pro-seat-map"
+        },
+        {
+          "seat_id": "A4",
+          "local_binding": "unbound",
+          "selector_state": "unavailable",
+          "runtime_auth": "unverified",
+          "evidence": "tracked-pro-seat-map"
+        },
+        {
+          "seat_id": "A5",
+          "local_binding": "unbound",
+          "selector_state": "unavailable",
+          "runtime_auth": "unverified",
+          "evidence": "tracked-pro-seat-map"
+        },
+        {
+          "seat_id": "AZ",
+          "local_binding": "bound",
+          "selector_state": "available",
+          "runtime_auth": "unverified",
+          "evidence": "tracked-pro-seat-map"
+        }
+      ]
+    },
+    "openai": {
+      "binding_surface": "codex-home",
+      "canonical_roster": ["O1", "O2"],
+      "o2_alias_policy": "canonical-plus-compatibility-name-is-one-seat",
+      "seats": [
+        {
+          "seat_id": "O1",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        },
+        {
+          "seat_id": "O2",
+          "local_binding": "unverified",
+          "selector_state": "unverified",
+          "runtime_auth": "unverified",
+          "evidence": "no-host-evidence"
+        }
+      ]
+    }
+  },
+  "operator_actions": [
+    "operator[profile_binding]: bind A4 and A5 locally before making either selector-visible",
+    "operator[interactive_login]: produce a fresh host-local auth proof for every Claude or Codex seat before execution",
+    "operator[profile_binding]: normalize O2 canonical and compatibility names without counting a third seat"
+  ]
+}

--- a/scripts/conductor/host_identity.py
+++ b/scripts/conductor/host_identity.py
@@ -1,0 +1,100 @@
+"""Immutable, OS-derived identity for the local Conductor executor.
+
+Dispatch payloads and environment variables are claims, not host evidence. The
+only production observation exposed here comes from the kernel's effective UID
+and the hostname returned by the local socket API.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import socket
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+
+class HostIdentityError(RuntimeError):
+    """The current process cannot be bound to one known fleet host."""
+
+
+@dataclass(frozen=True, slots=True)
+class HostIdentity:
+    """A locally observed fleet identity which cannot be mutated by callers."""
+
+    machine: str
+    hostname: str
+    username: str
+    effective_uid: int = -1
+
+    @property
+    def fleet_label(self) -> str:
+        """Return the control-plane display label without changing runtime IDs."""
+
+        try:
+            return {
+                "pro": "Pro",
+                "mini-pro2": "Mini-Pro2",
+                "air-m5": "Air-M5",
+            }[self.machine]
+        except KeyError as error:
+            raise HostIdentityError("local machine id is not canonical") from error
+
+
+_FLEET_HOSTS: Mapping[str, tuple[str, str]] = MappingProxyType(
+    {
+        "nuzantara": ("pro", "nuzantara"),
+        "mini-pro2": ("mini-pro2", "nuzantara"),
+        "air-m5": ("air-m5", "balizero"),
+    }
+)
+
+
+def canonical_hostname(raw: str) -> str:
+    """Canonicalize the directly observed hostname without accepting aliases."""
+
+    if not isinstance(raw, str) or "\x00" in raw:
+        raise HostIdentityError("local hostname is invalid")
+    hostname = raw.strip().lower()
+    if hostname.endswith(".local"):
+        hostname = hostname[: -len(".local")]
+    if not hostname:
+        raise HostIdentityError("local hostname is invalid")
+    return hostname
+
+
+def observe_local_host() -> HostIdentity:
+    """Return one fresh kernel/account-database observation of the local host.
+
+    ``USER``, ``LOGNAME``, ``HOME`` and any dispatch-supplied machine name are
+    deliberately ignored. A renamed host or mismatched effective account is an
+    abstention condition, never an invitation to infer the machine remotely.
+    """
+
+    hostname = canonical_hostname(socket.gethostname())
+    expected = _FLEET_HOSTS.get(hostname)
+    if expected is None:
+        raise HostIdentityError("local host is outside the attested fleet")
+    effective_uid = os.geteuid()
+    try:
+        username = pwd.getpwuid(effective_uid).pw_name
+    except (KeyError, OSError) as error:
+        raise HostIdentityError("effective user cannot be resolved") from error
+    machine, expected_username = expected
+    if username != expected_username:
+        raise HostIdentityError("local hostname and effective user disagree")
+    return HostIdentity(
+        machine=machine,
+        hostname=hostname,
+        username=username,
+        effective_uid=effective_uid,
+    )
+
+
+__all__ = [
+    "HostIdentity",
+    "HostIdentityError",
+    "canonical_hostname",
+    "observe_local_host",
+]

--- a/scripts/tests/test_conductor_host_identity.py
+++ b/scripts/tests/test_conductor_host_identity.py
@@ -1,0 +1,101 @@
+"""OS-derived local Conductor host identity tests."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts.conductor.host_identity import (
+    HostIdentityError,
+    canonical_hostname,
+    observe_local_host,
+)
+
+
+class ConductorHostIdentityTest(unittest.TestCase):
+    def test_effective_uid_and_socket_hostname_ignore_spoofed_environment(self) -> None:
+        spoofed = {
+            "USER": "balizero",
+            "LOGNAME": "attacker",
+            "HOSTNAME": "Mini-Pro2",
+            "HOME": "/tmp/spoofed-home",
+        }
+        with (
+            patch.dict(os.environ, spoofed, clear=False),
+            patch(
+                "scripts.conductor.host_identity.socket.gethostname",
+                return_value="Nuzantara.local",
+            ),
+            patch("scripts.conductor.host_identity.os.geteuid", return_value=501),
+            patch(
+                "scripts.conductor.host_identity.pwd.getpwuid",
+                return_value=SimpleNamespace(pw_name="nuzantara"),
+            ) as account_lookup,
+        ):
+            identity = observe_local_host()
+
+        account_lookup.assert_called_once_with(501)
+        self.assertEqual(identity.machine, "pro")
+        self.assertEqual(identity.fleet_label, "Pro")
+        self.assertEqual(identity.hostname, "nuzantara")
+        self.assertEqual(identity.username, "nuzantara")
+        self.assertEqual(identity.effective_uid, 501)
+
+    def test_fleet_labels_preserve_runtime_machine_ids(self) -> None:
+        observations = (
+            ("Nuzantara", "nuzantara", "pro", "Pro"),
+            ("Mini-Pro2.local", "nuzantara", "mini-pro2", "Mini-Pro2"),
+            ("Air-M5", "balizero", "air-m5", "Air-M5"),
+        )
+        for hostname, username, machine, label in observations:
+            with (
+                self.subTest(hostname=hostname),
+                patch(
+                    "scripts.conductor.host_identity.socket.gethostname",
+                    return_value=hostname,
+                ),
+                patch("scripts.conductor.host_identity.os.geteuid", return_value=502),
+                patch(
+                    "scripts.conductor.host_identity.pwd.getpwuid",
+                    return_value=SimpleNamespace(pw_name=username),
+                ),
+            ):
+                identity = observe_local_host()
+                self.assertEqual(identity.machine, machine)
+                self.assertEqual(identity.fleet_label, label)
+
+    def test_unknown_host_and_effective_user_mismatch_fail_closed(self) -> None:
+        with (
+            patch(
+                "scripts.conductor.host_identity.socket.gethostname",
+                return_value="remote-claim",
+            ),
+            self.assertRaisesRegex(HostIdentityError, "outside the attested fleet"),
+        ):
+            observe_local_host()
+
+        with (
+            patch(
+                "scripts.conductor.host_identity.socket.gethostname",
+                return_value="Air-M5",
+            ),
+            patch("scripts.conductor.host_identity.os.geteuid", return_value=503),
+            patch(
+                "scripts.conductor.host_identity.pwd.getpwuid",
+                return_value=SimpleNamespace(pw_name="nuzantara"),
+            ),
+            self.assertRaisesRegex(HostIdentityError, "effective user disagree"),
+        ):
+            observe_local_host()
+
+    def test_canonical_hostname_rejects_invalid_observations(self) -> None:
+        self.assertEqual(canonical_hostname(" Mini-Pro2.local "), "mini-pro2")
+        for invalid in ("", "   ", "Air-M5\x00.local"):
+            with self.subTest(invalid=invalid), self.assertRaises(HostIdentityError):
+                canonical_hostname(invalid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_conductor_host_seat_maps.py
+++ b/scripts/tests/test_conductor_host_seat_maps.py
@@ -1,0 +1,153 @@
+"""Drift and disclosure gates for static Universal Conductor host seat maps."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+REPO = Path(__file__).resolve().parents[2]
+FLEET = REPO / "FLEET_TOPOLOGY.json"
+SCHEMA = REPO / "infra" / "conductor" / "host_seat_map.schema.json"
+MAP_DIR = REPO / "infra" / "conductor" / "seat_maps"
+MAPS = {
+    "Pro": MAP_DIR / "pro.v1.json",
+    "Mini": MAP_DIR / "mini.v1.json",
+    "Air-M5": MAP_DIR / "air-m5.v1.json",
+}
+CLAUDE_ROSTER = ["A1", "A2", "A3", "A4", "A5", "AZ"]
+CODEX_ROSTER = ["O1", "O2"]
+
+
+def _read(path: Path) -> dict[str, Any]:
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def _seat_statuses(
+    manifest: dict[str, Any], provider: str
+) -> dict[str, dict[str, str]]:
+    return {seat["seat_id"]: seat for seat in manifest["providers"][provider]["seats"]}
+
+
+def test_every_host_map_validates_against_the_committed_schema() -> None:
+    schema = _read(SCHEMA)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+
+    for machine, path in MAPS.items():
+        manifest = _read(path)
+        errors = sorted(
+            validator.iter_errors(manifest), key=lambda item: list(item.path)
+        )
+        assert not errors, (machine, [error.message for error in errors])
+        assert manifest["machine"] == machine
+
+
+def test_fleet_and_all_host_maps_share_one_exact_opaque_roster() -> None:
+    fleet = _read(FLEET)
+    assert list(fleet["accounts"]["anthropic"]["slots"]) == CLAUDE_ROSTER
+    assert list(fleet["accounts"]["openai"]["slots"]) == CODEX_ROSTER
+
+    for path in MAPS.values():
+        manifest = _read(path)
+        assert manifest["providers"]["anthropic"]["canonical_roster"] == CLAUDE_ROSTER
+        assert manifest["providers"]["openai"]["canonical_roster"] == CODEX_ROSTER
+
+
+def test_pro_records_only_verified_static_selector_state() -> None:
+    pro = _read(MAPS["Pro"])
+    claude = _seat_statuses(pro, "anthropic")
+
+    assert {
+        seat
+        for seat, status in claude.items()
+        if status["selector_state"] == "available"
+    } == {"A1", "A2", "A3", "AZ"}
+    assert {
+        seat for seat, status in claude.items() if status["local_binding"] == "unbound"
+    } == {"A4", "A5"}
+    assert all(status["runtime_auth"] == "unverified" for status in claude.values())
+    assert all(
+        status["selector_state"] == "unverified"
+        for status in _seat_statuses(pro, "openai").values()
+    )
+
+
+def test_mini_and_air_never_inherit_or_infer_pro_bindings() -> None:
+    for machine in ("Mini", "Air-M5"):
+        manifest = _read(MAPS[machine])
+        for provider in ("anthropic", "openai"):
+            for status in _seat_statuses(manifest, provider).values():
+                assert status == {
+                    "seat_id": status["seat_id"],
+                    "local_binding": "unverified",
+                    "selector_state": "unverified",
+                    "runtime_auth": "unverified",
+                    "evidence": "no-host-evidence",
+                }
+
+
+def test_static_maps_cannot_claim_runtime_auth_or_embed_sensitive_locator_data() -> (
+    None
+):
+    forbidden_keys = {
+        "email",
+        "account_identity",
+        "token_value",
+        "secret",
+        "path",
+        "profile_dir",
+        "codex_home",
+    }
+    credential_shape = re.compile(
+        r"(?:sk-|bearer\s+|oauth[_-]?token|refresh[_-]?token)", re.IGNORECASE
+    )
+    local_path_shape = re.compile(r"(?:/Users/|/home/|[A-Za-z]:\\\\|~/)")
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            assert forbidden_keys.isdisjoint(value)
+            for nested in value.values():
+                walk(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                walk(nested)
+        elif isinstance(value, str):
+            assert "@" not in value
+            assert not credential_shape.search(value)
+            assert not local_path_shape.search(value)
+
+    for path in MAPS.values():
+        manifest = _read(path)
+        walk(manifest)
+        serialized = json.dumps(manifest, sort_keys=True)
+        assert "endpoint_id" not in serialized
+        assert "model_id" not in serialized
+        assert all(
+            status["runtime_auth"] == "unverified"
+            for provider in ("anthropic", "openai")
+            for status in _seat_statuses(manifest, provider).values()
+        )
+
+
+def test_o2_alias_policy_never_creates_a_third_codex_seat() -> None:
+    for path in MAPS.values():
+        openai = _read(path)["providers"]["openai"]
+        assert openai["canonical_roster"] == ["O1", "O2"]
+        assert [seat["seat_id"] for seat in openai["seats"]] == ["O1", "O2"]
+        assert (
+            openai["o2_alias_policy"] == "canonical-plus-compatibility-name-is-one-seat"
+        )
+
+
+def test_claude_profiles_and_headless_oauth_slots_stay_unmapped() -> None:
+    for path in MAPS.values():
+        surface = _read(path)["providers"]["anthropic"]["headless_oauth_surface"]
+        assert surface == {
+            "relationship_to_profiles": "separate-surface",
+            "logical_seat_mapping": "unverified",
+        }


### PR DESCRIPTION
## Scope

Adds static, non-secret Host Seat Truth for Pro, Mini, and Air-M5: a strict JSON schema, per-host opaque seat maps, fail-closed OS-derived host identity, and drift/privacy tests. The maps deliberately do not select models or prove runtime authentication; every committed runtime auth value remains `unverified`, and `FLEET_TOPOLOGY.json` is unchanged.

## Verification

- Targeted tests: **11 passed, 6 subtests passed**.
- Ruff check and format check passed.
- Python 3.11 py_compile passed.
- JSON/schema validation, including negative cases, passed.
- Prettier and `git diff --check` passed.
- Worktree clean; exact head `a94d9ebc42cbfb83345193e12a8941b7359bbba5`.
- External Claude A4 exact-head gate: **PASS**, zero P0/P1/P2 and no unresolved findings. Claude Code 2.1.237, first-party OAuth A4 selector, paid API environment removed, one synchronous Sonnet-low turn with tools disabled. Packet: 33,245 bytes, SHA-256 `a9c513c4d542da576804e5843c07f6f44a886af48e159947030960e5b2988d5f`; successful cost `$0.563805`.
- Nonblocking P3 notes: `host_identity.py` canonicalizes only the `.local` suffix; the static manifests are intentionally not wired into runtime selection in this tranche.

No provider calls, secrets, installs, runtime/router/profile/config mutation, deployment, or external publication beyond this PR.