### PR TITLE
fix(portal): billing fixture asserted a payment status the backend cannot emit

### DIFF
--- a/apps/mouth/src/app/portal/(authenticated)/billing/page.test.tsx
+++ b/apps/mouth/src/app/portal/(authenticated)/billing/page.test.tsx
@@ -69,7 +69,7 @@ const BILLING = {
       practice_id: 12,
       practice_name: "PT PMA Setup",
       practice_category: "Company",
-      payment_status: "overdue",
+      payment_status: "unpaid",
     },
   ],
 };
@@ -119,7 +119,12 @@ describe("BillingPage", () => {
     expect(outstandingAmount?.style.color).toBe("var(--state-warning)");
 
     // Invoice rows: token surfaces, invoice numbers, status badges reading
-    // the semantic --state-* tokens (paid → success, overdue → danger).
+    // the semantic --state-* tokens (paid → success, unpaid → warning).
+    // `overdue` is never a real payment_status here: the backend's payment
+    // vocabulary is a closed set {unpaid, partial, paid} (crm_practices.py
+    // PAYMENT_STATUS_VALUES) and no invoice due-date data exists to derive
+    // an "overdue" state from — `overdue` is only ever emitted for deadline
+    // states elsewhere in the portal (dashboard mixin), not billing.
     expect(screen.getByText("INV-2026-001")).toBeInTheDocument();
     expect(screen.getByText("INV-2026-002")).toBeInTheDocument();
     // ("Paid" also appears as a summary-card label, so pick the badge by
@@ -129,8 +134,8 @@ describe("BillingPage", () => {
       .map((el) => el.closest("div"))
       .find((el) => el?.style.background.includes("color-mix"));
     expect(paidBadge?.style.color).toBe("var(--state-success)");
-    const overdueBadge = screen.getByText("Overdue").closest("div");
-    expect(overdueBadge?.style.color).toBe("var(--state-danger)");
+    const unpaidBadge = screen.getByText("Unpaid").closest("div");
+    expect(unpaidBadge?.style.color).toBe("var(--state-warning)");
 
     // Card surfaces read theme tokens, not the old dark rgba glass.
     expect(container.innerHTML).toContain("var(--bz-card)");


### PR DESCRIPTION
## What

The billing page test carried `payment_status: "overdue"` and asserted the badge rendered `--state-danger`. No code path can produce that value.

Found by the kita↔my handoff audit (opened 2026-08-20, closing now).

## Why `overdue` is impossible, not merely absent

- The vocabulary is a closed set: `PAYMENT_STATUS_VALUES = {"unpaid", "partial", "paid"}` (`crm_practices.py:242`, mirrored in `services/accounting/reconcile_service.py:28` with a keep-in-sync comment), enforced by a pydantic validator (`crm_practices.py:344-350`).
- The portal payload passes the practice's value straight through: `payment_status = row["payment_status"] or "unpaid"` (`services/portal/_mixins/billing.py:108`).
- **It is not derivable either.** The invoice SELECT (`_mixins/billing.py:56-82`) returns no due date, and a repo-wide search for `due_date|due_at|payment_terms|net_days` finds only passport expiry, tax deadlines, the WA action queue and team promises — never an invoice. Teaching the backend to emit `overdue` would first require inventing invoice payment terms, which is a business decision, not a test fix.

`overdue` **is** legitimate elsewhere — for DEADLINES (`_mixins/dashboard.py:246,820,852`, `schemas/portal.py:20`), which is why `StatusBadge` keeps the mapping. It is simply not a billing state.

## The assertion is replaced, not deleted

`page.test.tsx:132-133` was the only check in this file that the page wires `payment_status` into `StatusBadge` at all (`page.tsx:238`); deleting it would have cost real coverage while looking like a tidy-up. None of the three real billing states maps to `danger` (`StatusBadge.tsx:55-57`: paid→success, unpaid→warning, partial→warning), so the truthful equivalent asserts the `unpaid` badge carries `--state-warning`. The comment now records why, so the next reader does not re-add `overdue`.

The sibling scar test ("names the operator's real payment states instead of falling back to None") is untouched.

## Two findings this surfaced — NOT fixed here

1. `backend/scripts/seed_portal_qa.py:470` INSERTs `payment_status='pending'` — **outside** the closed set — into `practices`. So the comment at `_mixins/billing.py:107` ("pending is not a state this system emits") is factually false: the QA seed emits it, `or "unpaid"` does not catch it (it is truthy), and it reaches the client as a "Pending" badge.
2. There is **no CHECK constraint or DEFAULT** on `practices.payment_status` in any migration — the closed vocabulary is enforced only by two hand-synced Python constants. A CHECK constraint is the structural fix; it is a migration, so it belongs in its own PR with its own Squawk gate.

## Reviewed by

Kimi K3 as refuter, tasked to falsify the decision. Verdict: claim holds — but it broke my stated premise, correctly. "Closed vocabulary" is enforced only in Python, not the DB (finding 2 above), and it caught that swapping the fixture without replacing the badge assertion would silently drop coverage. Both corrections are incorporated above; the second changed the shape of this diff.

Frontend deps are not installed on the machine this was authored on, so the vitest run for this file is pending CI.