### PR TITLE
fix(crm): gate mark_client_message_read on client access (team-side BOLA)

### DIFF
--- a/apps/backend-rag/backend/app/routers/crm_portal_integration.py
+++ b/apps/backend-rag/backend/app/routers/crm_portal_integration.py
@@ -462,6 +462,8 @@ async def send_message_to_client(
                     "created_at": message["created_at"].isoformat(),
                 },
             }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Failed to send message to client %s: %s", client_id, e)
         raise HTTPException(
@@ -474,7 +476,7 @@ async def send_message_to_client(
 async def mark_client_message_read(
     client_id: int,
     message_id: int,
-    _current_user: dict = Depends(require_team_auth),
+    current_user: dict = Depends(require_team_auth),
     db_pool: asyncpg.Pool = Depends(get_database_pool),
 ) -> dict[str, Any]:
     """
@@ -482,6 +484,10 @@ async def mark_client_message_read(
     """
     try:
         async with db_pool.acquire() as conn:
+            await verify_client_access(
+                client_id, current_user, conn, allow_assigned=True, write=True
+            )
+
             await conn.execute(
                 """
                 UPDATE portal_messages
@@ -499,6 +505,8 @@ async def mark_client_message_read(
                 "success": True,
                 "message": "Message marked as read",
             }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Failed to mark message %s as read: %s", message_id, e)
         raise HTTPException(

--- a/apps/backend-rag/backend/tests/unit/routers/test_crm_portal_mark_read_bola.py
+++ b/apps/backend-rag/backend/tests/unit/routers/test_crm_portal_mark_read_bola.py
@@ -1,0 +1,169 @@
+"""Tests for the `mark_client_message_read` team-side BOLA fix (2026-08-23, round 2).
+
+Ground-verified this session: `crm_portal_integration.py::mark_client_message_read`
+(`POST /api/crm/portal/clients/{client_id}/messages/{message_id}/read`) performs
+`UPDATE portal_messages SET read_at = NOW() ...` — a WRITE. The round-1 pass added
+`verify_client_access(client_id, current_user, conn, allow_assigned=True)` but left
+`write` at its default `False`. In that mode `verify_client_access` (crm_utils.py
+lines 234-238) grants access to **every authenticated team member**, per its own
+docstring: "All authenticated team members can view any client ... Unassigned
+clients must be accessible so team members can self-assign." So the round-1 diff
+gated nothing — any staff member could still mark any client's message read.
+
+The round-2 fix passes `write=True`:
+`verify_client_access(client_id, current_user, conn, allow_assigned=True, write=True)`.
+With `write=True` (crm_utils.py lines 212-232), a non-admin caller is granted
+access only if their email matches the client's `assigned_to` OR `created_by`;
+anyone else gets `HTTPException(403)`. Admins (crm_utils.py lines 208-210) always
+pass, before the write check ever runs.
+
+The handler's bare `except Exception` at the bottom of the try block would
+otherwise convert that HTTPException(403) — or the HTTPException(404) for a
+missing/soft-deleted client — into an opaque 500. The `except HTTPException:
+raise` added just above it is what lets the real status code reach the caller;
+several tests below pin that explicitly (403/404, never 500).
+
+IMPORTANT — nothing in this file mocks `verify_client_access` itself (that would
+assert nothing about the fix: patching the guard away runs no guard at all). Every
+test here drives the REAL `verify_client_access`, mocking only the asyncpg
+connection it reads from (`mock_db_pool._mock_conn.fetchrow`, the shared fixture
+in `conftest.py`, same harness as `test_crm_clients_coverage.py::test_delete_client_*`).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from backend.app.routers.crm_portal_integration import mark_client_message_read
+
+ADMIN_EMAIL = "asya@balizero.com"  # backend.app.utils.crm_utils.CRM_EXTRA_ADMIN_EMAILS
+
+
+def _client_row(*, assigned_to: str | None, created_by: str | None = None) -> dict[str, object]:
+    return {
+        "id": 1,
+        "assigned_to": assigned_to,
+        "created_by": created_by if created_by is not None else assigned_to,
+    }
+
+
+@pytest.mark.asyncio
+async def test_assigned_team_member_marks_own_clients_message_succeeds(mock_db_pool) -> None:
+    """Team member whose email == the client's assigned_to → 200, UPDATE executed."""
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="alice@balizero.com")
+    mock_db_pool._mock_conn.execute.return_value = "UPDATE 1"
+
+    current_user = {"email": "alice@balizero.com", "role": "team"}
+
+    result = await mark_client_message_read(
+        client_id=1,
+        message_id=10,
+        current_user=current_user,
+        db_pool=mock_db_pool,
+    )
+
+    assert result == {"success": True, "message": "Message marked as read"}
+    mock_db_pool._mock_conn.execute.assert_awaited_once()
+    args, _kwargs = mock_db_pool._mock_conn.execute.await_args
+    assert args[1:] == (10, 1)  # (message_id, client_id) bind params
+
+
+@pytest.mark.asyncio
+async def test_created_by_team_member_marks_message_succeeds(mock_db_pool) -> None:
+    """Non-assigned team member who IS the client's created_by → 200.
+
+    write=True's owner check (crm_utils.py:212-219) accepts assigned_to OR
+    created_by — this pins the created_by half of that OR, which the assigned_to
+    test above cannot exercise on its own.
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="carol@balizero.com"
+    )
+    mock_db_pool._mock_conn.execute.return_value = "UPDATE 1"
+
+    current_user = {"email": "carol@balizero.com", "role": "team"}
+
+    result = await mark_client_message_read(
+        client_id=1,
+        message_id=11,
+        current_user=current_user,
+        db_pool=mock_db_pool,
+    )
+
+    assert result == {"success": True, "message": "Message marked as read"}
+    mock_db_pool._mock_conn.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_admin_marks_any_clients_message_succeeds(mock_db_pool) -> None:
+    """Admin keeps full access regardless of assignment (CLAUDE.md §13)."""
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(assigned_to="bob@balizero.com")
+    mock_db_pool._mock_conn.execute.return_value = "UPDATE 1"
+
+    current_user = {"email": ADMIN_EMAIL, "role": "team"}
+
+    result = await mark_client_message_read(
+        client_id=1,
+        message_id=99,
+        current_user=current_user,
+        db_pool=mock_db_pool,
+    )
+
+    assert result == {"success": True, "message": "Message marked as read"}
+    mock_db_pool._mock_conn.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_assigned_non_admin_team_member_denied_403_not_500(mock_db_pool) -> None:
+    """GUILT — the case the round-1 fix silently failed to gate.
+
+    A non-admin team member who is neither `assigned_to` nor `created_by` for
+    this client must be denied with 403 (not 500), and the UPDATE must never
+    run. This drives the REAL `verify_client_access` write=True branch
+    (crm_utils.py:212-232) — nothing here mocks the guard. Before the round-2
+    fix (i.e. with the round-1 call, which omits `write=True`), this exact
+    setup returns 200 instead of raising: `write=False` grants access to any
+    authenticated team member regardless of assignment (crm_utils.py:234-238).
+    So this test fails without `write=True` — that is what makes it a real
+    guard test rather than a tautology.
+    """
+    mock_db_pool._mock_conn.fetchrow.return_value = _client_row(
+        assigned_to="alice@balizero.com", created_by="alice@balizero.com"
+    )
+
+    # not admin, not assigned, not creator
+    current_user = {"email": "bob@balizero.com", "role": "team"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await mark_client_message_read(
+            client_id=1,
+            message_id=10,
+            current_user=current_user,
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.status_code != 500
+    mock_db_pool._mock_conn.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_client_returns_404_not_500(mock_db_pool) -> None:
+    """Client that does not exist or is soft-deleted → 404, not 500; UPDATE never runs."""
+    # no row => 404 inside verify_client_access
+    mock_db_pool._mock_conn.fetchrow.return_value = None
+
+    current_user = {"email": "alice@balizero.com", "role": "team"}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await mark_client_message_read(
+            client_id=999999,
+            message_id=10,
+            current_user=current_user,
+            db_pool=mock_db_pool,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.status_code != 500
+    mock_db_pool._mock_conn.execute.assert_not_awaited()


### PR DESCRIPTION
## What

`POST /api/crm/portal/clients/{client_id}/messages/{message_id}/read` took a `client_id`, ran `UPDATE portal_messages SET read_at = NOW()`, and was guarded only by `require_team_auth` — which asserts nothing beyond `is_human_team_member(role)`. Its four siblings in the same router all call `verify_client_access`. Any staff member could clear the unread flag on any client's message, against the CRM RBAC rule that a non-admin reaches only clients assigned to them.

Found by the kita↔my handoff audit (opened 2026-08-20, closing now).

## The part that is easy to get wrong

The gate passes **`write=True`**, not the siblings' default. With `write=False` (`crm_utils.py:234-238`) `verify_client_access` returns True for *every* authenticated team member — that mode exists so anyone can view an unassigned client and self-assign. An earlier pass of this fix used the default and closed nothing.

Marking read is an `UPDATE`, so it takes the write mode used by the other mutating call sites (`crm_enhanced_documents.py:136,271,407`, `crm_clients.py::delete_client`): admin, `assigned_to`, or `created_by`.

**Proven by mutation, not asserted:** removing `write=True` makes `test_non_assigned_non_admin_team_member_denied_403_not_500` fail with `DID NOT RAISE`.

## Second defect fixed: the guard's 403 was becoming a 500

Both handlers gain `except HTTPException: raise`. Without it the bare `except Exception` converts the guard's 403/404 into an opaque 500 — so `send_message_to_client`, which has had a `verify_client_access` call since the S03-S3 fix, was already reporting its denials as 500. The INSERT never ran, so this is a status-code defect, not a second hole. **Behaviour change:** callers that saw 500 on an unauthorised send now see 403.

## Live consumer

`PortalMessages.tsx:39` auto-marks messages read when a staff member opens a client's detail page, and swallows errors. After this change a non-assigned viewer's auto-mark silently no-ops — which is the intent: a colleague merely opening the page no longer clears the owner's unread flag. No visible UI breakage.

## Deliberately NOT changed

`send_message_to_client` still gates its INSERT in read mode, so any team member can message any client. Whether a non-assigned colleague may write to a client is a business rule, not a bug to tighten silently.

## Verification

- 5 new tests; the real `verify_client_access` runs (the guard is never patched out — mocking is at the connection level).
- Mutation-tested as above.
- `pytest backend/tests/unit/routers/ backend/tests/routers/` → **1981 passed**.
- `ruff check` clean.

## Reviewed by

Codex GPT-5.6 red-team (read-only, xhigh) on the auth diffs. It confirmed this change works and raised one **LOW** residual: a TOCTOU window between the ownership read and the UPDATE — an assigned user can race reassignment and mutate once after authority is revoked. The `message_id + client_id + direction` predicates prevent pivoting to another message. Inherent to the pattern every sibling uses; not fixed here.

The same review surfaced **pre-existing** holes in other endpoints, unrelated to this diff and not worsened by it — reported separately.