### PR TITLE
fix(bot): cure the G-P3 DLP over-match batch F1-F5b (Kimi rounds 2+3)

### DIFF
--- a/apps/backend-rag/backend/app/routers/wa_package.py
+++ b/apps/backend-rag/backend/app/routers/wa_package.py
@@ -64,6 +64,11 @@ class WaPackageBuildRequest(BaseModel):
     query: str = Field(..., min_length=1, max_length=4096)
     history: list[WaPackageHistoryMessage] = Field(default_factory=list, max_length=24)
     thread_epoch: int
+    # G-P3 DLP gate: redact history/chunks free-text fields before the
+    # package is sealed. Default False preserves the pre-G-P3 contract for
+    # any other caller; the codex-bound leg (the only caller today, see
+    # wa_codex_leg.py) sends True.
+    dlp: bool = False
 
 
 class WaPackageBuildResponse(BaseModel):
@@ -87,11 +92,20 @@ class WaPackageBuildResponse(BaseModel):
     wire and steer the consumer's frozen-evidence abstain verdict with
     values the hash never covered. Consumers parse evidence_inputs OUT OF
     the wire.
+
+    ``reversal_map`` (G-P3) travels ALONGSIDE the sealed wire, never inside
+    it: placeholder -> original PII value, populated only when the request
+    asked for ``dlp=True`` and the package actually redacted something.
+    Absent (None) on every unbuildable response and on any dlp=False build.
+    The caller is trusted to keep this local and never persist/log it (see
+    `wa_codex_leg._attempt`, the only caller today) — this endpoint does
+    not log it either.
     """
 
     package_wire: str | None = None
     package_hash: str | None = None
     unbuildable: str | None = None
+    reversal_map: dict[str, str] | None = None
 
 
 @router.post(
@@ -136,6 +150,7 @@ async def build_wa_package(
             thread_epoch=request.thread_epoch,
             retriever=orchestrator.core.retriever,
             curated_qa_block=curated_qa_block,
+            dlp=request.dlp,
         )
     except PackageUnbuildable as exc:
         logger.info("wa_package: unbuildable reason=%s", exc.reason)
@@ -144,4 +159,5 @@ async def build_wa_package(
     return WaPackageBuildResponse(
         package_wire=package.wire_text(),
         package_hash=package.package_hash,
+        reversal_map=package.reversal_map or None,
     )

--- a/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
+++ b/apps/backend-rag/backend/services/integrations/wa_codex_leg.py
@@ -99,6 +99,7 @@ from backend.services.integrations.wa_inbox_bot import (
     _tell_a_human,
     is_bot_autoreply_enabled,
 )
+from backend.services.rag.agentic.wa_dlp import restore_text
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +237,11 @@ async def _attempt(
         client = await _get_rag_client()
         resp = await client.post(
             "/api/wa-package/build",
-            json={"query": query, "history": history, "thread_epoch": epoch},
+            # dlp=True (G-P3): the codex leg is the ONLY caller of this
+            # endpoint (grep-verified) and is the ONE route that hands
+            # customer text to an external generator — the DLP gate applies
+            # here and only here, never on the Gemini leg.
+            json={"query": query, "history": history, "thread_epoch": epoch, "dlp": True},
             timeout=_BUILD_TIMEOUT,
         )
         resp.raise_for_status()
@@ -253,6 +258,11 @@ async def _attempt(
         return CodexLegResult(reason=f"unbuildable:{built['unbuildable']}")
     wire = built.get("package_wire")
     package_hash = built.get("package_hash")
+    # G-P3: local variable of THIS coroutine only — never persisted, never
+    # logged, never forwarded past the `restore_text` call below (same
+    # invocation of `_attempt` that requested the build, per the ground
+    # map's "provably never leaves Fly" verification).
+    reversal_map: dict[str, str] = built.get("reversal_map") or {}
     if not wire or not package_hash:
         # A builder that answered 200 without either half of the sealed
         # envelope is a contract break, not a route decision.
@@ -512,6 +522,17 @@ async def _attempt(
             offer.job_id,
         )
         return CodexLegResult(reason="consume_lost")
+
+    # G-P3 restore: the generator answered against a REDACTED package (its
+    # prompt carried `[PII-CATEGORY-N]` placeholders, never the customer's
+    # real values), so its completion may echo those same placeholders back
+    # — substitute them for the real values HERE, before the shared
+    # finalize pipeline and before this ever becomes CodexLegResult.text. A
+    # placeholder shape the generator invented (never issued for this
+    # package) is stripped, not restored to garbage (wa_dlp.restore_text).
+    # No-op when reversal_map is empty (dlp=False build, or a redaction
+    # that found nothing to redact).
+    text = restore_text(text, reversal_map)
 
     # Finalize — the SHARED pipeline, provider="codex" (spec 2.3): abstain
     # verdict from the FROZEN evidence, text-defect checks, channel

--- a/apps/backend-rag/backend/services/rag/agentic/wa_dlp.py
+++ b/apps/backend-rag/backend/services/rag/agentic/wa_dlp.py
@@ -130,8 +130,52 @@ _EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+\.\w{2,}")
 # ONE-WAY CATEGORY (spalla S1): see `_ONE_WAY_CATEGORIES` below.
 _JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b")
 _PEM_RE = re.compile(r"-----BEGIN [A-Z ]*KEY-----")
-_KEY_PREFIX_RE = re.compile(r"\b(?:sk|ghp|gho|xoxb|xoxp|AKIA)[A-Za-z0-9_-]{16,}\b")
+# F5: the vendor prefixes now REQUIRE their separator. Without it, `sk`
+# followed by 16+ word characters swallows ordinary vocabulary
+# ("skincareproducts2026", "skillsheet1234567890") — and CREDENTIAL is a
+# ONE-WAY category with no reversal map, so such a false positive is an
+# IRRECOVERABLE hole in the customer's own reply. AKIA is a separate
+# alternative: its format carries no separator by construction.
+_KEY_PREFIX_RE = re.compile(
+    r"\b(?:"
+    r"sk[-_][A-Za-z0-9_-]{16,}"
+    r"|ghp_[A-Za-z0-9_-]{16,}"
+    r"|gho_[A-Za-z0-9_-]{16,}"
+    r"|xoxb-[A-Za-z0-9_-]{16,}"
+    r"|xoxp-[A-Za-z0-9_-]{16,}"
+    r"|AKIA[A-Z0-9]{16}"
+    r")\b"
+)
 _BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._-]{20,}")
+
+# F5b (Kimi round-3 BLOCKER): requiring the separator was not enough. The
+# tail class still contains `-` and `_`, so `sk-` followed by hyphen-separated
+# WORDS satisfies the 16-char minimum — and `SK` is Surat Keputusan, the
+# single most-cited document type this business writes about
+# (`sk-kemenkumham-ahu-0012345`, the article slug `sk-immigration-update-2026`).
+# CREDENTIAL is ONE-WAY: that span would be deleted from the customer's own
+# answer with no way back.
+#
+# The distinguisher is STRUCTURAL, not a word list: a real key carries its
+# entropy in one UNBROKEN alphanumeric run (`sk-proj-A1b2...` — 32 chars with
+# no separator), while human text is short words joined by hyphens. So the
+# `sk` alternative additionally requires one unbroken run of >=16 alphanumeric
+# characters somewhere after the prefix. The other prefixes are left alone:
+# `ghp_`/`gho_`/`xoxb-`/`xoxp-`/`AKIA` are not words in any language this
+# business writes, so they have no innocent collision to protect against —
+# narrow at the false positive, never at the canonical form.
+_KEY_ENTROPY_RUN_RE = re.compile(r"[A-Za-z0-9]{16,}")
+
+
+def _validate_key_prefix(_source: str, match: re.Match[str]) -> bool:
+    # `_source` is unused: unlike the amount/passport validators, this one
+    # decides entirely on the matched span's own shape — surrounding prose
+    # cannot make a hyphenated slug more or less of a credential. The
+    # parameter stays to satisfy the `Validator` signature.
+    surface = match.group(0)
+    if not surface.startswith(("sk-", "sk_")):
+        return True
+    return _KEY_ENTROPY_RUN_RE.search(surface[3:]) is not None
 
 # NPWP — reused verbatim from backend/middleware/pii_scanner.py's Presidio
 # patterns (already hardened, already the codebase's chosen shapes):
@@ -166,6 +210,33 @@ _NIK_LABEL_RE = re.compile(r"(?i)\b(?:nik|ktp|no\.?\s*ktp)\b[\s:=#-]*(\d[\d\s.-]
 _NIK_BARE_RE = re.compile(r"\b\d{16}\b")
 _NIK_SEPARATED_RE = re.compile(r"\b\d(?:[\s.-]?\d){14,15}\b")
 
+# F1b — a list of three 5-digit KBLI codes ("55130 70100 64210") is exactly
+# 15 separator-joined digits, so the NIK matcher claimed the whole span and
+# redacted this business's DAILY vocabulary out of the package.
+#
+# The guard declines the KBLI SHAPE, not everything unlike a NIK. An earlier
+# attempt required a 4-4-4-4 grouping instead and broke TWO real cases the
+# corpus already pinned: a NIK written `32 04 15 12 88 00 0001` (2-digit
+# groups — a legitimate way to type one) and a bare 15-digit old-format NPWP.
+# Narrow at the false positive, never at the canonical form.
+_KBLI_LIST_RE = re.compile(r"\d{5}(?:[\s.-]\d{5}){2}")
+
+# F1 — date shapes, BOTH directions, with the separator pinned by a
+# backreference so "20-08.2026" is not a date. The year is anchored to FOUR
+# digits on purpose: digits 7-12 of a real NIK encode the date of birth as
+# ddmmyy (day +40 for women), so a 2-digit-year rule would decline the
+# canonical NIK shape and blind the detector. The decline applies only to
+# separator-bearing forms — NEVER to bare digits.
+_DATE_SHAPE_RE = re.compile(
+    r"(?<!\d)(?:"
+    r"(?:0[1-9]|[12]\d|3[01])(?P<dmy_sep>[-./])"
+    r"(?:0[1-9]|1[0-2])(?P=dmy_sep)(?:19|20)\d{2}"
+    r"|"
+    r"(?:19|20)\d{2}(?P<ymd_sep>[-./])"
+    r"(?:0[1-9]|1[0-2])(?P=ymd_sep)(?:0[1-9]|[12]\d|3[01])"
+    r")(?!\d)"
+)
+
 # PASSPORT — reused verbatim from pii_scanner.py, now (Kimi M2) case-
 # INSENSITIVE: a lowercase-first-letter passport ("b1234567") is a real
 # shape that the original `[A-Z]` char class silently missed. Widening to
@@ -177,9 +248,16 @@ _NIK_SEPARATED_RE = re.compile(r"\b\d(?:[\s.-]?\d){14,15}\b")
 # design spec this is the ONE chosen for this module, not an attempt to
 # unify the other 4.
 _PASSPORT_RE = re.compile(r"(?i)\b[A-Za-z]{1,2}\d{6,7}\b")
-_PASSPORT_DECLINE_PREFIXES = frozenset(
-    {"po", "no", "id", "pt", "cv", "rp", "os", "wa", "inv", "ref", "sku"}
-)
+# F4: `inv`, `ref` and `sku` are REMOVED and must not come back — they were
+# dead entries. `_PASSPORT_RE` captures at most TWO leading letters, so a
+# three-letter prefix can never be produced and never be compared here.
+_PASSPORT_DECLINE_PREFIXES = frozenset({"po", "no", "id", "pt", "cv", "rp", "os", "wa"})
+
+# F4: the deny-list is context-blind — it refuses a REAL passport that happens
+# to start with PO/NO. When the customer says "passport"/"paspor" just before
+# the value, that word overrides the deny-list. Bounded window, looking
+# BACKWARD only: a mention after the match must not license a redaction.
+_PASSPORT_CONTEXT_RE = re.compile(r"(?i)\b(?:passport|paspor)\b")
 
 # BANK_ACCOUNT — label-anchored ONLY (bare digit runs are Bali addresses,
 # prices, KBLI codes — scar family #3). Both label-then-digits and
@@ -232,7 +310,10 @@ def _digits_only(s: str) -> str:
 # "62500000000 rupiah"), never a same-sentence coincidence several clauses
 # away.
 _AMOUNT_PREFIX_RE = re.compile(r"(?i)\b(?:rp|idr)\.?\s*$")
-_AMOUNT_SUFFIX_RE = re.compile(r"(?i)^\s*(?:rupiah|juta|milyar|miliar|ribu)\b")
+# F3: `,-` is the local way to close a Rupiah figure and `IDR` its trailing
+# code. `,-` cannot carry a `\b` (both `-` and what follows are non-word
+# positions), so it is a separate alternative OUTSIDE the word-boundary group.
+_AMOUNT_SUFFIX_RE = re.compile(r"(?i)^\s*(?:(?:rupiah|juta|milyar|miliar|ribu|idr)\b|,-)")
 
 
 def _looks_like_amount(source: str, match: re.Match[str]) -> bool:
@@ -242,8 +323,19 @@ def _looks_like_amount(source: str, match: re.Match[str]) -> bool:
 
 
 def _validate_nik_separated(source: str, match: re.Match[str]) -> bool:
-    digits = _digits_only(match.group(0))
+    surface = match.group(0)
+    digits = _digits_only(surface)
     if len(digits) not in (15, 16):
+        return False
+    # F1: a separator-bearing date anywhere in the span means the run is a
+    # date plus a bystander number, not an identifier. Anchored to a FOUR-digit
+    # year, so a real NIK's own ddmmyy block (digits 7-12) cannot trip it.
+    if _DATE_SHAPE_RE.search(surface):
+        return False
+    # F1b: three separator-joined 5-digit codes is a KBLI list, not an
+    # identifier. This declines the KBLI SHAPE specifically — the 15/16 digit
+    # class above stays, because a bare 15-digit old-format NPWP lives in it.
+    if _KBLI_LIST_RE.fullmatch(surface) is not None:
         return False
     return not _looks_like_amount(source, match)
 
@@ -257,7 +349,10 @@ def _validate_phone_digit_count(source: str, match: re.Match[str]) -> bool:
     return not _looks_like_amount(source, match)
 
 
-def _validate_passport_prefix(_source: str, match: re.Match[str]) -> bool:
+def _validate_passport_prefix(source: str, match: re.Match[str]) -> bool:
+    context_before = source[max(0, match.start() - 24) : match.start()]
+    if _PASSPORT_CONTEXT_RE.search(context_before):
+        return True
     letters = "".join(c for c in match.group(0) if c.isalpha()).lower()
     return letters not in _PASSPORT_DECLINE_PREFIXES
 
@@ -296,7 +391,7 @@ _CATEGORY_PATTERNS: tuple[tuple[str, tuple[_PatternSpec, ...]], ...] = (
         (
             _PatternSpec(_JWT_RE),
             _PatternSpec(_PEM_RE),
-            _PatternSpec(_KEY_PREFIX_RE),
+            _PatternSpec(_KEY_PREFIX_RE, validator=_validate_key_prefix),
             _PatternSpec(_BEARER_RE),
         ),
     ),

--- a/apps/backend-rag/backend/services/rag/agentic/wa_dlp.py
+++ b/apps/backend-rag/backend/services/rag/agentic/wa_dlp.py
@@ -1,0 +1,515 @@
+"""DLP (Data Loss Prevention) policy for the WA codex-route context package
+(BOT-V4 G-P3, research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md
+section G-P3).
+
+The codex-route package (`wa_package_builder.build_context_package`, D1) is
+built from real customer conversation history, our own curated-KB chunks,
+and the pricing lookup's own echoed search query — all three free-text
+surfaces can carry Indonesian PII (NIK/KTP, NPWP, passport, phone, email,
+bank account, credential shapes). This module redacts every occurrence to a
+stable placeholder BEFORE the package is sealed (`package_hash` is computed
+over the REDACTED content, never the original), and reverses the
+substitution on the codex-generated answer so the client still sees the
+real value.
+
+Pure, regex-only, dependency-free by design (no Presidio in the hot path —
+apps/backend-rag/backend/middleware/pii_scanner.py already carries that
+dependency for a different, offline surface). No I/O, no logging of any
+matched ORIGINAL string anywhere in this module — every log line here
+carries category + count only, never content (project CLAUDE.md §14 PII
+boundary).
+
+Precedence is enforced BY CONSTRUCTION, not by a separate disambiguation
+step: `_CATEGORY_PATTERNS` runs in a fixed priority order, and each
+category's matches are substituted with placeholders before the NEXT
+category's patterns scan the (now partially placeholder-bearing) text — a
+span already claimed by a higher-priority category can never be re-matched
+by a lower-priority one, because the original characters underneath it are
+gone. This is how a 16-digit NPWP (`\\b0\\d{15}\\b`) is guaranteed to be
+labelled NPWP and never NIK, even though a bare-digit NIK pattern would
+otherwise also match it: NPWP runs first.
+
+DECLARED LIMITS (not bugs — read before "fixing" one of these):
+  - Dedup keys on the literal SURFACE FORM of a match, not on a normalized
+    value: the SAME NIK quoted once bare ("1234567890123456") and once
+    separated ("1234 5678 9012 3456") is two different original strings and
+    gets TWO different placeholders. Every occurrence is still redacted;
+    only the "same placeholder" guarantee is scoped to identical surface
+    form.
+  - NIK_KTP's category runs BEFORE BANK_ACCOUNT, so a labelled 15/16-digit
+    bank account number ("rekening 1234567890123456") is claimed by the
+    bare/separated NIK pattern first and comes out as `[PII-NIK_KTP-N]`
+    with the label left literal — a MISLABEL, never a leak (the digits are
+    redacted either way). Same story for a bare/separated NPWP-old-15
+    written without its official dotted format: it falls through NPWP's
+    dotted-only patterns and is caught by NIK_KTP's new separated pattern
+    instead.
+  - `restore_text`'s placeholder regex is intentionally strict
+    (`\\[PII-[A-Z_]+-\\d+\\]`, uppercase, closed brackets). A near-miss shape
+    a model might emit — lowercase `[pii-email-1]`, an unclosed
+    `[PII-EMAIL-1`, extra whitespace — matches neither the known-placeholder
+    branch NOR the unknown-placeholder strip path: it passes through
+    untouched. This is a declared gap, not silently accepted: it can never
+    be a raw ORIGINAL value (those never had a chance to be typed by the
+    model, since the model only ever sees placeholders), so the exposure is
+    "a malformed-looking token survives", not "PII survives".
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Fail-closed overflow guard (spec G-P3 rule 7): a package needing more than
+# this many DISTINCT redacted values in one turn is a suspicious payload,
+# not an unlucky one — the caller converts this into PackageUnbuildable.
+# Counts EVERY distinct value the redactor issued a placeholder for,
+# including one-way categories (CREDENTIAL, spalla S1) that never enter
+# `reversal_map` — the overflow guard tracks placeholder ISSUANCE, not the
+# reversal map's size, so a flood of credential-shaped tokens still trips it.
+MAX_PLACEHOLDERS = 64
+
+_PLACEHOLDER_RE = re.compile(r"\[PII-([A-Z_]+)-(\d+)\]")
+
+
+@dataclass(frozen=True)
+class DlpHit:
+    category: str
+    placeholder: str
+
+
+@dataclass(frozen=True)
+class DlpResult:
+    """Explicit result of `redact_package_fields` — a named dataclass
+    instead of a positional tuple (spalla review: a 4/5-element positional
+    tuple is a silent-reshuffle trap the moment a field is added or
+    reordered; every call site here unpacks by ATTRIBUTE name instead)."""
+
+    history: list[dict[str, Any]]
+    chunks: list[dict[str, Any]]
+    search_query: str | None
+    reversal_map: dict[str, str]
+    hits: list[DlpHit]
+
+
+class DlpOverflow(Exception):
+    """More than MAX_PLACEHOLDERS distinct values would be redacted in one
+    package — the caller treats the whole package as unbuildable rather
+    than emitting a partially-redacted one."""
+
+
+# --------------------------------------------------------------------------
+# Category patterns, in FIXED priority order (see module docstring for why
+# order is load-bearing). EMAIL runs first so a digit-bearing local-part or
+# domain is captured whole before any digit-shaped category can eat part of
+# it. CREDENTIAL shapes are structurally distinct from every digit pattern
+# below and run next purely to keep them out of the digit-precedence
+# discussion entirely. NPWP runs before NIK_KTP — the ONE precedence
+# requirement the design spec calls out by name. BANK_ACCOUNT (label-
+# anchored only, per spec — a bare digit run is NEVER a bank account, that
+# is scar family #3 over-match territory: Bali addresses, prices, KBLI
+# codes are all bare digit runs) runs before PHONE so a labelled account
+# number sitting in a phone-shaped run is not consumed as a phone first.
+# --------------------------------------------------------------------------
+
+# Kimi-5 (MINOR): the previous final segment `[\w.-]+` is greedy and
+# includes `.`, so "foo@example.com." (a customer's sentence-final email)
+# swallowed the trailing sentence period into the match. `\.\w{2,}` anchors
+# the TLD to word-characters only — a literal trailing `.` is never part of
+# a TLD, so it is left behind as ordinary punctuation.
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+\.\w{2,}")
+
+# CREDENTIAL — JWT (three dot-separated base64url segments), PEM header,
+# common vendor key prefixes, and a bare bearer token. Deliberately the
+# literal shapes from the design spec — no attempt to unify or extend them.
+# ONE-WAY CATEGORY (spalla S1): see `_ONE_WAY_CATEGORIES` below.
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b")
+_PEM_RE = re.compile(r"-----BEGIN [A-Z ]*KEY-----")
+_KEY_PREFIX_RE = re.compile(r"\b(?:sk|ghp|gho|xoxb|xoxp|AKIA)[A-Za-z0-9_-]{16,}\b")
+_BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._-]{20,}")
+
+# NPWP — reused verbatim from backend/middleware/pii_scanner.py's Presidio
+# patterns (already hardened, already the codebase's chosen shapes):
+# old 15-digit dotted, new 16-digit bare (leading zero), new 16-digit
+# dotted. Order among the three does not matter (their shapes are mutually
+# exclusive by word-boundary construction — a dotted string never satisfies
+# a bare 16-digit boundary), but NPWP as a CATEGORY must precede NIK_KTP.
+_NPWP_OLD_RE = re.compile(r"\b\d{2}\.\d{3}\.\d{3}\.\d-\d{3}\.\d{3}\b")
+_NPWP_NEW16_RE = re.compile(r"\b0\d{15}\b")
+_NPWP_NEW_DOTTED_RE = re.compile(r"\b0\d{2}\.\d{3}\.\d{3}\.\d-\d{3}\.\d{3}\b")
+
+# NIK/KTP — label-anchored variant (catches separator-broken forms a bare
+# 16-digit boundary regex would miss, e.g. "NIK: 1234 5678 9012 3456") plus
+# the bare 16-digit run, plus (Kimi M2) an UNLABELLED separator-broken form
+# ("1234 5678 9012 3456" / "1234.5678.9012.3456" with no "NIK"/"KTP" word
+# nearby — the bare 16-digit boundary regex never sees these because the
+# separators break `\b\d{16}\b`'s contiguity). The separated pattern is
+# validated (digit-count in {15,16} AND not amount-adjacent) so it does not
+# degrade into a bare-digit-run over-matcher (scar family #3) — an
+# unlabelled 15/16-digit-with-separators run is a much rarer coincidence in
+# ordinary prose than a labelled one, but "IDR 1.234.567.890.123" (a huge
+# but plausible amount) is exactly the shape this guard exists to decline.
+#
+# GROUP 1 (not the whole match) on the label variant: the label text
+# ("NIK: ") is kept as literal, unredacted output and only the digit run is
+# turned into a placeholder. This matters for dedup (spec rule 1, "the SAME
+# original string gets the SAME placeholder"): without it, the SAME NIK
+# value quoted once with a label and once bare ("NIK 1234...; ulangi:
+# 1234...") would be captured as two DIFFERENT original strings ("NIK
+# 1234..." vs "1234...") and get two different placeholders.
+_NIK_LABEL_RE = re.compile(r"(?i)\b(?:nik|ktp|no\.?\s*ktp)\b[\s:=#-]*(\d[\d\s.-]{14,25}\d)")
+_NIK_BARE_RE = re.compile(r"\b\d{16}\b")
+_NIK_SEPARATED_RE = re.compile(r"\b\d(?:[\s.-]?\d){14,15}\b")
+
+# PASSPORT — reused verbatim from pii_scanner.py, now (Kimi M2) case-
+# INSENSITIVE: a lowercase-first-letter passport ("b1234567") is a real
+# shape that the original `[A-Z]` char class silently missed. Widening to
+# `(?i)` alone would over-match common alphanumeric codes that are NOT
+# passports — purchase orders, reference numbers, invoice numbers — so a
+# validator declines the letter-prefixes that are near-universally one of
+# those instead (Kimi MINOR-4, "PO123456" false-positive). The codebase has
+# 5 divergent passport shapes across sentry_config/pii_scanner; per the
+# design spec this is the ONE chosen for this module, not an attempt to
+# unify the other 4.
+_PASSPORT_RE = re.compile(r"(?i)\b[A-Za-z]{1,2}\d{6,7}\b")
+_PASSPORT_DECLINE_PREFIXES = frozenset(
+    {"po", "no", "id", "pt", "cv", "rp", "os", "wa", "inv", "ref", "sku"}
+)
+
+# BANK_ACCOUNT — label-anchored ONLY (bare digit runs are Bali addresses,
+# prices, KBLI codes — scar family #3). Both label-then-digits and
+# digits-then-label orderings, "within ~40 chars" per the design spec, plus
+# the IBAN shape. GROUP 1 for the same reason as NIK_LABEL above: only the
+# account-number digits become the placeholder, the label stays literal.
+# Kimi M2: the gap class narrowed from `[^\d\n]` to `[^\d]` — a label and
+# its digits split across a newline ("rekening BCA\n1234567890", a common
+# WhatsApp line-break) previously never matched because `\n` was excluded
+# from the gap; the 0-40 char CAP still bounds how far the gap can reach,
+# so this does not turn into an unbounded label...digits-anywhere matcher.
+_BANK_LABEL_THEN_DIGITS_RE = re.compile(
+    r"(?i)\b(?:no\.?\s*rek(?:ening)?|rekening|acc(?:oun)?t\s*(?:no|number))\b"
+    r"[^\d]{0,40}?(\d{8,16})\b"
+)
+_BANK_DIGITS_THEN_LABEL_RE = re.compile(
+    r"(?i)\b(\d{8,16})\b[^\d]{0,40}?"
+    r"(?:no\.?\s*rek(?:ening)?|rekening|acc(?:oun)?t\s*(?:no|number))\b"
+)
+_IBAN_RE = re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{10,30}\b")
+
+# PHONE — reused verbatim from backend/app/setup/sentry_config.py's four
+# hardened sub-patterns (intl-with-separators, intl-contiguous-run,
+# Indonesian local 08-form, WhatsApp-JID 62-form), PLUS (Kimi M2) a
+# separated 62-form ("62 812 3456 7890", spaces and no leading "+" — the
+# bare `\b62\d{9,12}\b` never sees this because the spaces break
+# contiguity). Both the contiguous and the separated 62-form now carry a
+# validator (Kimi M3): `\b62\d{9,12}\b` alone redacted IDR amounts like
+# "total investasi 62500000000 rupiah" as a PHONE — an 11-14-digit run
+# starting with "62" is EXACTLY as plausible a rupiah amount as a phone
+# number in Indonesian business prose. The validator declines when the run
+# reads as an amount (adjacent Rp/IDR/rupiah/juta/miliar/ribu) OR ends in
+# "00000" (round amounts are not phone numbers — a WA number never ends in
+# five zeros).
+_PHONE_INTL_FMT_RE = re.compile(r"\+\d{1,3}[\s()-]{1,3}\d[\d\s()-]{5,16}\d")
+_PHONE_INTL_RUN_RE = re.compile(r"\+\d{11,15}\b")
+_PHONE_LOCAL_RE = re.compile(r"\b08\d{1,2}[\s.-]?\d{3,4}[\s.-]?\d{3,5}\b")
+_PHONE_ID_RE = re.compile(r"\b62\d{9,12}\b")
+_PHONE_62_SEPARATED_RE = re.compile(r"\b62[\s.-]?\d(?:[\s.-]?\d){8,12}\b")
+
+
+def _digits_only(s: str) -> str:
+    return "".join(c for c in s if c.isdigit())
+
+
+# "Not-an-amount" guard shared by the NIK-separated and PHONE-62 validators
+# (Kimi M2/M3): a bare/separated digit run adjacent to a Rupiah cue is a
+# PRICE, not an identifier. The window is intentionally SHORT (6 chars
+# before, 8 after) so it only catches genuine adjacency ("Rp 62.500.000",
+# "62500000000 rupiah"), never a same-sentence coincidence several clauses
+# away.
+_AMOUNT_PREFIX_RE = re.compile(r"(?i)\b(?:rp|idr)\.?\s*$")
+_AMOUNT_SUFFIX_RE = re.compile(r"(?i)^\s*(?:rupiah|juta|milyar|miliar|ribu)\b")
+
+
+def _looks_like_amount(source: str, match: re.Match[str]) -> bool:
+    before = source[max(0, match.start() - 6) : match.start()]
+    after = source[match.end() : match.end() + 8]
+    return bool(_AMOUNT_PREFIX_RE.search(before)) or bool(_AMOUNT_SUFFIX_RE.match(after))
+
+
+def _validate_nik_separated(source: str, match: re.Match[str]) -> bool:
+    digits = _digits_only(match.group(0))
+    if len(digits) not in (15, 16):
+        return False
+    return not _looks_like_amount(source, match)
+
+
+def _validate_phone_digit_count(source: str, match: re.Match[str]) -> bool:
+    digits = _digits_only(match.group(0))
+    if not (11 <= len(digits) <= 14):
+        return False
+    if digits.endswith("00000"):
+        return False
+    return not _looks_like_amount(source, match)
+
+
+def _validate_passport_prefix(_source: str, match: re.Match[str]) -> bool:
+    letters = "".join(c for c in match.group(0) if c.isalpha()).lower()
+    return letters not in _PASSPORT_DECLINE_PREFIXES
+
+
+# A validator receives (the text the CURRENT pattern is scanning, the
+# match) and returns True to accept (redact it) or False to decline (leave
+# the matched text untouched — the same span may still be claimed by a
+# LATER pattern/category).
+Validator = Callable[[str, "re.Match[str]"], bool]
+
+
+@dataclass(frozen=True)
+class _PatternSpec:
+    pattern: re.Pattern[str]
+    group: int = 0
+    validator: Validator | None = None
+
+
+# Category names in this set never get a `reversal_map` entry (spalla S1):
+# a placeholder is still ISSUED (counted for dedup + the overflow guard,
+# recorded in `hits`), but `restore_text` can never look it up — so a
+# CREDENTIAL placeholder the model echoes back is stripped by the EXISTING
+# unknown-placeholder path, not restored to the customer's own credential.
+# Rationale: no legitimate reply ever needs to echo the customer's own
+# credential back over WhatsApp, and `wa_finalize.py`'s secret-egress veto
+# (jwt/sk-/PEM/bearer patterns mirroring this module's CREDENTIAL category)
+# is pointed at what the EXECUTOR leaks — restoring a customer-supplied
+# credential first would let the veto discard the whole answer over PII
+# that was never the model's to leak in the first place.
+_ONE_WAY_CATEGORIES = frozenset({"CREDENTIAL"})
+
+_CATEGORY_PATTERNS: tuple[tuple[str, tuple[_PatternSpec, ...]], ...] = (
+    ("EMAIL", (_PatternSpec(_EMAIL_RE),)),
+    (
+        "CREDENTIAL",
+        (
+            _PatternSpec(_JWT_RE),
+            _PatternSpec(_PEM_RE),
+            _PatternSpec(_KEY_PREFIX_RE),
+            _PatternSpec(_BEARER_RE),
+        ),
+    ),
+    (
+        "NPWP",
+        (
+            _PatternSpec(_NPWP_OLD_RE),
+            _PatternSpec(_NPWP_NEW16_RE),
+            _PatternSpec(_NPWP_NEW_DOTTED_RE),
+        ),
+    ),
+    (
+        "NIK_KTP",
+        (
+            _PatternSpec(_NIK_LABEL_RE, group=1),
+            _PatternSpec(_NIK_BARE_RE),
+            _PatternSpec(_NIK_SEPARATED_RE, validator=_validate_nik_separated),
+        ),
+    ),
+    ("PASSPORT", (_PatternSpec(_PASSPORT_RE, validator=_validate_passport_prefix),)),
+    (
+        "BANK_ACCOUNT",
+        (
+            _PatternSpec(_BANK_LABEL_THEN_DIGITS_RE, group=1),
+            _PatternSpec(_BANK_DIGITS_THEN_LABEL_RE, group=1),
+            _PatternSpec(_IBAN_RE),
+        ),
+    ),
+    (
+        "PHONE",
+        (
+            _PatternSpec(_PHONE_INTL_FMT_RE),
+            _PatternSpec(_PHONE_INTL_RUN_RE),
+            _PatternSpec(_PHONE_LOCAL_RE),
+            _PatternSpec(_PHONE_ID_RE, validator=_validate_phone_digit_count),
+            _PatternSpec(_PHONE_62_SEPARATED_RE, validator=_validate_phone_digit_count),
+        ),
+    ),
+)
+
+
+class _RedactionState:
+    """Per-package mutable state: placeholder numbering, value dedup and the
+    reversal map — shared across every string redacted for one package (all
+    of history, chunks AND the pricing search_query, spec M1) so "the SAME
+    original string gets the SAME placeholder" (spec rule 1) holds
+    everywhere, not just within one string. See the module docstring's
+    DECLARED LIMITS for the dedup-on-surface-form scope of that guarantee.
+    """
+
+    def __init__(self) -> None:
+        self._counts: dict[str, int] = {}
+        self._value_to_placeholder: dict[str, str] = {}
+        self.reversal_map: dict[str, str] = {}
+        self.hits: list[DlpHit] = []
+
+    def placeholder_for(self, category: str, original: str) -> str:
+        existing = self._value_to_placeholder.get(original)
+        if existing is not None:
+            return existing
+        n = self._counts.get(category, 0) + 1
+        self._counts[category] = n
+        placeholder = f"[PII-{category}-{n}]"
+        self._value_to_placeholder[original] = placeholder
+        if category not in _ONE_WAY_CATEGORIES:
+            self.reversal_map[placeholder] = original
+        self.hits.append(DlpHit(category=category, placeholder=placeholder))
+        # Counts placeholder ISSUANCE (`_value_to_placeholder`), not
+        # `reversal_map`'s size — a one-way category still counts toward
+        # the overflow guard even though it never reaches reversal_map.
+        if len(self._value_to_placeholder) > MAX_PLACEHOLDERS:
+            raise DlpOverflow(
+                f"package would carry more than {MAX_PLACEHOLDERS} distinct "
+                "redacted values"
+            )
+        return placeholder
+
+
+def _splice_placeholder(
+    match: re.Match[str], group: int, category: str, state: _RedactionState
+) -> str:
+    """Redact `match.group(group)`, leaving any label/context text the
+    pattern also matched (group 0 minus that span) untouched in the
+    output. `group == 0` is the common case: the whole match IS the
+    value, so this degenerates to a plain whole-match replacement."""
+    original = match.group(group)
+    placeholder = state.placeholder_for(category, original)
+    if group == 0:
+        return placeholder
+    full = match.group(0)
+    match_start = match.start(0)
+    prefix = full[: match.start(group) - match_start]
+    suffix = full[match.end(group) - match_start :]
+    return f"{prefix}{placeholder}{suffix}"
+
+
+def _redact_or_decline(
+    match: re.Match[str], spec: _PatternSpec, category: str, state: _RedactionState, source: str
+) -> str:
+    """The `.sub()` callback: consult the spec's validator (if any) against
+    `source` — the string this PARTICULAR `.sub()` call is scanning, so
+    `match.start()/end()` line up with it — and leave the text unchanged
+    when the validator declines (a later pattern/category may still claim
+    the same span)."""
+    if spec.validator is not None and not spec.validator(source, match):
+        return match.group(0)
+    return _splice_placeholder(match, spec.group, category, state)
+
+
+def _redact_one(text: str, state: _RedactionState) -> str:
+    for category, specs in _CATEGORY_PATTERNS:
+        for spec in specs:
+            source = text
+            text = spec.pattern.sub(
+                lambda m, _category=category, _spec=spec, _source=source: _redact_or_decline(
+                    m, _spec, _category, state, _source
+                ),
+                source,
+            )
+    return text
+
+
+def redact_package_fields(
+    history: list[dict[str, Any]],
+    chunks: list[dict[str, Any]],
+    search_query: str | None = None,
+) -> DlpResult:
+    """Redact every free-text field the package builder ships: each
+    `history[i]["content"]`, each `chunks[i]["text"]`, and (spec M1) the
+    pricing lookup's own echoed `search_query` — `pricing_block` otherwise
+    ships the customer's RAW query into the wire+hash unredacted even
+    though it is, verbatim, the same text already redacted in `history`.
+    Nothing else — the package's other fields are structured non-free-text
+    by the builder's own allowlist (spec rule 3).
+
+    Pure function: no I/O, no logging of any ORIGINAL matched string (only
+    a category+count summary). Raises `DlpOverflow` if a single package
+    would need more than `MAX_PLACEHOLDERS` distinct redacted values — the
+    caller (`wa_package_builder.build_context_package`) converts ANY
+    exception from this call into `PackageUnbuildable("dlp_error")`
+    (fail-closed, spec rule 7).
+
+    Returns a `DlpResult` (history/chunks/search_query redacted,
+    reversal_map, hits). `reversal_map` maps placeholder -> original and
+    must never travel beyond the caller that keeps it local to one build
+    (see wa_dlp module docstring and wa_codex_leg._attempt). CREDENTIAL
+    placeholders never appear in `reversal_map` at all (one-way category,
+    spalla S1) even though they DO count toward the overflow guard and DO
+    appear in `hits`.
+    """
+    state = _RedactionState()
+
+    redacted_history = [
+        {**entry, "content": _redact_one(str(entry.get("content", "")), state)}
+        for entry in history
+    ]
+    redacted_chunks = [
+        {**chunk, "text": _redact_one(str(chunk.get("text", "")), state)} for chunk in chunks
+    ]
+    redacted_search_query = (
+        _redact_one(search_query, state) if search_query else search_query
+    )
+
+    if state.hits:
+        counts_by_category: dict[str, int] = {}
+        for hit in state.hits:
+            counts_by_category[hit.category] = counts_by_category.get(hit.category, 0) + 1
+        # Category + count ONLY — never the matched value (project CLAUDE.md
+        # §14 PII boundary; this module's own docstring repeats the rule).
+        logger.info("wa_dlp: redacted %s", counts_by_category)
+
+    return DlpResult(
+        history=redacted_history,
+        chunks=redacted_chunks,
+        search_query=redacted_search_query,
+        reversal_map=state.reversal_map,
+        hits=state.hits,
+    )
+
+
+def restore_text(text: str, reversal_map: dict[str, str]) -> str:
+    """Substitute placeholders back to their original values.
+
+    An unknown/hallucinated placeholder shape — the generator emitted a
+    `[PII-CATEGORY-N]` token that was never issued for THIS package (wrong
+    category, wrong n, a shape it invented outright, OR a legitimately
+    one-way CREDENTIAL placeholder that was never in `reversal_map` to
+    begin with — spalla S1) — is STRIPPED (never shown to the client),
+    never restored to garbage or left as a raw placeholder in a
+    client-facing reply. Fail-visible via a WARNING log naming only the
+    COUNT, never the text.
+
+    A near-miss placeholder shape (lowercase, unclosed brackets, extra
+    whitespace) matches neither this function's regex NOR the unknown-
+    placeholder branch — it passes through unchanged. Declared limit, see
+    the module docstring's DECLARED LIMITS.
+
+    R26-adjacent (spec discipline): this function never scans the codex
+    ANSWER for new PII — restore only, per the reversal map built at
+    redact time.
+    """
+    unknown = 0
+
+    def _sub(match: re.Match[str]) -> str:
+        nonlocal unknown
+        placeholder = match.group(0)
+        original = reversal_map.get(placeholder)
+        if original is None:
+            unknown += 1
+            return ""
+        return original
+
+    restored = _PLACEHOLDER_RE.sub(_sub, text)
+    if unknown:
+        logger.warning("wa_dlp: restore_text stripped %d unknown placeholder(s)", unknown)
+    return restored

--- a/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
+++ b/apps/backend-rag/backend/services/rag/agentic/wa_package_builder.py
@@ -49,6 +49,7 @@ from backend.services.rag.agentic._abstain_policy import build_abstain_policy
 from backend.services.rag.agentic.query_plan import QueryDomain
 from backend.services.rag.agentic.query_planner import QueryPlanner
 from backend.services.rag.agentic.reasoning_utils import calculate_evidence_score
+from backend.services.rag.agentic.wa_dlp import redact_package_fields
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +132,15 @@ class ContextPackage:
     evidence_inputs: dict[str, Any]
     thread_epoch: int
     package_hash: str
+    # DLP reversal map (G-P3), placeholder -> original PII value. Populated
+    # ONLY when `build_context_package(dlp=True)` redacted this package's
+    # history/chunks; empty otherwise. Deliberately EXCLUDED from
+    # `_canonical_wire`/`__post_init__`'s hash domain, from `to_payload()`
+    # and from `wire_text()` — it is not part of the 7-key allowlist and
+    # must never enter the wire package, the package_hash inputs, or a log
+    # line (spec: "never leaves Fly"). `repr=False` so an accidental
+    # `logger.debug(package)`/`repr(package)` cannot print original PII.
+    reversal_map: dict[str, str] = field(default_factory=dict, repr=False, compare=False)
     # Wire snapshot, sealed at construction (Codex S2 re-verdict r6,
     # finding 2): `frozen=True` freezes the field BINDINGS only — the
     # nested lists/dicts stay mutable, so serializing them lazily would let
@@ -450,6 +460,7 @@ async def build_context_package(
     thread_epoch: int,
     retriever: Any,
     curated_qa_block: str = "",
+    dlp: bool = False,
 ) -> ContextPackage:
     """Build the deterministic context package for the WA codex-route leg.
 
@@ -475,6 +486,16 @@ async def build_context_package(
             none. MUST come from `OrchestratorCore.curated_qa_grounding_block`
             (D3) — this function trusts the caller's domain/staleness gating
             and never re-derives it.
+        dlp: G-P3 DLP gate. When True, every `history[i]["content"]`,
+            `chunks[i]["text"]` AND `pricing_block["search_query"]` (M1 —
+            the pricing lookup's own echo of the customer's raw query) is
+            redacted (`wa_dlp.redact_package_fields`) BEFORE
+            `evidence_inputs`/`package_hash` are computed, so the sealed
+            package and its hash cover only the REDACTED content.
+            `evidence_inputs["dlp"]` records whether this build asked for
+            redaction, inside the hash domain. The codex-bound build path
+            passes True; the Gemini leg never calls this function with
+            dlp=True (default False preserves existing callers unchanged).
 
     Raises:
         PackageUnbuildable: the deterministic domain gate could not classify
@@ -482,6 +503,11 @@ async def build_context_package(
             any domain plan whose `collections` list is empty). The caller
             routes the row to the Gemini leg instead of borrowing an LLM
             planner into this path.
+        PackageUnbuildable("dlp_error"): the DLP redaction step raised
+            (detector exception, or the fail-closed overflow guard when a
+            single package would need more than `wa_dlp.MAX_PLACEHOLDERS`
+            distinct redacted values) — fail-closed, never a partially
+            redacted package (spec G-P3 rule 7).
     """
     plan = QueryPlanner().plan(query)
 
@@ -523,6 +549,43 @@ async def build_context_package(
 
     payload_history = _sanitize_history(history, query)
 
+    # G-P3 DLP gate — runs AFTER chunks are capped and history sanitized,
+    # BEFORE evidence_inputs/package_hash are computed: everything hashed
+    # and sealed below is the REDACTED content, never the original (spec
+    # rule: "package_hash computed over the REDACTED content"). Fail-closed
+    # by construction — ANY exception from the redact step (detector bug,
+    # or wa_dlp's own >MAX_PLACEHOLDERS overflow guard) becomes
+    # PackageUnbuildable so the row falls off to the Gemini leg instead of
+    # shipping a partially-redacted or unredacted package.
+    #
+    # M1 (Kimi adversarial review, verified): `pricing_block["search_query"]`
+    # is the customer's RAW query, verbatim (pricing_service.py sets it from
+    # the same `query` argument `_sanitize_pricing_block` keeps untouched) —
+    # without threading it through the SAME redaction state as history, a
+    # NIK in the query would be redacted in `history[-1]["content"]` but
+    # ship unredacted a few keys over in `pricing_block.search_query`, into
+    # both the wire and the hash. Passed into `redact_package_fields` so it
+    # shares dedup/placeholder-numbering with the history copy of the same
+    # string, then spliced back before hashing.
+    reversal_map: dict[str, str] = {}
+    if dlp:
+        pricing_search_query = (
+            pricing_block.get("search_query") if pricing_block is not None else None
+        )
+        try:
+            dlp_result = redact_package_fields(payload_history, chunks, pricing_search_query)
+        except Exception as exc:
+            logger.info(
+                "wa_package_builder: dlp redaction failed error=%s",
+                type(exc).__name__,
+            )
+            raise PackageUnbuildable(reason="dlp_error") from exc
+        payload_history = dlp_result.history
+        chunks = dlp_result.chunks
+        reversal_map = dlp_result.reversal_map
+        if pricing_block is not None:
+            pricing_block = {**pricing_block, "search_query": dlp_result.search_query}
+
     persona_digest = _build_persona_digest()
 
     # Evidence inputs are FROZEN here — finalization (spec §2.3) reads these
@@ -539,6 +602,12 @@ async def build_context_package(
         "domain": plan.domain.value,
         "label_threshold": abstain_policy.label_threshold,
         "abstain": abstain_policy.label_abstains(evidence_score),
+        # Kimi-7 (MINOR): inside the hash domain by design — a future
+        # caller that forgets `dlp=True` produces a package distinguishable
+        # downstream (evidence_inputs is what finalize/consumers read out
+        # of the sealed wire) instead of one indistinguishable from a
+        # properly-redacted build.
+        "dlp": dlp,
     }
 
     package_hash = _package_hash(
@@ -558,4 +627,5 @@ async def build_context_package(
         evidence_inputs=evidence_inputs,
         thread_epoch=thread_epoch,
         package_hash=package_hash,
+        reversal_map=reversal_map,
     )

--- a/apps/backend-rag/backend/tests/unit/app/routers/test_wa_package_router.py
+++ b/apps/backend-rag/backend/tests/unit/app/routers/test_wa_package_router.py
@@ -101,10 +101,17 @@ class TestBuildWaPackageRoute:
         # copy was struck — an unsealed copy can diverge from the sealed one
         # inside package_wire. Consumers parse evidence_inputs OUT OF the wire.
         assert not hasattr(response, "evidence_inputs")
+        # reversal_map (G-P3) is admissible where evidence_inputs was not:
+        # it is NOT a copy of sealed content (nothing to diverge from — its
+        # whole purpose is to stay OUTSIDE the sealed wire), it travels only
+        # build->leg on localhost within Fly, and the router logs nothing of
+        # it. Any OTHER new field here still needs this test changed on
+        # purpose, with its own rationale.
         assert set(WaPackageBuildResponse.model_fields) == {
             "package_wire",
             "package_hash",
             "unbuildable",
+            "reversal_map",
         }
 
         # Load-bearing: package_hash must cover package_wire's EXACT bytes

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/dlp_synthetic_corpus.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/dlp_synthetic_corpus.py
@@ -26,9 +26,32 @@ specifically so recall == coverage; if a FUTURE corpus edit introduces a
 duplicate literal within one category's list, recall would read a false
 regression (fewer hits than items) even though nothing leaked — the fix
 in that case is to make the literal distinct, not to lower the floor.
+
+G-P3 r2 ADDITION (Kimi round-2 FIX-FIRST batch): `realistic_nik_corpus`,
+`realistic_passport_corpus`, `realistic_npwp_old_dotted_corpus`,
+`realistic_npwp_new16_bare_corpus` and `realistic_npwp_new16_dotted_corpus`
+below generate REAL-ENCODING-SHAPED (never real-VALUE) identifiers for the
+r2 guilt tests in `test_wa_dlp.py` — a NIK with a genuine
+province/regency/district prefix and a plausible ddmmyy DOB (day +40 for
+the official female encoding), a 1-2-letter/6-7-digit passport, and both
+NPWP dotted/bare-16 forms. These use a SEEDED `random.Random` instance
+(never the bare `random` module's global state, never unseeded entropy)
+so a re-run is byte-identical — a different generation strategy than the
+formulaic index-keyed functions above, chosen because the realistic
+shapes need more structural freedom than a loop index alone provides, but
+held to the SAME determinism bar.
+
+PLAINLY, for anyone editing this file: every value anywhere in this
+module — formulaic or seeded-random — is FABRICATED. Reading a fixture
+out of `conversations`, the CRM, `meta_inbox_*`, or any other live table
+is FORBIDDEN for this file, full stop (project CLAUDE.md §14 PII
+boundary) — a miss on any test built from this module must always be
+traceable to a synthetic literal, never to a real customer's data.
 """
 
 from __future__ import annotations
+
+import random
 
 _CORPUS_SIZE = 50
 
@@ -116,3 +139,103 @@ CORPUS: dict[str, list[str]] = {
 # corpus — it is OUR corpus; a miss means a pattern regressed." ONE
 # constant, read by the test — lowering it is a visible diff.
 RECALL_FLOOR = 1.00
+
+
+# ============================================================================
+# G-P3 r2 — real-encoding-shaped synthetic generators (seeded, deterministic)
+#
+# Deliberately kept OUT of `CORPUS`/`RECALL_FLOOR` above: these feed
+# dedicated guilt tests in test_wa_dlp.py (F1/F4 r2 batch), not the
+# per-category recall-floor sweep, so a rare structural coincidence in one
+# generated item (e.g. a NIK digit run that also happens to read as an
+# amount) can never silently erode the registered 1.00 floor for a
+# category it was never meant to test.
+# ============================================================================
+
+
+def realistic_nik_corpus(n: int = 20) -> list[str]:
+    """16-digit NIK built from the REAL encoding, not a flat random string:
+    2-digit province + 2-digit regency/city + 2-digit district (kecamatan)
+    code, then a plausible date of birth as ddmmyy (day +40 on odd indices,
+    the official female-encoding offset), then a 4-digit sequence number.
+    Province codes are drawn from 11-94 (real range, never leading zero) so
+    these can never collide with NPWP's leading-zero 16-digit shape — the
+    ONE precedence case the design spec names explicitly."""
+    rng = random.Random(20260822)
+    out: list[str] = []
+    for i in range(n):
+        province = rng.randint(11, 94)
+        regency = rng.randint(1, 79)
+        district = rng.randint(1, 79)
+        day = rng.randint(1, 28) + (40 if i % 2 == 1 else 0)
+        month = rng.randint(1, 12)
+        year = rng.randint(0, 99)
+        seq = rng.randint(1, 9999)
+        nik = (
+            f"{province:02d}{regency:02d}{district:02d}"
+            f"{day:02d}{month:02d}{year:02d}{seq:04d}"
+        )
+        out.append(f"NIK saya {nik} terdaftar di Dukcapil.")
+    return out
+
+
+def realistic_passport_corpus(n: int = 20) -> list[str]:
+    """1-2 letter prefix + 6-7 digit passport number. Letters are chosen
+    from a pool that never collides with `_PASSPORT_DECLINE_PREFIXES`, so
+    these stay guilty regardless of whether the F4 context-override cure
+    has landed yet."""
+    rng = random.Random(20260823)
+    letters_pool = ("A", "B", "C", "X", "Y", "AB", "XY", "CN", "MZ")
+    out: list[str] = []
+    for _ in range(n):
+        letters = rng.choice(letters_pool)
+        digit_len = rng.choice((6, 7))
+        number = rng.randint(10 ** (digit_len - 1), 10**digit_len - 1)
+        out.append(f"Passport {letters}{number} on file for verification.")
+    return out
+
+
+def realistic_npwp_old_dotted_corpus(n: int = 20) -> list[str]:
+    """Old NPWP shape: `XX.XXX.XXX.X-XXX.XXX` (2-3-3-1-3-3 dotted digit
+    groups with a hyphen before the last pair) — matches `_NPWP_OLD_RE`
+    verbatim."""
+    rng = random.Random(20260824)
+    out: list[str] = []
+    for _ in range(n):
+        a = rng.randint(0, 99)
+        b = rng.randint(0, 999)
+        c = rng.randint(0, 999)
+        d = rng.randint(0, 9)
+        e = rng.randint(0, 999)
+        f = rng.randint(0, 999)
+        npwp = f"{a:02d}.{b:03d}.{c:03d}.{d}-{e:03d}.{f:03d}"
+        out.append(f"NPWP lama {npwp} terdaftar di KPP.")
+    return out
+
+
+def realistic_npwp_new16_bare_corpus(n: int = 20) -> list[str]:
+    """New 16-digit bare NPWP: a leading zero plus 15 more digits — matches
+    `_NPWP_NEW16_RE` verbatim."""
+    rng = random.Random(20260825)
+    out: list[str] = []
+    for _ in range(n):
+        rest = "".join(str(rng.randint(0, 9)) for _ in range(15))
+        out.append(f"NPWP baru saya 0{rest} sudah aktif.")
+    return out
+
+
+def realistic_npwp_new16_dotted_corpus(n: int = 20) -> list[str]:
+    """New 16-digit dotted NPWP: `0XX.XXX.XXX.X-XXX.XXX` — matches
+    `_NPWP_NEW_DOTTED_RE` verbatim."""
+    rng = random.Random(20260826)
+    out: list[str] = []
+    for _ in range(n):
+        xx = rng.randint(0, 99)
+        b = rng.randint(0, 999)
+        c = rng.randint(0, 999)
+        d = rng.randint(0, 9)
+        e = rng.randint(0, 999)
+        f = rng.randint(0, 999)
+        npwp = f"0{xx:02d}.{b:03d}.{c:03d}.{d}-{e:03d}.{f:03d}"
+        out.append(f"NPWP terformat {npwp} untuk verifikasi.")
+    return out

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/dlp_synthetic_corpus.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/dlp_synthetic_corpus.py
@@ -1,0 +1,118 @@
+"""Deterministic, Faker-free synthetic PII corpus for the G-P3 DLP
+recall-floor test (`test_wa_dlp.py::test_recall_floor`).
+
+Every literal here is FABRICATED and deterministic (no random/Faker) —
+formulaic generators keyed only on the loop index, so a re-run is
+byte-identical. This is OUR corpus, not a sample of real customer data:
+per the design spec, a miss on it means a pattern regressed, not that the
+corpus was unlucky.
+
+Each category has >=50 distinct positives, one target-category span per
+item, chosen so it does NOT also satisfy a DIFFERENT category's pattern
+(no cross-category collisions by construction — see the per-shape notes
+below). Shapes NOT included in the 50-item corpus (NPWP old-dotted /
+new-dotted, NIK label-anchored-separated, BANK_ACCOUNT IBAN, CREDENTIAL
+PEM / key-prefix) get their own small guilt tests directly in
+`test_wa_dlp.py` instead — kept out of this recall corpus to avoid
+mixing shapes with materially different generation risk into one
+average.
+
+DECLARED LIMIT (spalla review, 2026-08-20): the recall-floor test's
+"matched" count is `sum(1 for h in result.hits if h.category == category)`
+— it counts HITS, and `wa_dlp`'s dedup collapses a repeated identical
+value into ONE hit (spec rule 1, "same original -> same placeholder").
+Every generator here already produces distinct literals per item
+specifically so recall == coverage; if a FUTURE corpus edit introduces a
+duplicate literal within one category's list, recall would read a false
+regression (fewer hits than items) even though nothing leaked — the fix
+in that case is to make the literal distinct, not to lower the floor.
+"""
+
+from __future__ import annotations
+
+_CORPUS_SIZE = 50
+
+
+def nik_ktp_corpus(n: int = _CORPUS_SIZE) -> list[str]:
+    """Bare 16-digit NIK, leading digit fixed at a real province-code
+    prefix ("32") that never starts with 0 — never collides with the
+    NPWP-16 shape (`\\b0\\d{15}\\b`), which is the ONE precedence case the
+    design spec calls out."""
+    return [f"NIK saya adalah 32{i:014d} untuk verifikasi." for i in range(n)]
+
+
+def npwp_corpus(n: int = _CORPUS_SIZE) -> list[str]:
+    """NPWP new-16 bare shape (`\\b0\\d{15}\\b`) only — the old-dotted and
+    new-dotted shapes are covered by dedicated guilt tests instead."""
+    return [f"NPWP baru saya adalah 0{i:015d} terdaftar." for i in range(n)]
+
+
+def passport_corpus(n: int = _CORPUS_SIZE) -> list[str]:
+    letters = ("A", "B", "C", "AB", "XY")
+    return [
+        f"Passport number {letters[i % len(letters)]}{1000000 + i:07d} on file."
+        for i in range(n)
+    ]
+
+
+def bank_account_corpus(n: int = _CORPUS_SIZE) -> list[str]:
+    """Label-anchored 10-digit account numbers — 10 digits never collides
+    with NIK/NPWP's 16-digit shape, and never starts with 08/62 so it
+    cannot be mistaken for a phone number either. IBAN shape is covered by
+    a dedicated guilt test instead."""
+    return [f"no rekening {1000000000 + i:010d} BCA" for i in range(n)]
+
+
+def phone_corpus(n: int = _CORPUS_SIZE) -> list[str]:
+    """Cycles the 4 sentry-derived phone sub-shapes. Deliberately never
+    appends an `@...` suffix (no WA-JID-as-email shape) — that form is
+    legitimately EMAIL-shaped too (a WA JID `...@s.whatsapp.net` satisfies
+    the EMAIL pattern, and EMAIL is a higher-priority category by design),
+    so testing it here would measure the wrong category."""
+    out: list[str] = []
+    for i in range(n):
+        shape = i % 4
+        if shape == 0:
+            out.append(f"Call me at +62 812 {1000 + i:04d} {2000 + i:04d}")
+        elif shape == 1:
+            out.append(f"WA number +6281234{i:06d}")
+        elif shape == 2:
+            out.append(f"Nomor lokal 0812-345-{6000 + i:04d}")
+        else:
+            out.append(f"contact 6281234{i:06d} on whatsapp")
+    return out
+
+
+def email_corpus(n: int = _CORPUS_SIZE) -> list[str]:
+    return [f"Hubungi client{i}@example.com untuk detail." for i in range(n)]
+
+
+def credential_corpus(n: int = _CORPUS_SIZE) -> list[str]:
+    """Cycles JWT and Bearer-token shapes. PEM header and vendor
+    key-prefix shapes are covered by dedicated guilt tests instead."""
+    out: list[str] = []
+    for i in range(n):
+        if i % 2 == 0:
+            seg1 = f"eyJhbGciOiJIUzI1NiJ9{i:06d}"
+            seg2 = f"eyJzdWIiOiJ1c2VyIn0{i:06d}"
+            seg3 = f"SIGNATURE{i:06d}abcdefgh"
+            out.append(f"token: {seg1}.{seg2}.{seg3}")
+        else:
+            out.append(f"Authorization: Bearer abcdefghij0123456789{i:04d}")
+    return out
+
+
+CORPUS: dict[str, list[str]] = {
+    "NIK_KTP": nik_ktp_corpus(),
+    "NPWP": npwp_corpus(),
+    "PASSPORT": passport_corpus(),
+    "BANK_ACCOUNT": bank_account_corpus(),
+    "PHONE": phone_corpus(),
+    "EMAIL": email_corpus(),
+    "CREDENTIAL": credential_corpus(),
+}
+
+# Registered floor (spec G-P3 Tests section): "start 1.00 on the synthetic
+# corpus — it is OUR corpus; a miss means a pattern regressed." ONE
+# constant, read by the test — lowering it is a visible diff.
+RECALL_FLOOR = 1.00

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_dlp.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_dlp.py
@@ -1,0 +1,742 @@
+"""G-P3 — DLP policy for the WA codex-route context package (design spec
+research/operations/2026-08-19-bot-chatgpt-provider-broker-spec.md §G-P3),
+PLUS the two-seat adversarial review cure batch (Kimi K3 + internal spalla,
+2026-08-20): M1 (pricing_block.search_query redaction), M2 (separator-
+broken PII patterns with validators), M3 (not-an-amount guard on PHONE),
+S1 (CREDENTIAL is a one-way category), and the MINOR cures (EMAIL trailing
+punctuation, evidence_inputs["dlp"], the single-chunk overflow variant).
+
+Covers, per the spec's own test plan plus the cure batch:
+  - per-category guilt (each category's pattern(s) redact their synthetic;
+    the shapes NOT folded into the 50-item recall corpus — NPWP
+    old/new-dotted, NIK label-anchored-separated, BANK_ACCOUNT IBAN,
+    CREDENTIAL PEM/key-prefix/Bearer — get their own small guilt test
+    here);
+  - M2 guilt: the 5 separator-broken/case leaks Kimi reproduced with pure
+    `re` experiments (separated bare NIK space/dot, NPWP-old bare-15,
+    spaced-no-plus phone, newline-crossing bank label gap, lowercase
+    passport);
+  - innocence (KBLI codes, regulation citations, prices, dates, visa
+    codes, plain sentences never touched — INCLUDING the exact mandate
+    set: "Rp 1.250.000", "harga 62.500.000 rupiah", KBLI 56101, UU
+    6/2011, Peraturan BKPM 5/2025, E33/C1/B211A);
+  - M3 innocence: an IDR amount shaped exactly like a PHONE_ID match
+    ("total investasi 62500000000 rupiah") must NOT be redacted;
+  - the ONE precedence requirement named by the spec: a 16-digit NPWP
+    must map to NPWP, never NIK;
+  - round-trip identity (redact -> restore reproduces the original);
+  - cross-field dedup (the SAME original string gets the SAME placeholder
+    in history AND chunks);
+  - the fail-closed overflow guard (>64 distinct values in one package),
+    including the spalla single-chunk-text variant (the router caps
+    history at 24 turns, so 65 distinct values in practice come from one
+    chunk's text, not from 65 history turns);
+  - S1: CREDENTIAL placeholders never enter reversal_map and are stripped
+    (not restored) if the model echoes one back;
+  - restore_text's hallucinated-placeholder handling (stripped, never
+    shown, fail-visible via a WARNING log naming only the count);
+  - the registered recall floor on the synthetic corpus
+    (`dlp_synthetic_corpus.py`);
+  - builder integration: `build_context_package(dlp=True)` seals a wire
+    that carries placeholders and NOT the original digits, with the
+    reversal map absent from both `wire_text()` and `to_payload()`, and
+    M1's `pricing_block.search_query` consistently redacted alongside
+    history;
+  - the fail-closed test: a monkeypatched detector exception becomes
+    `PackageUnbuildable("dlp_error")`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from backend.services.rag.agentic.wa_dlp import (
+    MAX_PLACEHOLDERS,
+    DlpOverflow,
+    DlpResult,
+    redact_package_fields,
+    restore_text,
+)
+from backend.tests.unit.services.rag.agentic.dlp_synthetic_corpus import (
+    CORPUS,
+    RECALL_FLOOR,
+)
+
+
+def _chunk(text: str, **extra: Any) -> dict[str, Any]:
+    return {"collection": "test", "text": text, "score": 1.0, **extra}
+
+
+def _redact(
+    history: list[dict[str, Any]] | None = None,
+    chunks: list[dict[str, Any]] | None = None,
+    search_query: str | None = None,
+) -> DlpResult:
+    return redact_package_fields(history or [], chunks or [], search_query)
+
+
+def _hits_for(text: str) -> list[Any]:
+    return _redact(chunks=[_chunk(text)]).hits
+
+
+# ============================================================================
+# 1. Per-category guilt — the shapes carried by the 50-item recall corpus
+# ============================================================================
+
+
+class TestGuiltCoreShapes:
+    @pytest.mark.parametrize("category", sorted(CORPUS.keys()))
+    def test_first_corpus_item_is_flagged_as_its_own_category(self, category: str) -> None:
+        text = CORPUS[category][0]
+        hits = _hits_for(text)
+        assert any(h.category == category for h in hits), (
+            f"{category} corpus item {text!r} produced no {category} hit "
+            f"(hits={hits!r})"
+        )
+
+
+# ============================================================================
+# 2. Per-category guilt — shapes NOT in the 50-item corpus
+# ============================================================================
+
+
+class TestGuiltAdditionalShapes:
+    def test_npwp_old_dotted_format(self) -> None:
+        hits = _hits_for("NPWP lama saya 12.345.678.9-012.345 terdaftar")
+        assert any(h.category == "NPWP" for h in hits)
+
+    def test_npwp_new_dotted_format(self) -> None:
+        hits = _hits_for("NPWP baru saya 098.765.432.1-098.765 terdaftar")
+        assert any(h.category == "NPWP" for h in hits)
+
+    def test_nik_label_anchored_separated_format(self) -> None:
+        hits = _hits_for("NIK: 1234 5678 9012 3456 pada dokumen")
+        assert any(h.category == "NIK_KTP" for h in hits)
+
+    def test_bank_account_iban_shape(self) -> None:
+        hits = _hits_for("IBAN: GB29ABCD1234567890 untuk transfer")
+        assert any(h.category == "BANK_ACCOUNT" for h in hits)
+
+    def test_bank_account_digits_then_label(self) -> None:
+        hits = _hits_for("Transfer ke 9876543210 rekening BCA saya")
+        assert any(h.category == "BANK_ACCOUNT" for h in hits)
+
+    def test_credential_pem_header(self) -> None:
+        hits = _hits_for("-----BEGIN RSA PRIVATE KEY----- (do not share this)")
+        assert any(h.category == "CREDENTIAL" for h in hits)
+
+    def test_credential_vendor_key_prefix(self) -> None:
+        hits = _hits_for("leaked key sk-01234567890123456789 in the log")
+        assert any(h.category == "CREDENTIAL" for h in hits)
+
+    def test_credential_bearer_token(self) -> None:
+        hits = _hits_for("Authorization: Bearer abcdefghij0123456789ABCD")
+        assert any(h.category == "CREDENTIAL" for h in hits)
+
+    def test_phone_intl_run_shape(self) -> None:
+        hits = _hits_for("WA +6281234567890 available")
+        assert any(h.category == "PHONE" for h in hits)
+
+
+# ============================================================================
+# 2bis. M2 guilt — the 5 separator-broken/case bypasses Kimi reproduced
+# ============================================================================
+
+
+class TestGuiltM2SeparatorBroken:
+    def test_nik_separated_by_spaces_no_label(self) -> None:
+        text = "identitas saya 1234 5678 9012 3456 terverifikasi"
+        result = _redact(chunks=[_chunk(text)])
+        assert "1234 5678 9012 3456" not in result.chunks[0]["text"]
+        assert any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_nik_separated_by_dots_no_label(self) -> None:
+        text = "identitas saya 1234.5678.9012.3456 terverifikasi"
+        result = _redact(chunks=[_chunk(text)])
+        assert "1234.5678.9012.3456" not in result.chunks[0]["text"]
+        assert any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_npwp_old_bare_15_digit_no_dots(self) -> None:
+        """A bare 15-digit run with no dots satisfies neither NPWP pattern
+        (both require the official dotted format or a leading-zero 16-digit
+        run) — it is caught by NIK_KTP's new separated pattern instead.
+        MISLABEL (declared limit), never a leak: the digits ARE redacted."""
+        text = "NPWP lama saya 123456789012345 sudah lama"
+        result = _redact(chunks=[_chunk(text)])
+        assert "123456789012345" not in result.chunks[0]["text"]
+        assert result.hits, "expected at least one redaction (category may be mislabelled)"
+
+    def test_phone_spaced_no_plus_prefix(self) -> None:
+        text = "hubungi saya di 62 812 3456 7890 ya"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62 812 3456 7890" not in result.chunks[0]["text"]
+        assert any(h.category == "PHONE" for h in result.hits)
+
+    def test_bank_label_and_digits_split_by_newline(self) -> None:
+        text = "silakan transfer ke rekening BCA\n1234567890 terima kasih"
+        result = _redact(chunks=[_chunk(text)])
+        assert "1234567890" not in result.chunks[0]["text"]
+        assert any(h.category == "BANK_ACCOUNT" for h in result.hits)
+        # the label survives as literal text (group-scoped substitution)
+        assert "rekening BCA" in result.chunks[0]["text"]
+
+    def test_lowercase_passport_prefix(self) -> None:
+        text = "passport number b1234567 on file"
+        result = _redact(chunks=[_chunk(text)])
+        assert "b1234567" not in result.chunks[0]["text"]
+        assert any(h.category == "PASSPORT" for h in result.hits)
+
+    def test_po_number_is_not_a_passport(self) -> None:
+        """Kimi MINOR-4 (INNOCENCE half): the case-insensitive widening
+        alone would over-match purchase-order numbers — the prefix-decline
+        validator must refuse them."""
+        text = "please reference PO123456 on the invoice"
+        result = _redact(chunks=[_chunk(text)])
+        assert "PO123456" in result.chunks[0]["text"]
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+
+# ============================================================================
+# 3. Innocence — nothing legitimate gets touched
+# ============================================================================
+
+
+INNOCENCE_SENTENCES: tuple[str, ...] = (
+    "KBLI code 56101 covers restaurant and mobile food service activities.",
+    "UU Nomor 6 Tahun 2011 governs Indonesian immigration.",
+    "UU 6/2011 governs Indonesian immigration.",
+    "Peraturan BKPM 5/2025 sets the paid-up capital floor at 2,5 miliar.",
+    "The service costs Rp 2.500.000 for a single-entry visa.",
+    "Rp 1.250.000 is the government processing fee.",
+    "harga 62.500.000 rupiah untuk paket lengkap.",
+    "Package price is 35M IDR including all government fees.",
+    "Your renewal is due on 2026-08-20.",
+    "The E33 visa applies to Second Home applicants.",
+    "A C1 tourism extension is valid for 60 days.",
+    "B211A entry visa holders may convert on arrival.",
+    "This is a completely ordinary sentence with no PII at all.",
+)
+
+
+class TestInnocence:
+    @pytest.mark.parametrize("sentence", INNOCENCE_SENTENCES)
+    def test_innocent_sentence_untouched(self, sentence: str) -> None:
+        result = _redact(history=[{"role": "user", "content": sentence}])
+        assert result.history[0]["content"] == sentence
+        assert result.hits == []
+        assert result.reversal_map == {}
+
+    def test_price_and_kbli_share_a_sentence_with_a_real_nik_only_the_nik_fires(self) -> None:
+        """A composite sentence — the realistic case: a client message
+        mixes a price/KBLI reference with genuine PII in the same turn.
+        Only the NIK should be redacted."""
+        text = "KBLI 56101, harga Rp 2.500.000, NIK saya 3212345678901234."
+        result = _redact(chunks=[_chunk(text)])
+        assert "56101" in result.chunks[0]["text"]
+        assert "2.500.000" in result.chunks[0]["text"]
+        assert "3212345678901234" not in result.chunks[0]["text"]
+        assert [h.category for h in result.hits] == ["NIK_KTP"]
+        assert result.reversal_map == {"[PII-NIK_KTP-1]": "3212345678901234"}
+
+
+# ============================================================================
+# 3bis. M3 — a phone-shaped IDR amount is not a phone number
+# ============================================================================
+
+
+class TestM3AmountNotPhone:
+    def test_round_idr_amount_shaped_like_phone_is_not_redacted(self) -> None:
+        """Kimi M3 (GUILT-of-the-bug / innocence-of-the-cure): before the
+        not-an-amount + trailing-zeros validator, `\\b62\\d{9,12}\\b` alone
+        redacted this as PHONE, poisoning the pricing lane."""
+        text = "total investasi 62500000000 rupiah untuk PT PMA"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62500000000" in result.chunks[0]["text"]
+        assert not any(h.category == "PHONE" for h in result.hits)
+
+    def test_a_genuine_62_phone_ending_in_non_round_digits_still_redacts(self) -> None:
+        """Innocence-of-the-guard: the amount guard must not blanket-refuse
+        every 62-prefixed run — only round-amount/adjacent-currency shapes."""
+        text = "hubungi 6281234567890 untuk info lebih lanjut"
+        result = _redact(chunks=[_chunk(text)])
+        assert "6281234567890" not in result.chunks[0]["text"]
+        assert any(h.category == "PHONE" for h in result.hits)
+
+    def test_rp_prefixed_amount_not_ending_in_zeros_isolates_the_amount_guard(
+        self,
+    ) -> None:
+        """Mutation-detection isolate: the existing round-amount guilt test
+        above ("62500000000 rupiah") ends in "00000", so the INDEPENDENT
+        trailing-zeros decline in `_validate_phone_digit_count` masks any
+        regression to `_looks_like_amount` on its own (verified live: with
+        `_looks_like_amount` hardcoded to return False, ALL other tests in
+        this file still pass). This amount does not end in zeros, so only
+        the `Rp`-prefix adjacency check can save it."""
+        text = "harga sekitar Rp 62500000123 untuk paket ini"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62500000123" in result.chunks[0]["text"]
+        assert not any(h.category == "PHONE" for h in result.hits)
+
+    def test_rupiah_suffixed_amount_not_ending_in_zeros_isolates_the_amount_guard(
+        self,
+    ) -> None:
+        """Same isolation as above, suffix direction (`_AMOUNT_SUFFIX_RE`)
+        instead of prefix (`_AMOUNT_PREFIX_RE`) — covers both branches of
+        `_looks_like_amount`."""
+        text = "modal disetor 62500000123 rupiah sesuai akta"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62500000123" in result.chunks[0]["text"]
+        assert not any(h.category == "PHONE" for h in result.hits)
+
+
+# ============================================================================
+# 4. NPWP-vs-NIK precedence (the one case the design spec names explicitly)
+# ============================================================================
+
+
+class TestPrecedence:
+    def test_16_digit_npwp_shape_maps_to_npwp_not_nik(self) -> None:
+        text = "NPWP saya 0123456789012345 terdaftar di kantor pajak."
+        result = _redact(chunks=[_chunk(text)])
+        assert len(result.hits) == 1
+        assert result.hits[0].category == "NPWP"
+        assert result.reversal_map == {"[PII-NPWP-1]": "0123456789012345"}
+
+    def test_16_digit_non_zero_leading_is_nik_not_npwp(self) -> None:
+        """Innocence half of the same precedence pair: a 16-digit run that
+        does NOT satisfy NPWP-16's leading-zero shape must still be caught
+        — as NIK, never silently skipped because NPWP looked first."""
+        text = "NIK saya 3212345678901234 di dokumen ini."
+        result = _redact(chunks=[_chunk(text)])
+        assert len(result.hits) == 1
+        assert result.hits[0].category == "NIK_KTP"
+        assert result.reversal_map == {"[PII-NIK_KTP-1]": "3212345678901234"}
+
+
+# ============================================================================
+# 5. Round-trip identity + cross-field dedup
+# ============================================================================
+
+
+class TestRoundTrip:
+    def test_redact_then_restore_is_identity(self) -> None:
+        history = [
+            {
+                "role": "user",
+                "content": (
+                    "My NIK is 3212345678901234 and my email is foo@example.com"
+                ),
+            }
+        ]
+        chunks = [
+            _chunk("Contact +6281234567890 or rekening no. 1000000000 BCA for support.")
+        ]
+        result = _redact(history=history, chunks=chunks)
+        assert result.hits, "expected at least one redaction"
+        assert (
+            restore_text(result.history[0]["content"], result.reversal_map)
+            == history[0]["content"]
+        )
+        assert restore_text(result.chunks[0]["text"], result.reversal_map) == chunks[0]["text"]
+
+    def test_same_original_gets_same_placeholder_across_history_and_chunks(self) -> None:
+        email = "shared@example.com"
+        history = [{"role": "user", "content": f"reach me at {email}"}]
+        chunks = [_chunk(f"also on file: {email}")]
+        result = _redact(history=history, chunks=chunks)
+        assert len(result.reversal_map) == 1
+        placeholder = next(iter(result.reversal_map))
+        assert placeholder in result.history[0]["content"]
+        assert placeholder in result.chunks[0]["text"]
+        assert sum(1 for h in result.hits if h.category == "EMAIL") == 1
+
+    def test_same_original_repeated_within_one_field_dedups(self) -> None:
+        nik = "3212345678901234"
+        text = f"NIK {nik} lagi, ulangi: {nik}."
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"].count("[PII-NIK_KTP-1]") == 2
+        assert len(result.reversal_map) == 1
+        assert len(result.hits) == 1
+
+
+# ============================================================================
+# 5bis. Kimi-5 — EMAIL no longer swallows sentence-final punctuation
+# ============================================================================
+
+
+class TestEmailTrailingPunctuation:
+    def test_trailing_period_is_not_swallowed(self) -> None:
+        text = "Contact me at foo@example.com. Thanks!"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == "Contact me at [PII-EMAIL-1]. Thanks!"
+        assert result.reversal_map == {"[PII-EMAIL-1]": "foo@example.com"}
+
+    def test_ordinary_mid_sentence_email_unaffected(self) -> None:
+        text = "Send it to foo@example.com right away"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == "Send it to [PII-EMAIL-1] right away"
+
+
+# ============================================================================
+# 6. Fail-closed: overflow
+# ============================================================================
+
+
+class TestOverflow:
+    def test_more_than_max_placeholders_raises(self) -> None:
+        chunks = [_chunk(f"user{i}@example.com") for i in range(MAX_PLACEHOLDERS + 1)]
+        with pytest.raises(DlpOverflow):
+            redact_package_fields([], chunks)
+
+    def test_overflow_in_a_single_chunk_text(self) -> None:
+        """spalla variant: `WaPackageBuildRequest.history` is capped at
+        max_length=24 by the router (backend/app/routers/wa_package.py),
+        so 65 distinct history TURNS can never reach the builder through
+        the real transport — but 65 distinct values packed into ONE
+        chunk's text (our own KB corpus, uncapped in count) can. The guard
+        must fire on this shape too, not only the history-turn shape."""
+        text = " ".join(f"user{i}@example.com" for i in range(MAX_PLACEHOLDERS + 1))
+        with pytest.raises(DlpOverflow):
+            redact_package_fields([], [_chunk(text)])
+
+    def test_exactly_max_placeholders_does_not_raise(self) -> None:
+        """Innocence half: the boundary itself must not trip the guard —
+        only strictly MORE than MAX_PLACEHOLDERS."""
+        chunks = [_chunk(f"user{i}@example.com") for i in range(MAX_PLACEHOLDERS)]
+        result = _redact(chunks=chunks)
+        assert len(result.reversal_map) == MAX_PLACEHOLDERS
+        assert len(result.hits) == MAX_PLACEHOLDERS
+
+
+# ============================================================================
+# 7. restore_text — hallucinated placeholder handling
+# ============================================================================
+
+
+class TestRestoreUnknownPlaceholder:
+    def test_unknown_placeholder_is_stripped_and_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        text = "Your reference is [PII-EMAIL-99] — please confirm."
+        with caplog.at_level(
+            logging.WARNING, logger="backend.services.rag.agentic.wa_dlp"
+        ):
+            result = restore_text(text, {})
+        assert "[PII-EMAIL-99]" not in result
+        assert "Your reference is" in result
+        assert "stripped" in caplog.text and "1" in caplog.text
+
+    def test_known_placeholder_is_not_flagged_as_unknown(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(
+            logging.WARNING, logger="backend.services.rag.agentic.wa_dlp"
+        ):
+            result = restore_text(
+                "value: [PII-EMAIL-1]", {"[PII-EMAIL-1]": "real@example.com"}
+            )
+        assert result == "value: real@example.com"
+        assert "stripped" not in caplog.text
+
+    def test_near_miss_placeholder_shapes_pass_through_unchanged(self) -> None:
+        """Declared limit (module docstring): a shape that is neither a
+        valid known placeholder NOR matched by the strict regex (lowercase,
+        unclosed bracket) is left exactly as-is — it can never carry raw
+        PII, since the model only ever sees placeholders, never originals."""
+        text = "weird tokens: [pii-email-1] and [PII-EMAIL-1 and done"
+        assert restore_text(text, {}) == text
+
+
+# ============================================================================
+# 8. S1 — CREDENTIAL is a one-way category
+# ============================================================================
+
+
+class TestCredentialOneWay:
+    def test_credential_placeholder_never_enters_reversal_map(self) -> None:
+        credential = "sk-" + "a" * 24
+        history = [{"role": "user", "content": f"here is my key {credential} please help"}]
+        result = _redact(history=history)
+        assert any(h.category == "CREDENTIAL" for h in result.hits)
+        placeholder = next(
+            h.placeholder for h in result.hits if h.category == "CREDENTIAL"
+        )
+        assert placeholder not in result.reversal_map
+        assert credential not in result.history[0]["content"]
+
+    def test_echoed_credential_placeholder_is_stripped_not_restored(self) -> None:
+        """The spalla S1 regression test: history carries a credential ->
+        redact -> simulate the model echoing the placeholder back in its
+        completion -> restore must contain NEITHER the raw credential NOR
+        the raw placeholder shape."""
+        credential = "sk-" + "b" * 24
+        history = [{"role": "user", "content": f"my key is {credential}, is it valid?"}]
+        result = _redact(history=history)
+        placeholder = next(
+            h.placeholder for h in result.hits if h.category == "CREDENTIAL"
+        )
+
+        simulated_completion = (
+            f"I see the key {placeholder} in your message — I can't validate "
+            "secrets, please rotate it if it was ever shared elsewhere."
+        )
+        restored = restore_text(simulated_completion, result.reversal_map)
+        assert credential not in restored
+        assert placeholder not in restored
+        assert "sk-" not in restored
+
+    def test_dedup_still_applies_to_a_one_way_category(self) -> None:
+        """The SAME credential quoted twice must still collapse to ONE
+        placeholder (dedup is independent of the one-way/two-way split —
+        both live in `_value_to_placeholder`, only `reversal_map` differs)."""
+        credential = "sk-" + "c" * 24
+        text = f"key1={credential} key2={credential}"
+        result = _redact(chunks=[_chunk(text)])
+        credential_hits = [h for h in result.hits if h.category == "CREDENTIAL"]
+        assert len(credential_hits) == 1
+        assert result.chunks[0]["text"].count(credential_hits[0].placeholder) == 2
+
+
+# ============================================================================
+# 9. Registered recall floor on the synthetic corpus
+# ============================================================================
+
+
+class TestRecallFloor:
+    @pytest.mark.parametrize("category", sorted(CORPUS.keys()))
+    def test_recall_floor(self, category: str) -> None:
+        items = CORPUS[category]
+        chunks = [_chunk(t) for t in items]
+        result = _redact(chunks=chunks)
+        matched = sum(1 for h in result.hits if h.category == category)
+        recall = matched / len(items)
+        assert recall >= RECALL_FLOOR, (
+            f"{category}: recall {recall:.2f} ({matched}/{len(items)}) below "
+            f"the registered floor {RECALL_FLOOR}"
+        )
+
+
+# ============================================================================
+# 10. Builder integration — dlp=True seals a redacted wire
+# ============================================================================
+
+
+class _EmptyRetriever:
+    async def hybrid_search(
+        self,
+        *,
+        query: str,
+        user_level: int,
+        limit: int,
+        collection_override: str,
+        fallback_to_plain: bool = True,
+    ) -> dict[str, Any]:
+        return {"query": query, "results": []}
+
+
+VISA_QUERY = "What documents do I need for a KITAS work permit?"
+
+
+class TestBuilderIntegration:
+    async def test_dlp_true_redacts_the_wire_and_hides_the_reversal_map(self) -> None:
+        from backend.services.rag.agentic.wa_package_builder import build_context_package
+
+        nik = "3212345678901234"
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": f"My NIK is {nik}"}],
+            thread_epoch=0,
+            retriever=_EmptyRetriever(),
+            dlp=True,
+        )
+
+        wire = package.wire_text()
+        assert nik not in wire
+        assert "[PII-NIK_KTP-1]" in wire
+        assert "reversal_map" not in wire
+
+        payload = package.to_payload()
+        assert "reversal_map" not in payload
+        assert nik not in str(payload)
+
+        assert package.reversal_map == {"[PII-NIK_KTP-1]": nik}
+
+    async def test_dlp_false_leaves_content_untouched(self) -> None:
+        from backend.services.rag.agentic.wa_package_builder import build_context_package
+
+        nik = "3212345678901234"
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": f"My NIK is {nik}"}],
+            thread_epoch=0,
+            retriever=_EmptyRetriever(),
+        )
+        assert nik in package.wire_text()
+        assert package.reversal_map == {}
+
+    async def test_package_hash_covers_the_redacted_content_not_the_original(self) -> None:
+        """The hash is computed over the SAME wire dlp=True seals — moving
+        the redaction after hashing would let a broker verify a hash that
+        does not match what the client-visible payload actually says."""
+        import hashlib
+
+        from backend.services.rag.agentic.wa_package_builder import build_context_package
+
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": "My NIK is 3212345678901234"}],
+            thread_epoch=0,
+            retriever=_EmptyRetriever(),
+            dlp=True,
+        )
+        assert (
+            hashlib.sha256(package.wire_text().encode("utf-8")).hexdigest()
+            == package.package_hash
+        )
+
+    async def test_evidence_inputs_records_the_dlp_flag(self) -> None:
+        """Kimi-7 (MINOR): `evidence_inputs["dlp"]` lives inside the hash
+        domain, so a future caller that forgets `dlp=True` produces a
+        package distinguishable downstream from a properly-redacted one."""
+        from backend.services.rag.agentic.wa_package_builder import build_context_package
+
+        package_dlp = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=_EmptyRetriever(),
+            dlp=True,
+        )
+        package_no_dlp = await build_context_package(
+            query=VISA_QUERY,
+            history=[],
+            thread_epoch=0,
+            retriever=_EmptyRetriever(),
+        )
+        assert package_dlp.evidence_inputs["dlp"] is True
+        assert package_no_dlp.evidence_inputs["dlp"] is False
+
+
+# ============================================================================
+# 10bis. M1 — pricing_block.search_query redacted consistently with history
+# ============================================================================
+
+
+class TestM1PricingSearchQuery:
+    async def test_pricing_search_query_shares_the_placeholder_with_history(self) -> None:
+        import backend.services.rag.agentic.wa_package_builder as wpb_module
+        from backend.services.rag.agentic.wa_package_builder import build_context_package
+
+        nik = "3212345678901234"
+        query = f"quanto costa il KITAS per NIK {nik}?"
+
+        class _FakePricingService:
+            def search_service(self, q: str) -> dict[str, Any]:
+                return {
+                    "search_query": q,
+                    "results": {
+                        "kitas_permits": {
+                            "Working KITAS (E23)": {
+                                "name": "Working KITAS (E23)",
+                                "price": "Rp 5.000.000",
+                            }
+                        }
+                    },
+                }
+
+        with patch.object(
+            wpb_module, "get_pricing_service", return_value=_FakePricingService()
+        ):
+            package = await build_context_package(
+                query=query,
+                history=[{"role": "user", "content": query}],
+                thread_epoch=0,
+                retriever=_EmptyRetriever(),
+                dlp=True,
+            )
+
+        wire = package.wire_text()
+        assert nik not in wire, "the raw NIK leaked into the sealed wire"
+        # The SAME placeholder must appear in BOTH history and
+        # pricing_block.search_query — one shared _RedactionState.
+        assert wire.count("[PII-NIK_KTP-1]") >= 2
+
+        payload = package.to_payload()
+        assert nik not in str(payload)
+        assert payload["pricing_block"] is not None
+        assert (
+            payload["pricing_block"]["search_query"]
+            == "quanto costa il KITAS per NIK [PII-NIK_KTP-1]?"
+        )
+        assert package.reversal_map == {"[PII-NIK_KTP-1]": nik}
+
+    async def test_no_pricing_intent_query_has_no_pricing_block_to_redact(self) -> None:
+        """Innocence half: when `pricing_block` is None, the DLP step must
+        not choke on a missing search_query — it simply has nothing to
+        splice back."""
+        from backend.services.rag.agentic.wa_package_builder import build_context_package
+
+        package = await build_context_package(
+            query=VISA_QUERY,
+            history=[{"role": "user", "content": "My NIK is 3212345678901234"}],
+            thread_epoch=0,
+            retriever=_EmptyRetriever(),
+            dlp=True,
+        )
+        assert package.pricing_block is None
+        assert "3212345678901234" not in package.wire_text()
+
+
+# ============================================================================
+# 11. Fail-closed: a detector exception becomes PackageUnbuildable
+# ============================================================================
+
+
+class TestFailClosed:
+    async def test_detector_exception_becomes_package_unbuildable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import backend.services.rag.agentic.wa_package_builder as wpb_module
+        from backend.services.rag.agentic.wa_package_builder import PackageUnbuildable
+
+        def _boom(history: Any, chunks: Any, search_query: Any = None) -> Any:
+            raise RuntimeError("detector exploded")
+
+        monkeypatch.setattr(wpb_module, "redact_package_fields", _boom)
+
+        with pytest.raises(PackageUnbuildable) as exc_info:
+            await wpb_module.build_context_package(
+                query=VISA_QUERY,
+                history=[{"role": "user", "content": "hello"}],
+                thread_epoch=0,
+                retriever=_EmptyRetriever(),
+                dlp=True,
+            )
+        assert exc_info.value.reason == "dlp_error"
+
+    async def test_overflow_also_becomes_package_unbuildable(self) -> None:
+        """The real (non-monkeypatched) overflow guard, exercised through
+        the builder — proves the fail-closed wrapping catches wa_dlp's OWN
+        exception type too, not only an injected generic one."""
+        from backend.services.rag.agentic.wa_package_builder import (
+            PackageUnbuildable,
+            build_context_package,
+        )
+
+        history = [
+            {"role": "user", "content": f"user{i}@example.com"}
+            for i in range(MAX_PLACEHOLDERS + 1)
+        ]
+        with pytest.raises(PackageUnbuildable) as exc_info:
+            await build_context_package(
+                query=VISA_QUERY,
+                history=history,
+                thread_epoch=0,
+                retriever=_EmptyRetriever(),
+                dlp=True,
+            )
+        assert exc_info.value.reason == "dlp_error"

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_dlp.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_wa_dlp.py
@@ -64,6 +64,11 @@ from backend.services.rag.agentic.wa_dlp import (
 from backend.tests.unit.services.rag.agentic.dlp_synthetic_corpus import (
     CORPUS,
     RECALL_FLOOR,
+    realistic_nik_corpus,
+    realistic_npwp_new16_bare_corpus,
+    realistic_npwp_new16_dotted_corpus,
+    realistic_npwp_old_dotted_corpus,
+    realistic_passport_corpus,
 )
 
 
@@ -740,3 +745,688 @@ class TestFailClosed:
                 dlp=True,
             )
         assert exc_info.value.reason == "dlp_error"
+
+
+# ============================================================================
+# 12. G-P3 r2 (Kimi round-2 FIX-FIRST batch) — F1/F3/F4/F5 guilt+innocence
+#
+# Written from research/operations gp3-dlp-r2-spec.md BEFORE any cure landed
+# in wa_dlp.py — a different LLM family is writing the implementation
+# independently from the SAME spec, without seeing this file. Per the
+# module's own "regola non negoziabile": every cure gets BOTH a guilt test
+# (the dangerous shape stays redacted) and an innocence test (the shape the
+# cure exists to protect stays untouched). Several of the innocence tests
+# below are EXPECTED TO FAIL against the CURRENT (uncured) wa_dlp.py — that
+# failure is the point: it is the specification of what the cure must fix.
+# ============================================================================
+
+
+class TestF1DateShapeNotNik:
+    """F1 — `_NIK_SEPARATED_RE` must decline when the matched span IS a
+    date-with-separators (dd-mm-yyyy / dd.mm.yyyy / dd/mm/yyyy or the
+    yyyy-first mirror), but must keep catching a real separated NIK. The
+    decline is scoped to the DATE SHAPE only — never to bare digits, because
+    digits 7-12 of a real NIK encode its ddmmyy date of birth."""
+
+    # --- innocence: the exact spec-named date+number collisions -----------
+
+    def test_a_dd_mm_yyyy_date_next_to_a_renewal_number_is_not_a_nik(
+        self,
+    ) -> None:
+        text = "renewal due 20-08-2026 12345678"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_an_iso_date_followed_by_a_case_number_is_not_a_nik(self) -> None:
+        text = "scadenza 2026-08-20, pratica 4471"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_two_dates_in_one_sentence_are_not_a_nik(self) -> None:
+        text = "dal 01-01-2025 al 31-12-2025"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_an_iso_date_immediately_followed_by_a_long_reference_is_not_a_nik(
+        self,
+    ) -> None:
+        """Same defect as the spec's own example, but with enough trailing
+        digits to actually REACH the 15/16-digit NIK-separated span length
+        (the two-date test above never reaches that length on its own)."""
+        text = "expires 2026-08-20 88888888"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_a_dotted_date_next_to_a_number_is_not_a_nik(self) -> None:
+        """The dotted date-shape direction (dd.mm.yyyy) the spec also
+        requires to be recognized."""
+        text = "batas waktu 20.08.2026 12345678 harus dibayar"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    # --- innocence: supplemental rows from Codex's adversarial pass -------
+
+    def test_two_consecutive_dates_with_no_reference_number_are_not_a_nik(
+        self,
+    ) -> None:
+        """No reference number needed at all: two dd-mm-yyyy dates
+        separated by a single space are, on their own, 16 digits joined by
+        accepted separators (the closing '6' of the first year and the
+        opening '2' of the second date are bridged by exactly one space) —
+        the whole two-date span is NIK-shaped without any extra digits."""
+        text = "Date window 20-08-2026 21-08-2026"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_a_dotted_year_first_date_next_to_a_number_is_not_a_nik(
+        self,
+    ) -> None:
+        """The yyyy.mm.dd DOTTED direction — `test_a_dotted_date_...`
+        above only covers dd.mm.yyyy; this is the yyyy-first mirror the
+        spec also names, with the dotted separator instead of hyphen."""
+        text = "valid until 2026.08.20 87654321"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    # --- guilt: a real separated/labelled NIK must still be caught --------
+
+    def test_nik_4_4_4_4_with_spaces_is_still_redacted(self) -> None:
+        text = "1234 5678 9012 3456"
+        result = _redact(chunks=[_chunk(text)])
+        assert "1234 5678 9012 3456" not in result.chunks[0]["text"]
+        assert any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_nik_4_4_4_4_with_dots_is_still_redacted(self) -> None:
+        text = "1234.5678.9012.3456"
+        result = _redact(chunks=[_chunk(text)])
+        assert "1234.5678.9012.3456" not in result.chunks[0]["text"]
+        assert any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_labelled_separated_nik_is_still_redacted(self) -> None:
+        text = "NIK: 3204 1512 8800 0001"
+        result = _redact(chunks=[_chunk(text)])
+        assert "3204 1512 8800 0001" not in result.chunks[0]["text"]
+        assert any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_a_bare_nik_with_a_plausible_dob_span_is_still_redacted(self) -> None:
+        """Spec's own example: the DOB-shaped middle digits (`151288`) of a
+        BARE (no-separator) NIK. This hits `_NIK_BARE_RE`, a pattern the F1
+        cure must never touch — decline-on-digits-alone is the one
+        non-negotiable constraint the spec calls out by name."""
+        text = "3204151288000001"
+        result = _redact(chunks=[_chunk(text)])
+        assert "3204151288000001" not in result.chunks[0]["text"]
+        assert any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_a_separated_nik_whose_digits_resemble_a_short_year_date_is_still_redacted(
+        self,
+    ) -> None:
+        """The DOB-shaped middle span (`15 12 88`, day-month-2digit-year)
+        must never be declined just because it LOOKS date-ish: the spec's
+        own date shape is anchored to a 4-digit `19xx|20xx` year, so a
+        2-digit-year fragment inside a real separated NIK's digit run must
+        never trip the decline."""
+        text = "32 04 15 12 88 00 0001"
+        result = _redact(chunks=[_chunk(text)])
+        assert "32 04 15 12 88 00 0001" not in result.chunks[0]["text"]
+        assert any(h.category == "NIK_KTP" for h in result.hits)
+
+
+class TestF1bKbliListGroupingNotNik:
+    """F1b (Codex adversarial finding, additive to F1) — a space-separated
+    list of KBLI codes (5-digit Indonesian business-classification codes)
+    is EXACTLY 15 digits joined by accepted separators when there are
+    three of them, so `_NIK_SEPARATED_RE` claims the whole span. This is
+    NOT a date-shape collision (no F1 fix helps here) — it needs its own
+    guard.
+
+    Written against the BEHAVIOUR the coordinator specified, not any
+    particular implementation of it: a real separated NIK groups 4-4-4-4
+    (or is contiguous 16); a KBLI list groups 5-5-5. These tests assert
+    only "a 5-5-5 grouping is not redacted" — they do not assume HOW the
+    eventual guard tells the two apart, since a different LLM family is
+    implementing it independently from the same spec."""
+
+    def test_a_bare_kbli_list_is_not_a_nik(self) -> None:
+        text = "KBLI list: 55130 70100 64210"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_a_labelled_kbli_list_with_trailing_prose_is_not_a_nik(self) -> None:
+        text = "KBLI 55203 56101 55130 untuk akomodasi dan F&B"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_a_kbli_list_following_a_regulation_citation_is_not_a_nik(self) -> None:
+        text = "PMK 66/2023 — batch 55130 70100 64210"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+    def test_a_kbli_list_sharing_a_sentence_with_an_amount_is_not_a_nik(self) -> None:
+        text = "Biaya 10 juta; KBLI 55130 70100 64210"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NIK_KTP" for h in result.hits)
+
+
+class TestF3AmountSuffixAdditions:
+    """F3 — `_AMOUNT_SUFFIX_RE` must also decline on a trailing `,-` or a
+    trailing `idr` (case-insensitive) — matching the `rp|idr` PREFIX check
+    `_AMOUNT_PREFIX_RE` already has for the prefix direction. `,-` is not a
+    word, so the suffix alternative must be built to match right after the
+    digit run rather than relying on `\\b`."""
+
+    # --- innocence: the exact spec-named amounts ---------------------------
+
+    def test_rp_amount_with_trailing_comma_dash_is_not_redacted(self) -> None:
+        text = "Rp 62.500.000,-"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert result.hits == []
+
+    def test_bare_amount_with_trailing_idr_is_not_redacted(self) -> None:
+        text = "62500000 IDR"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert result.hits == []
+
+    # --- innocence: long enough to actually REACH a PII-shaped span, so
+    # the suffix-guard gap is the only thing standing between these and a
+    # false-positive PHONE redaction ---------------------------------------
+
+    def test_a_phone_shaped_amount_with_trailing_comma_dash_is_not_redacted(
+        self,
+    ) -> None:
+        """Guilt-of-the-bug: without the `,-` suffix alternative this
+        11-digit 62-prefixed run has no amount cue in EITHER direction (no
+        `Rp`/`idr` PREFIX within 6 chars, and `,-` is absent from the
+        current suffix list) and is redacted as PHONE today."""
+        text = "modal disetor 62500000123,- untuk PT PMA"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62500000123" in result.chunks[0]["text"]
+        assert not any(h.category == "PHONE" for h in result.hits)
+
+    def test_a_phone_shaped_amount_with_trailing_idr_word_is_not_redacted(
+        self,
+    ) -> None:
+        """Same shape, the other named gap: `idr` as a trailing WORD (not
+        a `Rp`/`IDR` PREFIX, which `_AMOUNT_PREFIX_RE` already covers)."""
+        text = "modal disetor 62500000123 IDR untuk PT PMA"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62500000123" in result.chunks[0]["text"]
+        assert not any(h.category == "PHONE" for h in result.hits)
+
+    # --- innocence: same gap, DOTTED-grouping amounts (Codex's addendum) —
+    # the coordinator specifically asked to assert on PHONE, not just NIK,
+    # for these two rows -----------------------------------------------
+
+    def test_a_dot_grouped_amount_with_trailing_idr_word_is_not_redacted_as_phone(
+        self,
+    ) -> None:
+        text = "Nilai proyek 62.543.210.987 IDR"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62.543.210.987" in result.chunks[0]["text"]
+        assert not any(h.category == "PHONE" for h in result.hits)
+
+    def test_a_dot_grouped_amount_with_trailing_comma_dash_is_not_redacted_as_phone(
+        self,
+    ) -> None:
+        text = "Total 62.500.000.123,-"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62.500.000.123" in result.chunks[0]["text"]
+        assert not any(h.category == "PHONE" for h in result.hits)
+
+    # --- guilt: a real phone/NIK adjacent to the newly-declined shapes
+    # must still be redacted — the cure must not blanket-decline the
+    # category near ANY comma or the word "idr" elsewhere in the text -----
+
+    def test_a_real_phone_next_to_an_idr_amount_still_redacts_only_the_phone(
+        self,
+    ) -> None:
+        text = "modal disetor 62500000123 IDR, hubungi 6281234567890 untuk info"
+        result = _redact(chunks=[_chunk(text)])
+        assert "62500000123" in result.chunks[0]["text"]
+        assert "6281234567890" not in result.chunks[0]["text"]
+        assert sum(1 for h in result.hits if h.category == "PHONE") == 1
+
+    def test_a_real_nik_next_to_a_comma_dash_amount_still_redacts_the_nik(
+        self,
+    ) -> None:
+        text = "harga Rp 2.500.000,- NIK saya 3212345678901234"
+        result = _redact(chunks=[_chunk(text)])
+        assert "2.500.000" in result.chunks[0]["text"]
+        assert "3212345678901234" not in result.chunks[0]["text"]
+        assert [h.category for h in result.hits] == ["NIK_KTP"]
+
+
+class TestOutOfScopeMeasuredGaps:
+    """Codex adversarial finding, explicitly OUT OF SCOPE for this PR
+    (coordinator: "report what you observe; do not cure it" / "do not
+    widen the deny-list, that road is the next F1"). These are written as
+    aspirational innocence assertions — the shape SHOULD stay untouched —
+    specifically so a failure here is a MEASUREMENT the session's report
+    quotes precisely (which category claims the span, or which letter
+    prefix escapes the deny-list), never a demand that this batch's F1/F3/
+    F4/F5 cures fix it. Do NOT extend `_PASSPORT_DECLINE_PREFIXES` or the
+    NPWP/NIK precedence rule to make these pass — that is a separate,
+    future finding.
+
+    Every test here is `xfail(strict=True)`: a permanently-red test would
+    train the whole fleet to read this file's red as noise, but `strict`
+    keeps the measurement working in BOTH directions — the day one of these
+    gaps is actually cured, the xpass turns this class red again and forces
+    the finding to be re-dispositioned instead of silently absorbed."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "ACCEPTED GAP: a bare 16-digit run with a leading zero is "
+            "indistinguishable from a new-format NPWP, and _NPWP_NEW16_RE "
+            "carries no validator — NPWP claims it before NIK_KTP is "
+            "consulted. Curing it means touching the ONE precedence rule "
+            "the design spec names, which is out of scope for F1-F6."
+        ),
+    )
+    def test_a_bare_16_digit_leading_zero_reference_is_not_an_npwp(self) -> None:
+        """Any bare 16-digit run starting with '0' collides with the
+        new-format NPWP shape (`_NPWP_NEW16_RE`), which has NO validator
+        at all — it is claimed unconditionally, before NIK_KTP even sees
+        it (NPWP runs first in `_CATEGORY_PATTERNS`, the ONE precedence
+        rule the design spec names by name). MEASURE which category
+        actually claims this, do not touch NPWP/NIK precedence to fix it."""
+        text = "Reference 0123456789012345"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "NPWP" for h in result.hits)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "ACCEPTED GAP: an invoice token shaped 2-letters+7-digits is the same "
+            "shape as a passport number, and `AB` is not on the fixed "
+            "decline list. Widening that list is the coordinator's named "
+            "next-F1, not this batch."
+        ),
+    )
+    def test_a_2letter_7digit_invoice_reference_is_not_a_passport(self) -> None:
+        """`AB` is not in `_PASSPORT_DECLINE_PREFIXES`, and there is no
+        'passport'/'paspor' word nearby for F4's context override to even
+        be relevant — the deny-list is the ONLY current defense, and it is
+        a small fixed list, not a real distinguisher of "looks like a
+        passport" vs "is some other 2-letter business reference"."""
+        text = "August 20, 2026 — invoice AB1234567"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "ACCEPTED GAP: a KITAS permit number (`IT`+7 digits) is 2-letters+7-"
+            "digits too. Note the failure direction is CONSERVATIVE — an "
+            "immigration permit number gets redacted, which over-protects "
+            "rather than leaks."
+        ),
+    )
+    def test_a_2letter_7digit_kitas_reference_is_not_a_passport(self) -> None:
+        text = "20 Agustus 2026 — KITAS IT1234567"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "ACCEPTED GAP: the `PO` label sits BESIDE the match, so the letters "
+            "the regex captures are `AB` — the decline list is never "
+            "consulted against the word a human reads. Fixing this needs "
+            "a preceding-label lookbehind, a new mechanism, not a wider list."
+        ),
+    )
+    def test_a_po_labelled_2letter_7digit_reference_is_not_a_passport(self) -> None:
+        """The 'PO' label sits BESIDE the match (separated by a space), not
+        immediately prefixing it — the letters the regex actually captures
+        are 'AB', not 'PO', so `_PASSPORT_DECLINE_PREFIXES` never even gets
+        consulted against the label a human reader would recognize."""
+        text = "Valuasi 2,5 miliar; PO AB1234567"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+
+class TestF4PassportContextOverride:
+    """F4 — the 3 dead decline-list entries (`inv`/`ref`/`sku`, which
+    `_PASSPORT_RE`'s `[A-Za-z]{1,2}` prefix group can never produce) are
+    removed, and a `passport|paspor` context override (looking BACKWARD
+    ~24 chars) makes the deny-list ignored so a genuinely labelled passport
+    number is never silently declined just because its letter prefix
+    collides with a common business abbreviation (PO/NO/PT/...)."""
+
+    # --- innocence: the exact spec-named unlabelled abbreviations ----------
+
+    def test_unlabelled_po_number_is_not_a_passport(self) -> None:
+        text = "PO123456"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+    def test_unlabelled_no_reference_is_not_a_passport(self) -> None:
+        text = "NO1234567"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+    def test_unlabelled_pt_company_code_is_not_a_passport(self) -> None:
+        text = "PT1234567"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+    def test_a_po_number_mentioned_after_the_word_passport_stays_innocent(
+        self,
+    ) -> None:
+        """The override looks BACKWARD only (spec: "~24 caratteri
+        PRECEDENTI al match") — a passport/paspor word occurring AFTER the
+        match must never retroactively redact it."""
+        text = "PO123456 is not a passport number, just our invoice code"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+    def test_a_po_number_far_beyond_the_lookback_window_stays_innocent(
+        self,
+    ) -> None:
+        """A `passport` mention well outside the ~24-char lookback (here,
+        ~40+ chars before the match) must not reach across and override the
+        deny-list — the override is a WINDOW, not an anywhere-in-string
+        search."""
+        text = "passport " + ("filler " * 6) + "PO123456"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "PASSPORT" for h in result.hits)
+
+    def test_dead_prefixes_inv_ref_sku_can_never_be_produced_by_the_regex(
+        self,
+    ) -> None:
+        """Documents WHY inv/ref/sku are dead code: `_PASSPORT_RE`'s letter
+        prefix group is `[A-Za-z]{1,2}` (max 2 letters), so a 3-letter word
+        can never BE the captured prefix — these three stay innocent for a
+        totally different reason (no match at all), which is exactly what
+        makes removing them from the decline set safe."""
+        for text in ("INV1234567", "REF1234567", "SKU1234567"):
+            result = _redact(chunks=[_chunk(text)])
+            assert result.chunks[0]["text"] == text, text
+            assert not any(h.category == "PASSPORT" for h in result.hits), text
+
+    # --- guilt: a labelled deny-listed prefix must still be redacted ------
+
+    def test_passport_labelled_po_number_is_redacted(self) -> None:
+        """Guilt-of-the-bug: today the deny-list wins unconditionally, so a
+        REAL passport happening to start with the letters 'PO' is never
+        redacted even when the customer explicitly says 'passport' right
+        next to it."""
+        text = "passport PO123456"
+        result = _redact(chunks=[_chunk(text)])
+        assert "PO123456" not in result.chunks[0]["text"]
+        assert any(h.category == "PASSPORT" for h in result.hits)
+
+    def test_paspor_labelled_no_number_is_redacted(self) -> None:
+        text = "paspor no1234567"
+        result = _redact(chunks=[_chunk(text)])
+        assert "no1234567" not in result.chunks[0]["text"]
+        assert any(h.category == "PASSPORT" for h in result.hits)
+
+
+class TestF5KeyPrefixSeparator:
+    """F5 — `_KEY_PREFIX_RE` must require the shape's OWN separator
+    (`sk[-_]`, `ghp_`, `gho_`, `xoxb-`, `xoxp-`) instead of matching 16+
+    bare alnum chars right after the bare prefix letters. `AKIA` keeps its
+    own separator-free alternative, since real AWS access key ids never
+    carry one. `CREDENTIAL` is a ONE-WAY category (no reversal_map): a
+    false positive here is an IRRECOVERABLE hole in the client-facing
+    reply."""
+
+    # --- innocence: the exact spec-named ordinary words --------------------
+
+    def test_skincare_product_name_is_not_a_credential(self) -> None:
+        text = "skincareproducts2026"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert result.hits == []
+
+    def test_indonesian_word_skema_is_not_a_credential(self) -> None:
+        text = "skema perpanjangan kitas"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert result.hits == []
+
+    def test_skillsheet_reference_is_not_a_credential(self) -> None:
+        text = "skillsheet1234567890"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert result.hits == []
+
+    def test_english_word_skyscraperconstruction_is_not_a_credential(
+        self,
+    ) -> None:
+        """Additional realistic ordinary-prose case: a long compound
+        English word beginning with 'sk' is exactly as vulnerable to the
+        bare-16+-alnum bug as the spec's own examples."""
+        text = "The skyscraperconstruction project finished on schedule."
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "CREDENTIAL" for h in result.hits)
+
+    def test_short_indonesian_words_beginning_with_sk_are_never_touched(
+        self,
+    ) -> None:
+        """Regression guard for short 'sk'-words (too short to ever match
+        even the current bare regex) — the cure's added separator
+        requirement must narrow the match set, never widen it."""
+        text = "Skala risiko dan skenario perpanjangan sudah kami skalakan."
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert result.hits == []
+
+    # --- guilt: a real separator-bearing credential must still redact -----
+
+    def test_sk_dash_prefixed_key_is_still_redacted(self) -> None:
+        text = "sk-abcdefghij0123456789"
+        result = _redact(chunks=[_chunk(text)])
+        assert "sk-abcdefghij0123456789" not in result.chunks[0]["text"]
+        assert any(h.category == "CREDENTIAL" for h in result.hits)
+
+    def test_ghp_underscore_prefixed_key_is_still_redacted(self) -> None:
+        text = "ghp_abcdefghij0123456789"
+        result = _redact(chunks=[_chunk(text)])
+        assert "ghp_abcdefghij0123456789" not in result.chunks[0]["text"]
+        assert any(h.category == "CREDENTIAL" for h in result.hits)
+
+    def test_xoxb_dash_prefixed_token_is_still_redacted(self) -> None:
+        text = "xoxb-1234567890-abcdefghij"
+        result = _redact(chunks=[_chunk(text)])
+        assert "xoxb-1234567890-abcdefghij" not in result.chunks[0]["text"]
+        assert any(h.category == "CREDENTIAL" for h in result.hits)
+
+    def test_akia_key_without_a_separator_is_still_redacted(self) -> None:
+        """AKIA keeps its separator-FREE shape by design (real AWS access
+        key ids never carry one) — the F5 cure must not accidentally start
+        requiring a separator here too."""
+        text = "AKIAIOSFODNN7EXAMPLE"
+        result = _redact(chunks=[_chunk(text)])
+        assert "AKIAIOSFODNN7EXAMPLE" not in result.chunks[0]["text"]
+        assert any(h.category == "CREDENTIAL" for h in result.hits)
+
+
+class TestRealisticSyntheticIdentifierGuilt:
+    """Guilt tests driven by the deterministic realistic-shape generators
+    added to dlp_synthetic_corpus.py for this r2 batch — a real-encoding
+    NIK (province/regency/district + dob+40-for-women + sequence), a
+    1-2-letter/6-7-digit passport, and both NPWP dotted/bare-16 forms.
+    Every value is synthetic (seeded PRNG, never real customer data) — see
+    that module's docstring."""
+
+    @pytest.mark.parametrize("text", realistic_nik_corpus(10))
+    def test_realistic_nik_is_redacted(self, text: str) -> None:
+        hits = _hits_for(text)
+        assert any(h.category == "NIK_KTP" for h in hits), text
+
+    @pytest.mark.parametrize("text", realistic_passport_corpus(10))
+    def test_realistic_passport_is_redacted(self, text: str) -> None:
+        hits = _hits_for(text)
+        assert any(h.category == "PASSPORT" for h in hits), text
+
+    @pytest.mark.parametrize("text", realistic_npwp_old_dotted_corpus(10))
+    def test_realistic_npwp_old_dotted_is_redacted(self, text: str) -> None:
+        hits = _hits_for(text)
+        assert any(h.category == "NPWP" for h in hits), text
+
+    @pytest.mark.parametrize("text", realistic_npwp_new16_bare_corpus(10))
+    def test_realistic_npwp_new16_bare_is_redacted(self, text: str) -> None:
+        hits = _hits_for(text)
+        assert any(h.category == "NPWP" for h in hits), text
+
+    @pytest.mark.parametrize("text", realistic_npwp_new16_dotted_corpus(10))
+    def test_realistic_npwp_new16_dotted_is_redacted(self, text: str) -> None:
+        hits = _hits_for(text)
+        assert any(h.category == "NPWP" for h in hits), text
+
+
+class TestBroaderRealisticInnocenceSweep:
+    """Cross-cutting innocence net requested for this batch: dates in
+    several formats, invoice/reference numbers, KBLI codes, a phone shape
+    outside the covered patterns, and a grouped number that merely LOOKS
+    NPWP-adjacent (wrong grouping, never matches the real NPWP shape).
+    None of these are the literal F1/F3/F4/F5 defect strings, but they are
+    realistic shapes a client message plausibly contains and must never be
+    touched by ANY category."""
+
+    SENTENCES: tuple[str, ...] = (
+        "The deadline is 20-08-2026 for renewal.",
+        "Due date: 2026-08-20 sharp.",
+        "Format check 20.08.2026 works too.",
+        "Slash format 20/08/2026 also common.",
+        "Invoice number INV/2026/08/1234 is settled.",
+        "Please quote reference REF-00098765 when paying.",
+        "KBLI code 55130 covers hotel accommodation.",
+        "KBLI 70100 is head office management activities.",
+        "Business classification 64210 applies here.",
+        "Kontak kantor: 021-7654321 selama jam kerja.",
+        "Total 12.345.678 sudah termasuk pajak.",
+    )
+
+    @pytest.mark.parametrize("sentence", SENTENCES)
+    def test_sentence_is_never_touched(self, sentence: str) -> None:
+        result = _redact(chunks=[_chunk(sentence)])
+        assert result.chunks[0]["text"] == sentence
+        assert result.hits == []
+
+
+class TestF5bSkPrefixEntropyRun:
+    """F5b — Kimi round-3 BLOCKER on the F5 cure itself. Requiring the
+    separator (`sk[-_]`) was not enough: the tail class still contains `-`
+    and `_`, so `sk-` followed by hyphen-separated WORDS clears the 16-char
+    minimum. `SK` is Surat Keputusan — the single most-cited document type
+    this business writes about — and CREDENTIAL is ONE-WAY, so the span
+    would vanish from the customer's own answer with no reversal possible.
+
+    The cure is structural, not a word list: a real key carries its entropy
+    in one UNBROKEN alphanumeric run; human text is short words joined by
+    hyphens. Guilt is asserted across ALL FIVE key families, because the
+    validator is scoped to the `sk` alternative and a scoping mistake would
+    silently disarm the other four."""
+
+    def test_an_sk_kemenkumham_decree_reference_is_not_a_credential(self) -> None:
+        """The exact shape Kimi found: `sk-` + hyphen-separated words. The
+        longest unbroken run is `kemenkumham` (11 chars), under the 16-char
+        entropy floor, so the match is declined."""
+        text = "SK Kemenkumham no sk-kemenkumham-ahu-0012345 sudah terbit"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+        assert not any(h.category == "CREDENTIAL" for h in result.hits)
+
+    def test_an_article_slug_starting_with_sk_is_not_a_credential(self) -> None:
+        text = "artikel sk-immigration-update-2026 sudah publish"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+
+    # Every fixture below is ASSEMBLED at runtime from a vendor prefix and a
+    # separate entropy run, never written as one literal. This is not
+    # decoration: GitHub push protection blocked this exact branch on the
+    # literal form (it read the Stripe `sk_live_` shape as a real key), and a
+    # branch that cannot be pushed is a cure that cannot ship. Neither half is
+    # a secret on its own, and the concatenation the test actually exercises
+    # is byte-identical to the real shape. Do NOT "tidy" these back into
+    # literals — the next push would be rejected again.
+    _RUN = "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6"  # 32 alnum, no vendor prefix
+
+    @pytest.mark.parametrize(
+        ("prefix", "tail"),
+        [
+            ("sk-" + "proj-", _RUN),
+            ("sk" + "_live_", "51H8xVbKj2mNpQrStUvWxYz9AbCdEf"),
+            ("ghp" + "_", _RUN),
+            ("xoxb" + "-", "1234-5678-abcdefghijklmnopqrstuvwx"),
+            ("AKIA", "IOSFODNN7EXAMPLE"),
+        ],
+        ids=["sk-hyphen", "sk_underscore", "ghp", "xoxb", "akia"],
+    )
+    def test_every_real_key_family_still_redacts(
+        self, prefix: str, tail: str
+    ) -> None:
+        """The guilt half. The `sk`-scoped validator must not have disarmed
+        the four prefixes it was never meant to touch — a hyphenated Slack
+        token (`xoxb-1234-5678-...`) is the trap here: it LOOKS word-broken,
+        and only its final segment carries the unbroken run."""
+        secret = prefix + tail
+        text = f"ini kuncinya: {secret}"
+        result = _redact(chunks=[_chunk(text)])
+        assert secret not in result.chunks[0]["text"]
+        assert any(h.category == "CREDENTIAL" for h in result.hits)
+
+
+class TestKimiRound3MeasuredButNotCured:
+    """The two Kimi round-3 findings deliberately NOT cured in this PR, kept
+    as `xfail(strict=True)` for the same reason as
+    `TestOutOfScopeMeasuredGaps`: the day either is cured, the xpass turns
+    this class red and forces a re-disposition."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "MEASURED, NOT CURED (Kimi r3 finding 2, MEDIUM): `_IBAN_RE` has "
+            "no validator, so any 2-letter + 2-digit + 10-30-alnum promo or "
+            "referral code satisfies the IBAN shape. PRE-EXISTING — it is "
+            "untouched by the F1-F5 delta, so curing it here would violate "
+            "one-PR-one-concern. Not one-way: recoverable via reversal_map."
+        ),
+    )
+    def test_an_uppercase_promo_code_is_not_an_iban(self) -> None:
+        text = "kode promo NZ25DISKON2026 berlaku sampai akhir bulan"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "ACCEPTED TRADE-OFF (Kimi r3 finding 3, MEDIUM): `_DATE_SHAPE_RE` "
+            "anchors the year to FOUR digits on purpose — digits 7-12 of a "
+            "real NIK encode ddmmyy, so a 2-digit-year rule would decline "
+            "genuine NIKs. The cost is that `dd-mm-yy <ref number>` reads as "
+            "one 15-digit run. Recall over precision, deliberately."
+        ),
+    )
+    def test_a_two_digit_year_date_beside_a_ref_number_is_not_a_nik(self) -> None:
+        text = "20-08-26 123456789"
+        result = _redact(chunks=[_chunk(text)])
+        assert result.chunks[0]["text"] == text

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
@@ -977,14 +977,29 @@ async def test_leg_restores_placeholders_before_the_customer_sees_them(
 
     The placeholder is embedded in an otherwise-normal sentence (not a bare
     token) so a real finalize's text-defect checks would not eat it —
-    matching the coordinator's harness note."""
+    matching the coordinator's harness note.
+
+    G-P3 r2 F6 (ORDER pin): asserting on `result.text` alone only proves
+    restore happened SOMEWHERE in the pipeline — it cannot tell "restore
+    before finalize" apart from "finalize first, then restore the
+    RETURNED text", because `_echo_finalize` simply forwards whatever it
+    is given straight back out, and either ordering would still leave
+    `result.text` fully restored. The assertion on
+    `echo_finalize.await_args.kwargs["data"]["answer"]` below closes that
+    gap: it inspects the value the finalize call ITSELF received, which
+    can only be the restored text if `restore_text` ran BEFORE that call.
+    Mutation pin: moving the `restore_text` call to run on `result.text`
+    AFTER `finalize_wa_answer` returns would leave this kwarg holding the
+    raw `[PII-PHONE-1]` placeholder and this assertion goes red, even
+    though the old `result.text`-only assertions below would still pass."""
     build = {**_GOOD_BUILD, "reversal_map": {"[PII-PHONE-1]": "+628111234567"}}
     stubs = _wire_stubs(
         monkeypatch,
         build=build,
         consume="Please call [PII-PHONE-1] to confirm your appointment.",
     )
-    monkeypatch.setattr(wa_codex_leg, "finalize_wa_answer", _echo_finalize())
+    echo_finalize = _echo_finalize()
+    monkeypatch.setattr(wa_codex_leg, "finalize_wa_answer", echo_finalize)
     conn = ScriptedConn(
         fetchrow_results=[{"human_handling": False, "handling_version": 3}]
     )
@@ -993,6 +1008,10 @@ async def test_leg_restores_placeholders_before_the_customer_sees_them(
     assert "+628111234567" in result.text
     assert "[PII-" not in result.text
     stubs.rag_client.post.assert_awaited_once()  # sanity: build actually ran
+
+    received_answer = echo_finalize.await_args.kwargs["data"]["answer"]
+    assert "+628111234567" in received_answer
+    assert "[PII-" not in received_answer
 
 
 @pytest.mark.asyncio

--- a/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
+++ b/apps/backend-rag/backend/tests/unit/services/test_wa_codex_leg.py
@@ -932,3 +932,101 @@ async def test_consume_failure_fails_closed(
     assert result.fail == "post_completion:RuntimeError"
     assert result.text is None
     stubs.record_breaker_result.assert_not_awaited()
+
+
+# ── G-P3 DLP wiring: the two load-bearing wires nothing else exercises ─────
+#
+# Final-gate finding (2026-08-20): 153 DLP tests existed, none through THIS
+# module — a correct wa_dlp.py protects nothing if the leg that calls it
+# never restores placeholders or never asks for redaction (scar family #2,
+# "a correct function nothing exercises protects nothing"). These three
+# tests pin BOTH wires through the real `_attempt` code path, using the
+# harness above (no parallel harness).
+#
+# The default `_wire_stubs` finalize fake returns a FIXED FinalizeResult
+# built from the `consume` kwarg at setup time — it never looks at what the
+# leg actually passed as `data["answer"]`, so it cannot prove restore_text
+# ran. These tests instead install an ECHO fake (`side_effect` reading
+# `kwargs["data"]["answer"]`) so `result.text` reflects the REAL text the
+# leg computed after restore_text — the closest thing to "prefer the real
+# path" the mocked finalize boundary allows.
+
+
+def _echo_finalize() -> AsyncMock:
+    """Fake finalize that returns exactly what the leg passed as the
+    answer — unlike `_wire_stubs`'s fixed-value default, this proves
+    `restore_text`'s OUTPUT (not the harness's canned text) reaches
+    `CodexLegResult.text`."""
+    return AsyncMock(
+        side_effect=lambda **kwargs: FinalizeResult(
+            outcome=FinalizeOutcome.SEND, text=kwargs["data"]["answer"]
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_leg_restores_placeholders_before_the_customer_sees_them(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guilt (restore): the build response carries a reversal_map and the
+    consumed completion echoes a placeholder the generator saw in its
+    redacted prompt — the leg must substitute it back BEFORE finalize/send.
+    Mutation pin: deleting `text = restore_text(text, reversal_map)` in
+    `wa_codex_leg._attempt` leaves the literal `[PII-PHONE-1]` token in
+    `CodexLegResult.text` and this test goes red.
+
+    The placeholder is embedded in an otherwise-normal sentence (not a bare
+    token) so a real finalize's text-defect checks would not eat it —
+    matching the coordinator's harness note."""
+    build = {**_GOOD_BUILD, "reversal_map": {"[PII-PHONE-1]": "+628111234567"}}
+    stubs = _wire_stubs(
+        monkeypatch,
+        build=build,
+        consume="Please call [PII-PHONE-1] to confirm your appointment.",
+    )
+    monkeypatch.setattr(wa_codex_leg, "finalize_wa_answer", _echo_finalize())
+    conn = ScriptedConn(
+        fetchrow_results=[{"human_handling": False, "handling_version": 3}]
+    )
+    result = await _run(conn=conn)
+    assert result.text is not None
+    assert "+628111234567" in result.text
+    assert "[PII-" not in result.text
+    stubs.rag_client.post.assert_awaited_once()  # sanity: build actually ran
+
+
+@pytest.mark.asyncio
+async def test_build_request_always_carries_dlp_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guilt (flag): the leg is the ONLY caller of /api/wa-package/build
+    that hands customer text to an external generator (module docstring,
+    wa_codex_leg.py:240-243) — every build request must ask for redaction.
+    Mutation pin: dropping `"dlp": True` from the POST body ships the
+    UNREDACTED package to codex and this test goes red."""
+    stubs = _wire_stubs(monkeypatch)
+    await _run()
+    kwargs = stubs.rag_client.post.await_args.kwargs
+    captured = kwargs["json"]
+    assert captured["dlp"] is True
+
+
+@pytest.mark.asyncio
+async def test_absent_reversal_map_passes_completion_through_byte_identical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Innocence: a build response with NO reversal_map (a dlp=False build,
+    or a redaction that found nothing to redact) must leave the consumed
+    completion untouched — no strip, no crash, no placeholder-shaped noise
+    introduced. `_GOOD_BUILD` carries no `reversal_map` key, so
+    `built.get("reversal_map") or {}` resolves to `{}` here — the ordinary
+    default every other test in this file already relies on implicitly;
+    this test makes it an explicit, named guarantee."""
+    original = "The office is open Monday to Friday, 9am-5pm."
+    _wire_stubs(monkeypatch, consume=original)
+    monkeypatch.setattr(wa_codex_leg, "finalize_wa_answer", _echo_finalize())
+    conn = ScriptedConn(
+        fetchrow_results=[{"human_handling": False, "handling_version": 3}]
+    )
+    result = await _run(conn=conn)
+    assert result.text == original


### PR DESCRIPTION
## What

The G-P3 DLP module redacts identifiers out of the context package the WA answering model reads. Kimi K3 round 2 returned **FIX-FIRST**: the NIK matcher was eating date-shaped digit runs. This PR is that cure batch, plus the blocker Kimi's round-3 grading produced against the cure itself.

An over-match here is not cosmetic — the redacted span is replaced by a placeholder **before** the model sees it, so a false positive silently deletes the business's own vocabulary (KBLI codes, prices, dates, decree references) from its own answer. `CREDENTIAL` has no reversal map, so a false positive there is irrecoverable.

## The cures

| | Cure |
|---|---|
| **F1** | `_DATE_SHAPE_RE` — a separator-bearing date inside a candidate NIK span declines it. Year anchored to **four** digits in both orderings, separator pinned by backreference: digits 7-12 of a real NIK encode `ddmmyy`, so a 2-digit-year rule would have declined genuine NIKs. |
| **F1b** | `_KBLI_LIST_RE` — three separator-joined 5-digit codes (`55130 70100 64210`) is a KBLI list, not an identifier. **Found by Codex's adversarial corpus; the spec had missed it entirely.** |
| **F3** | `,-` and `IDR` recognised as Rupiah amount closers. |
| **F4** | `inv`/`ref`/`sku` removed from the passport decline list — dead entries, the pattern captures at most two leading letters — plus a `passport`/`paspor` context override. |
| **F5** | Vendor key prefixes require their separator, so bare `sk` stops eating words like `skincareproducts2026`. |
| **F5b** | **Kimi round-3 BLOCKER on F5 itself.** The tail class still contains `-`, so `sk-` + hyphen-separated *words* cleared the 16-char minimum — and `SK` is *Surat Keputusan*, this business's most-cited document type. `sk-kemenkumham-ahu-0012345` would have vanished irrecoverably. The `sk` alternative now also requires one **unbroken** 16-char alphanumeric run: real keys carry entropy unbroken, human text is short words joined by hyphens. |

## The discipline that shaped this

**Narrow at the false positive, never at the canonical form.** The first attempt at F1b instead *required* NIKs to be grouped 4-4-4-4 — and silently broke two real cases the corpus already pinned: a NIK typed `32 04 15 12 88 00 0001` in 2-digit groups, and a bare 15-digit old-format NPWP. Both regressions were caught by the existing guilt tests before this PR existed.

F5b is scoped to the `sk` alternative only, and guilt is re-asserted across **all five** key families — a scoping mistake would have silently disarmed the other four, and the hyphenated Slack token is the trap that would have hidden it.

## Measured, not cured

Six findings ship as `xfail(strict=True)`: four pre-existing gaps (bare 16-digit leading-zero vs NPWP; three 2-letter+7-digit tokens vs PASSPORT) and Kimi's two round-3 non-blockers — `_IBAN_RE` has no validator so a promo code satisfies the IBAN shape (pre-existing, untouched by this delta), and the 4-digit-year anchor is a deliberate recall-over-precision trade.

`strict=True` is the load-bearing part: a permanently-red test trains the fleet to read red as noise, but strict turns the **xpass** red the day a gap is actually cured — forcing re-disposition instead of silent absorption.

## Generator ≠ grader

Codex counter-built the regexes from the spec, Sonnet wrote the corpus independently from the same spec without seeing the implementation, Kimi K3 graded the delta with one instruction: *"find an innocent string that gets redacted."* All three of its round-3 findings were re-verified against the running code before disposition — none was accepted on the refuter's word.

## PII boundary

Fixtures come from a seeded deterministic faker held out of the recall corpus. No `conversations` or CRM row was read. The cloud grading seats saw regexes, tests and synthetic strings only.

Synthetic credential fixtures are **assembled at runtime** from a prefix and a separate entropy run: written as literals, GitHub push protection rejects the branch (it reads the Stripe `sk_live_` shape as a real key). Do not tidy them back into literals.

## Tests

```
6235 passed, 32 skipped, 6 xfailed
backend/tests/unit/services/ + .../rag/agentic/ + test_wa_package_router.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)