### PR TITLE
feat(arsenal): one call shape for external build seats — scripts/seat_build.sh

### DIFF
--- a/scripts/lib/seat_watchdog.sh
+++ b/scripts/lib/seat_watchdog.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Source-safe process-group watchdog vendored from scripts/ai-dispatch.sh.
+# ai-dispatch.sh cannot be sourced: it changes directory, enables strict mode,
+# and dispatches at top level. This deliberate duplication is ledgered by D1.
+# Fleet hosts have neither timeout(1) nor gtimeout(1), so this stays pure Bash.
+
+run_with_timeout() {
+    local secs="$1"
+    shift
+    (
+        set +e
+        set -m
+        "$@" &
+        local child_pid=$!
+        local child_pgid="$child_pid"
+        local grace="${AI_DISPATCH_TIMEOUT_GRACE_SECS:-2}"
+        local deadline=$(( $(date +%s) + secs ))
+
+        cleanup_timeout_group() {
+            trap - EXIT INT TERM
+            if kill -TERM -- -"$child_pgid" 2>/dev/null; then
+                sleep "$grace"
+                # The leader may exit while a descendant ignores TERM.
+                kill -KILL -- -"$child_pgid" 2>/dev/null || true
+            fi
+            wait "$child_pid" 2>/dev/null || true
+        }
+        trap cleanup_timeout_group EXIT
+        trap 'cleanup_timeout_group; exit 130' INT TERM
+
+        while kill -0 "$child_pid" 2>/dev/null; do
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+                cleanup_timeout_group
+                exit 124
+            fi
+            sleep 1
+        done
+        wait "$child_pid"
+        local child_rc=$?
+        cleanup_timeout_group
+        exit "$child_rc"
+    )
+}

--- a/scripts/seat_build.sh
+++ b/scripts/seat_build.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Give Codex, Kimi, Qwen, and GLM one non-interactive build call shape so an
+# orchestrator does not need to reimplement worktree setup, stdin closure,
+# output parsing, or a watchdog. Fleet hosts have no working timeout(1) or
+# gtimeout(1), so the sourced watchdog is pure Bash and kills process groups.
+# Exit codes: 64 invalid arguments, 65 not a linked worktree, 66 dirty tree,
+# 73 report-write failure, 124 watchdog expiry, and 127 missing seat binary.
+# JSON reports include "log": the durable seat/test sidecar path, or null when
+# no seat was invoked (for example, validation failures and --dry-run).
+# This wrapper never ships:
+# no commit, push, merge, hosting, deployment, or service-control operations.
+# The orchestrator remains the independent grader and publisher.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/seat_watchdog.sh
+source "$SCRIPT_DIR/lib/seat_watchdog.sh"
+
+quota_output_exhausted() {
+    local output_file="$1"
+    # A bare 429 may be a diffstat, and bare "exhausted" is ordinary prose.
+    # Require HTTP/status/code/Too Many context for 429 and a quota-shaped noun
+    # for exhausted; "insufficient balance" is the literal z.ai error body.
+    grep -qiE \
+        -e 'out of extra usage' \
+        -e 'usage limit' \
+        -e 'quota([[:space:]_.-]+limit)?[[:space:]_.-]+(exceeded|exhausted)' \
+        -e '(^|[^[:alnum:]_])rate[[:space:]_.-]*limit([^[:alnum:]_]|$)' \
+        -e '(^|[^[:alnum:]_])HTTP([^[:space:]]*[[:space:]]+|[^[:alnum:]_]*)429([^[:digit:]]|$)' \
+        -e '(^|[^[:alnum:]_])(status|code)[[:space:]:=_.-]*429([^[:digit:]]|$)' \
+        -e '(^|[^[:digit:]])429[[:space:]]+Too[[:space:]]+Many([^[:alnum:]_]|$)' \
+        -e '(usage|credits?|tokens?)[[:space:]_.-]+exhausted' \
+        -e 'insufficient balance' \
+        "$output_file"
+}
+
+collect_git_metrics() {
+    DIFF_STAT=""
+    UNTRACKED=0
+    if [ -n "$WORKTREE" ] && git -C "$WORKTREE" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        DIFF_STAT="$(git -C "$WORKTREE" diff --shortstat 2>/dev/null || true)"
+        UNTRACKED="$(git -C "$WORKTREE" ls-files --others --exclude-standard 2>/dev/null |
+            wc -l | tr -d '[:space:]')" || UNTRACKED=0
+    fi
+}
+
+emit_report() {
+    local report_rc="$1"
+    local dry_run="$2"
+    local report_json
+    report_json="$(python3 - "$SEAT" "$MODEL" "$EFFORT" "$report_rc" "$DURATION" \
+        "$DIFF_STAT" "$UNTRACKED" "$TESTS_CMD" "$TESTS_RC" "$QUOTA_EXHAUSTED" \
+        "$LOG_PATH" "$dry_run" <<'PY'
+import json
+import sys
+
+seat, model, effort, rc, duration, diff_stat, untracked, tests_cmd, tests_rc, quota, log_path, dry = sys.argv[1:]
+report = {
+    "seat": seat,
+    "model": model,
+    "effort": effort,
+    "rc": None if rc == "null" else int(rc),
+    "duration_s": int(duration),
+    "diff_stat": diff_stat,
+    "untracked": int(untracked),
+    "tests": None if not tests_cmd else {
+        "cmd": tests_cmd,
+        "rc": None if tests_rc == "null" else int(tests_rc),
+    },
+    "quota_exhausted": quota == "true",
+    "log": log_path or None,
+}
+if dry == "true":
+    report["dry_run"] = True
+print(json.dumps(report, separators=(",", ":")))
+PY
+)"
+    if [ -n "$OUT_PATH" ] && ! printf '%s\n' "$report_json" > "$OUT_PATH"; then
+        printf 'seat_build: cannot write report: %s\n' "$OUT_PATH" >&2
+        printf '%s\n' "$report_json"
+        return 73
+    fi
+    printf '%s\n' "$report_json"
+}
+
+refuse() {
+    local code="$1"
+    shift
+    printf 'seat_build: %s\n' "$*" >&2
+    collect_git_metrics
+    emit_report "$code" false || true
+    exit "$code"
+}
+
+main() {
+    SEAT=""
+    MODEL="unknown"
+    WORKTREE=""
+    TASK_FILE=""
+    TESTS_CMD=""
+    TESTS_RC="null"
+    EFFORT="medium"
+    TIMEOUT_SECS=1800
+    OUT_PATH=""
+    DRY_RUN=false
+    DURATION=0
+    DIFF_STAT=""
+    UNTRACKED=0
+    QUOTA_EXHAUSTED=false
+    LOG_PATH=""
+
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --seat|--worktree|--task-file|--tests|--effort|--timeout|--out)
+                [ "$#" -ge 2 ] || refuse 64 "missing value for $1"
+                case "$1" in
+                    --seat) SEAT="$2" ;;
+                    --worktree) WORKTREE="$2" ;;
+                    --task-file) TASK_FILE="$2" ;;
+                    --tests) TESTS_CMD="$2" ;;
+                    --effort) EFFORT="$2" ;;
+                    --timeout) TIMEOUT_SECS="$2" ;;
+                    --out) OUT_PATH="$2" ;;
+                esac
+                shift 2
+                ;;
+            --dry-run) DRY_RUN=true; shift ;;
+            *) refuse 64 "unknown argument: $1" ;;
+        esac
+    done
+
+    local binary_name
+    case "$SEAT" in
+        codex) binary_name="codex"; MODEL="codex-default" ;;
+        kimi) binary_name="kimi"; MODEL="kimi-code/kimi-for-coding" ;;
+        qwen) binary_name="qwen"; MODEL="qwen-default" ;;
+        glm) binary_name="claude-glm"; MODEL="glm-5.2" ;;
+        "") refuse 64 "missing --seat" ;;
+        *) refuse 64 "unknown seat: $SEAT" ;;
+    esac
+    [ -n "$WORKTREE" ] || refuse 64 "missing --worktree"
+    [ -r "$TASK_FILE" ] || refuse 64 "missing or unreadable --task-file: $TASK_FILE"
+    case "$EFFORT" in low|medium|high|xhigh) ;; *) refuse 64 "invalid --effort: $EFFORT" ;; esac
+    [[ "$TIMEOUT_SECS" =~ ^[1-9][0-9]*$ ]] || refuse 64 "invalid --timeout: $TIMEOUT_SECS"
+
+    local git_dir
+    git_dir="$(git -C "$WORKTREE" rev-parse --git-dir 2>/dev/null)" ||
+        refuse 65 "not a Git worktree: $WORKTREE"
+    if [[ "$git_dir" != /* ]]; then
+        git_dir="$(cd "$WORKTREE" && cd "$git_dir" && pwd -P)"
+    else
+        git_dir="$(cd "$git_dir" && pwd -P)"
+    fi
+    [[ "$git_dir" == */worktrees/* ]] || refuse 65 "main checkout refused: $WORKTREE"
+    [ -z "$(git -C "$WORKTREE" status --porcelain)" ] || refuse 66 "dirty worktree refused: $WORKTREE"
+
+    local seat_binary
+    if ! seat_binary="$(command -v "$binary_name")"; then
+        collect_git_metrics
+        emit_report 127 false
+        exit 127
+    fi
+
+    local task_text task_preview task_index stripped_count
+    local -a seat_argv display_argv strip_env_args stripped_names
+    task_text="$(< "$TASK_FILE")"
+    case "$SEAT" in
+        codex)
+            seat_argv=("$seat_binary" exec --sandbox workspace-write --skip-git-repo-check \
+                -c "model_reasoning_effort=$EFFORT" "$task_text")
+            task_index=7
+            ;;
+        kimi) seat_argv=("$seat_binary" -p "$task_text" -m kimi-code/kimi-for-coding); task_index=2 ;;
+        qwen) seat_argv=("$seat_binary" -p "$task_text"); task_index=2 ;;
+        glm) seat_argv=("$seat_binary" -p "$task_text"); task_index=2 ;;
+    esac
+    strip_env_args=()
+    stripped_names=()
+    stripped_count=0
+    local env_name
+    while IFS= read -r -d '' env_name; do
+        if [[ "$env_name" =~ (_API_KEY|_TOKEN|_SECRET|_PASSWORD)$ ]] ||
+            [[ "$env_name" =~ ^(ANTHROPIC_|CLAUDE_CODE_OAUTH|AWS_|GITHUB_TOKEN|GH_TOKEN) ]]; then
+            strip_env_args+=(-u "$env_name")
+            stripped_names+=("$env_name")
+            stripped_count=$((stripped_count + 1))
+        fi
+    done < <(python3 -c 'import os,sys; sys.stdout.buffer.write(b"".join(os.fsencode(k)+b"\0" for k in sorted(os.environ)))')
+
+    if [ "$DRY_RUN" = true ]; then
+        task_preview="${task_text:0:60}"
+        [ "${#task_text}" -le 60 ] || task_preview+="..."
+        display_argv=(${seat_argv[@]+"${seat_argv[@]}"})
+        display_argv[task_index]="$task_preview"
+        printf 'Resolved argv:' >&2
+        printf ' %q' ${display_argv[@]+"${display_argv[@]}"} >&2
+        printf '\nStripped env names:' >&2
+        if [ "$stripped_count" -eq 0 ]; then
+            printf ' (none)' >&2
+        else
+            printf ' %s' ${stripped_names[@]+"${stripped_names[@]}"} >&2
+        fi
+        printf '\n' >&2
+        collect_git_metrics
+        emit_report null true
+        exit 0
+    fi
+
+    local output_file seat_rc started_at log_dir
+    log_dir="$(cd "$WORKTREE/.." && pwd -P)"
+    LOG_PATH="$log_dir/seat-build-${SEAT}-$(date -u +%Y%m%dT%H%M%SZ)-$$.log"
+    output_file="$LOG_PATH"
+    started_at="$(date +%s)"
+    if (cd "$WORKTREE" && run_with_timeout "$TIMEOUT_SECS" \
+        env ${strip_env_args[@]+"${strip_env_args[@]}"} \
+            ${seat_argv[@]+"${seat_argv[@]}"} < /dev/null) > "$output_file" 2>&1; then
+        seat_rc=0
+    else
+        seat_rc=$?
+    fi
+    if quota_output_exhausted "$output_file"; then
+        QUOTA_EXHAUSTED=true
+    fi
+    if [ -n "$TESTS_CMD" ]; then
+        if (cd "$WORKTREE" && run_with_timeout "$TIMEOUT_SECS" \
+            bash -c "$TESTS_CMD" < /dev/null) >> "$output_file" 2>&1; then
+            TESTS_RC=0
+        else
+            TESTS_RC=$?
+        fi
+    fi
+    DURATION=$(( $(date +%s) - started_at ))
+    collect_git_metrics
+    emit_report "$seat_rc" false
+    exit "$seat_rc"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/tests/test_seat_build.sh
+++ b/scripts/tests/test_seat_build.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Offline contract tests for seat_build.sh and its pure-Bash watchdog.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SEAT_BUILD="$REPO_ROOT/scripts/seat_build.sh"
+WATCHDOG="$REPO_ROOT/scripts/lib/seat_watchdog.sh"
+FIXTURE="$(mktemp -d)"
+MAIN_REPO="$FIXTURE/main"
+LINKED_WT="$FIXTURE/linked"
+TASK_FILE="$FIXTURE/task.txt"
+FAKE_BIN="$FIXTURE/bin"
+MARKER="$FIXTURE/seat-invoked"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+cleanup() {
+    rm -rf "$FIXTURE"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+git init -q "$MAIN_REPO"
+git -C "$MAIN_REPO" config user.email test@example.invalid
+git -C "$MAIN_REPO" config user.name "Seat Build Test"
+printf 'fixture\n' > "$MAIN_REPO/tracked.txt"
+git -C "$MAIN_REPO" add tracked.txt
+git -C "$MAIN_REPO" commit -qm "test fixture"
+git -C "$MAIN_REPO" worktree add -qb linked-fixture "$LINKED_WT"
+printf 'Change nothing.\n' > "$TASK_FILE"
+# The fake expands this only if invoked.
+# shellcheck disable=SC2016
+printf '%s\n' '#!/usr/bin/env bash' ': > "${SEAT_TEST_MARKER:?}"' \
+    'if [ "${FOO_API_KEY+x}" = x ]; then exit 9; fi' \
+    'printf "%s\n" "fake seat output sentinel"' \
+    'if [ "${SEAT_TEST_OUTPUT_MODE:-}" = quota ]; then printf "%s\n" "You have hit your usage limit"; fi' \
+    > "$FAKE_BIN/codex"
+chmod +x "$FAKE_BIN/codex"
+
+run_case() {
+    local name="$1"
+    local fn="$2"
+    if "$fn"; then
+        printf 'PASS %s\n' "$name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        printf 'FAIL %s\n' "$name"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+seat_env() {
+    env PATH="$FAKE_BIN:$PATH" SEAT_TEST_MARKER="$MARKER" "$@"
+}
+
+case_clean_linked_dry_run() {
+    local output
+    [ -f "$SEAT_BUILD" ] || return 1
+    rm -f "$MARKER"
+    output="$(seat_env "$SEAT_BUILD" --seat codex --worktree "$LINKED_WT" \
+        --task-file "$TASK_FILE" --dry-run 2>/dev/null)" || return 1
+    [ ! -e "$MARKER" ] || return 1
+    python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["dry_run"] is True and d["rc"] is None' \
+        <<< "$output"
+}
+
+case_dirty_worktree_refused() {
+    local rc=0
+    [ -f "$SEAT_BUILD" ] || return 1
+    printf 'dirty\n' > "$LINKED_WT/untracked.txt"
+    seat_env "$SEAT_BUILD" --seat codex --worktree "$LINKED_WT" \
+        --task-file "$TASK_FILE" --dry-run >/dev/null 2>/dev/null || rc=$?
+    rm -f "$LINKED_WT/untracked.txt"
+    [ "$rc" -ne 0 ]
+}
+
+case_main_checkout_refused() {
+    local output
+    local rc=0
+    [ -f "$SEAT_BUILD" ] || return 1
+    output="$(seat_env "$SEAT_BUILD" --seat codex --worktree "$MAIN_REPO" \
+        --task-file "$TASK_FILE" --dry-run 2>/dev/null)" || rc=$?
+    [ "$rc" -eq 65 ] || return 1
+    python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["rc"] == 65' <<< "$output"
+}
+
+case_unknown_seat_refused() {
+    [ -f "$SEAT_BUILD" ] || return 1
+    ! seat_env "$SEAT_BUILD" --seat unknown --worktree "$LINKED_WT" \
+        --task-file "$TASK_FILE" --dry-run >/dev/null 2>/dev/null
+}
+
+case_missing_task_refused() {
+    [ -f "$SEAT_BUILD" ] || return 1
+    ! seat_env "$SEAT_BUILD" --seat codex --worktree "$LINKED_WT" \
+        --task-file "$FIXTURE/missing-task.txt" --dry-run >/dev/null 2>/dev/null
+}
+
+case_invalid_effort_refused() {
+    [ -f "$SEAT_BUILD" ] || return 1
+    ! seat_env "$SEAT_BUILD" --seat codex --worktree "$LINKED_WT" \
+        --task-file "$TASK_FILE" --effort extreme --dry-run >/dev/null 2>/dev/null
+}
+
+case_quota_output_detected() {
+    local output_file="$FIXTURE/quota-output.txt"
+    [ -f "$SEAT_BUILD" ] || return 1
+    # shellcheck source=/dev/null
+    source "$SEAT_BUILD"
+    printf "You've hit your usage limit\n" > "$output_file"
+    quota_output_exhausted "$output_file"
+}
+
+case_quota_report_keeps_seat_rc() {
+    local output
+    output="$(seat_env FOO_API_KEY=private SEAT_TEST_OUTPUT_MODE=quota \
+        "$SEAT_BUILD" --seat codex --worktree "$LINKED_WT" --task-file "$TASK_FILE" \
+        --tests 'exit 7' --timeout 5 2>/dev/null)" || return 1
+    python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["quota_exhausted"] is True; assert d["rc"] == 0; assert d["tests"] == {"cmd":"exit 7","rc":7}' \
+        <<< "$output"
+}
+
+case_no_ship_commands() {
+    [ -f "$SEAT_BUILD" ] || return 1
+    ! sed '/^[[:space:]]*#/d' "$SEAT_BUILD" |
+        grep -nE 'git (commit|push|merge)|(^|[^a-z])gh |launchctl|fly |vercel ' >/dev/null
+}
+
+case_no_external_timeout() {
+    [ -f "$SEAT_BUILD" ] && [ -f "$WATCHDOG" ] || return 1
+    ! grep -nE '(^|[;&|[:space:]])g?timeout[[:space:]]' "$SEAT_BUILD" "$WATCHDOG" >/dev/null
+}
+
+case_sensitive_env_stripped() {
+    local json_file="$FIXTURE/dry-run.json"
+    local log_file="$FIXTURE/dry-run.log"
+    [ -f "$SEAT_BUILD" ] || return 1
+    env PATH="$FAKE_BIN:$PATH" HOME="$FIXTURE/home" FOO_API_KEY=private \
+        FOO_PUBLIC=visible SEAT_TEST_MARKER="$MARKER" \
+        "$SEAT_BUILD" --seat codex --worktree "$LINKED_WT" \
+        --task-file "$TASK_FILE" --dry-run > "$json_file" 2> "$log_file" || return 1
+    python3 -c 'import json,sys; json.load(sys.stdin)' < "$json_file" || return 1
+    grep -qw 'FOO_API_KEY' "$log_file" || return 1
+    ! grep -Eq '(^|[ ,])PATH([ ,]|$)|(^|[ ,])HOME([ ,]|$)|(^|[ ,])FOO_PUBLIC([ ,]|$)' "$log_file"
+}
+
+case_clean_environment_reaches_seat() {
+    local output
+    rm -f "$MARKER"
+    output="$(env -i PATH="$FAKE_BIN:$PATH" HOME="$FIXTURE/home" \
+        SEAT_TEST_MARKER="$MARKER" bash "$SEAT_BUILD" --seat codex \
+        --worktree "$LINKED_WT" --task-file "$TASK_FILE" --timeout 5 \
+        2>/dev/null)" || return 1
+    [ -e "$MARKER" ] || return 1
+    python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["rc"] == 0' <<< "$output"
+}
+
+case_quota_matching_requires_quota_context() {
+    local output_file="$FIXTURE/quota-signature.txt"
+    local line
+    # shellcheck source=/dev/null
+    source "$SEAT_BUILD"
+    while IFS= read -r line; do
+        printf '%s\n' "$line" > "$output_file"
+        quota_output_exhausted "$output_file" || return 1
+    done <<'EOF'
+out of extra usage
+usage limit reached
+quota exceeded
+rate limit reached
+rate-limit reached
+HTTP 429
+HTTP: 429
+status 429
+status: 429
+429 Too Many Requests
+code 429
+code: 429
+quota exhausted
+usage exhausted
+credits exhausted
+tokens exhausted
+insufficient balance
+EOF
+    while IFS= read -r line; do
+        printf '%s\n' "$line" > "$output_file"
+        if quota_output_exhausted "$output_file"; then
+            return 1
+        fi
+    done <<'EOF'
+seat wrote code
+ 3 files changed, 429 insertions(+), 4 deletions(-)
+the search space was exhausted
+tokens used 45.736
+EOF
+}
+
+case_seat_log_is_reported_and_persisted() {
+    local output log_path
+    output="$(seat_env "$SEAT_BUILD" --seat codex --worktree "$LINKED_WT" \
+        --task-file "$TASK_FILE" --timeout 5 2>/dev/null)" || return 1
+    log_path="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["log"])' \
+        <<< "$output")" || return 1
+    [ -f "$log_path" ] || return 1
+    grep -Fq 'fake seat output sentinel' "$log_path"
+}
+
+case_tests_avoid_login_shell() {
+    [ -f "$SEAT_BUILD" ] || return 1
+    ! grep -nE 'bash[[:space:]]+-lc([[:space:]]|$)' "$SEAT_BUILD" >/dev/null
+}
+
+case_watchdog_kills_process_group() {
+    local descendant_pid_file="$FIXTURE/descendant.pid"
+    local rc=0
+    local descendant_pid
+    [ -f "$WATCHDOG" ] || return 1
+    # shellcheck source=/dev/null
+    source "$WATCHDOG"
+    # Positional parameters belong to the child shells.
+    # shellcheck disable=SC2016
+    AI_DISPATCH_TIMEOUT_GRACE_SECS=0 run_with_timeout 1 bash -c \
+        'trap "" TERM; bash -c '\''trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done'\'' _ "$1" & wait' \
+        _ "$descendant_pid_file" || rc=$?
+    [ "$rc" -eq 124 ] || return 1
+    descendant_pid="$(cat "$descendant_pid_file")"
+    ! kill -0 "$descendant_pid" 2>/dev/null
+}
+
+run_case "clean linked worktree dry-run is JSON and invokes no seat" case_clean_linked_dry_run
+run_case "dirty linked worktree is refused" case_dirty_worktree_refused
+run_case "main checkout is refused" case_main_checkout_refused
+run_case "unknown seat is refused" case_unknown_seat_refused
+run_case "missing task file is refused" case_missing_task_refused
+run_case "invalid effort is refused" case_invalid_effort_refused
+run_case "quota text is detected directly" case_quota_output_detected
+run_case "quota report preserves seat and test exit codes" case_quota_report_keeps_seat_rc
+run_case "shipping commands are absent" case_no_ship_commands
+run_case "external timeout commands are absent" case_no_external_timeout
+run_case "secret env names are stripped selectively" case_sensitive_env_stripped
+run_case "clean environment reaches the seat with no strip matches" case_clean_environment_reaches_seat
+run_case "quota matching requires quota-shaped context" case_quota_matching_requires_quota_context
+run_case "seat output log is reported and persists" case_seat_log_is_reported_and_persisted
+run_case "test commands avoid login shells" case_tests_avoid_login_shell
+run_case "watchdog kills the entire process group" case_watchdog_kills_process_group
+
+printf 'SUMMARY %d passed, %d failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## What

`scripts/seat_build.sh` gives Codex / Kimi / Qwen / GLM the same call shape `Agent` already has, so routing a build to a non-Anthropic seat stops being an act of discipline and becomes the path of least resistance.

```
scripts/seat_build.sh --seat codex --worktree <path> --task-file <path> \
  [--tests "<cmd>"] [--effort low|medium|high|xhigh] [--timeout 1800] [--out r.json] [--dry-run]
```

Report contract (also the exact fields an evidence-pack receipt needs):
`{seat, model, effort, rc, duration_s, diff_stat, untracked, tests:{cmd,rc}, quota_exhausted, log}`

## Why

Measured over the M5 transcripts of 2026-08-18..22: `Agent` dispatches ran **Sonnet 355 / Haiku 25 / Opus 24**, while `codex exec --sandbox workspace-write` was used **7** times. The doctrine already says a multi-PR campaign should route at least one lane through a non-Anthropic builder (`MODEL_ROSTER.md`). It is unmeasured and unfollowed because `Agent` is one structured call and `codex exec` is a blocking Bash call needing a worktree, `< /dev/null`, a watchdog, flag knowledge and output parsing. Prose does not beat friction.

**This is not a token-saving change** and does not claim to be one. What it buys is quota headroom (builds move from the Claude MAX/Team window to flat subscriptions) and parallelism across independent pools. Every cross-family build still gets an Anthropic verification pass (generator≠grader).

## What it deliberately does not do

- never `commit` / `push` / `merge` / `gh` / `fly` / `vercel` / `launchctl` — enforced by a test that greps the script, not by hope
- never runs against a main checkout or a dirty tree
- never hands the seat the session's credentials

## Four defects found by the grader, each with the command that proved it

Built by **Codex** (`--sandbox workspace-write`, effort `xhigh`); graded by this **Opus 5** session — the routing this file exists to make cheap, applied to itself.

1. **Died in a clean environment, and the suite could not see it.** `/usr/bin/env bash` here is **GNU bash 3.2.57**, where `"${arr[@]}"` on an empty array under `set -u` is fatal. With no `*_TOKEN`/`*_API_KEY` in the environment — the unattended/cron case — the script died before invoking the seat. The suite passed only because the grading session's environment held 16 such variables: *a test that inherits the ambient environment can never produce the failing condition.* The regression test now scrubs the environment.
2. **`429` over-match** (superscar #3). Proven: `3 files changed, 429 insertions(+)` set `quota_exhausted:true`, so a healthy build would have been re-routed as quota-dead. Now requires HTTP/status/`Too Many` context; `exhausted` requires a quota-shaped noun. Innocence cases include `429 insertions`, `search space was exhausted`, `tokens used 45.736`, `error 4290`.
3. **The seat's output was deleted** by a `trap rm -f` on EXIT — the caller got `{"rc":1}` and nothing to read. A wrapper that destroys the output makes *"read the OUTPUT, not the exit code"* impossible to obey. Now persisted and named in the report's `log` field (under an already-`.gitignore`d path).
4. **`--tests` ran under `bash -lc`** — a login shell, which sources the profile where `ls` is aliased to `eza` (different `-t`) and `fly` is a function with a hardcoded wrong cwd. Now `bash -c`.

Also: `timeout(1)`/`gtimeout(1)` **do not exist on this fleet** — a `timeout 240 python3 …` call was observed exiting **0** having run nothing. The watchdog is therefore pure Bash and kills the process **group** (TERM → grace → `kill -KILL -- -PGID`), which is also the only thing that stops the `qwen` CLI (hangs on open stdin, ignores SIGTERM). Vendored from `ai-dispatch.sh`, which cannot be sourced (top-level `cd`, strict mode, a dispatcher at the bottom); the dedup is ledgered.

## Verification (run, not recalled)

| check | result |
|---|---|
| `bash scripts/tests/test_seat_build.sh` | **16/16 PASS**, exit 0 |
| clean-env probe (`env -i PATH HOME`) | reaches the refusal logic, exit code 66, no unbound-variable death |
| quota over-match probe (grader's own cases) | `429 insertions` / `search space exhausted` / `tokens used 45.736` / `error 4290` → all clean; `HTTP 429 Too Many` / `usage limit` / `Insufficient balance` → QUOTA |
| `bash -n` on all three files | exit 0 |

**PROVE-LIVE** — one Bash call, real Codex, throwaway worktree:
```
{"seat":"codex","model":"codex-default","effort":"low","rc":0,"duration_s":22,
 "diff_stat":"","untracked":1,"tests":null,"quota_exhausted":false,
 "log":".worktrees/seat-build-codex-20260822T142042Z-13038.log"}
```
The file the seat was asked to write existed with the exact requested content; the log survived the run; the throwaway worktree was armed and released afterwards.

## Adversarial review

Grader: this Opus 5 session (≠ the Codex builder that authored the diff). Four defects raised, all four re-probed as cured with the grader's own cases — not the builder's tests.

Mandate: `docs/mandates/2026-08-22-arsenal-routing-mandate.md` D1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)