### PR TITLE
fix(docs): fixing the 6quater collision created a 6quinquies collision — and now a guard

### DIFF
--- a/docs/runbooks/merge-queue-discipline.md
+++ b/docs/runbooks/merge-queue-discipline.md
@@ -260,7 +260,7 @@ merge commit; `gh pr update-branch` first, or use `mq requeue` / `queue_rearm.sh
 scoped exception, measured 2026-08-21:** when the red is an external commit status on an UNCHANGED
 head SHA (a Gear-3 gate verdict posted after the run finished) and the workflow checks out a pinned
 base SHA rather than a merge ref, `gh run rerun` on the original `pull_request` run is the only
-instrument that clears the rollup — see §6quinquies.
+instrument that clears the rollup — see §6septies.
 
 Test: `scripts/tests/test_pr_watch.sh` (fake `gh`, no network). `mq watch` is the post-arm drift
 guard for one PR against its armed SHA; `pr_watch.sh` is the terminal-state watcher for one or many
@@ -326,135 +326,9 @@ retried.**
   see §6ter, which is the shape that actually bit this repo on 2026-07-27/28.
 
 `gh run rerun <run_id> --failed` is the right gesture in the INFRA case and in the
-EXTERNAL-STATUS case (§6quinquies), and note the trap before using it: **`rerun` replays the OLD merge
+EXTERNAL-STATUS case (§6septies), and note the trap before using it: **`rerun` replays the OLD merge
 commit**, so on a branch that has since fallen behind it re-tests a stale base — `gh pr
 update-branch` first (`lesson_gh_run_rerun_replays_the_stale_merge_commit_2026_07_27`).
-
----
-
-## 6quinquies. The red is an external commit status, not the code
-
-A job that reads a commit status on the head SHA — the Gear-3 `harness/fable-gate` verdict is the
-one in this repo — fails identically whether the verdict is REWORK or simply **not posted yet**.
-Once the gate session posts it, the job has to run again, and the obvious gesture is the wrong one.
-
-**Do not use `gh workflow run --ref`.** A `workflow_dispatch` run creates its check-run in a
-DIFFERENT CHECK SUITE from the `pull_request` event's, and it does not enter the PR's
-`statusCheckRollup` **at all** — it is an absent entry, not a superseded one. Measured on #4543:
-the rollup holds exactly ONE `Harness floor recompute` entry and it points at the `pull_request`
-run; the dispatch run appears nowhere in it. So the dispatch goes green while the PR stays BLOCKED.
-This deadlocked #4543. (#4549 hit the same PENDING red but was cured by a rerun without ever taking the dispatch path — measured: 9 `pull_request` runs on its branch, **zero** `workflow_dispatch`. It is a second confirmation of the REMEDY, not of the deadlock.)
-
-**Use `gh run rerun <the original pull_request run id>`.** Find it with:
-
-```bash
-gh run list --branch <branch> --workflow <file>.yml --json databaseId,event,headSha,conclusion
-```
-
-and take the row whose `event` is `pull_request` and whose `headSha` is the PR's current head. Same
-SHA, same suite, verdict now posted — the rollup clears.
-
-**Why this does not repeal W111.** W111's hazard is a run whose ref RESOLVES THROUGH A MOVING BASE;
-its own incident was #3463 replayed against `refs/pull/3463/merge` — a pull-request merge ref, so
-"reruns are only dangerous on merge_group" is false. The exception here is not "pull_request reruns
-are safe"; it is that on the `pull_request` path _this_ workflow checks out
-`github.event.pull_request.base.sha` — a PINNED SHA — and never `refs/pull/N/merge`, so there is no
-moving ref for the rerun to resolve differently.
-
-Read the expression **per branch**, not as a whole. In full it is
-`github.event.merge_group.base_sha || github.event.pull_request.base.sha || 'main'`, and that third
-branch IS a moving ref — it is the one `workflow_dispatch` falls through to. So the expression as a
-whole is not "pinned"; only the branch a `pull_request` rerun takes is. **Before copying this to
-another workflow, read that workflow's `ref:` — and read the branch YOUR event takes.**
-
-And the honest limit: a rerun replays the ORIGINAL event payload, so the base checkout — and with
-it the versions of the helper scripts the job executes — stays frozen at PR-event time. A rerun
-will not pick up a base-side fix that landed on main since; only a new `pull_request` event will.
-Pinning makes the staleness deterministic; it does not make the rerun current.
-
-**Diagnostic trap.** While diagnosing, `gh pr checks` and `gh api …/check-runs` will appear to
-contradict each other. The cause is **pagination**, not the filter: the endpoint returns 30 rows by
-default and a PR head here carries ~55-63 check-runs. Measured on `76edf60e2` — no `per_page`:
-`returned=30 failures=0`; `filter=all` with no `per_page`: **still** `returned=30 failures=0`;
-`filter=all&per_page=100`: `returned=55 failures=1`. So `per_page=100` (or `--paginate`) is
-mandatory; `filter=all` alone reports zero failures on a head that has one. `filter=all` does a
-different job — it re-adds attempts superseded _within_ their own suite. Then compare
-`check_suite.id`, which is the field that actually explains the disagreement.
-
-**Do not classify by job name, and do not classify from a snapshot.** An empty `conclusion` is
-_"not yet known"_, never _"no failure"_ — #3326 was read while `in_progress`/`conclusion=∅` and
-filed as "ejected with ZERO failures"; at terminal state it was `failure`. Read the terminal state,
-and if it is not terminal yet, come back.
-
-Tooling, so the classification is not re-derived by hand each time:
-
-```bash
-scripts/ci/queue_rearm.sh              # dry-run: who is orphaned, and of which class
-scripts/ci/queue_rearm.sh --apply      # re-arm ONLY the INFRA/CANCELLED class
-```
-
-The verdict logic is a separate pure function (`scripts/ci/queue_rearm_classify.sh`) with a
-mutation-tested guilt+innocence corpus: unanimity (one non-infra failure forbids the retry even
-among nine infra ones), no concluding from an unfinished run, and an empty probe result fails
-closed rather than reading as clean.
-
-### Step 2b — After an ejection, the auto-merge request is GONE
-
-When a required check goes red the queue removes **that** pull request and recreates the temporary
-branches for the remaining entries without it (GitHub's documented behaviour — groupmates are
-_rebuilt_, not evicted; the collateral is wasted CI time). The ejected PR is left `OPEN` +
-`MERGEABLE` + `CLEAN` with `autoMergeRequest: null`, and **nothing puts it back**. Re-arm it.
-
-> **`autoMergeRequest: null` does not mean "not armed".** The queue _consumes_ the request when it
-> accepts the PR, so a healthy queued PR reads `null` too. The probe is the COMMAND, not the field:
-> `gh pr merge <N> --auto --squash` answering `already queued` means armed
-> (`lesson_automergerequest_goes_null_when_the_queue_accepts_the_pr_2026_07_27`). Reading the field
-> alone will have you "re-arming" PRs that are already in the queue, and calling the arm command as
-> a _measurement_ enqueues them — the probe changes the world.
-
-### Step 3 — Remove from queue if blocking other PRs
-
-```bash
-gh pr ready <N> --undo            # convert to draft → removed from queue
-# fix → push → gh pr ready <N>    # re-queue when green
-```
-
-#### Step 3b — When you need to PUSH to a queued branch (measured 2026-08-05)
-
-A queued branch is **protected**: every push is rejected with
-
-```
-remote: error: GH006: Protected branch update failed
-remote: - A pull request for this branch has been added to a merge queue.
-```
-
-This is the shape that bites: an adversarial review lands _after_ the PR was
-enqueued, finds a real defect, and the version already in the queue — the one
-with the defect — merges while you are still typing the fix. Dequeue first,
-push second, re-arm third.
-
-**`gh pr merge <N> --disable-auto` does NOT dequeue.** It prints
-`! Pull request ... is already queued to merge` and **exits 0** — a no-op that
-reads like a success. Verified live: the entry stayed at `pos=1`.
-
-The one that works:
-
-```bash
-PRID=$(gh pr view <N> --repo <owner/repo> --json id -q .id)
-gh api graphql -f query='mutation($id:ID!){ dequeuePullRequest(input:{id:$id}){ clientMutationId } }' -f id="$PRID"
-git push                                  # now accepted
-gh pr merge <N> --auto --repo <owner/repo>  # re-arm
-```
-
-The input field is **`id`**, not `pullRequestId` — the obvious guess returns
-`argumentNotAccepted`. Confirm with the queue itself, never with the exit code:
-
-```bash
-gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { mergeQueue(branch:"main") { entries(first:20){nodes{position state pullRequest{number}}} } } }' \
-  --jq '.data.repository.mergeQueue.entries.nodes[] | "pos=\(.position) \(.state) #\(.pullRequest.number)"'
-```
-
----
 
 ## 6bis. Queue parameters, and the one knob NOT to turn
 
@@ -635,6 +509,132 @@ branch (§Session discipline above: "post-arm commits remain orphaned") — `mq 
 ceiling with no verdict (an honest NO-VERDICT, never a fabricated "clean").
 
 Tests: `scripts/tests/test_mq_sh.sh` (fake `gh` on `PATH`, no network).
+
+---
+
+## 6septies. The red is an external commit status, not the code
+
+A job that reads a commit status on the head SHA — the Gear-3 `harness/fable-gate` verdict is the
+one in this repo — fails identically whether the verdict is REWORK or simply **not posted yet**.
+Once the gate session posts it, the job has to run again, and the obvious gesture is the wrong one.
+
+**Do not use `gh workflow run --ref`.** A `workflow_dispatch` run creates its check-run in a
+DIFFERENT CHECK SUITE from the `pull_request` event's, and it does not enter the PR's
+`statusCheckRollup` **at all** — it is an absent entry, not a superseded one. Measured on #4543:
+the rollup holds exactly ONE `Harness floor recompute` entry and it points at the `pull_request`
+run; the dispatch run appears nowhere in it. So the dispatch goes green while the PR stays BLOCKED.
+This deadlocked #4543. (#4549 hit the same PENDING red but was cured by a rerun without ever taking the dispatch path — measured: 9 `pull_request` runs on its branch, **zero** `workflow_dispatch`. It is a second confirmation of the REMEDY, not of the deadlock.)
+
+**Use `gh run rerun <the original pull_request run id>`.** Find it with:
+
+```bash
+gh run list --branch <branch> --workflow <file>.yml --json databaseId,event,headSha,conclusion
+```
+
+and take the row whose `event` is `pull_request` and whose `headSha` is the PR's current head. Same
+SHA, same suite, verdict now posted — the rollup clears.
+
+**Why this does not repeal W111.** W111's hazard is a run whose ref RESOLVES THROUGH A MOVING BASE;
+its own incident was #3463 replayed against `refs/pull/3463/merge` — a pull-request merge ref, so
+"reruns are only dangerous on merge_group" is false. The exception here is not "pull_request reruns
+are safe"; it is that on the `pull_request` path _this_ workflow checks out
+`github.event.pull_request.base.sha` — a PINNED SHA — and never `refs/pull/N/merge`, so there is no
+moving ref for the rerun to resolve differently.
+
+Read the expression **per branch**, not as a whole. In full it is
+`github.event.merge_group.base_sha || github.event.pull_request.base.sha || 'main'`, and that third
+branch IS a moving ref — it is the one `workflow_dispatch` falls through to. So the expression as a
+whole is not "pinned"; only the branch a `pull_request` rerun takes is. **Before copying this to
+another workflow, read that workflow's `ref:` — and read the branch YOUR event takes.**
+
+And the honest limit: a rerun replays the ORIGINAL event payload, so the base checkout — and with
+it the versions of the helper scripts the job executes — stays frozen at PR-event time. A rerun
+will not pick up a base-side fix that landed on main since; only a new `pull_request` event will.
+Pinning makes the staleness deterministic; it does not make the rerun current.
+
+**Diagnostic trap.** While diagnosing, `gh pr checks` and `gh api …/check-runs` will appear to
+contradict each other. The cause is **pagination**, not the filter: the endpoint returns 30 rows by
+default and a PR head here carries ~55-63 check-runs. Measured on `76edf60e2` — no `per_page`:
+`returned=30 failures=0`; `filter=all` with no `per_page`: **still** `returned=30 failures=0`;
+`filter=all&per_page=100`: `returned=55 failures=1`. So `per_page=100` (or `--paginate`) is
+mandatory; `filter=all` alone reports zero failures on a head that has one. `filter=all` does a
+different job — it re-adds attempts superseded _within_ their own suite. Then compare
+`check_suite.id`, which is the field that actually explains the disagreement.
+
+**Do not classify by job name, and do not classify from a snapshot.** An empty `conclusion` is
+_"not yet known"_, never _"no failure"_ — #3326 was read while `in_progress`/`conclusion=∅` and
+filed as "ejected with ZERO failures"; at terminal state it was `failure`. Read the terminal state,
+and if it is not terminal yet, come back.
+
+Tooling, so the classification is not re-derived by hand each time:
+
+```bash
+scripts/ci/queue_rearm.sh              # dry-run: who is orphaned, and of which class
+scripts/ci/queue_rearm.sh --apply      # re-arm ONLY the INFRA/CANCELLED class
+```
+
+The verdict logic is a separate pure function (`scripts/ci/queue_rearm_classify.sh`) with a
+mutation-tested guilt+innocence corpus: unanimity (one non-infra failure forbids the retry even
+among nine infra ones), no concluding from an unfinished run, and an empty probe result fails
+closed rather than reading as clean.
+
+### Step 2b — After an ejection, the auto-merge request is GONE
+
+When a required check goes red the queue removes **that** pull request and recreates the temporary
+branches for the remaining entries without it (GitHub's documented behaviour — groupmates are
+_rebuilt_, not evicted; the collateral is wasted CI time). The ejected PR is left `OPEN` +
+`MERGEABLE` + `CLEAN` with `autoMergeRequest: null`, and **nothing puts it back**. Re-arm it.
+
+> **`autoMergeRequest: null` does not mean "not armed".** The queue _consumes_ the request when it
+> accepts the PR, so a healthy queued PR reads `null` too. The probe is the COMMAND, not the field:
+> `gh pr merge <N> --auto --squash` answering `already queued` means armed
+> (`lesson_automergerequest_goes_null_when_the_queue_accepts_the_pr_2026_07_27`). Reading the field
+> alone will have you "re-arming" PRs that are already in the queue, and calling the arm command as
+> a _measurement_ enqueues them — the probe changes the world.
+
+### Step 3 — Remove from queue if blocking other PRs
+
+```bash
+gh pr ready <N> --undo            # convert to draft → removed from queue
+# fix → push → gh pr ready <N>    # re-queue when green
+```
+
+#### Step 3b — When you need to PUSH to a queued branch (measured 2026-08-05)
+
+A queued branch is **protected**: every push is rejected with
+
+```
+remote: error: GH006: Protected branch update failed
+remote: - A pull request for this branch has been added to a merge queue.
+```
+
+This is the shape that bites: an adversarial review lands _after_ the PR was
+enqueued, finds a real defect, and the version already in the queue — the one
+with the defect — merges while you are still typing the fix. Dequeue first,
+push second, re-arm third.
+
+**`gh pr merge <N> --disable-auto` does NOT dequeue.** It prints
+`! Pull request ... is already queued to merge` and **exits 0** — a no-op that
+reads like a success. Verified live: the entry stayed at `pos=1`.
+
+The one that works:
+
+```bash
+PRID=$(gh pr view <N> --repo <owner/repo> --json id -q .id)
+gh api graphql -f query='mutation($id:ID!){ dequeuePullRequest(input:{id:$id}){ clientMutationId } }' -f id="$PRID"
+git push                                  # now accepted
+gh pr merge <N> --auto --repo <owner/repo>  # re-arm
+```
+
+The input field is **`id`**, not `pullRequestId` — the obvious guess returns
+`argumentNotAccepted`. Confirm with the queue itself, never with the exit code:
+
+```bash
+gh api graphql -f query='{ repository(owner:"<owner>", name:"<repo>") { mergeQueue(branch:"main") { entries(first:20){nodes{position state pullRequest{number}}} } } }' \
+  --jq '.data.repository.mergeQueue.entries.nodes[] | "pos=\(.position) \(.state) #\(.pullRequest.number)"'
+```
+
+---
 
 ---
 

--- a/scripts/ci/harness_gate_read.py
+++ b/scripts/ci/harness_gate_read.py
@@ -56,7 +56,7 @@ is a ref that resolves through a MOVING base): on the pull_request path this wor
 `github.event.pull_request.base.sha`, a pinned SHA, never `refs/pull/N/merge`. The
 `workflow_dispatch:` trigger remains for the case where there is no PR to unblock. Full procedure,
 including the escapes when no rerunnable run exists:
-docs/runbooks/merge-queue-discipline.md section 6quinquies; CLAUDE.md Agent PR Contract rule 3.
+docs/runbooks/merge-queue-discipline.md section 6septies; CLAUDE.md Agent PR Contract rule 3.
 
 EVENT-TO-SHA RESOLUTION:
   - pull_request  : the PR's real head sha is already directly on the event payload.
@@ -207,7 +207,7 @@ def decide(state: str | None) -> tuple[int, str]:
             "`gh workflow run --ref` — a workflow_dispatch run lands its check-run in a different "
             "check suite and never enters the PR's rollup at all, so the PR stays BLOCKED "
             "(measured on #4543). Full procedure: "
-            "docs/runbooks/merge-queue-discipline.md section 6quinquies.",
+            "docs/runbooks/merge-queue-discipline.md section 6septies.",
         )
     if state == "success":
         return 0, f"{CONTEXT} verdict = success"

--- a/scripts/tests/test_runbook_section_numbers_are_unique.py
+++ b/scripts/tests/test_runbook_section_numbers_are_unique.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""A runbook section number is a citation target, so a duplicate silently breaks every `§N`
+reference pointing at it.
+
+This has now happened twice in two days, both times while FIXING the previous instance: #4557
+numbered a new section `6quater`, which the Dependabot section had held since #3381; the repair
+renamed it to `6quinquies`, which the Ledger-PRs section already held. Both collisions shipped
+green, because nothing checked. A citation that resolves to two different sections is worse than
+a dangling one — the reader gets a confident, wrong answer.
+
+The check is deliberately mechanical: heading text before the first '.' must be unique per file.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+RUNBOOKS = sorted((REPO / "docs" / "runbooks").glob("*.md"))
+
+
+def _numbered_headings(text: str) -> list[str]:
+    """Heading labels that look like citation targets: '## 6bis. ...' -> '6bis'.
+
+    Prose headings ('## Session discipline') are not citation targets and are skipped, so this
+    cannot fire on ordinary editorial headings.
+    """
+    out = []
+    for line in text.split("\n"):
+        m = re.match(r"^##\s+([0-9]+[a-z]*)\.\s", line)
+        if m:
+            out.append(m.group(1))
+    return out
+
+
+def test_runbook_section_numbers_are_unique_within_each_file():
+    failures = []
+    for path in RUNBOOKS:
+        labels = _numbered_headings(path.read_text(encoding="utf-8"))
+        dupes = sorted({n for n in labels if labels.count(n) > 1})
+        if dupes:
+            failures.append(f"{path.relative_to(REPO)}: duplicated section numbers {dupes}")
+    assert not failures, (
+        "a duplicated section number breaks every citation that points at it:\n  "
+        + "\n  ".join(failures)
+    )
+
+
+def test_the_check_can_actually_fail():
+    """Innocence is proven by the suite above passing on the real tree; guilt needs a fixture,
+    or this guard could be vacuous (it would pass on a file with no numbered headings at all)."""
+    guilty = "## 6bis. first\n\ntext\n\n## 6bis. second\n"
+    labels = _numbered_headings(guilty)
+    assert labels == ["6bis", "6bis"], labels
+    innocent = "## 6bis. first\n\n## 6ter. second\n\n## Session discipline\n"
+    assert _numbered_headings(innocent) == ["6bis", "6ter"]
+
+
+def test_at_least_one_runbook_carries_numbered_headings():
+    """Guards against the parser silently matching nothing (then uniqueness is trivially true)."""
+    total = sum(len(_numbered_headings(p.read_text(encoding="utf-8"))) for p in RUNBOOKS)
+    assert total > 0, "parser matched no numbered headings in any runbook — it is probably broken"


### PR DESCRIPTION
## Found by PROVE-LIVE, and it is my own regression

After #4560 merged I checked the doctrine surfaces on `origin/main` rather than assuming the merge finished the job. The runbook had **two `## 6quinquies` headings** — line 335 and line 584.

The trail:

| PR | did | broke |
|---|---|---|
| #4557 | numbered a new section `6quater` | collided with the Dependabot section (held since #3381) |
| #4560 | renamed it to `6quinquies` | collided with the Ledger-PRs section |

I swapped one duplicate for another **without reading the numbering space**.

## Why it happened, and the actual fix

The chain runs `6 · 6bis · 6ter · 6quater · 6quinquies · 6sexies`, and the new section had been inserted between `## 6` and `## 6bis` while carrying a suffix that belongs at the end.

It is now **`6septies`**, moved to sit after `6sexies`. The chain reads in order, every label is unique, and the four citations follow it — two internal, two in the CI failure annotation (`harness_gate_read.py`), which is the one text a blocked session is guaranteed to read.

## Why this needed a guard, not just a fix

A duplicate section number is **worse than a dangling reference**: a `§N` citation resolves to two different sections, so the reader gets a confident, wrong answer. Both collisions shipped green because nothing checked.

`scripts/tests/test_runbook_section_numbers_are_unique.py` now checks across every runbook.

## The guard is mutation-tested against the exact historical defect

- Renaming the new section back to `6quater` → **fails** the guard
- Restore verified **byte-identical** by sha256
- It carries its own guilt/innocence fixture, plus an anti-vacuity test — so it cannot pass by matching nothing, which is how a guard written in a hurry fails silently
- Prose headings (`## Session discipline`) are deliberately not citation targets and are skipped

## Verification

- `pytest` on the new guard + `test_harness_gate_read.py` → **42 passed**
- `prettier --check` clean
- Zero duplicated section numbers remain; zero dangling citations to the old names

🤖 Generated with [Claude Code](https://claude.com/claude-code)