### PR TITLE
feat(evidence-pack): declare lanes and their seats, and measure builder diversity

### DIFF
--- a/MODEL_ROSTER.md
+++ b/MODEL_ROSTER.md
@@ -223,8 +223,7 @@ Implementer routing is **task-shaped across the full roster above**, not Sonnet-
 - **Hard / architectural / red-team** → `opus-5` at `xhigh` / `codex-sol` at xhigh-max.
 - **Effort is a dial, not a constant** — pick per task; `low`/`medium` on Opus 5 are a real
   cost/latency lever, not a quality compromise to avoid by reflex.
-- Any multi-PR campaign should route **at least one lane through a non-Anthropic builder**
-  (heterogeneity per modus §Arsenal's inversion rationale).
+- Multi-PR campaigns must route **at least one lane through a non-Anthropic builder** — enforced by `scripts/evidence_pack_lint.py` (NOTICE until 2026-09-05, then FAIL) and the `model_routing_gate.py` routing floor hook.
 - **Refuter always a different family from the builder** — generator≠grader, family-exclusion is
   hard (fleet-order-spec §3.2).
 - **Final gate, all gears (ruling Zero 2026-08-20, supersedes the 2026-08-19 gear split)** — **Opus 5,

--- a/infra/guard-conformance/registry.json
+++ b/infra/guard-conformance/registry.json
@@ -413,6 +413,29 @@
             "test_gear_floor_innocence_declared_at_or_above_floor_passes",
             "test_gear_floor_innocence_skipped_without_changed_files"
           ]
+        },
+        "check_lanes_build_seat_diversity": {
+          "scar": ["D3", "fleet-order-spec-4"],
+          "guilt": [
+            "test_lanes_guilt_gear2_two_anthropic_builders_post_flip",
+            "test_lanes_guilt_gear3_three_anthropic_builders_post_flip",
+            "test_lanes_guilt_not_a_list",
+            "test_lanes_guilt_entry_not_mapping",
+            "test_lanes_guilt_missing_seat",
+            "test_lanes_guilt_invalid_role",
+            "test_is_anthropic_seat_guilt_anthropic_token_matches",
+            "test_lanes_gear3_opus5_sonnet5_flip_behavior"
+          ],
+          "innocence": [
+            "test_lanes_innocence_mixed_builders_clean_both_sides",
+            "test_lanes_innocence_one_build_plus_reviews",
+            "test_lanes_innocence_gear1_exempt",
+            "test_lanes_innocence_absent",
+            "test_lanes_innocence_overmatch_guard_opusculum_claude_ish",
+            "test_lanes_end_to_end_notice_pre_flip_does_not_fail",
+            "test_is_anthropic_seat_innocence_non_anthropic_token_matches",
+            "test_lanes_gear3_opus5_sonnet5_flip_behavior"
+          ]
         }
       }
     },

--- a/scripts/evidence_pack_lint.py
+++ b/scripts/evidence_pack_lint.py
@@ -115,12 +115,24 @@ WHAT IT VALIDATES (an Evidence Pack YAML, default path evidence/pack.yml):
                         contract. Skipped, same as rule 6, whenever
                         --changed-files-file is not supplied.
 
+  8. lanes seat diversity (D3) — a Gear >= 2 pack with >= 2 build lanes must
+                        include at least one non-Anthropic builder seat.
+                        Exemptions: Gear 1, fewer than 2 build lanes,
+                        `lanes:` absent. Shape violations (lanes not a list,
+                        entry not a mapping, missing/empty lane/role/seat,
+                        invalid role) fail immediately. The diversity floor
+                        itself is time-phased: before 2026-09-05 it emits a
+                        NOTICE and does not fail; on/after 2026-09-05 it is
+                        a violation. The flip date lives in code (not a
+                        ledger) so the gate enforces it mechanically.
+
 Floor check is SKIPPED (not silently passed — an explicit NOTICE on stderr)
 when --changed-files-file is not supplied: not every invocation of this linter
 has PR-diff context (e.g. a spot-check of a pack on a laptop). The CI workflow
 (harness-floor.yml) is the required check that always supplies it. The
 ceiling check (rule 7) is skipped under the same condition, for the same
-reason.
+reason. The lanes check (rule 8) does NOT depend on changed-files and always
+runs.
 
 VERDICT / EXIT CODES (fail-visible, superscar #2 "esiste != armato" antidote:
 a lint that scanned nothing must not report clean):
@@ -171,6 +183,7 @@ Registered in infra/guard-conformance/registry.json (surface
 from __future__ import annotations
 
 import argparse
+import datetime
 import fnmatch
 import subprocess
 import sys
@@ -205,6 +218,15 @@ HOTZONE_PATTERNS: tuple[str, ...] = (
 RECEIPT_REQUIRED_FIELDS = ("claim", "cmd", "exit", "ts", "seat")
 SIZE_TOKEN_CAP = 30_000
 VALID_GEARS = (1, 2, 3)
+
+# D3 seat-diversity rule (fleet-order program): a Gear >= 2 pack with >= 2
+# build lanes must include at least one non-Anthropic builder seat. The flip
+# date lives IN THE LINT because a ledger line nobody reads cannot gate a
+# merge — the code itself must enforce the grace window. Before 2026-09-05 the
+# linter NOTICES; on/after 2026-09-05 it FAILS. (14-day grace: rule ratified
+# 2026-08-22.)
+LANES_NON_ANTHROPIC_ENFORCEMENT_DATE = datetime.date(2026, 9, 5)
+VALID_LANE_ROLES = ("build", "review", "read")
 
 
 # --------------------------------------------------------------------- utils
@@ -556,6 +578,100 @@ def check_gear_floor(brief: dict[str, Any] | None, changed_files: list[str] | No
     return []
 
 
+def _is_anthropic_seat(seat: Any) -> bool:
+    """Token-based match for Anthropic seat names.
+
+    The normalised seat is split on ``-`` only (NOT on ``_``). It counts as
+    Anthropic when its FIRST token is exactly one of ``claude``, ``sonnet``,
+    ``opus``, or ``haiku``. This defends against BOTH failure directions of
+    superscar #3:
+
+    * over-match: ``opusculum`` / ``claude_ish`` are NOT Anthropic (the
+      underscore is not a separator, so the first token is not ``claude``);
+    * under-match: roster-style names such as ``opus-5``, ``sonnet-5`` and
+      ``haiku-4-5`` ARE Anthropic because the first token is the family name.
+    """
+    if not isinstance(seat, str):
+        return False
+    norm = seat.strip().lower()
+    if not norm:
+        return False
+    first_token = norm.split("-", 1)[0]
+    return first_token in {"claude", "sonnet", "opus", "haiku"}
+
+
+def check_lanes_build_seat_diversity(
+    pack: dict[str, Any],
+    gear: int | None = None,
+    today: datetime.date | None = None,
+) -> tuple[list[str], str | None]:
+    """D3 seat-diversity rule. GUILT/NOTICE: a Gear >= 2 pack with >= 2 build
+    lanes must include at least one non-Anthropic builder seat. Exemptions:
+    Gear 1, fewer than 2 build lanes, or `lanes:` absent. Shape violations
+    (lanes not a list, entry not a mapping, missing/empty lane/role/seat,
+    invalid role) are always failures regardless of the date.
+
+    Returns (violations, notice). `notice` is set only during the pre-
+    enforcement grace period (before LANES_NON_ANTHROPIC_ENFORCEMENT_DATE)
+    when the diversity rule would otherwise fail; violations is empty in that
+    window. On/after the enforcement date the same shape becomes a violation.
+
+    The `today` parameter makes the date overridable for tests without
+    monkeypatching date.today() or env vars."""
+    if "lanes" not in pack:
+        return [], None
+
+    lanes = pack["lanes"]
+    if not isinstance(lanes, list):
+        return [f"lanes: must be a list, got {type(lanes).__name__}"], None
+
+    violations: list[str] = []
+    build_lanes: list[tuple[int, dict[str, Any]]] = []
+
+    for idx, entry in enumerate(lanes):
+        if not isinstance(entry, dict):
+            violations.append(f"lanes[{idx}]: must be a mapping, got {type(entry).__name__}")
+            continue
+        for field in ("lane", "role", "seat"):
+            value = entry.get(field)
+            if not isinstance(value, str) or not value.strip():
+                violations.append(f"lanes[{idx}]: {field} missing/empty")
+                break
+        else:
+            role = entry.get("role", "").strip().lower()
+            if role not in VALID_LANE_ROLES:
+                violations.append(
+                    f"lanes[{idx}]: role must be one of {VALID_LANE_ROLES}, "
+                    f"got {entry.get('role')!r}"
+                )
+                continue
+            if role == "build":
+                build_lanes.append((idx, entry))
+
+    if violations:
+        return violations, None
+
+    if gear is None or gear < 2:
+        return [], None
+    if len(build_lanes) < 2:
+        return [], None
+    if not all(_is_anthropic_seat(entry.get("seat")) for _idx, entry in build_lanes):
+        return [], None
+
+    idxs = ",".join(str(i) for i, _e in build_lanes)
+    message = (
+        f"lanes: Gear-{gear} pack has {len(build_lanes)} build lane(s) "
+        f"([{idxs}]) and zero non-Anthropic builder seats "
+        f"(D3 seat-diversity rule)"
+    )
+
+    if today is None:
+        today = datetime.datetime.now(datetime.timezone.utc).date()
+    if today < LANES_NON_ANTHROPIC_ENFORCEMENT_DATE:
+        return [], message
+    return [message], None
+
+
 # ------------------------------------------------------------------- lint()
 
 
@@ -601,6 +717,11 @@ def lint(
     violations += brief_violations
     violations += check_dissent_nonempty_on_gear3(pack, gear)
     violations += check_gear_floor(brief, changed_files)
+
+    lane_violations, lane_notice = check_lanes_build_seat_diversity(pack, gear)
+    violations += lane_violations
+    if lane_notice:
+        print(f"evidence_pack_lint: NOTICE — {lane_notice}", file=sys.stderr)
 
     if changed_files is None:
         print("evidence_pack_lint: NOTICE — no --changed-files-file supplied, "
@@ -965,6 +1086,97 @@ def selftest() -> int:
         write(root / "evidence" / "brief.yml", {"task_id": "x", "gear": 1.0, "grader": "y"})
         rc, viol = lint(root / "evidence" / "pack.yml", root, None)
         check("guilt: gear=1.0 (float) rejected despite 1.0==1", rc == 1)
+
+        # ---- lanes seat-diversity (D3) -----------------------------------------
+        # shape violations always fail, regardless of date/gear
+        write(root / "evidence" / "brief.yml", {"task_id": "x", "gear": 2, "grader": "y"})
+        write(root / "evidence" / "pack.yml", {
+            "brief_ref": "evidence/brief.yml",
+            "receipts": [good_receipt], "dissent": [], "pii_scan": "clean",
+            "lanes": "not-a-list",
+        })
+        rc, viol = lint(root / "evidence" / "pack.yml", root, None)
+        check("guilt: lanes not a list rejected", rc == 1)
+
+        write(root / "evidence" / "pack.yml", {
+            "brief_ref": "evidence/brief.yml",
+            "receipts": [good_receipt], "dissent": [], "pii_scan": "clean",
+            "lanes": [{"lane": "D1", "role": "deploy", "seat": "codex"}],
+        })
+        rc, viol = lint(root / "evidence" / "pack.yml", root, None)
+        check("guilt: invalid lane role rejected", rc == 1)
+
+        # two Anthropic build lanes on Gear 2 -> violation on/after flip date
+        before_flip = datetime.date(2026, 9, 4)
+        after_flip = datetime.date(2026, 9, 5)
+        write(root / "evidence" / "pack.yml", {
+            "brief_ref": "evidence/brief.yml",
+            "receipts": [good_receipt], "dissent": [], "pii_scan": "clean",
+            "lanes": [
+                {"lane": "D1", "role": "build", "seat": "sonnet"},
+                {"lane": "D2", "role": "build", "seat": "opus"},
+            ],
+        })
+        viol_pre, notice_pre = check_lanes_build_seat_diversity(
+            {"lanes": [
+                {"lane": "D1", "role": "build", "seat": "sonnet"},
+                {"lane": "D2", "role": "build", "seat": "opus"},
+            ]},
+            gear=2, today=before_flip,
+        )
+        check("lanes: pre-flip Gear-2 + 2 Anthropic build lanes -> NOTICE (no violation)",
+              viol_pre == [] and notice_pre is not None and "D3" in notice_pre)
+        viol_post, notice_post = check_lanes_build_seat_diversity(
+            {"lanes": [
+                {"lane": "D1", "role": "build", "seat": "sonnet"},
+                {"lane": "D2", "role": "build", "seat": "opus"},
+            ]},
+            gear=2, today=after_flip,
+        )
+        check("lanes: post-flip Gear-2 + 2 Anthropic build lanes -> violation",
+              bool(viol_post) and notice_post is None and "D3" in viol_post[0])
+
+        # two build lanes with one non-Anthropic -> innocent on both sides
+        viol_mixed, notice_mixed = check_lanes_build_seat_diversity(
+            {"lanes": [
+                {"lane": "D1", "role": "build", "seat": "sonnet"},
+                {"lane": "D2", "role": "build", "seat": "codex"},
+            ]},
+            gear=2, today=after_flip,
+        )
+        check("innocence: Gear-2 + 2 build lanes with one non-Anthropic -> clean",
+              viol_mixed == [] and notice_mixed is None)
+
+        # Gear 1 with two Anthropic build lanes -> exempt
+        viol_g1, notice_g1 = check_lanes_build_seat_diversity(
+            {"lanes": [
+                {"lane": "D1", "role": "build", "seat": "sonnet"},
+                {"lane": "D2", "role": "build", "seat": "opus"},
+            ]},
+            gear=1, today=after_flip,
+        )
+        check("innocence: Gear-1 + 2 Anthropic build lanes -> exempt", viol_g1 == [] and notice_g1 is None)
+
+        # single build lane -> exempt
+        viol_single, notice_single = check_lanes_build_seat_diversity(
+            {"lanes": [
+                {"lane": "D1", "role": "build", "seat": "sonnet"},
+                {"lane": "D2", "role": "review", "seat": "opus"},
+            ]},
+            gear=2, today=after_flip,
+        )
+        check("innocence: Gear-2 + 1 build lane -> exempt", viol_single == [] and notice_single is None)
+
+        # substring trap: opusculum / claude_ish are NOT Anthropic
+        viol_trap, notice_trap = check_lanes_build_seat_diversity(
+            {"lanes": [
+                {"lane": "D1", "role": "build", "seat": "opusculum"},
+                {"lane": "D2", "role": "build", "seat": "claude_ish"},
+            ]},
+            gear=2, today=after_flip,
+        )
+        check("innocence: opusculum/claude_ish are non-Anthropic by word-aware match",
+              viol_trap == [] and notice_trap is None)
 
         # ---- blind-scan guard: pack file missing -------------------------------
         rc, viol = lint(root / "evidence" / "nope.yml", root, None)

--- a/scripts/tests/test_evidence_pack_lint.py
+++ b/scripts/tests/test_evidence_pack_lint.py
@@ -9,6 +9,7 @@ colpevolezza" — each guard needs BOTH proofs registered).
 
 from __future__ import annotations
 
+import datetime
 import subprocess
 import sys
 import tempfile
@@ -22,9 +23,12 @@ SCRIPTS = REPO / "scripts"
 
 sys.path.insert(0, str(SCRIPTS))
 from evidence_pack_lint import (  # noqa: E402
+    LANES_NON_ANTHROPIC_ENFORCEMENT_DATE,
+    _is_anthropic_seat,
     check_brief_ref_exists,
     check_dissent_nonempty_on_gear3,
     check_gear_floor,
+    check_lanes_build_seat_diversity,
     check_pii_scan_clean,
     check_receipts_have_provenance,
     check_size_budget,
@@ -702,3 +706,214 @@ def test_numstat_file_cli_flag_wired_end_to_end(tmp_path):
     )
     assert proc.returncode == 1, proc.stdout + proc.stderr
     assert "gear_override" in (proc.stdout + proc.stderr)
+
+
+# --------------------------------------------------------- check_lanes_build_seat_diversity
+
+
+def _lane_pack(*lanes):
+    return {"lanes": list(lanes)}
+
+
+LANE_BUILD_ANTHRO = {"lane": "D1", "role": "build", "seat": "sonnet"}
+LANE_BUILD_CODEX = {"lane": "D2", "role": "build", "seat": "codex"}
+LANE_REVIEW_ANTHRO = {"lane": "D3", "role": "review", "seat": "opus"}
+
+
+def test_lanes_guilt_gear2_two_anthropic_builders_post_flip():
+    """GUILT: Gear 2, two build lanes, both Anthropic -> violation on/after
+    the enforcement date."""
+    pack = _lane_pack(LANE_BUILD_ANTHRO, {"lane": "D2", "role": "build", "seat": "opus"})
+    violations, notice = check_lanes_build_seat_diversity(
+        pack, gear=2, today=LANES_NON_ANTHROPIC_ENFORCEMENT_DATE
+    )
+    assert violations
+    assert notice is None
+    assert "D3" in violations[0]
+
+
+def test_lanes_notice_gear2_two_anthropic_builders_pre_flip():
+    """NOTICE (not guilt): same shape as above, but before the flip date —
+    the rule reports via the notice return, not via violations."""
+    pack = _lane_pack(LANE_BUILD_ANTHRO, {"lane": "D2", "role": "build", "seat": "opus"})
+    before = LANES_NON_ANTHROPIC_ENFORCEMENT_DATE - datetime.timedelta(days=1)
+    violations, notice = check_lanes_build_seat_diversity(pack, gear=2, today=before)
+    assert violations == []
+    assert notice is not None
+    assert "D3" in notice
+
+
+def test_lanes_guilt_gear3_three_anthropic_builders_post_flip():
+    """GUILT: Gear 3, three Anthropic build lanes (mixed name styles) ->
+    violation on/after the enforcement date."""
+    pack = _lane_pack(
+        LANE_BUILD_ANTHRO,
+        {"lane": "D2", "role": "build", "seat": "opus"},
+        {"lane": "D3", "role": "build", "seat": "claude-sonnet-5"},
+    )
+    violations, notice = check_lanes_build_seat_diversity(
+        pack, gear=3, today=LANES_NON_ANTHROPIC_ENFORCEMENT_DATE
+    )
+    assert violations
+    assert notice is None
+
+
+def test_lanes_guilt_not_a_list():
+    """GUILT: `lanes` present but not a list is always a violation."""
+    violations, notice = check_lanes_build_seat_diversity({"lanes": "nope"}, gear=2)
+    assert violations
+    assert "list" in violations[0]
+    assert notice is None
+
+
+def test_lanes_guilt_entry_not_mapping():
+    """GUILT: a lane entry that is not a mapping is always a violation."""
+    pack = _lane_pack("not-a-mapping")
+    violations, notice = check_lanes_build_seat_diversity(pack, gear=2)
+    assert violations
+    assert "mapping" in violations[0]
+    assert notice is None
+
+
+def test_lanes_guilt_missing_seat():
+    """GUILT: a lane entry missing `seat` is always a violation."""
+    pack = {"lanes": [{"lane": "D1", "role": "build"}]}
+    violations, notice = check_lanes_build_seat_diversity(pack, gear=2)
+    assert violations
+    assert "seat" in violations[0]
+    assert notice is None
+
+
+def test_lanes_guilt_invalid_role():
+    """GUILT: `role: deploy` is not in {build, review, read}."""
+    pack = {"lanes": [{"lane": "D1", "role": "deploy", "seat": "codex"}]}
+    violations, notice = check_lanes_build_seat_diversity(pack, gear=2)
+    assert violations
+    assert "deploy" in violations[0]
+    assert notice is None
+
+
+def test_lanes_innocence_mixed_builders_clean_both_sides():
+    """INNOCENCE: Gear 2, two build lanes, one non-Anthropic (codex) ->
+    clean on both sides of the flip date."""
+    pack = _lane_pack(LANE_BUILD_ANTHRO, LANE_BUILD_CODEX)
+    before = LANES_NON_ANTHROPIC_ENFORCEMENT_DATE - datetime.timedelta(days=1)
+    for today in (before, LANES_NON_ANTHROPIC_ENFORCEMENT_DATE):
+        violations, notice = check_lanes_build_seat_diversity(pack, gear=2, today=today)
+        assert violations == []
+        assert notice is None
+
+
+def test_lanes_innocence_one_build_plus_reviews():
+    """INNOCENCE: Gear 2, only ONE build lane + two review lanes (all
+    Anthropic) -> exempt by the <2-build-lanes carve-out."""
+    pack = _lane_pack(LANE_BUILD_ANTHRO, LANE_REVIEW_ANTHRO, LANE_REVIEW_ANTHRO)
+    violations, notice = check_lanes_build_seat_diversity(
+        pack, gear=2, today=LANES_NON_ANTHROPIC_ENFORCEMENT_DATE
+    )
+    assert violations == []
+    assert notice is None
+
+
+def test_lanes_innocence_gear1_exempt():
+    """INNOCENCE: Gear 1 with two Anthropic build lanes is exempt."""
+    pack = _lane_pack(LANE_BUILD_ANTHRO, {"lane": "D2", "role": "build", "seat": "opus"})
+    violations, notice = check_lanes_build_seat_diversity(
+        pack, gear=1, today=LANES_NON_ANTHROPIC_ENFORCEMENT_DATE
+    )
+    assert violations == []
+    assert notice is None
+
+
+def test_lanes_innocence_absent():
+    """INNOCENCE: `lanes` key absent entirely -> clean."""
+    violations, notice = check_lanes_build_seat_diversity({}, gear=2)
+    assert violations == []
+    assert notice is None
+
+
+def test_lanes_innocence_overmatch_guard_opusculum_claude_ish():
+    """INNOCENCE: seats literally named `opusculum` or `claude_ish` are
+    treated as non-Anthropic (word/prefix-aware match, not bare substring)."""
+    pack = _lane_pack(
+        {"lane": "D1", "role": "build", "seat": "opusculum"},
+        {"lane": "D2", "role": "build", "seat": "claude_ish"},
+    )
+    violations, notice = check_lanes_build_seat_diversity(
+        pack, gear=2, today=LANES_NON_ANTHROPIC_ENFORCEMENT_DATE
+    )
+    assert violations == []
+    assert notice is None
+
+
+def test_lanes_end_to_end_notice_pre_flip_does_not_fail(tmp_repo):
+    """Wired through lint(): a Gear-2 pack with two Anthropic build lanes
+    before the flip date prints a NOTICE to stderr but returns exit 0."""
+    root, write_brief, write_pack = tmp_repo
+    write_brief(gear=2)
+    pack_path = write_pack(lanes=[
+        {"lane": "D1", "role": "build", "seat": "sonnet"},
+        {"lane": "D2", "role": "build", "seat": "opus"},
+    ])
+    # lint() uses the real clock; today is before 2026-09-05, so it must notice
+    rc, violations = lint(pack_path, root, None)
+    assert rc == 0
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "seat,expected",
+    [
+        ("opus-5", True),
+        ("sonnet-5", True),
+        ("haiku-4-5", True),
+        ("claude-opus-5", True),
+        ("claude-sonnet-5", True),
+        ("sonnet", True),
+        ("opus", True),
+        ("haiku", True),
+        ("Claude-Sonnet-5", True),
+        ("  sonnet  ", True),
+    ],
+)
+def test_is_anthropic_seat_guilt_anthropic_token_matches(seat, expected):
+    """GUILT (for the matcher): roster-style Anthropic names are recognised
+    regardless of trailing version tokens, case, or surrounding whitespace."""
+    assert _is_anthropic_seat(seat) is expected
+
+
+@pytest.mark.parametrize(
+    "seat,expected",
+    [
+        ("opusculum", False),
+        ("claude_ish", False),
+        ("codex", False),
+        ("kimi", False),
+        ("glm", False),
+        ("qwen", False),
+        ("codex-sol", False),
+    ],
+)
+def test_is_anthropic_seat_innocence_non_anthropic_token_matches(seat, expected):
+    """INNOCENCE (for the matcher): non-Anthropic names are not swept up by
+    substring or prefix matching, and ``_`` is not treated as a separator."""
+    assert _is_anthropic_seat(seat) is expected
+
+
+def test_lanes_gear3_opus5_sonnet5_flip_behavior():
+    """End-to-end under-match regression: roster-style Anthropic build seats
+    must be a VIOLATION post-flip and a NOTICE pre-flip."""
+    pack = _lane_pack(
+        {"lane": "D1", "role": "build", "seat": "opus-5"},
+        {"lane": "D2", "role": "build", "seat": "sonnet-5"},
+    )
+    before = LANES_NON_ANTHROPIC_ENFORCEMENT_DATE - datetime.timedelta(days=1)
+    violations, notice = check_lanes_build_seat_diversity(pack, gear=3, today=before)
+    assert violations == []
+    assert notice is not None
+
+    violations, notice = check_lanes_build_seat_diversity(
+        pack, gear=3, today=LANES_NON_ANTHROPIC_ENFORCEMENT_DATE
+    )
+    assert violations
+    assert notice is None


### PR DESCRIPTION
## What

`evidence/pack.yml` gains an optional `lanes:` list:

```yaml
lanes:
  - {lane: D1-wrapper, role: build,  seat: codex}
  - {lane: D2-hook,    role: build,  seat: sonnet}
  - {lane: D3-lint,    role: review, seat: opus-5}
```

A **Gear ≥ 2** pack declaring **≥ 2 build lanes** with **zero non-Anthropic seats** is flagged: **NOTICE until 2026-09-05, violation from that date on.**

`MODEL_ROSTER.md` line ~226 loses its unenforced prose and points at what now enforces it.

## Why

The roster has said for a while that a multi-PR campaign should route at least one lane through a non-Anthropic builder. Nothing measured it, so nothing followed it: over the M5 transcripts of 2026-08-18..22, `Agent` dispatches ran **Sonnet 355 / Haiku 25 / Opus 24** against **7** Codex `workspace-write` builds.

**The flip date lives in the lint**, as a module constant — a date in a ledger line nobody reads cannot flip a gate. It is a function parameter for tests, not an env var and not a monkeypatched `date.today()`, so tests exercise both sides of the flip without being able to soften production.

**Exempt by construction, never by judgement:** Gear 1 · fewer than two build lanes (a one-lane task has nothing to diversify) · `lanes:` absent.

## The defect the grader found: the guard was defeated by the repo's own vocabulary

The first cut was armed against **over**-match and correctly refused `opusculum` as `opus`. It then classified `opus-5`, `sonnet-5` and `haiku-4-5` as **non-Anthropic** — which is exactly how `MODEL_ROSTER.md` itself spells them ("`opus-5` at `xhigh`", line ~224).

Measured, before the fix:

```python
check_lanes_build_seat_diversity(
  {"lanes":[{"lane":"a","role":"build","seat":"opus-5"},
            {"lane":"b","role":"build","seat":"sonnet-5"}]}, 3, date(2026,9,10))
-> ([], None)      # CLEAN. Two Anthropic build lanes satisfy the diversity floor.
```

The same pack with `seat: opus` / `seat: sonnet` correctly produced a violation. So the rule was defeated purely by how the author spells the model — and the spelling that defeated it is the one the roster teaches. That is the **UNDER-match twin of superscar #3 (W82)**: a guard watching a literal form while the same fact, written another way, sails past green.

Rule now: split the normalised seat on `-` only; Anthropic iff the **first token** is exactly `claude`/`sonnet`/`opus`/`haiku`.

Graded against 21 cases in both directions — including four the builder never wrote:

| seat | verdict |
|---|---|
| `opus-5` `sonnet-5` `haiku-4-5` `claude-opus-5` `sonnet` `OPUS-5` `Claude-Sonnet-5` `  sonnet  ` | Anthropic |
| `opusculum` `claude_ish` `opus_5` `sonnetish-5` `codex-sol` `codex` `kimi` `glm` `qwen` | non-Anthropic |

0 mismatches. The end-to-end case that was CLEAN is now a violation post-flip and a NOTICE pre-flip; a pack with one `codex` build lane stays silent on both sides.

## Verification (run, not recalled)

| check | result |
|---|---|
| `test_evidence_pack_lint.py` | exit 0 — **90 cases**, no regression on the pre-existing ones |
| `evidence_pack_lint.py --selftest` | exit 0 |
| `check_guard_conformance.py` | **0 violations**, new check censused with guilt+innocence |
| `registry.json` | valid JSON |
| grader's own 21-case matcher table | 0 mismatches |

## Adversarial review

Built by **Kimi** (`kimi-code/kimi-for-coding`), graded by this **Opus 5** session — generator ≠ grader, and the cross-family routing this change enforces, applied to itself.

Registry note: `check_guard_conformance.py` reads `surface["test_file"]` as a single string, so a separate `test_evidence_pack_lint_lanes.py` could not be censused; the lane tests live in the existing suite, as the task's stated fallback required.

Mandate: `docs/mandates/2026-08-22-arsenal-routing-mandate.md` D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)