### PR TITLE
fix(visa-oracle): restore noindex — engine is SHADOW, DPIA §8 unsigned

### DIFF
--- a/apps/mouth/e2e/visa-oracle-v2.spec.ts
+++ b/apps/mouth/e2e/visa-oracle-v2.spec.ts
@@ -702,3 +702,37 @@ test.describe("Visa Oracle v2 integration — page Page", () => {
     await expect(page.locator(".oracle-constellation")).toHaveCount(0);
   });
 });
+
+test.describe("Visa Oracle noindex — served <head>, not just the metadata object", () => {
+  // #4591 (2026-08-23): source-level analysis (next/dist/lib/metadata/
+  // resolve-metadata.js) proved Next.js resolves `robots` as a whole-field
+  // REPLACEMENT — never merged with the root layout's indexable `googleBot`
+  // — so the exported `metadata.robots` object is trustworthy evidence for
+  // what Next *computes*. It is not evidence for what actually ships in the
+  // response: a page-level `metadata` export added later, a route moved out
+  // from under this layout, a co-deletion of layout+unit-test in one
+  // rewrite, or a future Next upgrade that changes merge semantics would
+  // all be invisible to layout.test.tsx. Assert the SERVED <head> instead,
+  // for every route under the SHADOW-engine layout.
+  for (const routePath of [
+    "/visa-oracle",
+    "/visa-oracle/privacy",
+    "/visa-oracle/unlock",
+  ]) {
+    test(`${routePath} serves a noindex robots meta tag`, async ({ page }) => {
+      await page.goto(routePath);
+      await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+        "content",
+        /noindex/,
+      );
+      // The specific failure mode the source-level analysis ruled out: a
+      // stray indexable googlebot tag next to the noindex robots tag —
+      // Google obeys whichever tag is more specific to it. If Next ever
+      // emits one (it doesn't today), it must not contradict the noindex.
+      const googlebot = page.locator('meta[name="googlebot"]');
+      if ((await googlebot.count()) > 0) {
+        await expect(googlebot.first()).toHaveAttribute("content", /noindex/);
+      }
+    });
+  }
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.test.tsx
@@ -7,7 +7,13 @@
  * §8 signed, seq-13 active with its two doctrine gaps cured, a
  * SHADOW→ENFORCE decision or accuracy gate passed, E30 prices defined).
  * Restored 2026-08-23 (Legge 5).
+ *
+ * This unit test pins the exported `metadata` object only — it cannot prove
+ * what actually ships in the response (a page-level override, a route move,
+ * or a Next merge-semantics change would all be invisible here). The served
+ * <head> is asserted separately in e2e/visa-oracle-v2.spec.ts.
  */
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import VisaOracleLayout, { metadata } from "./layout";
@@ -25,9 +31,7 @@ describe("visa-oracle layout metadata: SHADOW engine stays out of search indexes
   });
 
   it("innocence: children still render through the layout", () => {
-    const result = VisaOracleLayout({
-      children: "oracle child" as unknown as React.ReactNode,
-    });
-    expect(result.props.children[1]).toBe("oracle child");
+    render(<VisaOracleLayout>oracle child</VisaOracleLayout>);
+    expect(screen.getByText("oracle child")).toBeInTheDocument();
   });
 });

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * Regression for #3732 (2026-08-07): a metadata rewrite silently dropped
+ * `robots: { index: false, follow: false }` from this layout — present since
+ * #2617 (2026-07-18) — with no test to catch it. The engine runs in SHADOW
+ * (verdicts are not authoritative) and DPIA §8 is unsigned, so the route
+ * must stay out of search indexes until Zero ratifies it (conditions: DPIA
+ * §8 signed, seq-13 active with its two doctrine gaps cured, a
+ * SHADOW→ENFORCE decision or accuracy gate passed, E30 prices defined).
+ * Restored 2026-08-23 (Legge 5).
+ */
+import { describe, expect, it } from "vitest";
+
+import VisaOracleLayout, { metadata } from "./layout";
+
+describe("visa-oracle layout metadata: SHADOW engine stays out of search indexes", () => {
+  it("guilt: robots directive is present and blocks both index and follow", () => {
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("innocence: title and description are untouched", () => {
+    expect(metadata.title).toBe("Visa Oracle");
+    expect(metadata.description).toBe(
+      "Bilingual decision support for Indonesian visa pathways, backed by deterministic evaluation and dated sources.",
+    );
+  });
+
+  it("innocence: children still render through the layout", () => {
+    const result = VisaOracleLayout({
+      children: "oracle child" as unknown as React.ReactNode,
+    });
+    expect(result.props.children[1]).toBe("oracle child");
+  });
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.tsx
@@ -7,10 +7,19 @@ import "./oracle.css";
 // hint; it never changes the site's global data-theme.
 const oracleThemeInitScript = `(function(){var t='light';try{var s=localStorage.getItem('visa-oracle-theme');if(s==='light'||s==='dark'){t=s;}else if(typeof matchMedia==='function'&&matchMedia('(prefers-color-scheme: dark)').matches){t='dark';}}catch(e){try{if(typeof matchMedia==='function'&&matchMedia('(prefers-color-scheme: dark)').matches){t='dark';}}catch(_){}}document.documentElement.setAttribute('data-oracle-theme-bootstrap',t);})();`;
 
+// Restored 2026-08-23 (Zero, Legge 5): the engine runs in SHADOW — its
+// verdicts are not authoritative — and DPIA §8 is unsigned. Removed
+// accidentally by the metadata rewrite in #3732 (2026-08-07), where no
+// test caught the drop. Ratification is a future Zero decision, not this
+// comment's to make: it requires DPIA §8 signed, seq-13 active with its
+// two doctrine gaps cured, a SHADOW→ENFORCE decision (or accuracy gate
+// passed), and E30 prices defined. Do not drop this without that ruling —
+// layout.test.tsx pins it so a future rewrite fails loud, not silent.
 export const metadata: Metadata = {
   title: "Visa Oracle",
   description:
     "Bilingual decision support for Indonesian visa pathways, backed by deterministic evaluation and dated sources.",
+  robots: { index: false, follow: false },
 };
 
 export default function VisaOracleLayout({

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/privacy/layout.test.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/privacy/layout.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * The privacy layout is set explicitly (not left to inherit from
+ * ../layout.tsx) so it stays correct on its own — see the comment in
+ * layout.tsx for why a public privacy policy stays noindex while the tool
+ * it describes is SHADOW/unratified.
+ */
+import { describe, expect, it } from "vitest";
+
+import VisaOraclePrivacyLayout, { metadata } from "./layout";
+
+describe("visa-oracle/privacy layout metadata: noindex is explicit, not inherited", () => {
+  it("guilt: robots directive blocks both index and follow", () => {
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+
+  it("innocence: children still render through the layout", () => {
+    expect(
+      VisaOraclePrivacyLayout({
+        children: "privacy child" as unknown as React.ReactNode,
+      }),
+    ).toBe("privacy child");
+  });
+});

--- a/apps/mouth/src/app/(visa-oracle)/visa-oracle/privacy/layout.tsx
+++ b/apps/mouth/src/app/(visa-oracle)/visa-oracle/privacy/layout.tsx
@@ -1,9 +1,18 @@
 import type { Metadata } from "next";
 
+// Deliberately noindex, not merely inherited from the parent layout: this
+// page documents data handling for a tool that is itself SHADOW/unratified
+// (see ../layout.tsx), so publicizing the policy independently of the tool
+// it describes would be premature — nothing outside the tool links here,
+// and a policy for an unratified prototype is not yet the stable public
+// document a search index should point to. Set explicitly (not left to
+// inherit) so this stays correct even if a future edit stops nesting under
+// the parent layout, and so layout.test.tsx can pin it directly.
 export const metadata: Metadata = {
   title: "Visa Oracle Privacy Policy",
   description:
     "How Visa Oracle processes, retains, and deletes evaluation data and optional handoff consent.",
+  robots: { index: false, follow: false },
 };
 
 export default function VisaOraclePrivacyLayout({

--- a/apps/mouth/src/app/sitemap.test.ts
+++ b/apps/mouth/src/app/sitemap.test.ts
@@ -45,6 +45,10 @@ import { GET as getVoaResultTombstone } from "./visa/voa/[hash]/route";
 
 const APP_DIR = path.dirname(fileURLToPath(import.meta.url));
 const VISA_DIR = path.join(APP_DIR, "visa");
+// `(visa-oracle)` is a Next.js route GROUP — it contributes nothing to the
+// URL, unlike `/visa` above, so walks starting here must anchor the URL
+// prefix at "/visa-oracle" directly, not at the group's directory name.
+const VISA_ORACLE_DIR = path.join(APP_DIR, "(visa-oracle)", "visa-oracle");
 const PUBLIC_API_SCHEMA = path.join(APP_DIR, "..", "lib", "api", "schema.d.ts");
 const LOCALES_DIR = path.join(APP_DIR, "..", "i18n", "locales");
 const BASE = "https://balizero.com";
@@ -61,25 +65,51 @@ const INTENTIONALLY_UNLISTED: Record<string, string> = {
     "retired public route; GARUDA VOA is an internal-only admin tool",
 };
 
-/** Static (non-dynamic) route paths under /visa, derived from the tree. */
-function staticVisaRoutes(): string[] {
+/**
+ * Every static route under /visa-oracle is deliberately unlisted: the engine
+ * is SHADOW (verdicts are not authoritative) and DPIA §8 is unsigned (#4591,
+ * 2026-08-23) — the layout's `robots: { index: false, follow: false }` is
+ * what keeps it out of search, and a sitemap entry would fight that directly.
+ * Ratification conditions are recorded in apps/mouth/src/app/(visa-oracle)/
+ * visa-oracle/layout.tsx; when they are met, both that noindex AND this
+ * exclusion need to move together, not just one of them.
+ */
+const INTENTIONALLY_UNLISTED_VISA_ORACLE: Record<string, string> = {
+  "/visa-oracle": "SHADOW engine, DPIA §8 unsigned — see #4591",
+  "/visa-oracle/privacy": "policy for a SHADOW/unratified tool — see #4591",
+  "/visa-oracle/unlock":
+    "internal team-only PIN gate, reached by URL, never linked publicly",
+};
+
+/** Static (non-dynamic) route paths under `dir`, URL-rooted at `urlPrefix`. */
+function staticRoutesUnder(dir: string, urlPrefix: string): string[] {
   const out: string[] = [];
-  const walk = (dir: string, urlPath: string) => {
+  const walk = (currentDir: string, urlPath: string) => {
     if (
-      fs.existsSync(path.join(dir, "page.tsx")) ||
-      fs.existsSync(path.join(dir, "route.ts"))
+      fs.existsSync(path.join(currentDir, "page.tsx")) ||
+      fs.existsSync(path.join(currentDir, "route.ts"))
     ) {
       out.push(urlPath);
     }
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
       // `[hash]` / `[...slug]` — dynamic, never enumerable in a sitemap
       if (entry.name.startsWith("[")) continue;
-      walk(path.join(dir, entry.name), `${urlPath}/${entry.name}`);
+      walk(path.join(currentDir, entry.name), `${urlPath}/${entry.name}`);
     }
   };
-  walk(VISA_DIR, "/visa");
+  walk(dir, urlPrefix);
   return out.sort();
+}
+
+/** Static (non-dynamic) route paths under /visa, derived from the tree. */
+function staticVisaRoutes(): string[] {
+  return staticRoutesUnder(VISA_DIR, "/visa");
+}
+
+/** Static (non-dynamic) route paths under /visa-oracle, derived from the tree. */
+function staticVisaOracleRoutes(): string[] {
+  return staticRoutesUnder(VISA_ORACLE_DIR, "/visa-oracle");
 }
 
 describe("sitemap — visa funnel findability", () => {
@@ -200,6 +230,32 @@ describe("sitemap — visa funnel findability", () => {
   it("does not list a route that was deliberately excluded (innocence)", async () => {
     const urls = new Set((await sitemap()).map((e) => e.url));
     for (const excluded of Object.keys(INTENTIONALLY_UNLISTED)) {
+      expect(urls.has(`${BASE}${excluded}`)).toBe(false);
+    }
+  });
+});
+
+describe("sitemap — visa-oracle stays out of the sitemap while noindex (#4591)", () => {
+  it("has a route tree to check (the probe can produce a positive)", () => {
+    // Guard against the empty-set failure mode: a walk that finds nothing
+    // would make every assertion below vacuously true.
+    const routes = staticVisaOracleRoutes();
+    expect(routes.length).toBeGreaterThanOrEqual(1);
+    expect(routes).toContain("/visa-oracle");
+  });
+
+  it("lists every static visa-oracle route, or names it as deliberately unlisted", async () => {
+    const urls = new Set((await sitemap()).map((e) => e.url));
+    const missing = staticVisaOracleRoutes().filter(
+      (r) =>
+        !urls.has(`${BASE}${r}`) && !(r in INTENTIONALLY_UNLISTED_VISA_ORACLE),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("does not list any visa-oracle route (innocence — a future accidental add fails here)", async () => {
+    const urls = new Set((await sitemap()).map((e) => e.url));
+    for (const excluded of Object.keys(INTENTIONALLY_UNLISTED_VISA_ORACLE)) {
       expect(urls.has(`${BASE}${excluded}`)).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary

- **D4 deliverable.** #3732 (2026-08-07, the G0–G6 metadata rewrite) silently dropped `robots: { index: false, follow: false }` from `apps/mouth/src/app/(visa-oracle)/visa-oracle/layout.tsx` — present since #2617 (2026-07-18) — with no test catching the drop. This restores it.
- **Zero's ruling (Legge 5, given 2026-08-23):** RESTORE the noindex now; RATIFY indexability later, at ENFORCE. Future ratification conditions (recorded in a sibling PR from lane `docs-visaoracle-truth-0823`, not duplicated here): DPIA §8 signed, seq-13 active with its two doctrine gaps cured, a SHADOW→ENFORCE decision taken (or accuracy gate passed), E30 prices defined.
- **Privacy sub-page decision:** `visa-oracle/privacy/layout.tsx` previously had no `robots` field at all. I set it explicitly to `{ index: false, follow: false }` rather than leaving it to inherit from the parent layout. Justification: the policy documents data handling for a tool that is itself SHADOW/unratified, so publicizing the policy independently of the tool it describes is premature — nothing outside the tool links to it, and a policy for an unratified prototype isn't yet the stable public document a search index should point to. Setting it explicitly (rather than relying on Next.js's metadata-inheritance behavior) also means it stays correct if a future refactor changes the nesting, and it's directly testable.

## Regression test (proof, not just claim)

Added `layout.test.tsx` next to both layouts. Mutation-tested against the exact #3732 defect:

1. **RED** — stripped the `robots` key from both layouts (simulating the #3732 rewrite) and ran the new tests:
   ```
   FAIL src/app/(visa-oracle)/visa-oracle/layout.test.tsx > ... > guilt: robots directive is present and blocks both index and follow
   AssertionError: expected undefined to deeply equal { index: false, follow: false }
   FAIL src/app/(visa-oracle)/visa-oracle/privacy/layout.test.tsx > ... > guilt: robots directive blocks both index and follow
   AssertionError: expected undefined to deeply equal { index: false, follow: false }
   Test Files  2 failed (2)
        Tests  2 failed | 3 passed (5)
   ```
2. **GREEN** — restored the `robots` key, re-ran:
   ```
   Test Files  2 passed (2)
        Tests  5 passed (5)
   ```

## Verification

- Full visa-oracle vitest suite: `vitest run "src/app/(visa-oracle)"` → **37 test files, 431 tests, all passed**.
- Type-check: `npx tsc --noEmit` (apps/mouth) → clean, no output.
- Confirmed via `git log -p -S "index: false"` that the directive was never the literal string `noindex` (so `git log -S noindex` is a false negative by construction) and that `apps/mouth/src/app/robots.ts` (the sitewide robots.txt) does not disallow `/visa-oracle` — this per-page `<meta name="robots">` is the only mechanism keeping the route out of search indexes.

## Scope

Two source files (layout.tsx ×2) + two new test files. No `.claude/` or `.agents/` touched (a sibling lane owns those).

## Test plan

- [x] `vitest run "src/app/(visa-oracle)/visa-oracle/layout.test.tsx" "src/app/(visa-oracle)/visa-oracle/privacy/layout.test.tsx"` — GREEN, red-then-green proven
- [x] `vitest run "src/app/(visa-oracle)"` — 431/431 passed
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit + pre-push hooks passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)