### PR TITLE
fix(review): classify provider failures before verdict parsing

### DIFF
--- a/scripts/check_worker_plane_review.py
+++ b/scripts/check_worker_plane_review.py
@@ -111,6 +111,49 @@ CLAUDE_EXECUTABLE = "/Users/nuzantara/.local/share/claude/versions/2.1.214"
 GEMINI_EXECUTABLE = "/Users/nuzantara/.local/bin/agy"
 MCP_CONFIG = '{"mcpServers":{}}'
 HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SAFE_GATE_META = re.compile(r"^[A-Za-z0-9_.:-]{1,64}$")
+SAFE_GATE_STATUS_VALUES = frozenset(
+    {
+        "ok",
+        "success",
+        "error",
+        "api_error",
+        "api_error_status",
+        "quota_exceeded",
+        "rate_limit",
+        "rate_limited",
+        "authentication_error",
+        "auth_error",
+        "unauthorized",
+        "forbidden",
+        "execution_error",
+        "timeout",
+    }
+)
+SAFE_GATE_TERMINAL_REASONS = frozenset(
+    {
+        "success",
+        "error",
+        "api_error",
+        "quota_exceeded",
+        "rate_limit",
+        "rate_limited",
+        "authentication_error",
+        "execution_error",
+        "timeout",
+    }
+)
+PROCESS_FAILURE_CATEGORIES = frozenset(
+    {
+        "timeout",
+        "nonzero_rc",
+        "api_error_429",
+        "api_error_quota",
+        "auth",
+        "execution_error",
+        "stdout_empty",
+    }
+)
 FINDING_ID = re.compile(r"\[([A-Z0-9][A-Z0-9._-]{2,63})\]")
 COMMIT_ID = re.compile(r"^[0-9a-f]{7,64}$")
 EVIDENCE_REFERENCE = re.compile(
@@ -247,6 +290,56 @@ PLACEHOLDER_VALUES = frozenset(
 
 class ReviewValidationError(RuntimeError):
     """Raised when immutable review evidence fails closed."""
+
+
+@dataclass(frozen=True)
+class ClaudeGateDiagnostic:
+    """Safe, bounded metadata for one Claude CLI normalization attempt.
+
+    This deliberately contains no prompt, response body, stderr text, token,
+    or credential.  It is suitable for a receipt or a structured log when a
+    caller needs to explain why a gate did not produce a verdict.
+    """
+
+    stdout_bytes: int
+    stdout_sha256: str
+    stderr_bytes: int
+    stderr_sha256: str
+    timeout: bool
+    category: str
+    rc: int | None
+    status: int | str | None
+    terminal_reason: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        """Return only non-sensitive diagnostic metadata."""
+        return {
+            "stdout_bytes": self.stdout_bytes,
+            "stdout_sha256": self.stdout_sha256,
+            "stderr_bytes": self.stderr_bytes,
+            "stderr_sha256": self.stderr_sha256,
+            "timeout": self.timeout,
+            "category": self.category,
+            "rc": self.rc,
+            "status": self.status,
+            "terminal_reason": self.terminal_reason,
+        }
+
+
+@dataclass(frozen=True)
+class ClaudeGateResponse:
+    """Normalized Claude CLI result; invalid results retain safe diagnostics."""
+
+    category: str
+    result: str | None
+    provider_session_id: str | None
+    reported_model: str | None
+    diagnostic: ClaudeGateDiagnostic
+
+    @property
+    def valid(self) -> bool:
+        """Whether the response is safe to pass to the internal verdict gate."""
+        return self.category == "valid"
 
 
 @dataclass(frozen=True)
@@ -767,28 +860,386 @@ def _emitted_string(
     return value
 
 
+def _safe_gate_meta_value(
+    value: object,
+    allowed_values: frozenset[str],
+    *,
+    allow_http_status: bool = False,
+) -> int | str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if allow_http_status and 100 <= value <= 599 else None
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not SAFE_GATE_META.fullmatch(normalized):
+        return None
+    if normalized in allowed_values or (
+        allow_http_status and re.fullmatch(r"[1-5][0-9]{2}", normalized)
+    ):
+        return normalized
+    return None
+
+
+def _safe_status(envelope: Mapping[str, Any]) -> int | str | None:
+    """Extract a bounded status value without retaining provider payloads."""
+    status: object = envelope.get("api_error_status")
+    if status is None:
+        status = envelope.get("status")
+    error = envelope.get("error")
+    if status is None and isinstance(error, Mapping):
+        status = (
+            error.get("api_error_status")
+            or error.get("status")
+            or error.get("status_code")
+        )
+    return _safe_gate_meta_value(
+        status,
+        SAFE_GATE_STATUS_VALUES,
+        allow_http_status=True,
+    )
+
+
+def _safe_terminal_reason(envelope: Mapping[str, Any]) -> str | None:
+    """Extract only the short terminal reason used for classification."""
+    value = envelope.get("terminal_reason")
+    safe_value = _safe_gate_meta_value(value, SAFE_GATE_TERMINAL_REASONS)
+    return safe_value if isinstance(safe_value, str) else None
+
+
+def _diagnostic_text(envelope: Mapping[str, Any], stderr: bytes) -> str:
+    """Build a short classification haystack, never emitted or persisted."""
+    fields: list[str] = []
+
+    def bounded(value: object) -> str | None:
+        if isinstance(value, str):
+            return value[:256]
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+        return None
+
+    for key in (
+        "type",
+        "subtype",
+        "error",
+        "message",
+        "status",
+        "api_error_status",
+        "terminal_reason",
+    ):
+        value = envelope.get(key)
+        text = bounded(value)
+        if text is not None:
+            fields.append(text)
+        elif isinstance(value, Mapping):
+            for nested_key in ("type", "code", "name", "message", "status"):
+                nested_text = bounded(value.get(nested_key))
+                if nested_text is not None:
+                    fields.append(nested_text)
+    fields.append(stderr[:1024].decode("utf-8", errors="replace"))
+    return " ".join(fields)[:4096].lower()
+
+
+def _classify_error_metadata(
+    metadata: Mapping[str, Any], stderr: bytes
+) -> tuple[str | None, int | str | None, str | None]:
+    """Classify bounded process/provider metadata without parsing stdout."""
+    status = _safe_status(metadata)
+    terminal_reason = _safe_terminal_reason(metadata)
+    diagnostic_text = _diagnostic_text(metadata, stderr)
+    if status == 429 or re.search(r"(?:429|too many requests)", diagnostic_text):
+        return "api_error_429", status, terminal_reason
+    if re.search(r"quota|rate[ _-]?limit|exhausted|capacity", diagnostic_text):
+        return "api_error_quota", status, terminal_reason
+    if re.search(
+        r"auth|unauthor|forbidden|not logged in|credential|oauth|token expired",
+        diagnostic_text,
+    ):
+        return "auth", status, terminal_reason
+    if re.search(
+        r"execution[_ -]?error|execution failed|internal error|process failed|cli error",
+        diagnostic_text,
+    ):
+        return "execution_error", status, terminal_reason
+    return None, status, terminal_reason
+
+
+def _gate_diagnostic(
+    *,
+    stdout: bytes,
+    stderr: bytes,
+    timeout: bool,
+    category: str,
+    rc: int | None,
+    status: int | str | None = None,
+    terminal_reason: str | None = None,
+) -> ClaudeGateDiagnostic:
+    return ClaudeGateDiagnostic(
+        stdout_bytes=len(stdout),
+        stdout_sha256=sha256_bytes(stdout),
+        stderr_bytes=len(stderr),
+        stderr_sha256=sha256_bytes(stderr),
+        timeout=timeout,
+        category=category,
+        rc=rc,
+        status=status,
+        terminal_reason=terminal_reason,
+    )
+
+
+def normalize_claude_gate_response(
+    stdout: bytes | str,
+    *,
+    stderr: bytes | str = b"",
+    rc: int | None = 0,
+    timeout: bool = False,
+    metadata: Mapping[str, Any] | None = None,
+    expected_manifest_sha256: str | None = None,
+    expected_packet_sha256: str | None = None,
+) -> ClaudeGateResponse:
+    """Normalize a Claude ``--output-format json`` response fail-closed.
+
+    Classification happens before any caller can inspect or validate the
+    inner verdict.  The function is provider-free and accepts fake/local
+    payloads, making it suitable for subprocess wrappers and tests alike.
+    Only hashes, byte counts, process status and bounded envelope metadata are
+    exposed through ``diagnostic``.
+    """
+    if isinstance(stdout, str):
+        stdout_bytes = stdout.encode("utf-8")
+    else:
+        stdout_bytes = stdout
+    if isinstance(stderr, str):
+        stderr_bytes = stderr.encode("utf-8")
+    else:
+        stderr_bytes = stderr
+    if not isinstance(stdout_bytes, bytes) or not isinstance(stderr_bytes, bytes):
+        raise TypeError("stdout and stderr must be bytes or str")
+    timeout_flag = timeout is True
+    safe_rc = rc if isinstance(rc, int) and not isinstance(rc, bool) else None
+    if metadata is None:
+        metadata = {}
+    elif not isinstance(metadata, Mapping):
+        raise TypeError("metadata must be a mapping or None")
+
+    def response(
+        category: str,
+        *,
+        result: str | None = None,
+        provider_session_id: str | None = None,
+        reported_model: str | None = None,
+        status: int | str | None = None,
+        terminal_reason: str | None = None,
+    ) -> ClaudeGateResponse:
+        return ClaudeGateResponse(
+            category=category,
+            result=result,
+            provider_session_id=provider_session_id,
+            reported_model=reported_model,
+            diagnostic=_gate_diagnostic(
+                stdout=stdout_bytes,
+                stderr=stderr_bytes,
+                timeout=timeout_flag,
+                category=category,
+                rc=safe_rc,
+                status=status,
+                terminal_reason=terminal_reason,
+            ),
+        )
+
+    metadata_category, metadata_status, metadata_terminal_reason = (
+        _classify_error_metadata(metadata, stderr_bytes)
+    )
+
+    # Ordering is intentional: process state and bounded provider diagnostics
+    # are never reinterpreted as a parse failure merely because stdout is
+    # partial or empty.
+    if timeout_flag:
+        return response(
+            "timeout", status=metadata_status, terminal_reason=metadata_terminal_reason
+        )
+    if rc is not None and (not isinstance(rc, int) or isinstance(rc, bool) or rc != 0):
+        return response(
+            "nonzero_rc",
+            status=metadata_status,
+            terminal_reason=metadata_terminal_reason,
+        )
+    if metadata_category is not None:
+        return response(
+            metadata_category,
+            status=metadata_status,
+            terminal_reason=metadata_terminal_reason,
+        )
+    if not stdout_bytes.strip():
+        return response("stdout_empty")
+
+    try:
+        outer = json.loads(stdout_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return response("outer_json_invalid")
+    if not isinstance(outer, dict):
+        return response("envelope_unexpected")
+
+    outer_status = _safe_status(outer)
+    outer_terminal_reason = _safe_terminal_reason(outer)
+    status = outer_status if outer_status is not None else metadata_status
+    terminal_reason = (
+        outer_terminal_reason
+        if outer_terminal_reason is not None
+        else metadata_terminal_reason
+    )
+    outer_category, _, _ = _classify_error_metadata(outer, stderr_bytes)
+    if outer_category is not None:
+        return response(outer_category, status=status, terminal_reason=terminal_reason)
+
+    is_error = outer.get("is_error")
+    if is_error is True or (
+        outer.get("type") == "result" and outer.get("subtype") not in (None, "success")
+    ):
+        return response(
+            "envelope_is_error", status=status, terminal_reason=terminal_reason
+        )
+    if "is_error" in outer and not isinstance(is_error, bool):
+        return response(
+            "envelope_unexpected", status=status, terminal_reason=terminal_reason
+        )
+    if "result" not in outer:
+        return response(
+            "envelope_unexpected", status=status, terminal_reason=terminal_reason
+        )
+    result = outer.get("result")
+    if not isinstance(result, str) or not result.strip():
+        return response(
+            "result_invalid", status=status, terminal_reason=terminal_reason
+        )
+
+    try:
+        provider_session_id = _emitted_string(
+            outer, "session_id", Path("<claude-gate>")
+        )
+        reported_model = _emitted_string(outer, "model", Path("<claude-gate>"))
+    except ReviewValidationError:
+        return response(
+            "envelope_unexpected", status=status, terminal_reason=terminal_reason
+        )
+    if expected_manifest_sha256 is not None and expected_packet_sha256 is not None:
+        try:
+            _validate_verdict(
+                result,
+                manifest_sha256=expected_manifest_sha256,
+                packet_sha256=expected_packet_sha256,
+                path=Path("<claude-gate>"),
+            )
+        except ReviewValidationError:
+            return response(
+                "verdict_invalid",
+                result=result,
+                provider_session_id=provider_session_id,
+                reported_model=reported_model,
+                status=status,
+                terminal_reason=terminal_reason,
+            )
+    return response(
+        "valid",
+        result=result,
+        provider_session_id=provider_session_id,
+        reported_model=reported_model,
+        status=status,
+        terminal_reason=terminal_reason,
+    )
+
+
+def _pre_verdict_process_metadata(
+    review_path: Path,
+) -> tuple[int | None, bytes, bool, dict[str, object]]:
+    """Read only safe invocation metadata needed before verdict validation.
+
+    The full invocation receipt remains validated later.  This narrow pass
+    exists so a recorded nonzero exit or bounded stderr diagnostic cannot be
+    mistaken for a malformed/invalid model verdict.  Timeout is propagated
+    only when an artifact explicitly records a boolean timeout flag; the
+    configured wall timeout alone is not evidence that a timeout occurred.
+    """
+    invocation_path = review_path.with_suffix(".invocation.json")
+    try:
+        invocation, _ = _load_canonical_json(
+            invocation_path,
+            "invocation companion",
+            newline=True,
+        )
+    except ReviewValidationError:
+        return None, b"", False, {}
+
+    raw_rc = invocation.get("exit_status")
+    rc = raw_rc if isinstance(raw_rc, int) and not isinstance(raw_rc, bool) else None
+    timeout = any(
+        invocation.get(field) is True
+        for field in ("timeout", "timed_out", "timeout_flag")
+    )
+    stderr_path = review_path.with_suffix(".stderr.bin")
+    try:
+        stderr = _read_bytes(stderr_path, "raw stderr companion")
+    except ReviewValidationError:
+        stderr = b""
+    metadata = {
+        key: invocation[key]
+        for key in ("api_error_status", "status", "terminal_reason")
+        if key in invocation
+    }
+    return rc, stderr, timeout, metadata
+
+
 def _extract_raw_proof(
-    raw_path: Path, raw_bytes: bytes, requested_route: str
+    raw_path: Path,
+    raw_bytes: bytes,
+    requested_route: str,
+    *,
+    stderr: bytes | str = b"",
+    rc: int | None = 0,
+    timeout: bool = False,
+    metadata: Mapping[str, Any] | None = None,
+    expected_manifest_sha256: str | None = None,
+    expected_packet_sha256: str | None = None,
 ) -> tuple[str, str | None, str | None]:
     if raw_path.suffix == ".txt":
+        # Gemini's text body has no Claude envelope, but process failures still
+        # must be classified before the body can reach verdict validation.
+        process_state = normalize_claude_gate_response(
+            raw_bytes,
+            stderr=stderr,
+            rc=rc,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        if process_state.category in PROCESS_FAILURE_CATEGORIES:
+            raise ReviewValidationError(
+                f"Claude gate response category={process_state.category}: {raw_path}"
+            )
         try:
             return raw_bytes.decode("utf-8"), None, None
         except UnicodeDecodeError as exc:
             raise ReviewValidationError(
                 f"raw response is not UTF-8: {raw_path}"
             ) from exc
-    try:
-        envelope = json.loads(raw_bytes.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    normalized = normalize_claude_gate_response(
+        raw_bytes,
+        stderr=stderr,
+        rc=rc,
+        timeout=timeout,
+        metadata=metadata,
+        expected_manifest_sha256=expected_manifest_sha256,
+        expected_packet_sha256=expected_packet_sha256,
+    )
+    if not normalized.valid:
         raise ReviewValidationError(
-            f"raw JSON response is invalid: {raw_path}"
-        ) from exc
-    if not isinstance(envelope, dict) or not isinstance(envelope.get("result"), str):
-        raise ReviewValidationError(
-            f"raw JSON response lacks string result: {raw_path}"
+            f"Claude gate response category={normalized.category}: {raw_path}"
         )
-    provider_session_id = _emitted_string(envelope, "session_id", raw_path)
-    reported_model = _emitted_string(envelope, "model", raw_path)
+    assert normalized.result is not None
+    envelope = json.loads(raw_bytes.decode("utf-8"))
+    assert isinstance(envelope, dict)
+    provider_session_id = normalized.provider_session_id
+    reported_model = normalized.reported_model
     if "modelUsage" in envelope:
         model_usage = envelope["modelUsage"]
         if not isinstance(model_usage, dict) or not all(
@@ -818,7 +1269,7 @@ def _extract_raw_proof(
                 f"raw provider model fields disagree: {raw_path}"
             )
         reported_model = reported_model or emitted_model
-    return envelope["result"], provider_session_id, reported_model
+    return normalized.result, provider_session_id, reported_model
 
 
 def _expected_argv(route: str) -> list[str]:
@@ -969,8 +1420,7 @@ def _validate_invocation(
     if (
         invocation.get("review_input_schema") != REVIEW_INPUT_SCHEMA
         or invocation.get("review_input_bytes") != len(expected_review_input)
-        or invocation.get("review_input_sha256")
-        != sha256_bytes(expected_review_input)
+        or invocation.get("review_input_sha256") != sha256_bytes(expected_review_input)
     ):
         raise ReviewValidationError(
             f"invocation review-input attestation mismatch: {invocation_path}"
@@ -1248,6 +1698,30 @@ def _validate_review(
 ) -> ReviewProof:
     text = _read_utf8(review_path, "normalized review")
     frontmatter, body = _parse_frontmatter(text, review_path)
+    raw_path = _raw_companion(review_path)
+    raw_bytes = _read_bytes(raw_path, "raw response companion")
+    frontmatter_route = frontmatter.get("requested_route")
+    if (
+        not isinstance(frontmatter_route, str)
+        or frontmatter_route not in EXPECTED_ROUTES
+    ):
+        raise ReviewValidationError(
+            f"normalized review has invalid requested_route: {review_path}"
+        )
+    process_rc, stderr_bytes, timeout, process_metadata = _pre_verdict_process_metadata(
+        review_path
+    )
+    # Normalize the provider envelope before parsing the internal verdict.  A
+    # provider error is an execution outcome, never a malformed verdict.
+    raw_body, emitted_provider_session_id, emitted_reported_model = _extract_raw_proof(
+        raw_path,
+        raw_bytes,
+        frontmatter_route,
+        stderr=stderr_bytes,
+        rc=process_rc,
+        timeout=timeout,
+        metadata=process_metadata,
+    )
     sections = _section_map(body, review_path)
     for heading, section in sections.items():
         if heading not in {
@@ -1271,20 +1745,6 @@ def _validate_review(
         sections["# Important findings"],
         severity="Important",
         path=review_path,
-    )
-
-    raw_path = _raw_companion(review_path)
-    raw_bytes = _read_bytes(raw_path, "raw response companion")
-    frontmatter_route = frontmatter.get("requested_route")
-    if (
-        not isinstance(frontmatter_route, str)
-        or frontmatter_route not in EXPECTED_ROUTES
-    ):
-        raise ReviewValidationError(
-            f"normalized review has invalid requested_route: {review_path}"
-        )
-    raw_body, emitted_provider_session_id, emitted_reported_model = _extract_raw_proof(
-        raw_path, raw_bytes, frontmatter_route
     )
     route, launcher_uuid = _validate_invocation(
         repo_root=repo_root,

--- a/scripts/tests/test_check_worker_plane_review.py
+++ b/scripts/tests/test_check_worker_plane_review.py
@@ -19,6 +19,7 @@ from scripts.check_worker_plane_review import (
     VALIDATOR_REPO_PATH,
     ReviewValidationError,
     main,
+    normalize_claude_gate_response,
     validate_review_panel,
 )
 from scripts.freeze_worker_plane_review import (
@@ -79,6 +80,178 @@ GEMINI_REQUIREMENT = (
     "leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and "
     "certificate leaf[subject.OU] = EQHXZ8M8AV"
 )
+
+
+@pytest.mark.parametrize(
+    ("name", "stdout", "stderr", "rc", "timeout", "expected"),
+    [
+        ("timeout", b"partial secret prompt", b"", 0, True, "timeout"),
+        ("nonzero rc", b"{}", b"secret stderr", 7, False, "nonzero_rc"),
+        (
+            "is_error",
+            b'{"is_error": true, "terminal_reason": "api_error"}',
+            b"",
+            0,
+            False,
+            "envelope_is_error",
+        ),
+        (
+            "429",
+            b'{"is_error": true, "api_error_status": 429}',
+            b"",
+            0,
+            False,
+            "api_error_429",
+        ),
+        (
+            "quota",
+            b'{"is_error": true, "api_error_status": "quota_exceeded"}',
+            b"",
+            0,
+            False,
+            "api_error_quota",
+        ),
+        (
+            "auth",
+            b'{"is_error": true, "error": {"type": "authentication_error"}}',
+            b"",
+            0,
+            False,
+            "auth",
+        ),
+        (
+            "execution",
+            b'{"is_error": true, "error": {"type": "execution_error"}}',
+            b"",
+            0,
+            False,
+            "execution_error",
+        ),
+        (
+            "execution terminal reason",
+            b'{"terminal_reason": "execution_error", "is_error": true}',
+            b"",
+            0,
+            False,
+            "execution_error",
+        ),
+        (
+            "auth stderr",
+            b"",
+            b"authentication required",
+            0,
+            False,
+            "auth",
+        ),
+        (
+            "execution stderr",
+            b"",
+            b"execution failed",
+            0,
+            False,
+            "execution_error",
+        ),
+        ("stdout empty", b" \n", b"", 0, False, "stdout_empty"),
+        ("outer JSON invalid", b"not json", b"", 0, False, "outer_json_invalid"),
+        (
+            "invalid JSON with 429 stderr",
+            b"not json",
+            b"429 Too Many Requests token-sentinel",
+            0,
+            False,
+            "api_error_429",
+        ),
+        (
+            "empty stdout with quota stderr",
+            b"",
+            b"quota exceeded token-sentinel",
+            0,
+            False,
+            "api_error_quota",
+        ),
+        (
+            "invalid JSON with auth stderr",
+            b"not json",
+            b"authentication required token-sentinel",
+            0,
+            False,
+            "auth",
+        ),
+        ("envelope unexpected", b"[]", b"", 0, False, "envelope_unexpected"),
+        ("result invalid", b'{"result": 7}', b"", 0, False, "result_invalid"),
+        (
+            "invalid emitted session",
+            b'{"result": "ok", "session_id": 7}',
+            b"",
+            0,
+            False,
+            "envelope_unexpected",
+        ),
+    ],
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+def test_normalize_claude_gate_response_fail_closed(
+    name: str,
+    stdout: bytes,
+    stderr: bytes,
+    rc: int,
+    timeout: bool,
+    expected: str,
+) -> None:
+    del name
+    normalized = normalize_claude_gate_response(
+        stdout,
+        stderr=stderr,
+        rc=rc,
+        timeout=timeout,
+    )
+
+    assert normalized.category == expected
+    assert not normalized.valid
+    safe = normalized.diagnostic.as_dict()
+    assert safe["stdout_bytes"] == len(stdout)
+    assert safe["stderr_bytes"] == len(stderr)
+    assert safe["stdout_sha256"] == sha256_bytes(stdout)
+    assert safe["stderr_sha256"] == sha256_bytes(stderr)
+    assert "secret" not in json.dumps(safe)
+    assert "token-sentinel" not in json.dumps(safe)
+
+
+def test_normalize_claude_gate_response_bounds_provider_metadata() -> None:
+    normalized = normalize_claude_gate_response(
+        b'{"result": "ok", "status": "secret token", "terminal_reason": "secret token"}'
+    )
+
+    assert normalized.valid
+    assert normalized.diagnostic.status is None
+    assert normalized.diagnostic.terminal_reason is None
+
+    metadata_error = normalize_claude_gate_response(
+        b"not json",
+        metadata={"api_error_status": 429, "terminal_reason": "api_error"},
+    )
+    assert metadata_error.category == "api_error_429"
+
+
+def test_normalize_claude_gate_response_distinguishes_verdict_and_valid() -> None:
+    manifest_sha = "a" * 64
+    packet_sha = "b" * 64
+    invalid = normalize_claude_gate_response(
+        b'{"result": "not a verdict"}',
+        expected_manifest_sha256=manifest_sha,
+        expected_packet_sha256=packet_sha,
+    )
+    assert invalid.category == "verdict_invalid"
+    assert invalid.result == "not a verdict"
+
+    body = f"GO-WITH-CHANGES — confidence 91\ninput_manifest_sha256: {manifest_sha}\n"
+    valid = normalize_claude_gate_response(
+        json.dumps({"result": body}).encode("utf-8"),
+        expected_manifest_sha256=manifest_sha,
+        expected_packet_sha256=packet_sha,
+    )
+    assert valid.category == "valid"
+    assert valid.valid
 
 
 @dataclass
@@ -573,6 +746,86 @@ def _rewrite_invocation(
     review_path.write_text("".join(lines), encoding="utf-8")
 
 
+def _rewrite_claude_process(
+    bundle: Bundle,
+    *,
+    raw_bytes: bytes,
+    stderr: bytes = b"",
+    exit_status: int = 0,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Rewrite one local Claude receipt and its bounded process companions."""
+    review_path = bundle.reviews[0]
+    raw_path = _raw_path(review_path)
+    assert raw_path.suffix == ".json"
+    raw_path.write_bytes(raw_bytes)
+
+    stderr_path = review_path.with_suffix(".stderr.bin")
+    stderr_path.write_bytes(stderr)
+
+    invocation_path = _invocation_path(review_path)
+    invocation = json.loads(invocation_path.read_text(encoding="utf-8"))
+    invocation["exit_status"] = exit_status
+    invocation["stdout_bytes"] = len(raw_bytes)
+    invocation["stdout_sha256"] = sha256_bytes(raw_bytes)
+    invocation["stderr_bytes"] = len(stderr)
+    invocation["stderr_sha256"] = sha256_bytes(stderr)
+    for key, value in (metadata or {}).items():
+        invocation[key] = value
+    _canonical_file(invocation_path, invocation)
+
+    review_text = review_path.read_text(encoding="utf-8")
+    marker = review_text.find("---\n", 4)
+    assert marker >= 0
+    frontmatter = review_text[: marker + 4]
+    body = review_text[marker + 4 :]
+    lines = frontmatter.splitlines(keepends=True)
+    replacements = {
+        "launcher_proof_sha256:": sha256_bytes(invocation_path.read_bytes()),
+        "raw_response_sha256:": sha256_bytes(raw_bytes),
+    }
+    for line_index, line in enumerate(lines):
+        for key, value in replacements.items():
+            if line.startswith(key):
+                lines[line_index] = f"{key} {value}\n"
+    review_path.write_text("".join(lines) + body, encoding="utf-8")
+
+
+def _rewrite_text_process(
+    bundle: Bundle,
+    *,
+    stderr: bytes = b"",
+    exit_status: int = 0,
+) -> None:
+    """Rewrite the local Gemini text receipt's process companions."""
+    review_path = bundle.reviews[1]
+    raw_path = _raw_path(review_path)
+    assert raw_path.suffix == ".txt"
+    stderr_path = review_path.with_suffix(".stderr.bin")
+    stderr_path.write_bytes(stderr)
+
+    invocation_path = _invocation_path(review_path)
+    invocation = json.loads(invocation_path.read_text(encoding="utf-8"))
+    invocation["exit_status"] = exit_status
+    invocation["stderr_bytes"] = len(stderr)
+    invocation["stderr_sha256"] = sha256_bytes(stderr)
+    _canonical_file(invocation_path, invocation)
+
+    review_text = review_path.read_text(encoding="utf-8")
+    marker = review_text.find("---\n", 4)
+    assert marker >= 0
+    frontmatter = review_text[: marker + 4]
+    body = review_text[marker + 4 :]
+    lines = frontmatter.splitlines(keepends=True)
+    for line_index, line in enumerate(lines):
+        if line.startswith("launcher_proof_sha256:"):
+            lines[line_index] = (
+                f"launcher_proof_sha256: {sha256_bytes(invocation_path.read_bytes())}\n"
+            )
+            break
+    review_path.write_text("".join(lines) + body, encoding="utf-8")
+
+
 def test_valid_review_panel_passes_and_cli_emits_canonical_summary(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -615,14 +868,134 @@ def test_valid_review_panel_passes_and_cli_emits_canonical_summary(
     assert json.loads(capsys.readouterr().out) == result
 
 
+def test_checker_classifies_malformed_stdout_with_429_before_verdict(
+    tmp_path: Path,
+) -> None:
+    bundle = make_bundle(tmp_path)
+    _rewrite_claude_process(
+        bundle,
+        raw_bytes=b"not json",
+        stderr=b"429 Too Many Requests token-sentinel",
+    )
+    _commit_artifact_mutation(bundle)
+
+    with pytest.raises(ReviewValidationError, match="category=api_error_429") as error:
+        _validate(bundle)
+    assert "token-sentinel" not in str(error.value)
+
+
+def test_checker_classifies_nonzero_exit_before_verdict(tmp_path: Path) -> None:
+    bundle = make_bundle(tmp_path)
+    _rewrite_claude_process(
+        bundle,
+        raw_bytes=_raw_path(bundle.reviews[0]).read_bytes(),
+        stderr=b"execution failed token-sentinel",
+        exit_status=7,
+    )
+    _commit_artifact_mutation(bundle)
+
+    with pytest.raises(ReviewValidationError, match="category=nonzero_rc") as error:
+        _validate(bundle)
+    assert "token-sentinel" not in str(error.value)
+
+
+def test_checker_classifies_nonzero_exit_for_raw_text_before_verdict(
+    tmp_path: Path,
+) -> None:
+    bundle = make_bundle(tmp_path)
+    _rewrite_text_process(
+        bundle,
+        stderr=b"execution failed token-sentinel",
+        exit_status=7,
+    )
+    _commit_artifact_mutation(bundle)
+
+    with pytest.raises(ReviewValidationError, match="category=nonzero_rc") as error:
+        _validate(bundle)
+    assert "token-sentinel" not in str(error.value)
+
+
+def test_checker_classifies_is_error_envelope_before_verdict(tmp_path: Path) -> None:
+    bundle = make_bundle(tmp_path)
+    envelope = json.loads(_raw_path(bundle.reviews[0]).read_text(encoding="utf-8"))
+    envelope["is_error"] = True
+    _rewrite_claude_process(
+        bundle,
+        raw_bytes=canonical_json_bytes(envelope) + b"\n",
+        stderr=b"token-sentinel",
+    )
+    _commit_artifact_mutation(bundle)
+
+    with pytest.raises(
+        ReviewValidationError, match="category=envelope_is_error"
+    ) as error:
+        _validate(bundle)
+    assert "token-sentinel" not in str(error.value)
+
+
+def test_checker_accepts_valid_verdict_without_leaking_stderr(
+    tmp_path: Path,
+) -> None:
+    bundle = make_bundle(tmp_path)
+    _rewrite_claude_process(
+        bundle,
+        raw_bytes=_raw_path(bundle.reviews[0]).read_bytes(),
+        stderr=b"token-sentinel",
+    )
+    _commit_artifact_mutation(bundle)
+
+    result = _validate(bundle)
+
+    assert result["valid"] is True
+    assert "token-sentinel" not in json.dumps(result)
+
+
+def test_normalize_drops_unknown_metadata_values_from_diagnostics() -> None:
+    normalized = normalize_claude_gate_response(
+        b"not json",
+        metadata={
+            "status": "token-sentinel",
+            "terminal_reason": "token-sentinel",
+        },
+    )
+
+    assert normalized.category == "outer_json_invalid"
+    safe = normalized.diagnostic.as_dict()
+    assert safe["status"] is None
+    assert safe["terminal_reason"] is None
+    assert "token-sentinel" not in json.dumps(safe)
+
+
+@pytest.mark.parametrize("status", (99, 600, 700, True))
+def test_normalize_drops_invalid_http_status_metadata(status: object) -> None:
+    normalized = normalize_claude_gate_response(
+        b"not json",
+        metadata={"api_error_status": status},
+    )
+
+    assert normalized.category == "outer_json_invalid"
+    assert normalized.diagnostic.status is None
+
+
+def test_normalize_keeps_valid_http_status_and_rejects_integer_terminal_reason() -> (
+    None
+):
+    normalized = normalize_claude_gate_response(
+        b"not json",
+        metadata={"api_error_status": 429, "terminal_reason": 429},
+    )
+
+    assert normalized.category == "api_error_429"
+    assert normalized.diagnostic.status == 429
+    assert normalized.diagnostic.terminal_reason is None
+
+
 def test_v3_reviewer_evidence_cannot_authorize_without_fable_final_gate(
     tmp_path: Path,
 ) -> None:
     bundle = make_bundle(tmp_path)
     receipt = json.loads(bundle.receipt.read_text(encoding="utf-8"))
-    receipt["route_config_path"] = (
-        "scripts/review_routes/worker-plane-council-v3.json"
-    )
+    receipt["route_config_path"] = "scripts/review_routes/worker-plane-council-v3.json"
     _canonical_file(bundle.receipt, receipt)
     h1 = _commit(bundle.repo, "mark evidence as council v3")
     v3_bundle = replace(bundle, h1=h1)
@@ -641,9 +1014,7 @@ def test_v3_final_gate_blocker_does_not_trust_declared_generator_version(
 ) -> None:
     bundle = make_bundle(tmp_path)
     receipt = json.loads(bundle.receipt.read_text(encoding="utf-8"))
-    receipt["route_config_path"] = (
-        "scripts/review_routes/worker-plane-council-v3.json"
-    )
+    receipt["route_config_path"] = "scripts/review_routes/worker-plane-council-v3.json"
     receipt["generator_version"] = generator_version
     _canonical_file(bundle.receipt, receipt)
     h1 = _commit(bundle.repo, "forge the declared generator version")
@@ -776,9 +1147,7 @@ def test_rejects_non_empty_text_before_verdict_heading(tmp_path: Path) -> None:
     )
     _commit_artifact_mutation(bundle)
 
-    with pytest.raises(
-        ReviewValidationError, match="non-empty text before # Verdict"
-    ):
+    with pytest.raises(ReviewValidationError, match="non-empty text before # Verdict"):
         _validate(bundle)
 
 
@@ -787,7 +1156,9 @@ def test_allows_whitespace_before_verdict_heading(tmp_path: Path) -> None:
     _rewrite_body_and_raw(bundle, 0, lambda text: f" \n\t\n{text}")
     _commit_artifact_mutation(bundle)
 
-    _validate(bundle)
+    result = _validate(bundle)
+
+    assert result["valid"] is True
 
 
 def test_rejects_manifest_hash_after_second_non_empty_verdict_line(
@@ -798,8 +1169,7 @@ def test_rejects_manifest_hash_after_second_non_empty_verdict_line(
         bundle,
         0,
         lambda text: text.replace(
-            "GO-WITH-CHANGES — confidence 91\n\n"
-            "input_manifest_sha256:",
+            "GO-WITH-CHANGES — confidence 91\n\ninput_manifest_sha256:",
             "GO-WITH-CHANGES — confidence 91\n\n"
             "Provider preamble inside the verdict section.\n\n"
             "input_manifest_sha256:",
@@ -1094,7 +1464,7 @@ def test_rejects_duplicate_launcher_uuid(tmp_path: Path) -> None:
         ("wall_timeout_seconds", 0, "wall_timeout_seconds"),
         ("xdg_config_home", "/tmp/wrong-xdg", "xdg_config_home"),
         ("shell", True, "shell=false"),
-        ("exit_status", 1, "exit status"),
+        ("exit_status", 1, "category=nonzero_rc"),
     ],
 )
 def test_rejects_invalid_invocation_proof(

--- a/scripts/tests/test_detect_secrets_auto_triage.py
+++ b/scripts/tests/test_detect_secrets_auto_triage.py
@@ -51,9 +51,9 @@ from scripts.detect_secrets_auto_triage import CONTENT_KEYED_RULES, classify, tr
 CHECK_WORKER_PLANE_REVIEW = "scripts/check_worker_plane_review.py"
 LAUNCH_WORKER_PLANE_REVIEW_PANEL = "scripts/launch_worker_plane_review_panel.py"
 
-# Line numbers verified against the actual files on disk 2026-07-26 (the
+# Line numbers re-verified against the actual files on disk 2026-08-22 (the
 # exact 18 findings `Detect Secrets` flagged on PR #3127).
-CHECK_WORKER_PLANE_REVIEW_PIN_LINES = [142, 143, 153, 154]
+CHECK_WORKER_PLANE_REVIEW_PIN_LINES = [185, 186, 196, 197]
 LAUNCH_WORKER_PLANE_REVIEW_PANEL_PIN_LINES = [
     210,
     211,


### PR DESCRIPTION
## Summary

- normalize Claude CLI gate envelopes before internal verdict parsing
- classify timeout, non-zero exit, 429/quota, authentication, execution, and empty-output failures without leaking provider payloads
- retain only bounded diagnostic metadata (byte counts, hashes, safe status/reason values)
- apply the same process-first failure handling to Gemini text companions
- refresh the content-keyed identity-pin test anchors shifted by the validator additions

## Why

A provider or process failure could previously be reported as a malformed verdict, obscuring the actionable cause. This change keeps execution failures distinct while preserving the validator's fail-closed behavior and immutable evidence checks.

## Tests

- `python -m pytest scripts/tests/test_check_worker_plane_review.py -q` — 96 passed
- required worker-plane suite — 285 passed, 2 skipped
- `ruff check` on all three changed Python files
- `ruff format --check` on the two implementation patch files
- `python -m py_compile` on all three changed Python files
- anti-reward-hacking lint on both changed test files
- `git diff --check origin/main...HEAD`
- direct positive/negative classifier probe: valid envelope, 429 envelope, approved pin, unrelated line

## Review contract

Generator != grader: this draft was prepared by an external Codex landing lane. A separate Claude session must independently review the exact pushed head and required checks before the draft can advance. This PR must not be armed, merged, or deployed by the generator lane.
