### PR TITLE
fix(research-os): remove ReDoS from the P04 contract identifier regexes

### DIFF
--- a/apps/backend-rag/backend/tests/unit/research_os/test_hashing.py
+++ b/apps/backend-rag/backend/tests/unit/research_os/test_hashing.py
@@ -8,13 +8,6 @@ from typing import Literal, cast
 import pytest
 import research_os.hashing as hashing
 from pydantic import BaseModel
-from research_os.hashing import (
-    CanonicalizationError,
-    HashFormatError,
-    canonicalize,
-    object_hash,
-    validate_sha256_hex,
-)
 from research_os.version import CONTRACT_VERSION
 
 TYPED_CONTRACT_VERSION = cast(Literal["research-os/v1.0.0"], CONTRACT_VERSION)
@@ -29,25 +22,25 @@ def test_hash_wire_format_rejects_every_noncanonical_form() -> None:
         "g" * 64,
     )
     for value in invalid_values:
-        with pytest.raises(HashFormatError):
-            validate_sha256_hex(value)
+        with pytest.raises(hashing.HashFormatError):
+            hashing.validate_sha256_hex(value)
 
 
 def test_canonicalize_translates_rfc8785_failure_to_typed_error() -> None:
-    with pytest.raises(CanonicalizationError):
-        canonicalize({"unsafe": float("nan")})
+    with pytest.raises(hashing.CanonicalizationError):
+        hashing.canonicalize({"unsafe": float("nan")})
 
 
 def test_rfc8785_number_serialization_reference_vector() -> None:
     value = [333333333.33333329, 1e30, 4.50, 2e-3, 1e-27]
 
-    assert canonicalize(value) == b"[333333333.3333333,1e+30,4.5,0.002,1e-27]"
+    assert hashing.canonicalize(value) == b"[333333333.3333333,1e+30,4.5,0.002,1e-27]"
 
 
 def test_rfc8785_unicode_and_escaping_reference_vector() -> None:
     value = {"string": '\u20ac$\u000f\nA\'B"\\\\"/', "literals": [None, True, False]}
 
-    assert canonicalize(value) == (
+    assert hashing.canonicalize(value) == (
         b'{"literals":[null,true,false],"string":"\xe2\x82\xac$\\u000f\\nA\'B\\"\\\\\\\\\\"/"}'
     )
 
@@ -55,7 +48,7 @@ def test_rfc8785_unicode_and_escaping_reference_vector() -> None:
 def test_object_hash_is_stable_across_key_permutations_and_runs() -> None:
     pairs = [("contract_version", CONTRACT_VERSION), ("alpha", 1), ("beta", "é")]
     hashes = {
-        object_hash(dict(permutation))
+        hashing.object_hash(dict(permutation))
         for permutation in itertools.permutations(pairs)
         for _ in range(3)
     }
@@ -67,14 +60,14 @@ def test_hash_changes_only_for_non_omitted_fields() -> None:
     changed_content = {**base, "value": 2}
     changed_omitted = {**base, "object_hash": "f" * 64}
 
-    assert object_hash(base) != object_hash(changed_content)
-    assert object_hash(base) == object_hash(changed_omitted)
+    assert hashing.object_hash(base) != hashing.object_hash(changed_content)
+    assert hashing.object_hash(base) == hashing.object_hash(changed_omitted)
 
 
 def test_caller_cannot_choose_a_different_omission_set() -> None:
-    assert "omit" not in signature(object_hash).parameters
+    assert "omit" not in signature(hashing.object_hash).parameters
     with pytest.raises(TypeError, match="unexpected keyword argument 'omit'"):
-        object_hash(  # type: ignore[call-arg]
+        hashing.object_hash(  # type: ignore[call-arg]
             {"contract_version": CONTRACT_VERSION, "value": 1},
             omit=frozenset({"value"}),
         )
@@ -91,7 +84,7 @@ def test_explicit_null_remains_present_in_canonical_bytes() -> None:
         optional_value=None,
     )
 
-    assert canonicalize(explicit_null) == (
+    assert hashing.canonicalize(explicit_null) == (
         b'{"contract_version":"research-os/v1.0.0","optional_value":null}'
     )
 
@@ -103,7 +96,7 @@ def test_explicit_null_and_absent_optional_field_hash_differ() -> None:
         optional_value=None,
     )
 
-    assert object_hash(absent) != object_hash(explicit_null)
+    assert hashing.object_hash(absent) != hashing.object_hash(explicit_null)
 
 
 def test_v1_transport_metadata_omission_set_is_frozen_empty() -> None:
@@ -116,9 +109,9 @@ def test_unicode_forms_are_each_stable_without_silent_normalization() -> None:
     hashes = []
     for form in ("NFC", "NFD", "NFKC", "NFKD"):
         value = unicodedata.normalize(form, "é")
-        first = object_hash({"contract_version": CONTRACT_VERSION, "value": value})
+        first = hashing.object_hash({"contract_version": CONTRACT_VERSION, "value": value})
         assert all(
-            object_hash({"value": value, "contract_version": CONTRACT_VERSION}) == first
+            hashing.object_hash({"value": value, "contract_version": CONTRACT_VERSION}) == first
             for _ in range(5)
         )
         hashes.append(first)
@@ -127,6 +120,6 @@ def test_unicode_forms_are_each_stable_without_silent_normalization() -> None:
 
 def test_changing_each_non_omitted_field_changes_hash() -> None:
     base = {"contract_version": CONTRACT_VERSION, "alpha": 1, "beta": "two"}
-    baseline = object_hash(base)
+    baseline = hashing.object_hash(base)
     mutations = ({**base, "alpha": 2}, {**base, "beta": "changed"})
-    assert all(object_hash(mutation) != baseline for mutation in mutations)
+    assert all(hashing.object_hash(mutation) != baseline for mutation in mutations)

--- a/apps/backend-rag/backend/tests/unit/research_os/test_primitives_redos.py
+++ b/apps/backend-rag/backend/tests/unit/research_os/test_primitives_redos.py
@@ -1,0 +1,99 @@
+"""Regression guard for the CodeQL py/redos findings on PR #4586.
+
+`_IDENTIFIER_RE` and `_REGISTERED_NAME_RE` in `research_os.primitives` used to
+have `*`/`+` quantifiers whose body character class overlapped the separator
+character class that follows them (hyphen in both, and for
+`_REGISTERED_NAME_RE` underscore too). That overlap let the backtracking
+engine parse the same run of hyphens/underscores as "body" or as
+"separator + next repetition" in exponentially many ways, so a pathological
+input took seconds on a ~30-50 character string.
+
+Measured on this machine BEFORE the fix (plain `*`/`+`, alarm-timed,
+`re.Pattern.fullmatch`):
+
+    _IDENTIFIER_RE       "a" + "-"*n + "!"    n=26 ->    8.71 ms
+                                                n=32 ->  154.77 ms
+    _REGISTERED_NAME_RE  "a" + "-0"*n + "!"   n=26 -> 1760.59 ms
+                                                n=28 -> 7024.26 ms
+
+The fix is a restructuring to disjoint character classes -- NOT possessive
+quantifiers (`*+`/`++`). An earlier version of this fix used possessives,
+which resolve the ambiguity for Python's `re` but do not exist in ECMA-262
+(the dialect JSON Schema's "pattern" keyword is specified against, since
+these same compiled patterns' `.pattern` text is reused verbatim as
+`Field(pattern=...)` and flows into the checked-in cross-language
+schemas/*.schema.json). `_IDENTIFIER_RE` drops the redundant `-` from its
+separator class (`-` was already accepted by the body class, so the
+separator reduces to a bare `\\.`, leaving body and separator strictly
+disjoint). `_REGISTERED_NAME_RE` needed real restructuring: a mandatory
+`[._-][a-z0-9]` opening followed by a tail loop offering two
+first-character-disjoint alternatives (`[a-z0-9_-]` or `\\.[a-z0-9]`), so
+the engine never has two ways to consume the same character. See
+`test_every_schema_pattern_compiles_under_ecma_262` in test_schemas.py for
+the guard that a possessive (or any other ECMA-incompatible) variant would
+trip.
+
+AFTER the fix, both patterns resolve the same pathological inputs in well
+under a millisecond -- these tests pin that with a threshold that the
+pre-fix regex would have blown through by 1-3 orders of magnitude, so a
+regression (someone reintroducing a plain, ambiguous `*`/`+` here) fails
+loudly instead of silently degrading back into a ReDoS.
+"""
+
+from __future__ import annotations
+
+import time
+
+from research_os.primitives import _IDENTIFIER_RE, _REGISTERED_NAME_RE
+
+# Generous relative to the <1ms the fixed regex actually takes, but far
+# below the 154ms / 1760ms the vulnerable regex took on the same inputs.
+_FAST_THRESHOLD_SECONDS = 0.1
+
+
+def test_identifier_re_resolves_pathological_hyphen_run_fast() -> None:
+    pathological = "a" + "-" * 32 + "!"
+
+    start = time.perf_counter()
+    result = _IDENTIFIER_RE.fullmatch(pathological)
+    elapsed = time.perf_counter() - start
+
+    assert result is None  # trailing "!" is never valid -- must still reject
+    assert elapsed < _FAST_THRESHOLD_SECONDS, (
+        f"_IDENTIFIER_RE took {elapsed * 1000:.2f} ms on a pathological input "
+        f"(threshold {_FAST_THRESHOLD_SECONDS * 1000:.0f} ms) -- possible ReDoS regression"
+    )
+
+
+def test_registered_name_re_resolves_pathological_hyphen_digit_run_fast() -> None:
+    pathological = "a" + "-0" * 26 + "!"
+
+    start = time.perf_counter()
+    result = _REGISTERED_NAME_RE.fullmatch(pathological)
+    elapsed = time.perf_counter() - start
+
+    assert result is None  # trailing "!" is never valid -- must still reject
+    assert elapsed < _FAST_THRESHOLD_SECONDS, (
+        f"_REGISTERED_NAME_RE took {elapsed * 1000:.2f} ms on a pathological input "
+        f"(threshold {_FAST_THRESHOLD_SECONDS * 1000:.0f} ms) -- possible ReDoS regression"
+    )
+
+
+def test_identifier_re_still_accepts_representative_valid_identifiers() -> None:
+    for value in ("a", "a-b", "a.b-c", "a_b.c-d", "a" + "-" * 20, "a" + "." + "0" * 5):
+        assert _IDENTIFIER_RE.fullmatch(value) is not None, value
+
+
+def test_identifier_re_still_rejects_representative_invalid_identifiers() -> None:
+    for value in ("", "A", "1abc", "a.", "a..b", "-a", "a b"):
+        assert _IDENTIFIER_RE.fullmatch(value) is None, value
+
+
+def test_registered_name_re_still_accepts_representative_valid_names() -> None:
+    for value in ("a.b", "a-b0", "a_b", "com.balizero.example", "a0.b_c-d9"):
+        assert _REGISTERED_NAME_RE.fullmatch(value) is not None, value
+
+
+def test_registered_name_re_still_rejects_representative_invalid_names() -> None:
+    for value in ("", "a", "abc", "a.", "a..b", "a-", "a__", "A.b", ".ab"):
+        assert _REGISTERED_NAME_RE.fullmatch(value) is None, value

--- a/apps/backend-rag/backend/tests/unit/research_os/test_schemas.py
+++ b/apps/backend-rag/backend/tests/unit/research_os/test_schemas.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
+from typing import Any
 
 import pytest
 from jsonschema import (  # type: ignore[import-untyped]
@@ -9,6 +12,7 @@ from jsonschema import (  # type: ignore[import-untyped]
 )
 from research_os.schemas import (
     SCHEMA_DIRECTORY,
+    SCHEMA_MODELS,
     checked_in_schemas_match,
     validate_schema_artifacts,
 )
@@ -20,6 +24,107 @@ def test_checked_in_schemas_are_byte_identical_to_fresh_regeneration() -> None:
 
 def test_generated_schemas_are_valid_draft_2020_12() -> None:
     assert validate_schema_artifacts() == ()
+
+
+def _collect_pattern_values(node: Any, out: list[str]) -> None:
+    """Recursively collect every JSON Schema "pattern" keyword value."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "pattern" and isinstance(value, str):
+                out.append(value)
+            else:
+                _collect_pattern_values(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_pattern_values(item, out)
+
+
+def _schema_pattern_values() -> list[tuple[str, str]]:
+    """(schema filename, pattern) pairs for every checked-in schema.json."""
+    pairs: list[tuple[str, str]] = []
+    for contract_kind in SCHEMA_MODELS:
+        path = SCHEMA_DIRECTORY / f"{contract_kind}.schema.json"
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        patterns: list[str] = []
+        _collect_pattern_values(schema, patterns)
+        pairs.extend((path.name, pattern) for pattern in patterns)
+    return pairs
+
+
+def _ecma_regexes_that_fail_to_compile(patterns: list[str]) -> list[tuple[str, str]]:
+    """Ask Node's V8 (the engine JSON Schema's "pattern" keyword is specified
+    against -- ECMA-262) to compile each pattern with `new RegExp(...)`.
+    Returns (pattern, error_message) for every one that fails.
+
+    This deliberately does NOT use Python's `re` module: `re` (and
+    pydantic-core, and the `jsonschema` package used elsewhere in this file)
+    accepts a strictly larger dialect than ECMA-262 -- possessive quantifiers
+    (`*+`, `++`), atomic groups, etc. A pattern can be perfectly valid Python
+    and still be uncompilable by every non-Python consumer (Go, TypeScript,
+    Java) of this schema file, which is the cross-language wire contract.
+    """
+    script = (
+        "const patterns = JSON.parse(require('fs').readFileSync(0, 'utf8'));"
+        "const failures = [];"
+        "for (const p of patterns) {"
+        "  try { new RegExp(p); }"
+        "  catch (e) { failures.push([p, String(e.message)]); }"
+        "}"
+        "process.stdout.write(JSON.stringify(failures));"
+    )
+    result = subprocess.run(
+        ["node", "-e", script],
+        input=json.dumps(patterns),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    failures: list[list[str]] = json.loads(result.stdout)
+    return [(pattern, message) for pattern, message in failures]
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH")
+def test_every_schema_pattern_compiles_under_ecma_262() -> None:
+    """Guard against a defect this suite cannot otherwise see.
+
+    `test_checked_in_schemas_are_byte_identical_to_fresh_regeneration` and
+    `test_generated_schemas_are_valid_draft_2020_12` both validate these
+    files with Python's `jsonschema` package, which compiles the "pattern"
+    keyword with Python's `re` -- a strictly larger dialect than the
+    ECMA-262 regex grammar the JSON Schema spec actually names. That means a
+    pattern that is valid Python (e.g. a possessive quantifier `*+`/`++`)
+    but invalid ECMA-262 passes every other test in this file while being
+    uncompilable by every non-Python consumer of the schema (Go, TypeScript,
+    Java): the schema is the cross-language wire contract, and "no consumer
+    has been written against it yet" is not the same claim as "the contract
+    is valid". This test asks Node's V8 -- a real ECMA-262 engine -- to
+    compile every "pattern" value in both checked-in schema.json files.
+
+    Proven to fail loudly against the disease this guards: pointed at the
+    possessive-quantifier `Identifier`/`RegisteredName` patterns that were
+    briefly on this branch (`^[a-z][a-z0-9_-]*+(?:[.-][a-z0-9_-]++)*$` /
+    `^[a-z][a-z0-9]*+(?:[._-][a-z0-9][a-z0-9_-]*+)+$`), this exact check
+    fails with "SyntaxError: Invalid regular expression: ... Nothing to
+    repeat" -- see the primitives.py history / PR discussion for the
+    transcript. Never weaken this to "compiles under Python `re`".
+    """
+    pairs = _schema_pattern_values()
+    assert pairs, "expected at least one 'pattern' keyword in the checked-in schemas"
+
+    patterns = [pattern for _, pattern in pairs]
+    failures = _ecma_regexes_that_fail_to_compile(patterns)
+
+    if failures:
+        failed_patterns = {pattern for pattern, _ in failures}
+        offending_fields = [
+            f"{filename}: {pattern!r}" for filename, pattern in pairs if pattern in failed_patterns
+        ]
+        raise AssertionError(
+            "the following schema 'pattern' values are not valid ECMA-262 "
+            f"regexes (uncompilable by node -- Go/TS/Java consumers would "
+            f"also reject them): {failures!r}\nOffending fields: {offending_fields!r}"
+        )
 
 
 @pytest.mark.parametrize(

--- a/packages/research-os-core/research_os/primitives.py
+++ b/packages/research-os-core/research_os/primitives.py
@@ -26,8 +26,61 @@ _REVERSE_DNS_RE = re.compile(
     r"^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+"
     r"[a-z](?:[a-z0-9-]*[a-z0-9])?$"
 )
-_REGISTERED_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$")
-_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$")
+# Restructured with disjoint character classes -- NOT possessive quantifiers
+# (`*+`/`++`). This text is reused verbatim as the JSON Schema "pattern"
+# keyword for these fields (`Field(pattern=...)` below feeds both pydantic
+# runtime validation AND `model_json_schema()` / the checked-in
+# schemas/*.schema.json, which are a cross-language wire contract). ECMA-262
+# -- the dialect JSON Schema's "pattern" keyword is specified against, and
+# what any Go/TypeScript/Java consumer of that contract compiles with -- has
+# no possessive quantifiers or atomic groups; `new RegExp(...)` raises
+# "Nothing to repeat" on them. So the fix has to be an unambiguous pattern
+# using only constructs ECMA (and Python `re`) both support, not merely a
+# non-backtracking instrument that's Python-only. One pattern string per
+# field, used everywhere -- never a possessive Python-only variant paired
+# with a plain schema-only variant; two texts encoding "the same" constraint
+# is itself a defect class (test_every_schema_pattern_compiles_under_ecma_262
+# in test_schemas.py guards this, red-tested against the possessive form).
+#
+# Root cause (CodeQL py/redos, PR #4586): the body character class of each
+# repeated group overlapped the separator character class that follows it --
+# hyphen was in both the "identifier body" set and the original "." / "-"
+# separator set. _IDENTIFIER_RE's fix drops the redundant "-" from the
+# separator class: "-" is already accepted by the body class
+# `[a-z0-9_-]`, so the separator can be reduced to a bare `\.` with the
+# accepted language unchanged (the "-"-as-separator branch never described
+# any string the body class didn't already accept unconstrained). That
+# leaves dot and body strictly disjoint -- dot can only ever be a
+# separator, body chars can never be dots -- so there is nothing left to
+# backtrack between; plain `*`/`+` are safe here without any special
+# instrument.
+#
+# _REGISTERED_NAME_RE needed real restructuring, not just a class
+# reduction: unlike _IDENTIFIER_RE, "_"/"-" as separators there aren't
+# redundant (e.g. "a_b" has no dot at all and must still match), so the
+# separator class can't just be trimmed to "\.". Instead: the leading
+# `[a-z0-9]*` run is alnum-only (disjoint from the separator set by
+# construction, so it's already unambiguous), then exactly one mandatory
+# `[._-][a-z0-9]` opening establishes the (required) first separator, and
+# the tail loop offers two alternatives disjoint on their first character --
+# a single `[a-z0-9_-]` body char, or a literal `.` that must be followed by
+# one more alnum char. Every subsequent "_"/"-" is just more body (it was
+# never required to re-trigger a fresh separator+mandatory-alnum pair to
+# stay in the accepted language); every "." still forces the
+# alnum-immediately-after constraint the original grammar had. No two ways
+# to consume the same character exist, so nothing to backtrack into.
+#
+# Verified three ways for both patterns: (1) exhaustive comparison old vs.
+# new over the alphabet {a,0,-,_,.} for every string of length 1-7/1-8 plus
+# a curated set of realistic longer identifiers, run under Python `re` --
+# zero differences; (2) the same exhaustive comparison run under Node's V8
+# (a real ECMA-262 engine, not just "is it valid Python") -- zero
+# differences; (3) a pathological-input timing series ("a"+"-"*n+"!" /
+# "a"+"-0"*n+"!" for n up to 200) showing a flat curve in both Python and
+# Node, versus the old pattern's exponential blowup (seconds at n=26-28).
+# See backend/tests/unit/research_os/test_primitives_redos.py.
+_REGISTERED_NAME_RE = re.compile(r"^[a-z][a-z0-9]*[._-][a-z0-9](?:[a-z0-9_-]|\.[a-z0-9])*$")
+_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z0-9_-]+)*$")
 _UTC_OFFSET_PATTERN = r"(?:Z|\+00:00)$"
 
 # Frozen union of the canonical field vocabulary in CONTRACTS.md for

--- a/packages/research-os-core/research_os/schemas/object_successor_edge.schema.json
+++ b/packages/research-os-core/research_os/schemas/object_successor_edge.schema.json
@@ -49,7 +49,7 @@
           "type": "string"
         },
         "object_kind": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Object Kind",
           "type": "string"
         }
@@ -106,7 +106,7 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Name",
           "type": "string"
         },
@@ -219,7 +219,7 @@
       "title": "Extensions"
     },
     "family_id": {
-      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$",
+      "pattern": "^[a-z][a-z0-9]*[._-][a-z0-9](?:[a-z0-9_-]|\\.[a-z0-9])*$",
       "title": "Family Id",
       "type": "string"
     },
@@ -232,7 +232,7 @@
       "type": "string"
     },
     "object_kind": {
-      "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+      "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
       "title": "Object Kind",
       "type": "string"
     },
@@ -248,7 +248,7 @@
       "$ref": "#/$defs/Producer"
     },
     "reason_code": {
-      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$",
+      "pattern": "^[a-z][a-z0-9]*[._-][a-z0-9](?:[a-z0-9_-]|\\.[a-z0-9])*$",
       "title": "Reason Code",
       "type": "string"
     },

--- a/packages/research-os-core/research_os/schemas/revocation_receipt.schema.json
+++ b/packages/research-os-core/research_os/schemas/revocation_receipt.schema.json
@@ -63,7 +63,7 @@
           "type": "string"
         },
         "object_kind": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Object Kind",
           "type": "string"
         }
@@ -120,7 +120,7 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Name",
           "type": "string"
         },
@@ -141,7 +141,7 @@
           "$ref": "#/$defs/ExactObjectRef"
         },
         "system": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "System",
           "type": "string"
         }
@@ -199,7 +199,7 @@
       "additionalProperties": false,
       "properties": {
         "role": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Role",
           "type": "string"
         },
@@ -309,7 +309,7 @@
       "$ref": "#/$defs/Producer"
     },
     "reason_code": {
-      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$",
+      "pattern": "^[a-z][a-z0-9]*[._-][a-z0-9](?:[a-z0-9_-]|\\.[a-z0-9])*$",
       "title": "Reason Code",
       "type": "string"
     },


### PR DESCRIPTION
Follow-up to #4586, which merged at `c3fd3ccfc` while its CodeQL check was red. The two high-severity `py/redos` alerts it reported are therefore **live on `main`** right now, in the contract package five downstream packets are about to build on.

## The defect is real — measured before fixing

| regex | input | n=20 | n=24 | n=26 |
|---|---|---:|---:|---:|
| `_REGISTERED_NAME_RE` | `"a" + "-0"*n + "!"` | 26.59 ms | 434.20 ms | **1760.59 ms** |
| `_IDENTIFIER_RE` | `"a" + "-"*n + "!"` | 0.44 ms | 3.20 ms | 8.45 ms |

These validate namespaced identifiers arriving from producers, so a ~70-character identifier stalls a worker. `_REVERSE_DNS_RE` measured flat out to n=40 and is **left untouched** — it was never vulnerable, and changing a safe regex only risks the language.

## Root cause

The hyphen — and for `_REGISTERED_NAME_RE` the underscore too — sat in **both** the repeated body class and the separator class, so the engine had two ways to parse the same run and explored both.

## The fix removes the ambiguity structurally, not with a quantifier

```
Identifier      ^[a-z][a-z0-9_-]*(?:\.[a-z0-9_-]+)*$
RegisteredName  ^[a-z][a-z0-9]*[._-][a-z0-9](?:[a-z0-9_-]|\.[a-z0-9])*$
```

In the first, the `-` inside the separator class `[.-]` was always redundant — `-` is already in the body class — so removing it costs nothing and kills the two-way parse. In the second, the tail loop's two alternatives are disjoint on their first character.

**Language unchanged, proven exhaustively in BOTH engines** over `{a,0,-,_,.}`: 97,676 strings for Identifier, 488,301 for RegisteredName — zero differences in Python and zero under node/V8. New timings are flat rather than merely smaller: 0.0008–0.026 ms out to n=200.

## Why there is a new guard

An earlier attempt used Python possessive quantifiers (`*+`, `++`). That works in Python and **silently breaks the contract**: JSON Schema `pattern` is ECMA-262, which has no possessive quantifiers, so node rejects the generated schemas with `Nothing to repeat` — while the test suite stays green, because `jsonschema` validates with Python's `re`, the one engine that cannot see the defect. The probe agreed with the object.

`test_every_schema_pattern_compiles_under_ecma_262` walks every `"pattern"` in both checked-in schema files and compiles it with node. It was proven **RED** against the possessive patterns (10 occurrences) before going green, so it is a guard and not decoration.

Also collapses a dual import of `research_os.hashing` (the `py/import-and-import-from` note). No assertion changed.

## Gates

Bytecode purged, `PYTHONDONTWRITEBYTECODE=1` (W121): **104 passed**, pytest exit 0 · `ruff check` 0 · `ruff format --check` 0 · `mypy --strict` clean on 11 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)