### PR TITLE
fix(research-os): cure two high-severity ReDoS in the canonical name validators

### DIFF
--- a/apps/backend-rag/backend/tests/unit/research_os/test_primitives_redos.py
+++ b/apps/backend-rag/backend/tests/unit/research_os/test_primitives_redos.py
@@ -1,0 +1,142 @@
+"""Guard the two canonical-name regexes against catastrophic backtracking.
+
+CodeQL raised two high-severity `py/redos` alerts against
+`packages/research-os-core/research_os/primitives.py` (lines 29-30 as merged in
+PR #4586, which merged with that check red). The alerts were real: the separator
+character class overlapped the body class beside it, so `_` and `-` belonged to
+both and a run of them could be split between the two roles in exponentially many
+ways. Measured on the pre-cure patterns before writing this file: a 46-character
+non-match took 1.0s, and every further 2 characters doubled it — so an ~80
+character input stalls for minutes. Both patterns back `Field(pattern=...)`
+validators (`RegisteredName`, `Identifier`), so the input is attacker-controlled
+by construction.
+
+Three independent properties, deliberately not the same claim:
+
+* STRUCTURE  — the separator and body classes must stay disjoint. This is the
+               root cause, and it fails INSTANTLY on a reintroduced pattern.
+* TIMING     — the exponential blowup must be gone, measured rather than argued.
+               Sized so a reintroduced pattern fails in about a second: `re.match`
+               runs in C and cannot be interrupted by a signal, so a guard aimed
+               at a longer input would hang the CI job instead of failing it.
+               (Learned the hard way — an earlier draft of this file used
+               `repeats=48` and ran past 600s against the vulnerable pattern
+               without ever reporting.)
+* LANGUAGE   — the cure must not have quietly narrowed what the canonical grammar
+               accepts. Proven exhaustively, not by example.
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+import time
+
+import pytest
+from research_os.primitives import _IDENTIFIER_RE, _REGISTERED_NAME_RE
+
+# The exact patterns as they stood on main before the cure. Used ONLY as the
+# reference for the equivalence proof, and ONLY against the short generated
+# strings below — never against adversarial input.
+PRE_CURE_REGISTERED_NAME = r"^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$"
+PRE_CURE_IDENTIFIER = r"^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$"
+
+PATTERNS = [
+    (_REGISTERED_NAME_RE, PRE_CURE_REGISTERED_NAME, "_REGISTERED_NAME_RE"),
+    (_IDENTIFIER_RE, PRE_CURE_IDENTIFIER, "_IDENTIFIER_RE"),
+]
+
+# Every character class in play: a letter, a digit, and all three characters that
+# appear in some separator class (`.`, `_`, `-`). The wider alphabet catches
+# anything needing two distinct letters or digits; shorter strings keep it cheap.
+ALPHABET = "a0_-."
+WIDE_ALPHABET = "ab01_-."
+
+
+def _all_strings(alphabet: str, max_len: int):
+    for n in range(1, max_len + 1):
+        for tup in itertools.product(alphabet, repeat=n):
+            yield "".join(tup)
+
+
+@pytest.mark.parametrize(("pattern", "_pre_cure", "name"), PATTERNS)
+def test_separator_and_body_classes_stay_disjoint(pattern, _pre_cure, name):
+    """STRUCTURE: the root cause, asserted directly so it fails instantly.
+
+    A repeated group whose separator class shares a character with the body class
+    beside it is the ReDoS condition. `-` and `_` live in the body class already,
+    so neither ever needed to be a separator; only `.` adds expressive power.
+    """
+    source = pattern.pattern
+    assert "[.-]" not in source, (
+        f"{name} uses separator class [.-], which shares '-' with its body class "
+        f"[a-z0-9_-] — that overlap is the py/redos condition"
+    )
+    # `[._-]` is permitted at most once: in _REGISTERED_NAME_RE it is the single
+    # mandatory first separator, preceded by [a-z0-9], which is disjoint from it.
+    # Inside a REPEATED group it would reintroduce the blowup.
+    assert source.count("[._-]") <= 1, (
+        f"{name} uses [._-] more than once; every repeated separator must be the "
+        f"disjoint literal '\\.'"
+    )
+
+
+@pytest.mark.parametrize(("pattern", "_pre_cure", "name"), PATTERNS)
+@pytest.mark.parametrize("repeats", [10, 16, 22])
+def test_no_catastrophic_backtracking(pattern, _pre_cure, name, repeats):
+    """TIMING: the CodeQL witness shape stays cheap, measured.
+
+    `a-0-0-0...!` is exactly what the alert annotation described: an accepted
+    prefix, a long run of characters belonging to both classes, and a final
+    character that cannot match — forcing every partition of the run to be tried
+    before failure can be reported.
+
+    22 repeats costs ~1.0s on the vulnerable pattern and ~0s on the cured one, so
+    a 0.3s budget separates them by a wide margin while staying far too short to
+    flake on a loaded runner. Larger inputs are deliberately NOT used: they would
+    hang rather than fail.
+    """
+    subject = "a" + "-0" * repeats + "!"
+    start = time.perf_counter()
+    assert pattern.match(subject) is None
+    elapsed = time.perf_counter() - start
+    assert elapsed < 0.3, (
+        f"{name} took {elapsed:.3f}s on a {len(subject)}-character non-match "
+        f"({repeats} repeats) — the exponential-backtracking signature CodeQL "
+        f"py/redos flags, not a slow machine. Check whether a separator class "
+        f"again overlaps its body class."
+    )
+
+
+# NOTE — there is deliberately NO test here that feeds a very long adversarial
+# string (e.g. 800 characters). It would pass on the cured patterns in
+# microseconds and is tempting to add as a flourish, but on a REINTRODUCED
+# vulnerable pattern it does not fail: it diverges. Measured while writing this
+# file, such a test ran past 600s twice and had to be killed, leaving a mutated
+# source tree behind both times. A guard whose failure mode is "hang the runner"
+# is worse than no guard, because CI reports a timeout instead of a red
+# assertion and the cause is not named anywhere. The 22-repeat case above
+# separates cured (~0s) from vulnerable (~1.0s) by a factor of thousands, which
+# is all the signal needed; linearity at length 800 is recorded in the PR body,
+# where a number cannot hang anything.
+
+@pytest.mark.parametrize(("pattern", "pre_cure", "name"), PATTERNS)
+@pytest.mark.parametrize(("alphabet", "max_len"), [(ALPHABET, 6), (WIDE_ALPHABET, 5)])
+def test_cure_accepts_exactly_the_same_language(pattern, pre_cure, name, alphabet, max_len):
+    """LANGUAGE: the cure is a rewrite, not a restriction.
+
+    Exhaustive over the alphabet. If the cured pattern rejected even one string
+    the original accepted, the canonical grammar would have silently narrowed and
+    records that used to validate would start failing — a worse outcome than the
+    ReDoS for anything already in flight.
+    """
+    reference = re.compile(pre_cure)
+    divergent = [
+        s
+        for s in _all_strings(alphabet, max_len)
+        if bool(reference.match(s)) != bool(pattern.match(s))
+    ]
+    assert not divergent, (
+        f"{name} changed the accepted language for {len(divergent)} string(s); "
+        f"first few: {divergent[:8]!r}"
+    )

--- a/packages/research-os-core/research_os/primitives.py
+++ b/packages/research-os-core/research_os/primitives.py
@@ -26,8 +26,29 @@ _REVERSE_DNS_RE = re.compile(
     r"^(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+"
     r"[a-z](?:[a-z0-9-]*[a-z0-9])?$"
 )
-_REGISTERED_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$")
-_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$")
+# ReDoS note (CodeQL py/redos, two high-severity alerts, cured 2026-08-23).
+# Both patterns below previously used a separator class that OVERLAPPED the body
+# class next to it — `[._-]` beside `[a-z0-9_-]`, and `[.-]` beside `[a-z0-9_-]`.
+# `_` and `-` therefore belonged to both, so a run of them could be partitioned
+# between "separator" and "body" in exponentially many ways and a non-matching
+# suffix forced the engine to try all of them. Measured on the pre-cure patterns:
+# 46 characters took 1.0s and each further 2 characters doubled it, i.e. an ~80
+# character identifier stalls the process for minutes. These are pydantic
+# `Field(pattern=...)` validators (see RegisteredName / Identifier below), so the
+# input is attacker-controlled by construction.
+#
+# The cure keeps every class pairwise DISJOINT. It relies on one observation: the
+# body class already contains `_` and `-`, so those two never needed to be
+# separators as well — only `.` adds expressive power, and it must be followed by
+# a body character. The accepted language is therefore UNCHANGED, which is proven
+# exhaustively rather than argued: see
+# apps/backend-rag/backend/tests/unit/research_os/test_primitives_redos.py, which
+# compares old and new over every string of an alphabet containing all the
+# interesting characters.
+_REGISTERED_NAME_RE = re.compile(
+    r"^[a-z][a-z0-9]*[._-][a-z0-9][a-z0-9_-]*(?:\.[a-z0-9][a-z0-9_-]*)*$"
+)
+_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z0-9_-]+)*$")
 _UTC_OFFSET_PATTERN = r"(?:Z|\+00:00)$"
 
 # Frozen union of the canonical field vocabulary in CONTRACTS.md for

--- a/packages/research-os-core/research_os/schemas/object_successor_edge.schema.json
+++ b/packages/research-os-core/research_os/schemas/object_successor_edge.schema.json
@@ -49,7 +49,7 @@
           "type": "string"
         },
         "object_kind": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Object Kind",
           "type": "string"
         }
@@ -106,7 +106,7 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Name",
           "type": "string"
         },
@@ -219,7 +219,7 @@
       "title": "Extensions"
     },
     "family_id": {
-      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$",
+      "pattern": "^[a-z][a-z0-9]*[._-][a-z0-9][a-z0-9_-]*(?:\\.[a-z0-9][a-z0-9_-]*)*$",
       "title": "Family Id",
       "type": "string"
     },
@@ -232,7 +232,7 @@
       "type": "string"
     },
     "object_kind": {
-      "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+      "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
       "title": "Object Kind",
       "type": "string"
     },
@@ -248,7 +248,7 @@
       "$ref": "#/$defs/Producer"
     },
     "reason_code": {
-      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$",
+      "pattern": "^[a-z][a-z0-9]*[._-][a-z0-9][a-z0-9_-]*(?:\\.[a-z0-9][a-z0-9_-]*)*$",
       "title": "Reason Code",
       "type": "string"
     },

--- a/packages/research-os-core/research_os/schemas/revocation_receipt.schema.json
+++ b/packages/research-os-core/research_os/schemas/revocation_receipt.schema.json
@@ -63,7 +63,7 @@
           "type": "string"
         },
         "object_kind": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Object Kind",
           "type": "string"
         }
@@ -120,7 +120,7 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Name",
           "type": "string"
         },
@@ -141,7 +141,7 @@
           "$ref": "#/$defs/ExactObjectRef"
         },
         "system": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "System",
           "type": "string"
         }
@@ -199,7 +199,7 @@
       "additionalProperties": false,
       "properties": {
         "role": {
-          "pattern": "^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$",
+          "pattern": "^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$",
           "title": "Role",
           "type": "string"
         },
@@ -309,7 +309,7 @@
       "$ref": "#/$defs/Producer"
     },
     "reason_code": {
-      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$",
+      "pattern": "^[a-z][a-z0-9]*[._-][a-z0-9][a-z0-9_-]*(?:\\.[a-z0-9][a-z0-9_-]*)*$",
       "title": "Reason Code",
       "type": "string"
     },


### PR DESCRIPTION
## A red CodeQL check was bypassed, and the vulnerability is on `main`

PR #4586 merged at `2026-08-23T02:15:46Z` with its `CodeQL` check **red**. That check was not a stale gate or a flake — it reported two genuine **high**-severity `py/redos` alerts, and it completed at `01:46:59Z`, about 29 minutes before the merge. The one commit that landed after the alerts (`c3fd3ccfc`, "close seven refuter findings") fixed a *different* regex, `_REVERSE_DNS_RE`, for a different bug class; both flagged patterns went in untouched.

`base: 3981a3a17a1e9062bafd01848f143949c9b65df1`

## The defect

```python
_REGISTERED_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9][a-z0-9_-]*)+$")
_IDENTIFIER_RE      = re.compile(r"^[a-z][a-z0-9_-]*(?:[.-][a-z0-9_-]+)*$")
```

In both, the **separator class overlaps the body class beside it**. `_` and `-` belong to both roles, so a run of them can be partitioned between "separator" and "body" in exponentially many ways; a final non-matching character then forces the engine to try every partition.

Measured against the patterns as they sit on `main`, with the CodeQL witness shape `a-0-0-0…!`:

| repeats | length | time |
|---:|---:|---:|
| 14 | 30 | 0.0034s |
| 16 | 34 | 0.0126s |
| 18 | 38 | 0.0950s |
| 20 | 42 | 0.5243s |
| 22 | 46 | **1.0054s** |

A clean doubling every two characters. A 46-character input already costs a second; an ~80-character one stalls for minutes. **These are `Field(pattern=...)` validators** (`RegisteredName`, `Identifier`) — the ones P04 exists to put in front of every producer's input — so the input is attacker-controlled by construction. The same patterns were exported into the checked-in JSON Schema artifacts, i.e. shipped to consumers.

## The cure, and why it does not narrow the grammar

The body class already contains `_` and `-`, so neither ever needed to be a separator as well; only `.` adds expressive power, and it must be followed by a body character. Making `.` the sole repeated separator leaves every class pairwise disjoint.

```python
_REGISTERED_NAME_RE = re.compile(
    r"^[a-z][a-z0-9]*[._-][a-z0-9][a-z0-9_-]*(?:\\.[a-z0-9][a-z0-9_-]*)*$"
)
_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_-]*(?:\\.[a-z0-9_-]+)*$")
```

Equivalence is **proven, not argued**: `test_cure_accepts_exactly_the_same_language` compares old against new over *every* string of two alphabets containing all the interesting characters (`a0_-.` to length 6, `ab01_-.` to length 5). A silently narrowed grammar would be worse than the ReDoS for anything already in flight. Cured timings: `0.0000s` at n=22, and `0.0000s` on an 802-character input.

## The guard is built to fail, not to hang

An earlier draft of the test asserted linearity on an 800-character input. That passes in microseconds on the cured pattern — and **diverges** on a reintroduced vulnerable one. Under deliberate mutation it ran past 600s twice and had to be killed, leaving a mutated source tree behind both times. A guard whose failure mode is "hang the runner" makes CI report a job timeout instead of a named assertion, so:

- the timing case is capped at 22 repeats — ~1.0s vulnerable versus ~0s cured, a margin of thousands against a loose 0.3s budget that cannot flake on a loaded runner;
- the root cause is asserted **structurally** (`test_separator_and_body_classes_stay_disjoint`), which fails *instantly* and names the overlapping class.

That reasoning is recorded in the test file itself, so the next person is not tempted to re-add the long case.

**Mutation-verified** with `PYTHONDONTWRITEBYTECODE=1` and `__pycache__` purged (W121 — mutation testing can otherwise run on poisoned bytecode): restoring the pre-cure patterns makes the guard fail in **0s**; with the cure in place all **109** tests in the package pass.

## Derived artifacts travel in this commit

The two JSON Schemas are regenerated here. The package has a test asserting the checked-in schemas are byte-identical to a fresh regeneration — it caught the drift, and shipping without them would have left consumers validating against the vulnerable pattern (W86: derived contracts travel in the commit you arm on).

## Worth a separate look, not fixed here

A required-looking `CodeQL` check was red at merge on #4586 and the PR merged anyway. Whether that check is actually required, and whether the merge queue honours it, is a governance question about the gate rather than about this diff — flagged for the codeowner, not silently patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
