### PR TITLE
fix(bot): answer German and Spanish users in their own language

### DIFF
--- a/apps/backend-rag/backend/services/rag/agentic/_reasoning_stubs.py
+++ b/apps/backend-rag/backend/services/rag/agentic/_reasoning_stubs.py
@@ -43,26 +43,43 @@ would be false on the others. Channel-specific hand-off belongs at the channel
 boundary (``wa_inbox_bot``), not in this table.
 
 Language coverage: ``query_helpers.detect_query_language`` can emit ten
-values; this table carries full translations for the five protocol languages
-(``PROTOCOL_LANGUAGES``) and lets the rest fall back to ENGLISH by design.
+values; this table carries full translations for the seven protocol languages
+(``PROTOCOL_LANGUAGES``) and lets the rest (CHINESE/ARABIC/FRENCH — see
+``DECLARED_ENGLISH_FALLBACK`` in ``test_reasoning_stubs_language_coverage.py``)
+fall back to ENGLISH by design.
 ``test_reasoning_stubs_language_coverage.py`` pins both halves of that claim,
 so a language added to the detector cannot silently start serving English.
+
+GERMAN and SPANISH joined the protocol set on 2026-08-23: ``detect_query_language``
+could already emit both (the ``_LATIN_MARKERS`` detector rows), but this table
+only had them in the silent-English-fallback set — a DE/ES client hit any
+abstain/error/confused branch in ``reasoning.py`` and read English. Promoted
+here, not left as a one-off patch, because the same table backs every call site
+(``reasoning.py``'s ReAct loop, ``wa_finalize.py``'s abstain-fairness path) —
+the fix has to live where the silent fallback did.
 """
 
 from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 _FALLBACK_MESSAGE = "I'm sorry, I cannot fulfill this request."
 
 #: The languages ZANTARA's LANGUAGE_PROTOCOL commits to (zantara_core.py).
 #: Every key in STUB_MESSAGES must carry a real translation for each — a
 #: missing one degrades to English silently, which is how Russian and
-#: Ukrainian clients were reading English refusals until 2026-07-27.
+#: Ukrainian clients were reading English refusals until 2026-07-27, and how
+#: German and Spanish clients were reading it until 2026-08-23.
 PROTOCOL_LANGUAGES: tuple[str, ...] = (
     "ITALIAN",
     "ENGLISH",
     "INDONESIAN",
     "RUSSIAN",
     "UKRAINIAN",
+    "GERMAN",
+    "SPANISH",
 )
 
 STUB_MESSAGES: dict[str, dict[str, str]] = {
@@ -101,6 +118,20 @@ STUB_MESSAGES: dict[str, dict[str, str]] = {
             "Це має подивитися колега з Bali Zero. "
             "Якщо тим часом надішлете документ або дату, на яку спираєтесь, "
             "я спробую ще раз із ними."
+        ),
+        "GERMAN": (
+            "Dazu habe ich keine verlässliche Quelle, und ich möchte lieber nicht raten — "
+            "bei Genehmigungen und Fristen ist eine falsche Antwort teuer. "
+            "Das muss sich ein Kollege von Bali Zero ansehen. "
+            "Wenn Sie mir in der Zwischenzeit ein Dokument oder ein Bezugsdatum schicken, "
+            "versuche ich es damit noch einmal."
+        ),
+        "SPANISH": (
+            "Para esto no tengo una fuente fiable, y prefiero no adivinar — "
+            "con permisos y plazos, una respuesta equivocada sale cara. "
+            "Esto lo tiene que revisar un colega de Bali Zero. "
+            "Si mientras tanto me envía un documento o una fecha de referencia, "
+            "puedo intentarlo de nuevo con eso."
         ),
     },
     # Same refusal, for the one case where the promise is now backed: a human
@@ -151,6 +182,20 @@ STUB_MESSAGES: dict[str, dict[str, str]] = {
             "Якщо тим часом надішлете документ або дату, на яку спираєтесь, "
             "я спробую ще раз із ними."
         ),
+        "GERMAN": (
+            "Dazu habe ich keine verlässliche Quelle, und ich möchte lieber nicht raten — "
+            "bei Genehmigungen und Fristen ist eine falsche Antwort teuer. "
+            "Ich habe es an das Bali-Zero-Team weitergeleitet. "
+            "Wenn Sie mir in der Zwischenzeit ein Dokument oder ein Bezugsdatum schicken, "
+            "versuche ich es damit noch einmal."
+        ),
+        "SPANISH": (
+            "Para esto no tengo una fuente fiable, y prefiero no adivinar — "
+            "con permisos y plazos, una respuesta equivocada sale cara. "
+            "Se lo he pasado al equipo de Bali Zero. "
+            "Si mientras tanto me envía un documento o una fecha de referencia, "
+            "puedo intentarlo de nuevo con eso."
+        ),
     },
     # WHAT THE ``truncated_tail`` TEXT IS FOR (2026-08-11)
     # ----------------------------------------------------
@@ -188,6 +233,14 @@ STUB_MESSAGES: dict[str, dict[str, str]] = {
             "\n\n_(Я скоротив відповідь, щоб вона вмістилася в ліміт WhatsApp. "
             "Запитайте про конкретний пункт — розкажу докладніше.)_"
         ),
+        "GERMAN": (
+            "\n\n_(Ich habe die Antwort gekürzt, damit sie ins WhatsApp-Limit passt. "
+            "Fragen Sie mich nach einem bestimmten Punkt, und ich gehe genauer darauf ein.)_"
+        ),
+        "SPANISH": (
+            "\n\n_(He acortado la respuesta para que quepa en el límite de WhatsApp. "
+            "Pregúnteme por un punto concreto y se lo detallo.)_"
+        ),
     },
     # WHAT THE ``low_confidence_note`` TEXT IS FOR (2026-08-11)
     # --------------------------------------------------------
@@ -221,6 +274,14 @@ STUB_MESSAGES: dict[str, dict[str, str]] = {
         "UKRAINIAN": (
             "\n\n_(Ця відповідь спирається на джерела, які я не змогла повністю "
             "перевірити: колега з Bali Zero їх перевіряє.)_"
+        ),
+        "GERMAN": (
+            "\n\n_(Diese Antwort stützt sich auf Quellen, die ich nicht vollständig prüfen "
+            "konnte: ein Kollege von Bali Zero überprüft sie noch einmal.)_"
+        ),
+        "SPANISH": (
+            "\n\n_(Esta respuesta se basa en fuentes que no pude verificar del todo: "
+            "un colega de Bali Zero la está revisando.)_"
         ),
     },
     "abstain_detailed": {
@@ -279,6 +340,28 @@ STUB_MESSAGES: dict[str, dict[str, str]] = {
             "Якщо ваше питання про це — переформулюйте, і я спробую ще раз. "
             "Якщо ні — на нього має подивитися колега з Bali Zero."
         ),
+        "GERMAN": (
+            "Zu dieser konkreten Frage habe ich in den offiziellen Dokumenten nicht genug "
+            "verifizierte Informationen, und ich sage das lieber, statt mir etwas auszudenken.\n\n"
+            "Darin bin ich dagegen sicher:\n"
+            "• Visa und KITAS\n"
+            "• Firmengründung (PT PMA)\n"
+            "• Steuern und Meldungen\n"
+            "• Verfahren und Unterlagen\n\n"
+            "Wenn Ihre Frage dazu gehört, formulieren Sie sie gerne neu. "
+            "Andernfalls muss sich ein Kollege von Bali Zero das ansehen."
+        ),
+        "SPANISH": (
+            "Sobre esta pregunta concreta no tengo suficiente información verificada en los "
+            "documentos oficiales, y prefiero decírselo antes que inventar algo.\n\n"
+            "En esto sí estoy seguro:\n"
+            "• Visados y KITAS\n"
+            "• Constitución de empresa (PT PMA)\n"
+            "• Impuestos y trámites\n"
+            "• Procedimientos y documentos\n\n"
+            "Si su pregunta entra ahí, puede reformularla. "
+            "Si no, lo tiene que revisar un colega de Bali Zero."
+        ),
     },
     "error": {
         "ITALIAN": (
@@ -300,6 +383,14 @@ STUB_MESSAGES: dict[str, dict[str, str]] = {
         "UKRAINIAN": (
             "У мене технічний збій, і зараз я не можу виконати запит. "
             "Спробуйте, будь ласка, за кілька хвилин."
+        ),
+        "GERMAN": (
+            "Ich habe gerade ein technisches Problem und kann die Anfrage im Moment nicht "
+            "bearbeiten. Bitte versuchen Sie es in ein paar Minuten erneut."
+        ),
+        "SPANISH": (
+            "Tengo un problema técnico y no puedo completar la solicitud en este momento. "
+            "Por favor, inténtelo de nuevo en unos minutos."
         ),
     },
     "confused": {
@@ -323,6 +414,15 @@ STUB_MESSAGES: dict[str, dict[str, str]] = {
             "Вибачте, я не зовсім зрозумів ваш запит. Не могли б ви сформулювати інакше? "
             "Я допоможу з візами, компаніями та законами в Індонезії."
         ),
+        "GERMAN": (
+            "Entschuldigung, ich habe Ihre Anfrage nicht ganz verstanden. Könnten Sie sie "
+            "anders formulieren? Ich kann Ihnen bei Visa, Unternehmen und Gesetzen in "
+            "Indonesien helfen."
+        ),
+        "SPANISH": (
+            "Disculpe, no he entendido bien su solicitud. ¿Podría reformularla? "
+            "Puedo ayudarle con visados, empresas y leyes en Indonesia."
+        ),
     },
 }
 
@@ -332,6 +432,26 @@ def get_localized_stub(key: str, language: str) -> str:
 
     Fallback order: requested language → ENGLISH → generic hardcoded message.
     Returns the generic message if the key itself is unknown.
+
+    Logs a warning whenever the requested language is not a direct hit — this
+    covers BOTH the deliberately-undeclared-for-translation languages
+    (CHINESE/ARABIC/FRENCH — see ``DECLARED_ENGLISH_FALLBACK`` in
+    ``test_reasoning_stubs_language_coverage.py``) and a genuinely wrong value
+    (e.g. a caller feeding this the lowercase codes
+    ``backend.services.communication.language_detector.detect_language``
+    emits — 'de', 'es' — instead of the protocol names this table keys on).
+    Before 2026-08-23 that second case degraded to English with nothing to
+    grep for; a caller wiring the wrong detector into this function now at
+    least leaves a trace instead of a silent, undiagnosable language drift.
     """
     lang_stubs = STUB_MESSAGES.get(key, {})
+    if language not in lang_stubs:
+        logger.warning(
+            "get_localized_stub: no %r translation for key=%r — falling back to "
+            "ENGLISH. If %r is a language detect_query_language can emit, translate "
+            "it here or add it to DECLARED_ENGLISH_FALLBACK on purpose.",
+            language,
+            key,
+            language,
+        )
     return lang_stubs.get(language, lang_stubs.get("ENGLISH", _FALLBACK_MESSAGE))

--- a/apps/backend-rag/backend/services/response/cleaner.py
+++ b/apps/backend-rag/backend/services/response/cleaner.py
@@ -52,6 +52,16 @@ _OUT_OF_DOMAIN_BY_LANGUAGE: dict[str, dict[str, str]] = {
             "телефонів чи домашніх адрес. Можу допомогти з візами, відкриттям компанії "
             "або юридичними питаннями в Індонезії. Що вас цікавить?"
         ),
+        "GERMAN": (
+            "Ich habe keinen Zugriff auf personenbezogene Daten Dritter wie Steuernummern, "
+            "Telefonnummern oder Privatadressen. Kann ich Ihnen bei Visa, Firmengründung "
+            "oder rechtlichen Fragen in Indonesien helfen?"
+        ),
+        "SPANISH": (
+            "No tengo acceso a datos personales de terceros, como números de identificación "
+            "fiscal, teléfonos o direcciones privadas. ¿Puedo ayudarle con visados, "
+            "constitución de empresas o cuestiones legales en Indonesia?"
+        ),
     },
     "realtime_info": {
         "ITALIAN": (
@@ -78,6 +88,18 @@ _OUT_OF_DOMAIN_BY_LANGUAGE: dict[str, dict[str, str]] = {
             "Я не маю доступу до даних у реальному часі — котирувань чи курсів валют: "
             "я назвав би цифру, яку не можу перевірити. Для цього краще дивитися "
             "актуальне джерело. А з візами, KITAS чи бізнесом в Індонезії — допоможу."
+        ),
+        "GERMAN": (
+            "Ich habe keinen Zugriff auf Echtzeitdaten wie Marktpreise oder Wechselkurse — "
+            "ich würde eine Zahl nennen, die ich nicht überprüfen kann. Dafür schauen Sie "
+            "besser in eine aktuelle Quelle. Bei Visa, KITAS oder Geschäften in Indonesien "
+            "helfe ich stattdessen gerne."
+        ),
+        "SPANISH": (
+            "No tengo acceso a datos en tiempo real, como precios de mercado o tipos de "
+            "cambio — le daría una cifra que no puedo verificar. Para eso, consulte una "
+            "fuente actualizada. En cambio, puedo ayudarle con visados, KITAS o negocios "
+            "en Indonesia."
         ),
     },
     "off_topic": {
@@ -107,6 +129,16 @@ _OUT_OF_DOMAIN_BY_LANGUAGE: dict[str, dict[str, str]] = {
             "імміграція, реєстрація компанії (PT PMA) та юридичні питання для "
             "іноземців в Індонезії. Чи можу допомогти в цих темах?"
         ),
+        "GERMAN": (
+            "Das liegt außerhalb meines Fachgebiets. Ich bin Zantara, die KI-Assistentin "
+            "von {company}: Visa, Einwanderung, Firmengründung (PT PMA) und rechtliche "
+            "Angelegenheiten für Ausländer in Indonesien. Kann ich Ihnen dabei helfen?"
+        ),
+        "SPANISH": (
+            "Ese tema está fuera de mi área. Soy Zantara, la asistente de IA de {company}: "
+            "visados, inmigración, constitución de empresas (PT PMA) y asuntos legales para "
+            "extranjeros en Indonesia. ¿Puedo ayudarle en algo de eso?"
+        ),
     },
     "unknown": {
         "ITALIAN": (
@@ -130,6 +162,16 @@ _OUT_OF_DOMAIN_BY_LANGUAGE: dict[str, dict[str, str]] = {
             "З цієї теми в мене немає конкретної інформації. Можу допомогти з візами, "
             "KITAS, реєстрацією PT PMA чи локальної PT та іншими бізнес-питаннями в Індонезії."
         ),
+        "GERMAN": (
+            "Dazu habe ich keine konkreten Informationen. Ich kann Ihnen bei Visa, KITAS, "
+            "der Gründung einer PT PMA oder einer lokalen PT sowie anderen geschäftlichen "
+            "Fragen in Indonesien helfen."
+        ),
+        "SPANISH": (
+            "No tengo información específica sobre eso. Puedo ayudarle con visados, KITAS, "
+            "la constitución de una PT PMA o una PT local, y otros asuntos de negocios "
+            "en Indonesia."
+        ),
     },
 }
 
@@ -141,8 +183,21 @@ def get_out_of_domain_response(reason: str, language: str = "ITALIAN") -> str:
     the ``unknown`` refusal. An unmapped language degrading to ENGLISH is
     deliberate and declared; an unmapped language degrading to ITALIAN — which is
     what shipping the raw table did — is not.
+
+    Logs a warning on that fallback, same rationale as ``get_localized_stub``
+    (this table's own SSOT docstring above): a caller feeding the wrong
+    detector's vocabulary in here degraded silently before 2026-08-23.
     """
     by_language = _OUT_OF_DOMAIN_BY_LANGUAGE.get(reason) or _OUT_OF_DOMAIN_BY_LANGUAGE["unknown"]
+    if language not in by_language:
+        logger.warning(
+            "get_out_of_domain_response: no %r entry for reason=%r — falling back "
+            "to ENGLISH. If %r is a language detect_query_language can emit, "
+            "translate it here or add it to DECLARED_ENGLISH_FALLBACK on purpose.",
+            language,
+            reason,
+            language,
+        )
     text = by_language.get(language) or by_language["ENGLISH"]
     return text.format(company=settings.COMPANY_NAME)
 

--- a/apps/backend-rag/backend/tests/services/response/test_out_of_domain_language_coverage.py
+++ b/apps/backend-rag/backend/tests/services/response/test_out_of_domain_language_coverage.py
@@ -33,9 +33,10 @@ from backend.services.response.cleaner import (
 #: Languages the detector emits that these refusals knowingly serve in English.
 #: Kept identical in spirit to the stub table's declaration: a new detector
 #: language must be translated or declared here on purpose.
-DECLARED_ENGLISH_FALLBACK: frozenset[str] = frozenset(
-    {"CHINESE", "ARABIC", "FRENCH", "SPANISH", "GERMAN"}
-)
+#:
+#: GERMAN and SPANISH moved OUT of this set on 2026-08-23, in lockstep with
+#: _reasoning_stubs.PROTOCOL_LANGUAGES — see that module's docstring.
+DECLARED_ENGLISH_FALLBACK: frozenset[str] = frozenset({"CHINESE", "ARABIC", "FRENCH"})
 
 
 def _languages_the_detector_can_emit() -> set[str]:

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning_stubs_german_spanish.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning_stubs_german_spanish.py
@@ -1,0 +1,146 @@
+"""A German or Spanish client reads a refusal in their own language, not English.
+
+RECORDED DEFECT
+----------------
+``detect_query_language`` (query_helpers.py) could already emit ``"GERMAN"``
+and ``"SPANISH"`` — the ``_LATIN_MARKERS`` detector rows cover both — but
+``STUB_MESSAGES`` (``_reasoning_stubs.py``) only translated five protocol
+languages and silently declared GERMAN/SPANISH as English-fallback. Every
+call site that resolves an abstain/error/confused stub from the detected
+language (``reasoning.py``'s ReAct loop, ``wa_finalize.py``'s
+``_safe_abstain_reply``) therefore answered a German or Spanish question with
+English copy, and nothing failed — the exact shape ``test_reasoning_stubs_
+language_coverage.py``'s own docstring describes for Russian/Ukrainian before
+2026-07-27.
+
+THE TRAP THIS FILE DOES NOT WALK INTO
+--------------------------------------
+A SEPARATE detector, ``backend.services.communication.language_detector.
+detect_language``, emits lowercase codes ("de" is not even one of its five
+codes — it has no German/Spanish support at all, only it/en/id/uk/ru) and is
+used by the WA outbox worker's ack/apology sends, which key their OWN small
+dict on those lowercase codes. This file never touches that detector or that
+dict — mixing the two vocabularies is the documented regression, not a fix
+(see ``test_whatsapp_send_fits_limit.py::
+test_an_unknown_language_name_must_not_silently_become_an_english_apology``).
+
+GUILT below proves a real German/Spanish query is detected AND answered in
+that language, end to end through both the reasoning-engine stub table and
+the WA-finalize abstain path. INNOCENCE proves the five previously-covered
+protocol languages are byte-identical to what they were before this change —
+this addition only ADDS coverage, it does not touch existing translations.
+"""
+
+from __future__ import annotations
+
+from backend.services.integrations.wa_finalize import _safe_abstain_reply
+from backend.services.rag.agentic._reasoning_stubs import (
+    PROTOCOL_LANGUAGES,
+    STUB_MESSAGES,
+    get_localized_stub,
+)
+from backend.services.rag.agentic.query_helpers import detect_query_language
+
+# Real questions, not synthetic language tags — the detector must fire on the
+# actual marker words, not on a hand-picked language name.
+GERMAN_QUERY = "Welche Dokumente brauche ich, um eine PT PMA zu gründen?"
+SPANISH_QUERY = "¿Qué documentos necesito para abrir una empresa en Indonesia?"
+
+
+class TestGuiltGermanAndSpanishAreDetectedAndAnswered:
+    def test_german_query_is_detected_as_german(self) -> None:
+        assert detect_query_language(GERMAN_QUERY) == "GERMAN"
+
+    def test_spanish_query_is_detected_as_spanish(self) -> None:
+        assert detect_query_language(SPANISH_QUERY) == "SPANISH"
+
+    def test_german_stub_is_german_not_english(self) -> None:
+        stub = get_localized_stub("abstain", "GERMAN")
+        assert stub != STUB_MESSAGES["abstain"]["ENGLISH"]
+        # A cheap but real signal this is actually German prose, not a
+        # mistranslated copy-paste: the umlaut/eszett characters this
+        # vocabulary uses show up somewhere in the sentence.
+        assert any(ch in stub for ch in "äöüßÄÖÜ")
+
+    def test_spanish_stub_is_spanish_not_english(self) -> None:
+        stub = get_localized_stub("abstain", "SPANISH")
+        assert stub != STUB_MESSAGES["abstain"]["ENGLISH"]
+        assert any(ch in stub for ch in "áéíóúñ¿¡")
+
+    def test_german_query_gets_the_german_stub_end_to_end(self) -> None:
+        """The full path a client actually hits: detect -> resolve -> send."""
+        reply = _safe_abstain_reply(GERMAN_QUERY)
+        assert reply == get_localized_stub("abstain", "GERMAN")
+        assert reply != get_localized_stub("abstain", "ENGLISH")
+
+    def test_spanish_query_gets_the_spanish_stub_end_to_end(self) -> None:
+        reply = _safe_abstain_reply(SPANISH_QUERY)
+        assert reply == get_localized_stub("abstain", "SPANISH")
+        assert reply != get_localized_stub("abstain", "ENGLISH")
+
+    def test_german_and_spanish_are_now_protocol_languages(self) -> None:
+        assert "GERMAN" in PROTOCOL_LANGUAGES
+        assert "SPANISH" in PROTOCOL_LANGUAGES
+
+
+class TestInnocenceExistingLanguagesAreUnchanged:
+    """This addition must not have touched any previously-shipped translation."""
+
+    _PREVIOUSLY_SHIPPED_ABSTAIN = {
+        "ITALIAN": (
+            "Su questo non ho una fonte certa e preferisco non tirare a indovinare: "
+            "con permessi e scadenze una risposta sbagliata costa. "
+            "Questa la deve guardare un collega di Bali Zero. "
+            "Se intanto mi mandi un documento o una data di riferimento, "
+            "posso riprovare con quelli."
+        ),
+        "ENGLISH": (
+            "I don't have a reliable source for this one, and I'd rather not guess — "
+            "with permits and deadlines a wrong answer is expensive. "
+            "This one needs a Bali Zero colleague to look at it. "
+            "If you can send me a document or a reference date in the meantime, "
+            "I can try again with those."
+        ),
+        "INDONESIAN": (
+            "Untuk yang ini saya tidak punya sumber yang pasti, dan saya lebih baik "
+            "tidak menebak — untuk izin dan tenggat waktu, jawaban yang salah itu mahal. "
+            "Yang ini perlu dilihat oleh rekan dari Bali Zero. "
+            "Sementara itu, kalau Anda kirim dokumen atau tanggal acuan, "
+            "saya bisa coba lagi dengan itu."
+        ),
+        "RUSSIAN": (
+            "По этому вопросу у меня нет надёжного источника, и я предпочитаю не гадать: "
+            "когда речь идёт о разрешениях и сроках, неверный ответ обходится дорого. "
+            "Здесь нужен взгляд коллеги из Bali Zero. "
+            "Если пока пришлёте документ или дату, на которую опираетесь, "
+            "я попробую ещё раз с ними."
+        ),
+        "UKRAINIAN": (
+            "Щодо цього я не маю надійного джерела і волію не вгадувати: "
+            "коли йдеться про дозволи та строки, неправильна відповідь дорого коштує. "
+            "Це має подивитися колега з Bali Zero. "
+            "Якщо тим часом надішлете документ або дату, на яку спираєтесь, "
+            "я спробую ще раз із ними."
+        ),
+    }
+
+    def test_the_five_original_protocol_languages_are_byte_identical(self) -> None:
+        for language, text in self._PREVIOUSLY_SHIPPED_ABSTAIN.items():
+            assert get_localized_stub("abstain", language) == text, (
+                f"{language}'s 'abstain' stub changed — this cure must only ADD "
+                f"GERMAN/SPANISH, never touch an existing translation"
+            )
+
+    def test_the_five_original_languages_still_route_correctly(self) -> None:
+        cases = {
+            "ENGLISH": "What documents do I need to open a company in Indonesia?",
+            "ITALIAN": "Di cosa ho bisogno per aprire una società in Indonesia?",
+            "INDONESIAN": "Saya mau tanya berapa biaya untuk bikin PT PMA?",
+            "RUSSIAN": "Здравствуйте, подскажите пожалуйста как открыть компанию?",
+            "UKRAINIAN": "Доброго дня, підкажіть будь ласка як відкрити компанію?",
+        }
+        for expected_language, query in cases.items():
+            assert detect_query_language(query) == expected_language, (
+                f"query written for {expected_language} was misdetected — "
+                f"this cure must not have perturbed the existing detector rows"
+            )

--- a/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning_stubs_language_coverage.py
+++ b/apps/backend-rag/backend/tests/unit/services/rag/agentic/test_reasoning_stubs_language_coverage.py
@@ -42,9 +42,10 @@ from backend.services.rag.agentic._reasoning_stubs import (
 #: Languages ``detect_query_language`` can return that we knowingly serve in
 #: English. Adding a language to the detector without translating it forces a
 #: deliberate entry here — that is the point. "UNKNOWN" is not a language.
-DECLARED_ENGLISH_FALLBACK: frozenset[str] = frozenset(
-    {"CHINESE", "ARABIC", "FRENCH", "SPANISH", "GERMAN"}
-)
+#:
+#: GERMAN and SPANISH moved OUT of this set on 2026-08-23 (translated into
+#: PROTOCOL_LANGUAGES instead) — see _reasoning_stubs.py's module docstring.
+DECLARED_ENGLISH_FALLBACK: frozenset[str] = frozenset({"CHINESE", "ARABIC", "FRENCH"})
 
 
 def _languages_the_detector_can_emit() -> set[str]:


### PR DESCRIPTION
## The measurement

On the 2026-08-11 WA transcript, German and Spanish queries came back **in English**.

The cause is not the language detector. DE and ES were simply **absent** from the two mirroring tables, so every lookup fell through to the English default — and fell through *silently*.

## The cure

- `_reasoning_stubs.PROTOCOL_LANGUAGES` gains `GERMAN` and `SPANISH`, with translations for all **7** `STUB_MESSAGES` keys.
- `cleaner._OUT_OF_DOMAIN_BY_LANGUAGE` gains the same two across **every** bucket (`third_party_pii`, `realtime_info`, `off_topic`, `unknown`, …).
- `get_localized_stub` now emits a `logger.warning` on fallback.

That last line is the part that outlives these two languages. The fallback was silent, which is precisely why answering a German client in English could persist unnoticed until someone read a transcript by hand. **The next missing language now announces itself in the logs** instead of waiting for a human to notice.

The two coverage tests narrow `DECLARED_ENGLISH_FALLBACK` to `{CHINESE, ARABIC, FRENCH}` — the languages that remain a *deliberate* English fallback, now stated explicitly rather than implied by omission.

## Verified on disk, beyond the suite

- **Zero placeholder drift**: every language in every bucket carries the same format fields as its English reference, so no translation can raise `KeyError` at format time.
- DE/ES present in all 7 stub keys and all out-of-domain buckets.
- Register is formal throughout (*Sie* / *usted*), matching how this business addresses clients in the languages it already supports.

## Pre-existing failure, deliberately not touched

`backend/tests/services/response/test_standard_templates.py` shows 3 failures when co-executed with `backend/tests/unit/services/rag/agentic/`. This is **pre-existing on `origin/main`** — verified by running the identical selection on a clean tree without this diff and getting the identical 3 failures, same tests, same count. The cause is the agentic `conftest.py` patching `settings` in a way that leaks into the sibling directory.

Different concern, different PR. Recording it here so the next reader does not attribute it to this diff.

## Tests

```
1927 passed, 30 skipped   (the two affected directories)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)